### PR TITLE
Add /dev/cuaU* USB serial devices on FreeBSD

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -200,6 +200,11 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 				bUseDirectPath=true;
 				ret.push_back("/dev/" + fname);
 			}
+			else if (fname.find("cuaU")!=std::string::npos)
+			{
+				bUseDirectPath=true;
+				ret.push_back("/dev/" + fname);
+			}
 #endif
 #ifdef __APPLE__
 			else if (fname.find("cu.")!=std::string::npos)


### PR DESCRIPTION
Some ZWave devices are detect as modem (thru a kernel module).

Then it is working using /dev/cuaUx instead of /dev/ttyUx.

For example Aeotec Z-Stick S2 and also Enocean stick ESP3 as well.

Using /dev/ttyUx may stuck domoticz. So both ttyUx and cuaUx are usefull be depends of the context.

Regards.
