### PR TITLE
Add support for Rainforest RAVEn USB ZigBee Smart Meter Adapter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+#* text=auto
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-#* text=auto
+* text=auto
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ hardware/Tellstick.cpp
 hardware/Thermosmart.cpp
 hardware/ToonThermostat.cpp
 hardware/VolcraftCO20.cpp
+hardware/RAVEn.cpp
 hardware/Winddelen.cpp
 hardware/WOL.cpp
 hardware/Wunderground.cpp

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -1,7 +1,6 @@
 
 #include "stdafx.h"
 #ifndef WIN32
-#ifdef WITH_LIBUSB
 #include "RAVEn.h"
 #include "../main/Helper.h"
 #include "../main/Logger.h"
@@ -9,26 +8,14 @@
 #include "../main/RFXtrx.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
+#include "../tinyxpath/tinyxml.h"
 #include <usb.h>
 #include <stdint.h>
 
-#define VolcraftCO20_POLL_INTERVAL 30
-
-#define DRIVER_NAME_LEN	1024
-#define USB_BUF_LEN	1024
-
-#define USB_VENDOR_CO2_STICK	0x03eb
-#define USB_PRODUCT_CO2_STICK	0x2013
-
-#define round(a) ( int ) ( a + .5 )
-
-//code taken and modified form https://github.com/bwildenhain/air-quality-sensor/blob/master/src/air01.c
-//at this moment it does not work under windows... no idea why... help appreciated!
-
-RAVEn::RAVEn(const int ID, const std::string& port)
+RAVEn::RAVEn(const int ID, const std::string& devname)
+: device_(devname)
 {
-	m_HwdID=ID;
-	m_stoprequested=false;
+    m_HwdID = ID;
 }
 
 RAVEn::~RAVEn(void)
@@ -37,50 +24,71 @@ RAVEn::~RAVEn(void)
 
 bool RAVEn::StartHardware()
 {
-	//Start worker thread
-	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&RAVEn::Do_Work, this)));
-	m_bIsStarted=true;
-	sOnConnected(this);
+    StartHeartbeatThread();
+    //Try to open the Serial Port
+    try
+    {
+        _log.Log(LOG_STATUS, "RAVEn: Using serial port: %s", device_.c_str());
+        open(device_.c_str(), 115200);
+    }
+    catch (boost::exception & e)
+    {
+        _log.Log(LOG_ERROR, "RAVEn: Error opening serial port!");
+#ifdef _DEBUG
+        _log.Log(LOG_ERROR, "-----------------\n%s\n-----------------", boost::diagnostic_information(e).c_str());
+#else
+        (void)e;
+#endif
+        return false;
+    }
+    catch (...)
+    {
+        _log.Log(LOG_ERROR, "RAVEn: Error opening serial port!!!");
+        return false;
+    }
+    setReadCallback(boost::bind(&RAVEn::readCallback, this, _1, _2));
+    m_bIsStarted = true;
+    sOnConnected(this);
 
-	return (m_thread!=NULL);
+    return true;
 }
 
 bool RAVEn::StopHardware()
 {
-	/*
-    m_stoprequested=true;
-	if (m_thread)
-		m_thread->join();
-	return true;
-    */
-	if (m_thread!=NULL)
-	{
-		assert(m_thread);
-		m_stoprequested = true;
-		m_thread->join();
-	}
-	m_bIsStarted=false;
+    terminate();
+    StopHeartbeatThread();
+    m_bIsStarted = false;
     return true;
 }
 
