### PR TITLE
Fix invalid TimeUntil value in evohome SetSetPoint

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -11082,6 +11082,8 @@ bool MainWorker::SetSetPoint(const std::string &idx, const float TempValue, cons
 		tsen.EVOHOME2.mode=newMode;
 		if(newMode==CEvohome::zmTmp)
 			CEvohomeDateTime::DecodeISODate(tsen.EVOHOME2,until.c_str());
+		else
+			tsen.EVOHOME2.year=0xFFFF;
 		WriteToHardware(HardwareID,(const char*)&tsen,sizeof(tsen.EVOHOME2));
 
 		//Pass across the current controller mode if we're going to update as per the hw device


### PR DESCRIPTION
Somehow the struct that controls the behaviour of this function is not correctly preloaded with the right values. I attempted various fixes to evohome.h and evohome.cpp, to no avail. This fix is to the SetSetPoint() function in mainworker and enforces the expected value for 'year' that makes the code call the hardware interface with the correct parameters.

I do not own an HGI80 but I suspect this will also solve issue #373 opened on Jan 22 by Jaap-Jan
