### PR TITLE
Improve tellstick support

### DIFF
--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -251,7 +251,7 @@ void CTellstick::ThreadSendCommands()
 
             SendCommand(it->first, it->second.genSwitch);
             ++it->second.repeat;
-            if (it->second.repeat >= m_numRepeats)
+            if (it->second.repeat > m_numRepeats)
                 m_commands.erase(it++);
             else
             {
@@ -282,7 +282,7 @@ namespace http {
 
             string hwIdStr = request::findValue(&req, "idx");
             string repeatsStr = request::findValue(&req, "repeats");
-            string repeatIntervalStr = request::findValue(&req, "repeats");
+            string repeatIntervalStr = request::findValue(&req, "repeatInterval");
 
             if (hwIdStr.empty() || repeatsStr.empty() || repeatIntervalStr.empty())
                 return;

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -1,4 +1,4 @@
- #include "stdafx.h"
+#include "stdafx.h"
 #ifdef WITH_TELLDUSCORE
 #include "Tellstick.h"
 
@@ -9,196 +9,256 @@
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
 #include "../json/json.h"
-#include "hardwaretypes.h"
 #include <telldus-core.h>
 
+using namespace std;
+
+int CTellstick::s_maxRetries(5);
+boost::posix_time::milliseconds CTellstick::s_retryDelay(500);
+
 CTellstick::CTellstick(const int ID)
+    : m_deviceEventId(-1),
+      m_rawDeviceEventId(-1),
+      m_sensorEventId(-1)
+
 {
-	m_HwdID=ID;
-	m_bSkipReceiveCheck = true;
-	deviceEventId = -1;
-	sensorEventId = -1;
-}
-
-CTellstick::~CTellstick(void)
-{
-	m_bIsStarted=false;
-}
-
-bool CTellstick::AddSwitchIfNotExits(const int id, const char* devname, bool isDimmer)
-{
-        char sid[16];
-        sprintf(sid, "%08X", id);
-  
-	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (SubType==%d)", m_HwdID, sid, pTypeGeneralSwitch, sSwitchTypeAC);
-	if (result.size()<1)
-	{
-	        _log.Log(LOG_NORM, "Tellstick: device %d %s: %s", id, sid ,devname);
-		m_sql.safe_query(
-			"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, SignalLevel, BatteryLevel, Name, nValue, sValue) "
-			"VALUES (%d,'%q',%d,%d,%d,%d,12,255,'%q',0,' ')",
-			m_HwdID, sid, 3, pTypeGeneralSwitch, sSwitchTypeAC, isDimmer ? STYPE_Dimmer : STYPE_OnOff, devname);
-		return true;
-	}
-	return false;
-}
-
-void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *model, int dataType, const char *value) {
-  // _log.Log(LOG_NORM, "Tellstick: SensorEvent %d,%s,%s,%d,%s", deviceId, protocol, model, dataType, value);
-
-    switch (dataType) {
-      
-    case TELLSTICK_TEMPERATURE:
-      SendTempSensor(deviceId, 255, atof(value), "Temp");
-      break;
-      
-    case TELLSTICK_HUMIDITY:
-      SendHumiditySensor(deviceId, 255, atof(value), "Humid");
-      break;
-
-    case TELLSTICK_RAINRATE:
-      break;
-
-    case TELLSTICK_RAINTOTAL:
-      break;
-
-    case TELLSTICK_WINDDIRECTION:
-      break;
-
-    case TELLSTICK_WINDAVERAGE:
-      break;
-
-    case  TELLSTICK_WINDGUST:
-      break;
-  }
-}
-
-
-void CTellstick::deviceEvent(int deviceId, int method, const char *data) {
-	_log.Log(LOG_NORM, "Tellstick: deviceEvent %d %d: %s", deviceId, method, data);
-
-        char sid[16];
-        sprintf(sid, "%08d", deviceId);  
-
-	_tGeneralSwitch gswitch;
-	// TODO pTypeGeneralSwitch
-	gswitch.subtype = sSwitchTypeAC;
-	gswitch.id = deviceId;
-	gswitch.unitcode = 3;
-	gswitch.level = 0;
-	gswitch.battery_level = 255;
-	gswitch.rssi = 12;
-	gswitch.seqnbr = 0;
-  
-	if (method == TELLSTICK_TURNON) {
-		gswitch.cmnd = gswitch_sOn;
-		sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
-	} else if (method == TELLSTICK_TURNOFF) {
-		gswitch.cmnd = gswitch_sOff;
-		sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
-	} else if (method == TELLSTICK_DIM) {
-		gswitch.cmnd = gswitch_sSetLevel;
-		gswitch.level = atoi(data)*99/255;
-		sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
-	} else {
-		_log.Log(LOG_NORM, "Unknown event from device %i\n", deviceId);
-	}
-}
-void CTellstick::deviceEventCallback(int deviceId, int method, const char *data, int callbackId, void *context) {
-  CTellstick *t = reinterpret_cast<CTellstick *>(context);
-  if (t) {
-    /** Please note!
-     * We are here in another thread than the main. Some measures to syncronize
-     * this must be taken!
-     **/
-    t->deviceEvent(deviceId, method, data);
-  }
-}
-
-void CTellstick::sensorEventCallback(const char *protocol, const char *model, int deviceId, int dataType, 
-				     const char *value, int timestamp, int callbackId, void *context) {
-  CTellstick *t = reinterpret_cast<CTellstick *>(context);
-  if (t) {
-    /** Please note!
-     * We are here in another thread than the main. Some measures to syncronize
-     * this must be taken!
-     **/
-    t->sensorEvent(deviceId, protocol, model, dataType, value);
- }
-}
-
-void CTellstick::Init()
-{
-  tdInit();
-  deviceEventId = tdRegisterDeviceEvent( reinterpret_cast<TDDeviceEvent>(&CTellstick::deviceEventCallback), this);
-  int intNumberOfDevices = tdGetNumberOfDevices();
-
-  sensorEventId = tdRegisterSensorEvent( reinterpret_cast<TDSensorEvent>(&CTellstick::sensorEventCallback), this);
-  _log.Log(LOG_NORM, "Tellstick: Registering Sensor Event Calback %d", sensorEventId);
-  
-  
-  for (int i = 0; i < intNumberOfDevices; i++) {
-    int id = tdGetDeviceId(i);
-    char *name = tdGetName(id);
-    _log.Log(LOG_NORM, "Tellstick: %s method %d", name, tdMethods(id, TELLSTICK_TURNON | TELLSTICK_TURNOFF | TELLSTICK_DIM) & TELLSTICK_DIM);
-    bool isDimmer = tdMethods(id, TELLSTICK_TURNON | TELLSTICK_TURNOFF | TELLSTICK_DIM) & TELLSTICK_DIM;
-    AddSwitchIfNotExits(id, name, isDimmer);
-    tdReleaseString(name);
-  }
-  
-}
-
-bool CTellstick::StartHardware()
-{
-	Init();
-	m_bIsStarted=true;
-	sOnConnected(this);
-	_log.Log(LOG_NORM, "Tellstick: StartHardware");
-	return true;
-}
-
-bool CTellstick::StopHardware()
-{
-  if (deviceEventId != -1)
-    tdUnregisterCallback( deviceEventId );
-  if (sensorEventId != -1)
-    tdUnregisterCallback( sensorEventId );
-  
-	tdClose();
- 	m_bIsStarted=false;
-	return true;
+    m_HwdID = ID;
+    m_bSkipReceiveCheck = true;
 }
 
 bool CTellstick::WriteToHardware(const char *pdata, const unsigned char length)
 {
-	const _tGeneralSwitch *pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pdata);
-	//tRBUF *pCmd=(tRBUF*) pdata;
-	_log.Log(LOG_NORM, "Tellstick: WriteToHardware %d id: %d cmd: %d", pSwitch->type, pSwitch->id, pSwitch->cmnd);
+    const _tGeneralSwitch *pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pdata);
+    _log.Log(LOG_NORM, "Tellstick: WriteToHardware %d id: %d cmd: %d", pSwitch->type, pSwitch->id, pSwitch->cmnd);
 