-void RAVEn::Do_Work()
+void RAVEn::readCallback(const char *data, size_t len)
 {
-	int sec_counter=VolcraftCO20_POLL_INTERVAL-5;
-	while (!m_stoprequested)
-	{
-		sleep_seconds(1);
-		sec_counter++;
-		if (sec_counter%12==0)
-		{
-			m_LastHeartbeat=mytime(NULL);
-		}
+    boost::lock_guard<boost::mutex> l(readQueueMutex);
+    if (!m_bEnableReceive)
+        return; //receiving not enabled
 
-		if (sec_counter%VolcraftCO20_POLL_INTERVAL==0)
-		{
-			GetSensorDetails();
-		}
-	}
-	_log.Log(LOG_STATUS,"Voltcraft CO-20: Worker stopped...");
+#ifdef _DEBUG
+        _log.Log(LOG_INFO, "RAVEn::readCallback got %d: %s", len, data)
+#endif
+    TiXmlDocument doc;
+//FIXME: Null terminated?
+    if (doc.Parse(data))
+    {
+        _log.Log(LOG_ERROR, "RAVEn: Not enough data received: ", data);
+        return;
+    }
+
+    TiXmlElement *pRoot;
+
+    pRoot = doc.FirstChildElement("InstantaneousDemand");
+    if (!pRoot)
+    {
+        _log.Log(LOG_ERROR, "RAVEn: Unknown node");
+        return;
+    }
+    double currUsage = double(strtoul(pRoot->FirstChildElement("Demand")->GetText(), NULL, 16))/strtoul(pRoot->FirstChildElement("Divisor")->GetText(), NULL, 16);
+    SendKwhMeter(CDomoticzHardwareBase::m_HwdID, 1, 255, currUsage, 5, "Power Meter");
+
 }
 
 bool RAVEn::WriteToHardware(const char *pdata, const unsigned char length)
@@ -88,139 +96,5 @@ bool RAVEn::WriteToHardware(const char *pdata, const unsigned char length)
 	return false;
 }
 
