### PR TITLE
Return version with successful auth, fix unauthorized getconfig

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1946,6 +1946,10 @@ namespace http {
 		{
 			root["status"] = "OK";
 			root["title"] = "GetAuth";
+			if (session.rights != -1)
+			{
+			  root["version"] = szAppVersion;
+      }
 			root["user"] = session.username;
 			root["rights"] = session.rights;
 		}
@@ -2054,8 +2058,8 @@ namespace http {
 
 		void CWebServer::Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root)
 		{
-			//if (session.rights != 2)
-				//return;//Only admin user allowed
+			if (session.rights != -1)
+				return;//Only auth user allowed
 
 			root["status"] = "OK";
 			root["title"] = "GetConfig";

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2058,7 +2058,7 @@ namespace http {
 
 		void CWebServer::Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root)
 		{
-			if (session.rights != -1)
+			if (session.rights == -1)
 				return;//Only auth user allowed
 
 			root["status"] = "OK";


### PR DESCRIPTION
This is a security fix, currently it is possible to read someone's config (Lat/Long for instance) without (login-based) authentication. Furthermore I'd like to be able to use the app version upon successful authentication.
