### PR TITLE
Fixed harmony hub url to use http

### DIFF
--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -40,7 +40,7 @@ Cleanup and changes: GizMoCuz
 
 #define HARMONY_COMMUNICATION_PORT					5222
 #define TEMP_AUTH_TOKEN								"TEMP_AUT_TOKEN"
-#define LOGITECH_AUTH_URL							"https://svcs.myharmony.com/CompositeSecurityServices/Security.svc/json/GetUserAuthToken"
+#define LOGITECH_AUTH_URL							"http://svcs.myharmony.com/CompositeSecurityServices/Security.svc/json/GetUserAuthToken"
 #define LOGITECH_AUTH_HOSTNAME						"svcs.myharmony.com"
 #define LOGITECH_AUTH_PATH							"/CompositeSecurityServices/Security.svc/json/GetUserAuthToken"
 #define HARMONY_HUB_AUTHORIZATION_TOKEN_FILENAME	"HarmonyHub.AuthorizationToken"


### PR DESCRIPTION
Implementation should be fixed to use ssl later - now it uses http, but this one url has https prefix -> Squid proxy won't allow connections trough with invalid request