-static int read_one_sensor (struct usb_device *dev, uint16_t &value)
-{
-	int ret;
-	struct usb_dev_handle *devh;
-	char driver_name[DRIVER_NAME_LEN] = "";
-	char usb_io_buf[USB_BUF_LEN] =	
-		"\x40\x68\x2a\x54"
-		"\x52\x0a\x40\x40"
-		"\x40\x40\x40\x40"
-		"\x40\x40\x40\x40";
 
-	/* Open USB device.  */
-	devh = usb_open (dev);
-	if (! dev) {
-		fprintf (stderr, "Failed to usb_open(%p)\n", (void *) dev);
-		ret = -1;
-		goto out;
-	}
-
-	/* Ensure that the device isn't claimed.  */
-	ret = usb_get_driver_np (devh, 0/*intrf*/, driver_name, sizeof (driver_name));
-	if (! ret) {
-		_log.Log(LOG_ERROR,"Voltcraft CO-20: Warning: device is claimed by driver %s, trying to unbind it.", driver_name);
-		ret = usb_detach_kernel_driver_np (devh, 0/*intrf*/);
-		if (ret) {
-			_log.Log(LOG_ERROR,"Voltcraft CO-20: Warning: Failed to detatch kernel driver.");
-			ret = -2;
-			goto out;
-		}
-	}
-
-	/* Claim device.  */
-	ret = usb_claim_interface (devh, 0/*intrf*/);
-	if (ret) {
-		_log.Log(LOG_ERROR,"Voltcraft CO-20: usb_claim_interface() failed with error %d=%s",	ret, strerror (-ret));
-		ret = -3;
-		goto out;
-	}
-
-	/* Send query command.  */
-	ret = usb_interrupt_write(devh, 0x0002/*endpoint*/,
-		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
-	if (ret < 0) {
-		_log.Log(LOG_ERROR,"Voltcraft CO-20:  Failed to usb_interrupt_write() the initial buffer, ret = %d", ret);
-		ret = -4;
-		goto out_unlock;
-	}
-
-	/* Read answer.  */
-	ret = usb_interrupt_read(devh, 0x0081/*endpoint*/,
-		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
-	if (ret < 0) {
-		_log.Log(LOG_ERROR,"Voltcraft CO-20: Failed to usb_interrupt_read() #1");
-		ret = -5;
-		goto out_unlock;
-	}
-
-	/* On empty read, read again.  */
-	if (ret == 0) {
-		ret = usb_interrupt_read(devh, 0x0081/*endpoint*/,
-			usb_io_buf, 0x10/*len*/, 1000/*msec*/);
-		if (ret == 0) {
-			//give up!
-			goto out_unlock;
-		}
-	}
-
-	/* Prepare value from first read.  */
-	value = ((unsigned char *)usb_io_buf)[3] << 8
-		| ((unsigned char *)usb_io_buf)[2] << 0;
-
-	/* Dummy read.  */
-	usb_interrupt_read(devh, 0x0081/*endpoint*/,
-		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
-out_unlock:
-	ret = usb_release_interface(devh, 0/*intrf*/);
-	if (ret) {
-		fprintf(stderr, "Failed to usb_release_interface()\n");
-		ret = -5;
-	}
-out:
-	if (devh)
-		usb_close (devh);
-	return ret;
-}
-
-static int get_voc_value(int vendor, int product, uint16_t &voc)
-{
-	voc=0;
-	struct usb_bus *bus;
-	struct usb_device *dev;
-	int ret = 0;
-
-	for (bus = usb_get_busses(); bus; bus = bus->next)
-	{
-		for (dev = bus->devices; dev; dev = dev->next)
-		{
-			if (dev->descriptor.idVendor == vendor && dev->descriptor.idProduct == product)
-			{
-				ret |= read_one_sensor(dev,voc);
-			}
-		}
-	}
-	return ret;
-}
-
-void RAVEn::GetSensorDetails()
-{
-	try
-	{
-		uint16_t voc;
-
-		usb_init ();
-		usb_set_debug (0);
-		usb_find_busses ();
-		usb_find_devices ();
-
-		get_voc_value(USB_VENDOR_CO2_STICK,USB_PRODUCT_CO2_STICK,voc);
-		if (voc!=0)
-		{
-			if (voc==3000)
-			{
-				_log.Log(LOG_ERROR, "Voltcraft CO-20: Sensor data out of range!!");
-				return;
-			}
-			SendAirQualitySensor(1, 1, 255, voc, "Air Quality");
-		}
-	}
-	catch (...)
-	{
-	
-	}
-}
-
-#endif //WITH_LIBUSB
 #endif //WIN32

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -1,0 +1,226 @@
+
+#include "stdafx.h"
+#ifndef WIN32
+#ifdef WITH_LIBUSB
+#include "RAVEn.h"
+#include "../main/Helper.h"
+#include "../main/Logger.h"
+#include "hardwaretypes.h"
+#include "../main/RFXtrx.h"
+#include "../main/localtime_r.h"
+#include "../main/mainworker.h"
+#include <usb.h>
+#include <stdint.h>
+
+#define VolcraftCO20_POLL_INTERVAL 30
+
+#define DRIVER_NAME_LEN	1024
+#define USB_BUF_LEN	1024
+
+#define USB_VENDOR_CO2_STICK	0x03eb
+#define USB_PRODUCT_CO2_STICK	0x2013
+
+#define round(a) ( int ) ( a + .5 )
+
+//code taken and modified form https://github.com/bwildenhain/air-quality-sensor/blob/master/src/air01.c
+//at this moment it does not work under windows... no idea why... help appreciated!
+
+RAVEn::RAVEn(const int ID, const std::string& port)
+{
+	m_HwdID=ID;
+	m_stoprequested=false;
+}
+
+RAVEn::~RAVEn(void)
+{
+}
+
+bool RAVEn::StartHardware()
+{
+	//Start worker thread
+	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&RAVEn::Do_Work, this)));
+	m_bIsStarted=true;
+	sOnConnected(this);
+
+	return (m_thread!=NULL);
+}
+
+bool RAVEn::StopHardware()
+{
+	/*
+    m_stoprequested=true;
+	if (m_thread)
+		m_thread->join();
+	return true;
+    */
+	if (m_thread!=NULL)
+	{
+		assert(m_thread);
+		m_stoprequested = true;
+		m_thread->join();
+	}
+	m_bIsStarted=false;
+    return true;
+}
+
+void RAVEn::Do_Work()
+{
+	int sec_counter=VolcraftCO20_POLL_INTERVAL-5;
+	while (!m_stoprequested)
+	{
+		sleep_seconds(1);
+		sec_counter++;
+		if (sec_counter%12==0)
+		{
+			m_LastHeartbeat=mytime(NULL);
+		}
+
+		if (sec_counter%VolcraftCO20_POLL_INTERVAL==0)
+		{
+			GetSensorDetails();
+		}
+	}
+	_log.Log(LOG_STATUS,"Voltcraft CO-20: Worker stopped...");
+}
+
+bool RAVEn::WriteToHardware(const char *pdata, const unsigned char length)
+{
+	return false;
+}
+
+static int read_one_sensor (struct usb_device *dev, uint16_t &value)
+{
+	int ret;
+	struct usb_dev_handle *devh;
+	char driver_name[DRIVER_NAME_LEN] = "";
+	char usb_io_buf[USB_BUF_LEN] =	
+		"\x40\x68\x2a\x54"
+		"\x52\x0a\x40\x40"
+		"\x40\x40\x40\x40"
+		"\x40\x40\x40\x40";
+
+	/* Open USB device.  */
+	devh = usb_open (dev);
+	if (! dev) {
+		fprintf (stderr, "Failed to usb_open(%p)\n", (void *) dev);
+		ret = -1;
+		goto out;
+	}
+
+	/* Ensure that the device isn't claimed.  */
+	ret = usb_get_driver_np (devh, 0/*intrf*/, driver_name, sizeof (driver_name));
+	if (! ret) {
+		_log.Log(LOG_ERROR,"Voltcraft CO-20: Warning: device is claimed by driver %s, trying to unbind it.", driver_name);
+		ret = usb_detach_kernel_driver_np (devh, 0/*intrf*/);
+		if (ret) {
+			_log.Log(LOG_ERROR,"Voltcraft CO-20: Warning: Failed to detatch kernel driver.");
+			ret = -2;
+			goto out;
+		}
+	}
+
+	/* Claim device.  */
+	ret = usb_claim_interface (devh, 0/*intrf*/);
+	if (ret) {
+		_log.Log(LOG_ERROR,"Voltcraft CO-20: usb_claim_interface() failed with error %d=%s",	ret, strerror (-ret));
+		ret = -3;
+		goto out;
+	}
+
+	/* Send query command.  */
+	ret = usb_interrupt_write(devh, 0x0002/*endpoint*/,
+		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
+	if (ret < 0) {
+		_log.Log(LOG_ERROR,"Voltcraft CO-20:  Failed to usb_interrupt_write() the initial buffer, ret = %d", ret);
+		ret = -4;
+		goto out_unlock;
+	}
+
+	/* Read answer.  */
+	ret = usb_interrupt_read(devh, 0x0081/*endpoint*/,
+		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
+	if (ret < 0) {
+		_log.Log(LOG_ERROR,"Voltcraft CO-20: Failed to usb_interrupt_read() #1");
+		ret = -5;
+		goto out_unlock;
+	}
+
+	/* On empty read, read again.  */
+	if (ret == 0) {
+		ret = usb_interrupt_read(devh, 0x0081/*endpoint*/,
+			usb_io_buf, 0x10/*len*/, 1000/*msec*/);
+		if (ret == 0) {
+			//give up!
+			goto out_unlock;
+		}
+	}
+
+	/* Prepare value from first read.  */
+	value = ((unsigned char *)usb_io_buf)[3] << 8
+		| ((unsigned char *)usb_io_buf)[2] << 0;
+
+	/* Dummy read.  */
+	usb_interrupt_read(devh, 0x0081/*endpoint*/,
+		usb_io_buf, 0x10/*len*/, 1000/*msec*/);
+out_unlock:
+	ret = usb_release_interface(devh, 0/*intrf*/);
+	if (ret) {
+		fprintf(stderr, "Failed to usb_release_interface()\n");
+		ret = -5;
+	}
+out:
+	if (devh)
+		usb_close (devh);
+	return ret;
+}
+
+static int get_voc_value(int vendor, int product, uint16_t &voc)
+{
+	voc=0;
+	struct usb_bus *bus;
+	struct usb_device *dev;
+	int ret = 0;
+
+	for (bus = usb_get_busses(); bus; bus = bus->next)
+	{
+		for (dev = bus->devices; dev; dev = dev->next)
+		{
+			if (dev->descriptor.idVendor == vendor && dev->descriptor.idProduct == product)
+			{
+				ret |= read_one_sensor(dev,voc);
+			}
+		}
+	}
+	return ret;
+}
+
+void RAVEn::GetSensorDetails()
+{
+	try
+	{
+		uint16_t voc;
+
+		usb_init ();
+		usb_set_debug (0);
+		usb_find_busses ();
+		usb_find_devices ();
+
+		get_voc_value(USB_VENDOR_CO2_STICK,USB_PRODUCT_CO2_STICK,voc);
+		if (voc!=0)
+		{
+			if (voc==3000)
+			{
+				_log.Log(LOG_ERROR, "Voltcraft CO-20: Sensor data out of range!!");
+				return;
+			}
+			SendAirQualitySensor(1, 1, 255, voc, "Air Quality");
+		}
+	}
+	catch (...)
+	{
+	
+	}
+}
+
+#endif //WITH_LIBUSB
+#endif //WIN32

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -96,7 +96,9 @@ void RAVEn::readCallback(const char *indata, size_t inlen)
     const char* endPtr = doc.Parse(buffer_);
     if (!endPtr)
     {
-        _log.Log(LOG_ERROR, "RAVEn: Not enough data received (%d): %s", len, data);
+#ifdef _DEBUG
+        _log.Log(LOG_ERROR, "RAVEn: Not enough data received (%d): %s", len, buffer_);
+#endif
         return;
     }
     else

--- a/hardware/RAVEn.h
+++ b/hardware/RAVEn.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifndef WIN32
+#ifdef WITH_LIBUSB
+#include "DomoticzHardware.h"
+#include <iostream>
+
+class RAVEn : public CDomoticzHardwareBase
+{
+public:
+	explicit RAVEn(const int ID, const std::string& port);
+	~RAVEn(void);
+
+	bool WriteToHardware(const char *pdata, const unsigned char length);
+private:
+	volatile bool m_stoprequested;
+	boost::shared_ptr<boost::thread> m_thread;
+
+	bool StartHardware();
+	bool StopHardware();
+	void Do_Work();
+	void GetSensorDetails();
+};
+
+#endif //WITH_LIBUSB
+#endif //WIN32

--- a/hardware/RAVEn.h
+++ b/hardware/RAVEn.h
@@ -1,26 +1,25 @@
 #pragma once
 
 #ifndef WIN32
-#ifdef WITH_LIBUSB
 #include "DomoticzHardware.h"
+#include "ASyncSerial.h"
 #include <iostream>
 
-class RAVEn : public CDomoticzHardwareBase
+class RAVEn : public CDomoticzHardwareBase, 
+              public AsyncSerial
 {
 public:
-	explicit RAVEn(const int ID, const std::string& port);
+	explicit RAVEn(const int ID, const std::string& devname);
 	~RAVEn(void);
 
 	bool WriteToHardware(const char *pdata, const unsigned char length);
 private:
-	volatile bool m_stoprequested;
+    const std::string device_;
 	boost::shared_ptr<boost::thread> m_thread;
 
 	bool StartHardware();
 	bool StopHardware();
-	void Do_Work();
-	void GetSensorDetails();
+	void readCallback(const char *data, size_t len);
 };
 
-#endif //WITH_LIBUSB
 #endif //WIN32

--- a/hardware/RAVEn.h
+++ b/hardware/RAVEn.h
@@ -5,6 +5,8 @@
 #include "ASyncSerial.h"
 #include <iostream>
 
+#define MAX_BUFFER_LEN  10000
+
 class RAVEn : public CDomoticzHardwareBase, 
               public AsyncSerial
 {
@@ -19,7 +21,13 @@ private:
 
 	bool StartHardware();
 	bool StopHardware();
-	void readCallback(const char *data, size_t len);
+	void readCallback(const char *indata, size_t inlen);
+
+    char buffer_[MAX_BUFFER_LEN];
+    char* wptr_;
+
+    double currUsage_;
+    double totalUsage_;
 };
 
 #endif //WIN32

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -223,7 +223,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_Sterbox, "Sterbox v2-3 PLC with LAN interface" },
 		{ HTYPE_HTTPPOLLER, "HTTP/HTTPS poller" },
 		{ HTYPE_FITBIT, "Fitbit" },
-		{ HTYPE_RAVEn, "Rainforest RAVEn" },
+		{ HTYPE_RAVEn, "Rainforest RAVEn USB" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -223,6 +223,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_Sterbox, "Sterbox v2-3 PLC with LAN interface" },
 		{ HTYPE_HTTPPOLLER, "HTTP/HTTPS poller" },
 		{ HTYPE_FITBIT, "Fitbit" },
+		{ HTYPE_RAVEn, "Rainforest RAVEn" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);
@@ -3324,7 +3325,8 @@ bool IsSerialDevice(const _eHardwareTypes htype)
 		(htype == HTYPE_RFXtrx315) || (htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868) ||
 		(htype == HTYPE_P1SmartMeter) || (htype == HTYPE_Rego6XX) || (htype == HTYPE_DavisVantage) || (htype == HTYPE_S0SmartMeter) || (htype == HTYPE_OpenThermGateway) ||
 		(htype == HTYPE_TeleinfoMeter) || (htype == HTYPE_OpenZWave) || (htype == HTYPE_EnOceanESP2) || (htype == HTYPE_EnOceanESP3) || (htype == HTYPE_Meteostick) ||
-		(htype == HTYPE_MySensorsUSB) || (htype == HTYPE_RFLINKUSB) || (htype == HTYPE_KMTronicUSB) || (htype == HTYPE_KMTronic433) || (htype == HTYPE_CurrentCostMeter)
+		(htype == HTYPE_MySensorsUSB) || (htype == HTYPE_RFLINKUSB) || (htype == HTYPE_KMTronicUSB) || (htype == HTYPE_KMTronic433) || (htype == HTYPE_CurrentCostMeter) ||
+        (htype == HTYPE_RAVEn)
 		);
 }
 

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -243,3 +243,4 @@ bool IsLightSwitchOn(const std::string &lstatus);
 
 bool IsSerialDevice(const _eHardwareTypes htype);
 void ConvertToGeneralSwitchType(std::string &devid, int &dtype, int &subtype);