-	if (pSwitch->type != pTypeGeneralSwitch)
-		return false; //only allowed to control switches
+    if (pSwitch->type != pTypeGeneralSwitch)
+        return false; //only allowed to control switches
 
-	if (pSwitch->cmnd == gswitch_sOn)
-	{
-	  _log.Log(LOG_NORM, "Tellstick: Switch ON");
-	  tdTurnOn(pSwitch->id);
-	}
-	else if(pSwitch->cmnd == gswitch_sOff)
-	{
-	  _log.Log(LOG_NORM, "Tellstick: Switch OFF");
-	  tdTurnOff(pSwitch->id);
-	}
-	else if(pSwitch->cmnd == gswitch_sSetLevel)
-	{
-	  _log.Log(LOG_NORM, "Tellstick: Dim level %d %d", pSwitch->level, pSwitch->level * 255 / 99);
-	  tdDim(pSwitch->id, pSwitch->level * 255 / 99);
-	}
-
-	return true;
+    boost::unique_lock<boost::mutex> lock(m_mutex);
+    m_commands[pSwitch->id] = Command(*pSwitch);
+    m_cond.notify_all();
+    return true;
 }
-void CTellstick::SendCommand(const int ID, const std::string &command)
+
+bool CTellstick::AddSwitchIfNotExits(const int id, const char* devname, bool isDimmer)
 {
-	_log.Log(LOG_NORM, "Tellstick: SendCommand");
+    char sid[16];
+    sprintf(sid, "%08X", id);
+  
+    std::vector<std::vector<std::string> > result;
+    result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (SubType==%d)", 
+                              m_HwdID, sid, pTypeGeneralSwitch, sSwitchTypeAC);
+    if (result.size() < 1)
+    {
+        _log.Log(LOG_NORM, "Tellstick: device %d %s: %s", id, sid ,devname);
+        m_sql.safe_query(
+            "INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, SignalLevel, BatteryLevel, Name, nValue, sValue) "
+            "VALUES (%d,'%q',%d,%d,%d,%d,12,255,'%q',0,' ')",
+            m_HwdID, sid, 3, pTypeGeneralSwitch, sSwitchTypeAC, isDimmer ? STYPE_Dimmer : STYPE_OnOff, devname);
+        return true;
+    }
+    return false;
+}
+
+void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *model, int dataType, const char *value)
+{
+    _log.Log(LOG_NORM, "Tellstick: sensorEvent %d,%s,%s,%d,%s", deviceId, protocol, model, dataType, value);
+    switch (dataType)
+    {
+    case TELLSTICK_TEMPERATURE:
+        SendTempSensor(deviceId, 255, atof(value), "Temp");
+        break;
+    case TELLSTICK_HUMIDITY:
+        SendHumiditySensor(deviceId, 255, atof(value), "Humid");
+        break;
+    case TELLSTICK_RAINRATE:
+    case TELLSTICK_RAINTOTAL:
+    case TELLSTICK_WINDDIRECTION:
+    case TELLSTICK_WINDAVERAGE:
+    case TELLSTICK_WINDGUST:
+        break;
+    }
+}
+
+void CTellstick::deviceEvent(int deviceId, int method, const char *data)
+{
+    _log.Log(LOG_NORM, "Tellstick: deviceEvent %d %d: %s", deviceId, method, data);
+
+    char sid[16];
+    sprintf(sid, "%08d", deviceId);  
+
+    _tGeneralSwitch gswitch;
+    gswitch.id = deviceId;
+    gswitch.unitcode = 3;
+  
+    switch (method)
+    {
+    case TELLSTICK_TURNON:
+        gswitch.cmnd = gswitch_sOn;
+        sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
+        break;
+    case TELLSTICK_TURNOFF:
+        gswitch.cmnd = gswitch_sOff;
+        sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
+        break;
+    case TELLSTICK_DIM:
+        gswitch.cmnd = gswitch_sSetLevel;
+        gswitch.level = atoi(data)*99/255;
+        sDecodeRXMessage(this, (const unsigned char *)&gswitch, NULL, 255);
+        break;
+    default:
+        _log.Log(LOG_NORM, "Unknown event from device %i\n", deviceId);
+        break;
+    }
+}
+
+void CTellstick::rawDeviceEvent(int controllerId, const char *data)
+{
+    _log.Log(LOG_NORM, "Tellstick: rawDeviceEvent %d: %s", controllerId, data);
+}
+
+void CTellstick::deviceEventCallback(int deviceId, int method, const char *data, int callbackId, void *context)
+{
+    CTellstick *t = reinterpret_cast<CTellstick *>(context);
+    if (t) 
+    {
+        /** Please note!
+        * We are here in another thread than the main. Some measures to syncronize
+        * this must be taken!
+        **/
+        t->deviceEvent(deviceId, method, data);
+    }
+}
+
+void CTellstick::rawDeviceEventCallback(const char *data, int controllerId, int callbackId, void *context)
+{
+    CTellstick *t = reinterpret_cast<CTellstick *>(context);
+    if (t) 
+    {
+        /** Please note!
+        * We are here in another thread than the main. Some measures to syncronize
+        * this must be taken!
+        **/
+        t->rawDeviceEvent(controllerId, data);
+    }
+}
+
+void CTellstick::sensorEventCallback(const char *protocol, const char *model, int deviceId, int dataType, 
+                                     const char *value, int timestamp, int callbackId, void *context) 
+ {
+    CTellstick *t = reinterpret_cast<CTellstick *>(context);
+    if (t) 
+    {
+        /** Please note!
+        * We are here in another thread than the main. Some measures to syncronize
+        * this must be taken!
+        **/
+        t->sensorEvent(deviceId, protocol, model, dataType, value);
+    }
+}
+
+void CTellstick::Init()
+{
+    tdInit();
+    m_deviceEventId = tdRegisterDeviceEvent(reinterpret_cast<TDDeviceEvent>(&CTellstick::deviceEventCallback), this);
+    m_rawDeviceEventId = tdRegisterRawDeviceEvent(reinterpret_cast<TDRawDeviceEvent>(&CTellstick::rawDeviceEventCallback), this);
+    m_sensorEventId = tdRegisterSensorEvent(reinterpret_cast<TDSensorEvent>(&CTellstick::sensorEventCallback), this);
+
+    for (int i = 0; i < tdGetNumberOfDevices(); i++)
+    {
+        int id = tdGetDeviceId(i);
+        char *name = tdGetName(id);
+        _log.Log(LOG_NORM, "Tellstick: %s method %d", name, tdMethods(id, TELLSTICK_TURNON | TELLSTICK_TURNOFF | TELLSTICK_DIM) & TELLSTICK_DIM);
+        bool isDimmer = tdMethods(id, TELLSTICK_TURNON | TELLSTICK_TURNOFF | TELLSTICK_DIM) & TELLSTICK_DIM;
+        AddSwitchIfNotExits(id, name, isDimmer);
+        tdReleaseString(name);
+    }
+}
+
+bool CTellstick::StartHardware()
+{
+    Init();
+    m_bIsStarted=true;
+    sOnConnected(this);
+    _log.Log(LOG_NORM, "Tellstick: StartHardware");
+    //Start worker thread
+    m_thread = boost::thread(boost::bind(&CTellstick::ThreadSendCommands, this));
+    return true;
+}
+
+bool CTellstick::StopHardware()
+{
+    if (m_deviceEventId != -1)
+        tdUnregisterCallback(m_deviceEventId);
+    if (m_rawDeviceEventId != -1)
+        tdUnregisterCallback(m_rawDeviceEventId);
+    if (m_sensorEventId != -1)
+        tdUnregisterCallback(m_sensorEventId);
+  
+    tdClose();
+    boost::unique_lock<boost::mutex> lock(m_mutex);
+    m_bIsStarted = false;
+    m_cond.notify_all();
+    m_thread.join();
+    return true;
+}
+
+void CTellstick::SendCommand(int devID, const _tGeneralSwitch &genSwitch)
+{
+    _log.Log(LOG_NORM, "Tellstick: SendCommand %d id: %d cmd: %d",
+             genSwitch.type, genSwitch.id, genSwitch.cmnd);
+    switch (genSwitch.cmnd)
+    {
+    case gswitch_sOn:
+        _log.Log(LOG_NORM, "Tellstick: Switch ON");
+        tdTurnOn(genSwitch.id);
+        break;
+    case gswitch_sOff:
+        _log.Log(LOG_NORM, "Tellstick: Switch OFF");
+        tdTurnOff(genSwitch.id);
+        break;
+    case gswitch_sSetLevel:
+        _log.Log(LOG_NORM, "Tellstick: Dim level %d %d",
+                 genSwitch.level, genSwitch.level * 255 / 99);
+        tdDim(genSwitch.id, genSwitch.level * 255 / 99);
+        break;
+    }
+}
+
+void CTellstick::ThreadSendCommands()
+{
+    boost::unique_lock<boost::mutex> lock(m_mutex);
+    while (m_bIsStarted)
+    {
+        boost::system_time now = boost::get_system_time();
+        boost::system_time nextTime = now + s_retryDelay;
+        for (map<int, Command>::iterator it = m_commands.begin();
+             it != m_commands.end();
+             /* no increment */)
+        {
+            if (it->second.retryTimePoint > now)
+            {
+                ++it;
+                continue;
+            }
+
+            SendCommand(it->first, it->second.genSwitch);
+            ++it->second.retry;
+            if (it->second.retry >= s_maxRetries)
+                m_commands.erase(it++);
+            else
+            {
+                it->second.retryTimePoint += s_retryDelay;
+                if (it->second.retryTimePoint < nextTime)
+                    nextTime = it->second.retryTimePoint;
+                ++it;
+            }
+        }
+
+        if (m_commands.empty())
+            m_cond.wait(lock);
+        else
+            m_cond.timed_wait(lock, nextTime);
+    }
 }
 #endif //WITH_TELLDUSCORE

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -204,7 +204,9 @@ bool CTellstick::StopHardware()
     boost::unique_lock<boost::mutex> lock(m_mutex);
     m_bIsStarted = false;
     m_cond.notify_all();
