### PR TITLE
Fix a security issue (DOS) in webserver

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -79,6 +79,7 @@ Version 2.4xxx
 - Fixed: Fix Security devices edit form by hiding Selector switch options (#473).
 - Fixed: Fix missing Selector switch levels in MQTT device info response by returning all device options (#459)
 - Fixed: Fix dead code in the AsyncSerial::close method causing the method not to stop or close the background resources.
+- Fixed: Fix a security issue (DOS) in webserver to prevent a remote_endpoint exception to be thrown to the WebServer class causing the webserver to be down (no possible stop and no possible connection). Now, the webserver can be scanned using the nmap tool (for the SSL configuration purpose).
 - Updated: OpenZWave, configuration files
 
 Version 2.3530 (November 1th 2015)


### PR DESCRIPTION
Fix a security issue (DOS) in webserver to prevent a remote_endpoint exception to be thrown to the WebServer class causing the webserver to be down (no possible stop and no possible connection). Now, the webserver can be scanned using the nmap tool (for the SSL configuration purpose).
