### PR TITLE
MQTT Implement "Toggle" switchcmd for switchlight 

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -240,7 +240,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		if (!root["switchcmd"].isString())
 			goto mqttinvaliddata;
 		std::string switchcmd = root["switchcmd"].asString();
-		if ((switchcmd != "On") && (switchcmd != "Off") && (switchcmd != "Set Level"))
+		if ((switchcmd != "On") && (switchcmd != "Off") && (switchcmd != "Toggle") && (switchcmd != "Set Level"))
 			goto mqttinvaliddata;
 		int level = 0;
 		if (!root["level"].empty())

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9839,6 +9839,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string> &sd, std::string 
 	unsigned char dSubType=atoi(sd[4].c_str());
 	_eSwitchType switchtype=(_eSwitchType)atoi(sd[5].c_str());
 
+        //when asking for Toggle, just switch to the opposite value
+        if (switchcmd=="Toggle") {
+                switchcmd=(atoi(sd[7].c_str())==1?"Off":"On");
+        }
+
 	//when level = 0, set switch command to Off
 	if (switchcmd=="Set Level")
 	{


### PR DESCRIPTION
Implemented simple management of Light Switch "Toggle" command when issued from MQTT call, ie:

domoticz/in => {"command": "switchlight", "idx": 8, "switchcmd": "Toggle", "level": 100 }