-    m_thread.join();
+    lock.unlock();
+    if (m_thread.joinable())
+        m_thread.join();
     return true;
 }
 

--- a/hardware/Tellstick.h
+++ b/hardware/Tellstick.h
@@ -3,32 +3,63 @@
 #ifdef WITH_TELLDUSCORE
 
 #include "DomoticzHardware.h"
+#include "hardwaretypes.h"
 #include <iostream>
+#include <map>
+#include <boost/thread/thread.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/thread_time.hpp>
 
 class CTellstick : public CDomoticzHardwareBase
 {
 public:
-	explicit CTellstick(const int ID);
-	~CTellstick(void);
-	bool WriteToHardware(const char *pdata, const unsigned char length);
-	void SendCommand(const int ID, const std::string &command);
-
-	void deviceEvent(int deviceId, int method, const char *data);
-	static void deviceEventCallback(int deviceId, int method, const char *data, int callbackId, void *context);
-
-	void sensorEvent(int deviceId, const char *protocol, const char *model, int dataType, const char *value);
-	static void sensorEventCallback(const char *protocol, const char *model, int id, int dataType, const char *value,
-					int timestamp, int callbackId, void *context);
+    explicit CTellstick(const int ID);
+    bool WriteToHardware(const char *pdata, const unsigned char length);
 
 private:
-	bool AddSwitchIfNotExits(const int id, const char* devname, bool isDimmer);
-	void Init();
-	bool StartHardware();
-	bool StopHardware();
+    struct Command
+    {
+        Command()
+            : retry(0),
+              retryTimePoint(boost::get_system_time()) {}
+        Command(_tGeneralSwitch genSwitch)
+            : genSwitch(genSwitch),
+              retry(0),
+              retryTimePoint(boost::get_system_time()) {}
 
-	int deviceEventId;
-	int sensorEventId;
+        _tGeneralSwitch genSwitch;
+        int retry;
+        boost::system_time retryTimePoint;
+    };
 
+    void deviceEvent(int deviceId, int method, const char *data);
+    static void deviceEventCallback(int deviceId, int method, const char *data, int callbackId, void *context);
+
+    void rawDeviceEvent(int controllerId, const char *data);
+    static void rawDeviceEventCallback(const char *data, int controllerId, int callbackId, void *context);
+
+    void sensorEvent(int deviceId, const char *protocol, const char *model, int dataType, const char *value);
+    static void sensorEventCallback(const char *protocol, const char *model, int id, int dataType, const char *value,
+                    int timestamp, int callbackId, void *context);
+    bool AddSwitchIfNotExits(const int id, const char* devname, bool isDimmer);
+    void Init();
+    bool StartHardware();
+    bool StopHardware();
+    void SendCommand(int devID, const _tGeneralSwitch &cmd);
+    
+    void ThreadSendCommands();
+
+    int m_deviceEventId;
+    int m_rawDeviceEventId;
+    int m_sensorEventId;
+
+    boost::thread m_thread;
+    boost::mutex m_mutex;
+    boost::condition_variable m_cond;
+    std::map<int, Command> m_commands;
+    static int s_maxRetries;
+    static boost::posix_time::milliseconds s_retryDelay;
 };
 
 #endif //WITH_TELLSTICK

