### PR TITLE
Refactor webserver server class v2

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -88,6 +88,7 @@ Version 2.4xxx
 - Fixed: Fix multiple session cleaner start after restarting webserver.
 - Fixed: Fix compilation issue in environment with boost <= 1.57 (in server_settings).
 - Fixed: Fix issue when no certificate file path is set in the command line.
+- Fixed: Fix the closure of the Web server sockets by making a graceful shutdown before closing.
 - Updated: OpenZWave, configuration files
 - Updated: SQLite3 v3.11.0.
 

--- a/History.txt
+++ b/History.txt
@@ -86,6 +86,8 @@ Version 2.4xxx
 - Fixed: Fix std::string::compare method issue (#507).
 - Fixed: Fix the webserver not stopping and not restarting issue after an exception occurred.
 - Fixed: Fix multiple session cleaner start after restarting webserver.
+- Fixed: Fix compilation issue in environment with boost <= 1.57 (in server_settings).
+- Fixed: Fix issue when no certificate file path is set in the command line.
 - Updated: OpenZWave, configuration files
 - Updated: SQLite3 v3.11.0.
 

--- a/History.txt
+++ b/History.txt
@@ -43,6 +43,8 @@ Version 2.4xxx
 - Changed: OpenZwave, kWh sensor now maybe compatible with more hardware
 - Changed: OpenZwave, not sending cold-white in the colorclass, solved issues on different Zipato bulbs
 - Changed: OpenZWave, Renamed internally 'Color Control' to 'Color"
+- Changed: Webserver, Refactor the webserver server class to separate the HTTP and HTTPS implementation, and gather all server settings in the new server_settings and ssl_server_settings classes.
+- Changed: Webserver, Add -sslmethod, -ssloptions and -ssldhparam arguments to domoticz executable.
 - Fixed: Alert Sensor, displaying sValue again
 - Fixed: Blockly, Set user variables (you need to resave your blockly's)
 - Fixed: Blockly, string uservariables where saved with quotes when not using with set-after
@@ -82,6 +84,8 @@ Version 2.4xxx
 - Fixed: Fix a security issue (DOS) in webserver to prevent a remote_endpoint exception to be thrown to the WebServer class causing the webserver to be down (no possible stop and no possible connection). Now, the webserver can be scanned using the nmap tool (for the SSL configuration purpose).
 - Fixed: Under FreeBSD Hardware Monitor works, but it needs the libsysinfo package to work.
 - Fixed: Fix std::string::compare method issue (#507).
+- Fixed: Fix the webserver not stopping and not restarting issue after an exception occurred.
+- Fixed: Fix multiple session cleaner start after restarting webserver.
 - Updated: OpenZWave, configuration files
 - Updated: SQLite3 v3.11.0.
 

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -31,7 +31,7 @@ public:
 	};
 	CWebServer(void);
 	~CWebServer(void);
-	bool StartServer(const std::string &listenaddress, const std::string &listenport, const std::string &serverpath, const bool bIgnoreUsernamePassword, const std::string &secure_cert_file = "", const std::string &secure_cert_passphrase = "");
+	bool StartServer(const server_settings & settings, const std::string &serverpath, const bool bIgnoreUsernamePassword);
 	void StopServer();
 	void RegisterCommandCode(const char* idname, webserver_response_function ResponseFunction, bool bypassAuthentication=false);
 	void RegisterRType(const char* idname, webserver_response_function ResponseFunction);
@@ -307,7 +307,7 @@ private:
 	std::vector<_tCustomIcon> m_custom_light_icons;
 	std::map<int, int> m_custom_light_icons_lookup;
 	bool m_bDoStop;
-	bool m_bIsSecure;
+	std::string m_server_alias;
 
 	void luaThread(lua_State *lua_state, const std::string &filename);
 	static void luaStop(lua_State *L, lua_Debug *ar);

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -35,7 +35,7 @@ namespace http {
 #endif
 		}
 
-		bool CWebServerHelper::StartServers(const std::string &listenaddress, const std::string &listenport, const std::string &secure_listenport, const std::string &serverpath, const std::string &secure_cert_file, const std::string &secure_cert_passphrase, const bool bIgnoreUsernamePassword, tcp::server::CTCPServer *sharedServer)
+		bool CWebServerHelper::StartServers(const server_settings & web_settings, const ssl_server_settings & secure_web_settings, const std::string &serverpath, const bool bIgnoreUsernamePassword, tcp::server::CTCPServer *sharedServer)
 		{
 			bool bRet = false;
 
@@ -43,18 +43,18 @@ namespace http {
 
 #ifdef NS_ENABLE_SSL
 			SSL_library_init();
-			serverCollection.resize(secure_listenport.empty() ? 1 : 2);
+			serverCollection.resize(secure_web_settings.is_enabled() ? 2 : 1);
 #else
 			serverCollection.resize(1);
 #endif
 			our_serverpath = serverpath;
 			plainServer_ = new CWebServer();
 			serverCollection[0] = plainServer_;
-			bRet |= plainServer_->StartServer(listenaddress, listenport, serverpath, bIgnoreUsernamePassword);
+			bRet |= plainServer_->StartServer(web_settings, serverpath, bIgnoreUsernamePassword);
 #ifdef NS_ENABLE_SSL
-			if (!secure_listenport.empty()) {
+			if (secure_web_settings.is_enabled()) {
 				secureServer_ = new CWebServer();
-				bRet |= secureServer_->StartServer(listenaddress, secure_listenport, serverpath, bIgnoreUsernamePassword, secure_cert_file, secure_cert_passphrase);
+				bRet |= secureServer_->StartServer(secure_web_settings, serverpath, bIgnoreUsernamePassword);
 				serverCollection[1] = secureServer_;
 			}
 #endif

--- a/main/WebServerHelper.h
+++ b/main/WebServerHelper.h
@@ -16,7 +16,7 @@ namespace http {
 			~CWebServerHelper();
 
 			// called from mainworker():
-			bool StartServers(const std::string &listenaddress, const std::string &listenport, const std::string &secure_listenport, const std::string &serverpath, const std::string &secure_cert_file, const std::string &secure_cert_passphrase, const bool bIgnoreUsernamePassword, tcp::server::CTCPServer *sharedServer);
+			bool StartServers(const server_settings & web_settings, const ssl_server_settings & secure_web_settings, const std::string &serverpath, const bool bIgnoreUsernamePassword, tcp::server::CTCPServer *sharedServer);
 			void StopServers();
 #ifndef NOCLOUD
 			void RestartProxy();

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -622,6 +622,10 @@ int main(int argc, char**argv)
 		std::string wwwport = cmdLine.GetSafeArgument("-sslwww", 0, "");
 		secure_webserver_settings.listening_port = wwwport;
 	}
+	if (!webserver_settings.listening_address.empty()) {
+		// Secure listening address has to be equal
+		secure_webserver_settings.listening_address = webserver_settings.listening_address;
+	}
 	if (cmdLine.HasSwitch("-sslcert"))
 	{
 		if (cmdLine.GetArgumentCount("-sslcert") != 1)

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -76,7 +76,10 @@ const char *szHelp=
 #ifdef NS_ENABLE_SSL
 	"\t-sslwww port (for example -sslwww 443, or -sslwww 0 to disable https)\n"
 	"\t-sslcert file_path (for example /opt/domoticz/server_cert.pem)\n"
-	"\t-sslpass passphrase for private key in certificate\n"
+	"\t-sslpass passphrase (to access to server private key in certificate)\n"
+	"\t-sslmethod method (for SSL method)\n"
+	"\t-ssloptions options (for SSL options, default is 'default_workarounds,no_sslv2,single_dh_use')\n"
+	"\t-ssldhparam file_path (for SSL DH parameters)\n"
 #endif
 #if defined WIN32
 	"\t-wwwroot file_path (for example D:\\www)\n"
@@ -585,6 +588,7 @@ int main(int argc, char**argv)
 		sleep_seconds(DelaySeconds);
 	}
 
+	http::server::server_settings webserver_settings;
 	if (cmdLine.HasSwitch("-wwwbind"))
 	{
 		if (cmdLine.GetArgumentCount("-wwwbind") != 1)
@@ -592,8 +596,7 @@ int main(int argc, char**argv)
 			_log.Log(LOG_ERROR, "Please specify an address");
 			return 1;
 		}
-		std::string wwwbind = cmdLine.GetSafeArgument("-wwwbind", 0, "0.0.0.0");
-		m_mainworker.SetWebserverAddress(wwwbind);
+		webserver_settings.listening_address = cmdLine.GetSafeArgument("-wwwbind", 0, "0.0.0.0");
 	}
 
 	if (cmdLine.HasSwitch("-www"))
@@ -603,12 +606,12 @@ int main(int argc, char**argv)
 			_log.Log(LOG_ERROR, "Please specify a port");
 			return 1;
 		}
-		std::string wwwport = cmdLine.GetSafeArgument("-www", 0, "8080");
-		if (wwwport == "0")
-			wwwport.clear();//HTTP server disabled
-		m_mainworker.SetWebserverPort(wwwport);
+		std::string wwwport = cmdLine.GetSafeArgument("-www", 0, "");
+		webserver_settings.listening_port = wwwport;
 	}
+	m_mainworker.SetWebserverSettings(webserver_settings);
 #ifdef NS_ENABLE_SSL
+	http::server::ssl_server_settings secure_webserver_settings;
 	if (cmdLine.HasSwitch("-sslwww"))
 	{
 		if (cmdLine.GetArgumentCount("-sslwww") != 1)
@@ -616,31 +619,55 @@ int main(int argc, char**argv)
 			_log.Log(LOG_ERROR, "Please specify a port");
 			return 1;
 		}
-		std::string wwwport = cmdLine.GetSafeArgument("-sslwww", 0, "443");
-		if (wwwport == "0")
-			wwwport.clear();//HTTPS server disabled
-		m_mainworker.SetSecureWebserverPort(wwwport);
+		std::string wwwport = cmdLine.GetSafeArgument("-sslwww", 0, "");
+		secure_webserver_settings.listening_port = wwwport;
 	}
 	if (cmdLine.HasSwitch("-sslcert"))
 	{
 		if (cmdLine.GetArgumentCount("-sslcert") != 1)
 		{
-			_log.Log(LOG_ERROR, "Please specify the file path");
+			_log.Log(LOG_ERROR, "Please specify a file path for your server certificate file");
 			return 1;
 		}
-		std::string ca_cert = cmdLine.GetSafeArgument("-sslcert", 0, "./server_cert.pem");
-		m_mainworker.SetSecureWebserverCert(ca_cert);
+		secure_webserver_settings.cert_file_path = cmdLine.GetSafeArgument("-sslcert", 0, "");
 	}
 	if (cmdLine.HasSwitch("-sslpass"))
 	{
 		if (cmdLine.GetArgumentCount("-sslpass") != 1)
 		{
-			_log.Log(LOG_ERROR, "Please specify a passphrase for your certificate file");
+			_log.Log(LOG_ERROR, "Please specify a passphrase to access to your server private key in certificate file");
 			return 1;
 		}
-		std::string ca_passphrase = cmdLine.GetSafeArgument("-sslpass", 0, "");
-		m_mainworker.SetSecureWebserverPass(ca_passphrase);
+		secure_webserver_settings.private_key_pass_phrase = cmdLine.GetSafeArgument("-sslpass", 0, "");
 	}
+	if (cmdLine.HasSwitch("-sslmethod"))
+	{
+		if (cmdLine.GetArgumentCount("-sslmethod") != 1)
+		{
+			_log.Log(LOG_ERROR, "Please specify a SSL method");
+			return 1;
+		}
+		secure_webserver_settings.ssl_method = cmdLine.GetSafeArgument("-sslmethod", 0, "");
+	}
+	if (cmdLine.HasSwitch("-ssloptions"))
+	{
+		if (cmdLine.GetArgumentCount("-ssloptions") != 1)
+		{
+			_log.Log(LOG_ERROR, "Please specify SSL options");
+			return 1;
+		}
+		secure_webserver_settings.options = cmdLine.GetSafeArgument("-ssloptions", 0, "");
+	}
+	if (cmdLine.HasSwitch("-ssldhparam"))
+	{
+		if (cmdLine.GetArgumentCount("-ssldhparam") != 1)
+		{
+			_log.Log(LOG_ERROR, "Please specify a file path for the SSL DH parameters file");
+			return 1;
+		}
+		secure_webserver_settings.tmp_dh_file_path = cmdLine.GetSafeArgument("-ssldhparam", 0, "");
+	}
+	m_mainworker.SetSecureWebserverSettings(secure_webserver_settings);
 #endif
 	if (cmdLine.HasSwitch("-nowwwpwd"))
 	{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -134,10 +134,7 @@ namespace server {
 } //namespace server
 } //namespace tcp
 
-MainWorker::MainWorker() :
-m_webserverport("8080"),
-m_webserveraddress("::"),
-m_secure_web_cert_file("./server_cert.pem")
+MainWorker::MainWorker()
 {
 	m_SecCountdown=-1;
 	m_stoprequested=false;
@@ -146,6 +143,24 @@ m_secure_web_cert_file("./server_cert.pem")
 	
 	m_bStartHardware=false;
 	m_hardwareStartCounter=0;
+
+	// Set default settings for web servers
+	m_webserver_settings.listening_address = "::"; // listen to all network interfaces
+	m_webserver_settings.listening_port = "8080";
+	m_secure_webserver_settings.listening_address = "::"; // listen to all network interfaces
+	m_secure_webserver_settings.listening_port = "443";
+	m_secure_webserver_settings.ssl_method = "sslv23";
+	m_secure_webserver_settings.certificate_chain_file_path = "./server_cert.pem";
+	m_secure_webserver_settings.ca_cert_file_path = m_secure_webserver_settings.certificate_chain_file_path; // not used
+	m_secure_webserver_settings.cert_file_path = m_secure_webserver_settings.certificate_chain_file_path;
+	m_secure_webserver_settings.private_key_file_path = m_secure_webserver_settings.certificate_chain_file_path;
+	m_secure_webserver_settings.private_key_pass_phrase = "";
+	m_secure_webserver_settings.options  = "default_workarounds,no_sslv2,single_dh_use";
+	m_secure_webserver_settings.tmp_dh_file_path = m_secure_webserver_settings.certificate_chain_file_path;
+	m_secure_webserver_settings.verify_peer = false;
+	m_secure_webserver_settings.verify_fail_if_no_peer_cert = false;
+	m_secure_webserver_settings.verify_file_path = "";
+
 	m_bIgnoreUsernamePassword=false;
 
 	time_t atime=mytime(NULL);
@@ -480,44 +495,29 @@ eVerboseLevel MainWorker::GetVerboseLevel()
   return m_verboselevel;
 }
 
-void MainWorker::SetWebserverAddress(const std::string &Address)
+void MainWorker::SetWebserverSettings(const server_settings & settings)
 {
-	m_webserveraddress = Address;
-}
-
-void MainWorker::SetWebserverPort(const std::string &Port)
-{
-	m_webserverport=Port;
+	m_webserver_settings.set(settings);
 }
 
 std::string MainWorker::GetWebserverAddress()
 {
-	return m_webserveraddress;
+	return m_webserver_settings.listening_address;
 }
 
 std::string MainWorker::GetWebserverPort()
 {
-	return m_webserverport;
-}
-
-void MainWorker::SetSecureWebserverPort(const std::string &Port)
-{
-	m_secure_webserverport = Port;
+	return m_webserver_settings.listening_port;
 }
 
 std::string MainWorker::GetSecureWebserverPort()
 {
-	return m_secure_webserverport;
+	return m_secure_webserver_settings.listening_port;
 }
 
-void MainWorker::SetSecureWebserverCert(const std::string &CertFile)
+void MainWorker::SetSecureWebserverSettings(const ssl_server_settings & ssl_settings)
 {
-	m_secure_web_cert_file = CertFile;
-}
-
-void MainWorker::SetSecureWebserverPass(const std::string &passphrase)
-{
-	m_secure_web_passphrase = passphrase;
+	m_secure_webserver_settings.set(ssl_settings);
 }
 
 bool MainWorker::RestartHardware(const std::string &idx)
@@ -945,10 +945,10 @@ bool MainWorker::Stop()
 
 bool MainWorker::StartThread()
 {
-	if (!m_webserverport.empty())
+	if (!m_webserver_settings.listening_port.empty())
 	{
 		//Start WebServer
-		if (!m_webservers.StartServers(m_webserveraddress, m_webserverport, m_secure_webserverport, szWWWFolder, m_secure_web_cert_file, m_secure_web_passphrase, m_bIgnoreUsernamePassword, &m_sharedserver))
+		if (!m_webservers.StartServers(m_webserver_settings, m_secure_webserver_settings, szWWWFolder, m_bIgnoreUsernamePassword, &m_sharedserver))
 		{
 #ifdef WIN32
 			MessageBox(0,"Error starting webserver, check if ports are not in use!", MB_OK, MB_ICONERROR);

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -12,6 +12,7 @@
 #include "DataPush.h"
 #include "HttpPush.h"
 #include "concurrent_queue.h"
+#include "../webserver/server_settings.hpp"
 
 enum eVerboseLevel
 {
@@ -46,14 +47,11 @@ public:
 
 	void SetVerboseLevel(eVerboseLevel Level);
 	eVerboseLevel GetVerboseLevel();
-	void SetWebserverAddress(const std::string &Address);
-	void SetWebserverPort(const std::string &Port);
+	void SetWebserverSettings(const http::server::server_settings & settings);
 	std::string GetWebserverAddress();
 	std::string GetWebserverPort();
-	void SetSecureWebserverPort(const std::string &Port);
+	void SetSecureWebserverSettings(const http::server::ssl_server_settings & ssl_settings);
 	std::string GetSecureWebserverPort();
-	void SetSecureWebserverCert(const std::string &CertFile);
-	void SetSecureWebserverPass(const std::string &passphrase);
 
 	void DecodeRXMessage(const CDomoticzHardwareBase *pHardware, const unsigned char *pRXCommand, const char *defaultName, const int BatteryLevel);
 	void PushAndWaitRxMessage(const CDomoticzHardwareBase *pHardware, const unsigned char *pRXCommand, const char *defaultName, const int BatteryLevel);
@@ -169,11 +167,8 @@ private:
 
 	std::vector<CDomoticzHardwareBase*> m_hardwaredevices;
 	eVerboseLevel m_verboselevel;
-	std::string m_webserverport;
-	std::string m_webserveraddress;
-	std::string m_secure_webserverport;
-	std::string m_secure_web_cert_file;
-	std::string m_secure_web_passphrase;
+	http::server::server_settings m_webserver_settings;
+	http::server::ssl_server_settings m_secure_webserver_settings;
 
 	volatile bool m_stoprequested;
 	boost::shared_ptr<boost::thread> m_thread;

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -578,6 +578,7 @@
     <ClInclude Include="..\webserver\request_handler.hpp" />
     <ClInclude Include="..\webserver\request_parser.hpp" />
     <ClInclude Include="..\webserver\server.hpp" />
+    <ClInclude Include="..\webserver\server_settings.hpp" />
     <ClInclude Include="..\webserver\utf.hpp" />
     <ClInclude Include="WindowsHelper.h" />
     <ClInclude Include="..\hardware\YouLess.h" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -1309,6 +1309,9 @@
     <ClInclude Include="..\webserver\header.hpp">
       <Filter>Webserver</Filter>
     </ClInclude>
+    <ClInclude Include="..\webserver\server_settings.hpp">
+      <Filter>Webserver</Filter>
+    </ClInclude>
     <ClInclude Include="..\webserver\utf.hpp">
       <Filter>Webserver</Filter>
     </ClInclude>

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -148,12 +148,9 @@ namespace http {
 		friend class CProxyClient;
 		public:
 			cWebem(
-				const std::string& address,
-				const std::string& port,
-				const std::string& doc_root,
-				const std::string& secure_cert_file,
-				const std::string& secure_cert_passphrase);
-
+				const server_settings & settings,
+				const std::string& doc_root);
+			~cWebem();
 			void Run();
 			void Stop();
 
@@ -217,6 +214,7 @@ namespace http {
 			//Whitelist url strings that bypass authentication checks (not used by basic-auth authentication)
 			std::vector < std::string > myWhitelistURLs;
 		private:
+			server_settings m_settings;
 			/// store map between include codes and application functions
 			std::map < std::string, webem_include_function > myIncludes;
 			/// store map between include codes and application functions returning UTF-16 strings
@@ -228,9 +226,7 @@ namespace http {
 			/// store map between pages and application functions
 			std::map < std::string, webem_page_function > myPages_w;
 			/// boost::asio web server (RK: plain or secure)
-			server myServer;
-			/// port server is listening on
-			std::string myPort;
+			server_base* myServer;
 			// actual theme selected
 			std::string m_actTheme;
 			// root of url for reverse proxy servers

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -244,10 +244,11 @@ void connection::handle_write(const boost::system::error_code& error)
 		if (keepalive_) {
 			// if a keep-alive connection is requested, we read the next request
 			read_more();
-		}
-		else {
+		} else {
 			connection_manager_.stop(shared_from_this());
 		}
+	} else {
+		connection_manager_.stop(shared_from_this());
 	}
 	m_lastresponse=mytime(NULL);
 }

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -103,6 +103,10 @@ void connection::start()
 
 void connection::stop()
 {
+	// Initiate graceful connection closure.
+	boost::system::error_code ignored_ec;
+	socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec); // @note For portable behaviour with respect to graceful closure of a
+																				// connected socket, call shutdown() before closing the socket.
 	socket().close();
 }
 
@@ -242,9 +246,6 @@ void connection::handle_write(const boost::system::error_code& error)
 			read_more();
 		}
 		else {
-			// Initiate graceful connection closure.
-			boost::system::error_code ignored_ec;
-			socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ignored_ec);
 			connection_manager_.stop(shared_from_this());
 		}
 	}

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -6,127 +6,222 @@
 #include <boost/bind.hpp>
 #include "server.hpp"
 #include <fstream>
+#include "../main/Logger.h"
 
 namespace http {
 namespace server {
 
-server::server(const std::string& address, const std::string& port,
-    request_handler& user_request_handler, std::string certificatefile, std::string passphrase)
-  : io_service_(),
-    acceptor_(io_service_), 
+
+server_base::server_base(const server_settings & settings, request_handler & user_request_handler) :
+		io_service_(),
+		acceptor_(io_service_),
+		settings_(settings),
+		request_handler_(user_request_handler),
+		timeout_(20), // default read timeout in seconds
+		first_run(true) {
+	//_log.Log(LOG_STATUS, "[web:%s] create server_base using settings : %s", settings.listening_port.c_str(), settings.to_string().c_str());
+	if (!settings.is_enabled()) {
+		throw std::invalid_argument("cannot initialize a disabled server (listening port cannot be empty or 0)");
+	}
+}
+
+void server_base::init() {
+
+	if (first_run) {
+		init_connection();
+		first_run = false;
+	}
+
+	// Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
+	boost::asio::ip::tcp::resolver resolver(io_service_);
+	boost::asio::ip::tcp::resolver::query query(settings_.listening_address, settings_.listening_port);
+	boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
+	acceptor_.open(endpoint.protocol());
+	acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+	// bind to our port
+	acceptor_.bind(endpoint);
+	// listen for incoming requests
+	acceptor_.listen();
+	// start the accept thread
+	acceptor_.async_accept(new_connection_->socket(),
+			boost::bind(&server_base::handle_accept, this,
+					boost::asio::placeholders::error));
+}
+
+void server_base::run() {
+	init();
+
+	// The io_service::run() call will block until all asynchronous operations
+	// have finished. While the server is running, there is always at least one
+	// asynchronous operation outstanding: the asynchronous accept call waiting
+	// for new incoming connections.
+	try {
+		io_service_.run();
+	} catch (std::exception& e) {
+		_log.Log(LOG_ERROR, "[web:%s] exception occurred : '%s' (need to run again)", settings_.listening_port.c_str(), e.what());
+		handle_stop(); // dispatch or post call does NOT work because it is pushed in the event queue (executed only on next io service run)
+		io_service_.reset(); // this call is needed before calling run() again
+		throw e;
+	}
+	catch (...) {
+		_log.Log(LOG_ERROR, "[web:%s] unknown exception occurred (need to run again)", settings_.listening_port.c_str());
+		handle_stop(); // dispatch or post call does NOT work because it is pushed in the event queue (executed only on next io service run)
+		io_service_.reset(); // this call is needed before calling run() again
+		throw;
+	}
+}
+
+void server_base::stop() {
+	// Post a call to the stop function so that server_base::stop() is safe to call
+	// from any thread.
+	io_service_.post(boost::bind(&server_base::handle_stop, this));
+}
+
+void server_base::handle_stop() {
+	// The server is stopped by cancelling all outstanding asynchronous
+	// operations. Once all operations have finished the io_service::run() call
+	// will exit.
+	acceptor_.close();
+	connection_manager_.stop_all();
+}
+
+server::server(const server_settings & settings, request_handler & user_request_handler) :
+		server_base(settings, user_request_handler) {
+	//_log.Log(LOG_STATUS, "[web:%s] create server using settings : %s", settings.listening_port.c_str(), settings.to_string().c_str());
+}
+
+void server::init_connection() {
+	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_));
+}
+
+/**
+ * accepting incoming requests and start the client connection loop
+ */
+void server::handle_accept(const boost::system::error_code& e) {
+	if (!e) {
+		connection_manager_.start(new_connection_);
+		new_connection_.reset(new connection(io_service_,
+				connection_manager_, request_handler_, timeout_));
+		// listen for a subsequent request
+		acceptor_.async_accept(new_connection_->socket(),
+				boost::bind(&server::handle_accept, this,
+						boost::asio::placeholders::error));
+	}
+}
+
 #ifdef NS_ENABLE_SSL
-	passphrase_(passphrase),
-    context_(io_service_, boost::asio::ssl::context::sslv23),
-#endif
-    request_handler_( user_request_handler),
-	timeout_(20), // default read timeout in seconds
-	secure_(false)
+ssl_server::ssl_server(const ssl_server_settings & ssl_settings, request_handler & user_request_handler) :
+		server_base(ssl_settings, user_request_handler),
+		settings_(ssl_settings),
+		context_(io_service_, ssl_settings.get_ssl_method())
 {
-#ifdef NS_ENABLE_SSL
-	secure_ = (certificatefile != "");
-#endif
-  if (!secure_)
-  {
-	  new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_));
-  }
-  else
-  {
-#ifdef NS_ENABLE_SSL
-	  new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_,context_));
-#endif
-  }
-  // Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
-  boost::asio::ip::tcp::resolver resolver(io_service_);
-  boost::asio::ip::tcp::resolver::query query(address, port);
-  boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
-  acceptor_.open(endpoint.protocol());
-  acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
-  if (secure_) {
-#ifdef NS_ENABLE_SSL
+	//_log.Log(LOG_STATUS, "[web:%s] create ssl_server using ssl_server_settings : %s", ssl_settings.listening_port.c_str(), ssl_settings.to_string().c_str());
+}
+
+// this constructor will send std::bad_cast exception if the settings argument is not a ssl_server_settings object
+ssl_server::ssl_server(const server_settings & settings, request_handler & user_request_handler) :
+		server_base(settings, user_request_handler),
+		settings_(dynamic_cast<ssl_server_settings const &>(settings)),
+		context_(io_service_, dynamic_cast<ssl_server_settings const &>(settings).get_ssl_method()) {
+	//_log.Log(LOG_STATUS, "[web:%s] create ssl_server using server_settings : %s", settings.listening_port.c_str(), settings.to_string().c_str());
+}
+
+void ssl_server::init_connection() {
+	//_log.Log(LOG_STATUS, "[web:%s] ssl_server::init_connection() : new connection using settings : %s", settings_.listening_port.c_str(), settings_.to_string().c_str());
+
+	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_, context_));
+
 	// the following line gets the passphrase for protected private server keys
