### PR TITLE
Attempt a reconnect if the proxy connect attempt fails

### DIFF
--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -97,20 +97,28 @@ namespace http {
 
 		void CProxyClient::ContinueConnect(const boost::system::error_code& error)
 		{
-			std::string address = "myproxy.domoticz.com";
-			std::string port = "9999";
+			try
+			{
+				std::string address = "myproxy.domoticz.com";
+				std::string port = "9999";
 
-			_socket.reset(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(_io_service, _context));
-			// set timeout timer
-			timer_.expires_from_now(boost::posix_time::seconds(timeout_));
-			timer_.async_wait(boost::bind(&CProxyClient::handle_timeout, shared_from_this(), boost::asio::placeholders::error));
-			boost::asio::ip::tcp::resolver resolver(_io_service);
-			boost::asio::ip::tcp::resolver::query query(address, port);
-			boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
-			boost::asio::ip::tcp::endpoint endpoint = *iterator;
-			_socket->lowest_layer().async_connect(endpoint,
-				boost::bind(&CProxyClient::handle_connect, shared_from_this(),
-					boost::asio::placeholders::error, iterator));
+				_socket.reset(new boost::asio::ssl::stream<boost::asio::ip::tcp::socket>(_io_service, _context));
+				// set timeout timer
+				timer_.expires_from_now(boost::posix_time::seconds(timeout_));
+				timer_.async_wait(boost::bind(&CProxyClient::handle_timeout, shared_from_this(), boost::asio::placeholders::error));
+				boost::asio::ip::tcp::resolver resolver(_io_service);
+				boost::asio::ip::tcp::resolver::query query(address, port);
+				boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
+				boost::asio::ip::tcp::endpoint endpoint = *iterator;
+				_socket->lowest_layer().async_connect(endpoint,
+					boost::bind(&CProxyClient::handle_connect, shared_from_this(),
+						boost::asio::placeholders::error, iterator));
+			}
+			catch (std::exception& e)
+			{
+				_log.Log(LOG_ERROR, "PROXY: Connect failed, reconnecting: %s", e.what());
+				Reconnect();
+			}
 		}
 
 		void CProxyClient::handle_connect(const boost::system::error_code& error, boost::asio::ip::tcp::resolver::iterator endpoint_iterator)


### PR DESCRIPTION
The 'resolver.resolve(query)' throws as exception if it cannot resolve the network address. If the network connection is lost, the resolve fails, and the exception is not catched untill the execution reaches CProxyManager::StartThread(). This will exit the proxy thread, which again is never restarted.

This is very easy to test:
- Configure Domoticz to connect to MyDomoticz
- Pull the network plug. After a while Domoticz gets disconnected from MyDomoticz
- Reconnect the network. Without this change, Domoticz does not reconnect to MyDomoticz