### PR TITLE
Add debug entry for open ended messages

### DIFF
--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -366,6 +366,24 @@ void P1MeterBase::ParseData(const unsigned char *pData, int Len, unsigned char d
 
 	// reenable reading pData when a new message starts, empty buffers
 	if (pData[ii]==0x2f) {
+/*
+/	Debug entry for open ended messages: start
+/
+/	P1 Wifi Gateway sends open ended messages which used to pass silently as delayed messages in
+/	Domoticz prior to v3.5592. With the introduction of the P1 message CRC validation this became
+/	an illegal procedure. Enclosed code re-enables the possibility to commit delayed data while
+/	printing a warning in the log file.
+*/
+		if ((l_buffer[0]==0x21) && !l_exclmarkfound && (m_linecount>0)) {
+			_log.Log(LOG_STATUS,"P1: WARNING: got new message but buffer still contains unprocessed data from previous message.");
+			l_buffer[l_bufferpos] = 0;
+			if (disable_crc || CheckCRC()) {
+				MatchLine();
+			}
+		}
+/*
+/	Debug entry for open ended messages: end
+*/
 		m_linecount = 1;
 		l_bufferpos = 0;
 		m_bufferpos = 0;


### PR DESCRIPTION
One more (I hope final) addition to P1MeterBase

There appears to be a second mode for running P1 Wifi Gateway which does not send fractions but only complete messages. The trouble with these messages is that they are open ended in the current firmware, i.e. the last line is not terminated with a newline character. As a result the commit of the data in versions prior to v3.5592 would have been done on a line similar to this one:

> !E6FF/XMX5LGBBFG1009015444

That is the last line of the previous message combined with the first line of the current message. Meaning that the data you would see would in fact be 10 seconds old. This construct became illegal with v3.5592 where the start of a new message empties all buffers regardless of whether a commit of the data inside it was triggered. 

This debug entry will re-allow such delayed messages to be committed with an explicit  warning in the log file.

Gordon
