### PR TITLE
MQTT client support for Battery and RSSI data.

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -229,7 +229,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		bool b_signallevel = ! root["RSSI"].empty();
 		if (b_signallevel)
 		{
-			if (not root["RSSI"].isInt())
+			if (! root["RSSI"].isInt())
 				goto mqttinvaliddata;
 			signallevel = root["RSSI"].asInt();
 		}
@@ -238,7 +238,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		bool b_batterylevel = ! root["Battery"].empty();
 		if (b_batterylevel)
 		{
-			if (not root["Battery"].isInt())
+			if (! root["Battery"].isInt())
 				goto mqttinvaliddata;
 			batterylevel = root["Battery"].asInt();
 		}

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -225,25 +225,25 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		std::string svalue = (bsvalue) ? root["svalue"].asString() : "";
 		bool bParseTrigger = (bParseValue) ? root["parse"].asBool() : true;
 
-		int signal_level = 12;
-		bool b_signal_level = not root["RSSI"].empty();
-		if (b_signal_level)
+		int signallevel = 12;
+		bool b_signallevel = ! root["RSSI"].empty();
+		if (b_signallevel)
 		{
 			if (not root["RSSI"].isInt())
 				goto mqttinvaliddata;
-			signal_level = root["RSSI"].asInt();
+			signallevel = root["RSSI"].asInt();
 		}
 
-		int battery_level = 255;
-		bool b_battery_level = not root["Battery"].empty();
-		if (b_battery_level)
+		int batterylevel = 255;
+		bool b_batterylevel = ! root["Battery"].empty();
+		if (b_batterylevel)
 		{
 			if (not root["Battery"].isInt())
 				goto mqttinvaliddata;
-			battery_level = root["Battery"].asInt();
+			batterylevel = root["Battery"].asInt();
 		}
 
-		if (!m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, nvalue, svalue, signal_level, battery_level, bParseTrigger))
+		if (!m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, nvalue, svalue, signallevel, batterylevel, bParseTrigger))
 		{
 			_log.Log(LOG_ERROR, "MQTT: Problem updating sensor (check idx, hardware enabled)");
 			return;

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -225,10 +225,25 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		std::string svalue = (bsvalue) ? root["svalue"].asString() : "";
 		bool bParseTrigger = (bParseValue) ? root["parse"].asBool() : true;
 
-		int signallevel = 12;
-		int batterylevel = 255;
+		int signal_level = 12;
+		bool b_signal_level = not root["RSSI"].empty();
+		if (b_signal_level)
+		{
+			if (not root["RSSI"].isInt())
+				goto mqttinvaliddata;
+			signal_level = root["RSSI"].asInt();
+		}
 
-		if (!m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, nvalue, svalue, signallevel, batterylevel, bParseTrigger))
+		int battery_level = 255;
+		bool b_battery_level = not root["Battery"].empty();
+		if (b_battery_level)
+		{
+			if (not root["Battery"].isInt())
+				goto mqttinvaliddata;
+			battery_level = root["Battery"].asInt();
+		}
+
+		if (!m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, nvalue, svalue, signal_level, battery_level, bParseTrigger))
 		{
 			_log.Log(LOG_ERROR, "MQTT: Problem updating sensor (check idx, hardware enabled)");
 			return;


### PR DESCRIPTION
This is to remove the hard-coded values for Battery (=255) and RSSI (=12) in the MQTT Client current implementation by parsing them, if found, from the incoming MQTT message. Default values as reported above are still applied if not otherwise specified in the MQTT Message.

A sample incoming MQTT message json payload for this should be

`{ "idx": 1, "nvalue": 0, "svalue": "20.400;48.200;1", "Battery": 95, "RSSI": 44 }`

echoed back as

`{
   "Battery" : 95,
   "RSSI" : 44,
   "dtype" : "Temp + Humidity",
   "id" : "82001",
   "idx" : 1,
   "name" : "1_th",
   "nvalue" : 0,
   "stype" : "THGN122/123, THGN132, THGR122/228/238/268",
   "svalue1" : "20.400",
   "svalue2" : "48.200",
   "svalue3" : "1",
   "unit" : 1
}`
