### PR TITLE
trying to fix the AppVeyor build

### DIFF
--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -727,7 +727,10 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="..\MQTT\mosquittopp.cpp" />
+    <ClCompile Include="..\MQTT\mosquittopp.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+    </ClCompile>
     <ClCompile Include="..\MQTT\net_mosq.c">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>


### PR DESCRIPTION
using precompiled header should be disabled for "mosquittopp.cpp":

```
  mosquittopp.cpp
..\MQTT\mosquittopp.cpp(18): warning C4627: '#include "mosquitto.h"': skipped when looking for precompiled header use [C:\projects\domoticz\msbuild\domoticz.vcxproj]
  ..\MQTT\mosquittopp.cpp(18): note: Add directive to 'stdafx.h' or rebuild precompiled header
..\MQTT\mosquittopp.cpp(19): warning C4627: '#include "mosquittopp.h"': skipped when looking for precompiled header use [C:\projects\domoticz\msbuild\domoticz.vcxproj]
  ..\MQTT\mosquittopp.cpp(19): note: Add directive to 'stdafx.h' or rebuild precompiled header
..\MQTT\mosquittopp.cpp(313): fatal error C1010: unexpected end of file while looking for precompiled header. Did you forget to add '#include "stdafx.h"' to your source? [C:\projects\domoticz\msbuild\domoticz.vcxproj]
```
