### PR TITLE
Energenie 5-gang house codes go up to P 

### DIFF
--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -3172,7 +3172,7 @@ define(['app'], function (app) {
 				totunits=4;
 			}
 			else if (lighttype==9) {
-				tothousecodes=4;
+				tothousecodes=16;
 				totunits=4;
 			}
 			else if (lighttype==10) {


### PR DESCRIPTION
These wireless remote controlled outlets are sold by Amazon in the US by Etekcity and use the Energenie 5-gang protocol.  Their programmable outlets have house codes that actually all the way up to P (which I found out since mine shipped with a default code of H and it took me forever to figure why I couldn't control them via Domoticz).  This is also documented on page 27/40 of the rtxtrx user's guide where they talk about the Energenie 5-gang.

This change just makes the webpage allow you to send a code house up to P.  
