### PR TITLE
Handle DT_UNKNOWN in directory entries

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1096,7 +1096,7 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const unsigned long 
 		while ((ent = readdir(lDir)) != NULL)
 		{
 			std::string filename = ent->d_name;
-			if (ent->d_type == DT_REG)
+			if (dirent_is_file(lua_Dir, ent))
 			{
 				if ((filename.length() < 4) || (filename.compare(filename.length() - 4, 4, ".lua") != 0))
 				{
@@ -1146,7 +1146,7 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const unsigned long 
 			while ((ent = readdir(lDir)) != NULL)
 			{
 				std::string filename = ent->d_name;
-				if (ent->d_type == DT_REG)
+				if (dirent_is_file(python_Dir, ent))
 				{
 					if ((filename.length() < 4) || (filename.compare(filename.length() - 3, 3, ".py") != 0))
 					{

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -647,3 +647,33 @@ int MStoBeaufort(const float ms)
 		return 11;
 	return 12;
 }
+
+bool dirent_is_directory(std::string dir, struct dirent *ent)
+{
+	if (ent->d_type == DT_DIR)
+		return true;
+#ifndef WIN32
+	if (ent->d_type == DT_UNKNOWN) {
+		std::string fname = dir + "/" + ent->d_name;
+		struct stat st;
+		if (!lstat(fname.c_str(), &st))
+			return S_ISDIR(st.st_mode);
+	}
+#endif
+	return false;
+}
+
+bool dirent_is_file(std::string dir, struct dirent *ent)
+{
+	if (ent->d_type == DT_REG)
+		return true;
+#ifndef WIN32
+	if (ent->d_type == DT_UNKNOWN) {
+		std::string fname = dir + "/" + ent->d_name;
+		struct stat st;
+		if (!lstat(fname.c_str(), &st))
+			return S_ISREG(st.st_mode);
+	}
+#endif
+	return false;
+}

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -1,3 +1,4 @@
+
 #pragma once
 
 void StringSplit(std::string str, const std::string &delim, std::vector<std::string> &results);
@@ -41,3 +42,6 @@ bool IsLightOrSwitch(const int devType, const int subType);
 
 int MStoBeaufort(const float ms);
 
+struct dirent;
+bool dirent_is_directory(std::string dir, struct dirent *ent);
+bool dirent_is_file(std::string dir, struct dirent *ent);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -683,7 +683,7 @@ namespace http {
 			{
 				while ((ent = readdir(dir)) != NULL)
 				{
-					if (ent->d_type == DT_DIR)
+					if (dirent_is_directory(DirPath, ent))
 					{
 						if ((strcmp(ent->d_name, ".") != 0) && (strcmp(ent->d_name, "..") != 0) && (strcmp(ent->d_name, ".svn") != 0))
 						{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -252,7 +252,7 @@ void MainWorker::GetAvailableWebThemes()
 		while ((de = readdir(d)))
 		{
 			std::string dirname = de->d_name;
-			if (de->d_type == DT_DIR)
+			if (dirent_is_directory(ThemeFolder, de))
 			{
 				if ((dirname != ".") && (dirname != "..") && (dirname != ".svn"))
 				{


### PR DESCRIPTION
Not all file systems (and indeed not all ext4 file systems) return a
useful d_type in getdents(). The man page explicitly tells us that we
should handle DT_UNKNOWN. Do so.
