### PR TITLE
Added "POST" method to HTTP notification

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2420,6 +2420,11 @@ bool CSQLHelper::OpenDatabase()
 		std::string sencoded = base64_encode((const unsigned char*)sValue.c_str(), sValue.size());
 		UpdatePreferencesVar("HTTPURL", sencoded);
 	}
+	if ((!GetPreferencesVar("HTTPPostContentType", sValue)) || (sValue.empty()))
+	{
+		sValue = "application/json";
+		UpdatePreferencesVar("HTTPPostContentType", sValue);
+	}
 	if (!GetPreferencesVar("ShowUpdateEffect", nValue))
 	{
 		UpdatePreferencesVar("ShowUpdateEffect", 0);

--- a/notifications/NotificationHTTP.cpp
+++ b/notifications/NotificationHTTP.cpp
@@ -16,6 +16,8 @@ CNotificationHTTP::CNotificationHTTP() : CNotificationBase(std::string("http"), 
 	SetupConfigBase64(std::string("HTTPField4"), _HTTPField4);
 	SetupConfigBase64(std::string("HTTPTo"), _HTTPTo);
 	SetupConfigBase64(std::string("HTTPURL"), _HTTPURL);
+	SetupConfigBase64(std::string("HTTPPostData"), _HTTPPostData);
+	SetupConfigBase64(std::string("HTTPPostContentType"), _HTTPPostContentType);
 }
 
 CNotificationHTTP::~CNotificationHTTP()
@@ -41,8 +43,20 @@ bool CNotificationHTTP::SendMessageImplementation(const std::string &Subject, co
 		stdreplace(destURL, "#TO", CURLEncode::URLEncode(_HTTPTo));
 		stdreplace(destURL, "#SUBJECT", CURLEncode::URLEncode(Subject));
 		stdreplace(destURL, "#MESSAGE", CURLEncode::URLEncode(Text));
+
 		std::string sResult;
-		bRet = HTTPClient::GET(destURL, sResult, true);
+		if (_HTTPPostData.length() > 0)
+		{
+			std::vector<std::string> ExtraHeaders;
+			ExtraHeaders.push_back("Content-type: " + _HTTPPostContentType);
+			std::string httpData = _HTTPPostData;
+			stdreplace(httpData, "#MESSAGE", Text);
+			bRet = HTTPClient::POST(destURL, httpData, ExtraHeaders, sResult);
+		}
+		else
+		{
+			bRet = HTTPClient::GET(destURL, sResult, true);
+		}
 	}
 	else if (destURL.find("script://") == 0)
 	{

--- a/notifications/NotificationHTTP.h
+++ b/notifications/NotificationHTTP.h
@@ -15,4 +15,6 @@ private:
 	std::string _HTTPField4;
 	std::string _HTTPTo;
 	std::string _HTTPURL;
+	std::string _HTTPPostData;
+	std::string _HTTPPostContentType;
 };

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -49,12 +49,18 @@ define(['app'], function (app) {
 				var HTTPField3=encodeURIComponent($("#httptable #HTTPField3").val());
 				var HTTPField4=encodeURIComponent($("#httptable #HTTPField4").val());
 				var HTTPTo=encodeURIComponent($("#httptable #HTTPTo").val());
-				var HTTPURL=encodeURIComponent($("#httptable #HTTPURL").val());
+				var HTTPURL = encodeURIComponent($("#httptable #HTTPURL").val());
+				var HTTPPostData = encodeURIComponent($("#httptable #HTTPPostData").val());
+				var HTTPPostContentType = encodeURIComponent($("#httptable #HTTPPostContentType").val());
+				if (HTTPPostData != "" && HTTPPostContentType=="") {
+				    ShowNotify($.t('Please specify the content type...'), 3500, true);
+				    return;
+				}
 				if (HTTPURL=="") {
 					ShowNotify($.t('Please specify the base URL!...'), 3500, true);
 					return;
 				}
-				extraparams = "HTTPField1=" + HTTPField1 + "&HTTPField2=" + HTTPField2 + "&HTTPField3=" + HTTPField3 + "&HTTPField4=" + HTTPField4 + "&HTTPTo=" + HTTPTo + "&HTTPURL=" + HTTPURL;
+				extraparams = "HTTPField1=" + HTTPField1 + "&HTTPField2=" + HTTPField2 + "&HTTPField3=" + HTTPField3 + "&HTTPField4=" + HTTPField4 + "&HTTPTo=" + HTTPTo + "&HTTPURL=" + HTTPURL + "&HTTPPostData=" + HTTPPostData + "&HTTPPostContentType=" + HTTPPostContentType;
 				break;
 			case "prowl":
 				var ProwlAPI=encodeURIComponent($("#prowltable #ProwlAPI").val());
@@ -304,6 +310,12 @@ define(['app'], function (app) {
 			  }
 			  if (typeof data.HTTPURL != 'undefined') {
 				$("#httptable #HTTPURL").val(atob(data.HTTPURL));
+			  }
+			  if (typeof data.HTTPPostData != 'undefined') {
+			      $("#httptable #HTTPPostData").val(atob(data.HTTPPostData));
+			  }
+			  if (typeof data.HTTPPostContentType != 'undefined') {
+			      $("#httptable #HTTPPostContentType").val(atob(data.HTTPPostContentType));
 			  }
 
 			  if (typeof data.KodiEnabled != 'undefined') {

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -494,9 +494,22 @@
 									<tr>
 										<td align="right"><label for="HTTPURL"><span data-i18n="URL"></span>/<span data-i18n="Action"></span>: </label></td>
 										<td>
-											<textarea id="HTTPURL" name="HTTPURL" rows="4" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all"></textarea>  <button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('http')">Test</button><br>
+											<textarea id="HTTPURL" name="HTTPURL" rows="4" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all"></textarea><br>
 											<span data-i18n="(Should start with http:// or script://)">(Should start with http://, https:// or script://)</span><br>
 											<span data-i18n="(Optional)">(Optional)</span> #SUBJECT, #MESSAGE
+										</td>
+									</tr>
+                                    <tr>
+										<td align="right"><label for="HTTPPostData">POST Data: </label></td>
+										<td>
+											<textarea id="HTTPPostData" name="HTTPPostData" rows="4" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all"></textarea><br>
+											<span data-i18n="(Optional)">(Optional)</span> #SUBJECT, #MESSAGE
+										</td>
+									</tr>
+                                    <tr>
+										<td align="right"><label for="HTTPPostContentType">POST Content-Type: </label></td>
+										<td>
+                                            <input type="input" id="HTTPPostContentType" name="HTTPPostContentType" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" />  <button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('http')">Test</button><br>
 										</td>
 									</tr>
 									</table>


### PR DESCRIPTION
Added POST method to HTTP notification (see #692)

Example:
HTTP url : https://hooks.slack.com/services/...... (see https://api.slack.com/incoming-webhooks)
HTTP POST Data : {"text":"#MESSAGE"}
HTTP POST Content Type : application/json
