### PR TITLE
Force static build of libraries

### DIFF
--- a/MQTT/CMakeLists.txt
+++ b/MQTT/CMakeLists.txt
@@ -31,4 +31,4 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	SET(OperatingSystem "Linux")
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-ADD_LIBRARY(mqtt ${LIB} ${CORE})
+ADD_LIBRARY(mqtt STATIC ${LIB} ${CORE})

--- a/lua/src/CMakeLists.txt
+++ b/lua/src/CMakeLists.txt
@@ -12,7 +12,7 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	add_definitions(-DLUA_USE_LINUX)
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-ADD_LIBRARY(lua ${LIB} ${CORE})
+ADD_LIBRARY(lua STATIC ${LIB} ${CORE})
 #ADD_EXECUTABLE(luaexec lua.c)
 #TARGET_LINK_LIBRARIES(luaexec lua m) 
 

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -15,4 +15,4 @@ IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	SET(OperatingSystem "Linux")
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-ADD_LIBRARY(sqlite ${LIB})
+ADD_LIBRARY(sqlite STATIC ${LIB})


### PR DESCRIPTION
Add STATIC to cmake add_library function to force the static build of mqtt,
sqlite and lua libraries
