### PR TITLE
if dimmer svalue is 255 that is 100%

### DIFF
--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -2318,7 +2318,11 @@ define(['app'], function (app) {
 						if (isdimmer==true) {
 							var dslider=$(id + " #slider");
 							if (typeof dslider != 'undefined') {
-								dslider.slider( "value", item.LevelInt+1 );
+								if (item.LevelInt == 255) {
+									dslider.slider( "value", 100 );
+								} else {
+									dslider.slider( "value", item.LevelInt+1 );
+								}
 							}
 						}
 						if (item.SwitchType === "Selector") {


### PR DESCRIPTION
if a dimmer reports to the WebUI with a svalue of 255 it does not render the slider @ 100%

this fixes that problem.
