### PR TITLE
Adds support for other serial-port Z-Wave devices

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -188,6 +188,11 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 				bUseDirectPath=true;
 				ret.push_back("/dev/" + fname);
 			}
+			else if (fname.find("ttyS") != std::string::npos)
+			{
+				bUseDirectPath = true;
+				ret.push_back("/dev/" + fname);
+			}
 #ifdef __FreeBSD__            
 			else if (fname.find("ttyU")!=std::string::npos)
 			{

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -171,7 +171,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_OpenThermGateway, "OpenTherm Gateway USB" },
 		{ HTYPE_TeleinfoMeter, "Teleinfo EDF USB" },
 		{ HTYPE_OpenThermGatewayTCP, "OpenTherm Gateway with LAN interface" },
-		{ HTYPE_OpenZWave, "OpenZWave USB" },
+		{ HTYPE_OpenZWave, "OpenZWave" },
 		{ HTYPE_LimitlessLights, "Limitless/AppLamp/Mi Light with LAN/WiFi interface" },
 		{ HTYPE_System, "Motherboard sensors" },
 		{ HTYPE_EnOceanESP2, "EnOcean USB (ESP2)" },


### PR DESCRIPTION
For example, Razberry on BananaPi / BananaPro binds to ttyS2 by default.  Other RPi-like devices are bound to other ports.

This does add a bit of UI overhead: users are now greeted with more tty\* devices.  However, I believe the tradeoff is worth it in terms of supporting the additional devices OOTB without weird workarounds like linking ttySx to ttyAMAx

The PR also changes "OpenZWave USB" to simply "OpenZWave" to reflect the fact that the serial ports may not be USB.
