### PR TITLE
Leading zero in backup filenames

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1226,7 +1226,7 @@ void MainWorker::HandleAutomaticBackups()
 		if ((lDir = opendir(sbackup_DirH.c_str())) != NULL)
 		{
 			std::stringstream sTmp;
-			sTmp << "backup-hour-" << hour << ".db";
+			sTmp << "backup-hour-" << std::setw(2) << std::setfill('0') << hour << ".db";
 
 			std::string OutputFileName=sbackup_DirH + sTmp.str();
 			if (m_sql.BackupDatabase(OutputFileName)) {
@@ -1246,7 +1246,7 @@ void MainWorker::HandleAutomaticBackups()
 		if ((lDir = opendir(sbackup_DirD.c_str())) != NULL)
 		{
 			std::stringstream sTmp;
-			sTmp << "backup-day-" << day << ".db";
+			sTmp << "backup-day-" << std::setw(2) << std::setfill('0') << day << ".db";
 
 			std::string OutputFileName=sbackup_DirD + sTmp.str();
 			if (m_sql.BackupDatabase(OutputFileName)) {
@@ -1265,7 +1265,7 @@ void MainWorker::HandleAutomaticBackups()
 		if ((lDir = opendir(sbackup_DirM.c_str())) != NULL)
 		{
 			std::stringstream sTmp;
-			sTmp << "backup-month-" << month+1 << ".db";
+			sTmp << "backup-month-" << std::setw(2) << std::setfill('0') << month+1 << ".db";
 
 			std::string OutputFileName=sbackup_DirM + sTmp.str();
 			if (m_sql.BackupDatabase(OutputFileName)) {


### PR DESCRIPTION
just it ;)

+ one question:
what do you think about adding dependency to boost-filesystem? (beside it's a bad idea:P)

than instead of:
#ifdef WIN32
      backup_DirH << szUserDataFolder << "backups\\hourly\\";
...

we could use:
boost::filesystem::path::preferred_separator

also I thought about compressing files *before* storing them to drive to reduce amount of writes, but I'm missing portable "mktemp" which could be find there too ;) [temp_directory_path/unique_path]
we have zlib already...

