### PR TITLE
more responsive event system

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1930,7 +1930,7 @@ bool CEventSystem::parseBlocklyActions(const std::string &Actions, const std::st
 					StripQuotes(doWhat);
 				}
 				doWhat = ProcessVariableArgument(doWhat);
-				if (afterTimerSeconds < (1./TASK_PROCESSOR_HZ/2))
+				if (afterTimerSeconds < (1./timer_resolution_hz/2))
 				{
 					std::vector<std::vector<std::string> > result;
 					result = m_sql.safe_query("SELECT Name, ValueType FROM UserVariables WHERE (ID == '%q')", variableNo.c_str());
@@ -2989,7 +2989,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 
 			variableValue = ProcessVariableArgument(variableValue);
 
-			if (afterTimerSeconds < (1./TASK_PROCESSOR_HZ/2))
+			if (afterTimerSeconds < (1./timer_resolution_hz/2))
 			{
 				std::string updateResult = m_sql.UpdateUserVariable(sd[0], variableName, sd[1], variableValue, false);
 				if (updateResult != "OK") {
@@ -3211,7 +3211,7 @@ bool CEventSystem::ScheduleEvent(std::string deviceName, const std::string &Acti
 
 
 		std::string subject = cAction;
-		if (delay < (1./TASK_PROCESSOR_HZ/2))
+		if (delay < (1./timer_resolution_hz/2))
 		{
 			m_mainworker.m_cameras.EmailCameraSnapshot(deviceName, subject);
 		}
@@ -3350,11 +3350,11 @@ bool CEventSystem::ScheduleEvent(int deviceID, std::string Action, bool isScene,
 	}
 	float DelayTime = 0;
 
-	if (randomTimer > (1./TASK_PROCESSOR_HZ/2)) {
+	if (randomTimer > (1./timer_resolution_hz/2)) {
 		float rTime;
 		srand((unsigned int)mytime(NULL));
 		rTime = (float)rand()/(float)(RAND_MAX/randomTimer);
-		DelayTime = rTime + (1./TASK_PROCESSOR_HZ); //prevent it from running again immediately the next minute if blockly script doesn't handle that
+		DelayTime = rTime + (1./timer_resolution_hz); //prevent it from running again immediately the next minute if blockly script doesn't handle that
 		//alreadyScheduled = isEventscheduled(deviceID, randomTimer, isScene);
 	}
 	if (afterTimerSeconds > 0)
@@ -3403,9 +3403,9 @@ bool CEventSystem::ScheduleEvent(int deviceID, std::string Action, bool isScene,
 	}
 	m_sql.AddTaskItem(tItem);
 
-	if (suspendTimer > (1./TASK_PROCESSOR_HZ/2))
+	if (suspendTimer > (1./timer_resolution_hz/2))
 	{
-		DelayTime = suspendTimer + (1./TASK_PROCESSOR_HZ); //prevent it from running again immediately the next minute if blockly script doesn't handle that
+		DelayTime = suspendTimer + (1./timer_resolution_hz); //prevent it from running again immediately the next minute if blockly script doesn't handle that
 		_tTaskItem delayedtItem;
 		if (isScene) {
 			if (Action == "On") {

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2505,12 +2505,12 @@ void CSQLHelper::Do_Work()
 
 	while (!m_stoprequested)
 	{
-		sleep_milliseconds(1000./TASK_PROCESSOR_HZ);
+		sleep_milliseconds(1000./timer_resolution_hz);
 
 		if (m_bAcceptHardwareTimerActive)
 		{
-			m_iAcceptHardwareTimerCounter -= (1./TASK_PROCESSOR_HZ);
-			if (m_iAcceptHardwareTimerCounter <= (1./TASK_PROCESSOR_HZ/2))
+			m_iAcceptHardwareTimerCounter -= (1./timer_resolution_hz);
+			if (m_iAcceptHardwareTimerCounter <= (1./timer_resolution_hz/2))
 			{
 				m_bAcceptHardwareTimerActive = false;
 				m_bAcceptNewHardware = m_bPreviousAcceptNewHardware;
@@ -2531,8 +2531,8 @@ void CSQLHelper::Do_Work()
 				std::vector<_tTaskItem>::iterator itt=m_background_task_queue.begin();
 				while (itt!=m_background_task_queue.end())
 				{
-					itt->_DelayTime -= (1./TASK_PROCESSOR_HZ);
-					if (itt->_DelayTime<=(1./TASK_PROCESSOR_HZ/2))
+					itt->_DelayTime -= (1./timer_resolution_hz);
+					if (itt->_DelayTime<=(1./timer_resolution_hz/2))
 					{
 						_items2do.push_back(*itt);
 						itt=m_background_task_queue.erase(itt);
@@ -6111,7 +6111,7 @@ void CSQLHelper::AddTaskItem(const _tTaskItem &tItem)
 			if (itt->_idx == tItem._idx && itt->_ItemType == tItem._ItemType)
 			{
 				float iDelayDiff = tItem._DelayTime - itt->_DelayTime;
-				if (iDelayDiff < (1./TASK_PROCESSOR_HZ/2))
+				if (iDelayDiff < (1./timer_resolution_hz/2))
 				{
 					// _log.Log(LOG_NORM, "=> Already present. Cancelling previous task item");
 					itt = m_background_task_queue.erase(itt);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2505,13 +2505,12 @@ void CSQLHelper::Do_Work()
 
 	while (!m_stoprequested)
 	{
-		//sleep 1 second
-		sleep_seconds(1);
+		sleep_milliseconds(1000./TASK_PROCESSOR_HZ);
 
 		if (m_bAcceptHardwareTimerActive)
 		{
-			m_iAcceptHardwareTimerCounter--;
-			if (m_iAcceptHardwareTimerCounter <= 0)
+			m_iAcceptHardwareTimerCounter -= (1./TASK_PROCESSOR_HZ);
+			if (m_iAcceptHardwareTimerCounter <= (1./TASK_PROCESSOR_HZ/2))
 			{
 				m_bAcceptHardwareTimerActive = false;
 				m_bAcceptNewHardware = m_bPreviousAcceptNewHardware;
@@ -2523,26 +2522,30 @@ void CSQLHelper::Do_Work()
 			}
 		}
 
-		if (m_background_task_queue.size()>0)
-		{
-			_items2do.clear();
+		{ // additional scope for lock (accessing size should be within lock too)
 			boost::lock_guard<boost::mutex> l(m_background_task_mutex);
-
-			std::vector<_tTaskItem>::iterator itt=m_background_task_queue.begin();
-			while (itt!=m_background_task_queue.end())
+			if (m_background_task_queue.size()>0)
 			{
-				itt->_DelayTime--;
-				if (itt->_DelayTime<=0)
+				_items2do.clear();
+
+				std::vector<_tTaskItem>::iterator itt=m_background_task_queue.begin();
+				while (itt!=m_background_task_queue.end())
 				{
-					_items2do.push_back(*itt);
-					itt=m_background_task_queue.erase(itt);
+					itt->_DelayTime -= (1./TASK_PROCESSOR_HZ);
+					if (itt->_DelayTime<=(1./TASK_PROCESSOR_HZ/2))
+					{
+						_items2do.push_back(*itt);
+						itt=m_background_task_queue.erase(itt);
+					}
+					else
+						++itt;
 				}
-				else
-					++itt;
 			}
 		}
-		if (_items2do.size()<1)
+
+		if (_items2do.size() < 1) {
 			continue;
+		}
 
 		std::vector<_tTaskItem>::iterator itt=_items2do.begin();
 		while (itt!=_items2do.end())
@@ -4176,7 +4179,7 @@ void CSQLHelper::UpdateUVLog()
 	GetPreferencesVar("SensorTimeout", SensorTimeOut);
 
 	std::vector<std::vector<std::string> > result;
-	result=safe_query("SELECT ID,Type,SubType,nValue,sValue,LastUpdate FROM DeviceStatus WHERE (Type=%d) OR (Type=%d AND SubType=%d)", 
+	result=safe_query("SELECT ID,Type,SubType,nValue,sValue,LastUpdate FROM DeviceStatus WHERE (Type=%d) OR (Type=%d AND SubType=%d)",
 		pTypeUV,
 		pTypeGeneral, sTypeUV
 	);
@@ -6107,8 +6110,8 @@ void CSQLHelper::AddTaskItem(const _tTaskItem &tItem)
 			// _log.Log(LOG_NORM, "Comparing with item in queue: idx=%llu, DelayTime=%d, Command='%s', Level=%d, Hue=%d, RelatedEvent='%s'", itt->_idx, itt->_DelayTime, itt->_command.c_str(), itt->_level, itt->_Hue, itt->_relatedEvent.c_str());
 			if (itt->_idx == tItem._idx && itt->_ItemType == tItem._ItemType)
 			{
-				int iDelayDiff = tItem._DelayTime - itt->_DelayTime;
-				if (iDelayDiff < 3)
+				float iDelayDiff = tItem._DelayTime - itt->_DelayTime;
+				if (iDelayDiff < (1./TASK_PROCESSOR_HZ/2))
 				{
 					// _log.Log(LOG_NORM, "=> Already present. Cancelling previous task item");
 					itt = m_background_task_queue.erase(itt);

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -6,6 +6,8 @@
 #include "../httpclient/UrlEncode.h"
 #include <map>
 
+#define TASK_PROCESSOR_HZ 25
+
 struct sqlite3;
 
 enum _eWindUnit
@@ -40,7 +42,7 @@ enum _eTaskItemType
 struct _tTaskItem
 {
 	_eTaskItemType _ItemType;
-	int _DelayTime;
+	float _DelayTime;
 	int _HardwareID;
 	unsigned long long _idx;
 	std::string _ID;
@@ -56,7 +58,7 @@ struct _tTaskItem
     unsigned char _level;
 	int _Hue;
     std::string _relatedEvent;
-    
+
 	_tTaskItem()
 	{
 
@@ -146,7 +148,7 @@ struct _tTaskItem
 		tItem._idx=idx;
         tItem._command= Command;
         tItem._relatedEvent = eventName;
-        
+
 		return tItem;
 	}
 	static _tTaskItem GetHTTPPage(const int DelayTime, const std::string &URL, const std::string &eventName)
@@ -169,7 +171,7 @@ struct _tTaskItem
 		tItem._nValue = (eventtrigger==true)?1:0;
 		return tItem;
 	}
-	
+
 };
 
 class CSQLHelper
@@ -193,7 +195,7 @@ public:
 	unsigned long long UpdateValueHomeConfortGroupCmd(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction = true);
 
 	bool GetLastValue(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, int &nvalue, std::string &sValue, struct tm &LastUpdateTime);
-	
+
 	void Lighting2GroupCmd(const std::string &ID, const unsigned char subType, const unsigned char GroupCmd);
 	void HomeConfortGroupCmd(const std::string &ID, const unsigned char subType, const unsigned char GroupCmd);
 	void GeneralSwitchGroupCmd(const std::string &ID, const unsigned char subType, const unsigned char GroupCmd);
@@ -234,13 +236,13 @@ public:
 	void VacuumDatabase();
 
 	void DeleteHardware(const std::string &idx);
-    
+
     void DeleteCamera(const std::string &idx);
 
     void DeletePlan(const std::string &idx);
 
     void DeleteEvent(const std::string &idx);
-    
+
 	void DeleteDevices(const std::string &idx);
 
 	void TransferDevice(const std::string &oldidx, const std::string &newidx);
@@ -248,9 +250,9 @@ public:
 	bool DoesSceneByNameExits(const std::string &SceneName);
 
 	void AddTaskItem(const _tTaskItem &tItem);
-    
+
     void EventsGetTaskItems(std::vector<_tTaskItem> &currentTasks);
-   
+
 	void SetUnitsAndScale();
 
 	void CheckDeviceTimeout();
@@ -297,7 +299,7 @@ private:
 	std::map<unsigned long long, int> m_timeoutlastsend;
 	std::map<unsigned long long, int> m_batterylowlastsend;
 	bool			m_bAcceptHardwareTimerActive;
-	int				m_iAcceptHardwareTimerCounter;
+	float			m_iAcceptHardwareTimerCounter;
 	bool			m_bPreviousAcceptNewHardware;
 
 	std::vector<_tTaskItem> m_background_task_queue;

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -6,7 +6,7 @@
 #include "../httpclient/UrlEncode.h"
 #include <map>
 
-#define TASK_PROCESSOR_HZ 25
+#define timer_resolution_hz 25
 
 struct sqlite3;
 


### PR DESCRIPTION
This change will make the event system more responsive as discussed in this thread on the developer forums. I know that for many an interval of 1 second is more than enough, but my situation requires a much shorter interval. Both are now possible. Existing systems won't require any change to keep on working like they did, and for others it's now possible to trigger events much quicker.

http://www.domoticz.com/forum/viewtopic.php?f=9&t=13509

A few notes:
- Comparing a float with zero doesn't make sense, so on all those situations I've used halve an interval to compare with.
- Accessing size of a list should also be thread safe in SQLHelper.cpp.
- This code doesn't have a visual impact on performance on my Raspberry Pi 2.
- If and when this code is implemented I've got additional code ready that uses this for AFTER, RANDOM and FOR to use MSECONDS, SECONDS, MINUTES or HOURS, a feature that has been requested on the forums in multiple threads.
