### PR TITLE
Extended the lua_parsers with the access to the complete url arguments

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2,6 +2,8 @@
 #include "WebServer.h"
 #include <boost/bind.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <fstream>
 #include "mainworker.h"
@@ -2233,7 +2235,7 @@ namespace http {
 			{
 				// Supported format ares :
 				// - idx (integer), svalue (string), nvalue (string), [rssi(integer)], [battery(integer)]
-				// - idx (integer), svalue (string,) nvalue (integer), [rssi(integer)], [battery(integer)]
+				// - idx (integer), svalue (string), nvalue (integer), [rssi(integer)], [battery(integer)]
 				if (lua_isnumber(lua_state, 1) && (lua_isstring(lua_state, 2) || lua_isnumber(lua_state, 2)) && lua_isstring(lua_state, 3))
 				{
 					// Extract the parameters from the lua 'updateDevice' function	
@@ -2347,8 +2349,33 @@ namespace http {
 			lua_rawset(lua_state, -3);
 			lua_setglobal(lua_state, "request");
 
-			std::string fullfilename = lua_Dir + script;
+			// Keep the url content on the right of the '?'
+			std::vector<std::string> allParts;
+			StringSplit(req.uri, "?", allParts);
+			if (allParts.size() > 0)
+			{
+				// Split all url parts separated by a '&'
+				std::vector<std::string> allParameters;
+				StringSplit(allParts[1], "&", allParameters);
 
+				// Push all url parameters as a map indexed by the parameter name
+				// Each entry will be uri[<param name>] = <param value>
+				lua_createtable(lua_state, allParameters.size(), 0);
+				for (unsigned int i = 0; i < allParameters.size(); i++)
+				{
+					std::vector<std::string> parameterCouple;
+					StringSplit(allParameters[i], "=", parameterCouple);
+					if (parameterCouple.size() == 2) {
+						// Add an url parameter after 'url' decoding it
+						lua_pushstring(lua_state, CURLEncode::URLDecode(parameterCouple[0]).c_str());
+						lua_pushstring(lua_state, CURLEncode::URLDecode(parameterCouple[1]).c_str());
+						lua_rawset(lua_state, -3);
+					}
+				}
+				lua_setglobal(lua_state, "uri");
+			}
+
+			std::string fullfilename = lua_Dir + script;
 			int status = luaL_loadfile(lua_state, fullfilename.c_str());
 			if (status == 0)
 			{


### PR DESCRIPTION
Extended the lua_parsers with the access to the complete url arguments stored into an associative array. For example : uri[timestamp] will
return the content of the argument called 'timestamp' passed in the url.
