### PR TITLE
setup: Tweak Pushover labels, add direct link to clone app

### DIFF
--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -394,22 +394,22 @@
 							</div>
 							<div class="row-fluid">
 								<div class="span6">
-									<h2><span data-i18n="Pushover (Android/iOs)"></span>:</h2>
+									<h2><span data-i18n="Pushover (Android/iOS)"></span>:</h2>
 									<table class="display" id="pushovertable" border="0" cellpadding="0" cellspacing="0">
 									<tr>
 										<td align="right" style="width:80px"><label for="PushoverEnabled"><span data-i18n="Enabled"></span>: </label></td>
 										<td><input type="checkbox" id="PushoverEnabled" name="PushoverEnabled"/></td>
 									</tr>
 									<tr>
-										<td align="right"><label for="PushoverUser"><span data-i18n="USER KEY"></span>: </label></td>
+										<td align="right"><label for="PushoverUser"><span data-i18n="User Key"></span>: </label></td>
 										<td><input type="input" id="PushoverUser" name="PushoverUser" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" />  </td>
 									</tr>
 									<tr>
-										<td align="right"><label for="PushoverAPI"><span data-i18n="API Key"></span>: </label></td>
+										<td align="right"><label for="PushoverAPI"><span data-i18n="API Token"></span>: </label></td>
 										<td><input type="input" id="PushoverAPI" name="PushoverAPI" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" />  <button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('pushover')">Test</button></td>
 									</tr>
 									</table>
-									<span data-i18n="To get a free account/API key click"></span> <a class="norm-link" href="https://pushover.net" target="_blank"><span class="norm-link" data-i18n="Here"></span></a><br>
+									<span data-i18n="To get a free account/API key click"></span> <a class="norm-link" href="https://pushover.net/apps/clone/domoticz" target="_blank"><span class="norm-link" data-i18n="Here"></span></a><br>
 									<br>
 								</div>
 								<div class="span6">


### PR DESCRIPTION
(I am the author of Pushover)

Pushover calls an "API key" an "API token", and now that it is listed as a public app on https://pushover.net/apps, users can easily clone it at https://pushover.net/apps/clone/domoticz to get the same Domoticz icon and app name.
