### PR TITLE
Removed some warnings (extra parentheses), comments in comments..

### DIFF
--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -423,7 +423,7 @@ int CNetatmo::GetBatteryLevel(const std::string &ModuleType, const int battery_v
 		3600 high
 		3300 medium
 		3000 low
-		/* below 3000: very low */
+		below 3000: very low */
 		if (battery_vp <= 3000)
 			batValue = 0;
 	}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -4816,7 +4816,7 @@ namespace http {
 					root["result"][ii]["ptag"] = Notification_Type_Desc(NTYPE_TEMPERATURE, 1);
 					ii++;
 				}
-				if ((dType == pTypeEvohomeZone))
+				if (dType == pTypeEvohomeZone)
 				{
 					root["result"][ii]["val"]=NTYPE_TEMPERATURE;
 					root["result"][ii]["text"]=Notification_Type_Desc(NTYPE_SETPOINT,0); //FIXME NTYPE_SETPOINT implementation?

--- a/zip/unzip.h
+++ b/zip/unzip.h
@@ -1449,7 +1449,7 @@ inline int ZEXPORT unzReadCurrentFile  (unzFile file, voidp buf, unsigned len)
     }
 
 
-    if ((pfile_in_zip_read_info->read_buffer == NULL))
+    if (pfile_in_zip_read_info->read_buffer == NULL)
         return UNZ_END_OF_LIST_OF_FILE;
     if (len==0)
         return 0;


### PR DESCRIPTION
Clang complains about some basics stuff while compiling.
I fixed some easy ones.
There is some others that can be scary (not fixed here) lile in : Kodi.cpp on line 1179 : 
hardware/Kodi.cpp:1179:51: warning: '&&' within '||' [-Wlogical-op-parentheses]
        while ((!m_pNodes.empty()) || (!m_ios.stopped()) && (iRetryCounter < 15))
                                   ~~ ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
Maybe this will need a review there ?
