### PR TITLE
Allowing multiple Toon agreements

### DIFF
--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -83,9 +83,10 @@ const std::string TOON_SWITCH_ALL = "/toonMobileBackendWeb/client/auth/smartplug
 //	STATE_HOLIDAY	//4
 //};
 
-CToonThermostat::CToonThermostat(const int ID, const std::string &Username, const std::string &Password) :
+CToonThermostat::CToonThermostat(const int ID, const std::string &Username, const std::string &Password, const int &Agreement) :
 m_UserName(Username),
-m_Password(Password)
+m_Password(Password),
+m_Agreement(Agreement)
 {
 	m_HwdID=ID;
 
@@ -356,8 +357,9 @@ bool CToonThermostat::Login()
 		_log.Log(LOG_ERROR, "ToonThermostat: No agreements found, did you setup your toon correctly?");
 		return false;
 	}
-	agreementId = root["agreements"][0]["agreementId"].asString();
-	agreementIdChecksum = root["agreements"][0]["agreementIdChecksum"].asString();
+
+	agreementId = root["agreements"][m_Agreement]["agreementId"].asString();
+	agreementIdChecksum = root["agreements"][m_Agreement]["agreementIdChecksum"].asString();
 
 	std::stringstream sstr2;
 	sstr2 << "clientId=" << m_ClientID 

--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -352,9 +352,9 @@ bool CToonThermostat::Login()
 		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password!");
 		return false;
 	}
-	if (root["agreements"].size() < 1)
+	if (root["agreements"].size() < (m_Agreement+1))
 	{
-		_log.Log(LOG_ERROR, "ToonThermostat: No agreements found, did you setup your toon correctly?");
+		_log.Log(LOG_ERROR, "ToonThermostat: Agreement not found, did you setup your toon correctly?");
 		return false;
 	}
 

--- a/hardware/ToonThermostat.h
+++ b/hardware/ToonThermostat.h
@@ -7,7 +7,7 @@
 class CToonThermostat : public CDomoticzHardwareBase
 {
 public:
-	CToonThermostat(const int ID, const std::string &Username, const std::string &Password);
+	CToonThermostat(const int ID, const std::string &Username, const std::string &Password, const int &Agreement);
 	~CToonThermostat(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);
 	void SetSetpoint(const int idx, const float temp);
@@ -31,6 +31,7 @@ private:
 
 	std::string m_UserName;
 	std::string m_Password;
+	int m_Agreement;
 	std::string m_ClientID;
 	std::string m_ClientIDChecksum;
 	volatile bool m_stoprequested;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -813,7 +813,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CICYThermostat(ID,Username,Password);
 		break;
 	case HTYPE_TOONTHERMOSTAT:
-		pHardware = new CToonThermostat(ID, Username, Password);
+		pHardware = new CToonThermostat(ID, Username, Password, Mode1);
 		break;
 	case HTYPE_AtagOne:
 		pHardware = new CAtagOne(ID, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -508,9 +508,32 @@ define(['app'], function (app) {
                      }
                 });
             }
+            else if (text.indexOf("Toon") >= 0)  
+            {
+                var username = $("#hardwarecontent #divlogin #username").val();
+                var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+                var agreement = $("#hardwarecontent #divenecotoon #agreement").val();
+                $.ajax({
+                    url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
+                       "&username=" + encodeURIComponent(username) +
+                       "&password=" + encodeURIComponent(password) +
+                       "&name=" + encodeURIComponent(name) +
+                       "&enabled=" + bEnabled +
+                       "&idx=" + idx +
+                       "&datatimeout=" + datatimeout +
+                       "&Mode1=" + agreement,
+                    async: false,
+                    dataType: 'json',
+                    success: function (data) {
+                        RefreshHardwareTable();
+                    },
+                    error: function () {
+                        ShowNotify($.t('Problem updating hardware!'), 2500, true);
+                    }
+                });
+            }
             else if (
 				(text.indexOf("ICY") >= 0) ||
-				(text.indexOf("Toon") >= 0) ||
 				(text.indexOf("Atag") >= 0) ||
 				(text.indexOf("Nest Th") >= 0) ||
 				(text.indexOf("PVOutput") >= 0) ||
@@ -1155,9 +1178,31 @@ define(['app'], function (app) {
                      }
                 });
             }
