### PR TITLE
Fix selector buttons state on device refresh

### DIFF
--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -712,8 +712,18 @@ define(['app'], function (app) {
 											var selector$ = $(id + " #selector" + item.idx);
 											if (typeof selector$ !== 'undefined') {
 												if (item.SelectorStyle === 0) {
-													selector$.find('input[value="' + item.LevelInt + '"]').prop("checked", true);
-													selector$.buttonset('refresh');
+													selector$
+														.find('label')
+															.removeClass('ui-state-active')
+															.removeClass('ui-state-focus')
+															.end()
+														.find('input:radio')
+															.removeProp('checked')
+															.filter('[value="' + item.LevelInt + '"]')
+																.prop('checked', true)
+																.end()
+															.end()
+														.buttonset('refresh');
 												} else if (item.SelectorStyle === 1) {
 													selector$.val(item.LevelInt);
 													selector$.selectmenu('refresh');

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -2126,8 +2126,18 @@ define(['app'], function (app) {
 							var selector$ = $(id + " #selector" + item.idx);
 							if (typeof selector$ !== 'undefined') {
 								if (item.SelectorStyle === 0) {
-									selector$.find('input[value="' + item.LevelInt + '"]').prop("checked", true);
-									selector$.buttonset('refresh');
+									selector$
+										.find('label')
+											.removeClass('ui-state-active')
+											.removeClass('ui-state-focus')
+											.end()
+										.find('input:radio')
+											.removeProp('checked')
+											.filter('[value="' + item.LevelInt + '"]')
+												.prop('checked', true)
+												.end()
+											.end()
+										.buttonset('refresh');
 								} else if (item.SelectorStyle === 1) {
 									selector$.val(item.LevelInt);
 									selector$.selectmenu('refresh');

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# ref 1163
+# ref 1164
 
 CACHE:
 # CSS


### PR DESCRIPTION
Fix selector buttons state on device refresh (due to a jqueryui bug) by unselecting all buttons and removing "active" style (ui-state-active or ui-state-focus class).
