### PR TITLE
FIX: possible deadlock when closing app

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -255,14 +255,17 @@ void MainWorker::StartDomoticzHardware()
 
 void MainWorker::StopDomoticzHardware()
 {
-	boost::lock_guard<boost::mutex> l(m_devicemutex);
-	std::vector<CDomoticzHardwareBase*>::iterator itt;
-	for (itt=m_hardwaredevices.begin(); itt!=m_hardwaredevices.end(); ++itt)
+	boost::lock_guard<boost::mutex> l2(m_stoppinghardwaremutex);
 	{
-		(*itt)->Stop();
-		delete (*itt);
+		boost::lock_guard<boost::mutex> l(m_devicemutex);
+		std::vector<CDomoticzHardwareBase*>::iterator itt;
+		for (itt=m_hardwaredevices.begin(); itt!=m_hardwaredevices.end(); ++itt)
+		{
+			(*itt)->Stop();
+			delete (*itt);
+		}
+		m_hardwaredevices.clear();
 	}
-	m_hardwaredevices.clear();
 }
 
 void MainWorker::GetAvailableWebThemes()
@@ -348,6 +351,8 @@ void MainWorker::AddDomoticzHardware(CDomoticzHardwareBase *pHardware)
 	{
 		RemoveDomoticzHardware(m_hardwaredevices[devidx]);
 	}
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return;
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	pHardware->sDecodeRXMessage.connect( boost::bind( &MainWorker::DecodeRXMessage, this, _1, _2, _3, _4 ) );
 	pHardware->sOnConnected.connect( boost::bind( &MainWorker::OnHardwareConnected, this, _1 ) );
@@ -356,6 +361,9 @@ void MainWorker::AddDomoticzHardware(CDomoticzHardwareBase *pHardware)
 
 void MainWorker::RemoveDomoticzHardware(CDomoticzHardwareBase *pHardware)
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return;
+
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
 	for (itt=m_hardwaredevices.begin(); itt!=m_hardwaredevices.end(); ++itt)
@@ -386,6 +394,8 @@ void MainWorker::RemoveDomoticzHardware(int HwdId)
 
 int MainWorker::FindDomoticzHardware(int HwdId)
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return -1;
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
 	for (itt=m_hardwaredevices.begin(); itt!=m_hardwaredevices.end(); ++itt)
@@ -400,6 +410,9 @@ int MainWorker::FindDomoticzHardware(int HwdId)
 
 int MainWorker::FindDomoticzHardwareByType(const _eHardwareTypes HWType)
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return -1;
+
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
 	for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
@@ -414,6 +427,9 @@ int MainWorker::FindDomoticzHardwareByType(const _eHardwareTypes HWType)
 
 CDomoticzHardwareBase* MainWorker::GetHardware(int HwdId)
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return NULL;
+
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
 	for (itt=m_hardwaredevices.begin(); itt!=m_hardwaredevices.end(); ++itt)
@@ -441,6 +457,9 @@ CDomoticzHardwareBase* MainWorker::GetHardwareByIDType(const std::string &HwdId,
 
 CDomoticzHardwareBase* MainWorker::GetHardwareByType(const _eHardwareTypes HWType)
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return NULL;
+
 	boost::lock_guard<boost::mutex> l(m_devicemutex);
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
 	for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
@@ -1486,16 +1505,20 @@ void MainWorker::Do_Work()
 				if (ltime.tm_hour == 4)
 				{
 					//Heal the OpenZWave network
-					boost::lock_guard<boost::mutex> l(m_devicemutex);
-					std::vector<CDomoticzHardwareBase*>::iterator itt;
-					for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
+					if (m_stoppinghardwaremutex.try_lock())
 					{
-						CDomoticzHardwareBase *pHardware = (*itt);
-						if (pHardware->HwdType == HTYPE_OpenZWave)
+						boost::lock_guard<boost::mutex> l(m_devicemutex);
+						std::vector<CDomoticzHardwareBase*>::iterator itt;
+						for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
 						{
-							COpenZWave *pZWave = (COpenZWave *)pHardware;
-							pZWave->NightlyNodeHeal();
+							CDomoticzHardwareBase *pHardware = (*itt);
+							if (pHardware->HwdType == HTYPE_OpenZWave)
+							{
+								COpenZWave *pZWave = (COpenZWave *)pHardware;
+								pZWave->NightlyNodeHeal();
+							}
 						}
+						m_stoppinghardwaremutex.unlock();
 					}
 				}
 #endif
@@ -12063,6 +12086,9 @@ void MainWorker::HeartbeatRemove(const std::string &component)
 
 void MainWorker::HeartbeatCheck()
 {
+	boost::mutex::scoped_lock lock(m_stoppinghardwaremutex, boost::try_to_lock);
+	if (!lock) return;
+
 	boost::lock_guard<boost::mutex> l(m_heartbeatmutex);
 	boost::lock_guard<boost::mutex> l2(m_devicemutex);
 

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -168,6 +168,7 @@ private:
 
 
 	boost::mutex m_devicemutex;
+	boost::mutex m_stoppinghardwaremutex;
 
 	std::string m_szDomoticzUpdateChecksumURL;
 	bool m_bDoDownloadDomoticzUpdate;


### PR DESCRIPTION
deadlock occurs when clossing app:
- MainWorker::StopDomoticzHardware() locks m_devicemutex and waits for devices to stop
- eg. MQTT got message in meantime and waits for lock on m_devicemutex in MQTT::on_message -> MainWorker::UpdateDevice -> MainWorker::GetHardware

added another mutex which is locked on app closing and checked before trying to lock m_devicemutex
