### PR TITLE
Fixed missing usage value in (virtual) P1 Smart Meter device

### DIFF
--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -770,7 +770,7 @@ define(['app'], function (app) {
 							if (item.CounterDeliv!=0) {
 								status+='<br>' + $.t("Return") + ': ' + item.CounterDeliv + ', ' + $.t("Today") + ': ' + item.CounterDelivToday;
 								if (item.UsageDeliv.charAt(0) != 0) {
-									bigtext='-' + item.UsageDeliv;
+									bigtext+='-' + item.UsageDeliv;
 								}
 							}
 						}


### PR DESCRIPTION
When the utility page gets refreshed with new data, the p1 smart meter device only showed the return watts. This is fixed so that it now show both the used and returned energie.
