### PR TITLE
Fix the .travis.yml build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,3 @@ script:
   - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only
   - make
   - tar czf domoticz_${TRAVIS_OS_NAME}_x86_64.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease --exclude .svn www/ scripts/ Config/
-addons:
-  artifacts:
-    paths:
-    - domoticz_${TRAVIS_OS_NAME}_x86_64.tgz


### PR DESCRIPTION
OK, Travis-CI does not have a built-in artifact archive. It is able to deploy the build artifacts to a number of targets (see http://docs.travis-ci.com/user/deployment/). So only appveyor.com keeps the artifacts by default, for this service we'd need to have some deployment service.
