### PR TITLE
Fix environment variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,14 +88,14 @@ matrix:
 # What to do with the build artifacts
 # - Upload to the Domoticz file server
 before_deploy:
-  - tar czf domoticz_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE)_latest.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease www/ scripts/ Config/
-  - shasum -a 256 domoticz_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE)_latest.tgz > domoticz_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE)_latest.tgz.sha256sum
-  - cp appversion.h.txt version_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE).h
-  - cp History.txt history_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE).txt
+  - tar czf domoticz_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}_latest.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease www/ scripts/ Config/
+  - shasum -a 256 domoticz_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}_latest.tgz > domoticz_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}_latest.tgz.sha256sum
+  - cp appversion.h.txt version_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}.h
+  - cp History.txt history_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}.txt
 deploy:
   skip_cleanup: true
   provider: script
-  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE)_latest.tgz -T domoticz_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE)_latest.tgz.sha256sum -T version_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE).h -T history_${TRAVIS_OS_NAME}_$(TARGET_ARCHITECTURE).txt -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST/beta/"
+  script: curl --ftp-ssl -T domoticz_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}_latest.tgz -T domoticz_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}_latest.tgz.sha256sum -T version_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}.h -T history_${TRAVIS_OS_NAME}_${TARGET_ARCHITECTURE}.txt -k -u "$FTP_USER:$FTP_PASSWORD" "ftp://$FTP_HOST/beta/"
   on:
     branch: master
     repo: domoticz/domoticz


### PR DESCRIPTION
This is getting embarrasing... Appveyor uses $(ENVVAR) and Travis-CI uses ${ENVVAR}, and guess who had those mixed up...
