### PR TITLE
PiFace counter types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ CMakeCache.txt
 domoticz
 stdafx.h.gch
 .DS_Store
+.AppleDouble
 Config/OZW_Log.txt
 Config/zwscene.xml
 backups/

--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -1,30 +1,32 @@
 /************************************************************************
-*
-PiFace Interface board driver for Domoticz
-Date: 01-10-2013
-Written by: Robin Stevenhagen
-License: Public domain
-
-Date: 18-06-2015
-GizMoCuz: Added messages to a send queue
-
-
-SPI code is based on code from:
-The WiringPi project
+ *
+ PiFace Interface board driver for Domoticz
+ Date: 01-10-2013
+ Written by: Robin Stevenhagen
+ License: Public domain
+ 
+ Date: 18-06-2015
+ GizMoCuz: Added messages to a send queue
+ 
+ Date: 08-04-2016
+ BobKersten: Added multiple counter types
+ 
+ SPI code is based on code from:
+ The WiringPi project
  *    Copyright (c) 2012 Gordon Henderson
  ***********************************************************************
  * See    https://projects.drogon.net/raspberry-pi/wiringpi/
  ***********************************************************************
-
+ 
  Code uses SPI dev 0.0, as this is the interface were the PiFace resides.
  PiFace has 8 Input (4 buttons) and 8 Output pins, of which output 0 and 1 are relay outputs.
  Driver autodetects all available PiFace boards on startup, and scans them.
-
+ 
  Default config (without config):
  Input 0..3 enabled with rising edge detection
  Input 4..7 enabled for pulse counting
  Output 0..7 enbled with level feedback reporting.
-
+ 
  ************************************************************************/
 
 #include "stdafx.h"
@@ -36,7 +38,7 @@ The WiringPi project
 #include <string.h>
 #include <string>
 #ifdef __arm__
-	#include <linux/types.h>
+    #include <linux/types.h>
     #include <linux/spi/spidev.h>
     #include <unistd.h>
     #include <sys/ioctl.h>
@@ -55,33 +57,38 @@ The WiringPi project
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 
-#define PIFACE_INPUT_PROCESS_INTERVAL 5                //100 msec
-#define PIFACE_COUNTER_COUNTER_INTERVAL 1
-#define PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS 20
+#define PIFACE_INPUT_PROCESS_INTERVAL           5                // 100 msec
+#define PIFACE_COUNTER_COUNTER_INTERVAL         1
+#define PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS  20
 
 #define DISABLE_NEW_FUNCTIONS
 
 extern std::string szUserDataFolder;
+
+const std::string CPiFace::ParameterNames[CONFIG_NR_OF_PARAMETER_TYPES]                       = {"enable","enabled","pin_type","count_enable","count_enabled","count_update_interval_sec","count_update_interval_s","count_update_interval","count_initial_value","count_minimum_pulse_period_msec","count_type","count_divider"};
+const std::string CPiFace::ParameterBooleanValueNames[CONFIG_NR_OF_PARAMETER_BOOL_TYPES]      = {"false","0","true","1"};
+const std::string CPiFace::ParameterPinTypeValueNames[CONFIG_NR_OF_PARAMETER_PIN_TYPES]       = {"level","inv_level","rising","falling"};
+const std::string CPiFace::ParameterCountTypeValueNames[CONFIG_NR_OF_PARAMETER_COUNT_TYPES]   = {"generic","rfxmeter","energy"};
 
 CPiFace::CPiFace(const int ID)
 {
     m_stoprequested=false;
     m_HwdID=ID;
     m_bIsStarted=false;
-
-	for (int i = 0; i < 4; i++)
-	{
-		m_Inputs[i].Callback_pntr = (void*)this; // Set callback pointer, to enable events from IO class
-		m_Inputs[i].SetID(i);
-		m_Outputs[i].Callback_pntr = (void*)this; // Set callback pointer, to enable events from IO class
-		m_Outputs[i].SetID(i);
-	}
-	m_fd = 0;
+    
+    for (int i = 0; i < 4; i++)
+    {
+        m_Inputs[i].Callback_pntr = (void*)this; // Set callback pointer, to enable events from IO class
+        m_Inputs[i].SetID(i);
+        m_Outputs[i].Callback_pntr = (void*)this; // Set callback pointer, to enable events from IO class
+        m_Outputs[i].SetID(i);
+    }
+    m_fd = 0;
 }
 
 CPiFace::~CPiFace()
 {
-
+    
 }
 
 
@@ -112,43 +119,43 @@ std::string & CPiFace::preprocess(std::string &s)
 {
     std::string temp;
     std::string tempstripped;
-
+    
     temp.resize(s.size());
     std::transform(s.begin(),s.end(),temp.begin(),::tolower);
-
+    
     tempstripped = trim(temp);
-
+    
     s=tempstripped;
     return s;
 }
 
 int CPiFace::LocateValueInParameterArray(std::string Parametername,const std::string *ParameterArray,int Items)
 {
- int NameFound=-1; //assume not found
- int Parameter_Index;
-
+    int NameFound=-1; //assume not found
+    int Parameter_Index;
+    
     for (Parameter_Index=0;(Parameter_Index < Items) && (NameFound==-1);Parameter_Index++)
     {
-      if (Parametername.compare(ParameterArray[Parameter_Index])==0)
-       {
-        NameFound=Parameter_Index;
-       }
+        if (Parametername.compare(ParameterArray[Parameter_Index])==0)
+        {
+            NameFound=Parameter_Index;
+        }
     }
- return (NameFound);
+    return (NameFound);
 }
 
 int CPiFace::GetParameterString(std::string TargetString,const char * SearchStr, int StartPos,  std::string &Parameter)
 {
-   int EndPos=-1;
-   std::string Substring;
-   std::string SearchString(SearchStr);
-
-   EndPos=TargetString.find(SearchString,StartPos);
-   if (EndPos >= 0)
+    int EndPos=-1;
+    std::string Substring;
+    std::string SearchString(SearchStr);
+    
+    EndPos=TargetString.find(SearchString,StartPos);
+    if (EndPos >= 0)
     {
-       Substring=TargetString.substr(StartPos,EndPos-StartPos);
-       Parameter=preprocess(Substring);
-       EndPos=EndPos+SearchString.length(); //set endposition to new search start position
+        Substring=TargetString.substr(StartPos,EndPos-StartPos);
+        Parameter=preprocess(Substring);
+        EndPos=EndPos+SearchString.length(); //set endposition to new search start position
     }
     return EndPos;
 }
