### PR TITLE
LightwaveRF inline relay

### DIFF
--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -2185,12 +2185,21 @@ bool GetLightCommand(
 		else if (dSubType!=sTypeLightwaveRF)
 		{
 			//Only LightwaveRF devices have a set-level
-			if (switchcmd=="Set Level")
-				switchcmd="On";
+ 			if (switchcmd=="Set Level")
+ 				switchcmd="On";
+ 		}
+			// The LightwaveRF inline relay has to be controlled by Venetian blinds logic as it has a stop setting
+		else if ((dSubType==sTypeLightwaveRF)&&(switchtype==STYPE_VenetianBlindsEU)){
+				if (switchcmd=="On")
+					switchcmd="Close inline relay";
+				else if (switchcmd=="Off")
+					switchcmd="Open inline relay";
+				else if (switchcmd=="Stop")
+					switchcmd="Stop inline relay";
 		}
-
-		if (switchtype==STYPE_Doorbell)
-		{
+ 
+ 		if (switchtype==STYPE_Doorbell)
+ 		{
 			if ((switchcmd=="On")||(switchcmd=="Group On"))
 			{
 				cmd=light5_sGroupOn;
@@ -2234,9 +2243,24 @@ bool GetLightCommand(
 			return true;
 		}
 		else if (switchcmd=="Group On")
-		{
-			cmd=light5_sGroupOn;
+ 		{
+ 			cmd=light5_sGroupOn;
 			return true;
+		}
+		else if (switchcmd=="Close inline relay")
+		{
+			cmd=light5_sClose;
+			return true;
+		}
+		else if (switchcmd=="Stop inline relay")
+		{
+			cmd=light5_sStop;
+			return true;
+		}
+		else if (switchcmd=="Open inline relay")
+		{
+			cmd=light5_sOpen;
+ 			return true;
 		}
 		else
 			return false;

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1344,15 +1344,12 @@ void GetLightStatus(
 				break;
 			case light5_sClose:
 				lstatus="Close inline relay";
-//				lstatus="Closed";
 				break;
 			case light5_sStop:
 				lstatus="Stop inline relay";
-//				lstatus="Stopped";
 				break;
 			case light5_sOpen:
 				lstatus="Open inline relay";
-//				lstatus="Open";
 				break;
 			case light5_sSetLevel:
 				sprintf(szTmp,"Set Level: %d %%" ,llevel);
@@ -2191,9 +2188,18 @@ bool GetLightCommand(
  			if (switchcmd=="Set Level")
  				switchcmd="On";
  		}
-
-		if (switchtype==STYPE_Doorbell)
-		{
+			// The LightwaveRF inline relay has to be controlled by Venetian blinds logic as it has a stop setting
+		else if ((dSubType==sTypeLightwaveRF)&&(switchtype==STYPE_VenetianBlindsEU)){
+				if (switchcmd=="On")
+					switchcmd="Close inline relay";
+				else if (switchcmd=="Off")
+					switchcmd="Open inline relay";
+				else if (switchcmd=="Stop")
+					switchcmd="Stop inline relay";
+		}
+ 
+ 		if (switchtype==STYPE_Doorbell)
+ 		{
 			if ((switchcmd=="On")||(switchcmd=="Group On"))
 			{
 				cmd=light5_sGroupOn;
@@ -2237,27 +2243,24 @@ bool GetLightCommand(
 			return true;
 		}
 		else if (switchcmd=="Group On")
-		{
-			cmd=light5_sGroupOn;
+ 		{
+ 			cmd=light5_sGroupOn;
 			return true;
 		}
-		// The LightwaveRF inline relay has to be controlled by Venetian blinds logic as it has a stop setting
-		else if ((dSubType==sTypeLightwaveRF)&&(switchtype==STYPE_VenetianBlindsEU)){
-				if (switchcmd=="On")
-				{
-					cmd=light5_sClose;
-					return true;
-				}
-				else if (switchcmd=="Off")
-				{	
-					cmd=light5_sOpen;
-					return true;
-				}
-				else if (switchcmd=="Stop")
-				{
-					cmd=light5_sStop;
-					return true;
-				}
+		else if (switchcmd=="Close inline relay")
+		{
+			cmd=light5_sClose;
+			return true;
+		}
+		else if (switchcmd=="Stop inline relay")
+		{
+			cmd=light5_sStop;
+			return true;
+		}
+		else if (switchcmd=="Open inline relay")
+		{
+			cmd=light5_sOpen;
+ 			return true;
 		}
 		else
 			return false;

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1344,12 +1344,15 @@ void GetLightStatus(
 				break;
 			case light5_sClose:
 				lstatus="Close inline relay";
+//				lstatus="Closed";
 				break;
 			case light5_sStop:
 				lstatus="Stop inline relay";
+//				lstatus="Stopped";
 				break;
 			case light5_sOpen:
 				lstatus="Open inline relay";
+//				lstatus="Open";
 				break;
 			case light5_sSetLevel:
 				sprintf(szTmp,"Set Level: %d %%" ,llevel);
@@ -2188,18 +2191,9 @@ bool GetLightCommand(
  			if (switchcmd=="Set Level")
  				switchcmd="On";
  		}
-			// The LightwaveRF inline relay has to be controlled by Venetian blinds logic as it has a stop setting
-		else if ((dSubType==sTypeLightwaveRF)&&(switchtype==STYPE_VenetianBlindsEU)){
-				if (switchcmd=="On")
-					switchcmd="Close inline relay";
-				else if (switchcmd=="Off")
-					switchcmd="Open inline relay";
-				else if (switchcmd=="Stop")
-					switchcmd="Stop inline relay";
-		}
- 
- 		if (switchtype==STYPE_Doorbell)
- 		{
+
+		if (switchtype==STYPE_Doorbell)
+		{
 			if ((switchcmd=="On")||(switchcmd=="Group On"))
 			{
 				cmd=light5_sGroupOn;
@@ -2243,24 +2237,27 @@ bool GetLightCommand(
 			return true;
 		}
 		else if (switchcmd=="Group On")
- 		{
- 			cmd=light5_sGroupOn;
+		{
+			cmd=light5_sGroupOn;
 			return true;
 		}
-		else if (switchcmd=="Close inline relay")
-		{
-			cmd=light5_sClose;
-			return true;
-		}
-		else if (switchcmd=="Stop inline relay")
-		{
-			cmd=light5_sStop;
-			return true;
-		}
-		else if (switchcmd=="Open inline relay")
-		{
-			cmd=light5_sOpen;
- 			return true;
+		// The LightwaveRF inline relay has to be controlled by Venetian blinds logic as it has a stop setting
+		else if ((dSubType==sTypeLightwaveRF)&&(switchtype==STYPE_VenetianBlindsEU)){
+				if (switchcmd=="On")
+				{
+					cmd=light5_sClose;
+					return true;
+				}
+				else if (switchcmd=="Off")
+				{	
+					cmd=light5_sOpen;
+					return true;
+				}
+				else if (switchcmd=="Stop")
+				{
+					cmd=light5_sStop;
+					return true;
+				}
 		}
 		else
 			return false;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -7702,12 +7702,11 @@ namespace http {
 							)
 						{
 							root["result"][ii]["TypeImg"] = "blinds";
-							if (lstatus == "On") {
-								lstatus = "Closed";
-							}
-							else if (lstatus == "Stop") {
-								lstatus = "Stopped";
-							}
+							if ((lstatus == "On")||(lstatus=="Close inline relay")) {
+ 								lstatus = "Closed";
+ 							}
+ 							else if ((lstatus == "Stop")||(lstatus=="Stop inline relay")) {
+ 								lstatus = "Stopped";
 							else {
 								lstatus = "Open";
 							}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1715,6 +1715,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			std::string sactivetype = request::findValue(&req, "activetype");
 			std::string activeidx = request::findValue(&req, "activeidx");
+
 			if (
 				(idx == "") ||
 				(sactivetype == "") ||
@@ -2477,6 +2478,7 @@ namespace http {
 
 			int signallevel = 12;
 			int batterylevel = 255;
+
 
 			if (idx.empty())
 			{
@@ -7702,10 +7704,10 @@ namespace http {
 							)
 						{
 							root["result"][ii]["TypeImg"] = "blinds";
-							if ((lstatus == "On")||(lstatus=="Close inline relay")) {
+							if (lstatus == "On") {
 								lstatus = "Closed";
 							}
-							else if ((lstatus == "Stop")||(lstatus=="Stop inline relay")) {
+							else if (lstatus == "Stop") {
 								lstatus = "Stopped";
 							}
 							else {

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1715,7 +1715,6 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			std::string sactivetype = request::findValue(&req, "activetype");
 			std::string activeidx = request::findValue(&req, "activeidx");
-
 			if (
 				(idx == "") ||
 				(sactivetype == "") ||
@@ -2478,7 +2477,6 @@ namespace http {
 
 			int signallevel = 12;
 			int batterylevel = 255;
-
 
 			if (idx.empty())
 			{
@@ -7704,10 +7702,10 @@ namespace http {
 							)
 						{
 							root["result"][ii]["TypeImg"] = "blinds";
-							if (lstatus == "On") {
+							if ((lstatus == "On")||(lstatus=="Close inline relay")) {
 								lstatus = "Closed";
 							}
-							else if (lstatus == "Stop") {
+							else if ((lstatus == "Stop")||(lstatus=="Stop inline relay")) {
 								lstatus = "Stopped";
 							}
 							else {

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -7703,10 +7703,11 @@ namespace http {
 						{
 							root["result"][ii]["TypeImg"] = "blinds";
 							if ((lstatus == "On")||(lstatus=="Close inline relay")) {
- 								lstatus = "Closed";
- 							}
- 							else if ((lstatus == "Stop")||(lstatus=="Stop inline relay")) {
- 								lstatus = "Stopped";
+								lstatus = "Closed";
+							}
+							else if ((lstatus == "Stop")||(lstatus=="Stop inline relay")) {
+								lstatus = "Stopped";
+							}
 							else {
 								lstatus = "Open";
 							}


### PR DESCRIPTION
Summary: Additions to allow the LightwaveRF inline relay to be operated from Domoticz via the Venetian Blind subtype. Previously the stop function was not available. Only open or close worked. I have not changed the icons in the LightsController.

The LightwaveRF inline relay device is recognised by Domoticz as a Switch. Automatic set up in Domoticz via its remote control, identifies the Switch as of type Blinds. 

The LightwaveRF inline relay controls a SPDT switch. A  common supply terminal can be switched between two output terminals. Using the available Switch types, it is possible to have Domoticz turn the relay on or off, ie to switch the common supply between two outputs. However, the device can also be sent a stop signal. This removes the common supply from both outputs. This can be used to stop the drive motor before a window or blind is fully open or closed.  I could not find any way of configuring the current version of Domoticz to send this stop signal. (Using the stop button on Venetian Blind results in no signal and an error message).

The modifications in the patches provided allow the LightwaveRF inline relay to be treated as a Venetian Blind in Domoticz. I chose this type because it provides three possible signals (open/close/stop) and three possible states (open/closed/stopped).

I tested these modifications using a LightwaveRF inline relay controlled by an RFXCOM transceiver. I used Domoticz 2.4020 running on a Linux Mint 17 machine for development.  My active Domoticz system runs on a Raspberry Pi B.

I am not familiar with the Domoticz architecture and coding, and could not find any relevant documentation, so my crude attempts to get this fix working may not be optimal. I have tried to write them in a way that should not impact other devices, but please treat them as a suggestion rather than necessarily a suitable long term solution.
