### PR TITLE
Update PhilipsHue.cpp to support OSRAM Lightify lights

### DIFF
--- a/hardware/PhilipsHue.cpp
+++ b/hardware/PhilipsHue.cpp
@@ -512,7 +512,8 @@ bool CPhilipsHue::GetLightStates()
 		std::string ltype = root["lights"][szNode]["type"].asString();
 		if (
 			(ltype == "Dimmable plug-in unit") ||
-			(ltype == "Dimmable light")
+			(ltype == "Dimmable light") ||
+			(ltype == "Color temperature light")
 			)
 		{
 			//Normal light (with dim option)


### PR DESCRIPTION
Added  light type "Color temperature light" (OSRAM Lightify) as a simple dimmable light. Setting the Color Temperature is not supported yet.
