### PR TITLE
Fix the possible breakage between || and && in a if condition in Kodi.

### DIFF
--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -1176,7 +1176,7 @@ void CKodi::UnloadNodes()
 	m_ios.stop();	// stop the service if it is running
 	sleep_milliseconds(100);
 
-	while ((!m_pNodes.empty()) || (!m_ios.stopped()) && (iRetryCounter < 15))
+	while (((!m_pNodes.empty()) || (!m_ios.stopped())) && (iRetryCounter < 15))
 	{
 		std::vector<boost::shared_ptr<CKodiNode> >::iterator itt;
 		for (itt = m_pNodes.begin(); itt != m_pNodes.end(); ++itt)


### PR DESCRIPTION
Clang is picky but it is right : 
[ 38%] Building CXX object CMakeFiles/domoticz.dir/hardware/Kodi.cpp.o
domoticz/hardware/Kodi.cpp:1179:51: warning: '&&' within '||' [-Wlogical-op-parentheses]
        while ((!m_pNodes.empty()) || (!m_ios.stopped()) && (iRetryCounter < 15))
                                   ~~ ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
hardware/Kodi.cpp:1179:51: note: place parentheses around the '&&' expression to silence this warning
        while ((!m_pNodes.empty()) || (!m_ios.stopped()) && (iRetryCounter < 15))
                                                         ^
                                      (                                         )

This code has to be checked by a Kodi user to see if its doesn't break anything.
