### PR TITLE
Quick fix for Toon Eneco blocking Domoticz UserAgent

### DIFF
--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -167,6 +167,7 @@ void CToonThermostat::Init()
 
 
 	m_bDoLogin = true;
+	HTTPClient::SetUserAgent("chrome/1.0");
 }
 
 bool CToonThermostat::StartHardware()
@@ -327,19 +328,19 @@ bool CToonThermostat::Login()
 	Json::Reader jReader;
 	if (!jReader.parse(sResult, root))
 	{
-		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password!");
+		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password! Could not parse data.\n");
 		return false;
 	}
 
 	if (root["clientId"].empty() == true)
 	{
-		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password!");
+		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password! No clientId found.");
 		return false;
 	}
 	m_ClientID = root["clientId"].asString();
 	if (root["clientIdChecksum"].empty() == true)
 	{
-		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password!");
+		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password! No cliedIdChecksum found.");
 		return false;
 	}
 	m_ClientIDChecksum = root["clientIdChecksum"].asString();
@@ -349,7 +350,7 @@ bool CToonThermostat::Login()
 
 	if (root["agreements"].empty() == true)
 	{
-		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password!");
+		_log.Log(LOG_ERROR, "ToonThermostat: Invalid data received, or invalid username/password! No agreements found.");
 		return false;
 	}
 	if (root["agreements"].size() < (size_t)(m_Agreement+1))


### PR DESCRIPTION
Toon servers are blocking the default domoticz useragent string recently. This is a quickfix to get the Toon to work again, setting the UserAgent string to 'chrome' in the Toon part of domoticz only.
When I have more time I will try to create a config field in the hardware properties of the Toon in Domoticz so that users can choose their own UserAgent string, as it will only take time for this new 'fake' string to be blocked also.
