### PR TITLE
webserver: Log error message if file not found

### DIFF
--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -319,6 +319,7 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 					  if (full_path.find('.') != std::string::npos)
 					  {
 						  rep = reply::stock_reply(reply::not_found);
+						  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 						  return;
 					  }
 					  request_path += "/index.html";
@@ -327,6 +328,7 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 					  if (!is.is_open())
 					  {
 						  rep = reply::stock_reply(reply::not_found);
+						  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 						  return;
 					  }
 					  extension = "html";
@@ -354,6 +356,7 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 	  if (m_uf==NULL)
 	  {
 		  rep = reply::stock_reply(reply::not_found);
+		  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 		  return;
 	  }
 
@@ -367,6 +370,7 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 			  if (myWebem && do_extract_currentfile(m_uf,myWebem->m_zippassword.c_str(),rep.content)!=UNZ_OK)
 			  {
 				  rep = reply::stock_reply(reply::not_found);
+				  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 				  return;
 			  }
 			  bHaveLoadedgzip=true;
@@ -377,11 +381,13 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 		  if (unzLocateFile(m_uf,request_path.c_str(),0)!=UNZ_OK)
 		  {
 			  rep = reply::stock_reply(reply::not_found);
+			  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 			  return;
 		  }
 		  if (myWebem && do_extract_currentfile(m_uf,myWebem->m_zippassword.c_str(),rep.content)!=UNZ_OK)
 		  {
 			  rep = reply::stock_reply(reply::not_found);
+			  _log.Log(LOG_ERROR, "Webserver: File '%s': %s (%d)", request_path.c_str(), strerror(errno), errno);
 			  return;
 		  }
 	  }


### PR DESCRIPTION
In case of proglem finding requested web server file on this, message:
Error: Webserver: File '/index.html': No such file or directory (2)
will be logged.

It helps a lot debugging problems with permissions and run
configurations.
