### PR TITLE
Panasonic fix

### DIFF
--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -218,23 +218,14 @@ bool CPanasonicNode::handleConnect(boost::asio::ip::tcp::socket& socket, boost::
 			if (!ec)
 			{
 				if (DEBUG_LOGGING) _log.Log(LOG_NORM, "Panasonic Plugin: (%s) Connected to '%s:%s'.", m_Name.c_str(), m_IP.c_str(), (m_Port[0] != '-' ? m_Port.c_str() : m_Port.substr(1).c_str()));
-				if (m_CurrentStatus.Status() != MSTAT_ON)
-				{
-					m_CurrentStatus.Clear();
-					m_CurrentStatus.Status(MSTAT_ON);
-					UpdateStatus();
-				}
 				return true;
 			}
 			else
 			{
-				if ((DEBUG_LOGGING) ||
-					((ec.value() != 113) && (ec.value() != 111) &&
+				if (DEBUG_LOGGING)
+					if (((ec.value() != 113) && (ec.value() != 111) &&
 						(ec.value() != 10060) && (ec.value() != 10061) && (ec.value() != 10064) && (ec.value() != 10061))) // Connection failed due to no response, no route or active refusal
 					_log.Log(LOG_NORM, "Panasonic Plugin: (%s) Connect to '%s:%s' failed: (%d) %s", m_Name.c_str(), m_IP.c_str(), (m_Port[0] != '-' ? m_Port.c_str() : m_Port.substr(1).c_str()), ec.value(), ec.message().c_str());
-				m_CurrentStatus.Clear();
-				m_CurrentStatus.Status(MSTAT_OFF);
-				UpdateStatus();
 				return false;
 			}
 		}
@@ -429,6 +420,20 @@ void CPanasonicNode::Do_Work()
 				if (_volReply != "ERROR")
 				{
 					m_CurrentStatus.Volume(handleMessage(_volReply));
+					if (m_CurrentStatus.Status() != MSTAT_ON)
+					{
+						m_CurrentStatus.Status(MSTAT_ON);
+						UpdateStatus();
+					}
+				}
+				else
+				{
+					if (m_CurrentStatus.Status() != MSTAT_OFF)
+					{
+						m_CurrentStatus.Clear();
+						m_CurrentStatus.Status(MSTAT_OFF);
+						UpdateStatus();
+					}
 				}
 
 				//_muteReply = handleWriteAndRead(buildXMLStringRendCtl("Get", "Mute"));

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -419,8 +419,9 @@ void CPanasonicNode::Do_Work()
 				_volReply = handleWriteAndRead(buildXMLStringRendCtl("Get", "Volume"));
 				if (_volReply != "ERROR")
 				{
-					m_CurrentStatus.Volume(handleMessage(_volReply));
-					if (m_CurrentStatus.Status() != MSTAT_ON)
+					int iVol = handleMessage(_volReply);
+					m_CurrentStatus.Volume(iVol);
+					if (m_CurrentStatus.Status() != MSTAT_ON && iVol > -1)
 					{
 						m_CurrentStatus.Status(MSTAT_ON);
 						UpdateStatus();

--- a/hardware/PanasonicTV.h
+++ b/hardware/PanasonicTV.h
@@ -31,7 +31,7 @@ class CPanasonicNode //: public boost::enable_shared_from_this<CPanasonicNode>
 		bool			UpdateRequired(CPanasonicStatus&);
 		bool			OnOffRequired(CPanasonicStatus&);
 		bool			IsOn() { return (m_nStatus != MSTAT_OFF); };
-		void			Volume(int pVolume) { m_VolumeLevel = pVolume; };
+		void				Volume(int pVolume) { m_VolumeLevel = pVolume;};
 		void			Muted(bool pMuted) { m_Muted = pMuted; };
 	private:
 		_eMediaStatus	m_nStatus;

--- a/hardware/PanasonicTV.h
+++ b/hardware/PanasonicTV.h
@@ -31,7 +31,7 @@ class CPanasonicNode //: public boost::enable_shared_from_this<CPanasonicNode>
 		bool			UpdateRequired(CPanasonicStatus&);
 		bool			OnOffRequired(CPanasonicStatus&);
 		bool			IsOn() { return (m_nStatus != MSTAT_OFF); };
-		void				Volume(int pVolume) { m_VolumeLevel = pVolume;};
+		void			Volume(int pVolume) { m_VolumeLevel = pVolume;};
 		void			Muted(bool pMuted) { m_Muted = pMuted; };
 	private:
 		_eMediaStatus	m_nStatus;


### PR DESCRIPTION
Fix for double events when device is detected on.

Change of logic, don't assume device is on and correct just because we connect to a port, we wait until we have a volume reply.

Was a change to header file but changed it back and has gone through as a commit by mistake but no actual change.
