### PR TITLE
custom-icons: if temporary file is not writable try putting it in /tmp

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6598,10 +6598,12 @@ bool CSQLHelper::InsertCustomIconFromZip(const std::string &szZip, std::string &
 	outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 	if (!outfile.is_open())
 	{
+#ifndef WIN32
 		//path might not be writable on linux, fall back to good old /tmp
 		outputfile = "/tmp/custom_icons.zip";
 		outfile.clear();
 		outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
+#endif
 		if (!outfile.is_open())
 		{
 			ErrorMessage = "Error writing zip to disk";

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6597,8 +6597,8 @@ bool CSQLHelper::InsertCustomIconFromZip(const std::string &szZip, std::string &
 	std::ofstream outfile;
 	outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 	if (!outfile.is_open())
-#ifndef WIN32
 	{
+#ifndef WIN32
 		//path might not be writable on linux, fall back to good old /tmp
 		outputfile = "/tmp/custom_icons.zip";
 		outfile.clear();

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6597,14 +6597,14 @@ bool CSQLHelper::InsertCustomIconFromZip(const std::string &szZip, std::string &
 	std::ofstream outfile;
 	outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 	if (!outfile.is_open())
-	{
 #ifndef WIN32
+	{
 		//path might not be writable on linux, fall back to good old /tmp
 		outputfile = "/tmp/custom_icons.zip";
 		outfile.clear();
 		outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
-#endif
 		if (!outfile.is_open())
+#endif
 		{
 			ErrorMessage = "Error writing zip to disk";
 			return false;

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6598,8 +6598,15 @@ bool CSQLHelper::InsertCustomIconFromZip(const std::string &szZip, std::string &
 	outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 	if (!outfile.is_open())
 	{
-		ErrorMessage = "Error writing zip to disk";
-		return false;
+		//path might not be writable on linux, fall back to good old /tmp
+		outputfile = "/tmp/custom_icons.zip";
+		outfile.clear();
+		outfile.open(outputfile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
+		if (!outfile.is_open())
+		{
+			ErrorMessage = "Error writing zip to disk";
+			return false;
+		}
 	}
 	outfile << szZip;
 	outfile.flush();


### PR DESCRIPTION
On my linux system domoticz is started with systemd and whatever the default path is (likely root) is not writable. This results in a broken custom icon uploader.

This small patch tries to fall back to /tmp before tossing an error. 
