### PR TITLE
Add ByronSX door button to RFLink

### DIFF
--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -616,7 +616,6 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 			bHaveBlind = true;
 			blind = RFLinkGetIntStringValue(results[ii]);
 		}
-
 		else if (results[ii].find("KWATT") != std::string::npos)
 		{
 			iTemp = RFLinkGetHexStringValue(results[ii]);
@@ -675,6 +674,13 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 			switchunit = 1;
 			bHaveSwitchCmd = true;
 			switchcmd = RFLinkGetStringValue(results[ii]);
+		}
+		else if (results[ii].find("CHIME") != std::string::npos)
+		{
+			bHaveSwitch = true;
+			switchunit = 2;
+			bHaveSwitchCmd = true;
+			switchcmd = "ON";
 		}
 	}
 


### PR DESCRIPTION
In fact it adds all chimes supported by RFLink. Apart from ByronSX it allows to use:
- Select Plus wireless Doorbell
- Plieger York Doorbell protocol
- Deltronic Doorbell
- RL-02 Digital Doorbell
- Lidl/SilverCrest Doorbell  Z31370-TX