@@ -156,286 +163,311 @@ int CPiFace::GetParameterString(std::string TargetString,const char * SearchStr,
 
 int CPiFace::LoadConfig(void)
 {
-  int result=-1;
-
-  int StartPos=-1;
-  int EndPos=-1;
-
-  std::string input;
-
-  std::string Line;
-  std::string Parameter;
-  std::string Porttype;
-  std::string Pinnumber;
-  std::string Parametername;
-  std::string Parametervalue;
-
-  const std::string ParameterNames[CONFIG_NR_OF_PARAMETER_TYPES]={"enable","enabled","pin_type","count_enable","count_enabled","count_update_interval_sec","count_update_interval_s","count_update_interval","count_initial_value","count_minimum_pulse_period_msec"};
-  const std::string ParameterBooleanValueNames[CONFIG_NR_OF_PARAMETER_BOOL_TYPES]={"false","0","true","1"};
-  const std::string ParameterPinTypeValueNames[CONFIG_NR_OF_PARAMETER_PIN_TYPES]={"level","inv_level","rising","falling"};
-  unsigned char Address=0;
-  unsigned char PinNumber=0;
-  unsigned char PortType=0;
-  int NameFound=0;
-  int ValueFound=0;
-  CIOPort *IOport=NULL;
-  bool Regenerate_Config=false;
-
-  std::string configfile=szUserDataFolder + "piface.conf";
-
-  fstream ConfigFile(configfile.c_str(), ios::in);
-
-  if (!ConfigFile.is_open())
-   {
-     //try to create one for the default board 0
-	 ConfigFile.close();
-	 _log.Log(LOG_ERROR,"PiFace: Error config file: %s not found ", configfile.c_str() );
-	 _log.Log(LOG_ERROR,"PiFace: Auto creating for board 0 ");
-	 LoadDefaultConfig();
-         AutoCreate_piface_config();
-	 fstream ConfigFile(configfile.c_str(), ios::in);
-   }
-
-
-  if (ConfigFile.is_open())
-  {
-    while (ConfigFile.good()==true)
+    int result=-1;
+    
+    int StartPos=-1;
+    int EndPos=-1;
+    
+    std::string input;
+    
+    std::string Line;
+    std::string Parameter;
+    std::string Porttype;
+    std::string Pinnumber;
+    std::string Parametername;
+    std::string Parametervalue;
+    
+    unsigned char Address=0;
+    unsigned char PinNumber=0;
+    unsigned char PortType=0;
+    int NameFound=0;
+    int ValueFound=0;
+    CIOPort *IOport=NULL;
+    bool Regenerate_Config=false;
+    
+    std::string configfile=szUserDataFolder + "piface.conf";
+    
+    fstream ConfigFile(configfile.c_str(), ios::in);
+    
+    if (!ConfigFile.is_open())
     {
-        do
+        //try to create one for the default board 0
+        ConfigFile.close();
+        _log.Log(LOG_ERROR,"PiFace: Error config file: %s not found", configfile.c_str() );
+        _log.Log(LOG_ERROR,"PiFace: Auto creating for board 0");
+        LoadDefaultConfig();
+        AutoCreate_piface_config();
+        fstream ConfigFile(configfile.c_str(), ios::in);
+    }
+    
+    
+    if (ConfigFile.is_open())
+    {
+        while (ConfigFile.good()==true)
         {
-         StartPos=-1;
-         EndPos=-1;
-         getline(ConfigFile,input,'\n');    //get line from config file
-         Line=preprocess(input);
-
-         //find any comments
-         StartPos=Line.find("//",0);
-         if (StartPos>=0)
-           {
-             //comment found, remove it
-             Line=Line.substr(0,StartPos);
-             StartPos=-1; // reset marker
-           }
-
-         //find linesync
-         EndPos=GetParameterString(Line,".",0,Parameter);
-            if (EndPos>=0)
-              {
-               if (Parameter.compare("piface")==0)
-                {
-                 StartPos=EndPos;
-                }
-              }
-        }
-        while ((StartPos<0) && (ConfigFile.good()==true));
-
-        if (StartPos > 0)
-        {
-            //first lets get PiFace Address
-            EndPos=GetParameterString(Line,".",StartPos,Parameter);
-            if (EndPos>=0)
-              {
-                Address=(unsigned char)(strtol(Parameter.c_str(),NULL,0) & 0xFF); //data can be restricted further but as we check later on keep it wide for future use.
-                StartPos=EndPos;
-              }
-
-            //Now lets get Port Type
-            EndPos=GetParameterString(Line,".",StartPos,Parameter);
-            if (EndPos>=0)
-              {
-                if ( Parameter.compare("input") == 0)
-                  {
-                    // we have an input
-                    PortType='I';
-                  }
-                  else if ( Parameter.compare("output") == 0)
-                          {
-                            // we have an output
-                            PortType='O';
-                          }
-
-                StartPos=EndPos;
-              }
-
-            //Now lets get Pinnumber
-            EndPos=GetParameterString(Line,".",StartPos,Parameter);
-            if (EndPos>=0)
-              {
-                PinNumber=(unsigned char)(strtol(Parameter.c_str(),NULL,0) & 0xFF); //data can be restricted further but as we check later on keep it wide for future use.
-                StartPos=EndPos;
-              }
-
-            //Now lets get parameter name
-            EndPos=GetParameterString(Line,"=",StartPos,Parameter);
-            if (EndPos>=0)
-              {
-                Parametername=Parameter;
-                StartPos=EndPos;
-              }
-
-            //finaly lets get parameter value
-            Parametervalue=Line.substr(StartPos,Line.length()-StartPos);
-            Parametervalue=preprocess(Parametervalue);
-
-            if ((Address <= 3) && (PinNumber <= 7) && ((PortType=='I') || (PortType=='O')) && (Parametername.length() >0 ) && (Parametervalue.length() >0 ))
+            do
             {
-                _log.Log(LOG_STATUS,"PiFace: config file: Valid address: %d , Pin: %d and Port %c Parameter: %s , Value %s",Address,PinNumber,PortType,Parametername.c_str(),Parametervalue.c_str());
-                NameFound=LocateValueInParameterArray(Parametername,ParameterNames,CONFIG_NR_OF_PARAMETER_TYPES);
-
-                if (PortType=='I')
-                  {
-                    IOport=&m_Inputs[Address];
-                    m_Inputs[Address].Pin[PinNumber].Direction = 'I';
-                  }
-                 else {
+                StartPos=-1;
+                EndPos=-1;
+                getline(ConfigFile,input,'\n');    //get line from config file
+                Line=preprocess(input);
+                
+                //find any comments
+                StartPos=Line.find("//",0);
+                if (StartPos>=0)
+                {
+                    //comment found, remove it
+                    Line=Line.substr(0,StartPos);
+                    StartPos=-1; // reset marker
+                }
+                
+                //find linesync
+                EndPos=GetParameterString(Line,".",0,Parameter);
+                if (EndPos>=0)
+                {
+                    if (Parameter.compare("piface")==0)
+                    {
+                        StartPos=EndPos;
+                    }
+                }
+            }
+            while ((StartPos<0) && (ConfigFile.good()==true));
+            
+            if (StartPos > 0)
+            {
+                //first lets get PiFace Address
+                EndPos=GetParameterString(Line,".",StartPos,Parameter);
+                if (EndPos>=0)
+                {
+                    Address=(unsigned char)(strtol(Parameter.c_str(),NULL,0) & 0xFF); //data can be restricted further but as we check later on keep it wide for future use.
+                    StartPos=EndPos;
+                }
+                
+                //Now lets get Port Type
+                EndPos=GetParameterString(Line,".",StartPos,Parameter);
+                if (EndPos>=0)
+                {
+                    if ( Parameter.compare("input") == 0)
+                    {
+                        // we have an input
+                        PortType='I';
+                    }
+                    else if ( Parameter.compare("output") == 0)
+                    {
+                        // we have an output
+                        PortType='O';
+                    }
+                    
+                    StartPos=EndPos;
+                }
+                
+                //Now lets get Pinnumber
+                EndPos=GetParameterString(Line,".",StartPos,Parameter);
+                if (EndPos>=0)
+                {
+                    PinNumber=(unsigned char)(strtol(Parameter.c_str(),NULL,0) & 0xFF); //data can be restricted further but as we check later on keep it wide for future use.
+                    StartPos=EndPos;
+                }
+                
+                //Now lets get parameter name
+                EndPos=GetParameterString(Line,"=",StartPos,Parameter);
+                if (EndPos>=0)
+                {
+                    Parametername=Parameter;
+                    StartPos=EndPos;
+                }
+                
+                //finaly lets get parameter value
+                Parametervalue=Line.substr(StartPos,Line.length()-StartPos);
+                Parametervalue=preprocess(Parametervalue);
+                
+                if ((Address <= 3) && (PinNumber <= 7) && ((PortType=='I') || (PortType=='O')) && (Parametername.length() >0 ) && (Parametervalue.length() >0 ))
+                {
+                    _log.Log(LOG_STATUS,"PiFace: config file: Valid address: %d , Pin: %d and Port %c Parameter: %s , Value %s",Address,PinNumber,PortType,Parametername.c_str(),Parametervalue.c_str());
+                    NameFound=LocateValueInParameterArray(Parametername,ParameterNames,CONFIG_NR_OF_PARAMETER_TYPES);
+                    
+                    if (PortType=='I')
+                    {
+                        IOport=&m_Inputs[Address];
+                        m_Inputs[Address].Pin[PinNumber].Direction = 'I';
+                    }
+                    else {
                         IOport=&m_Outputs[Address];
                         m_Outputs[Address].Pin[PinNumber].Direction = 'O';
-                      }
-
-                result=0;
-
-                switch (NameFound)
-                {
-                    default:
-                            _log.Log(LOG_ERROR,"PiFace: Error config file: unknown parameter %s found ", Parametername.c_str() );
-                        break;
-                    case 0:
-                    case 1:
-                        //found enable(d)
-                          ValueFound=LocateValueInParameterArray(Parametervalue,ParameterBooleanValueNames,CONFIG_NR_OF_PARAMETER_BOOL_TYPES);
-                          if (ValueFound >=0)
-                           {
-                            if ((ValueFound == 0) || (ValueFound == 1))
+                    }
+                    
+                    result=0;
+                    
+                    switch (NameFound)
+                    {
+                        default:
+                            _log.Log(LOG_ERROR,"PiFace: Error config file: unknown parameter %s found", Parametername.c_str() );
+                            break;
+                        case 0:
+                        case 1:
+                            //found enable(d)
+                            ValueFound=LocateValueInParameterArray(Parametervalue,ParameterBooleanValueNames,CONFIG_NR_OF_PARAMETER_BOOL_TYPES);
+                            if (ValueFound >=0)
+                            {
+                                if ((ValueFound == 0) || (ValueFound == 1))
                                 {
-                                 IOport->Pin[PinNumber].Enabled=false;
+                                    IOport->Pin[PinNumber].Enabled=false;
                                 }
                                 else {
-                                      IOport->Pin[PinNumber].Enabled=true;
-                                     }
+                                    IOport->Pin[PinNumber].Enabled=true;
+                                }
+                                result++;
+                            }
+                            else _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found", Parametervalue.c_str() );
+                            break;
+                            
+                        case 2:
+                            //found pintype
+                            ValueFound=LocateValueInParameterArray(Parametervalue,ParameterPinTypeValueNames,CONFIG_NR_OF_PARAMETER_PIN_TYPES);
+                            switch ( ValueFound )
+                            {
+                                default:
+                                    _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found =>setting default level %d", Parametervalue.c_str(),ValueFound );
+                                    IOport->Pin[PinNumber].Type=LEVEL;
+                                    break;
+                                    
+                                case 0:
+                                    IOport->Pin[PinNumber].Type=LEVEL;
+                                    break;
+                                case 1:
+                                    IOport->Pin[PinNumber].Type=INV_LEVEL;
+                                    break;
+                                case 2:
+                                    IOport->Pin[PinNumber].Type=TOGGLE_RISING;
+                                    break;
+                                case 3:
+                                    IOport->Pin[PinNumber].Type=TOGGLE_FALLING;
+                                    break;
+                            }
                             result++;
-                           }
-                           else _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found ", Parametervalue.c_str() );
-                        break;
-
-                    case 2:
-                        //found pintype
-                          ValueFound=LocateValueInParameterArray(Parametervalue,ParameterPinTypeValueNames,CONFIG_NR_OF_PARAMETER_PIN_TYPES);
-                          switch (ValueFound )
-                           {
-                              default:
-                                        _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found =>setting default level %d", Parametervalue.c_str(),ValueFound );
-                                        IOport->Pin[PinNumber].Type=LEVEL;
-                                    break;
-
-                              case 0:
-                                        IOport->Pin[PinNumber].Type=LEVEL;
-                                    break;
-                              case 1:
-                                        IOport->Pin[PinNumber].Type=INV_LEVEL;
-                                    break;
-                              case 2:
-                                        IOport->Pin[PinNumber].Type=TOGGLE_RISING;
-                                    break;
-                              case 3:
-                                        IOport->Pin[PinNumber].Type=TOGGLE_FALLING;
-                                    break;
-                           }
-                           result++;
-                        break;
-
-                    case 3:
-                    case 4:
-                        //found count_enable(d)
-                         ValueFound=LocateValueInParameterArray(Parametervalue,ParameterBooleanValueNames,CONFIG_NR_OF_PARAMETER_BOOL_TYPES);
-
-                          if (ValueFound >=0)
-                           {
-                            if ((ValueFound == 0) || (ValueFound == 1))
+                            break;
+                            
+                        case 3:
+                        case 4:
+                            //found count_enable(d)
+                            ValueFound=LocateValueInParameterArray(Parametervalue,ParameterBooleanValueNames,CONFIG_NR_OF_PARAMETER_BOOL_TYPES);
+                            
+                            if (ValueFound >=0)
+                            {
+                                if ((ValueFound == 0) || (ValueFound == 1))
                                 {
-                                 IOport->ConfigureCounter(PinNumber,false);
+                                    IOport->ConfigureCounter(PinNumber,false);
                                 }
                                 else {
-                                      IOport->ConfigureCounter(PinNumber,true);
-                                     }
-                            result++;
-                           }
-                           else _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found", Parametervalue.c_str() );
-                        break;
-
-                    case 5:
-                    case 6:
-                    case 7:
-                        //count_update_interval(_s)(ec)
+                                    IOport->ConfigureCounter(PinNumber,true);
+                                }
+                                result++;
+                            }
+                            else _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found", Parametervalue.c_str() );
+                            break;
+                            
+                        case 5:
+                        case 6:
+                        case 7:
+                            //count_update_interval(_s)(ec)
                             unsigned long UpdateInterval;
-
+                            
                             UpdateInterval=strtol(Parametervalue.c_str(),NULL,0);
                             IOport->Pin[PinNumber].Count.SetUpdateInterval(UpdateInterval*1000);
                             result++;
-                        break;
-
+                            break;
+                            
 #ifndef DISABLE_NEW_FUNCTIONS
-		/*  disabled until code part is completed and tested */
-                    case 8:
-                        //count_initial_value
+                            /*  disabled until code part is completed and tested */
+                        case 8:
+                            //count_initial_value
                             unsigned long StartValue;
-
+                            
                             StartValue=strtol(Parametervalue.c_str(),NULL,0);
                             IOport->Pin[PinNumber].Count.SetCurrent(StartValue);
                             IOport->Pin[PinNumber].Count.SetTotal(StartValue);
                             result++;
                             Regenerate_Config=true;
-                        break;
-                    case 9:
-                        //count_minimum_pulse_period_msec
+                            break;
+#endif
+                        case 9:
+                            //count_minimum_pulse_period_msec
                             unsigned long Min_Pulse_Period;
-
-                            Min_Pulse_Period=strtol(Parametervalue.c_str(),NULL,0);
+                            
+                            Min_Pulse_Period=strtol(Parametervalue.c_str(),NULL,0); // results in 0 if str is invalid
                             IOport->Pin[PinNumber].Count.SetRateLimit(Min_Pulse_Period);
                             result++;
-                        break;
-#endif
+                            break;
+                        
+                        case 10:
+                            //count_type
+                            ValueFound=LocateValueInParameterArray(Parametervalue,ParameterCountTypeValueNames,CONFIG_NR_OF_PARAMETER_COUNT_TYPES);
+                            switch (ValueFound )
+                            {
+                                default:
+                                    _log.Log(LOG_ERROR,"PiFace: Error config file: unknown value %s found", Parametervalue.c_str());
+                                    break;
+                                    
+                                case 0: // generic
+                                    IOport->Pin[PinNumber].Count.Type = COUNT_TYPE_GENERIC;
+                                    break;
+                                case 1: // rfxmeter
+                                    IOport->Pin[PinNumber].Count.Type = COUNT_TYPE_RFXMETER;
+                                    break;
+                                case 2: // energy
+                                    IOport->Pin[PinNumber].Count.Type = COUNT_TYPE_ENERGY;
+                                    break;
+                            }
+                            result++;
+                            break;
+                        
+                        case 11:
+                            //count_divider
+                            IOport->Pin[PinNumber].Count.SetDivider(strtol(Parametervalue.c_str(), NULL, 0));
+                            result++;
+                            break;
+                    }
                 }
+                else _log.Log(LOG_ERROR,"PiFace: Error config file: misformed config line %s found", Line.c_str() );
             }
-            else _log.Log(LOG_ERROR,"PiFace: Error config file: misformed config line %s found ", Line.c_str() );
         }
-    }
-	ConfigFile.close();
+        ConfigFile.close();
 #ifndef DISABLE_NEW_FUNCTIONS
-	if (Regenerate_Config)
-	  {
-	      Regenerate_Config=false;
-	     _log.Log(LOG_ERROR,"PiFace: We got an initial value setting, so we are now recreating the logfile to avoid looping", configfile.c_str() );
-	     AutoCreate_piface_config();
-	  }
+        if (Regenerate_Config)
+        {
+            Regenerate_Config=false;
+            _log.Log(LOG_ERROR,"PiFace: We got an initial value setting, so we are now recreating the logfile to avoid looping", configfile.c_str() );
+            AutoCreate_piface_config();
+        }
 #endif
-  }
-  else {
-        _log.Log(LOG_ERROR,"PiFace: Error PiFace config file: %s not found ", configfile.c_str() );
+    }
+    else {
+        _log.Log(LOG_ERROR,"PiFace: Error PiFace config file: %s not found", configfile.c_str() );
         _log.Log(LOG_ERROR,"PiFace: loading defaults for PiFace(s)");
         LoadDefaultConfig();
         AutoCreate_piface_config();
-       }
-  return result;
+    }
+    return result;
 }
 
 void CPiFace::LoadDefaultConfig(void)
 {
-   for (int i=0; i<=3 ;i++)
+    for (int i=0; i<=3 ;i++)
     {
-       for (int Pnr=0; Pnr<=7 ;Pnr++)
+        for (int Pnr=0; Pnr<=7 ;Pnr++)
         {
             if (Pnr < 4)
-                {
-                    m_Inputs[i].Pin[Pnr].Enabled=true;
-                }
+            {
+                m_Inputs[i].Pin[Pnr].Enabled=true;
+            }
             m_Inputs[i].Pin[Pnr].Type=TOGGLE_RISING;
             m_Inputs[i].Pin[Pnr].Count.SetUpdateInterval(10000);
             m_Inputs[i].Pin[Pnr].Direction = 'I';
-
+            
             if (Pnr >= 4)
-                {
-                    m_Inputs[i].ConfigureCounter(Pnr,true);
-                }
+            {
+                m_Inputs[i].ConfigureCounter(Pnr,true);
+            }
             m_Outputs[i].ConfigureCounter(Pnr,true);
             m_Outputs[i].Pin[Pnr].Type=LEVEL;
             m_Outputs[i].Pin[Pnr].Count.SetUpdateInterval(10000);
@@ -446,205 +478,153 @@ void CPiFace::LoadDefaultConfig(void)
 
 void CPiFace::AutoCreate_piface_config(void)
 {
-    char explanation[52][200]={\
-    {"//piface.conf [Autogenerated]\r\n"},\
-    {"//This file is part of the PiFace driver (written by Robin Stevenhagen) for domoticz, and allows for more advanced pin configuration options\r\n"},\
-    {"//This file can optionaly hold all the configuration for all attached PiFace boards.\r\n"},\
-    {"//Please note that if this file is found the default config is discarded, and only the configuration in this file is used, all IO that is not specified will\r\n/"},\
-    {"//be configured as not used.\r\n"},\
-    {"//\r\n"},\
-    {"// Configuration line syntax:\r\n"},\
-    {"// piface.<board address>.<I/O>.<pin number>.<parameter>=<value>\r\n"},\
-    {"//\r\n"},\
-    {"// <board address>:                Check piface (JP1 & JP2) jumper settings, value between 0..3\r\n"},\
-    {"//\r\n"},\
-    {"// <I/O>:                          input\r\n"},\
-    {"//                                 output\r\n"},\
-    {"//\r\n"},\
-    {"// <pinnumber>:                    value between 0..7\r\n"},\
-    {"//\r\n"},\
-    {"// <parameter>:                    enabled\r\n"},\
-    {"//                                 pin_type\r\n"},\
-    {"//                                 count_enabled\r\n"},\
-    {"//                                 count_update_interval_sec\r\n"},\
-    {"//                                 count_initial_value\r\n"},\
-    {"//                                 count_minimum_pulse_period\r\n"},\
-    {"//\r\n"},\
-    {"// Available <parameter> / <values>:\r\n"},\
-    {"// enabled:                        true  or 1\r\n"},\
-    {"//                                 false or 0\r\n"},\
-    {"//\r\n"},\
-    {"// pin_type:                       level                     //best to keep this paramter to level for outputs, as Domoticz does not like other values\r\n"},\
-    {"//                                 inv_level\r\n"},\
-    {"//                                 rising\r\n"},\
-    {"//                                 falling\r\n"},\
-    {"//\r\n"},\
-    {"// count_enabled:                  true  or 1\r\n"},\
-    {"//                                 false or 0\r\n"},\
-    {"//\r\n"},\
-    {"// count_update_interval_sec:      0 to 3600\r\n"},\
-    {"//\r\n"},\
-    {"// count_initial_value:            0 to 4294967295 counts\r\n"},\
-    {"// Note1: The initial_value will only be used once. After it has been set, a new piface.conf will automatically be generated without the initial_value parameter(s)\r\n"},\
-    {"// to ensure that it will only be used once.\r\n"},\
-    {"// Using the initial_value to set a counter to a desired (start) value, will result in spikes in the Domoticz graphs.\r\n"},\
-    {"// Note2: The initial_value is in counter counts, Domoticz scales (divides) this by the factor that is set in the GUI settings \r\n"},\
-    {"//\r\n"},\
-    {"// count_minimum_pulse_period_msec:     0 to 4294967295 milliseconds\r\n"},\
-    {"//                                 This parameter sets a pulse rate limiter.\r\n"},\
-    {"//                                 If multiple pulses are detected within the specified time period, they are ignored until the specified idle time has been met.\r\n"},\
-    {"//                                 This can be usefull for opto reflective sensors that count slow moving dials. Like watermeters of gasmeters,\r\n"},\
-    {"//                                 where the dial can stop on an opto barrier and cause oscillations (and unwanted counts).\r\n"},\
-    {"//                                 0 = off \r\n"},\
-    {"//                                 < 100 msec times will not be very effective.\r\n"},\
-    {"//\r\n"}};
-
-
-  const std::string ParameterPinTypeValueNames[CONFIG_NR_OF_PARAMETER_PIN_TYPES]={"level","inv_level","rising","falling"};
-  char configline[100];
-  std::string ValueText;
-  std::string PortType;
-  int Value;
-  CIOPort *IOport;
-
-  std::string configfile=szUserDataFolder + "piface.conf";
-  fstream ConfigFile(configfile.c_str(), ios::out);
-
-  if (ConfigFile.is_open())
-  {
-    for (int i=0; i < 36 ;i++)
-     {
-      ConfigFile.write(explanation[i],strlen(explanation[i]));
-     }
-
-    for (int BoardNr=0; BoardNr< 1 ;BoardNr++) // Note there could be 4 boards, but this will create a lot of entires in the configfile
+    
+    int size = 57;
+    char explanation[size][200]={\
+        {"//piface.conf [Autogenerated]\r\n"},\
+        {"//This file is part of the PiFace driver (written by Robin Stevenhagen) for domoticz, and allows for more advanced pin configuration options\r\n"},\
+        {"//This file can optionaly hold all the configuration for all attached PiFace boards.\r\n"},\
+        {"//Please note that if this file is found the default config is discarded, and only the configuration in this file is used, all IO that is not specified will\r\n/"},\
+        {"//be configured as not used.\r\n"},\
+        {"//\r\n"},\
+        {"// Configuration line syntax:\r\n"},\
+        {"// piface.<board address>.<I/O>.<pin number>.<parameter>=<value>\r\n"},\
+        {"//\r\n"},\
+        {"// <board address>:                Check piface (JP1 & JP2) jumper settings, value between 0..3\r\n"},\
+        {"//\r\n"},\
+        {"// <I/O>:                          input\r\n"},\
+        {"//                                 output\r\n"},\
+        {"//\r\n"},\
+        {"// <pinnumber>:                    value between 0..7\r\n"},\
+        {"//\r\n"},\
+        {"// <parameter>:                    enabled\r\n"},\
+        {"//                                 pin_type\r\n"},\
+        {"//                                 count_enabled\r\n"},\
+        {"//                                 count_update_interval_sec\r\n"},\
+        {"//                                 count_initial_value\r\n"},\
+        {"//                                 count_minimum_pulse_period\r\n"},\
+        {"//\r\n"},\
+        {"// Available <parameter> / <values>:\r\n"},\
+        {"// enabled:                        true  or 1\r\n"},\
+        {"//                                 false or 0\r\n"},\
+        {"//\r\n"},\
+        {"// pin_type:                       level                     // best to keep this paramter to level for outputs, as Domoticz does not like other values\r\n"},\
+        {"//                                 inv_level\r\n"},\
+        {"//                                 rising\r\n"},\
+        {"//                                 falling\r\n"},\
+        {"//\r\n"},\
+        {"// count_enabled:                  true  or 1\r\n"},\
+        {"//                                 false or 0\r\n"},\
+        {"//\r\n"},\
+        {"// count_type:                     generic or rfxmeter       // default\r\n"},\
+        {"//                                 energy\r\n"},\
+        {"//\r\n"},\
+        {"// count_divider:                  1000                      // default\r\n"},\
+        {"//                                 Pulses per unit.\r\n"},\
+        {"//\r\n"},\
+        {"// count_update_interval_sec:      0 to 3600\r\n"},\
+        {"//\r\n"},\
+        {"// count_initial_value:            0 to 4294967295 counts\r\n"},\
+        {"// Note1: The initial_value will only be used once. After it has been set, a new piface.conf will automatically be generated without the initial_value parameter(s)\r\n"},\
+        {"// to ensure that it will only be used once.\r\n"},\
+        {"// Using the initial_value to set a counter to a desired (start) value, will result in spikes in the Domoticz graphs.\r\n"},\
+        {"// Note2: The initial_value is in counter counts, Domoticz scales (divides) this by the factor that is set in the GUI settings \r\n"},\
+        {"//\r\n"},\
+        {"// count_minimum_pulse_period_msec:     0 to 4294967295 milliseconds\r\n"},\
+        {"//                                 This parameter sets a pulse rate limiter.\r\n"},\
+        {"//                                 If multiple pulses are detected within the specified time period, they are ignored until the specified idle time has been met.\r\n"},\
+        {"//                                 This can be usefull for opto reflective sensors that count slow moving dials. Like watermeters of gasmeters,\r\n"},\
+        {"//                                 where the dial can stop on an opto barrier and cause oscillations (and unwanted counts).\r\n"},\
+        {"//                                 0 = off \r\n"},\
+        {"//                                 < 100 msec times will not be very effective.\r\n"},\
+        {"//\r\n"}\
+    };
+    
+    char configline[100];
+    std::string ValueText;
+    std::string PortType;
+    int Value;
+    CIOPort *IOport;
+    
+    std::string configfile=szUserDataFolder + "piface.conf";
+    fstream ConfigFile(configfile.c_str(), ios::out);
+    
+    if (ConfigFile.is_open())
     {
-       for (int PinNr=0; PinNr<=7 ;PinNr++)
+        for (int i=0; i < size ;i++)
         {
-            for (int IOType=0; IOType <= 1 ; IOType++)
+            ConfigFile.write(explanation[i],strlen(explanation[i]));
+        }
+        
+        for (int BoardNr=0; BoardNr< 1 ;BoardNr++) // Note there could be 4 boards, but this will create a lot of entires in the configfile
+        {
+            for (int PinNr=0; PinNr<=7 ;PinNr++)
+            {
+                for (int IOType=0; IOType <= 1 ; IOType++)
                 {
                     if (IOType==0)
-                        {
-                            PortType="output";
-                            IOport=&m_Outputs[BoardNr];
-                        }
-                        else {
-                                PortType="input";
-                                IOport=&m_Inputs[BoardNr];
-                             }
-
+                    {
+                        PortType="output";
+                        IOport=&m_Outputs[BoardNr];
+                    }
+                    else {
+                        PortType="input";
+                        IOport=&m_Inputs[BoardNr];
+                    }
+                    
                     if (IOport->Pin[PinNr].Enabled)
-                          ValueText="true";
-                     else ValueText="false";
+                        ValueText="true";
+                    else ValueText="false";
                     sprintf(configline,"piface.%d.%s.%d.enabled=%s\r\n",BoardNr,PortType.c_str(),PinNr,ValueText.c_str());
                     ConfigFile.write(configline,strlen(configline));
-
+                    
                     ValueText=ParameterPinTypeValueNames[IOport->Pin[PinNr].Type];
                     sprintf(configline,"piface.%d.%s.%d.pin_type=%s\r\n",BoardNr,PortType.c_str(),PinNr,ValueText.c_str());
                     ConfigFile.write(configline,strlen(configline));
-
+                    
                     if (IOport->Pin[PinNr].Count.Enabled)
-                          ValueText="true";
-                     else ValueText="false";
+                        ValueText="true";
+                    else ValueText="false";
                     sprintf(configline,"piface.%d.%s.%d.count_enabled=%s\r\n",BoardNr,PortType.c_str(),PinNr,ValueText.c_str());
                     ConfigFile.write(configline,strlen(configline));
 
+                    ValueText=ParameterCountTypeValueNames[IOport->Pin[PinNr].Count.Type];
+                    sprintf(configline,"piface.%d.%s.%d.count_type=%s\r\n",BoardNr,PortType.c_str(),PinNr,ValueText.c_str());
+                    ConfigFile.write(configline,strlen(configline));
+
+                    Value=IOport->Pin[PinNr].Count.GetDivider();
+                    sprintf(configline,"piface.%d.%s.%d.count_divider=%d\r\n",BoardNr,PortType.c_str(),PinNr,Value);
+                    ConfigFile.write(configline,strlen(configline));
+                    
                     Value=IOport->Pin[PinNr].Count.GetUpdateInterval()/1000;
                     sprintf(configline,"piface.%d.%s.%d.count_update_interval_sec=%d\r\n",BoardNr,PortType.c_str(),PinNr,Value);
-					ConfigFile.write(configline,strlen(configline));
-
-#ifndef DISABLE_NEW_FUNCTIONS
+                    ConfigFile.write(configline,strlen(configline));
+                    
                     Value=IOport->Pin[PinNr].Count.GetRateLimit();
                     sprintf(configline,"piface.%d.%s.%d.count_minimum_pulse_period_msec=%lu\r\n",BoardNr,PortType.c_str(),PinNr,Value);
-					ConfigFile.write(configline,strlen(configline));
-#endif
-
-					sprintf(configline,"\r\n");
-					ConfigFile.write(configline,strlen(configline));
+                    ConfigFile.write(configline,strlen(configline));
+                    
+                    sprintf(configline,"\r\n");
+                    ConfigFile.write(configline,strlen(configline));
                 }
+            }
         }
+        
     }
-
-  }
-  ConfigFile.close();
+    ConfigFile.close();
 }
-
 
 /***** end of config file stuff *****/
 
-
-void CPiFace::GetLastKnownValues(void)
-{
- unsigned char devType;
- unsigned char subType;
- unsigned char unit;
- int BoardNr;
- int PinNr;
- int meterid;
- char DeviceID[100];
- int nValue;
- std::string sValue;
- struct tm LastUpdateTime;
-
-  for (BoardNr=0;BoardNr < 4 ; BoardNr++)
-    {
-        for (PinNr=0;PinNr < 8 ; PinNr++)
-        {
-            meterid=100+PinNr + (m_Inputs[BoardNr].GetDevId()*10); //add 100 for input type
-              sprintf(DeviceID,"%d",meterid);
-            unit=0;
-            devType=pTypeRFXMeter;
-            subType=sTypeRFXMeterCount;
-
-
-            if (m_sql.GetLastValue(m_HwdID,DeviceID, unit, devType, subType, nValue, sValue,LastUpdateTime))
-               {
-                    if ((nValue == 0) && (sValue.size()!=0))
-                        {
-                            nValue=atoi(sValue.c_str());
-                        }
-                    m_Inputs[BoardNr].Pin[PinNr].Count.SetCurrent(nValue);
-                    m_Inputs[BoardNr].Pin[PinNr].Count.SetTotal(nValue);
-                    _log.Log(LOG_NORM,"PiFace: retrieved value for Input counter: BoardNr %d , Pin: %d, Value %d",BoardNr,PinNr,nValue);
-               }
-              // else _log.Log(LOG_ERROR,"PiFace no value retrieved for input: BoardNr %d , Pin: %d; DeviceID %s not found",BoardNr,PinNr,DeviceID);
-        }
-    }
-
-     for (BoardNr=0;BoardNr < 4 ; BoardNr++)
-    {
-        for (PinNr=0;PinNr < 8 ; PinNr++)
-        {
-            meterid=0+PinNr + (m_Inputs[BoardNr].GetDevId()*10); //add 0 for output type
-			sprintf(DeviceID,"%d",meterid);
-            unit=0;
-            devType=pTypeRFXMeter;
-            subType=sTypeRFXMeterCount;
-
-            if (m_sql.GetLastValue(m_HwdID,DeviceID, unit, devType, subType, nValue, sValue,LastUpdateTime))
-               {
-                    if ((nValue == 0) && (sValue.size()!=0))
-                        {
-                            nValue=atoi(sValue.c_str());
-                        }
-                    m_Outputs[BoardNr].Pin[PinNr].Count.SetCurrent(nValue);
-                    m_Outputs[BoardNr].Pin[PinNr].Count.SetTotal(nValue);
-                    _log.Log(LOG_NORM,"PiFace: retrieved value for Output counter: BoardNr %d , Pin: %d, Value %d",BoardNr,PinNr,nValue);
-               }
-              // else _log.Log(LOG_ERROR,"PiFace: no value retrieved for input: BoardNr %d , Pin: %d; DeviceID %s not found",BoardNr,PinNr,DeviceID);
-        }
-    }
-}
-
 void CPiFace::CallBackSendEvent(const unsigned char *pEventPacket, const unsigned int PacketLength)
 {
-	std::string sendData;
-	sendData.insert(sendData.begin(), pEventPacket, pEventPacket + PacketLength);
-	boost::lock_guard<boost::mutex> l(m_queue_mutex);
-	if (m_send_queue.size() < 100)
-		m_send_queue.push_back(sendData);
-	else
-		_log.Log(LOG_ERROR, "PiFace: to much messages on queue!");
+    std::string sendData;
+    sendData.insert(sendData.begin(), pEventPacket, pEventPacket + PacketLength);
+    boost::lock_guard<boost::mutex> l(m_queue_mutex);
+    if (m_send_queue.size() < 100)
+        m_send_queue.push_back(sendData);
+    else
+        _log.Log(LOG_ERROR, "PiFace: to much messages on queue!");
 }
 
 void CPiFace::CallBackSetPinInterruptMode(unsigned char devId,unsigned char pinID, bool Interrupt_Enable)
@@ -654,60 +634,60 @@ void CPiFace::CallBackSetPinInterruptMode(unsigned char devId,unsigned char pinI
     //make sure that we clear the interrupts states before we update the port
     Read_MCP23S17_Register (devId,MCP23x17_INTFB);
     Read_MCP23S17_Register (devId,MCP23x17_INTCAPB);
-
+    
     pinmask=1;
     pinmask<<=pinID;
     Cur_Int_Enable_State=Read_MCP23S17_Register (devId,MCP23x17_GPINTENB);
-
+    
     if (Interrupt_Enable)
-      Cur_Int_Enable_State|=pinmask; //enable pin interrupt
+        Cur_Int_Enable_State|=pinmask; //enable pin interrupt
     else Cur_Int_Enable_State&=~pinmask; //disable pin interrupt
-
+    
     Write_MCP23S17_Register (devId, MCP23x17_GPINTENB, Cur_Int_Enable_State);
-
+    
     //_log.Log(LOG_NORM,"PiFace: SetPin Interrupt mode: devid: %d, Pinnr: %d, Enable %d-- Prev 0x%02X Cur 0x%02X",devId,pinID,Interrupt_Enable,Prev_Int_Enable_State,Cur_Int_Enable_State);
 }
 
 
 bool CPiFace::StartHardware()
 {
-	StopHardware();
+    StopHardware();
     m_InputSample_waitcntr=(PIFACE_INPUT_PROCESS_INTERVAL)*20;
     m_CounterEdgeSample_waitcntr=(PIFACE_COUNTER_COUNTER_INTERVAL)*20;
-
+    
     m_stoprequested=false;
     memset(m_DetectedHardware,0,sizeof(m_DetectedHardware));
-
+    
 #ifndef DISABLE_NEW_FUNCTIONS
-        LoadConfig();
+    LoadConfig();
 #endif
     //Start worker thread
     if (Init_SPI_Device(1) > 0)
-     {
-       if (Detect_PiFace_Hardware() > 0)
-         {
+    {
+        if (Detect_PiFace_Hardware() > 0)
+        {
             //we have hardware, so lets use it
             for (int devId=0;  devId<4 ;devId++)
-              {
-               if (m_DetectedHardware[devId]==true)
+            {
+                if (m_DetectedHardware[devId]==true)
                     Init_Hardware(devId);
-              }
+            }
 #ifdef DISABLE_NEW_FUNCTIONS
             LoadConfig();
 #endif
-            GetLastKnownValues();
-            for (int devId=0;  devId<4 ;devId++)
-              {
-               if (m_DetectedHardware[devId]==true)
-                    GetAndSetInitialDeviceState(devId);
-              }
 
-			m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CPiFace::Do_Work, this)));
-			m_queue_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CPiFace::Do_Work_Queue, this)));
-	   }
-         else m_stoprequested=true;
-     }
-     else m_stoprequested=true;
+            for (int devId=0;  devId<4 ;devId++)
+            {
+                if (m_DetectedHardware[devId]==true)
+                    GetAndSetInitialDeviceState(devId);
+            }
+            
+            m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CPiFace::Do_Work, this)));
+            m_queue_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CPiFace::Do_Work_Queue, this)));
+        }
+        else m_stoprequested=true;
+    }
+    else m_stoprequested=true;
     m_bIsStarted=true;
     sOnConnected(this);
     return (m_thread!=NULL);
