### PR TITLE
add proper check for detecting header <execinfo.h>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,13 @@ SET(EXECUTABLE_OUTPUT_PATH "" CACHE INTERNAL
   "Where to put the executables for Domoticz"
   )
 
+INCLUDE(CheckIncludeFile)
+CHECK_INCLUDE_FILE (execinfo.h HAVE_EXECINFO_H)
+
+IF(HAVE_EXECINFO_H)
+  ADD_DEFINITIONS(-DHAVE_EXECINFO_H)
+ENDIF(HAVE_EXECINFO_H)
+
 #set(CMAKE_EXE_LINKER_FLAGS "-static")
 
 # Macro for setting up precompiled headers. Usage:

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -44,7 +44,7 @@
 	#include <string.h> 
 #endif
 
-#ifdef __gnu_linux__
+#ifdef HAVE_EXECINFO_H
 #include <execinfo.h>
 static void dumpstack(void) {
 	// Notes :


### PR DESCRIPTION
domoticz.cpp currently assumes that on GNU/Linux systems header
<execinfo.h> is available. But that is not true. Since it is provided
by C library and uClibc can be built without backtrace support. And in
such cases we get following build error.

  domoticz-3.4834/main/domoticz.cpp:48:22: fatal error: execinfo.h: No such file or directory
   #include <execinfo.h>
                        ^
  compilation terminated.

Instead of depending on **gnu_linux**, add check for detecting
presence of <execinfo.h> and guard code for dumpstack accordingly.

This build failure is detected by Buildroot autobuilder.
http://autobuild.buildroot.net/results/393/393f839e160b51ca12ac36058718ad2f0c1b50a6/

Signed-off-by: Rahul Bedarkar rahul.bedarkar@imgtec.com
