### PR TITLE
Add option to specify OpenZwave config directory

### DIFF
--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -97,6 +97,7 @@ unsigned char GetIndexFromAlarm(const std::string &sLabel)
 
 extern std::string szStartupFolder;
 extern std::string szUserDataFolder;
+extern std::string szOZWConfigFolder;
 
 #define round(a) ( int ) ( a + .5 )
 
@@ -953,14 +954,19 @@ bool COpenZWave::OpenSerialConnector()
 	m_bNeedSave = false;
 	std::string ConfigPath = szStartupFolder + "Config/";
 	std::string UserPath = ConfigPath;
-	if (szStartupFolder != szUserDataFolder)
+	if (!szUserDataFolder.empty())
 	{
-		UserPath = szUserDataFolder;
+		UserPath = szUserDataFolder + "Config/";
+	}
+	if (!szOZWConfigFolder.empty())
+	{
+		ConfigPath = szOZWConfigFolder;
 	}
 	// Create the OpenZWave Manager.
 	// The first argument is the path to the config files (where the manufacturer_specific.xml file is located
 	// The second argument is the path for saved Z-Wave network state and the log file.  If you leave it NULL 
 	// the log file will appear in the program's working directory.
+	_log.Log(LOG_STATUS, "OpenZWave: writing log and network state to: %s", UserPath.c_str());
 	_log.Log(LOG_STATUS, "OpenZWave: using config in: %s", ConfigPath.c_str());
 	OpenZWave::Options::Create(ConfigPath, UserPath, "--SaveConfiguration=true ");
 	EnableDisableDebug();

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -86,6 +86,7 @@ const char *szHelp=
 	"\t-wwwroot file_path (for example /opt/domoticz/www)\n"
 	"\t-dbase file_path (for example /opt/domoticz/domoticz.db)\n"
 	"\t-userdata file_path (for example /opt/domoticz)\n"
+	"\t-ozwconfig file_path (for example /opt/domoticz/Config)\n"
 #endif
 	"\t-webroot additional web root, useful with proxy servers (for example domoticz)\n"
 	"\t-verbose x (where x=0 is none, x=1 is debug)\n"
@@ -113,6 +114,7 @@ std::string szStartupFolder;
 std::string szUserDataFolder;
 std::string szWWWFolder;
 std::string szWebRoot;
+std::string szOZWConfigFolder;
 
 bool bHasInternalTemperature=false;
 std::string szInternalTemperatureCommand = "/opt/vc/bin/vcgencmd measure_temp";
@@ -554,6 +556,18 @@ int main(int argc, char**argv)
 		std::string szroot = cmdLine.GetSafeArgument("-userdata", 0, "");
 		if (szroot.size() != 0)
 			szUserDataFolder = szroot;
+	}
+
+	if (cmdLine.HasSwitch("-ozwconfig"))
+	{
+		if (cmdLine.GetArgumentCount("-ozwconfig") != 1)
+		{
+			_log.Log(LOG_ERROR, "Please specify a path for OpenZwave config location");
+			return 1;
+		}
+		std::string szroot = cmdLine.GetSafeArgument("-ozwconfig", 0, "");
+		if (szroot.size() != 0)
+			szOZWConfigFolder = szroot;
 	}
 
 	if (cmdLine.HasSwitch("-startupdelay"))


### PR DESCRIPTION
The config directory is one of the last static directories still located the userdata folder.
This patch will make it possible to move the static files from the Config directory to the specified directory. 
I'm not really happy with this approach because I would prefer to create a new directory inside the UserData directory to store the OpenZwave log and network state files, but I find no suitable crossplatform way to create  the directory (except boost, but i dont want to depend on a module just to do that). I guess the proper way would be to define these in the cmake and let cmake take care of the creation if necessary.

This has been discussed at #464 
