### PR TITLE
fix issue #281 : user variable with type 'Time' don't work in events

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,23 +153,24 @@ FIND_PROGRAM(GIT_EXECUTABLE git
 
 MACRO(Gitversion_GET_REVISION dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} rev-list HEAD --count
+    WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_GET_REVISION)
 
-Gitversion_GET_REVISION(. ProjectRevision)
+Gitversion_GET_REVISION("${CMAKE_SOURCE_DIR}" ProjectRevision)
 IF(NOT ProjectRevision)
   MESSAGE(STATUS "Failed to get ProjectRevision from git")
-  IF(EXISTS appversion.default)
+  IF(EXISTS ${CMAKE_SOURCE_DIR}/appversion.default)
     MESSAGE(STATUS "Read ProjectRevision from appversion.default")
-    FILE(STRINGS appversion.default AppVersionContent)
+    FILE(STRINGS ${CMAKE_SOURCE_DIR}/appversion.default AppVersionContent)
     LIST(GET AppVersionContent 0 AppVersionContent)
     STRING(REPLACE " " ";" AppVersionContent ${AppVersionContent})
     LIST(GET AppVersionContent 2 ProjectRevision)
-  ELSE(EXISTS appversion.default)
+  ELSE(EXISTS ${CMAKE_SOURCE_DIR}/appversion.default)
     MESSAGE(STATUS "No appversion.default, set ProjectRevision to 0")
     set (ProjectRevision 0)
-  ENDIF(EXISTS appversion.default)
+  ENDIF(EXISTS ${CMAKE_SOURCE_DIR}/appversion.default)
 ELSE(NOT ProjectRevision)
   MATH(EXPR ProjectRevision "${ProjectRevision}+2107")
 ENDIF(NOT ProjectRevision)

--- a/getgit.cmake
+++ b/getgit.cmake
@@ -1,3 +1,6 @@
+# this macro gets called as a custom build step by running make
+# please take into account, that the variable 'SOURCE_DIR' has been defined by the caller
+
 # the git.cmake module is part of the standard distribution
 find_package(Git)
 if(NOT GIT_FOUND)
@@ -6,63 +9,67 @@ endif()
 
 MACRO(Gitversion_GET_REVISION dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} rev-list HEAD --count
+    WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_GET_REVISION)
 
 MACRO(Gitversion_GET_HASH dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_GET_HASH)
 
 MACRO(Gitversion_GET_DATE dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} show -s --format=%ct
+    WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_GET_DATE)
 
 MACRO(Gitversion_CHECK_DIRTY dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} diff-index -m --name-only HEAD
+    WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_CHECK_DIRTY)
 
-Gitversion_GET_REVISION(. ProjectRevision)
+Gitversion_GET_REVISION("${SOURCE_DIR}" ProjectRevision)
 IF(NOT ProjectRevision)
   MESSAGE(STATUS "Failed to get ProjectRevision from git, set it to 0")
   set (ProjectRevision 0)
 ELSE(NOT ProjectRevision)
   MATH(EXPR ProjectRevision "${ProjectRevision}+2107")
 ENDIF(NOT ProjectRevision)
-Gitversion_GET_HASH(. ProjectHash)
+Gitversion_GET_HASH("${SOURCE_DIR}" ProjectHash)
 IF(NOT ProjectHash)
   MESSAGE(STATUS "Failed to get ProjectHash from git, set it to 0")
   set (ProjectHash 0)
 ENDIF(NOT ProjectHash)
-Gitversion_GET_DATE(. ProjectDate)
+Gitversion_GET_DATE("${SOURCE_DIR}" ProjectDate)
 IF(NOT ProjectDate)
   MESSAGE(STATUS "Failed to get ProjectDate from git, set it to 0")
   set (ProjectDate 0)
 ENDIF(NOT ProjectDate)
-Gitversion_CHECK_DIRTY(. ProjectDirty)
+Gitversion_CHECK_DIRTY("${SOURCE_DIR}" ProjectDirty)
 IF(ProjectDirty)
   MESSAGE(STATUS "domoticz has been modified locally: add \"-modified\" to hash")
   set (ProjectHash "${ProjectHash}-modified")
 ENDIF(ProjectDirty)
 
 # write a file with the APPVERSION define
-file(WRITE appversion.h.txt "#define APPVERSION ${ProjectRevision}\n#define APPHASH \"${ProjectHash}\"\n#define APPDATE ${ProjectDate}\n")
+file(WRITE ${SOURCE_DIR}/appversion.h.txt "#define APPVERSION ${ProjectRevision}\n#define APPHASH \"${ProjectHash}\"\n#define APPDATE ${ProjectDate}\n")
 
 # if ProjectDate is 0, create appversion.h.txt from a copy of appversion.default
-IF(NOT ProjectDate AND EXISTS appversion.default)
+IF(NOT ProjectDate AND EXISTS ${SOURCE_DIR}/appversion.default)
   MESSAGE(STATUS "ProjectDate is 0 and appversion.default exists, copy it")
   execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        appversion.default ${CMAKE_CURRENT_LIST_DIR}/appversion.h.txt)
-ENDIF(NOT ProjectDate AND EXISTS appversion.default)
+                        ${SOURCE_DIR}/appversion.default ${SOURCE_DIR}/appversion.h.txt)
+ENDIF(NOT ProjectDate AND EXISTS ${SOURCE_DIR}/appversion.default)
 
 # copy the file to the final header only if the version changes
 # reduces needless rebuilds
 
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
-                        appversion.h.txt ${CMAKE_CURRENT_LIST_DIR}/appversion.h)
+                        ${SOURCE_DIR}/appversion.h.txt ${SOURCE_DIR}/appversion.h)

--- a/www/eventsframe.html
+++ b/www/eventsframe.html
@@ -206,6 +206,11 @@
 					var valueA = $(timeBlock).children("title[name='SunriseSunset']")[0];
 					compareString = 'timeofday '+locOperand+' @'+$(valueA).text(); 
 				}
+				else if (timeBlock.attr("type").indexOf("uservariables") >= 0) {
+					var titleA = $(timeBlock).find("title[name='Variable']")[0];
+					var valueA = "variable["+$(titleA).text()+"]";         
+					compareString = 'timeofday '+locOperand+' tonumber(string.sub('+valueA+',1,2))*60+tonumber(string.sub('+valueA+',4,5))';
+				}
 				return compareString;	
 		}
 		

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# ref 1205
+# ref 1206
 
 CACHE:
 # CSS


### PR DESCRIPTION
two additional commits are included in this PR:
.) the getgit macro didn't use the 'SOURCE_DIR' variable provided by the caller ( see CMakeList.txt )
.) the changes for 'appversion.default',... have broken the out-of-source build by using the current directory instead of 'CMAKE_SOURCE_DIR'. the out-of-source build is now working again
