### PR TITLE
Remove a warning about extraneous parentheses

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -928,12 +928,8 @@ namespace http {
 					bDoAdd = false;
 #endif
 #ifndef WITH_GPIO
-				if (
-					(ii == HTYPE_RaspberryGPIO)
-					)
-				{
+				if (ii == HTYPE_RaspberryGPIO)
 					bDoAdd = false;
-				}
 #endif
 				if ((ii == HTYPE_1WIRE) && (!C1Wire::Have1WireSystem()))
 					bDoAdd = false;


### PR DESCRIPTION
Some parentheses are extraneous => removed them (and keep clang happy)
