### PR TITLE
fix MUSL build issue

### DIFF
--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -38,6 +38,7 @@
 #include <string.h>
 #include <string>
 #ifdef __arm__
+    #include <linux/ioctl.h>
     #include <linux/types.h>
     #include <linux/spi/spidev.h>
     #include <unistd.h>


### PR DESCRIPTION
Without <linux/ioctl.h> include compiler cannot find _IOC_SIZEBITS
macro, when using MUSL C library

Fixes:
  http://autobuild.buildroot.net/results/62ec0d348153dff0efd4c1975a9198c17f01f1fa

Signed-off-by: Fabrice Fontaine fabrice.fontaine@orange.com
