### PR TITLE
PTEC with no tempo option shoud be set

### DIFF
--- a/hardware/Teleinfo.cpp
+++ b/hardware/Teleinfo.cpp
@@ -310,6 +310,12 @@ void Teleinfo::MatchLine()
                                 m_bLabel_PTEC_JW = false;
                                 m_bLabel_PTEC_JR = true;
                         }
+                        else
+                        {
+                                m_bLabel_PTEC_JB = false;
+                                m_bLabel_PTEC_JW = false;
+                                m_bLabel_PTEC_JR = false;
+                        }
 
 			break;
 		case TELEINFO_TYPE_IINST:


### PR DESCRIPTION
Tele info do not work for now, if no tempo options, the current values are not correct
