### PR TITLE
Don't send out dozens of copies of the same message

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -1699,6 +1699,7 @@ void CEvohome::Do_Send()
 		{
 			std::string out(m_SendQueue.front().Encode()+"\r\n");
 			write(out.c_str(),out.length());
+			m_SendQueue.pop_front();
 		}
 	}
 }


### PR DESCRIPTION
For some reason, the Evohome integration doesn't pop messages of the send queue when it sends them, resulting in each of them being sent dozens of times.

I'm struggling to follow the flow, but I think the code only removes them after they've been sent 10 times - except I've definitely observed messages being sent more than that. This results in a very very very slow discovery of Evohome devices - especially in a large installation (like mine!)

This patch removes messages from the send queue once they've been sent out of the serial port.
