### PR TITLE
[Events] fixed endless loop when sending specific notification

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2716,9 +2716,9 @@ void CSQLHelper::Do_Work()
 			{
 				std::vector<std::string> splitresults;
 				StringSplit(itt->_command, "!#", splitresults);
-				if (splitresults.size() != 4)
-					continue; //impossible
-				m_notifications.SendMessageEx(NOTIFYALL, stdstring_trim(splitresults[0]), stdstring_trim(splitresults[1]), stdstring_trim(splitresults[2]), static_cast<int>(itt->_idx), stdstring_trim(splitresults[3]), true);
+				if (splitresults.size() == 4) {
+					m_notifications.SendMessageEx(NOTIFYALL, splitresults[0], splitresults[1], splitresults[2], static_cast<int>(itt->_idx), splitresults[3], true);
+				}
 			}
 
 			++itt;


### PR DESCRIPTION
When the notification contains an exclamation mark, Domoticz would end up in an endless loop. The code uses 'continue' to process the next event without incrementing the event iterator. This causes 100% cpu load ofcourse and a failing Event system.