### PR TITLE
Enable support for CM19A usb transmitter via mochad

### DIFF
--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -252,9 +252,9 @@ bool MochadTCP::WriteToHardware(const char *pdata, const unsigned char length)
 	if (pdata[1] == pTypeInterfaceControl && pdata[2] == sTypeInterfaceCommand && pdata[4] == cmdSTATUS) {
 		sprintf (s_buffer,"ST\n");
 	} else if (pdata[1] == pTypeLighting1 && pdata[2] == sTypeX10 && pdata[6] == light1_sOn) {
-		sprintf (s_buffer,"PL %c%d on\n",(char)(pdata[4]), pdata[5]);
+		sprintf (s_buffer,"RF %c%d on\n",(char)(pdata[4]), pdata[5]);
 	} else if (pdata[1] == pTypeLighting1 && pdata[2] == sTypeX10 && pdata[6] == light1_sOff) {
-		sprintf (s_buffer,"PL %c%d off\n",(char)(pdata[4]), pdata[5]);
+		sprintf (s_buffer,"RF %c%d off\n",(char)(pdata[4]), pdata[5]);
 	} else {
 //			case light1_sDim:
 //			case light1_sBright:

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -175,7 +175,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_TOONTHERMOSTAT, "Toon Thermostat" },
 		{ HTYPE_ECODEVICES, "Eco Devices via LAN interface" },
 		{ HTYPE_HARMONY_HUB, "Logitech Harmony Hub" },
-		{ HTYPE_Mochad, "Mochad CM15Pro bridge with LAN interface" },
+		{ HTYPE_Mochad, "Mochad CM15Pro bridge with LAN interface/CM19A USB" },
 		{ HTYPE_Philips_Hue, "Philips Hue Bridge" },
 		{ HTYPE_EVOHOME_SERIAL, "Evohome USB (for HGI/S80)" },
 		{ HTYPE_EVOHOME_SCRIPT, "Evohome via script" },


### PR DESCRIPTION
Fixes #250
This should enable the mochad plugin for domoticz to support the CM15Pro as well as the CM19A USB transmitter.
