### PR TITLE
Add support for pressure readings from 1Wire-devices by EDS

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -263,6 +263,7 @@ void C1Wire::GetDeviceDetails()
 		  {
 			  ReportTemperatureHumidity(device.devid, temperature, m_system->GetHumidity(device));
 		  }
+		  ReportPressure(device.devid,m_system->GetPressure(device));
 		  break;
 			}
 

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -229,7 +229,7 @@ float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
 
 float C1WireByOWFS::GetPressure(const _t1WireDevice& device) const
 {
-   std::string readValue=readRawData(std::string(device.filename+"/B1-R1-A/pressure"));
+   std::string readValue=readRawData(std::string(device.filename+"/pressure"));
    if (readValue.empty())
 	   return -1000.0;
    return static_cast<float>(atof(readValue.c_str()));
@@ -412,8 +412,35 @@ void C1WireByOWFS::GetDevice(const std::string &inDir, const std::string &dirnam
     }
     device.devid=id;
     
-    // Filename (full path)
     device.filename=inDir;
-    device.filename+="/" + dirname;
+    if (device.family == Environmental_Monitors || device.family == smart_battery_monitor) {
+        device.filename+="/" + dirname + "/" + nameHelper(dirname);;
+    } else { 
+        device.filename+="/" + dirname;
+    }
+}
+
+std::string C1WireByOWFS::nameHelper(const std::string& dirname) const {
+	std::string name;
+	DIR *d=NULL;
+	
+	d=opendir(std::string(std::string(OWFS_Base_Dir) + "/" + dirname.c_str()).c_str());
+        if (d != NULL)
+        {
+            struct dirent *de=NULL;
+            while ((de = readdir(d)))
+            {
+            name = de->d_name;
+            if (de->d_type==DT_DIR)
+            {
+		if (name.compare(0,3, "EDS") == 0 || name.compare(0,7, "B1-R1-A") == 0) {
+		    closedir(d);
+		    return name;
+		}
+            }
+        }
+        closedir(d);
+    }
+    return "";
 }
 

--- a/hardware/1Wire/1WireByOWFS.h
+++ b/hardware/1Wire/1WireByOWFS.h
@@ -30,4 +30,5 @@ protected:
    void GetDevices(const std::string &inDir, /*out*/std::vector<_t1WireDevice>& devices) const;
    std::string readRawData(const std::string& filename) const;
    void writeData(const _t1WireDevice& device,std::string propertyName,const std::string &value) const;
+   std::string nameHelper(const std::string& dirname) const;
 };


### PR DESCRIPTION
This adds support for pressure (barometric) readings from 1Wire devices by EDS. 

http://www.embeddeddatasystems.com/OW-ENV-TP--Temperature-Barometric-Pressure-Sensor_p_171.html
