### PR TITLE
Fixed Travis-CI FTPS URL, Appveyor to use an environment variable as FTP password

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ matrix:
 deploy:
   skip_cleanup: true
   provider: script
-  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST/beta"
+  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_x86_64_latest.tgz -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST/beta/"
   on:
     branch: master
     repo: domoticz/domoticz

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,7 @@ deploy:
   folder: beta
   protocol: ftps
   username: uploads@domoticz.com
-  password:
-    secure: 0O9f8y4I8JN+RYfEJ3f3cg==
+  password: $(FTP_PASSWORD)
   on:
     APPVEYOR_REPO_NAME: domoticz/domoticz
     APPVEYOR_REPO_BRANCH: master  


### PR DESCRIPTION
I hope this fixes the Travis-CI deployment, by adding the missing slash at the end of the FTP upload address.

For Appveyor, I also removed the encrypted password from the appveyor.yml. Please go to https://ci.appveyor.com/project/gizmocuz/domoticz/settings/environment and do 'Add variable' under 'Environment variables'. The variable name should be 'FTP_PASSWORD', and the value should be the FTP password. Click the lock icon 'Toggle variable encryption' to encrypt the password, and finally click 'Save'.

After this both Appveyor and Travis-CI will use FTP passwords which are set in the project, instead of the yml files, so the passwords are easier to change.
