### PR TITLE
Try OWFS again with no path, if the kernel driver is not available.

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -67,6 +67,8 @@ void C1Wire::DetectSystem()
 		m_system=new C1WireByOWFS(m_path);
 	} else if (C1WireByKernel::IsAvailable()) {
 		m_system=new C1WireByKernel();
+	} else {
+		m_system=new C1WireByOWFS(m_path);
 	}
 
 #endif // WIN32


### PR DESCRIPTION
This reinstates backwards compatibility for existing 1wire hardware on OWFS (which does not have a path set in the database).
