### PR TITLE
Ignore Serial_ID_Button devices in 1wire

### DIFF
--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -96,6 +96,13 @@ void C1WireByOWFS::GetDevices(const std::string &inDir, /*out*/std::vector<_t1Wi
 			{
 				_log.Log(LOG_STATUS, "1Wire (OWFS): Add device %s", device.filename.c_str());
 			}
+
+			if (device.family == Serial_ID_Button)
+			{
+				// ignore this family as it doe not contain any kind of data
+				continue;
+			}
+
             devices.push_back(device);
 
             // If device is a hub, scan for all hub connected devices (recursively)


### PR DESCRIPTION
Ignore Serial_ID_Button devices in 1wire as it does not contain usefull data and generate useless activity
