### PR TITLE
Fixed device unicity issue on 1wire device due to 1wire linux bug

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -244,7 +244,7 @@ void C1Wire::BuildSensorList() {
 		case _4k_ram_with_counter:
 		case quad_ad_converter:
 		case smart_battery_monitor:
-			m_sensors.push_back(*device);
+			m_sensors.insert(*device);
 			break;
 
 		default:
@@ -266,7 +266,7 @@ void C1Wire::PollSensors()
 	}
 
 	// Parse our devices (have to test m_stoprequested because it can take some time in case of big networks)
-	std::vector<_t1WireDevice>::const_iterator itt;
+	std::set<_t1WireDevice>::const_iterator itt;
 	for (itt=m_sensors.begin(); itt!=m_sensors.end() && !m_stoprequested; ++itt)
 	{
 		const _t1WireDevice& device=*itt;
@@ -361,7 +361,7 @@ void C1Wire::BuildSwitchList() {
 		case Temperature_IO:
 		case dual_channel_addressable_switch:
 		case _4k_EEPROM_with_PIO:
-			m_switches.push_back(*device);
+			m_switches.insert(*device);
 			break;
 
 		default:
@@ -378,7 +378,7 @@ void C1Wire::PollSwitches()
 		return;
 
 	// Parse our devices (have to test m_stoprequested because it can take some time in case of big networks)
-	std::vector<_t1WireDevice>::const_iterator itt;
+	std::set<_t1WireDevice>::const_iterator itt;
 	for (itt=m_switches.begin(); itt!=m_switches.end() && !m_stoprequested; ++itt)
 	{
 		const _t1WireDevice& device=*itt;

--- a/hardware/1Wire.h
+++ b/hardware/1Wire.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <set>
+
 #include "DomoticzHardware.h"
 #include "../hardware/1Wire/1WireCommon.h"
 
@@ -19,8 +21,8 @@ private:
 	boost::shared_ptr<boost::thread> m_threadSwitches;
 	I_1WireSystem* m_system;
 	std::map<std::string, bool> m_LastSwitchState;
-	std::vector<_t1WireDevice> m_sensors;
-	std::vector<_t1WireDevice> m_switches;
+	std::set<_t1WireDevice> m_sensors;
+	std::set<_t1WireDevice> m_switches;
 
 	int m_sensorThreadPeriod; // milliseconds
 	int m_switchThreadPeriod; // milliseconds

--- a/hardware/1Wire/1WireCommon.h
+++ b/hardware/1Wire/1WireCommon.h
@@ -80,6 +80,11 @@ struct _t1WireDevice
    _e1WireFamilyType family;
    std::string devid;
    std::string filename;
+
+   bool operator<(_t1WireDevice other) const
+   {
+	   return devid > other.devid;
+   }
 };
 
 _e1WireFamilyType ToFamily(const std::string& str);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -9655,7 +9655,7 @@ namespace http {
 			std::vector<std::vector<std::string> > result, result2, result3;
 
 			result = m_sql.safe_query("SELECT Key, nValue, sValue FROM Preferences WHERE Key LIKE 'Floorplan%%'");
-			if (result.size() < 0)
+			if (result.empty())
 				return;
 
 			std::vector<std::vector<std::string> >::const_iterator itt;
@@ -11090,7 +11090,7 @@ namespace http {
 			char szTmp[100];
 
 			result = m_sql.safe_query("SELECT Key, nValue, sValue FROM Preferences");
-			if (result.size() < 0)
+			if (result.empty())
 				return;
 			root["status"] = "OK";
 			root["title"] = "settings";


### PR DESCRIPTION
For some seasons, on linux, /mnt/1wire contains _twice_ the same device. So C1WireByOWFS is listing 2 times the same device and it is polled twice as well:

root@domoseb:~# ls -la /mnt/1wire/
drwxrwxrwx 1 root root 4096 Sep  8 15:25 28.D7438B030000
drwxrwxrwx 1 root root 4096 Sep  8 15:25 28.D7438B030000
drwxrwxrwx 1 root root 4096 Sep  8 15:25 81.46B730000000
drwxrwxrwx 1 root root 4096 Sep  8 15:25 81.46B730000000

To solve the issue, devices & switched are now considered as unique.
