### PR TITLE
New Dummy Switch

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -31,6 +31,7 @@ Version 2.4xxx
 - Implemented: Wind Beaufort scale
 - Implemented: Wind Graph, option to delete a short-log data point
 - Implemented: Panasonic TV support (Viera TV's after 2011 should work)
+- Changed: Dummy, Virtual Dimmers now have 100 steps instead of 15.
 - Changed: Alert sensor, removed level notation in user interface
 - Changed: EventSystem, don't process unused devices
 - Changed: Fritzbox, Now updating text sensor on connect/disconnect

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -134,7 +134,7 @@ namespace http {
 					unsigned char ID3 = (unsigned char)((nid & 0x0000FF00) >> 8);
 					unsigned char ID4 = (unsigned char)((nid & 0x000000FF));
 					sprintf(ID, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
-					DeviceRowIdx=m_sql.UpdateValue(HwdID, ID, 1, pTypeLighting2, sTypeAC, 12, 255, 0, "15", devname);
+					DeviceRowIdx=m_sql.UpdateValue(HwdID, ID, 1, pTypeLighting2, sTypeAC, 12, 255, 0, "100", devname);
 					bCreated = true;
 				}
 				break;

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -134,7 +134,7 @@ namespace http {
 					unsigned char ID3 = (unsigned char)((nid & 0x0000FF00) >> 8);
 					unsigned char ID4 = (unsigned char)((nid & 0x000000FF));
 					sprintf(ID, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
-					DeviceRowIdx=m_sql.UpdateValue(HwdID, ID, 1, pTypeLighting2, sTypeAC, 12, 255, 0, "100", devname);
+					DeviceRowIdx=m_sql.UpdateValue(HwdID, ID, 1, pTypeLighting2, sTypeDummy, 12, 255, 0, "100", devname);
 					bCreated = true;
 				}
 				break;

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -196,6 +196,9 @@
 #define sTypeZWaveUsage 0xA0
 #define sTypeZWaveSwitch 0xA1
 
+// Dummy Switch
+#define sTypeDummy 0xA2
+
 //types for evohome
 #define pTypeEvohome 0x45 
 #define sTypeEvohome 0x00 //Controller

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -538,6 +538,7 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeLighting2, sTypeHEU, "HomeEasy EU" },
 		{ pTypeLighting2, sTypeANSLUT, "Anslut" },
 		{ pTypeLighting2, sTypeZWaveSwitch, "ZWave" },
+		{ pTypeLighting2, sTypeDummy, "API" },
 
 		{ pTypeLighting3, sTypeKoppla, "Ikea Koppla" },
 
@@ -1237,7 +1238,7 @@ void GetLightStatus(
 		break;
 	case pTypeLighting2:
 		// Determine max dim level based on switch type
-		maxDimLevel=(dSubType != sTypeZWaveSwitch) ? 15 : 100;
+		maxDimLevel=((dSubType != sTypeZWaveSwitch) && (dSubType != sTypeDummy)) ? 15 : 100;
 
 		if (switchtype != STYPE_Media) {
 			// Calculate % that the light is currently on, taking the maxdimlevel into account.
@@ -1250,6 +1251,7 @@ void GetLightStatus(
 		case sTypeAC:
 		case sTypeHEU:
 		case sTypeANSLUT:
+		case sTypeDummy:
 		case sTypeKambrook:
 			bHaveDimmer=true;
 			bHaveGroupCmd=true;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9954,7 +9954,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string> &sd, std::string 
 			}
 
 			// ZWave allows 0 (for "off"), 255 (for "on") and 0-99 (in case of dimmers). 
-			if (dSubType == sTypeZWaveSwitch)
+			if ((dSubType == sTypeZWaveSwitch) || (pHardware->HwdType == HTYPE_Dummy))
 			{
 				// Only allow off/on for normal ZWave switches
 				if (switchtype == STYPE_OnOff)
@@ -9970,7 +9970,10 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string> &sd, std::string 
 						if (level == 0)
 							lcmd.LIGHTING2.cmnd = light2_sOff;
 						else if (level > 99)
+						{
 							lcmd.LIGHTING2.cmnd = light2_sOn;
+							level = 100;
+						}
 					}
 				}
 			}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9969,13 +9969,8 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string> &sd, std::string 
 						// Set command based on level value
 						if (level == 0)
 							lcmd.LIGHTING2.cmnd = light2_sOff;
-						else if (level == 255)
+						else if (level > 99)
 							lcmd.LIGHTING2.cmnd = light2_sOn;
-						else
-						{
-							// For dimmers we only allow level 0-99
-							level = (level > 99) ? 99 : level;
-						}
 					}
 				}
 			}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9978,7 +9978,8 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string> &sd, std::string 
 						{
 							// For dimmers we only allow level 0-99
 							level = (level > 99) ? 99 : level;
-						}					}
+						}
+					}
 				}
 			}
 			// Dummy Switches


### PR DESCRIPTION
Adds device pTypeLighting2, sTypeDummy, STYPE_Dimmer with 100 dimming steps instead of 15.

Wont break existing switches, will only effect new dummy switches created from here on.

does not change z-wave behavior, I reverted that back by hand.

![screen shot 2016-01-27 at 3 21 25 am](https://cloud.githubusercontent.com/assets/3732081/12610462/28101278-c4a5-11e5-92a4-35ee74c3b508.png)
![screen shot 2016-01-27 at 3 21 43 am](https://cloud.githubusercontent.com/assets/3732081/12610465/2bd8ab4a-c4a5-11e5-966f-bef14656eb7e.png)
