### PR TITLE
Rego6XX hardware device bugfixes

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2564,7 +2564,7 @@ unsigned long long CSQLHelper::UpdateValueInt(const int HardwareID, const char* 
             break;
         }
 	case pTypeGeneral:
-		if ((subType != sTypeTextStatus) && (subType != sTypeAlert))
+		if ((devType == pTypeGeneral) && (subType != sTypeTextStatus) && (subType != sTypeAlert))
 		{
 			break;
 		}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13341,7 +13341,7 @@ namespace http {
 						else
 						{
 							//Add last counter value
-							sprintf(szTmp, "%.3f", atof(sValue.c_str()) / 1000.0);
+							sprintf(szTmp, "%d", atoi(sValue.c_str()));
 							root["counter"] = szTmp;
 						}
 						//Actual Year

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -7010,7 +7010,8 @@ namespace http {
 						(dType == pTypeThermostat3) ||
 						(dType == pTypeRemote)||
 						(dType == pTypeGeneralSwitch) ||
-						((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator))
+						((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator)) ||
+						((dType == pTypeRego6XXValue) && (dSubType == sTypeRego6XXStatus))
 						)
 					{
 						//add light details
@@ -13337,6 +13338,12 @@ namespace http {
 								root["counter"] = szTmp;
 							}
 						}
+						else
+						{
+							//Add last counter value
+							sprintf(szTmp, "%.3f", atof(sValue.c_str()) / 1000.0);
+							root["counter"] = szTmp;
+						}
 						//Actual Year
 						result = m_sql.safe_query("SELECT Value, Date, Counter FROM %s WHERE (DeviceRowID==%llu AND Date>='%q' AND Date<='%q') ORDER BY Date ASC", dbasetable.c_str(), idx, szDateStart, szDateEnd);
 						if (result.size() > 0)
@@ -13382,6 +13389,15 @@ namespace http {
 										strcpy(szTmp, "0");
 									root["result"][ii]["c"] = szTmp;
 									break;
+								case MTYPE_COUNTER:
+									sprintf(szTmp, "%.0f", atof(szValue.c_str()));
+									root["result"][ii]["v"] = szTmp;
+									if (fcounter != 0)
+										sprintf(szTmp, "%.0f", (fcounter - atof(szValue.c_str())));
+									else
+										strcpy(szTmp, "0");
+									root["result"][ii]["c"] = szTmp;
+									break;
 								}
 								ii++;
 							}
@@ -13411,6 +13427,10 @@ namespace http {
 									break;
 								case MTYPE_WATER:
 									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / WaterDivider);
+									root["resultprev"][iPrev]["v"] = szTmp;
+									break;
+								case MTYPE_COUNTER:
+									sprintf(szTmp, "%.0f", atof(szValue.c_str()));
 									root["resultprev"][iPrev]["v"] = szTmp;
 									break;
 								}
@@ -13675,6 +13695,12 @@ namespace http {
 								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / WaterDivider);
 								root["result"][ii]["v"] = szTmp;
 								sprintf(szTmp, "%.3f", (atof(sValue.c_str()) - atof(szValue.c_str())) / WaterDivider);
+								root["result"][ii]["c"] = szTmp;
+								break;
+							case MTYPE_COUNTER:
+								sprintf(szTmp, "%.0f", atof(szValue.c_str()));
+								root["result"][ii]["v"] = szTmp;
+								sprintf(szTmp, "%.0f", (atof(sValue.c_str()) - atof(szValue.c_str())));
 								root["result"][ii]["c"] = szTmp;
 								break;
 							}


### PR DESCRIPTION
Long overdue fixes for problems that started somewhere around Christmas causing switch logs to be broken (including change notification and timeout) and  month and year graphs for counters to be empty.

The following changes has been done:
1, The follow-through intention of switch clause cases in SQLHelper.cpp didn't work for the Rego6XX type.
2, The Rego6XX switch wasn't recognized as a light switch in Webserver.cpp
3, The MTYPE_COUNTER wasn't implemented for general graphs.

I plan to revise the fixes for the MTYPE_COUNTER as it is unnecessary to use a float to represent an integer but it works for now.
