### PR TITLE
Remove appversion.h.txt from git repository

### DIFF
--- a/appversion.h.txt
+++ b/appversion.h.txt
@@ -1,3 +1,0 @@
-#define APPVERSION 4416
-#define APPHASH "2c36fbf"
-#define APPDATE 1454659536


### PR DESCRIPTION
Remove appversion.h.txt from git repository as default values for revision, hash and date are now in appversion.default. appversion.h.txt will continue to be generated at build time by domoticz.
