### PR TITLE
Changes in uvc camera module

### DIFF
--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -216,13 +216,16 @@ bool CCameraHandler::TakeRaspberrySnapshot(std::vector<unsigned char> &camimage)
 	return false;
 }
 
-bool CCameraHandler::TakeUVCSnapshot(std::vector<unsigned char> &camimage)
+bool CCameraHandler::TakeUVCSnapshot(const std::string &device, std::vector<unsigned char> &camimage)
 {
 	std::string uvcparams="-S80 -B128 -C128 -G80 -x800 -y600 -q100";
 	m_sql.GetPreferencesVar("UVCParams", uvcparams);
 	
 	std::string OutputFileName = szUserDataFolder + "tempcam.jpg";
 	std::string nvcmd="uvccapture " + uvcparams+ " -o" + OutputFileName;
+	if (!device.empty()) {
+		nvcmd += " -d/dev/" + device;
+	}
 	std::remove(OutputFileName.c_str());
 
 	try
@@ -272,7 +275,7 @@ bool CCameraHandler::TakeSnapshot(const unsigned long long CamID, std::vector<un
 	if (pCamera->ImageURL=="raspberry.cgi")
 		return TakeRaspberrySnapshot(camimage);
 	else if (pCamera->ImageURL=="uvccapture.cgi")
-		return TakeUVCSnapshot(camimage);
+		return TakeUVCSnapshot(pCamera->Username, camimage);
 
 	std::vector<std::string> ExtraHeaders;
 	return HTTPClient::GETBinary(szURL,ExtraHeaders,camimage,5);
@@ -416,7 +419,7 @@ namespace http {
 			}
 			else
 			{
-				if (!m_mainworker.m_cameras.TakeUVCSnapshot(camimage)) {
+				if (!m_mainworker.m_cameras.TakeUVCSnapshot("", camimage)) {
 					return;
 				}
 			}

--- a/main/Camera.h
+++ b/main/Camera.h
@@ -33,7 +33,7 @@ public:
 	bool TakeSnapshot(const unsigned long long CamID, std::vector<unsigned char> &camimage);
 	bool TakeSnapshot(const std::string &CamID, std::vector<unsigned char> &camimage);
 	bool TakeRaspberrySnapshot(std::vector<unsigned char> &camimage);
-	bool TakeUVCSnapshot(std::vector<unsigned char> &camimage);
+	bool TakeUVCSnapshot(const std::string &device, std::vector<unsigned char> &camimage);
 	cameraDevice* GetCamera(const unsigned long long CamID);
 	cameraDevice* GetCamera(const std::string &CamID);
 	unsigned long long IsDevSceneInCamera(const unsigned char DevSceneType, const unsigned long long DevSceneID);


### PR DESCRIPTION
Changes in camera module to allow for more usb cams at once on the Raspberry.

This is a quick and dirty patch. You can set the video device (video0, video1, etc.) in the username field of the camera settings. Note: Do not prepend /dev/...

It's quick and dirty because the web handling of the camera module is broken. It doesn't correctly url decode the parameters. I leave this as an excersise to the reader to fix this.
