### PR TITLE
issue] Master/slave setup with thermostat device #805

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1707,7 +1707,7 @@ unsigned long long MainWorker::PerformRealActionFromDomoticzClient(const unsigne
 		const _tThermostat *pMeter = reinterpret_cast<const _tThermostat*>(pResponse);
 		sprintf(szTmp, "%X%02X%02X%02X", pMeter->id1, pMeter->id2, pMeter->id3, pMeter->id4);
 		ID = szTmp;
-		Unit = 0;
+		Unit = pMeter->dunit;
 	}
 	else if (devType == pTypeThermostat2)
 	{


### PR DESCRIPTION
When Unit is hard coded to 0, the look up of original hardware id in the
client will fail.

#805 