### PR TITLE
Add support of nodon inwall module - 2 channels (Enocean)

### DIFF
--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -549,6 +549,7 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeLighting2, sTypeAC, "AC" },
 		{ pTypeLighting2, sTypeHEU, "HomeEasy EU" },
 		{ pTypeLighting2, sTypeANSLUT, "Anslut" },
+		{ pTypeLighting2, sTypeNodon, "Nodon" },
 
 		{ pTypeLighting3, sTypeKoppla, "Ikea Koppla" },
 

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -436,6 +436,7 @@ SDK version 4.9
 #define sTypeHEU 0x1
 #define sTypeANSLUT 0x2
 #define sTypeKambrook 0x03
+#define sTypeNodon 0x4
 
 #define light2_sOff 0x0
 #define light2_sOn 0x1


### PR DESCRIPTION
The patch decodes VLD (D2-04) to detect module channels.
I think it also should work for single channel module.
Beware: during detection of the 2 channels, 2 new devices
are added but domoticz only show one box to add device.
Both devices can be found in setup/devices page.

WriteToHardware was modified to use "Dimming" profile (A5-38-02)
only if a switch is a dimmer. Profile F6-02-01 is used
for basic switch (like nodon inwall module).

I'm not sure it really is necessary to add sTypeNodon as new subtype.

Pairing must be done like with a real switch:
1) in domoticz, use "learn light" to detect the module. switch the enocean module on or off to make it detectable.
2) Create a virtual switch in domoticz
3) put the enocean module into learning mode
4) press the virtual switch in domoticz
5) leave module learning mode
6) attach the light detected during step 1 as subdevice of virtual switch

Note: during pairing, domoticz complains about unhandled rorg (d4)
but it does not disturb learning and I found no explanation inside
Enocean Equipement Profile 2.6.5 PDF (what a mess^Wmind-blowing document)
