### PR TITLE
Change NaN value to NULL for JSON

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -432,7 +432,9 @@ double RoundDouble(const long double invalue, const short numberOfPrecisions)
 }
 
 double ConvertTemperature(const double tValue, const unsigned char tSign)
-{
+{	//Make NaN into NULL for JSON 
+	if (isnan(tValue))
+		return NULL;
 	if (tSign=='C')
 		return tValue;
 	return RoundDouble(ConvertToFahrenheit(tValue),1);


### PR DESCRIPTION
Database can give NaN values
JSON does support NaN only NULL.
With a NaN in JSON, highcharts gives no graph(JSON can not be parsed).
With a NULL only a blank value in the graph.