-	context_.set_password_callback(boost::bind(&server::get_passphrase, this));
-	context_.set_options(
-		boost::asio::ssl::context::default_workarounds
-		| boost::asio::ssl::context::no_sslv2
-		| boost::asio::ssl::context::single_dh_use);
-	context_.use_certificate_chain_file(certificatefile);
-	context_.use_private_key_file(certificatefile, boost::asio::ssl::context::pem);
+	context_.set_password_callback(boost::bind(&ssl_server::get_passphrase, this));
 
-	//Check if certificate contains DH parameters
-	std::ifstream ifs(certificatefile.c_str());
-	std::string content((std::istreambuf_iterator<char>(ifs)),
-		(std::istreambuf_iterator<char>()));
-	if (content.find("BEGIN DH PARAMETERS")!=std::string::npos)
-		context_.use_tmp_dh_file(certificatefile);
+	if (settings_.options.empty()) {
+		_log.Log(LOG_ERROR, "[web:%s] missing SSL options parameter !", settings_.listening_port.c_str());
+	} else {
+		context_.set_options(settings_.get_ssl_options());
+	}
+
+	if (settings_.certificate_chain_file_path.empty()) {
+		_log.Log(LOG_ERROR, "[web:%s] missing SSL certificate chain file parameter !", settings_.listening_port.c_str());
+	} else {
+		context_.use_certificate_chain_file(settings_.certificate_chain_file_path);
+	}
+	if (settings_.cert_file_path.empty()) {
+		_log.Log(LOG_ERROR, "[web:%s] missing SSL certificate file parameter !", settings_.listening_port.c_str());
+	} else {
+		context_.use_certificate_file(settings_.cert_file_path, boost::asio::ssl::context::pem);
+	}
+	if (settings_.private_key_file_path.empty()) {
+		_log.Log(LOG_ERROR, "[web:%s] missing SSL private key file parameter !", settings_.listening_port.c_str());
+	} else {
+		context_.use_private_key_file(settings_.private_key_file_path, boost::asio::ssl::context::pem);
+	}
+
+	// Do not work with mobile devices at this time (2016/02)
+	if (settings_.verify_peer || settings_.verify_fail_if_no_peer_cert) {
+		if (settings_.verify_file_path.empty()) {
+			_log.Log(LOG_ERROR, "[web:%s] missing SSL verify file parameter !", settings_.listening_port.c_str());
+		} else {
+			context_.load_verify_file(settings_.verify_file_path);
+			boost::asio::ssl::context::verify_mode verify_mode;
+			if (settings_.verify_peer) {
+				verify_mode |= boost::asio::ssl::context::verify_peer;
+			}
+			if (settings_.verify_fail_if_no_peer_cert) {
+				verify_mode |= boost::asio::ssl::context::verify_fail_if_no_peer_cert;
+			}
+			context_.set_verify_mode(verify_mode);
+		}
+	}
+	// Load DH parameters
+	if (settings_.tmp_dh_file_path.empty()) {
+		_log.Log(LOG_ERROR, "[web:%s] missing SSL DH file parameter", settings_.listening_port.c_str());
+	} else {
+		std::ifstream ifs(settings_.tmp_dh_file_path.c_str());
+		std::string content((std::istreambuf_iterator<char>(ifs)),
+				(std::istreambuf_iterator<char>()));
+		if (content.find("BEGIN DH PARAMETERS") != std::string::npos) {
+			context_.use_tmp_dh_file(settings_.tmp_dh_file_path);
+			//_log.Log(LOG_STATUS, "[web:%s] 'BEGIN DH PARAMETERS' found in file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
+		} else {
+			_log.Log(LOG_ERROR, "[web:%s] missing SSL DH parameters from file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
+		}
+	}
+}
+
+/**
+ * accepting incoming requests and start the client connection loop
+ */
+void ssl_server::handle_accept(const boost::system::error_code& e) {
+	if (!e) {
+		connection_manager_.start(new_connection_);
+		new_connection_.reset(new connection(io_service_,
+				connection_manager_, request_handler_, timeout_, context_));
+		// listen for a subsequent request
+		acceptor_.async_accept(new_connection_->socket(),
+				boost::bind(&ssl_server::handle_accept, this,
+						boost::asio::placeholders::error));
+	}
+}
+
+std::string ssl_server::get_passphrase() const {
+	return settings_.private_key_pass_phrase;
+}
 #endif
