### PR TITLE
If dimmer has value > 100%, set value to 100%

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -293,11 +293,13 @@ void ZWaveBase::SendSwitchIfNotExists(const _tZWaveDevice *pDevice)
 		// Now check the values
 		if (level == 0)
 			lcmd.LIGHTING2.cmnd = light2_sOff;
-		else if (level == 255)
+		else if (level > 99)
+			if (pDevice->devType==ZDTYPE_SWITCH_DIMMER)
+				level = 100;
+
 			lcmd.LIGHTING2.cmnd = light2_sOn;
 		else
 		{
-			level = (level > 99) ? 99 : level;
 			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
 		}
 
@@ -373,11 +375,13 @@ void ZWaveBase::SendDevice2Domoticz(const _tZWaveDevice *pDevice)
 		// Now check the values
 		if (level == 0)
 			lcmd.LIGHTING2.cmnd = light2_sOff;
-		else if ((level == 255) && (pDevice->devType == ZDTYPE_SWITCH_NORMAL))
+		else if (level > 99)
+			if (pDevice->devType==ZDTYPE_SWITCH_DIMMER)
+				level = 100;
+
 			lcmd.LIGHTING2.cmnd = light2_sOn;
 		else
 		{
-			level = (level > 99) ? 100 : level;
 			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
 		}
 

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -294,10 +294,13 @@ void ZWaveBase::SendSwitchIfNotExists(const _tZWaveDevice *pDevice)
 		if (level == 0)
 			lcmd.LIGHTING2.cmnd = light2_sOff;
 		else if (level > 99)
+		{
 			if (pDevice->devType==ZDTYPE_SWITCH_DIMMER)
+			{
 				level = 100;
-
+			}
 			lcmd.LIGHTING2.cmnd = light2_sOn;
+		}
 		else
 		{
 			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
@@ -376,10 +379,13 @@ void ZWaveBase::SendDevice2Domoticz(const _tZWaveDevice *pDevice)
 		if (level == 0)
 			lcmd.LIGHTING2.cmnd = light2_sOff;
 		else if (level > 99)
+		{
 			if (pDevice->devType==ZDTYPE_SWITCH_DIMMER)
+			{
 				level = 100;
-
+			}
 			lcmd.LIGHTING2.cmnd = light2_sOn;
+		}
 		else
 		{
 			lcmd.LIGHTING2.cmnd = light2_sSetLevel;

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -373,11 +373,11 @@ void ZWaveBase::SendDevice2Domoticz(const _tZWaveDevice *pDevice)
 		// Now check the values
 		if (level == 0)
 			lcmd.LIGHTING2.cmnd = light2_sOff;
-		else if (level == 255)
+		else if ((level == 255) && (pDevice->devType == ZDTYPE_SWITCH_NORMAL))
 			lcmd.LIGHTING2.cmnd = light2_sOn;
 		else
 		{
-			level = (level > 99) ? 99 : level;
+			level = (level > 99) ? 100 : level;
 			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
 		}
 


### PR DESCRIPTION
Z-Wave dimmers @ 100% Brightness should report 100% and not 255%
