### PR TITLE
P1 meter message validation

### DIFF
--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -82,12 +82,14 @@ void P1MeterBase::Init()
 	m_linecount=0;
 	m_exclmarkfound=0;
 	m_bufferpos=0;
+	l_bufferpos=0;
 	m_lastgasusage=0;
 	m_lastelectrausage=0;
 	m_lastSharedSendElectra=0;
 	m_lastSharedSendGas=0;
 
 	memset(&m_buffer,0,sizeof(m_buffer));
+	memset(&l_buffer,0,sizeof(l_buffer));
 
 	memset(&m_p1power,0,sizeof(m_p1power));
 	memset(&m_p1gas,0,sizeof(m_p1gas));
@@ -105,7 +107,7 @@ void P1MeterBase::Init()
 
 bool P1MeterBase::MatchLine()
 {
-	if ((strlen((const char*)&m_buffer)<1)||(m_buffer[0]==0x0a))
+	if ((strlen((const char*)&l_buffer)<1)||(l_buffer[0]==0x0a))
 		return true; //null value (startup)
 	uint8_t i;
 	uint8_t found=0;
@@ -119,7 +121,7 @@ bool P1MeterBase::MatchLine()
 		switch(t.matchtype)
 		{
 		case ID:
-			if(strncmp(t.key, (const char*)&m_buffer, strlen(t.key)) == 0) {
+			if(strncmp(t.key, (const char*)&l_buffer, strlen(t.key)) == 0) {
 				m_linecount=1;
 				found=1;
 			}
@@ -127,14 +129,14 @@ bool P1MeterBase::MatchLine()
 				continue;
 			break;
 		case STD:
-			if(strncmp(t.key, (const char*)&m_buffer, strlen(t.key)) == 0) {
+			if(strncmp(t.key, (const char*)&l_buffer, strlen(t.key)) == 0) {
 				found=1;
 			}
 			else 
 				continue;
 			break;
 		case LINE17:
-			if(strncmp(t.key, (const char*)&m_buffer, strlen(t.key)) == 0) {
+			if(strncmp(t.key, (const char*)&l_buffer, strlen(t.key)) == 0) {
 				m_linecount = 17;
 				found=1;
 			}
@@ -142,12 +144,12 @@ bool P1MeterBase::MatchLine()
 				continue;
 			break;
 		case LINE18:
-			if((m_linecount == 18)&&(strncmp(t.key, (const char*)&m_buffer, strlen(t.key)) == 0)) {
+			if((m_linecount == 18)&&(strncmp(t.key, (const char*)&l_buffer, strlen(t.key)) == 0)) {
 				found=1;
 			}
 			break;
 		case EXCLMARK:
-			if(strncmp(t.key, (const char*)&m_buffer, strlen(t.key)) == 0) {
+			if(strncmp(t.key, (const char*)&l_buffer, strlen(t.key)) == 0) {
 				m_exclmarkfound=1;
 				found=1;
 			}
@@ -186,7 +188,7 @@ bool P1MeterBase::MatchLine()
 		}
 		else
 		{
-			vString=(const char*)&m_buffer+t.start;
+			vString=(const char*)&l_buffer+t.start;
 			int ePos=t.width;
 			if (t.matchtype==STD)
 			{
@@ -278,46 +280,72 @@ bool P1MeterBase::MatchLine()
 /*
 / GB3:	ParseData() can be called with either a complete message (P1MeterTCP) or individual
 /	lines (P1MeterSerial).
+/
+/	While it is technically possible to do a CRC check line by line, we like to keep
+/	things organized and assemble the complete message before running that check. If the
+/	message is DSMR 4.0+ of course.
+/
+/	Because older DSMR standard does not contain a CRC we still need the validation rules
+/	in Matchline(). In fact, one of them is essential for keeping Domoticz from crashing
+/	in specific cases of bad data. In essence this means that a CRC check will only be
+/	done if the message passes all other validation rules
 */
 
 void P1MeterBase::ParseData(const unsigned char *pData, int Len)
 {
 	int ii=0;
 
-	// reenable reading pData when a new message starts
+	// reenable reading pData when a new message starts, empty buffers
 	if (pData[0]==0x2f) {
 		m_linecount = 1;
+		l_bufferpos = 0;
 		m_bufferpos = 0;
 	}
 
+	// assemble complete message in message buffer
+	while ((ii<Len) && (m_linecount>0) && (m_bufferpos<sizeof(m_buffer))){
+		const unsigned char c = pData[ii];
+		m_buffer[m_bufferpos] = c;
+		m_bufferpos++;
+		if(c==0x21){
+			// stop reading at exclamation mark (do not include CRC)
+			ii=Len;
+		}else{
+			ii++;
+		}
+	}
+
+	if(m_bufferpos==sizeof(m_buffer)){
+		// discard oversized message
+		return;
+	}
+
 	// read pData, ignore/stop if there is a message validation failure
+	ii=0;
 	while ((ii<Len) && (m_linecount>0))
 	{
 		const unsigned char c = pData[ii];
-		if(c == 0x0d)
-		{
-			ii++;
+		ii++;
+		if (c==0x0d) {
 			continue;
 		}
 
-		m_buffer[m_bufferpos] = c;
-		if(c == 0x0a || m_bufferpos == sizeof(m_buffer) - 1)
-		{
-			// discard newline, close string, parse line and clear it.
+		if (c==0x0a) {
+			// close string, parse line and clear it.
 			m_linecount++;
-			if (m_bufferpos > 0) {
-				m_buffer[m_bufferpos] = 0;
+			if ((l_bufferpos>0) && (l_bufferpos<sizeof(l_buffer))) {
+				// don't try to match empty or oversized lines
+				l_buffer[l_bufferpos] = 0;
 				if (!MatchLine()) {
 					// discard message
 					m_linecount=0;
 				}
 			}
-			m_bufferpos = 0;
+			l_bufferpos = 0;
 		}
-		else
-		{
-			m_bufferpos++;
+		else if (l_bufferpos<sizeof(l_buffer)) {
+			l_buffer[l_bufferpos] = c;
+			l_bufferpos++;
 		}
-		ii++;
 	}
 }

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -216,7 +216,7 @@ bool P1MeterBase::MatchLine()
 			}
 
 			unsigned long temp_usage = 0;
-			char *validate=NULL;
+			char *validate=value+ePos;
 
 			switch (t.type)
 			{
@@ -263,7 +263,7 @@ bool P1MeterBase::MatchLine()
 				break;
 			}
 
-			if ((temp_usage == 0) && (value == validate)) {
+			if (ePos>0 && ((validate - value) != ePos)) {
 				// invalid message: value is not a number
 				return false;
 			}

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -216,7 +216,7 @@ bool P1MeterBase::MatchLine()
 			}
 
 			unsigned long temp_usage = 0;
-			char *validate;
+			char *validate=NULL;
 
 			switch (t.type)
 			{

--- a/hardware/P1MeterBase.h
+++ b/hardware/P1MeterBase.h
@@ -26,6 +26,8 @@ private:
 	void ParseData(const unsigned char *pData, int Len);
 	unsigned char m_buffer[1028];
 	int m_bufferpos;
+	unsigned char l_buffer[128];
+	int l_bufferpos;
 
 };
 

--- a/hardware/P1MeterBase.h
+++ b/hardware/P1MeterBase.h
@@ -29,5 +29,6 @@ private:
 	unsigned char l_buffer[128];
 	int l_bufferpos;
 
+	bool CheckCRC();
 };
 


### PR DESCRIPTION
Does not yet include the CRC check, but just to let you know what I'm working on. When finished I can combine the individual commits into a single big one if you like (create a new pull request).

The first three commits are about an issue I discovered with my previous commit. With `P1MeterSerial` this is currently not an issue, but it will be in combination with commit  df8ea27. And it may already be an issue with `P1MeterTCP`, which I think does pass full messages into `P1MeterBase`. The trouble is that if a validation failure occurs of the type "value is not a number" it will keep producing this failure with every subsequent  message and it will do this on the message header (`ID`).

Also, I found that the test in fact was wrong as it would only fail if the first character was non-numerical. This is corrected in commit  2e1ec54 and it will now require the full length of the value to be numeric.

The fourth commit prepares for performing the CRC check. Since `m_buffer[1028]` was quite large already I decided to use that variable to assemble the complete message and moved the existing references to a new variable `l_buffer[128]` (we're building a single **l**ine to run through `MatchLine()`, not a **m**essage).
