### PR TITLE
Added multi-room zone support for HGI80 to Evohome.cpp

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -246,6 +246,7 @@ void CEvohome::Do_Work()
 	boost::system_time stLastRelayCheck(boost::posix_time::min_date_time);
 	int nStartup=0;
 	int sec_counter = 0;
+	bool startup = true;
 	while (!m_stoprequested)
 	{
 		sleep_seconds(1);
@@ -282,8 +283,19 @@ void CEvohome::Do_Work()
 				nStartup++;
 				if(nStartup==300)
 				{
-					InitControllerName();
-					InitZoneNames();
+					if (startup)
+					{
+						InitControllerName();
+						InitZoneNames();
+						startup = false;
+					}
+					else//Request each individual zone temperature every 300s as the controller omits multi-room zones
+					{
+						uint8_t nZoneCount = GetZoneCount();
+						for (uint8_t i = 0; i < nZoneCount; i++)
+							RequestZoneTemp(i);
+					}
+					nStartup = 0;
 				}
 			}
 			boost::lock_guard<boost::mutex> l(m_mtxRelayCheck);

--- a/hardware/evohome.h
+++ b/hardware/evohome.h
@@ -563,7 +563,7 @@ private:
 	static const uint8_t m_dczToEvoZoneMode[3];
 	static const uint8_t m_dczToEvoControllerMode[6];
 	
-	template <typename RT> RT ConvertMode(RT* pArray, uint8_t nIdx){return pArray[(nIdx<sizeof(pArray))?nIdx:0];}
+	template <typename RT> RT ConvertMode(RT* pArray, uint8_t nIdx){return pArray[nIdx];}
 	
 	boost::shared_ptr<boost::thread> m_thread;
 	volatile bool m_stoprequested;


### PR DESCRIPTION
This resolves the problem with not receiving regular temperature readings from any multi-room zones when using the HGI80.
