### PR TITLE
Ignore lines beginning with #

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -717,6 +717,12 @@ bool CEvohomeMsg::DecodePacket(const char * rawmsg)
 		std::string tkn(tkns[i]);
 		if(i==0)//this is some sort of status or flags but not sure what exactly
 		{
+			if(tkn=="#")
+			{
+				SetFlag(flgign);
+				CEvohome::Log(true,LOG_STATUS,"evohome: ignored message: %s",rawmsg);
+				return false;
+			}
 		}
 		else if(i==1)
 		{
@@ -832,7 +838,7 @@ void CEvohome::ProcessMsg(const char * rawmsg)
 		else
 			DecodePayload(msg);
 	}
-	else
+	else if(!msg.Ignore())
 		Log(true,LOG_ERROR,"evohome: invalid message structure - possible corrupt message");
 }
 

--- a/hardware/evohome.h
+++ b/hardware/evohome.h
@@ -276,7 +276,8 @@ public:
 		flgts=flgpkt<<1,
 		flgcmd=flgts<<1,//not optional but we can signal if we read it at least
 		flgps=flgcmd<<1,//not optional but we can signal if we read it at least
-		flgpay=flgps<<1,//not optional but we can signal if we read it at least
+		flgpay=flgps<<1,//not optional but we can signal if we read it at least,
+		flgign=flgpay<<1,
 		flgvalid=flgid1|flgpkt|flgcmd|flgps|flgpay,
 	};
 	enum packettype{
@@ -325,8 +326,9 @@ public:
 			return false;
 		return true;
 	}
-	
+
 	bool IsValid() const {return ((flags&flgvalid)==flgvalid)&&(flags&(flgid2|flgid3));}
+	bool Ignore() const {return ((flags&flgign)!=0);}
 	bool DecodePacket(const char * rawmsg);
 
 	template<typename T> CEvohomeMsg& Add(const T &in){CEvohomeDataType::Add(in,payload,payloadsize);return *this;}
@@ -377,10 +379,10 @@ public:
 		SetFlag(flgid1<<idx);
 	}
 	bool BadMsg(){return (enccount>30);}
-	
+
 	static char const szPacketType[5][8];
 
-	unsigned char flags;
+	uint16_t flags;
 	packettype type;
 	CEvohomeID id[3];
 	unsigned char timestamp;


### PR DESCRIPTION
I'm developing some custom firmware for Domoticz/Evohome integration on a Raspberry Pi. It is useful for me to have the firmware write "debug stuff" out to the serial interface, but obviously that needs to not interfere with the operation of Domoticz. 

This patch causes the Evohome integration to ignore all incoming lines from the serial interface which begin with #. Without this patch, it logs error messages about the message being corrupt, and there's no visibility of what the line was.

This is mostly useful for me at this point, so feel free to reject. 