+            else if (text.indexOf("Toon") >= 0) 
+	     {
+                var username=$("#hardwarecontent #divlogin #username").val();
+                var password=encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+                var agreement=encodeURIComponent($("#hardwarecontent #divenecotoon #agreement").val());
+                $.ajax({
+                     url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
+                     "&username=" + encodeURIComponent(username) +
+                     "&password=" + encodeURIComponent(password) +
+                     "&name=" + encodeURIComponent(name) +
+                     "&enabled=" + bEnabled +
+                     "&datatimeout=" + datatimeout+
+                     "&Mode1=" + agreement,
+                     async: false,
+                     dataType: 'json',
+                     success: function(data) {
+                        RefreshHardwareTable();
+                     },
+                     error: function(){
+                            ShowNotify($.t('Problem adding hardware!'), 2500, true);
+                     }
+                });
+	    }
             else if (
 				(text.indexOf("ICY") >= 0) ||
-				(text.indexOf("Toon") >= 0) ||
 				(text.indexOf("Atag") >= 0) ||
 				(text.indexOf("Nest Th") >= 0) ||
 				(text.indexOf("PVOutput") >= 0) ||
@@ -4156,6 +4201,9 @@ define(['app'], function (app) {
                             $("#hardwarecontent #hardwareparamssolaredgeapi #serial").val(data["Username"]);
                             $("#hardwarecontent #hardwareparamssolaredgeapi #apikey").val(data["Password"]);
                         }
+                        else if (data["Type"].indexOf("Toon") >= 0) {
+                            $("#hardwarecontent #hardwareparamsenecotoon #agreement").val(data["Mode1"]);
+                        }
                         else if (data["Type"].indexOf("Philips Hue") >= 0) {
                             $("#hardwarecontent #hardwareparamsremote #tcpaddress").val(data["Address"]);
                             $("#hardwarecontent #hardwareparamsremote #tcpport").val(data["Port"]);
@@ -4173,8 +4221,8 @@ define(['app'], function (app) {
                         if (
                             (data["Type"].indexOf("Domoticz") >= 0)||
                             (data["Type"].indexOf("ICY") >= 0) ||
+                            (data["Type"].indexOf("Toon") >= 0) ||
                             (data["Type"].indexOf("Harmony") >= 0)||
-                            (data["Type"].indexOf("Toon") >= 0)||
                             (data["Type"].indexOf("Atag") >= 0)||
                             (data["Type"].indexOf("Nest Th") >= 0)||
                             (data["Type"].indexOf("PVOutput") >= 0)||
@@ -4257,6 +4305,7 @@ define(['app'], function (app) {
             $("#hardwarecontent #divwinddelen").hide();
             $("#hardwarecontent #divmqtt").hide();
             $("#hardwarecontent #divsolaredgeapi").hide();
+            $("#hardwarecontent #divenecotoon").hide();
             $("#hardwarecontent #div1wire").hide();
 
             if ((text.indexOf("TE923") >= 0)||
@@ -4332,6 +4381,15 @@ define(['app'], function (app) {
                 $("#hardwarecontent #divunderground").hide();
                 $("#hardwarecontent #divhttppoller").hide();
             }
+            else if (text.indexOf("Toon") >= 0)
+            {
+		$("#hardwarecontent #divlogin").show();
+		$("#hardwarecontent #divenecotoon").show();
+                $("#hardwarecontent #divremote").hide();
+                $("#hardwarecontent #divserial").hide();
+                $("#hardwarecontent #divunderground").hide();
+                $("#hardwarecontent #divhttppoller").hide();
+            }
             else if (text.indexOf("SBFSpot") >= 0)
             {
                 $("#hardwarecontent #divlocation").show();
@@ -4345,7 +4403,6 @@ define(['app'], function (app) {
             }
             else if (
 				(text.indexOf("ICY") >= 0) ||
-				(text.indexOf("Toon") >= 0) ||
 				(text.indexOf("Atag") >= 0) ||
 				(text.indexOf("Nest Th") >= 0) ||
 				(text.indexOf("PVOutput") >= 0) ||

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1107,6 +1107,18 @@
 				</tr>
 			</table>
 		</div>
+		<div id="divenecotoon">
+			<br>
+			<table class="display" id="hardwareparamsenecotoon" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label><span data-i18n="Agreement">Agreement</span>:</label></td>
+					<td><input type="text" id="agreement" value="0" style="width: 20px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+				</tr>
+				<tr>    <td></td>
+					<td><span data-i18n="Toon Agreement">Change only to select another Toon when having multiple agreements</span></td>
+				</tr>
+			</table>
+		</div>
 		<div id="divlocation">
 			<br>
 			<table class="display" id="hardwareparamslocation" border="0" cellpadding="0" cellspacing="20">


### PR DESCRIPTION
Added 'agreement' in a Toon installation to allow another Toon in same account to be used. Default agreement is 0.

When having multiple Toon thermostats in your account the agremeent number shifts to the number of Toon's (with index 0). So the second Toon is '1' etc. 

Adding multiple Toon thermostats into Domoticz hardware, each with different agreement numbers allows Domoticz to pull information from the differents Toon thermostats.
