### PR TITLE
Fix ambiguous call to abs

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -14,6 +14,7 @@
 #include "../main/mainworker.h"
 #include "../main/SQLHelper.h"
 
+#include <cmath>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
Add cmath header to be able to call abs with a float otherwise call to
abs(temperature*10.0f) is ambiguous as abs from cstdlib accepts either
an int, a long int or a long long int.

Signed-off-by: Fabrice Fontaine fabrice.fontaine@orange.com
