### PR TITLE
Handle missing temperature sensor on some Qubino devices

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -324,6 +324,11 @@ unsigned char ZWaveBase::Convert_Battery_To_PercInt(const unsigned char level)
 
 void ZWaveBase::SendDevice2Domoticz(const _tZWaveDevice *pDevice)
 {
+	if (filterValue(pDevice) == true)
+	{
+		return;
+	}
+
 	unsigned char ID1=0;
 	unsigned char ID2=0;
 	unsigned char ID3=0;
@@ -1139,7 +1144,7 @@ void ZWaveBase::ForceUpdateForNodeDevices(const unsigned int homeID, const int n
 	{
 		if (itt->second.nodeID == nodeID)
 		{
-			itt->second.lastreceived = mytime(NULL)-1;
+			itt->second.lastreceived = mytime(NULL) - 1;
 
 			_tZWaveDevice zdevice = itt->second;
 
@@ -1166,5 +1171,22 @@ void ZWaveBase::ForceUpdateForNodeDevices(const unsigned int homeID, const int n
 
 		}
 	}
+}
+
+bool ZWaveBase::filterValue(const _tZWaveDevice *pDevice)
+{
+	bool ret = false;
+	if (
+		// Handle Qubino missing temperature sensor
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0001) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0051) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0002) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0052) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0053)
+		)
+	{
+		ret = (pDevice->floatValue == -999.9);
+	}
+	return ret;
 }
 

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -1177,12 +1177,15 @@ bool ZWaveBase::filterValue(const _tZWaveDevice *pDevice)
 {
 	bool ret = false;
 	if (
-		// Handle Qubino missing temperature sensor
+		// Handle missing temperature sensor on Qubino devices based on sigma 300 zwave chip
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0001) && (pDevice->Product_id == 0x0001) ||
 		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0001) ||
-		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0051) ||
 		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0002) ||
 		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0052) ||
-		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0002) && (pDevice->Product_id == 0x0053)
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0003) && (pDevice->Product_id == 0x0002) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0004) && (pDevice->Product_id == 0x0001) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0005) && (pDevice->Product_id == 0x0001) ||
+		(pDevice->Manufacturer_id == 0x0159) && (pDevice->Product_type == 0x0004) && (pDevice->Product_id == 0x0003)
 		)
 	{
 		ret = (pDevice->floatValue == -999.9);

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -141,6 +141,8 @@ private:
 	_tZWaveDevice* FindDevice(const int nodeID, const int instanceID, const int indexID, const int CommandClassID, const _eZWaveDeviceType devType);
 	_tZWaveDevice* FindDeviceEx(const int nodeID, const int instanceID, const _eZWaveDeviceType devType);
 
+	bool filterValue(const _tZWaveDevice *pDevice);
+
 	void ForceUpdateForNodeDevices(const unsigned int homeID, const int nodeID);
 	bool IsNodeRGBW(const unsigned int homeID, const int nodeID);
 


### PR DESCRIPTION
Handle missing temperature sensor on some Qubino devices based on sigma 300 zwave chip

If the sensor value is -999.9, the sensor value is not stored.

Related to #748 
