### PR TITLE
Prefer OWFS over W1

### DIFF
--- a/hardware/1Wire.h
+++ b/hardware/1Wire.h
@@ -26,7 +26,6 @@ private:
 	int m_switchThreadPeriod; // milliseconds
 	const std::string &m_path;
 
-	static void LogSystem();
 	void DetectSystem();
 	bool StartHardware();
 	bool StopHardware();

--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -27,6 +27,7 @@ C1WireByKernel::C1WireByKernel() :
    m_AllDevicesInitialized(false)
 {
    m_Thread = new boost::thread(&C1WireByKernel::ThreadFunction,this);
+   _log.Log(LOG_STATUS,"Using 1-Wire support (kernel W1 module)...");
 }
 
 C1WireByKernel::~C1WireByKernel()

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -21,6 +21,8 @@ C1WireByOWFS::C1WireByOWFS(const std::string& path) :
 
 	m_simultaneousTemperaturePath = m_path;
 	m_simultaneousTemperaturePath.append("/simultaneous/temperature");
+
+   _log.Log(LOG_STATUS,"Using 1-Wire support (OWFS)...");
 }
 
 bool C1WireByOWFS::FindDevice(const std::string &sID, /*out*/_t1WireDevice& device) const

--- a/hardware/1Wire/1WireForWindows.cpp
+++ b/hardware/1Wire/1WireForWindows.cpp
@@ -194,6 +194,7 @@ C1WireForWindows::C1WireForWindows()
 {
    // Connect to service
    m_Socket = ConnectToService();
+   _log.Log(LOG_STATUS,"Using 1-Wire support (Windows)...");
 }
 
 C1WireForWindows::~C1WireForWindows()


### PR DESCRIPTION
- Prefer OWFS over W1
  - Push the logging of which module is used down into the hardware specific drivers, as it is impossible for the static LogSystem call to access m_path which is required to determine which class will be loaded.
