### PR TITLE
Corrected Prerequisites for Ubuntu

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -164,7 +164,7 @@ make
 ### Ubuntu / Raspberry Pi (wheezy)
 ```
 sudo apt-get install build-essential -y
-sudo apt-get install cmake libboost-dev libboost-thread-dev libboost-system-dev libsqlite3-dev subversion curl libcurl4-openssl-dev libusb-dev libudev-dev zlib1g-dev
+sudo apt-get install cmake libboost-dev libboost-thread-dev libboost-system-dev libsqlite3-dev subversion curl libcurl4-openssl-dev libusb-dev libudev-dev zlib1g-dev libssl-dev
 ```
 
 Raspberry Pi (wheezy, 22 November 2012): (First time compile time: 25 minutes)


### PR DESCRIPTION
Added libssl-dev to prerequisites for Ubuntu. If not installed cmake results in an error not finding openssl.
Tested on Ubuntu 16.04
