### PR TITLE
Cleaned up connection.cpp.

### DIFF
--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -55,7 +55,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;PTW32_STATIC_LIB;WITH_OPENZWAVE;OPENZWAVE_USEDLL;NS_ENABLE_SSL;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>WIN32;_DEBUG;PTW32_STATIC_LIB;WITH_OPENZWAVE;OPENZWAVE_USEDLL;_CONSOLE;NS_ENABLE_SSL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>./Windows Libraries/Boost/boost_1_59_0;./libusb;..\hardware\openzwave;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -67,18 +67,11 @@ public:
 
 private:
   /// Handle completion of a read operation.
-  void handle_read_plain(const boost::system::error_code& e, std::size_t bytes_transferred);
-  void read_more_plain();
+  void handle_read(const boost::system::error_code& e, std::size_t bytes_transferred);
+  void read_more();
 
   /// Handle completion of a write operation.
-  void handle_write_plain(const boost::system::error_code& e);
-
-#ifdef NS_ENABLE_SSL
-  /// ssl handle functions
-  void handle_read_secure(const boost::system::error_code& e, std::size_t bytes_transferred);
-  void read_more_secure();
-  void handle_write_secure(const boost::system::error_code& e);
-#endif
+  void handle_write(const boost::system::error_code& e);
 
   /// Socket for the (PLAIN) connection.
   boost::asio::ip::tcp::socket *socket_;


### PR DESCRIPTION
Now there's only one handle_read(), etc. instead of different versions like handle_read_secure() and
handle_read_plain(). So if you want to update the code, now you only have to do this on one place instead of two.
I made this for a nifty new Domoticz feature-to-come. But since this is also convenient for others that work in connection.cpp, I made a separate pull request for this.
