### PR TITLE
Implemented invoke scenes on variable change in FibaroLink

### DIFF
--- a/main/DataPush.cpp
+++ b/main/DataPush.cpp
@@ -153,7 +153,13 @@ void CDataPush::DoFibaroPush()
 					if (bIsV4)
 						Url << "/" << targetVariable;
 
-					sPostData << "{\"name\": \"" << targetVariable << "\", \"value\": \"" << sendValue << "\"}";
+					sPostData << "{\"name\": \"" << targetVariable << "\", \"value\": \"" << sendValue << "\"";
+					
+					if (bIsV4)
+						sPostData << ", \"invokeScenes\": true";
+					
+					sPostData << " }";
+
 					if (fibaroDebugActive) {
 						_log.Log(LOG_NORM,"FibaroLink: sending global variable %s with value: %s",targetVariable.c_str(),sendValue.c_str());
 					}


### PR DESCRIPTION
This change will invoke LUA script on scene when Fibaro version 4+ is selected and variable changes on Fibaro Link settings. I think this can be invoked on all variable changes because this is the behavior users will expect. You can still avoid LUA execution if you don't define the variable in the header of the LUA code.