@@ -719,100 +699,100 @@ bool CPiFace::StopHardware()
     if (m_thread!=NULL)
     {
         m_stoprequested = true;
-		if (m_thread != NULL)
-		{
-			m_thread->join();
-			m_thread.reset();
-		}
-		if (m_queue_thread != NULL)
-		{
-			m_queue_thread->join();
-			m_queue_thread.reset();
-		}
-	}
+        if (m_thread != NULL)
+        {
+            m_thread->join();
+            m_thread.reset();
+        }
+        if (m_queue_thread != NULL)
+        {
+            m_queue_thread->join();
+            m_queue_thread.reset();
+        }
+    }
 #ifdef __arm__
-	if (m_fd > 0) {
-		close(m_fd);
-		m_fd = 0;
-	}
+    if (m_fd > 0) {
+        close(m_fd);
+        m_fd = 0;
+    }
 #endif
-	m_bIsStarted=false;
+    m_bIsStarted=false;
     return true;
 }
 
 bool CPiFace::WriteToHardware(const char *pdata, const unsigned char length)
 {
-	const tRBUF *SendData = reinterpret_cast<const tRBUF*>(pdata);
-  int mask=0x01;
-  unsigned char CurrentLatchState;
-  unsigned char OutputData;
-  unsigned char PortType=' ';
-
-  int devId =0;
-  int pinnr =0;
-
-  if ((SendData->LIGHTING1.packettype == pTypeLighting1) && (SendData->LIGHTING1.subtype == sTypeIMPULS))
-   {
-      PortType=(SendData->LIGHTING1.housecode);
+    const tRBUF *SendData = reinterpret_cast<const tRBUF*>(pdata);
+    int mask=0x01;
+    unsigned char CurrentLatchState;
+    unsigned char OutputData;
+    unsigned char PortType=' ';
+    
+    int devId =0;
+    int pinnr =0;
+    
+    if ((SendData->LIGHTING1.packettype == pTypeLighting1) && (SendData->LIGHTING1.subtype == sTypeIMPULS))
+    {
+        PortType=(SendData->LIGHTING1.housecode);
         devId=(SendData->LIGHTING1.unitcode /10)&0x03;
-      pinnr =(SendData->LIGHTING1.unitcode %10)&0x07;
-	  if (PortType == 'O')
-	  {
-		  //_log.Log(LOG_NORM,"Piface: WriteToHardware housecode %c, packetlength %d", SendData->LIGHTING1.housecode,SendData->LIGHTING1.packetlength );
-		  CurrentLatchState = Read_MCP23S17_Register(devId, MCP23x17_OLATA);
-		  //_log.Log(LOG_NORM,"PiFace: Read input state 0x%02X", m_OutputState[devId].Current);
-
-		  OutputData = CurrentLatchState;
-		  mask <<= pinnr;
-
-		  if (SendData->LIGHTING1.cmnd == light1_sOff)
-		  {
-			  OutputData &= ~mask;
-		  }
-		  else OutputData |= mask;
-
-		  Write_MCP23S17_Register(devId, MCP23x17_GPIOA, OutputData);
-		  //  _log.Log(LOG_NORM,"Piface: WriteToHardware housecode %c, devid %d, output %d, PrevOut 0x%02X, Set 0x%02X",PortType, devId, pinnr, CurrentLatchState,OutputData );
-	  }
-	  else
-	  {
-		  _log.Log(LOG_ERROR, "Piface: wrong housecode %c", PortType);
-		  return false;
-	  }
-  }
-  else
-  {
-	  _log.Log(LOG_ERROR, "PiFace: WriteToHardware packet type %d or subtype %d unknown\n", SendData->LIGHTING1.packettype, SendData->LIGHTING1.subtype);
-	  return false;
-  }
-  return true;
+        pinnr =(SendData->LIGHTING1.unitcode %10)&0x07;
+        if (PortType == 'O')
+        {
+            //_log.Log(LOG_NORM,"Piface: WriteToHardware housecode %c, packetlength %d", SendData->LIGHTING1.housecode,SendData->LIGHTING1.packetlength );
+            CurrentLatchState = Read_MCP23S17_Register(devId, MCP23x17_OLATA);
+            //_log.Log(LOG_NORM,"PiFace: Read input state 0x%02X", m_OutputState[devId].Current);
+            
+            OutputData = CurrentLatchState;
+            mask <<= pinnr;
+            
+            if (SendData->LIGHTING1.cmnd == light1_sOff)
+            {
+                OutputData &= ~mask;
+            }
+            else OutputData |= mask;
+            
+            Write_MCP23S17_Register(devId, MCP23x17_GPIOA, OutputData);
+            //  _log.Log(LOG_NORM,"Piface: WriteToHardware housecode %c, devid %d, output %d, PrevOut 0x%02X, Set 0x%02X",PortType, devId, pinnr, CurrentLatchState,OutputData );
+        }
+        else
+        {
+            _log.Log(LOG_ERROR, "Piface: wrong housecode %c", PortType);
+            return false;
+        }
+    }
+    else
+    {
+        _log.Log(LOG_ERROR, "PiFace: WriteToHardware packet type %d or subtype %d unknown", SendData->LIGHTING1.packettype, SendData->LIGHTING1.subtype);
+        return false;
+    }
+    return true;
 }
 
 void CPiFace::Do_Work()
 {
     int devId;
     _log.Log(LOG_STATUS,"PiFace: Worker started...");
-	int msec_counter = 0;
-	int sec_counter = 0;
+    int msec_counter = 0;
+    int sec_counter = 0;
     while (!m_stoprequested)
     {
-		boost::this_thread::sleep(boost::posix_time::millisec(PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS));
-		if (m_stoprequested)
-			break;
-
-		msec_counter++;
-		if (msec_counter == (1000 / PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS))
-		{
-			msec_counter = 0;
-			sec_counter++;
-			if (sec_counter % 12 == 0) {
-				m_LastHeartbeat = mytime(NULL);
-			}
-		}
-
+        boost::this_thread::sleep(boost::posix_time::millisec(PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS));
+        if (m_stoprequested)
+            break;
+        
+        msec_counter++;
+        if (msec_counter == (1000 / PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS))
+        {
+            msec_counter = 0;
+            sec_counter++;
+            if (sec_counter % 12 == 0) {
+                m_LastHeartbeat = mytime(NULL);
+            }
+        }
+        
         m_InputSample_waitcntr++;
         m_CounterEdgeSample_waitcntr++;
-
+        
         //sample interrupt states faster for edge detection on count
         if (m_CounterEdgeSample_waitcntr>=PIFACE_COUNTER_COUNTER_INTERVAL)
         {
@@ -822,8 +802,8 @@ void CPiFace::Do_Work()
                 Sample_and_Process_Input_Interrupts(devId);
             }
         }
-
-         //sample pin states more slowly to avoid spamming Domoticz
+        
+        //sample pin states more slowly to avoid spamming Domoticz
         if (m_InputSample_waitcntr>=PIFACE_INPUT_PROCESS_INTERVAL)
         {
             m_InputSample_waitcntr=0;
@@ -839,23 +819,23 @@ void CPiFace::Do_Work()
 
 void CPiFace::Do_Work_Queue()
 {
-	std::vector<std::string>::iterator itt;
-	while (!m_stoprequested)
-	{
-		boost::this_thread::sleep(boost::posix_time::millisec(100));
-		if (m_stoprequested)
-			break;
-		if (m_send_queue.empty())
-			continue;
-
-		std::string sendData;
-		m_queue_mutex.lock();
-		itt = m_send_queue.begin();
-		sendData = *itt;
-		m_send_queue.erase(itt);
-		m_queue_mutex.unlock();
-		sDecodeRXMessage(this, (const unsigned char*)sendData.c_str(), NULL, 255);
-	}
+    std::vector<std::string>::iterator itt;
+    while (!m_stoprequested)
+    {
+        boost::this_thread::sleep(boost::posix_time::millisec(100));
+        if (m_stoprequested)
+            break;
+        if (m_send_queue.empty())
+            continue;
+        
+        std::string sendData;
+        m_queue_mutex.lock();
+        itt = m_send_queue.begin();
+        sendData = *itt;
+        m_send_queue.erase(itt);
+        m_queue_mutex.unlock();
+        sDecodeRXMessage(this, (const unsigned char*)sendData.c_str(), NULL, 255);
+    }
 }
 
 // Open a connection to the piface
@@ -867,47 +847,47 @@ int CPiFace::Init_SPI_Device(int Init)
     unsigned char spiMode  = 0 ;
     unsigned char spiBPW   = 8 ;
     int           speed       = 4000000 ;
-
-     _log.Log(LOG_STATUS,"PiFace: Starting PiFace_SPI_Start()");
+    
+    _log.Log(LOG_STATUS,"PiFace: Starting PiFace_SPI_Start()");
 #ifdef __arm__
     // Open port for reading and writing
     if ((m_fd = open("/dev/spidev0.0", O_RDWR)) >= 0)
-      {
+    {
         // Set the port options and set the address of the device
         if (ioctl (m_fd, SPI_IOC_WR_MODE, &spiMode)         >= 0)
+        {
+            if (ioctl (m_fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) >= 0)
             {
-                  if (ioctl (m_fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) >= 0)
-                 {
-                    if (ioctl (m_fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed)   >= 0)
-                       {
-                        result=1;
-                        //we are successfull
-                        _log.Log(LOG_NORM,"PiFace: SPI device opened successfully");
-
-                       }
-                       else
-                        _log.Log(LOG_NORM,"PiFace: SPI Speed Change failure: %s\n", strerror (errno)) ;
-                 }
+                if (ioctl (m_fd, SPI_IOC_WR_MAX_SPEED_HZ, &speed)   >= 0)
+                {
+                    result=1;
+                    //we are successfull
+                    _log.Log(LOG_NORM,"PiFace: SPI device opened successfully");
+                    
+                }
                 else
-                   _log.Log(LOG_NORM,"PiFace: SPI BPW Change failure: %s\n", strerror (errno)) ;
-
+                    _log.Log(LOG_NORM,"PiFace: SPI Speed Change failure: %s", strerror (errno)) ;
             }
             else
-                _log.Log(LOG_NORM,"PiFace: SPI Mode Change failure: %s\n", strerror (errno)) ;
-      }
+                _log.Log(LOG_NORM,"PiFace: SPI BPW Change failure: %s", strerror (errno)) ;
+            
+        }
+        else
+            _log.Log(LOG_NORM,"PiFace: SPI Mode Change failure: %s", strerror (errno)) ;
+    }
     else
-      _log.Log(LOG_NORM,"PiFace: Unable to open SPI device: %s\n", strerror (errno));
-
+        _log.Log(LOG_NORM,"PiFace: Unable to open SPI device: %s", strerror (errno));
+    
 #endif
-
+    
     if (result == -1)
-     {
+    {
 #ifdef __arm__
-         close(m_fd);
+        close(m_fd);
 #endif
-      return -1;
-     }
-     else return m_fd;
+        return -1;
+    }
+    else return m_fd;
 }
 
 int CPiFace::Detect_PiFace_Hardware(void)
@@ -916,99 +896,99 @@ int CPiFace::Detect_PiFace_Hardware(void)
     unsigned char read_iocon;
     unsigned char read_ioconb;
     int devId;
-
+    
     //first write to all possible PiFace addresses.
     for (devId=0; devId<4; devId++)
-     {
+    {
         Write_MCP23S17_Register (devId, MCP23x17_IOCON,  IOCON_INIT | IOCON_HAEN) ;
         Write_MCP23S17_Register (devId, MCP23x17_IOCONB,  IOCON_INIT | IOCON_HAEN) ;
-     }
-
+    }
+    
     //now read them back, to determine if they are present
-
+    
     for (devId=0; devId<4; devId++)
     {
-      read_iocon=Read_MCP23S17_Register (devId, MCP23x17_IOCON);
-      read_ioconb=Read_MCP23S17_Register (devId, MCP23x17_IOCONB);
-
-      if ((read_iocon == ( IOCON_INIT | IOCON_HAEN)) && (read_ioconb == ( IOCON_INIT | IOCON_HAEN)))
+        read_iocon=Read_MCP23S17_Register (devId, MCP23x17_IOCON);
+        read_ioconb=Read_MCP23S17_Register (devId, MCP23x17_IOCONB);
+        
+        if ((read_iocon == ( IOCON_INIT | IOCON_HAEN)) && (read_ioconb == ( IOCON_INIT | IOCON_HAEN)))
         {
             //hé someone appears to be home...
             m_DetectedHardware[devId]=true;
             NrOfFoundBoards++;
         }
     }
-
+    
     if (NrOfFoundBoards)
-     {
-        _log.Log(LOG_STATUS,"PiFace: Found the following PiFaces:\n");
+    {
+        _log.Log(LOG_STATUS,"PiFace: Found the following PiFaces:");
         for (devId=0; devId<4; devId++)
         {
-           if (m_DetectedHardware[devId]==true)
-            _log.Log(LOG_STATUS,"PiFace: %d\n",devId);
+            if (m_DetectedHardware[devId]==true)
+                _log.Log(LOG_STATUS,"PiFace: %d",devId);
         }
-     }
-     else _log.Log(LOG_STATUS,"PiFace: Sorry, no PiFaces were found\n");
+    }
+    else _log.Log(LOG_STATUS,"PiFace: Sorry, no PiFaces were found");
     return NrOfFoundBoards;
 }
 
 void CPiFace::Init_Hardware(unsigned char devId)
 {
-	Write_MCP23S17_Register (devId, MCP23x17_IOCON,  IOCON_INIT | IOCON_HAEN) ;
-	Write_MCP23S17_Register (devId, MCP23x17_IOCONB, IOCON_INIT | IOCON_HAEN) ;
-
-	//setup PortA as output
-	Write_MCP23S17_Register (devId, MCP23x17_IODIRA,  0x00) ;         //set all pins on Port A as output
-
-	//lets init the other registers so we always have a clear startup situation
-	Write_MCP23S17_Register (devId, MCP23x17_GPINTENA, 0x00);          //The PiFace does not support the interrupt capabilities, so set it to 0, and useless for output.
-	Write_MCP23S17_Register (devId, MCP23x17_DEFVALA,     0x00);      //Default compare value register, useless for output
-	Write_MCP23S17_Register (devId, MCP23x17_INTCONA,     0x00);        //Interrupt based on current and prev pin state, not Default value
-	//Write_MCP23S17_Register (devId, MCP23x17_INTFA,     0);           // Read only interrupt flag register,not used on output
-	//Write_MCP23S17_Register (devId, MCP23x17_INTCAPA, );             // Read only interrupt status register, captures port status on interrupt, not ued on output
-	Write_MCP23S17_Register (devId, MCP23x17_OLATA, 0xFF);             // Set the output latches to 1, otherwise the relays are activated
-
-	//setup PortB as input
-	Write_MCP23S17_Register (devId, MCP23x17_IODIRB, 0xFF) ;         //set all pins on Port B as input
-	Write_MCP23S17_Register (devId, MCP23x17_GPPUB,  0xFF) ;          //Enable pullup resistors, so the buttons work immediately
-	Write_MCP23S17_Register (devId, MCP23x17_IPOLB,  0xFF) ;          //Invert input pin state, so we will see an active state as as 1.
-
-	//lets init the other registers so we always have a clear startup situation
-	Write_MCP23S17_Register (devId, MCP23x17_GPINTENB, 0x00);          //The PiFace does not support the interrupt capabilities, so set it to 0.
-	//Todo: use the int detection for small pulses
-	Write_MCP23S17_Register (devId, MCP23x17_DEFVALB,     0x00);      //Default compare value register, we do not use it (yet), but lets set it to 0 (assuming not active state).
-	Write_MCP23S17_Register (devId, MCP23x17_INTCONB,     0x00);         //Interrupt based on current and prev pin state, not Default value
-	//Write_MCP23S17_Register (devId, MCP23x17_INTFB,     0);           // Read only interrupt flag register, listed as a reminder
-	//Write_MCP23S17_Register (devId, MCP23x17_INTCAPB, );             // Read only interrupt status register, captures port status on interrupt, listed as a reminder
-	Write_MCP23S17_Register (devId, MCP23x17_OLATB, 0x00);             // Set the output latches to 0, note: not used.
-
-	Write_MCP23S17_Register (devId, MCP23x17_GPIOA,  0x00) ;         //set all pins on Port A as output, and deactivate
+    Write_MCP23S17_Register (devId, MCP23x17_IOCON,  IOCON_INIT | IOCON_HAEN) ;
+    Write_MCP23S17_Register (devId, MCP23x17_IOCONB, IOCON_INIT | IOCON_HAEN) ;
+    
+    //setup PortA as output
+    Write_MCP23S17_Register (devId, MCP23x17_IODIRA,  0x00) ;         //set all pins on Port A as output
+    
+    //lets init the other registers so we always have a clear startup situation
+    Write_MCP23S17_Register (devId, MCP23x17_GPINTENA, 0x00);          //The PiFace does not support the interrupt capabilities, so set it to 0, and useless for output.
+    Write_MCP23S17_Register (devId, MCP23x17_DEFVALA,     0x00);      //Default compare value register, useless for output
+    Write_MCP23S17_Register (devId, MCP23x17_INTCONA,     0x00);        //Interrupt based on current and prev pin state, not Default value
+    //Write_MCP23S17_Register (devId, MCP23x17_INTFA,     0);           // Read only interrupt flag register,not used on output
+    //Write_MCP23S17_Register (devId, MCP23x17_INTCAPA, );             // Read only interrupt status register, captures port status on interrupt, not ued on output
+    Write_MCP23S17_Register (devId, MCP23x17_OLATA, 0xFF);             // Set the output latches to 1, otherwise the relays are activated
+    
+    //setup PortB as input
+    Write_MCP23S17_Register (devId, MCP23x17_IODIRB, 0xFF) ;         //set all pins on Port B as input
+    Write_MCP23S17_Register (devId, MCP23x17_GPPUB,  0xFF) ;          //Enable pullup resistors, so the buttons work immediately
+    Write_MCP23S17_Register (devId, MCP23x17_IPOLB,  0xFF) ;          //Invert input pin state, so we will see an active state as as 1.
+    
+    //lets init the other registers so we always have a clear startup situation
+    Write_MCP23S17_Register (devId, MCP23x17_GPINTENB, 0x00);          //The PiFace does not support the interrupt capabilities, so set it to 0.
+    //Todo: use the int detection for small pulses
+    Write_MCP23S17_Register (devId, MCP23x17_DEFVALB,     0x00);      //Default compare value register, we do not use it (yet), but lets set it to 0 (assuming not active state).
+    Write_MCP23S17_Register (devId, MCP23x17_INTCONB,     0x00);         //Interrupt based on current and prev pin state, not Default value
+    //Write_MCP23S17_Register (devId, MCP23x17_INTFB,     0);           // Read only interrupt flag register, listed as a reminder
+    //Write_MCP23S17_Register (devId, MCP23x17_INTCAPB, );             // Read only interrupt status register, captures port status on interrupt, listed as a reminder
+    Write_MCP23S17_Register (devId, MCP23x17_OLATB, 0x00);             // Set the output latches to 0, note: not used.
+    
+    Write_MCP23S17_Register (devId, MCP23x17_GPIOA,  0x00) ;         //set all pins on Port A as output, and deactivate
 }
 
