### PR TITLE
Bugfix, logging group_on/group_off

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5463,6 +5463,33 @@ bool CSQLHelper::BackupDatabase(const std::string &OutputFile)
 	return ( rc==SQLITE_OK );
 }
 
+unsigned long long CSQLHelper::UpdateValueLighting2GroupCmd(const int HardwareID, const char* ID, const unsigned char unit,
+	const unsigned char devType, const unsigned char subType,
+	const unsigned char signallevel, const unsigned char batterylevel,
+	const int nValue, const char* sValue,
+	std::string &devname,
+	const bool bUseOnOffAction)
+{
+	// We only have to update all others units within the ID group. If the current unit does not have the same value, 
+	// it will be updated too. The reason we choose the UpdateValue is the propagation of the change to all units involved, including LogUpdate. 
+
+	unsigned long long devRowIndex = -1;
+	typedef std::vector<std::vector<std::string> > VectorVectorString;
+
+	VectorVectorString result = safe_query("SELECT Unit FROM DeviceStatus WHERE ((DeviceID=='%q') AND (Type==%d) AND (SubType==%d) AND (nValue!=%d))",
+		ID,
+		pTypeLighting2,
+		subType,
+		nValue);
+
+	for (VectorVectorString::const_iterator itt = result.begin(); itt != result.end(); ++itt)
+	{
+		unsigned char theUnit = atoi((*itt)[0].c_str()); // get the unit value
+		devRowIndex = UpdateValue(HardwareID, ID, theUnit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction);
+	}
+	return devRowIndex;
+}
+
 void CSQLHelper::Lighting2GroupCmd(const std::string &ID, const unsigned char subType, const unsigned char GroupCmd)
 {
 	time_t now = mytime(NULL);

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -189,6 +189,7 @@ public:
 	unsigned long long UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, std::string &devname, const bool bUseOnOffAction=true);
 	unsigned long long UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
 	unsigned long long UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
+	unsigned long long UpdateValueLighting2GroupCmd(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction = true);
 
 	bool GetLastValue(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, int &nvalue, std::string &sValue, struct tm &LastUpdateTime);
 	

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3873,18 +3873,27 @@ unsigned long long MainWorker::decode_Lighting2(const CDomoticzHardwareBase *pHa
 
 	sprintf(szTmp, "%d", level);
 	unsigned long long DevRowIdx = m_sql.UpdateValue(HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, m_LastDeviceName);
-	if (DevRowIdx == -1)
-		return -1;
-	unsigned char check_cmnd = cmnd;
-	if ((cmnd == light2_sGroupOff) || (cmnd == light2_sGroupOn))
-		check_cmnd = (cmnd == light2_sGroupOff) ? light2_sOff : light2_sOn;
 
-	if ((cmnd == light2_sGroupOff) || (cmnd == light2_sGroupOn))
+	bool isGroupCommand = ((cmnd == light2_sGroupOff) || (cmnd == light2_sGroupOn));
+	unsigned char single_cmnd = cmnd;
+
+	if (isGroupCommand)
 	{
+		single_cmnd = (cmnd == light2_sGroupOff) ? light2_sOff : light2_sOn;
+
+		// We write the GROUP_CMD into the log to differentiate between manual turn off/on and group_off/group_on
+		m_sql.UpdateValueLighting2GroupCmd(HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, m_LastDeviceName);
+
 		//set the status of all lights with the same code to on/off
-		m_sql.Lighting2GroupCmd(ID, subType, (cmnd == light2_sGroupOff) ? light2_sOff : light2_sOn);
+		m_sql.Lighting2GroupCmd(ID, subType, single_cmnd);
 	}
-	CheckSceneCode(DevRowIdx, devType, subType, check_cmnd, szTmp);
+
+	if (DevRowIdx == -1)
+	{
+		// not found nothing to do 
+		return -1;
+	}
+	CheckSceneCode(DevRowIdx, devType, subType, single_cmnd, szTmp);
 
 	if (m_verboselevel == EVBL_ALL)
 	{


### PR DESCRIPTION
Fixed the problem where a switch update from an AC lighting2 switch was
not logged. In case a group_on/group_off command is received, it will
also update all switches (units) from the same ID and updates their logs
too with a group_on/group_off. Therefore a real received off/on can be
distinguished from a group_off/off.
