### PR TITLE
HTU21D: 1 byte should be sent for commands instead of 2.

### DIFF
--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -280,7 +280,7 @@ int I2C::WriteCmd(int fd, uint8_t devAction)
 		{ BMPx8x_I2CADDR, 0, 2, datatosend }
 	};
 	struct i2c_msg htu_write_reg[1] = {
-		{ HTU21D_ADDRESS, 0, 2, datatosend }
+		{ HTU21D_ADDRESS, 0, 1, datatosend }
 	};
 
 	if (device == "BMP085")


### PR DESCRIPTION
A try to fix the error message HTU21D: Error reading temperature! as discussed here: https://www.domoticz.com/forum/viewtopic.php?f=6&t=12916&p=92847#p92847
