### PR TITLE
Fix webserver initialization failure

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -89,6 +89,7 @@ Version 2.4xxx
 - Fixed: Fix compilation issue in environment with boost <= 1.57 (in server_settings).
 - Fixed: Fix issue when no certificate file path is set in the command line.
 - Fixed: Fix the closure of the Web server sockets by making a graceful shutdown before closing.
+- Fixed: Fix webserver initialization failure if the local network interface is not IPv6 (due to wrong initialization sequence).
 - Updated: OpenZWave, configuration files
 - Updated: SQLite3 v3.11.0.
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -302,10 +302,7 @@ namespace http {
 				}
 			} while (exception);
 
-			if (settings_copy->listening_address != "0.0.0.0" && settings_copy->listening_address != "::")
-				_log.Log(LOG_STATUS, "Webserver(%s) started on address: %s, port: %s", m_server_alias.c_str(), settings_copy->listening_address.c_str(), settings_copy->listening_port.c_str());
-			else
-				_log.Log(LOG_STATUS, "Webserver(%s) started on port: %s", m_server_alias.c_str(), settings_copy->listening_port.c_str());
+			_log.Log(LOG_STATUS, "Webserver(%s) started on address: %s, port: %s", m_server_alias.c_str(), settings_copy->listening_address.c_str(), settings_copy->listening_port.c_str());
 
 			delete settings_copy;
 

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -17,20 +17,16 @@ server_base::server_base(const server_settings & settings, request_handler & use
 		acceptor_(io_service_),
 		settings_(settings),
 		request_handler_(user_request_handler),
-		timeout_(20), // default read timeout in seconds
-		first_run(true) {
+		timeout_(20) { // default read timeout in seconds
 	//_log.Log(LOG_STATUS, "[web:%s] create server_base using settings : %s", settings.listening_port.c_str(), settings.to_string().c_str());
 	if (!settings.is_enabled()) {
 		throw std::invalid_argument("cannot initialize a disabled server (listening port cannot be empty or 0)");
 	}
+	init();
 }
 
 void server_base::init() {
-
-	if (first_run) {
-		init_connection();
-		first_run = false;
-	}
+	init_connection();
 
 	// Open the acceptor with the option to reuse the address (i.e. SO_REUSEADDR).
 	boost::asio::ip::tcp::resolver resolver(io_service_);
@@ -49,8 +45,6 @@ void server_base::init() {
 }
 
 void server_base::run() {
-	init();
-
 	// The io_service::run() call will block until all asynchronous operations
 	// have finished. While the server is running, there is always at least one
 	// asynchronous operation outstanding: the asynchronous accept call waiting

--- a/webserver/server.hpp
+++ b/webserver/server.hpp
@@ -62,8 +62,6 @@ private:
 
 	/// Handle a request to stop the server.
 	void handle_stop();
-
-	bool first_run; // use to init connection on first run
 };
 
 class server : public server_base {


### PR DESCRIPTION
Because I changed the moment of acceptor initialization the server was always initialized with the listening address "::" which should be wrong in your environment.