-void CPiFace::GetAndSetInitialDeviceState(unsigned char devId)
+void CPiFace::GetAndSetInitialDeviceState(int devId)
 {
     unsigned char PortState;
     PortState= Read_MCP23S17_Register (devId, MCP23x17_OLATA) ;
-    m_Outputs[devId].Init(true,'O',PortState);
-
+    m_Outputs[devId].Init(true,m_HwdID,devId,'O',PortState);
+    
     PortState= Read_MCP23S17_Register (devId, MCP23x17_GPIOB) ;
-    m_Inputs[devId].Init(true,'I',PortState);
+    m_Inputs[devId].Init(true,m_HwdID,devId,'I',PortState);
 }
 
 int CPiFace::Read_Write_SPI_Byte(unsigned char *data, int len)
 {
 #ifdef __arm__
-  struct spi_ioc_transfer spi ;
-  memset (&spi, 0, sizeof(spi));
-
-  spi.tx_buf        = (unsigned long)data ;
-  spi.rx_buf        = (unsigned long)data ;
-  spi.len           = len ;
-  spi.delay_usecs   = 0 ;
-  spi.speed_hz      = 4000000;
-  spi.bits_per_word = 8 ;
-
-  return ioctl (m_fd, SPI_IOC_MESSAGE(1), &spi) ;
+    struct spi_ioc_transfer spi ;
+    memset (&spi, 0, sizeof(spi));
+    
+    spi.tx_buf        = (unsigned long)data ;
+    spi.rx_buf        = (unsigned long)data ;
+    spi.len           = len ;
+    spi.delay_usecs   = 0 ;
+    spi.speed_hz      = 4000000;
+    spi.bits_per_word = 8 ;
+    
+    return ioctl (m_fd, SPI_IOC_MESSAGE(1), &spi) ;
 #else
     return 0;
 #endif
@@ -1016,32 +996,32 @@ int CPiFace::Read_Write_SPI_Byte(unsigned char *data, int len)
 
 int CPiFace::Read_MCP23S17_Register(unsigned char devId, unsigned char reg)
 {
-  unsigned char spiData [4] ;
-
-  spiData [0] = CMD_READ | ((devId & 7) << 1);
-  spiData [1] = reg ;
-
-  Read_Write_SPI_Byte(spiData, 3);
-
-  return spiData [2];
+    unsigned char spiData [4] ;
+    
+    spiData [0] = CMD_READ | ((devId & 7) << 1);
+    spiData [1] = reg ;
+    
+    Read_Write_SPI_Byte(spiData, 3);
+    
+    return spiData [2];
 }
 
 int CPiFace::Write_MCP23S17_Register(unsigned char devId, unsigned char reg, unsigned char data)
 {
-  unsigned char spiData [4] ;
-
-  spiData [0] = CMD_WRITE | ((devId & 7) << 1) ;
-  spiData [1] = reg ;
-  spiData [2] = data ;
-
-  return (Read_Write_SPI_Byte( spiData, 3)) ;
+    unsigned char spiData [4] ;
+    
+    spiData [0] = CMD_WRITE | ((devId & 7) << 1) ;
+    spiData [1] = reg ;
+    spiData [2] = data ;
+    
+    return (Read_Write_SPI_Byte( spiData, 3)) ;
 }
 
 void CPiFace::Sample_and_Process_Inputs(unsigned char devId)
 {
-  unsigned char PortState;
-
-  if ( m_Inputs[devId].IsDevicePresent())
+    unsigned char PortState;
+    
+    if ( m_Inputs[devId].IsDevicePresent())
     {
         PortState=Read_MCP23S17_Register (devId, MCP23x17_GPIOB);
         m_Inputs[devId].Update(PortState);
@@ -1050,21 +1030,21 @@ void CPiFace::Sample_and_Process_Inputs(unsigned char devId)
 
 void CPiFace::Sample_and_Process_Outputs(unsigned char devId)
 {
-  unsigned char PortState;
-
-  if ( m_Outputs[devId].IsDevicePresent())
+    unsigned char PortState;
+    
+    if ( m_Outputs[devId].IsDevicePresent())
     {
-     PortState=Read_MCP23S17_Register (devId, MCP23x17_GPIOA);
-     m_Outputs[devId].Update(PortState);
+        PortState=Read_MCP23S17_Register (devId, MCP23x17_GPIOA);
+        m_Outputs[devId].Update(PortState);
     }
- }
+}
 
 void CPiFace::Sample_and_Process_Input_Interrupts(unsigned char devId)
 {
-  unsigned char PortInterruptState;
-  unsigned char PortState;
-
-  if ( m_Inputs[devId].IsDevicePresent())
+    unsigned char PortInterruptState;
+    unsigned char PortState;
+    
+    if ( m_Inputs[devId].IsDevicePresent())
     {
         PortInterruptState=Read_MCP23S17_Register(devId, MCP23x17_INTFB);
         PortState=Read_MCP23S17_Register(devId, MCP23x17_INTCAPB);
@@ -1080,99 +1060,98 @@ void CIOCount::SetUpdateInterval(unsigned long NewValue_ms)
 
 bool CIOCount::ProcessUpdateInterval(unsigned long PassedTime_ms)
 {
-   bool Update=false;
-   if (Enabled)
+    bool Update=false;
+    if (Enabled)
     {
-       if (UpdateDownCount_ms > PassedTime_ms)
+        if (UpdateDownCount_ms > PassedTime_ms)
             UpdateDownCount_ms-=PassedTime_ms;
         else {
-                UpdateDownCount_ms=UpdateInterval_ms;
-                Update=true;
-             }
-       if (!InitialStateSent)
-         {
+            UpdateDownCount_ms=UpdateInterval_ms;
+            Update=true;
+        }
+        if (!InitialStateSent)
+        {
             InitialStateSent=true;
             Update=true;
-         }
+        }
     }
-   return Update;
+    return Update;
 }
 
 int CIOCount::Update(unsigned long Counts)
 {
-  int result=-1;
-#ifndef DISABLE_NEW_FUNCTIONS
-
-  Cur_Call=boost::posix_time::microsec_clock::universal_time();
-
-  boost::posix_time::time_duration Diff= Cur_Call - Last_Call;
-
-  if ((Enabled) && ((Minimum_Pulse_Period_ms == 0) || (Minimum_Pulse_Period_ms <= Diff.total_milliseconds()))
-#else
-  if (Enabled)
-#endif
+    int result = -1;
+    
+    Last_Call = Cur_Call;
+    Cur_Call = boost::posix_time::microsec_clock::universal_time();
+    boost::posix_time::time_duration Diff = Cur_Call - Last_Call;
+    
+    if (
+        Enabled && (
+            Minimum_Pulse_Period_ms == 0 ||
+            Minimum_Pulse_Period_ms <= Diff.total_milliseconds()
+        )
+    )
     {
-        //we only update the counter, if its enabled, and if the time between the last pulse was faster than rate limit, or ratelimit was not used
-        Current+=Counts;
-        Total+=Counts;
-        result=1;
+        // We only update the counter, if its enabled, and if the time between the last pulse was
+        // faster than rate limit, or ratelimit was not used.
+        Current += Counts;
+        Total += Counts;
+        result = 1;
     }
 
-#ifndef DISABLE_NEW_FUNCTIONS
-   Last_Call = Cur_Call;
-#endif
-   return result;
+    return result;
 }
 
 
 CIOCount::CIOCount()
 {
-  ResetCurrent();
-  ResetTotal();
-  UpdateInterval_ms=10000;
-  Enabled=false;
-  InitialStateSent=false;
-  UpdateDownCount_ms = 0;
-  Minimum_Pulse_Period_ms = 0;
-#ifndef DISABLE_NEW_FUNCTIONS
-  Last_Call=boost::posix_time::microsec_clock::universal_time();
-  Cur_Call=boost::posix_time::microsec_clock::universal_time();
- #endif
+    ResetCurrent();
+    ResetTotal();
+    UpdateInterval_ms = 10000;
+    Enabled = false;
+    Type = COUNT_TYPE_RFXMETER;
+    InitialStateSent = false;
+    UpdateDownCount_ms = 0;
+    Minimum_Pulse_Period_ms = 0;
+    Divider = 1000;
+    Last_Call = boost::posix_time::microsec_clock::universal_time();
+    Cur_Call = boost::posix_time::microsec_clock::universal_time();
 };
 
 CIOCount::~CIOCount()
 {
-
+    
 };
 
 int CIOPinState::Update(bool New)
 {
     int StateChange=-1; //nothing changed
-
+    
     Last=Current;
     Current=New;
-
+    
     if (Enabled)
     {
         switch (Type)
         {
             default:
             case LEVEL:
-				if ((Last ^ Current) == true)
-				{
-					if (Current)
-						StateChange=1;
-					else
-						StateChange=0;
-				}
+                if ((Last ^ Current) == true)
+                {
+                    if (Current)
+                        StateChange=1;
+                    else
+                        StateChange=0;
+                }
                 break;
             case INV_LEVEL:    //inverted input
                 if ((Last ^ Current) == true)
                 {
-					if (Current)
-						StateChange=0;
-					else
-						StateChange=1;
+                    if (Current)
+                        StateChange=0;
+                    else
+                        StateChange=1;
                 }
                 break;
             case TOGGLE_RISING:
@@ -1181,7 +1160,7 @@ int CIOPinState::Update(bool New)
                     if (Toggle)
                         StateChange=1;
                     else
-						StateChange=0;
+                        StateChange=0;
                     Toggle=!Toggle;
                 }
                 break;
@@ -1191,32 +1170,32 @@ int CIOPinState::Update(bool New)
                     if (Toggle)
                         StateChange=1;
                     else
-						StateChange=0;
+                        StateChange=0;
                     Toggle=!Toggle;
                 }
                 break;
         }
     }
-
+    
     if (Direction == 'O')
-     {
+    {
         if (((Last ^ Current) == true) && (Current == true))
-          {
+        {
             Count.Update(1);
-          }
-     }
-
-   return StateChange;
+        }
+    }
+    
+    return StateChange;
 }
 
 int CIOPinState::UpdateInterrupt(bool IntFlag,bool PinState)
 {
-   int Changed=-1;
-
+    int Changed=-1;
+    
     if (IntFlag && PinState) //we have a rising edge so count
-      {
+    {
         Changed=Count.Update(1);
-      }
+    }
     return (Changed);
 }
 
@@ -1224,7 +1203,7 @@ int CIOPinState::UpdateInterrupt(bool IntFlag,bool PinState)
 int CIOPinState::GetInitialState(void)
 {
     int CurState=-1; //Report not enabled
-
+    
     if (Enabled)
     {
         switch (Type)
@@ -1234,72 +1213,143 @@ int CIOPinState::GetInitialState(void)
                 if (Current)
                     CurState=1;
                 else
-					CurState=0;
+                    CurState=0;
                 break;
             case INV_LEVEL:    //inverted input
                 if (Current)
                     CurState=0;
                 else
-					CurState=1;
+                    CurState=1;
                 break;
             case TOGGLE_RISING:
                 if (Toggle)
                     CurState=1;
                 else
-					CurState=0;
+                    CurState=0;
                 break;
-
+                
             case TOGGLE_FALLING:
                 if (Toggle)
                     CurState=1;
                 else
-					CurState=0;
+                    CurState=0;
                 break;
         }
     }
-   return CurState;
+    return CurState;
 }
 
 
 CIOPinState::CIOPinState()
 {
-  Last=false;
-  Current=true;
-  Id=0;
-  Type=0;
-  Enabled=false;
-  Toggle=false;
-  InitialStateSent=false;
-  Direction=' ';
+    Last=false;
+    Current=true;
+    Id=0;
+    Type=0;
+    Enabled=false;
+    Toggle=false;
+    InitialStateSent=false;
+    Direction=' ';
 };
 
 CIOPinState::~CIOPinState()
 {
-
+    
 };
 
-void CIOPort::Init(bool Available, unsigned char housecode, unsigned char initial_state)
+void CIOPort::Init(bool Available, int hwdId, int devId /* 0 - 4 */, unsigned char housecode, unsigned char initial_state)
 {
-  Present = Available;
+    int PinNr;
+    int hardware_type;
+    int meterid;
+    unsigned long value;
+    bool found;
 
-  //set generic packet info for LIGHTING1 packet, so we do not have every packet
-  IOPinStatusPacket.LIGHTING1.packetlength = sizeof(IOPinStatusPacket.LIGHTING1) -1;
-  IOPinStatusPacket.LIGHTING1.housecode = housecode;//report to user as input
-  IOPinStatusPacket.LIGHTING1.packettype = pTypeLighting1;
-  IOPinStatusPacket.LIGHTING1.subtype = sTypeIMPULS;
-  IOPinStatusPacket.LIGHTING1.rssi = 12;
-  IOPinStatusPacket.LIGHTING1.seqnbr = 0;
+    std::vector<std::vector<std::string> > result;
+    std::vector<std::string> resultparts;
 
-  //set generic packet info for RFXMETER packet, so we do not have every packet
-  IOPinCounterPacket.RFXMETER.packetlength = sizeof(IOPinStatusPacket.RFXMETER) -1;
-  IOPinCounterPacket.RFXMETER.packettype = pTypeRFXMeter;
-  IOPinCounterPacket.RFXMETER.subtype = sTypeRFXMeterCount;
-  IOPinCounterPacket.RFXMETER.rssi = 12;
-  IOPinCounterPacket.RFXMETER.seqnbr = 0;
+    Present = Available;
+    
+    //set generic packet info for LIGHTING1 packet, so we do not have every packet
+    IOPinStatusPacket.LIGHTING1.packetlength = sizeof(IOPinStatusPacket.LIGHTING1) -1;
+    IOPinStatusPacket.LIGHTING1.housecode = housecode;//report to user as input
+    IOPinStatusPacket.LIGHTING1.packettype = pTypeLighting1;
+    IOPinStatusPacket.LIGHTING1.subtype = sTypeIMPULS;
+    IOPinStatusPacket.LIGHTING1.rssi = 12;
+    IOPinStatusPacket.LIGHTING1.seqnbr = 0;
+    
+    for (PinNr=0;PinNr <= 7;PinNr++)
+    {
+        found = false;
+        switch( Pin[PinNr].Count.Type )
+        {
+            case COUNT_TYPE_GENERIC:
+            case COUNT_TYPE_RFXMETER:
+                //set generic packet info for RFXMETER packet, so we do not have every packet
+                Pin[PinNr].IOPinCounterPacket.RFXMETER.packetlength = sizeof(Pin[PinNr].IOPinCounterPacket.RFXMETER) -1;
+                Pin[PinNr].IOPinCounterPacket.RFXMETER.packettype = pTypeRFXMeter;
+                Pin[PinNr].IOPinCounterPacket.RFXMETER.subtype = sTypeRFXMeterCount;
+                Pin[PinNr].IOPinCounterPacket.RFXMETER.rssi = 12;
+                Pin[PinNr].IOPinCounterPacket.RFXMETER.seqnbr = 0;
 
-  Last=initial_state;
-  Current=initial_state;
-  Update(initial_state);
+                // GetLastKnownValues
+                hardware_type = pTypeRFXMeter;
+                if (housecode == 'I')
+                    meterid=100+PinNr + (devId*10);
+                else
+                    meterid=0+PinNr + (devId*10);
+                
+                result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID=%d AND Type=%d AND DeviceID='%d')", hwdId, hardware_type, meterid);
+                if (result.size() == 1)
+                {
+                    value = atol(result[0][0].c_str());
+                    found = true;
+                }
+                break;
+      
+            case COUNT_TYPE_ENERGY:
+                //set generic packet info for ENERGY packet, so we do not have every packet
+                Pin[PinNr].IOPinCounterPacket.ENERGY.packetlength = sizeof(Pin[PinNr].IOPinCounterPacket.ENERGY) -1;
+                Pin[PinNr].IOPinCounterPacket.ENERGY.packettype = pTypeENERGY;
+                Pin[PinNr].IOPinCounterPacket.ENERGY.subtype = sTypeELEC2;
+                Pin[PinNr].IOPinCounterPacket.ENERGY.rssi = 12;
+                Pin[PinNr].IOPinCounterPacket.ENERGY.seqnbr = 0;
+                Pin[PinNr].IOPinCounterPacket.ENERGY.battery_level = 9;
+
+                // GetLastKnownValues
+                hardware_type = pTypeGeneral;
+                if (housecode == 'I')
+                    meterid=300+PinNr + (devId*10);
+                else
+                    meterid=200+PinNr + (devId*10);
+                
+                result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID=%d AND Type=%d AND DeviceID='%08X')", hwdId, hardware_type, meterid);
+                if (result.size() == 1)
+                {
+                    StringSplit(result[0][0], ";", resultparts);
+                    if (resultparts.size() == 1)
+                    {
+                        value = atol(resultparts[0].c_str()) / ( 1000. / Pin[PinNr].Count.GetDivider() );
+                        found = true;
+                    }
+                    else if (resultparts.size() == 2)
+                    {
+                        value = atol(resultparts[1].c_str()) / ( 1000. / Pin[PinNr].Count.GetDivider() );
+                        found = true;
+                    }
+                }
+                break;
+        }
+    
+        if ( found ) {
+            Pin[PinNr].Count.SetCurrent(value);
+            Pin[PinNr].Count.SetTotal(value);
+        }
+    }
+    
+    Last=initial_state;
+    Current=initial_state;
+    Update(initial_state);
 }
 
 int CIOPort::Update(unsigned char New)
