### PR TITLE
Pifix

### DIFF
--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -378,7 +378,7 @@ bool DomoticzTCP::StartHardwareProxy()
 
 bool DomoticzTCP::ConnectInternalProxy()
 {
-	http::server::CProxyClient *proxy;
+	boost::shared_ptr<http::server::CProxyClient> proxy;
 	const int version = 1;
 	// we temporarily use the instance id as an identifier for this connection, meanwhile we get a token from the proxy
 	// this means that we connect connect twice to the same server
@@ -405,7 +405,7 @@ bool DomoticzTCP::StopHardwareProxy()
 
 void DomoticzTCP::DisconnectProxy()
 {
-	http::server::CProxyClient *proxy;
+	boost::shared_ptr<http::server::CProxyClient> proxy;
 
 	proxy = m_webservers.GetProxyForMaster(this);
 	if (proxy) {
@@ -423,7 +423,7 @@ void DomoticzTCP::writeProxy(const char *data, size_t size)
 {
 	/* send data to slave */
 	if (isConnectedProxy()) {
-		http::server::CProxyClient *proxy = m_webservers.GetProxyForMaster(this);
+		boost::shared_ptr<http::server::CProxyClient> proxy = m_webservers.GetProxyForMaster(this);
 		if (proxy) {
 			proxy->WriteMasterData(token, data, size);
 		}

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -106,7 +106,7 @@ namespace http {
 			}
 			// we are not connected yet. save this master and connect later.
 			sharedData.AddTCPClient(master);
-			return NULL;
+			return boost::shared_ptr<CProxyClient>();
 		}
 
 		void CWebServerHelper::RemoveMaster(DomoticzTCP *master) {

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -99,7 +99,7 @@ namespace http {
 			_log.Log(LOG_STATUS, "Proxymanager started.");
 		}
 
-		CProxyClient *CWebServerHelper::GetProxyForMaster(DomoticzTCP *master) {
+		boost::shared_ptr<CProxyClient> CWebServerHelper::GetProxyForMaster(DomoticzTCP *master) {
 			if (proxymanagerCollection.size() > 0) {
 				// todo: make this a random connection?
 				return proxymanagerCollection[0]->GetProxyForMaster(master);

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -84,9 +84,7 @@ namespace http {
 			sharedData.StopTCPClients();
 			for (proxy_iterator it = proxymanagerCollection.begin(); it != proxymanagerCollection.end(); ++it) {
 				(*it)->Stop();
-				// todo: This seems to crash on a Pi (fatal signal 6). Windows goes fine.
-				// stop old threads first
-				//delete (*it);
+				delete (*it);
 			}
 
 			// restart threads

--- a/main/WebServerHelper.h
+++ b/main/WebServerHelper.h
@@ -20,7 +20,7 @@ namespace http {
 			void StopServers();
 #ifndef NOCLOUD
 			void RestartProxy();
-			CProxyClient *GetProxyForMaster(DomoticzTCP *master);
+			boost::shared_ptr<CProxyClient> GetProxyForMaster(DomoticzTCP *master);
 			void RemoveMaster(DomoticzTCP *master);
 #endif
 			void SetAuthenticationMethod(int amethod);

--- a/tcpserver/TCPClient.cpp
+++ b/tcpserver/TCPClient.cpp
@@ -107,7 +107,7 @@ void CTCPClient::handleWrite(const boost::system::error_code& error)
 
 #ifndef NOCLOUD
 /* shared server via proxy client class */
-CSharedClient::CSharedClient(CTCPServerIntBase *pManager, http::server::CProxyClient *proxy, const std::string &token, const std::string &username) : CTCPClientBase(pManager)
+CSharedClient::CSharedClient(CTCPServerIntBase *pManager, boost::shared_ptr<http::server::CProxyClient> proxy, const std::string &token, const std::string &username) : CTCPClientBase(pManager)
 {
 	m_pProxyClient = proxy;
 	m_username = username;

--- a/tcpserver/TCPClient.h
+++ b/tcpserver/TCPClient.h
@@ -60,7 +60,7 @@ class CSharedClient : public CTCPClientBase,
 	public boost::enable_shared_from_this<CSharedClient>
 {
 public:
-	CSharedClient(CTCPServerIntBase *pManager, http::server::CProxyClient *proxy, const std::string &token, const std::string &username);
+	CSharedClient(CTCPServerIntBase *pManager, boost::shared_ptr<http::server::CProxyClient> proxy, const std::string &token, const std::string &username);
 	~CSharedClient();
 	virtual void start();
 	virtual void stop();
@@ -68,7 +68,7 @@ public:
 	void OnIncomingData(const unsigned char *data, size_t bytes_transferred);
 	bool CompareToken(const std::string &token);
 private:
-	http::server::CProxyClient *m_pProxyClient;
+	boost::shared_ptr<http::server::CProxyClient> m_pProxyClient;
 	std::string _token;
 };
 #endif

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -222,7 +222,7 @@ CTCPServerInt::~CTCPServerInt(void)
 
 #ifndef NOCLOUD
 // our proxied server
-CTCPServerProxied::CTCPServerProxied(CTCPServer *pRoot, http::server::CProxyClient *proxy) : CTCPServerIntBase(pRoot)
+CTCPServerProxied::CTCPServerProxied(CTCPServer *pRoot, boost::shared_ptr<http::server::CProxyClient> proxy) : CTCPServerIntBase(pRoot)
 {
 	m_pProxyClient = proxy;
 }
@@ -370,7 +370,7 @@ bool CTCPServer::StartServer(const std::string &address, const std::string &port
 }
 
 #ifndef NOCLOUD
-bool CTCPServer::StartServer(http::server::CProxyClient *proxy)
+bool CTCPServer::StartServer(boost::shared_ptr<http::server::CProxyClient> proxy)
 {
 	_log.Log(LOG_NORM, "Accepting shared server connections via MyDomotiz (see settings menu).");
 	m_pProxyServer = new CTCPServerProxied(this, proxy);

--- a/tcpserver/TCPServer.h
+++ b/tcpserver/TCPServer.h
@@ -77,7 +77,7 @@ private:
 #ifndef NOCLOUD
 class CTCPServerProxied : public CTCPServerIntBase {
 public:
-	CTCPServerProxied(CTCPServer *pRoot, http::server::CProxyClient *proxy);
+	CTCPServerProxied(CTCPServer *pRoot, boost::shared_ptr<http::server::CProxyClient> proxy);
 	~CTCPServerProxied(void);
 	virtual void start();
 	virtual void stop();
@@ -89,7 +89,7 @@ public:
 	bool OnIncomingData(const std::string &token, const unsigned char *data, size_t bytes_transferred);
 	CSharedClient *FindClient(const std::string &token);
 private:
-	http::server::CProxyClient *m_pProxyClient;
+	boost::shared_ptr<http::server::CProxyClient> m_pProxyClient;
 };
 #endif
 
@@ -102,7 +102,7 @@ public:
 
 	bool StartServer(const std::string &address, const std::string &port);
 #ifndef NOCLOUD
-	bool StartServer(http::server::CProxyClient *proxy);
+	bool StartServer(boost::shared_ptr<http::server::CProxyClient> proxy);
 #endif
 	void StopServer();
 	void SendToAll(const unsigned long long DeviceRowID, const char *pData, size_t Length, const CTCPClientBase* pClient2Ignore);

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -84,15 +84,15 @@ namespace http {
 			if (we_locked_prefs_mutex) {
 				// avoid deadlock if we got a read or write error in between handle_handshake() and HandleAuthresp()
 				we_locked_prefs_mutex = false;
-				sharedData.LockPrefsMutex();
+				sharedData.UnlockPrefsMutex();
 			}
 			if (doStop) {
 				return;
 			}
 			if (b_Connected) {
 				_socket.lowest_layer().close();
-				sleep_seconds(10);
 			}
+			sleep_seconds(15);
 			b_Connected = false;
 			boost::asio::ip::tcp::resolver resolver(_io_service);
 			boost::asio::ip::tcp::resolver::query query(address, port);
@@ -204,7 +204,7 @@ namespace http {
 			if (!error)
 			{
 				// lock until we have a valid api id
-				sharedData.UnlockPrefsMutex();
+				sharedData.LockPrefsMutex();
 				b_Connected = true;
 				we_locked_prefs_mutex = true;
 				LoginToService();

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -640,7 +640,6 @@ namespace http {
 
 		CProxyManager::CProxyManager(const std::string& doc_root, http::server::cWebem *webEm, tcp::server::CTCPServer *domServ)
 		{
-			proxyclient = NULL;
 			m_pWebEm = webEm;
 			m_pDomServ = domServ;
 			m_thread = NULL;

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -521,63 +521,6 @@ namespace http {
 			ONPDU(PDU_SERV_RECEIVE)
 			ONPDU(PDU_SERV_SEND)
 			ONPDU(PDU_SERV_ROSTERIND)
-#if 0
-			case PDU_REQUEST:
-				if (_allowed_subsystems & SUBSYSTEM_HTTP) {
-					HandleRequest(&pdu);
-				}
-				else {
-					_log.Log(LOG_ERROR, "PROXY: HTTP access disallowed, denying request.");
-				}
-				break;
-			case PDU_ASSIGNKEY:
-				HandleAssignkey(&pdu);
-				break;
-			case PDU_ENQUIRE:
-				HandleEnquire(&pdu);
-				break;
-			case PDU_AUTHRESP:
-				HandleAuthresp(&pdu);
-				break;
-			case PDU_SERV_CONNECT:
-				/* incoming connect from master */
-				if (_allowed_subsystems & SUBSYSTEM_SHAREDDOMOTICZ) {
-					HandleServConnect(&pdu);
-				}
-				else {
-					_log.Log(LOG_ERROR, "PROXY: Shared Server access disallowed, denying connect request.");
-				}
-				break;
-			case PDU_SERV_DISCONNECT:
-				if (_allowed_subsystems & SUBSYSTEM_SHAREDDOMOTICZ) {
-					HandleServDisconnect(&pdu);
-				}
-				else {
-					_log.Log(LOG_ERROR, "PROXY: Shared Server access disallowed, denying disconnect request.");
-				}
-				break;
-			case PDU_SERV_CONNECTRESP:
-				/* authentication result from slave */
-				HandleServConnectResp(&pdu);
-				break;
-			case PDU_SERV_RECEIVE:
-				/* data from slave to master */
-				if (_allowed_subsystems & SUBSYSTEM_SHAREDDOMOTICZ) {
-					HandleServReceive(&pdu);
-				}
-				else {
-					_log.Log(LOG_ERROR, "PROXY: Shared Server access disallowed, denying receive data request.");
-				}
-				break;
-			case PDU_SERV_SEND:
-				/* data from master to slave */
-				HandleServSend(&pdu);
-				break;
-			case PDU_SERV_ROSTERIND:
-				/* the slave that we want to connect to is back online */
-				HandleServRosterInd(&pdu);
-				break;
-#endif
 			default:
 				_log.Log(LOG_ERROR, "PROXY: pdu type: %d not expected.", pdu._type);
 				break;

--- a/webserver/proxyclient.h
+++ b/webserver/proxyclient.h
@@ -32,7 +32,7 @@ namespace http {
 #define PDUPROTO(type) virtual void Handle##type(const char *pduname, CValueLengthPart &part);
 #define PDUFUNCTION(type) void CProxyClient::Handle##type(const char *pduname, CValueLengthPart &part)
 
-		class CProxyClient {
+		class CProxyClient : public boost::enable_shared_from_this<CProxyClient> {
 		public:
 			CProxyClient(boost::asio::io_service& io_service, boost::asio::ssl::context& context, http::server::cWebem *webEm);
 			~CProxyClient();
@@ -110,11 +110,11 @@ namespace http {
 			~CProxyManager();
 			int Start(bool first);
 			void Stop();
-			CProxyClient *GetProxyForMaster(DomoticzTCP *master);
+			boost::shared_ptr<CProxyClient> GetProxyForMaster(DomoticzTCP *master);
 		private:
 			void StartThread();
 			boost::asio::io_service io_service;
-			CProxyClient *proxyclient;
+			boost::shared_ptr<CProxyClient> proxyclient;
 			boost::thread* m_thread;
 			http::server::cWebem *m_pWebEm;
 			tcp::server::CTCPServer *m_pDomServ;


### PR DESCRIPTION
This patch solves the signal 6 received crash upon exiting Domoticz on a raspberry pi.
At the same time, CProxyClient is made a shared pointer class, like it should be.
