### PR TITLE
Fix segmentation fault while cleaning timed out sessions

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -941,14 +941,18 @@ void cWebem::CleanTimedOutSessions() {
 	time_t now = mytime(NULL);
 	if (myNextSessionCleanup >= now) {
 		myNextSessionCleanup = now + 15 * 60; // in 15 minutes
-
+		std::vector<std::string> ssids;
 		std::map<std::string, WebEmSession>::iterator itt;
 		for (itt=m_sessions.begin(); itt!=m_sessions.end(); ++itt) {
 			if (itt->second.timeout < now) {
-				m_sessions.erase(itt);
+				ssids.push_back(itt->second.id);
 			}
 		}
-
+		std::vector<std::string>::iterator ssitt;
+		for (ssitt=ssids.begin(); ssitt!=ssids.end(); ++ssitt) {
+			std::string ssid = *ssitt;
+			m_sessions.erase(ssid);
+		}
 	}
 }
 


### PR DESCRIPTION
This evening I've got a core dump while erasing session from the session map.
I don't know why I never had this before but I had to change the erasing method to avoid CPU overload and then a segmentation fault.
