### PR TITLE
Fix webserver socket graceful shutdown

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -82,6 +82,7 @@ Version 2.4xxx
 - Fixed: Fix a security issue (DOS) in webserver to prevent a remote_endpoint exception to be thrown to the WebServer class causing the webserver to be down (no possible stop and no possible connection). Now, the webserver can be scanned using the nmap tool (for the SSL configuration purpose).
 - Fixed: Under FreeBSD Hardware Monitor works, but it needs the libsysinfo package to work.
 - Fixed: Fix std::string::compare method issue (#507).
+- Fixed: Fix the closure of the Web server sockets by making a graceful shutdown before closing.
 - Updated: OpenZWave, configuration files
 
 Version 2.3530 (November 1th 2015)

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -247,6 +247,8 @@ void connection::handle_write(const boost::system::error_code& error)
 		} else {
 			connection_manager_.stop(shared_from_this());
 		}
+	} else {
+		connection_manager_.stop(shared_from_this());
 	}
 	m_lastresponse=mytime(NULL);
 }

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -103,6 +103,10 @@ void connection::start()
 
 void connection::stop()
 {
+	// Initiate graceful connection closure.
+	boost::system::error_code ignored_ec;
+	socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec); // @note For portable behaviour with respect to graceful closure of a
+																				// connected socket, call shutdown() before closing the socket.
 	socket().close();
 }
 
@@ -240,11 +244,7 @@ void connection::handle_write(const boost::system::error_code& error)
 		if (keepalive_) {
 			// if a keep-alive connection is requested, we read the next request
 			read_more();
-		}
-		else {
-			// Initiate graceful connection closure.
-			boost::system::error_code ignored_ec;
-			socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
+		} else {
 			connection_manager_.stop(shared_from_this());
 		}
 	}


### PR DESCRIPTION
A socket close will always be preceding by a graceful shutdown.
