### PR TITLE
Change path of open-zwave folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,7 +485,7 @@ endif()
 # try to find open-zwave, if found, include support
 option(USE_STATIC_OPENZWAVE "Build with static OpenZwave libraries" YES)
 if(USE_STATIC_OPENZWAVE)
-  find_library(OpenZWave NAMES libopenzwave.a HINTS "../open-zwave-read-only" "../open-zwave-read-only/cpp/build")
+  find_library(OpenZWave NAMES libopenzwave.a HINTS "../open-zwave" "../open-zwave/cpp/build")
   set(OPENZWAVE_LIB ${OpenZWave})
 else()
   pkg_check_modules(OPENZWAVE libopenzwave)


### PR DESCRIPTION
Open-zwave is now on github. https://github.com/OpenZWave/open-zwave.git
The folder name now should be open-zwave.
