### PR TITLE
Fix a multiple buttons selected issue after refreshing a selector device status

### DIFF
--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -417,6 +417,7 @@ define(['app'], function (app) {
 														.find('label')
 															.removeClass('ui-state-active')
 															.removeClass('ui-state-focus')
+															.removeClass('ui-state-hover')
 															.end()
 														.find('input:radio')
 															.removeProp('checked')

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -2333,6 +2333,7 @@ define(['app'], function (app) {
 										.find('label')
 											.removeClass('ui-state-active')
 											.removeClass('ui-state-focus')
+											.removeClass('ui-state-hover')
 											.end()
 										.find('input:radio')
 											.removeProp('checked')

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,5 +1,5 @@
 CACHE MANIFEST
-# ref 1222
+# ref 1223
 
 CACHE:
 # CSS


### PR DESCRIPTION
This corrects a bad behavior of jqueryui : the old and new level can be selected at the same time.
