### PR TITLE
Change the splitting method used to extract option values

### DIFF
--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -4,6 +4,7 @@
 #include "../hardware/hardwaretypes.h"
 #include "../hardware/evohome.h"
 #include "Helper.h"
+#include <boost/algorithm/string.hpp>
 //#include "Logger.h"
 
 typedef struct _STR_TABLE_SINGLE {
@@ -1970,7 +1971,7 @@ void GetSelectorSwitchStatuses(const std::map<std::string, std::string> & option
 		//_log.Log(LOG_STATUS, "DEBUG : Get selector switch statuses...");
 		std::string sOptions = itt->second;
 		std::vector<std::string> strarray;
-		StringSplit(sOptions, "|", strarray);
+		boost::split(strarray, sOptions, boost::is_any_of("|"), boost::token_compress_off);
 		std::vector<std::string>::iterator itt;
 		int i = 0;
 		std::stringstream ss;
@@ -1995,7 +1996,7 @@ int GetSelectorSwitchLevel(const std::map<std::string, std::string> & options, c
 		//_log.Log(LOG_STATUS, "DEBUG : Get selector switch level...");
 		std::string sOptions = itt->second;
 		std::vector<std::string> strarray;
-		StringSplit(sOptions, "|", strarray);
+		boost::split(strarray, sOptions, boost::is_any_of("|"), boost::token_compress_off);
 		std::vector<std::string>::iterator itt;
 		int i = 0;
 		for (itt = strarray.begin(); (itt != strarray.end()) && (i <= 100); ++itt) {
@@ -2019,7 +2020,7 @@ std::string GetSelectorSwitchLevelAction(const std::map<std::string, std::string
 		//_log.Log(LOG_STATUS, "DEBUG : Get selector switch level action...");
 		std::string sOptions = itt->second;
 		std::vector<std::string> strarray;
-		StringSplit(sOptions, "|", strarray);
+		boost::split(strarray, sOptions, boost::is_any_of("|"), boost::token_compress_off);
 		std::vector<std::string>::iterator itt;
 		int i = 0;
 		for (itt = strarray.begin(); (itt != strarray.end()) && (i <= 100); ++itt) {


### PR DESCRIPTION
Change the splitting method used to extract option values to prevent the problem causing a shift of value (Helper::SplitString compresses empty strings).
