### PR TITLE
Update the build status badges to point to the Appveyor and Travis-CI services

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Some Information
 
 Status | Operating system
 ------------ | -------------
-![image](https://travis-ci.org/domoticz/domoticz.svg?branch=master "Linux Build Status") | Linux x86_64
-![image](https://ci.appveyor.com/api/projects/status/fskiwvjs1q7svwq9?svg=true "Windows Build Status") | Windows
+[![Linux/OSX build Status](https://travis-ci.org/domoticz/domoticz.svg?branch=master)](https://travis-ci.org/domoticz/domoticz) | Linux x86_64 & OSX
+[![Windows build status](https://ci.appveyor.com/api/projects/status/fskiwvjs1q7svwq9?svg=true)](https://ci.appveyor.com/project/gizmocuz/domoticz/branch/master) | Windows


### PR DESCRIPTION
The build badge images are now links to Appveyor and Travis-CI
