### PR TITLE
Add Math toolbox operators to Blockly Events Editor

### DIFF
--- a/www/eventsframe.html
+++ b/www/eventsframe.html
@@ -868,6 +868,49 @@
 	   		<block type="logic_setrandom"></block>
 	   		<block type="math_number"></block>
    		</category>
+   		<category name="Math">
+   			<block type="math_number"></block>
+			<block type="math_arithmetic"></block>
+			<block type="math_single"></block>
+			<block type="math_trig"></block>
+			<block type="math_constant"></block>
+			<block type="math_number_property"></block>
+			<block type="math_change">
+			<value name="DELTA">
+			  <block type="math_number">
+			    <field name="NUM">1</field>
+			  </block>
+			</value>
+			</block>
+			<block type="math_round"></block>
+			<block type="math_on_list"></block>
+			<block type="math_modulo"></block>
+			<block type="math_constrain">
+			<value name="LOW">
+			  <block type="math_number">
+			    <field name="NUM">1</field>
+			  </block>
+			</value>
+			<value name="HIGH">
+			  <block type="math_number">
+			    <field name="NUM">100</field>
+			  </block>
+			</value>
+			</block>
+			<block type="math_random_int">
+			<value name="FROM">
+			  <block type="math_number">
+			    <field name="NUM">1</field>
+			  </block>
+			</value>
+			<value name="TO">
+			  <block type="math_number">
+			    <field name="NUM">100</field>
+			  </block>
+			</value>
+			</block>
+			<block type="math_random_float"></block>
+   		</category>
    		<category name="Time">
 	   		<block type="logic_timeofday"></block>
 	   		<block type="logic_weekday"></block>

--- a/www/eventsframe.html
+++ b/www/eventsframe.html
@@ -875,13 +875,6 @@
 			<block type="math_trig"></block>
 			<block type="math_constant"></block>
 			<block type="math_number_property"></block>
-			<block type="math_change">
-			<value name="DELTA">
-			  <block type="math_number">
-			    <field name="NUM">1</field>
-			  </block>
-			</value>
-			</block>
 			<block type="math_round"></block>
 			<block type="math_on_list"></block>
 			<block type="math_modulo"></block>


### PR DESCRIPTION
Edits to eventsframe.html to enable blocky math operators. Tested in v3.4834 stable.
