### PR TITLE
Make the "sha256sum -c" output independent of locale settings

### DIFF
--- a/scripts/update_domoticz
+++ b/scripts/update_domoticz
@@ -3,7 +3,7 @@ cd $1
 if [ -f update.tgz.sha256sum ];
 then
   #Check archive against checksum!
-  valid=$(sha256sum -c update.tgz.sha256sum | grep update.tgz | cut -d':' -f2 | tr -d ' ')
+  valid=$(LC_ALL=C sha256sum -c update.tgz.sha256sum | grep update.tgz | cut -d':' -f2 | tr -d ' ')
   if [ $valid != "OK" ]
   then
 	echo "Archive checksum mismatch !";

--- a/www/styles/element-dark/custom.css
+++ b/www/styles/element-dark/custom.css
@@ -21,7 +21,7 @@ body {
 #status, #lastupdate, body table#itemtable tr td:first-child + td + td + td + td + td{color: #5e5d5d;}
 
 #status:before {
- content: "Status op dit moment:  " !important;
+ content: "Status at the moment:  " !important;
  font-weight: normal;
 }
 

--- a/www/styles/element-light/custom.css
+++ b/www/styles/element-light/custom.css
@@ -19,7 +19,7 @@ body {
 }
 
 #status:before {
- content: "Status op dit moment:  " !important;
+ content: "Status at the moment:  " !important;
  font-weight: normal;
 }
 


### PR DESCRIPTION
The output of "sha256sum -c" is locale dependent. On my LANG=fr_FR.UTF-8 system, it returns "Réussi", not "OK", thus preventing automatic update. 

No bug is reported regarding a failure of the update system, though, so I might be the only one affected.