--- a/hardware/Tellstick.h
+++ b/hardware/Tellstick.h
@@ -14,23 +14,24 @@
 class CTellstick : public CDomoticzHardwareBase
 {
 public:
-    explicit CTellstick(const int ID);
+    explicit CTellstick(const int ID, int repeats, int repeatInterval);
+    void SetSettings(int repeats, int repeatInterval);
     bool WriteToHardware(const char *pdata, const unsigned char length);
 
 private:
     struct Command
     {
         Command()
-            : retry(0),
-              retryTimePoint(boost::get_system_time()) {}
+            : repeat(0),
+              repeatTimePoint(boost::get_system_time()) {}
         Command(_tGeneralSwitch genSwitch)
             : genSwitch(genSwitch),
-              retry(0),
-              retryTimePoint(boost::get_system_time()) {}
+              repeat(0),
+              repeatTimePoint(boost::get_system_time()) {}
 
         _tGeneralSwitch genSwitch;
-        int retry;
-        boost::system_time retryTimePoint;
+        int repeat;
+        boost::system_time repeatTimePoint;
     };
 
     void deviceEvent(int deviceId, int method, const char *data);
@@ -58,8 +59,8 @@ private:
     boost::mutex m_mutex;
     boost::condition_variable m_cond;
     std::map<int, Command> m_commands;
-    static int s_maxRetries;
-    static boost::posix_time::milliseconds s_retryDelay;
+    int m_numRepeats;
+    boost::posix_time::milliseconds m_repeatInterval;
 };
 
 #endif //WITH_TELLSTICK

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -31,6 +31,9 @@
 #include "../hardware/Gpio.h"
 #include "../hardware/GpioPin.h"
 #endif // WITH_GPIO
