### PR TITLE
Allow 1wire polling threads to be disabled

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -100,9 +100,6 @@ void C1Wire::LogSystem()
 
 bool C1Wire::StartHardware()
 {
-	m_threadSensors = NULL;
-	m_threadSwitches = NULL;
-
 	// Start worker thread
 	if (0 != m_sensorThreadPeriod)
 	{

--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -100,9 +100,18 @@ void C1Wire::LogSystem()
 
 bool C1Wire::StartHardware()
 {
+	m_threadSensors = NULL;
+	m_threadSwitches = NULL;
+
 	// Start worker thread
-	m_threadSensors = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&C1Wire::SensorThread, this)));
-	m_threadSwitches = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&C1Wire::SwitchThread, this)));
+	if (0 != m_sensorThreadPeriod)
+	{
+		m_threadSensors = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&C1Wire::SensorThread, this)));
+	}
+	if (0 != m_switchThreadPeriod)
+	{
+		m_threadSwitches = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&C1Wire::SwitchThread, this)));
+	}
 	m_bIsStarted=true;
 	sOnConnected(this);
 	StartHeartbeatThread();


### PR DESCRIPTION
This pull request allows the 1wire polling threads to be disabled by setting their polling period to 0.

This is useful if you have sensors but no switches, or vice versa.
