### PR TITLE
Fix ugly separator at start of Evohome zone status message

### DIFF
--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -631,17 +631,28 @@ define(['app'], function (app) {
 								tUntil=item.Until;
 							if (typeof item.SetPoint != 'undefined'){
 								bigtext+=' ('+item.SetPoint + '\u00B0 ' + $scope.config.TempSign + ')';
-								status+=', '+$.t('Set Point') + ': ' + item.SetPoint + '\u00B0 ' + $scope.config.TempSign;
+								if (bHaveBefore==true) {
+									status+=', ';
+								}
+								status+=$.t('Set Point') + ': ' + item.SetPoint + '\u00B0 ' + $scope.config.TempSign;
 								setonclick='EditSetPoint(' + item.idx + ',\'' + item.Name + '\',\'' + item.Description + '\',' + item.SetPoint + ', \''+sHeatMode+'\', \''+tUntil+'\', \'ShowTemps\');';
+								bHaveBefore=true;
 							}
 							if (typeof item.State != 'undefined'){
 								bigtext+=' <img height="12" src="images/evohome/'+item.State+'.png" />'
-								status+=', '+$.t('State') + ': ' + item.State;
+								if (bHaveBefore==true) {
+									status+=', ';
+								}
+								status+=$.t('State') + ': ' + item.State;
 								setonclick='EditState(' + item.idx + ',\'' + item.Name + '\',\'' + item.Description + '\',\'' + item.State + '\', \''+sHeatMode+'\', \''+tUntil+'\', \'ShowTemps\');';
+								bHaveBefore=true;
 							}
 							if(sHeatMode!="Auto")
 								bigtext+=' <img height="15" src="images/evohome/'+sHeatMode+((item.SubType=="Hot Water")?"Inv":"")+'.png" />'
-							status+=', '+$.t('Mode') + ': ' + EvoDisplayTextMode(sHeatMode);
+							if (bHaveBefore==true) {
+								status+=', ';
+							}
+							status+=$.t('Mode') + ': ' + EvoDisplayTextMode(sHeatMode);
 							if (tUntil!=""){
 								status+=', '+$.t('Until') + ': ' + tUntil.replace(/T/,' ').replace(/\..+/, '');
 							}
@@ -698,6 +709,10 @@ define(['app'], function (app) {
 									nbackcolor="#DDDF2D";
 								}
 							}
+						}
+						if (status.substr(0,2)==", ") {
+							statusnew=status.substr(2);
+							status=statusnew;
 						}
 						//Evohome...
 						nbackcolor=EvoSetPointColor(item,sHeatMode,nbackcolor);
@@ -922,12 +937,20 @@ define(['app'], function (app) {
 							var bHaveBefore=false;
 							if (item.SubType=="Zone" || item.SubType=="Hot Water") {
 								if (typeof item.SetPoint != 'undefined'){
-									xhtm+=', '+$.t('Set Point') + ': ' + item.SetPoint + '\u00B0 ' + $scope.config.TempSign;
+									xhtm+=$.t('Set Point') + ': ' + item.SetPoint + '\u00B0 ' + $scope.config.TempSign;
+									bHaveBefore=true;
 								}
 								if (typeof item.State != 'undefined'){
-									xhtm+=', '+$.t('State') + ': ' + item.State;
+									if (bHaveBefore==true) {
+										xhtm+=', ';
+									}
+									xhtm+=$.t('State') + ': ' + item.State;
+									bHaveBefore=true;
 								}
-								xhtm+=', '+$.t('Mode') + ': ' + EvoDisplayTextMode(sHeatMode);
+								if (bHaveBefore==true) {
+									xhtm+=', ';
+								}
+								xhtm+=$.t('Mode') + ': ' + EvoDisplayTextMode(sHeatMode);
 								if (typeof item.Until != 'undefined'){
 									tUntil=item.Until;
 									xhtm+=', '+$.t('Until') + ': ' + tUntil.replace(/T/,' ').replace(/\..+/, '');


### PR DESCRIPTION
Current status message in Evohome zone objects in the Temperature view starts with ", "
