### PR TITLE
Crashuponwebserverstop when an exception occurs

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -614,6 +614,9 @@ namespace http {
 				if (m_pWebEm == NULL)
 					return;
 				m_pWebEm->Stop();
+				if (m_thread != NULL) {
+					m_thread->join();
+				}
 			}
 			catch (...)
 			{

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -117,11 +117,8 @@ namespace http {
 
 		CWebServer::~CWebServer(void)
 		{
-			if (m_pWebEm != NULL)
-			{
-				delete m_pWebEm;
-				m_pWebEm = NULL;
-			}
+			// RK, we call StopServer() instead of just deleting m_pWebEm. The Do_Work thread might still be accessing that object
+			StopServer();
 		}
 
 		void CWebServer::Do_Work()

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -601,7 +601,7 @@ namespace http {
 
 			//Start normal worker thread
 			m_bDoStop = false;
-			m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CWebServer::Do_Work, this)));
+			m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CWebServer::Do_Work, shared_from_this())));
 
 			return (m_thread != NULL);
 		}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -616,7 +616,10 @@ namespace http {
 				m_pWebEm->Stop();
 				if (m_thread != NULL) {
 					m_thread->join();
+					m_thread.reset();
 				}
+				delete m_pWebEm;
+				m_pWebEm = NULL;
 			}
 			catch (...)
 			{

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -18,7 +18,7 @@ namespace http {
 	namespace server {
 		class cWebem;
 		struct _tWebUserPassword;
-class CWebServer : public session_store
+class CWebServer : public session_store, public boost::enable_shared_from_this<CWebServer>
 {
 	typedef boost::function< void(WebEmSession & session, const request& req, Json::Value &root) > webserver_response_function;
 public:

--- a/main/WebServerHelper.h
+++ b/main/WebServerHelper.h
@@ -47,12 +47,12 @@ namespace http {
 			// called from CSQLHelper
 			void ReloadCustomSwitchIcons();
 		private:
-			CWebServer *plainServer_;
+			boost::shared_ptr<CWebServer> plainServer_;
 #ifdef WWW_ENABLE_SSL
-			CWebServer *secureServer_;
+			boost::shared_ptr<CWebServer> secureServer_;
 #endif
 			tcp::server::CTCPServer *m_pDomServ;
-			std::vector<CWebServer*> serverCollection;
+			std::vector<boost::shared_ptr<CWebServer> > serverCollection;
 
 			std::string our_serverpath;
 #ifndef NOCLOUD


### PR DESCRIPTION
A little background about this patch: In the webserver helper class, when the connection is stopped the CWebServer instance is deleted. At this time, the Do_Work() thread is still running.
So if -while stopping the server- an exception occurs, the catch handler will access member variables of the meanwhile already deleted object.
Two things are done to solve this:
1. The CWebServer class is made a shared pointer class, so it will only get deleted once no thread access it anymore.
2. In the StopServer() method, a join is introduced on the Do_Work() thread.
