### PR TITLE
[LUA] Ability to disable execution logging in the log (Cleaned version)

### DIFF
--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -164,7 +164,7 @@ private:
 	void reportMissingDevice(const int deviceID, const std::string &EventName, const unsigned long long eventID);
 	int getSunRiseSunSetMinutes(const std::string &what);
 	bool isEventscheduled(const std::string &eventName);
-	bool iterateLuaTable(lua_State *lua_state, const int tIndex, const std::string &filename);
+	std::pair<bool, bool> iterateLuaTable(lua_State *lua_state, const int tIndex, const std::string &filename);
 	bool processLuaCommand(lua_State *lua_state, const std::string &filename);
 	void report_errors(lua_State *L, int status, std::string filename);
 	unsigned char calculateDimLevel(int deviceID, int percentageLevel);


### PR DESCRIPTION
Add the ability to disable exection logging when a LUA script is
executed. This can be specified in the LUA script by adding
DoNotLogExecution to the commandArray and setting it to 1.
E.g.: commandArray['DoNotLogExecution'] = "1"