### PR TITLE
Windows installation package name change, CI build FTP deployment to 'beta' directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
 deploy:
   skip_cleanup: true
   provider: script
-  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST"
+  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST/beta"
   on:
     branch: master
     repo: domoticz/domoticz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ test: off
 deploy:
 - provider: FTP
   host: 62.84.241.110
+  folder: beta
   protocol: ftps
   username: uploads@domoticz.com
   password:

--- a/msbuild/package.proj
+++ b/msbuild/package.proj
@@ -11,9 +11,14 @@
       <ZipContents       Include="$(MSBuildStartupDirectory)\msbuild\WindowsInstaller\Readme.txt"/>
     </ItemGroup>
 
-    <!-- Extract the version string (like '2_3267') from the installer file, and create the zip file name -->
+    <!-- Extract the version string (like '2_3267') from the installer file, and create the zip file name
+         * Request from gizmocuz, rather always use the same filename
+    -->
     <PropertyGroup>
+<!--
       <ZipFile>$(MSBuildStartupDirectory)\domoticz-win32-$([System.Text.RegularExpressions.Regex]::Match(%(DomoticzInstaller.FileName), `\d+_\d+`))-setup.zip</ZipFile>
+-->
+      <ZipFile>$(MSBuildStartupDirectory)\domoticz-win32-latest.zip</ZipFile>
     </PropertyGroup>
 
     <!-- Copy the files into the current dir for flattening the zip contents -->


### PR DESCRIPTION
- Windows installer should now be called 'domoticz-win32-latest.zip'
- Appveyor and Travis-CI should upload to 'beta' subdirectory
