### PR TITLE
Added Nest Heating/Cooling logging in a "switch" device.

### DIFF
--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -561,14 +561,14 @@ void CNest::GetMeterDetails()
 			}
 
 			// Check if thermostat is currently Heating
-			if (nshared["can_heat"].asBool() and !nshared["hvac_heater_state"].empty())
+			if (nshared["can_heat"].asBool() && !nshared["hvac_heater_state"].empty())
 			{
 				bool bIsHeating = nshared["hvac_heater_state"].asBool();
 				UpdateSwitch(113,bIsHeating,"HeatingOn");		
 			}
 
 			// Check if thermostat is currently Cooling
-			if (nshared["can_cool"].asBool() and !nshared["hvac_ac_state"].empty())
+			if (nshared["can_cool"].asBool() && !nshared["hvac_ac_state"].empty())
 			{
 				bool bIsCooling = nshared["hvac_ac_state"].asBool();
 				UpdateSwitch(114,bIsCooling,"CoolingOn");		

--- a/hardware/Nest.h
+++ b/hardware/Nest.h
@@ -21,6 +21,7 @@ public:
 	void SetProgramState(const int newState);
 private:
 	void SendSetPointSensor(const unsigned char Idx, const float Temp, const std::string &defaultname);
+	void UpdateSwitch(const unsigned char Idx, const bool bOn, const std::string &defaultname);
 	void UpdateSmokeSensor(const unsigned char Idx, const bool bOn, const std::string &defaultname);
 	bool SetAway(const unsigned char Idx, const bool bIsAway);
 	bool Login();


### PR DESCRIPTION
Simple implementation for Nest Heating/Cooling logging in a "switch" device. 
Supports only basic heating/cooling.
Tested on a minimal linux compilation (no OpenZwave) with a real heating thermostat, and a  heating/cooling virtual thermostat.
