### PR TITLE
Make log timestamps optional

### DIFF
--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -27,6 +27,7 @@ CLogger::_tLogLineStruct::_tLogLineStruct(const _eLogLevel nlevel, const std::st
 CLogger::CLogger(void)
 {
 	m_bInSequenceMode=false;
+	m_bEnableLogTimestamps=true;
 	m_verbose_level=VBL_ALL;
 }
 
@@ -84,35 +85,39 @@ void CLogger::Log(const _eLogLevel level, const char* logline, ...)
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
 
-	char szDate[100];
-#if !defined WIN32
-	// Get a timestamp
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
-
-	struct tm timeinfo;
-	localtime_r(&tv.tv_sec, &timeinfo);
-
-	// create a time stamp string for the log message
-	snprintf(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d ",
-		timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
-		timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, (int)tv.tv_usec / 1000);
-#else
-	// Get a timestamp
-	SYSTEMTIME time;
-	::GetLocalTime(&time);
-	// create a time stamp string for the log message
-	sprintf_s(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d ", time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute, time.wSecond, time.wMilliseconds);
-#endif
-
 	std::stringstream sstr;
-	
+	if (m_bEnableLogTimestamps)
+	{
+		char szDate[100];
+#if !defined WIN32
+		// Get a timestamp
+		struct timeval tv;
+		gettimeofday(&tv, NULL);
+
+		struct tm timeinfo;
+		localtime_r(&tv.tv_sec, &timeinfo);
+
+		// create a time stamp string for the log message
+		snprintf(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d ",
+			timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
+			timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, (int)tv.tv_usec / 1000);
+#else
+		// Get a timestamp
+		SYSTEMTIME time;
+		::GetLocalTime(&time);
+		// create a time stamp string for the log message
+		sprintf_s(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d ", time.wYear, time.wMonth, time.wDay, time.wHour, time.wMinute, time.wSecond, time.wMilliseconds);
+#endif
+		sstr << szDate << " ";
+	}
+
 	if ((level==LOG_NORM)||(level==LOG_STATUS))
 	{
-		sstr << szDate << " " << cbuffer;
+		sstr << cbuffer;
 	}
-	else {
-		sstr << szDate << " Error: " << cbuffer;
+	else
+	{
+		sstr << "Error: " << cbuffer;
 	}
 
 	if (m_lastlog.size()>=MAX_LOG_LINE_BUFFER)
@@ -244,6 +249,11 @@ void CLogger::LogSequenceAdd(const char* logline)
 void CLogger::LogSequenceAddNoLF(const char* logline)
 {
 	m_sequencestring << logline;
+}
+
+void CLogger::EnableLogTimestamps(const bool bEnableTimestamps)
+{
+	m_bEnableLogTimestamps = bEnableTimestamps;
 }
 
 std::list<CLogger::_tLogLineStruct> CLogger::GetLog()

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -44,12 +44,15 @@ public:
 	void LogSequenceAddNoLF(const char* logline);
 	void LogSequenceEnd(const _eLogLevel level);
 
+	void EnableLogTimestamps(const bool bEnableTimestamps);
+
 	std::list<_tLogLineStruct> GetLog();
 private:
 	boost::mutex m_mutex;
 	std::ofstream m_outputfile;
 	std::deque<_tLogLineStruct> m_lastlog;
 	bool m_bInSequenceMode;
+	bool m_bEnableLogTimestamps;
 	std::stringstream m_sequencestring;
 	_eLogFileVerboseLevel m_verbose_level;
 };

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -100,6 +100,7 @@ const char *szHelp=
 	"\t-log file_path (for example /var/log/domoticz.log)\n"
 #endif
 	"\t-loglevel (0=All, 1=Status+Error, 2=Error)\n"
+	"\t-notimestamps (do not prepend timestamps to logs; useful with syslog, etc.)\n"
 #ifndef WIN32
 	"\t-daemon (run as background daemon)\n"
 	"\t-syslog (use syslog as log output)\n"
@@ -425,6 +426,10 @@ int main(int argc, char**argv)
 		}
 		int Level = atoi(cmdLine.GetSafeArgument("-loglevel", 0, "").c_str());
 		_log.SetVerboseLevel((_eLogFileVerboseLevel)Level);
+	}
+	if (cmdLine.HasSwitch("-notimestamps"))
+	{
+		_log.EnableLogTimestamps(false);
 	}
 
 	if (cmdLine.HasSwitch("-approot"))


### PR DESCRIPTION
Here's a change that prevents timestamps from being prepended to the logs.  My rationale is that systemd already timestamps the console output on my box, hence duplicating the timestamps.

> Oct 30 06:23:00 archlinux-vm domoticz[3038]: 2015-10-30 06:23:00.282  Domoticz V2.3502 (c)2012-2015 GizMoCuz
> Oct 30 06:23:00 archlinux-vm domoticz[3038]: 2015-10-30 06:23:00.282  Build Hash: 25eeb1a, Date: 2015-10-30 18:02:53
> Oct 30 06:23:00 archlinux-vm domoticz[3038]: 2015-10-30 06:23:00.282  Startup Path: /opt/domoticz/
> [...]

With this patch, the timestamps are (optionally) skipped entirely, making things more readable.

> Oct 30 06:24:35 archlinux-vm domoticz[4309]: Domoticz V2.3502 (c)2012-2015 GizMoCuz
> Oct 30 06:24:35 archlinux-vm domoticz[4309]: Build Hash: 25eeb1a, Date: 2015-10-30 18:02:53
> Oct 30 06:24:35 archlinux-vm domoticz[4309]: Startup Path: /opt/domoticz/
> [...]

Note that the default behavior is kept the same, with timestamps enabled by default.

Disclaimer: This is my first time going through the Domoticz codebase, so please let me know if I'm missed anything.
