### PR TITLE
MQTT: fix double message after broker restart

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -96,10 +96,14 @@ void MQTT::on_connect(int rc)
 	*/
 
 	if (rc == 0){
-		_log.Log(LOG_STATUS, "MQTT: connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
-		m_IsConnected = true;
-		sOnConnected(this);
-		m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&MQTT::SendDeviceInfo, this, _1, _2, _3, _4));
+		if (m_IsConnected) {
+			_log.Log(LOG_STATUS, "MQTT: re-connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
+		} else {
+			_log.Log(LOG_STATUS, "MQTT: connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
+			m_IsConnected = true;
+			sOnConnected(this);
+			m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&MQTT::SendDeviceInfo, this, _1, _2, _3, _4));
+		}
 		subscribe(NULL, TOPIC_IN);
 	}
 	else {


### PR DESCRIPTION
When the mqtt broker restarts or when the connection is lost,
Domoticz reconnects to the broker, but after each reconnect an extra
(identical) message is published.
