### PR TITLE
Linux & OSX build result FTPS upload, .travis.yml refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,3 +97,4 @@ deploy:
   script: echo curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST"
   on:
     branch: master
+    repo: domoticz/domoticz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,36 +4,8 @@ branches:
 
 language: cpp
 
-compiler:
-  - gcc
-
-os:
-  - linux
-  - osx
-
 cache:
   - apt
-
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - gcc-4.9
-      - g++-4.9
-      - libboost1.55-all-dev
-      - cmake
-      - libsqlite3-dev
-      - curl
-      - libcurl4-openssl-dev
-      - libusb-dev
-      - zlib1g-dev
-      - libssl-dev
-      - libudev-dev
-      - git
-    on:
-      os: linux
 
 update-alternatives:
   - install /usr/bin/gcc gcc /usr/bin/gcc-4.9 50
@@ -42,24 +14,86 @@ update-alternatives:
 sources:
   - trusty
 
-before_install:
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then git clone https://github.com/OpenZWave/open-zwave.git; fi
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then ln -s open-zwave open-zwave-read-only; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install cmake; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install boost || true; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install libusb; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install libusb-compat; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install zlib || true; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew install openssl; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then brew link openssl --force; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then export LDFLAGS=-L/usr/local/opt/openssl/lib; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then export CPPFLAGS=-I/usr/local/opt/openssl/include; fi
-  - git fetch --unshallow
 
-script:
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then (cd open-zwave-read-only; make); fi
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then cmake -DCMAKE_BUILD_TYPE=Release; fi
-  - make
-  - if [ ${TRAVIS_OS_NAME} == "linux" ]; then tar czf domoticz_${TRAVIS_OS_NAME}_x86_64.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease --exclude .svn www/ scripts/ Config/; fi
-  - if [ ${TRAVIS_OS_NAME} == "osx" ];   then tar czf domoticz_${TRAVIS_OS_NAME}_x86_64.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease; fi
+# Domoticz ftp server account & encrypted password
+env:
+  global:
+    - "FTP_HOST=62.84.241.110"
+    - "FTP_USER=uploads@domoticz.com"
+    - "FTP_PASSWORD=password"
+
+
+# What to install before the build
+before_install:
+  # Domoticz needs the full history to be able to calculate the version string
+  - git fetch --unshallow
+  # OpenZWave
+  - git clone https://github.com/OpenZWave/open-zwave.git
+  - ln -s open-zwave open-zwave-read-only
+
+
+# Build matrix definition
+# * Two builds
+#   1. Linux amd64
+#   2. Apple OSX
+matrix:
+  include:
+  # Linux amd64
+  - os: linux
+    compiler:
+      - gcc
+    env: TARGET_ARCHITECTURE=amd64
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+          - boost-latest
+        packages:
+          - gcc-4.9
+          - g++-4.9
+          - libboost1.55-all-dev
+          - cmake
+          - libsqlite3-dev
+          - curl
+          - libcurl4-openssl-dev
+          - libusb-dev
+          - zlib1g-dev
+          - libssl-dev
+          - libudev-dev
+          - git
+    script:
+      - (cd open-zwave-read-only; make)
+      - cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only
+      - make
+    before_deploy:
+      - tar czf domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease --exclude .svn www/ scripts/ Config/
+  # Apple OSX
+  - os: osx
+    compiler:
+      - gcc
+    env: TARGET_ARCHITECTURE=amd64
+    install:
+      - brew install cmake
+      - brew install boost|| true
+      - brew install libusb
+      - brew install libusb-compat
+      - brew install zlib || true
+      - brew install openssl
+      - brew link openssl --force
+      - export LDFLAGS=-L/usr/local/opt/openssl/lib
+      - export CPPFLAGS=-I/usr/local/opt/openssl/include
+    script:
+      - cmake -DCMAKE_BUILD_TYPE=Release
+      - make
+    before_deploy:
+      - tar czf domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease
+
+
+# What to do with the build artifacts
+# - Upload to the Domoticz file server
+deploy:
+  skip_cleanup: true
+  provider: script
+  script: echo curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST"
+  on:
+    branch: master


### PR DESCRIPTION
This change includes an example of how the FTPS upload deployment could be done, to automatically upload Linux and OSX builds. The missing parts are:
- Encrypted 'FTP_PASSWORD' environment variable (as I don't know your password:) ). Alternatives
  - Install the Travis-CI CLI, and use it to encrypt the variable. Modify the .travis.yml, replace the 'FTP_PASSWORD' with the encrypted string
  - Remove the 'FTP_PASSWORD' definition altogether from .travis.yml, and add the variable into the 'Settings' -> 'Environment variables' of the domoticz/domoticz project in Travis-CI
  - For more info, see http://docs.travis-ci.com/user/environment-variables/#Encrypted-Variables
- Now the deployment is a dummy 'echo' command which echoes the 'curl' command line. Remove the 'echo' to run 'curl' for real.

I also refactored the .travis.yml quite a bit, to get rid of the complex-looking shell script 'if' statement. I hope it's easier to read this after the change.

For a build example, please see https://travis-ci.org/ToniA/domoticz/builds/87298583
