### PR TITLE
Fix for P1 hardware submitting arbitrary partial lines

### DIFF
--- a/hardware/P1MeterBase.h
+++ b/hardware/P1MeterBase.h
@@ -29,6 +29,7 @@ private:
 	int m_bufferpos;
 	unsigned char l_buffer[128];
 	int l_bufferpos;
+	unsigned char l_exclmarkfound;
 
 	bool CheckCRC();
 };


### PR DESCRIPTION
I received a P1 Wifi Gateway today from Romix and got a chance to play with it. Turns out that the LAN connector actually does not submit full messages to ParseData(), but it also does not (always) submit full lines like the serial connector. As a result there can be trailing characters after the exclamation mark, causing the CRC calculation to fail.

This patch stops the extra characters from being added to the message buffer.
