### PR TITLE
Fix fo is_number() method

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -596,7 +596,7 @@ void rgb2hsb(const int r, const int g, const int b, float hsbvals[3])
 bool is_number(const std::string& s)
 {
 	std::string::const_iterator it = s.begin();
-	while (it != s.end() && (isdigit(*it) || (*it == '.') || (*it == '-') || (*it == ' '))) ++it;
+	while (it != s.end() && (isdigit(*it) || (*it == '.') || (*it == '-') || (*it == ' ') || (*it == 0x00))) ++it;
 	return !s.empty() && it == s.end();
 }
 


### PR DESCRIPTION
Sometimes owfs fill files with response by 0x00
But this is still properly number (teminated by white spaces)