@@ -1309,59 +1359,107 @@ int CIOPort::Update(unsigned char New)
     int ChangeState=-1;
     bool UpdateCounter=false;
     int meterid;
-
-	CPiFace *myCallback = reinterpret_cast<CPiFace*>(Callback_pntr);
-
+    
+    CPiFace *myCallback = reinterpret_cast<CPiFace*>(Callback_pntr);
+    
     Last=Current;
     Current=New;
-
+    
     for (i=0;i <= 7;i++)
     {
-      ChangeState=Pin[i].Update((New&mask)==mask);
-      if ((ChangeState >=0) || ((!Pin[i].InitialStateSent) && Pin[i].Enabled))
-       {
-        Pin[i].InitialStateSent=true;
-        if (ChangeState <0)
-          {
-            //we have to sent current state
-            ChangeState=Pin[i].GetInitialState();
-          }
-        //We have something to report to the upper layer
-		IOPinStatusPacket.LIGHTING1.cmnd = (ChangeState != 0) ? light1_sOn : light1_sOff;
-        IOPinStatusPacket.LIGHTING1.seqnbr++;
-        IOPinStatusPacket.LIGHTING1.unitcode = i + (devId*10) ; //report inputs from PiFace X (X0..X9)
-		myCallback->CallBackSendEvent((const unsigned char *)&IOPinStatusPacket, sizeof(IOPinStatusPacket.LIGHTING1));
-       }
-
-       UpdateCounter=Pin[i].Count.ProcessUpdateInterval(PIFACE_INPUT_PROCESS_INTERVAL*PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS);
-       if (UpdateCounter)
-       {
-        if (IOPinStatusPacket.LIGHTING1.housecode == 'I')
-            meterid=100+i + (devId*10);
-        else
-			meterid=0+i + (devId*10);
-
-        IOPinCounterPacket.RFXMETER.id1=((meterid >>8) & 0xFF);
-        IOPinCounterPacket.RFXMETER.id2= (meterid & 0xFF);
-
-		unsigned long Count = Pin[i].Count.GetTotal();
-		unsigned long LastCount = Pin[i].Count.GetLastTotal();
-		if (Count != LastCount)
-		{
-			Pin[i].Count.SetLastTotal(Count);
-			//    _log.Log(LOG_NORM,"Counter %lu\n",Count);
-			IOPinCounterPacket.RFXMETER.count1 = (unsigned char)((Count >> 24) & 0xFF);
-			IOPinCounterPacket.RFXMETER.count2 = (unsigned char)((Count >> 16) & 0xFF);
-			IOPinCounterPacket.RFXMETER.count3 = (unsigned char)((Count >> 8) & 0xFF);
-			IOPinCounterPacket.RFXMETER.count4 = (unsigned char)((Count)& 0xFF);
-			IOPinCounterPacket.RFXMETER.seqnbr++;
-			//    _log.Log(LOG_NORM,"RFXMeter Packet C1 %d, C2 %d C3 %d C4 %d\n",IOPinCounterPacket.RFXMETER.count1,IOPinCounterPacket.RFXMETER.count2,IOPinCounterPacket.RFXMETER.count3,IOPinCounterPacket.RFXMETER.count4);
-			myCallback->CallBackSendEvent((const unsigned char *)&IOPinCounterPacket, sizeof(IOPinCounterPacket.RFXMETER));
-		}
-       }
-       mask<<=1;
+        ChangeState=Pin[i].Update((New&mask)==mask);
+        if ((ChangeState >=0) || ((!Pin[i].InitialStateSent) && Pin[i].Enabled))
+        {
+            Pin[i].InitialStateSent=true;
+            if (ChangeState <0)
+            {
+                //we have to sent current state
+                ChangeState=Pin[i].GetInitialState();
+            }
+            //We have something to report to the upper layer
+            IOPinStatusPacket.LIGHTING1.cmnd = (ChangeState != 0) ? light1_sOn : light1_sOff;
+            IOPinStatusPacket.LIGHTING1.seqnbr++;
+            IOPinStatusPacket.LIGHTING1.unitcode = i + (devId*10) ; //report inputs from PiFace X (X0..X9)
+            myCallback->CallBackSendEvent((const unsigned char *)&IOPinStatusPacket, sizeof(IOPinStatusPacket.LIGHTING1));
+        }
+        
+        UpdateCounter=Pin[i].Count.ProcessUpdateInterval(PIFACE_INPUT_PROCESS_INTERVAL*PIFACE_WORKER_THREAD_SLEEP_INTERVAL_MS);
+        if (UpdateCounter)
+        {
+            unsigned long Count = Pin[i].Count.GetTotal();
+            unsigned long LastCount = Pin[i].Count.GetLastTotal();
+            
+            switch( Pin[i].Count.Type )
+            {
+                case COUNT_TYPE_GENERIC:
+                case COUNT_TYPE_RFXMETER:
+                    if (IOPinStatusPacket.LIGHTING1.housecode == 'I')
+                        meterid=100+i + (devId*10);
+                    else
+                        meterid=0+i + (devId*10);
+    
+                    Pin[i].IOPinCounterPacket.RFXMETER.id1=((meterid >>8) & 0xFF);
+                    Pin[i].IOPinCounterPacket.RFXMETER.id2= (meterid & 0xFF);
+                    
+                    if (Count != LastCount)
+                    {
+                        Pin[i].Count.SetLastTotal(Count);
+                        //    _log.Log(LOG_NORM,"Counter %lu\n",Count);
+                        Pin[i].IOPinCounterPacket.RFXMETER.count1 = (unsigned char)((Count >> 24) & 0xFF);
+                        Pin[i].IOPinCounterPacket.RFXMETER.count2 = (unsigned char)((Count >> 16) & 0xFF);
+                        Pin[i].IOPinCounterPacket.RFXMETER.count3 = (unsigned char)((Count >> 8) & 0xFF);
+                        Pin[i].IOPinCounterPacket.RFXMETER.count4 = (unsigned char)((Count)& 0xFF);
+                        Pin[i].IOPinCounterPacket.RFXMETER.seqnbr++;
+                        //    _log.Log(LOG_NORM,"RFXMeter Packet C1 %d, C2 %d C3 %d C4 %d\n",Pin[i].IOPinCounterPacket.RFXMETER.count1,Pin[i].IOPinCounterPacket.RFXMETER.count2,Pin[i].IOPinCounterPacket.RFXMETER.count3,Pin[i].IOPinCounterPacket.RFXMETER.count4);
+                        myCallback->CallBackSendEvent((const unsigned char *)&Pin[i].IOPinCounterPacket, sizeof(Pin[i].IOPinCounterPacket.RFXMETER));
+                    }
+                    break;
+                    
+                case COUNT_TYPE_ENERGY:
+                    if (IOPinStatusPacket.LIGHTING1.housecode == 'I')
+                        meterid=300+i + (devId*10); // this will create new devices if type is changed afterwards
+                    else
+                        meterid=200+i + (devId*10);
+    
+                    Pin[i].IOPinCounterPacket.ENERGY.id1=((meterid >>8) & 0xFF);
+                    Pin[i].IOPinCounterPacket.ENERGY.id2= (meterid & 0xFF);
+                    
+                    boost::posix_time::time_duration Diff = Pin[i].Count.Cur_Call - Pin[i].Count.Last_Call;
+                    boost::posix_time::ptime Now = boost::posix_time::microsec_clock::universal_time();
+                    if ( Now - Pin[i].Count.Cur_Call > Diff )
+                    {
+                        Diff = Now - Pin[i].Count.Cur_Call;
+                    }
+                    if (
+                        Diff.total_milliseconds() > 0 &&
+                        Pin[i].Count.GetDivider() > 0
+                    )
+                    {
+                        unsigned long long Energy = (unsigned long long)( ( 1000. / Pin[i].Count.GetDivider() ) * Count  ); // kWh
+                        Energy *= 223.666;
+                        unsigned long long Power = (unsigned long long)( ( 1000. / Pin[i].Count.GetDivider() ) * ( 1000. / Diff.total_milliseconds() ) * 3600 ); // Watt
+                        
+                        Pin[i].IOPinCounterPacket.ENERGY.instant1 = (unsigned char)((Power >> 24) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.instant2 = (unsigned char)((Power >> 16) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.instant3 = (unsigned char)((Power >> 8) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.instant4 = (unsigned char)((Power)& 0xFF);
+                        
+                        Pin[i].IOPinCounterPacket.ENERGY.total1 = (unsigned char)((Energy >> 40) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.total2 = (unsigned char)((Energy >> 32) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.total3 = (unsigned char)((Energy >> 24) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.total4 = (unsigned char)((Energy >> 16) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.total5 = (unsigned char)((Energy >> 8) & 0xFF);
+                        Pin[i].IOPinCounterPacket.ENERGY.total6 = (unsigned char)((Energy)& 0xFF);
+                        
+                        Pin[i].IOPinCounterPacket.ENERGY.seqnbr++;
+                        myCallback->CallBackSendEvent((const unsigned char *)&Pin[i].IOPinCounterPacket, sizeof(Pin[i].IOPinCounterPacket.ENERGY));
+                    }
+                    break;
+            }
+        }
+        mask<<=1;
     }
-
+    
     return (ChangeState);
 }
 
@@ -1371,46 +1469,46 @@ int CIOPort::UpdateInterrupt(unsigned char IntFlag,unsigned char PinState)
     int i;
     int ChangeState=-1; //nothing changed
     int Changed;
-
+    
     for (i=0;i <= 7;i++)
     {
-       Changed=Pin[i].UpdateInterrupt(((IntFlag&mask)==mask),((PinState&mask)==mask));
-       if (Changed != -1)
-         ChangeState=Changed;
-       mask<<=1;
+        Changed=Pin[i].UpdateInterrupt(((IntFlag&mask)==mask),((PinState&mask)==mask));
+        if (Changed != -1)
+            ChangeState=Changed;
+        mask<<=1;
     }
     return (ChangeState);
 }
 
 void CIOPort::ConfigureCounter(unsigned char Pinnr,bool Enable)
 {
-	CPiFace *myCallback = reinterpret_cast<CPiFace*>(Callback_pntr);
-
+    CPiFace *myCallback = reinterpret_cast<CPiFace*>(Callback_pntr);
+    
     Pin[Pinnr].Count.Enabled=Enable;
-	if (Pin[Pinnr].Direction == 'I')
-	{
-		myCallback->CallBackSetPinInterruptMode(devId, Pinnr, Enable);
-	}
+    if (Pin[Pinnr].Direction == 'I')
+    {
+        myCallback->CallBackSetPinInterruptMode(devId, Pinnr, Enable);
+    }
 }
 
 CIOPort::CIOPort()
 {
-  Last=0;
-  Current=0;
-  Present=false;
-  Callback_pntr = NULL;
-  PortType = 0;
-  devId = 0;
-  for (int i=0; i<8; i++)
-   {
-    Pin[i].Id=i;
-   }
-
+    Last=0;
+    Current=0;
+    Present=false;
+    Callback_pntr = NULL;
+    PortType = 0;
+    devId = 0;
+    for (int i=0; i<8; i++)
+    {
+        Pin[i].Id=i;
+    }
+    
 };
 
 CIOPort::~CIOPort()
 {
-
+    
 };
 
 

--- a/hardware/PiFace.h
+++ b/hardware/PiFace.h
@@ -3,164 +3,184 @@
 #include "DomoticzHardware.h"
 #include "../main/RFXtrx.h"
 
+#define CONFIG_NR_OF_PARAMETER_TYPES        12
+#define CONFIG_NR_OF_PARAMETER_BOOL_TYPES   4
+#define CONFIG_NR_OF_PARAMETER_PIN_TYPES    4
+#define CONFIG_NR_OF_PARAMETER_COUNT_TYPES  3
 
-#define CONFIG_NR_OF_PARAMETER_TYPES 10
-#define CONFIG_NR_OF_PARAMETER_BOOL_TYPES 4
-#define CONFIG_NR_OF_PARAMETER_PIN_TYPES 4
+#define LEVEL               0
+#define INV_LEVEL           1
+#define TOGGLE_RISING       2
+#define TOGGLE_FALLING      3
 
-#define LEVEL			0
-#define INV_LEVEL			1
-#define TOGGLE_RISING	2
-#define TOGGLE_FALLING 	3
-
+#define COUNT_TYPE_GENERIC  0
+#define COUNT_TYPE_RFXMETER 1
+#define COUNT_TYPE_ENERGY   2
 
 using namespace std;
 
 class CIOCount
 {
-   public:
-	   CIOCount();
-	   ~CIOCount();
-
-	   int Update(unsigned long Counts);
-	   unsigned long GetCurrent(void) const {return Current;};
-	   unsigned long GetTotal(void) const {return Total;};
-	   unsigned long GetLastTotal(void) const { return LastTotal; };
-	   unsigned long GetRateLimit(void) const { return Minimum_Pulse_Period_ms; };
-	   void SetCurrent(unsigned long NewCurValue) {Current=NewCurValue;};
-	   void SetTotal(unsigned long NewTotalValue) { Total = NewTotalValue; };
-	   void SetLastTotal(unsigned long NewTotalValue) { LastTotal = NewTotalValue; };
-	   void SetRateLimit(unsigned long NewRateLimit) { Minimum_Pulse_Period_ms = NewRateLimit; };
-	   void ResetCurrent(void) {Current=0;};
-	   void ResetTotal(void) {
-		   Total = 0;
-		   LastTotal = 0;
-	   };
-	   bool ProcessUpdateInterval(unsigned long PassedTime_ms);
-	   void SetUpdateInterval(unsigned long NewValue_ms);
-	   unsigned long GetUpdateInterval(void) {return UpdateInterval_ms;};
-	   bool Enabled;
-	   bool InitialStateSent;
-
-   private:
-	   unsigned long Current;
-	   unsigned long Total;
-	   unsigned long LastTotal;
-	   unsigned long UpdateInterval_ms;
-	   unsigned long UpdateDownCount_ms;
-	   unsigned long Minimum_Pulse_Period_ms;
-	   boost::posix_time::ptime Last_Call;
-	   boost::posix_time::ptime Cur_Call;
+    friend class CIOPort;
+    
+public:
+    CIOCount();
+    ~CIOCount();
+    
+    int Update(unsigned long Counts);
+    unsigned long GetCurrent(void) const {return Current;};
+    unsigned long GetTotal(void) const {return Total;};
+    unsigned long GetLastTotal(void) const { return LastTotal; };
+    unsigned long GetRateLimit(void) const { return Minimum_Pulse_Period_ms; };
+    unsigned long GetDivider(void) const { return Divider; };
+    unsigned long GetUpdatePulsePeriodDiff(void) const { return UpdatePulsePeriodDiff_ms; };
+    void SetCurrent(unsigned long NewCurValue) {Current=NewCurValue;};
+    void SetTotal(unsigned long NewTotalValue) { Total = NewTotalValue; };
+    void SetLastTotal(unsigned long NewTotalValue) { LastTotal = NewTotalValue; };
+    void SetRateLimit(unsigned long NewRateLimit) { Minimum_Pulse_Period_ms = NewRateLimit; };
+    void ResetCurrent(void) {Current=0;};
+    void ResetTotal(void) {
+        Total = 0;
+        LastTotal = 0;
+    };
+    bool ProcessUpdateInterval(unsigned long PassedTime_ms);
+    void SetUpdateInterval(unsigned long NewValue_ms);
+    void SetUpdatePulsePeriodDiff(unsigned long NewValue_ms) { UpdatePulsePeriodDiff_ms = NewValue_ms; };
+    void SetDivider(unsigned long NewValue) { Divider = NewValue; };
+    unsigned long GetUpdateInterval(void) {return UpdateInterval_ms;};
+    bool Enabled;
+    bool InitialStateSent;
+    int Type;
+    
+private:
+    unsigned long Current;
+    unsigned long Total;
+    unsigned long LastTotal;
+    unsigned long UpdateInterval_ms;
+    unsigned long UpdateDownCount_ms;
+    unsigned long Minimum_Pulse_Period_ms;
+    unsigned long UpdatePulsePeriodDiff_ms;
+    unsigned long Divider;
+    boost::posix_time::ptime Last_Call;
+    boost::posix_time::ptime Cur_Call;
 };
 
 class CIOPinState
 {
-   public:
-	   CIOPinState();
-	   ~CIOPinState();
-
-	   int Update(bool New);
-	   int UpdateInterrupt(bool IntFlag,bool PinState);
-	   int GetInitialState(void);
-	   bool GetCurrent(void) const { return Current;}
-	   bool Enabled;
-	   int Id;
-	   int Type;
-	   CIOCount Count;
-	   bool InitialStateSent;
-	   unsigned char Direction;
-
-   private:
-	   bool Last;
-	   bool Current;
-	   bool Toggle;
-
+    friend class CIOPort;
+    
+public:
+    CIOPinState();
+    ~CIOPinState();
+    
+    int Update(bool New);
+    int UpdateInterrupt(bool IntFlag,bool PinState);
+    int GetInitialState(void);
+    bool GetCurrent(void) const { return Current;}
+    bool Enabled;
+    int Id;
+    int Type;
+    CIOCount Count;
+    bool InitialStateSent;
+    unsigned char Direction;
+    
+private:
+    tRBUF IOPinCounterPacket;
+    bool Last;
+    bool Current;
+    bool Toggle;
 };
 
 
 
 class CIOPort
 {
-   public:
-	   CIOPort();
-	   ~CIOPort();
-	   int Update(unsigned char New);
-	   int UpdateInterrupt(unsigned char IntFlag,unsigned char PinState);
-	   unsigned char GetCurrent(void) const { return Current;}
-	   int GetDevId(void) const { return devId;}
-	   bool IsDevicePresent(void) const { return Present;}
-	   void Init(bool Available, unsigned char housecode, unsigned char initial_state);
-       void SetID(int devID) { devId= devID;}
-	   void ConfigureCounter(unsigned char Pin,bool Enable);
-	   void *Callback_pntr;
-	   CIOPinState  Pin[8];
-	   unsigned int PortType;
-
-   private:
-	   tRBUF IOPinStatusPacket;
-	   tRBUF IOPinCounterPacket;
-	   unsigned char Last;
-	   unsigned char Current;
-	   int devId;
-	   bool Present;
+    friend class CPiFace;
+    
+public:
+    CIOPort();
+    ~CIOPort();
+    int Update(unsigned char New);
+    int UpdateInterrupt(unsigned char IntFlag,unsigned char PinState);
+    unsigned char GetCurrent(void) const { return Current;}
+    int GetDevId(void) const { return devId;}
+    bool IsDevicePresent(void) const { return Present;}
+    void Init(bool Available, int hwdId, int devId, unsigned char housecode, unsigned char initial_state);
+    void SetID(int devID) { devId= devID;}
+    void ConfigureCounter(unsigned char Pin,bool Enable);
+    void *Callback_pntr;
+    CIOPinState  Pin[8];
+    unsigned int PortType;
+    
+private:
+    tRBUF IOPinStatusPacket;
+    unsigned char Last;
+    unsigned char Current;
+    int devId;
+    bool Present;
 };
 
 class CPiFace : public CDomoticzHardwareBase
 {
 public:
-	explicit CPiFace(const int ID);
-	~CPiFace();
-	bool WriteToHardware(const char *pdata, const unsigned char length);
-	void CallBackSendEvent(const unsigned char *pEventPacket, const unsigned int PacketLength);
-	void CallBackSetPinInterruptMode(unsigned char devId,unsigned char pinID, bool Interrupt_Enable);
-
+    explicit CPiFace(const int ID);
+    ~CPiFace();
+    bool WriteToHardware(const char *pdata, const unsigned char length);
+    void CallBackSendEvent(const unsigned char *pEventPacket, const unsigned int PacketLength);
+    void CallBackSetPinInterruptMode(unsigned char devId,unsigned char pinID, bool Interrupt_Enable);
+    
 private:
-	bool StartHardware();
-	bool StopHardware();
-
-	void Do_Work();
-	void Do_Work_Queue();
-	boost::shared_ptr<boost::thread> m_thread;
-	boost::shared_ptr<boost::thread> m_queue_thread;
-
-	volatile bool m_stoprequested;
-	int m_InputSample_waitcntr;
-	int m_CounterEdgeSample_waitcntr;
-
-	int Init_SPI_Device(int Init);
-	void Init_Hardware(unsigned char devId);
-	int Read_Write_SPI_Byte(unsigned char *data, int len);
-	int Read_MCP23S17_Register(unsigned char devId, unsigned char reg);
-	int Write_MCP23S17_Register(unsigned char devId, unsigned char reg, unsigned char data);
-	void Sample_and_Process_Inputs(unsigned char devId);
-	void Sample_and_Process_Outputs(unsigned char devId);
-	void Sample_and_Process_Input_Interrupts(unsigned char devId);
-	void GetAndSetInitialDeviceState(unsigned char devId);
-
-
-	int Detect_PiFace_Hardware(void);
-
-	int m_fd;
-	//int m_HwdID;
-
-	CIOPort m_Inputs[4];
-	CIOPort m_Outputs[4];
-
-	bool m_DetectedHardware[4];
-
-	//config file functions
-	std::string & preprocess(std::string &s);
-	std::string & trim(std::string &s);
-	std::string & ltrim(std::string &s);
-	std::string & rtrim(std::string &s);
-	int LocateValueInParameterArray(std::string Parametername,const std::string *ParameterArray,int Items);
-	int GetParameterString(std::string TargetString,const char * SearchStr, int StartPos,  std::string &Parameter);
-	int LoadConfig(void);
-	void LoadDefaultConfig(void);
-	void AutoCreate_piface_config(void);
-
-	void GetLastKnownValues(void);
-
-	boost::mutex m_queue_mutex;
-	std::vector<std::string> m_send_queue;
+    bool StartHardware();
+    bool StopHardware();
+    
+    void Do_Work();
+    void Do_Work_Queue();
+    boost::shared_ptr<boost::thread> m_thread;
+    boost::shared_ptr<boost::thread> m_queue_thread;
+    
+    volatile bool m_stoprequested;
+    int m_InputSample_waitcntr;
+    int m_CounterEdgeSample_waitcntr;
+    
+    int Init_SPI_Device(int Init);
+    void Init_Hardware(unsigned char devId);
+    int Read_Write_SPI_Byte(unsigned char *data, int len);
+    int Read_MCP23S17_Register(unsigned char devId, unsigned char reg);
+    int Write_MCP23S17_Register(unsigned char devId, unsigned char reg, unsigned char data);
+    void Sample_and_Process_Inputs(unsigned char devId);
+    void Sample_and_Process_Outputs(unsigned char devId);
+    void Sample_and_Process_Input_Interrupts(unsigned char devId);
+    void GetAndSetInitialDeviceState(int devId);
+    
+    
+    int Detect_PiFace_Hardware(void);
+    
+    int m_fd;
+    
+    CIOPort m_Inputs[4];
+    CIOPort m_Outputs[4];
+    
+    bool m_DetectedHardware[4];
+    
+    //config file functions
+    static const std::string ParameterNames[CONFIG_NR_OF_PARAMETER_TYPES];
+    static const std::string ParameterBooleanValueNames[CONFIG_NR_OF_PARAMETER_BOOL_TYPES];
+    static const std::string ParameterPinTypeValueNames[CONFIG_NR_OF_PARAMETER_PIN_TYPES];
+    static const std::string ParameterCountTypeValueNames[CONFIG_NR_OF_PARAMETER_COUNT_TYPES];
+    
+    std::string & preprocess(std::string &s);
+    std::string & trim(std::string &s);
+    std::string & ltrim(std::string &s);
+    std::string & rtrim(std::string &s);
+    int LocateValueInParameterArray(std::string Parametername,const std::string *ParameterArray,int Items);
+    int GetParameterString(std::string TargetString,const char * SearchStr, int StartPos,  std::string &Parameter);
+    int LoadConfig(void);
+    void LoadDefaultConfig(void);
+    void AutoCreate_piface_config(void);
+    
+    void GetLastKnownValues(void);
+    void GetLastKnownValues(int BoardNr, int PinNr, CIOPort port);
+    
+    boost::mutex m_queue_mutex;
+    std::vector<std::string> m_send_queue;
 };


### PR DESCRIPTION
Added the ability to configure the counter to be of a different type. Besides the default rfxmeter, energy is supported. In the future, support for gas, water or others can be added. A divider setting is added that is used to convert the pulses into the target meter type.