-  }
-  // bind to our port
-  acceptor_.bind(endpoint);
-  // listen for incoming requests
-  acceptor_.listen();
-  // start the accept thread
-  acceptor_.async_accept(new_connection_->socket(),
-      boost::bind(&server::handle_accept, this,
-        boost::asio::placeholders::error));
-}
 
-void server::run()
-{
-  // The io_service::run() call will block until all asynchronous operations
-  // have finished. While the server is running, there is always at least one
-  // asynchronous operation outstanding: the asynchronous accept call waiting
-  // for new incoming connections.
-  io_service_.run();
-}
-
-void server::stop()
-{
-  // Post a call to the stop function so that server::stop() is safe to call
-  // from any thread.
-  io_service_.post(boost::bind(&server::handle_stop, this));
-}
-
-// accepting incoming requests and start the client connection loop
-void server::handle_accept(const boost::system::error_code& e)
-{
-  if (!e)
-  {
-    connection_manager_.start(new_connection_);
+server_base * server_factory::create(const server_settings & settings, request_handler & user_request_handler) {
 #ifdef NS_ENABLE_SSL
-    if (secure_) {
-    	new_connection_.reset(new connection(io_service_,
-          connection_manager_, request_handler_, timeout_, context_));
-    }
-    else {
-    	new_connection_.reset(new connection(io_service_,
-          connection_manager_, request_handler_, timeout_));
-    }
-#else
-    new_connection_.reset(new connection(io_service_,
-          connection_manager_, request_handler_, timeout_));
+		if (settings.is_secure()) {
+			return create(dynamic_cast<ssl_server_settings const &>(settings), user_request_handler);
+		}
 #endif
-	// listen for a subsequent request
-    acceptor_.async_accept(new_connection_->socket(),
-        boost::bind(&server::handle_accept, this,
-          boost::asio::placeholders::error));
-  }
-}
+		return new server(settings, user_request_handler);
+	}
 
 #ifdef NS_ENABLE_SSL
