### PR TITLE
Changed TypeImg to baro for Barometer devices. This should solve the …

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -8938,7 +8938,7 @@ namespace http {
 						{
 							sprintf(szData, "%.1f Bar", atof(sValue.c_str()));
 							root["result"][ii]["Data"] = szData;
-							root["result"][ii]["TypeImg"] = "gauge";
+							root["result"][ii]["TypeImg"] = "baro";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["Pressure"] = atof(sValue.c_str());
 						}
@@ -8946,7 +8946,7 @@ namespace http {
 						{
 							sprintf(szData, "%.1f hPa", atof(sValue.c_str()));
 							root["result"][ii]["Data"] = szData;
-							root["result"][ii]["TypeImg"] = "gauge";
+							root["result"][ii]["TypeImg"] = "baro";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
 							std::vector<std::string> tstrarray;


### PR DESCRIPTION
…issue that barometer devices can not show their graph from the Floorplan.

Also in the list of all devices a baro image should be displayed, instead of a gauge image. Then the image shown should be identical as in the Weather Devices tab.
