### PR TITLE
Fix issue #538

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -3,6 +3,7 @@ Version 3.xxxx (March xx 2016)
 - Fixed: Better handling of white listed commands/urls
 - Fixed: Double checking command rights
 - Fixed: Fix on/off delays not saved on the selector switch edit form (#532).
+- Fixed: Fix Off Delay not handled for Selector switch (#538).
 
 Version 3.4834 (March 2nd 2016)
 - Implemented: Blockly, now possible to use expressions in notifications/email/SMS like "My temperature is {{temperaturedevice[1234]}} degrees" (see http://www.domoticz.com/wiki/Events)

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3316,21 +3316,24 @@ bool CEventSystem::ScheduleEvent(int deviceID, std::string Action, bool isScene,
 	}
 	else {
 		//Lights/Switches
+		//Get Device details, check for switch global OnDelay/OffDelay (stored in AddjValue2/AddjValue)
+		std::vector<std::vector<std::string> > result;
+		result = m_sql.safe_query("SELECT SwitchType, AddjValue, AddjValue2 FROM DeviceStatus WHERE (ID == %d)", deviceID);
+		if (result.size() < 1)
+			return false;
+
+		std::vector<std::string> sd = result[0];
+		_eSwitchType switchtype = (_eSwitchType) atoi(sd[0].c_str());
+		int iOffDelay = atoi(sd[1].c_str());
+		int iOnDelay = atoi(sd[2].c_str());
+
 		bool bIsOn = IsLightSwitchOn(Action);
-		if (bIsOn)
-		{
-			//Get Device details, check for switch global OnDelay (stored in AddjValue2)
-			std::vector<std::vector<std::string> > result;
-			result = m_sql.safe_query("SELECT AddjValue2 FROM DeviceStatus WHERE (ID == %d)",
-				deviceID);
-			if (result.size() < 1)
-				return false;
-
-			std::vector<std::string> sd = result[0];
-
-			int iOnDelay = atoi(sd[0].c_str());
-			DelayTime += iOnDelay;
+		if (switchtype == STYPE_Selector) {
+			bIsOn = (_level > 0) ? true : false;
 		}
+
+		int iDelay = bIsOn ? iOnDelay : iOffDelay;
+		DelayTime += iDelay;
 
 		tItem = _tTaskItem::SwitchLightEvent(DelayTime, deviceID, Action, _level, -1, eventName);
 	}

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3318,21 +3318,19 @@ bool CEventSystem::ScheduleEvent(int deviceID, std::string Action, bool isScene,
 		//Lights/Switches
 		//Get Device details, check for switch global OnDelay/OffDelay (stored in AddjValue2/AddjValue)
 		std::vector<std::vector<std::string> > result;
-		result = m_sql.safe_query("SELECT SwitchType, AddjValue, AddjValue2 FROM DeviceStatus WHERE (ID == %d)", deviceID);
+		result = m_sql.safe_query("SELECT SwitchType, AddjValue2 FROM DeviceStatus WHERE (ID == %d)", deviceID);
 		if (result.size() < 1)
 			return false;
 
 		std::vector<std::string> sd = result[0];
-		_eSwitchType switchtype = (_eSwitchType) atoi(sd[0].c_str());
-		int iOffDelay = atoi(sd[1].c_str());
-		int iOnDelay = atoi(sd[2].c_str());
+		_eSwitchType switchtype = (_eSwitchType)atoi(sd[0].c_str());
+		int iOnDelay = atoi(sd[1].c_str());
 
 		bool bIsOn = IsLightSwitchOn(Action);
 		if (switchtype == STYPE_Selector) {
 			bIsOn = (_level > 0) ? true : false;
 		}
-
-		int iDelay = bIsOn ? iOnDelay : iOffDelay;
+		int iDelay = bIsOn ? iOnDelay : 0;
 		DelayTime += iDelay;
 
 		tItem = _tTaskItem::SwitchLightEvent(DelayTime, deviceID, Action, _level, -1, eventName);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3220,11 +3220,12 @@ unsigned long long CSQLHelper::UpdateValueInt(const int HardwareID, const char* 
 					bool bAdd2DelayQueue=false;
 					int cmd=0;
 					if (
-						(switchtype==STYPE_OnOff)||
-						(switchtype==STYPE_Motion)||
+						(switchtype == STYPE_OnOff) ||
+						(switchtype == STYPE_Motion) ||
 						(switchtype == STYPE_Dimmer) ||
 						(switchtype == STYPE_PushOn) ||
-						(switchtype==STYPE_DoorLock)
+						(switchtype == STYPE_DoorLock) ||
+						(switchtype == STYPE_Selector)
 						)
 					{
 						switch (devType)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -10993,7 +10993,7 @@ bool MainWorker::SwitchLight(const unsigned long long idx, const std::string &sw
 	//Get Device details
 	std::vector<std::vector<std::string> > result;
 	result=m_sql.safe_query(
-		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue2,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %llu)",
+		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue,AddjValue2,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %llu)",
 		idx);
 	if (result.size()<1)
 		return false;
@@ -11003,30 +11003,36 @@ bool MainWorker::SwitchLight(const unsigned long long idx, const std::string &sw
 	//unsigned char dType = atoi(sd[3].c_str());
 	//unsigned char dSubType = atoi(sd[4].c_str());
 	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
-	int iOnDelay = atoi(sd[6].c_str());
-	int nValue = atoi(sd[7].c_str());
-	std::string sValue = sd[8].c_str();
-	std::string devName = sd[9].c_str();
-	//std::string sOptions = sd[10].c_str();
+	int iOffDelay = atoi(sd[6].c_str());
+	int iOnDelay = atoi(sd[7].c_str());
+	int nValue = atoi(sd[8].c_str());
+	std::string sValue = sd[9].c_str();
+	std::string devName = sd[10].c_str();
+	//std::string sOptions = sd[11].c_str();
 
 	bool bIsOn = IsLightSwitchOn(switchcmd);
 	if (ooc)//Only on change
 	{
-		int nNewVal=bIsOn?1:0;//Is that everything we need here
+		int nNewVal = bIsOn ? 1 : 0;//Is that everything we need here
 		if ((switchtype == STYPE_Selector) && (nValue == nNewVal) && (level == atoi(sValue.c_str()))) {
 			return true;
 		} else if (nValue == nNewVal) {
 			return true;//FIXME no return code for already set
 		}
 	}
-	//Check if we have an On-Delay, if yes, add it to the tasker
-	if (((bIsOn) && (iOnDelay != 0)) || ExtraDelay)
+	if (switchtype == STYPE_Selector) {
+		bIsOn = (level > 0) ? true : false;
+	}
+	int iDelay = bIsOn ? iOnDelay : iOffDelay;
+
+	//Check if we have an OnDelay/OffDelay, if yes, add it to the tasker
+	if ((iDelay != 0) || ExtraDelay)
 	{
 		if (ExtraDelay != 0)
 		{
 			_log.Log(LOG_NORM, "Delaying switch [%s] action (%s) for %d seconds", devName.c_str(), switchcmd.c_str(), ExtraDelay);
 		}
-		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(iOnDelay + ExtraDelay, idx, switchcmd, level, hue, "Switch with Delay"));
+		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(iDelay + ExtraDelay, idx, switchcmd, level, hue, "Switch with Delay"));
 		return true;
 	}
 	else

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -10993,7 +10993,7 @@ bool MainWorker::SwitchLight(const unsigned long long idx, const std::string &sw
 	//Get Device details
 	std::vector<std::vector<std::string> > result;
 	result=m_sql.safe_query(
-		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue,AddjValue2,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %llu)",
+		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %llu)",
 		idx);
 	if (result.size()<1)
 		return false;
@@ -11003,12 +11003,11 @@ bool MainWorker::SwitchLight(const unsigned long long idx, const std::string &sw
 	//unsigned char dType = atoi(sd[3].c_str());
 	//unsigned char dSubType = atoi(sd[4].c_str());
 	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
-	int iOffDelay = atoi(sd[6].c_str());
-	int iOnDelay = atoi(sd[7].c_str());
-	int nValue = atoi(sd[8].c_str());
-	std::string sValue = sd[9].c_str();
-	std::string devName = sd[10].c_str();
-	//std::string sOptions = sd[11].c_str();
+	int iOnDelay = atoi(sd[6].c_str());
+	int nValue = atoi(sd[7].c_str());
+	std::string sValue = sd[8].c_str();
+	std::string devName = sd[9].c_str();
+	//std::string sOptions = sd[10].c_str();
 
 	bool bIsOn = IsLightSwitchOn(switchcmd);
 	if (ooc)//Only on change
@@ -11023,9 +11022,9 @@ bool MainWorker::SwitchLight(const unsigned long long idx, const std::string &sw
 	if (switchtype == STYPE_Selector) {
 		bIsOn = (level > 0) ? true : false;
 	}
-	int iDelay = bIsOn ? iOnDelay : iOffDelay;
+	int iDelay = bIsOn ? iOnDelay : 0;
 
-	//Check if we have an OnDelay/OffDelay, if yes, add it to the tasker
+	//Check if we have an OnDelay, if yes, add it to the tasker
 	if ((iDelay != 0) || ExtraDelay)
 	{
 		if (ExtraDelay != 0)


### PR DESCRIPTION
This patch consists of :
- Handle OnDelay and OffDelay the same way for all devices ;
- Fix Selector switch OnDelay and OffDelay management.

**I've tested it with a button (On/Off), a Selector switch, a Scene and a Blockly script to control a button but I don't know if it covers all cases.**
