### PR TITLE
Fix issue 523

### DIFF
--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -23,7 +23,6 @@ namespace http {
 
 		CWebServerHelper::~CWebServerHelper()
 		{
-			StopServers();
 		}
 
 		bool CWebServerHelper::StartServers(server_settings & web_settings, ssl_server_settings & secure_web_settings, const std::string &serverpath, const bool bIgnoreUsernamePassword, tcp::server::CTCPServer *sharedServer)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -185,7 +185,6 @@ MainWorker::MainWorker()
 
 MainWorker::~MainWorker()
 {
-	Stop();
 }
 
 void MainWorker::AddAllDomoticzHardware()


### PR DESCRIPTION
This patch really fixes the issue because the execution of these destructors needs the global object _log which can already be destroyed, because the destruction order of static objects is not guaranteed.

(That is the answer I want before closing an issue)