+

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -243,4 +243,3 @@ bool IsLightSwitchOn(const std::string &lstatus);
 
 bool IsSerialDevice(const _eHardwareTypes htype);
 void ConvertToGeneralSwitchType(std::string &devid, int &dtype, int &subtype);
-

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -155,7 +155,7 @@ enum _eHardwareTypes {
 	HTYPE_Sterbox,				//73
 	HTYPE_HTTPPOLLER,			//74
 	HTYPE_FITBIT,				//75
-
+	HTYPE_RAVEn,	    		//75
 	HTYPE_END
 };
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -92,6 +92,7 @@
 #include "../hardware/AtagOne.h"
 #include "../hardware/Sterbox.h"
 #include "../hardware/Fitbit.h"
+#include "../hardware/RAVEn.h"
 
 // load notifications configuration
 #include "../notifications/NotificationHelper.h"
@@ -603,6 +604,7 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_EVOHOME_SERIAL:
 	case HTYPE_RFLINKUSB:
 	case HTYPE_CurrentCostMeter:
+    case HTYPE_RAVEn:
 	{
 			//USB/Serial
 			if (
@@ -678,6 +680,10 @@ bool MainWorker::AddHardwareFromParams(
 			else if (Type == HTYPE_RFLINKUSB)
 			{
 				pHardware = new CRFLinkSerial(ID, SerialPort);
+			}
+			else if (Type == HTYPE_RAVEn)
+			{
+				pHardware = new RAVEn(ID, SerialPort);
 			}
 			else if (Type == HTYPE_CurrentCostMeter)
 			{


### PR DESCRIPTION
Hello,

I've been using Domoticz for the past year and have found it incredibly useful.  When I found out the new smart meter we got had a separate radio for ZigBee connectivity, I couldn't resist hooking it up.  The Rainforest RAVEn is a pretty simple device -- plugs into a USB port and emulates a serial interface that spits out energy usage data in xml.  This pull request implements parsing out the current usage and cumulative usage reported by the meter.  The meter also supports reporting real-time price information but there didn't seem to be a good way to report $/hr usage in domoticz so I've left that out.

I also think there was some change to whitespace in this repo very recently as I had some weird commit diffs that I spent way too long trying to resolve but ultimately couldn't fix.  If you use ?w=1 when doing the compare, you'll see the changes are quite minimal.

Let me know if you have any questions or if you feel that something is missing.  And thanks for creating domoticz in the first place!
