### PR TITLE
OTGW: immediate update of Setpoint-values after setting them.

### DIFF
--- a/hardware/OTGWBase.h
+++ b/hardware/OTGWBase.h
@@ -63,5 +63,6 @@ private:
 	unsigned char m_buffer[1028];
 	int m_bufferpos;
 	int m_OutsideTemperatureIdx;
+	float m_OverrideTemperature;
 };
 


### PR DESCRIPTION
Special treatment of Room Setpoint, by reading value from 'PR=O'-command if thermostat-SetPoint is overriden (using 'TT'-command). Thus reflecting changes (almost) immediately.