-std::string server::get_passphrase() const
-{
-	return passphrase_;
-}
+server_base * server_factory::create(const ssl_server_settings & ssl_settings, request_handler & user_request_handler) {
+		return new ssl_server(ssl_settings, user_request_handler);
+	}
 #endif
-
-void server::handle_stop()
-{
-  // The server is stopped by cancelling all outstanding asynchronous
-  // operations. Once all operations have finished the io_service::run() call
-  // will exit.
-  acceptor_.close();
-  connection_manager_.stop_all();
-}
 
 } // namespace server
 } // namespace http

--- a/webserver/server.hpp
+++ b/webserver/server.hpp
@@ -11,63 +11,121 @@
 #include <boost/noncopyable.hpp>
 #include "connection_manager.hpp"
 #include "request_handler.hpp"
+#include "server_settings.hpp"
 
 namespace http {
 namespace server {
 
-/// The top-level class of the secure HTTP server.
-class server
-  : private boost::noncopyable
-{
+/// The top-level class of the HTTP(S) server.
+class server_base : private boost::noncopyable {
 public:
-  /// Construct the server to listen on the specified TCP address and port, and
-  /// serve up files from the given directory.
-  explicit server(const std::string& address, const std::string& port,
-      request_handler& user_request_handler, std::string certificatefile = "", std::string passphrase = "");
+	/// Construct the server to listen on the specified TCP address and port, and
+	/// serve up files from the given directory.
+	explicit server_base(const server_settings & settings, request_handler & user_request_handler);
+	virtual ~server_base() {}
 
-  /// Run the server's io_service loop.
-  void run();
+	/// Run the server's io_service loop.
+	void run();
 
-  /// Stop the server.
-  void stop();
+	/// Stop the server.
+	void stop();
 
+	/// Print server settings to string (debug purpose)
+	virtual std::string to_string() const = 0;
+protected:
+	/// Initialize acceptor
+	virtual void init_connection() =0;
+
+	/// Handle completion of an asynchronous accept operation.
+	virtual void handle_accept(const boost::system::error_code& error) = 0;
+
+	/// The io_service used to perform asynchronous operations.
+	boost::asio::io_service io_service_;
+
+	/// Acceptor used to listen for incoming connections.
+	boost::asio::ip::tcp::acceptor acceptor_;
+
+	/// The handler for all incoming requests.
+	request_handler& request_handler_;
+
+	/// The next connection to be accepted.
+	connection_ptr new_connection_;
+
+	connection_manager connection_manager_;
+	/// server settings
+	server_settings settings_;
+
+	/// read timeout in seconds
+	int timeout_;
 private:
-  /// Handle completion of an asynchronous accept operation.
-  void handle_accept(const boost::system::error_code& error);
+	void init();
 
-  /// Handle a request to stop the server.
-  void handle_stop();
+	/// Handle a request to stop the server.
+	void handle_stop();
 
-  /// The io_service used to perform asynchronous operations.
-  boost::asio::io_service io_service_;
+	bool first_run; // use to init connection on first run
+};
 
-  /// Acceptor used to listen for incoming connections.
-  boost::asio::ip::tcp::acceptor acceptor_;
+class server : public server_base {
+public:
+	/// Construct the HTTP server to listen on the specified TCP address and port, and
+	/// serve up files from the given directory.
+	server(const server_settings & settings, request_handler & user_request_handler);
+	virtual ~server() {}
 
-  /// The handler for all incoming requests.
-  request_handler& request_handler_;
+	/// Print server settings to string (debug purpose)
+	virtual std::string to_string() const {
+		return "'server[" + settings_.to_string() + "]'";
+	}
+protected:
+	/// Initialize acceptor
+	virtual void init_connection();
 
-  /// The next connection to be accepted.
-  connection_ptr new_connection_;
-
-  connection_manager connection_manager_;
-  /// determines if this is an SSL server or not
-  bool secure_;
-
-  /// read timeout in seconds
-  int timeout_;
+	/// Handle completion of an asynchronous accept operation.
+	virtual void handle_accept(const boost::system::error_code& error);
+};
 
 #ifdef NS_ENABLE_SSL
-  /// The SSL context
-  boost::asio::ssl::context context_;
+class ssl_server : public server_base {
+public:
+	/// Construct the HTTPS server to listen on the specified TCP address and port, and
+	/// serve up files from the given directory.
+	ssl_server(const ssl_server_settings & ssl_settings, request_handler & user_request_handler);
+	ssl_server(const server_settings & settings, request_handler & user_request_handler);
+	virtual ~ssl_server() {}
 
-  /// the certficiate passphrase
-  std::string passphrase_;
+	/// Print server settings to string (debug purpose)
+	virtual std::string to_string() const {
+		return "'ssl_server[" + settings_.to_string() + "]'";
+	}
 
-  /// callback for passphrase
-  std::string get_passphrase() const;
+protected:
+	/// Initialize acceptor
+	virtual void init_connection();
+
+	/// Handle completion of an asynchronous accept operation.
+	virtual void handle_accept(const boost::system::error_code& error);
+
+	// The HTTPS server settings
+	ssl_server_settings settings_;
+
+private:
+	/// callback for the certficiate passphrase
+	std::string get_passphrase() const;
+
+	/// The SSL context
+	boost::asio::ssl::context context_;
+};
 #endif
 
+/// server factory
+class server_factory {
+public:
+	static server_base * create(const server_settings & settings, request_handler & user_request_handler);
+
+#ifdef NS_ENABLE_SSL
+	static server_base * create(const ssl_server_settings & ssl_settings, request_handler & user_request_handler);
+#endif
 };
 
 } // namespace server

--- a/webserver/server_settings.hpp
+++ b/webserver/server_settings.hpp
@@ -208,9 +208,10 @@ public:
 
 		ssl_method = server_settings::get_valid_value(ssl_method, ssl_settings.ssl_method);
 
-		bool update_cert = cert_file_path != ssl_settings.cert_file_path;
-		cert_file_path = server_settings::get_valid_value(cert_file_path, ssl_settings.cert_file_path);
+		std::string path = server_settings::get_valid_value(cert_file_path, ssl_settings.cert_file_path);
+		bool update_cert = path.compare(ssl_settings.cert_file_path) == 0;
 		if (update_cert) {
+			cert_file_path = ssl_settings.cert_file_path;
 			// use certificate file for all usage by default
 			certificate_chain_file_path = ssl_settings.cert_file_path;
 			ca_cert_file_path = ssl_settings.cert_file_path;

--- a/webserver/server_settings.hpp
+++ b/webserver/server_settings.hpp
@@ -1,0 +1,262 @@
+/*
+ * server_settings.hpp
+ *
+ *  Created on: 15 févr. 2016
+ *      Author: gaudryc
+ */
+
+#ifndef WEBSERVER_SERVER_SETTINGS_HPP_
+#define WEBSERVER_SERVER_SETTINGS_HPP_
+
+#include <string>
+#include <boost/asio.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace http {
+namespace server {
+
+class server_settings;
+class ssl_server_settings;
+
+class server_settings {
+public:
+	std::string listening_address;
+	std::string listening_port;
+
+	server_settings() :
+		is_secure_(false) {}
+	server_settings(const server_settings & s) :
+		is_secure_(s.is_secure_),
+		listening_address(s.listening_address),
+		listening_port(s.listening_port) {}
+	virtual server_settings * clone() const {
+		return new server_settings(*this);
+	}
+	virtual ~server_settings() {}
+	server_settings & operator=(const server_settings & s) {
+		is_secure_ = s.is_secure_;
+		listening_address = s.listening_address;
+		listening_port = s.listening_port;
+		return *this;
+	}
+	bool is_secure() const {
+		return is_secure_;
+	}
+	bool is_enabled() const {
+		return ((listening_port != "0") && (listening_port != ""));
+	}
+	/**
+	 * Set relevant values
+	 */
+	virtual void set(const server_settings & settings) {
+		listening_address = get_valid_value(listening_address, settings.listening_address);
+		listening_port = get_valid_value(listening_port, settings.listening_port);
+		if (listening_port == "0") {
+			listening_port.clear();// server NOT enabled
+		}
+	}
+
+	virtual std::string to_string() const {
+		return std::string("'server_settings[is_secure_=") + (is_secure_ == true ? "true" : "false") +
+				", listening_address='" + listening_address + "'" +
+				", listening_port='" + listening_port + "'" +
+				"]'";
+	}
+
+protected:
+	server_settings(bool is_secure) :
+		is_secure_(is_secure) {}
+	std::string get_valid_value(const std::string & old_value, const std::string & new_value) {
+		if ((!new_value.empty()) && (new_value != old_value)) {
+			return new_value;
+		}
+		return old_value;
+	}
+private:
+	bool is_secure_;
+};
+
+class ssl_server_settings : public server_settings {
+public:
+	std::string ssl_method;
+	std::string certificate_chain_file_path;
+	std::string ca_cert_file_path;
+	std::string cert_file_path;
+
+	std::string private_key_file_path;
+	std::string private_key_pass_phrase;
+
+	std::string options;
+	std::string tmp_dh_file_path;
+
+	bool verify_peer;
+	bool verify_fail_if_no_peer_cert;
+	std::string verify_file_path;
+
+	ssl_server_settings() :
+			server_settings(true),
+			verify_peer(false),
+			verify_fail_if_no_peer_cert(false) {}
+	ssl_server_settings(const ssl_server_settings & s) :
+		server_settings::server_settings(s),
+		ssl_method(s.ssl_method),
+		certificate_chain_file_path(s.certificate_chain_file_path),
+		ca_cert_file_path(s.ca_cert_file_path),
+		cert_file_path(s.cert_file_path),
+		private_key_file_path(s.private_key_file_path),
+		private_key_pass_phrase(s.private_key_pass_phrase),
+		options(s.options),
+		tmp_dh_file_path(s.tmp_dh_file_path),
+		verify_peer(s.verify_peer),
+		verify_fail_if_no_peer_cert(s.verify_fail_if_no_peer_cert),
+		verify_file_path(s.verify_file_path) {}
+	virtual server_settings * clone() const {
+		return new ssl_server_settings(*this);
+	}
+	virtual ~ssl_server_settings() {}
+	ssl_server_settings & operator=(const ssl_server_settings & s) {
+		server_settings::operator=(s);
+		ssl_method = s.ssl_method;
+		certificate_chain_file_path = s.certificate_chain_file_path;
+		ca_cert_file_path = s.ca_cert_file_path;
+		cert_file_path = s.cert_file_path;
+		private_key_file_path = s.private_key_file_path;
+		private_key_pass_phrase = s.private_key_pass_phrase;
+		options = s.options;
+		tmp_dh_file_path = s.tmp_dh_file_path;
+		verify_peer = s.verify_peer;
+		verify_fail_if_no_peer_cert = s.verify_fail_if_no_peer_cert;
+		verify_file_path = s.verify_file_path;
+		return *this;
+	}
+
+	boost::asio::ssl::context::method get_ssl_method() const {
+		boost::asio::ssl::context::method method;
+		if (ssl_method.compare("tlsv1") == 0) {
+			method = boost::asio::ssl::context::tlsv1;
+		} else if (ssl_method.compare("tlsv1_server") == 0) {
+			method = boost::asio::ssl::context::tlsv1_server;
+		} else if (ssl_method.compare("sslv23") == 0) {
+			method = boost::asio::ssl::context::sslv23;
+		} else if (ssl_method.compare("sslv23_server") == 0) {
+			method = boost::asio::ssl::context::sslv23_server;
+		} else if (ssl_method.compare("tlsv11") == 0) {
+			method = boost::asio::ssl::context::tlsv11;
+		} else if (ssl_method.compare("tlsv11_server") == 0) {
+			method = boost::asio::ssl::context::tlsv11_server;
+		} else if (ssl_method.compare("tlsv12") == 0) {
+			method = boost::asio::ssl::context::tlsv12;
+		} else if (ssl_method.compare("tlsv12_server") == 0) {
+			method = boost::asio::ssl::context::tlsv12_server;
+		} else {
+			std::string error_message("invalid SSL method ");
+			error_message.append("'").append(ssl_method).append("'");
+			throw std::invalid_argument(error_message);
+		}
+		return method;
+	}
+
+	boost::asio::ssl::context::options get_ssl_options() const {
+		boost::asio::ssl::context::options opts(0x0L);
+
+		std::string error_message("");
+
+		std::vector<std::string> options_array;
+		boost::split(options_array, options, boost::is_any_of(","), boost::token_compress_on);
+		std::vector<std::string>::iterator itt;
+		for (itt = options_array.begin(); itt != options_array.end(); ++itt) {
+			std::string option = *itt;
+			if (option.compare("default_workarounds") == 0) {
+				update_options(opts, boost::asio::ssl::context::default_workarounds);
+			} else if (option.compare("single_dh_use") == 0) {
+				update_options(opts, boost::asio::ssl::context::single_dh_use);
+			} else if (option.compare("no_sslv2") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_sslv2);
+			} else if (option.compare("no_sslv3") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_sslv3);
+			} else if (option.compare("no_tlsv1") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_tlsv1);
+			} else if (option.compare("no_tlsv1_1") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_tlsv1_1);
+			} else if (option.compare("no_tlsv1_2") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_tlsv1_2);
+			} else if (option.compare("no_compression") == 0) {
+				update_options(opts, boost::asio::ssl::context::no_compression);
+			} else {
+				if (error_message.empty()) {
+					error_message.append("unknown SSL option(s) : ");
+				}
+				if (error_message.find("'") != std::string::npos) {
+					error_message.append(", ");
+				}
+				error_message.append("'").append(option).append("'");
+			}
+		}
+		if (!error_message.empty()) {
+			throw std::invalid_argument(error_message);
+		}
+		return opts;
+	}
+
+	/**
+	 * Set relevant values
+	 */
+	virtual void set(const ssl_server_settings & ssl_settings) {
+		server_settings::set(ssl_settings);
+
+		ssl_method = server_settings::get_valid_value(ssl_method, ssl_settings.ssl_method);
+
+		bool update_cert = cert_file_path != ssl_settings.cert_file_path;
+		cert_file_path = server_settings::get_valid_value(cert_file_path, ssl_settings.cert_file_path);
+		if (update_cert) {
+			// use certificate file for all usage by default
+			certificate_chain_file_path = ssl_settings.cert_file_path;
+			ca_cert_file_path = ssl_settings.cert_file_path;
+			private_key_file_path = ssl_settings.cert_file_path;
+			tmp_dh_file_path = ssl_settings.cert_file_path;
+			verify_file_path = ssl_settings.cert_file_path;
+		}
+
+		certificate_chain_file_path = server_settings::get_valid_value(certificate_chain_file_path, ssl_settings.certificate_chain_file_path);
+		ca_cert_file_path = server_settings::get_valid_value(ca_cert_file_path, ssl_settings.ca_cert_file_path);
+		private_key_file_path = server_settings::get_valid_value(private_key_file_path, ssl_settings.private_key_file_path);
+		private_key_pass_phrase = server_settings::get_valid_value(private_key_pass_phrase, ssl_settings.private_key_pass_phrase);
+
+		options = server_settings::get_valid_value(options, ssl_settings.options);
+		tmp_dh_file_path = server_settings::get_valid_value(tmp_dh_file_path, ssl_settings.tmp_dh_file_path);
+
+		verify_peer = ssl_settings.verify_peer;
+		verify_fail_if_no_peer_cert = ssl_settings.verify_fail_if_no_peer_cert;
+		verify_file_path = server_settings::get_valid_value(verify_file_path, ssl_settings.verify_file_path);
+	}
+
+	virtual std::string to_string() const {
+		return std::string("ssl_server_settings[") + server_settings::to_string() +
+				", ssl_method='" + ssl_method + "'" +
+				", certificate_chain_file_path='" + certificate_chain_file_path + "'" +
+				", ca_cert_file_path='" + ca_cert_file_path + "'" +
+				", cert_file_path=" + cert_file_path + "'" +
+				", private_key_file_path='" + private_key_file_path + "'" +
+				", private_key_pass_phrase='" + private_key_pass_phrase + "'" +
+				", options='" + options + "'" +
+				", tmp_dh_file_path='" + tmp_dh_file_path + "'" +
+				", verify_peer=" + (verify_peer == true ? "true" : "false") +
+				", verify_fail_if_no_peer_cert=" + (verify_fail_if_no_peer_cert == true ? "true" : "false") +
+				", verify_file_path='" + verify_file_path + "'" +
+				"]";
+	}
+
+protected:
+	void update_options(boost::asio::ssl::context::options & opts, boost::asio::ssl::context::options option) const {
+		if (opts != 0x0L) {
+			opts |= option;
+		} else {
+			opts = option;
+		}
+	}
+};
+
+} // namespace server
+} // namespace http
+
+#endif /* WEBSERVER_SERVER_SETTINGS_HPP_ */

--- a/webserver/server_settings.hpp
+++ b/webserver/server_settings.hpp
@@ -176,10 +176,12 @@ public:
 				update_options(opts, boost::asio::ssl::context::no_sslv3);
 			} else if (option.compare("no_tlsv1") == 0) {
 				update_options(opts, boost::asio::ssl::context::no_tlsv1);
+#if (BOOST_VERSION > 105700)
 			} else if (option.compare("no_tlsv1_1") == 0) {
 				update_options(opts, boost::asio::ssl::context::no_tlsv1_1);
 			} else if (option.compare("no_tlsv1_2") == 0) {
 				update_options(opts, boost::asio::ssl::context::no_tlsv1_2);
+#endif
 			} else if (option.compare("no_compression") == 0) {
 				update_options(opts, boost::asio::ssl::context::no_compression);
 			} else {


### PR DESCRIPTION
Same as "Refactor webserver server class" branch but : 
- Fix compilation issue in environment with boost <= 1.57.
- Fix issue when no certificate file path is set in the command line.
- Set the secure listening address like listening address defined with the -wwwbind argument.
- Fix webserver socket graceful shutdown (#509)