+#ifdef WITH_TELLDUSCORE
+#include "../hardware/Tellstick.h"
+#endif
 #include "../webserver/Base64.h"
 #include "../smtpclient/SMTPClient.h"
 #include "../json/json.h"
@@ -598,6 +601,10 @@ namespace http {
 			//scenepost.html
 			//thpost.html
 			RegisterRType("openzwavenodes", boost::bind(&CWebServer::RType_OpenZWaveNodes, this, _1, _2, _3));
+#endif
+
+#ifdef WITH_TELLDUSCORE
+            RegisterCommandCode("tellstickApplySettings", boost::bind(&CWebServer::Cmd_TellstickApplySettings, this, _1, _2, _3));
 #endif
 
 			m_pWebEm->RegisterWhitelistURLString("/html5.appcache");
@@ -1223,6 +1230,11 @@ namespace http {
 				mode1 = 30;
 				mode2 = 1000;
 			}			
+			else if (htype == HTYPE_Tellstick)
+			{
+				mode1 = 4;
+				mode2 = 500;
+			}
 
 			m_sql.safe_query(
 				"INSERT INTO Hardware (Name, Enabled, Type, Address, Port, SerialPort, Username, Password, Extra, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, DataTimeout) VALUES ('%q',%d, %d,'%q',%d,'%q','%q','%q','%q',%d,%d,%d,%d,%d,%d,%d)",

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -331,6 +331,9 @@ private:
 	void RType_OpenZWaveNodes(WebEmSession & session, const request& req, Json::Value &root);
 	int m_ZW_Hwidx;
 #endif
+#ifdef WITH_TELLDUSCORE
+    void Cmd_TellstickApplySettings(WebEmSession &session, const request &req, Json::Value &root);
+#endif
 	boost::shared_ptr<boost::thread> m_thread;
 
 	std::map < std::string, webserver_response_function > m_webcommands;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -887,7 +887,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 #ifdef WITH_TELLDUSCORE
 	case HTYPE_Tellstick:
-		pHardware = new CTellstick(ID);
+		pHardware = new CTellstick(ID, Mode1, Mode2);
 		break;
 #endif //WITH_TELLDUSCORE
 	case HTYPE_EVOHOME_SCRIPT:

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -1,4 +1,4 @@
-define(['app'], function (app) {
+pdefine(['app'], function (app) {
     app.controller('HardwareController', [ '$scope', '$rootScope', '$location', '$http', '$interval', function($scope,$rootScope,$location,$http,$interval) {
 
         $scope.SerialPortStr=[];
@@ -4261,6 +4261,47 @@ define(['app'], function (app) {
           });
         }
 
+        TellstickSettings = function (idx, name, repeats, repeatInterval) {
+            $.idx = idx;
+            cursordefault();
+            var htmlcontent = '';
+            htmlcontent = '<p><center><h2><span data-i18n="Device"></span>: ' + name + '</h2></center></p>\n';
+            htmlcontent += $('#tellstick').html();
+            $('#hardwarecontent').html(GetBackbuttonHTMLTable('ShowHardware') + htmlcontent);
+            $('#hardwarecontent').i18n();
+
+            $('#hardwarecontent #idx').val(idx);
+            $("#hardwarecontent #tellstickSettingsTable #repeats").val(repeats);
+            $("#hardwarecontent #tellstickSettingsTable #repeatInterval").val(repeatInterval);
+        }
+
+        TellstickApplySettings = function () {
+            var repeats = parseInt($("#hardwarecontent #tellstickSettingsTable #repeats").val());
+            if (repeats < 0)
+                repeats = 0;
+            if (repeats > 10)
+                repeats = 10;
+            var repeatInterval = parseInt($("#hardwarecontent #tellstickSettingsTable #repeatInterval").val());
+            if (repeatInterval < 10)
+                repeatInterval = 10;
+            if (repeatInterval > 2000)
+                repeatInterval = 2000;
+            $.ajax({
+                url: "json.htm?type=command&param=tellstickApplySettings" +
+                   "&idx=" + $.idx +
+                   "&repeats=" + repeats +
+                   "&repeatInterval=" + repeatInterval,
+                async: false,
+                dataType: 'json',
+                success: function (data) {
+                    bootbox.alert($.t('Settings saved'));
+                },
+                error: function () {
+                    ShowNotify($.t('Failed saving settings'), 2500, true);
+                }
+            });
+        }
+
         RefreshHardwareTable = function()
         {
           $('#modal').show();
@@ -4434,6 +4475,9 @@ define(['app'], function (app) {
                     }
                     else if (HwTypeStr.indexOf("CurrentCost Meter USB") >= 0) {
                         HwTypeStr+=' <span class="label label-info lcursor" onclick="EditCCUSB(' + item.idx + ',\'' + item.Name + '\',\'' + item.Address + '\');">' + $.t("Set Mode") + '</span>';
+                    }
+                    else if (HwTypeStr.indexOf("Tellstick") >= 0) {
+                        HwTypeStr += ' <span class="label label-info lcursor" onclick="TellstickSettings(' + item.idx + ',\'' + item.Name + '\',' + item.Mode1 + ',' + item.Mode2 + ');">' + $.t("Settings") + '</span>';
                     }
 
                     var sDataTimeout="";

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -1,4 +1,4 @@
-pdefine(['app'], function (app) {
+define(['app'], function (app) {
     app.controller('HardwareController', [ '$scope', '$rootScope', '$location', '$http', '$interval', function($scope,$rootScope,$location,$http,$interval) {
 
         $scope.SerialPortStr=[];

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1443,11 +1443,11 @@
     </div>
     <table class="display" id="tellstickSettingsTable" border="0" cellpadding="0" cellspacing="20">
         <tr>
-            <td align="right" style="width:110px"><label for="repeats"><span data-i18n="Repeats"></span>:</label></td>
+            <td align="right" style="width:110px"><label for="repeats"><span data-i18n="Repeats">Repeats</span>:</label></td>
             <td><input type="text" id="repeats" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all"</td>
         </tr>
         <tr>
-            <td align="right" style="width:110px"><label for="repeatInterval"><span data-i18n="Repeat Interval"></span>:</label></td>
+            <td align="right" style="width:110px"><label for="repeatInterval"><span data-i18n="Repeat Interval">Repeat Interval</span>:</label></td>
             <td><input type="text" id="repeatInterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" />&nbsp;(<span data-i18n="Milliseconds"></span>)</td>
         </tr>
         <tr>

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1431,3 +1431,29 @@
 				<input type="text" id="sensorname" style="width: 240px; padding: .2em;" class="text ui-widget-content ui-corner-all" />
 		</form>
 </div>
+<div id="tellstick" style="display:none;">
+    <div class="page-header-small">
+        <table border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+                <td>
+                    <h1 data-i18n="Settings">Settings</h1>
+                </td>
+            </tr>
+        </table>
+    </div>
+    <table class="display" id="tellstickSettingsTable" border="0" cellpadding="0" cellspacing="20">
+        <tr>
+            <td align="right" style="width:110px"><label for="repeats"><span data-i18n="Repeats"></span>:</label></td>
+            <td><input type="text" id="repeats" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all"</td>
+        </tr>
+        <tr>
+            <td align="right" style="width:110px"><label for="repeatInterval"><span data-i18n="Repeat Interval"></span>:</label></td>
+            <td><input type="text" id="repeatInterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" />&nbsp;(<span data-i18n="Milliseconds"></span>)</td>
+        </tr>
+        <tr>
+            <td></td>
+            <td><a class="btn-danger sub-tabs-apply" onclick="TellstickApplySettings();" data-i18n="Apply Settings"></a></td>
+        </tr>
+    </table>
+</div>
+    


### PR DESCRIPTION
New version of improved Tellstick support (without boost::chrono dependency)
Add support for logging raw device events. This is useful when detecting sensors and remote controls ID.
Sometimes a command sent from the Tellstick is lost due to poor wireless environment. Add support for repeating the transmits.
