### PR TITLE
[MySensors] Add MQTT gateway device

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,6 +287,7 @@ hardware/MultiFun.cpp
 hardware/MySensorsBase.cpp
 hardware/MySensorsSerial.cpp
 hardware/MySensorsTCP.cpp
+hardware/MySensorsMQTT.cpp
 hardware/NefitEasy.cpp
 hardware/Nest.cpp
 hardware/Netatmo.cpp

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -32,6 +32,8 @@ m_CAFilename(CAfilename)
 	m_stoprequested=false;
 	m_usIPPort=usIPPort;
 	m_publish_topics = (_ePublishTopics)Topics;
+	m_TopicIn = TOPIC_IN;
+	m_TopicOut = TOPIC_OUT;
 }
 
 MQTT::~MQTT(void)
@@ -106,7 +108,7 @@ void MQTT::on_connect(int rc)
 			sOnConnected(this);
 			m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&MQTT::SendDeviceInfo, this, _1, _2, _3, _4));
 		}
-		subscribe(NULL, TOPIC_IN);
+		subscribe(NULL, m_TopicIn.c_str());
 	}
 	else {
 		_log.Log(LOG_ERROR, "MQTT: Connection failed!, restarting (rc=%d)",rc);
@@ -124,14 +126,9 @@ void MQTT::on_message(const struct mosquitto_message *message)
 	if (qMessage.empty())
 		return;
 
-	if (topic.find("MyMQTT") != std::string::npos)
-	{
-		//MySensors message
-		ProcessMySensorsMessage(qMessage);
+	if (topic != m_TopicIn)
 		return;
-	}
-	else if (topic != TOPIC_IN)
-		return;
+
 	Json::Value root;
 	Json::Reader jReader;
 	std::string szCommand = "udevice";
@@ -468,10 +465,19 @@ void MQTT::Do_Work()
 					if (m_bDoReconnect)
 						ConnectIntEx();
 				}
+				if (isConnected() && sec_counter % 10 == 0)
+				{
+					SendHeartbeat();
+				}
 			}
 		}
 	}
 	_log.Log(LOG_STATUS,"MQTT: Worker stopped...");
+}
+
+void MQTT::SendHeartbeat()
+{
+	// not necessary for normal MQTT servers
 }
 
 void MQTT::SendMessage(const std::string &Topic, const std::string &Message)
@@ -496,16 +502,8 @@ void MQTT::WriteInt(const std::string &sendStr)
 	if (sendStr.size() < 2)
 		return;
 	//string the return and the end
-	std::string sMessage = std::string(sendStr.begin(), sendStr.begin() + sendStr.size()-1);
-	SendMessage("MyMQTT", sMessage);
-}
-
-void MQTT::ProcessMySensorsMessage(const std::string &MySensorsMessage)
-{
-	m_bufferpos = MySensorsMessage.size();
-	memcpy(&m_buffer, MySensorsMessage.c_str(), m_bufferpos);
-	m_buffer[m_bufferpos] = 0;
-	ParseLine();
+	std::string sMessage = std::string(sendStr.begin(), sendStr.begin() + sendStr.size());
+	SendMessage(m_TopicOut, sMessage);
 }
 
 void MQTT::SendDeviceInfo(const int m_HwdID, const uint64_t DeviceRowIdx, const std::string &DeviceName, const unsigned char *pRXCommand)

--- a/hardware/MQTT.h
+++ b/hardware/MQTT.h
@@ -18,9 +18,9 @@ public:
 	~MQTT(void);
 	bool isConnected(){ return m_IsConnected; };
 
-	void on_connect(int rc);
+	virtual void on_connect(int rc);
 	void on_disconnect(int rc);
-	void on_message(const struct mosquitto_message *message);
+	virtual void on_message(const struct mosquitto_message *message);
 	void on_subscribe(int mid, int qos_count, const int *granted_qos);
 
 	void OnMQTTMessage(char *topicName, int topicLen,  void *pMessage);
@@ -32,12 +32,8 @@ public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;
 private:
-	bool StartHardware();
-	bool StopHardware();
 	bool ConnectInt();
 	bool ConnectIntEx();
-	void WriteInt(const std::string &sendStr);
-	void ProcessMySensorsMessage(const std::string &MySensorsMessage);
 	void SendDeviceInfo(const int m_HwdID, const uint64_t DeviceRowIdx, const std::string &DeviceName, const unsigned char *pRXCommand);
 	void SendSceneInfo(const uint64_t SceneIdx, const std::string &SceneName);
 protected:
@@ -46,10 +42,16 @@ protected:
 	std::string m_UserName;
 	std::string m_Password;
 	std::string m_CAFilename;
+	std::string m_TopicIn;
+	std::string m_TopicOut;
 	boost::mutex m_mqtt_mutex;
+	virtual bool StartHardware();
+	virtual bool StopHardware();
 	void StopMQTT();
 	void Do_Work();
+	virtual void SendHeartbeat();
 	void OnData(const unsigned char *pData, size_t length);
+	void WriteInt(const std::string &sendStr);
 	boost::shared_ptr<boost::thread> m_thread;
 	volatile bool m_stoprequested;
 	boost::signals2::connection m_sConnection;

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -2242,7 +2242,8 @@ namespace http {
 				return;
 			if (
 				(pHardware->HwdType != HTYPE_MySensorsUSB)&&
-				(pHardware->HwdType != HTYPE_MySensorsTCP)
+				(pHardware->HwdType != HTYPE_MySensorsTCP)&&
+				(pHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pHardware);
@@ -2317,7 +2318,8 @@ namespace http {
 				return;
 			if (
 				(pHardware->HwdType != HTYPE_MySensorsUSB) &&
-				(pHardware->HwdType != HTYPE_MySensorsTCP)
+				(pHardware->HwdType != HTYPE_MySensorsTCP) &&
+				(pHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pHardware);
@@ -2400,7 +2402,8 @@ namespace http {
 				return;
 			if (
 				(pBaseHardware->HwdType != HTYPE_MySensorsUSB) &&
-				(pBaseHardware->HwdType != HTYPE_MySensorsTCP)
+				(pBaseHardware->HwdType != HTYPE_MySensorsTCP) &&
+				(pBaseHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pBaseHardware);
@@ -2430,7 +2433,8 @@ namespace http {
 				return;
 			if (
 				(pBaseHardware->HwdType != HTYPE_MySensorsUSB) &&
-				(pBaseHardware->HwdType != HTYPE_MySensorsTCP)
+				(pBaseHardware->HwdType != HTYPE_MySensorsTCP) &&
+				(pBaseHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pBaseHardware);
@@ -2462,7 +2466,8 @@ namespace http {
 				return;
 			if (
 				(pBaseHardware->HwdType != HTYPE_MySensorsUSB) &&
-				(pBaseHardware->HwdType != HTYPE_MySensorsTCP)
+				(pBaseHardware->HwdType != HTYPE_MySensorsTCP) &&
+				(pBaseHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pBaseHardware);
@@ -2499,7 +2504,8 @@ namespace http {
 				return;
 			if (
 				(pBaseHardware->HwdType != HTYPE_MySensorsUSB) &&
-				(pBaseHardware->HwdType != HTYPE_MySensorsTCP)
+				(pBaseHardware->HwdType != HTYPE_MySensorsTCP) &&
+				(pBaseHardware->HwdType != HTYPE_MySensorsMQTT)
 				)
 				return;
 			MySensorsBase *pMySensorsHardware = reinterpret_cast<MySensorsBase*>(pBaseHardware);

--- a/hardware/MySensorsBase.h
+++ b/hardware/MySensorsBase.h
@@ -7,6 +7,7 @@ class MySensorsBase : public CDomoticzHardwareBase
 {
 	friend class MySensorsSerial;
 	friend class MySensorsTCP;
+	friend class MySensorsMQTT;
 	friend class MQTT;
 public:
 	enum _eMessageType

--- a/hardware/MySensorsMQTT.cpp
+++ b/hardware/MySensorsMQTT.cpp
@@ -6,11 +6,15 @@
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 
-MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename, const int Topics):
-	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, Topics)
+#define TOPIC_IN	"domoticz/in/MyMQTT"
+#define TOPIC_OUT	"domoticz/out/MyMQTT"
+
+MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename) :
+	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, _ePublishTopics::PT_out)
 {
-	m_TopicIn = "domoticz/in/MyMQTT";
-	m_TopicOut = "domoticz/out/MyMQTT";
+	m_TopicInWithoutHash = TOPIC_IN;
+	m_TopicIn = m_TopicInWithoutHash + "/#";
+	m_TopicOut = TOPIC_OUT;
 }
 
 MySensorsMQTT::~MySensorsMQTT(void)
@@ -40,10 +44,24 @@ void MySensorsMQTT::on_message(const struct mosquitto_message *message)
 
 	_log.Log(LOG_NORM, "MySensorsMQTT: Topic: %s, Message: %s", topic.c_str(), qMessage.c_str());
 
-	if (qMessage.empty())
+	if (topic.empty() && qMessage.empty())
 		return;
 
-	ProcessMySensorsMessage(qMessage);
+	std::string sMessage = ConvertMessageToMySensorsLine(topic, qMessage);
+	ProcessMySensorsMessage(sMessage);
+}
+
+std::string MySensorsMQTT::ConvertMessageToMySensorsLine(const std::string &topic, const std::string &qMessage)
+{
+	std::string sMessage = topic + "/" + qMessage;
+	boost::replace_all(sMessage, m_TopicInWithoutHash, "");
+	boost::replace_all(sMessage, "/", ";");
+	if (sMessage[0] == ';')
+	{
+		sMessage = sMessage.substr(1);
+	}
+
+	return sMessage;
 }
 
 void MySensorsMQTT::ProcessMySensorsMessage(const std::string &MySensorsMessage)
@@ -61,7 +79,7 @@ void MySensorsMQTT::on_connect(int rc)
 	if (m_IsConnected)
 	{
 		_log.Log(LOG_STATUS, "MySensorsMQTT: connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
-		
+
 		//Request gateway version
 		std::string sRequest = "0;0;3;0;2;";
 		WriteInt(sRequest);
@@ -73,4 +91,40 @@ void MySensorsMQTT::SendHeartbeat()
 	//Send a MySensors Heartbeat message to the gateway
 	std::string sRequest = "0;0;3;0;18;PING";
 	WriteInt(sRequest);
+}
+
+void MySensorsMQTT::WriteInt(const std::string &sendStr)
+{
+	boost::lock_guard<boost::mutex> l(m_mqtt_mutex);
+
+	std::string sTopic;
+	std::string sPayload;
+	ConvertMySensorsLineToMessage(sendStr, sTopic, sPayload);
+
+	SendMessage(sTopic, sPayload);
+}
+
+void MySensorsMQTT::ConvertMySensorsLineToMessage(const std::string &sLine, std::string &sTopic, std::string &sPayload)
+{
+	if (sLine.size() < 2)
+	{
+		return;
+	}
+
+	size_t indexLastSeperator = sLine.find_last_of(';');
+	if (indexLastSeperator == std::string::npos)
+	{
+		return;
+	}
+
+	sTopic = std::string(sLine.substr(0, indexLastSeperator).c_str());
+	boost::replace_all(sTopic, ";", "/");
+	sTopic.insert(0, m_TopicOut + "/");
+
+	sPayload = std::string(sLine.substr(indexLastSeperator + 1).c_str());
+	if (!sPayload.empty() &&
+		sPayload[sPayload.length() - 1] == '\n')
+	{
+		sPayload.resize(sPayload.length() - 1);
+	}
 }

--- a/hardware/MySensorsMQTT.cpp
+++ b/hardware/MySensorsMQTT.cpp
@@ -1,4 +1,5 @@
 #include "stdafx.h"
+#include "MQTT.h"
 #include "MySensorsMQTT.h"
 #include "../main/Logger.h"
 #include "../main/Helper.h"
@@ -10,7 +11,7 @@
 #define TOPIC_OUT	"domoticz/out/MyMQTT"
 
 MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename) :
-	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, _ePublishTopics::PT_out)
+	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, MQTT::_ePublishTopics::PT_out)
 {
 	m_TopicInWithoutHash = TOPIC_IN;
 	m_TopicIn = m_TopicInWithoutHash + "/#";

--- a/hardware/MySensorsMQTT.cpp
+++ b/hardware/MySensorsMQTT.cpp
@@ -1,0 +1,76 @@
+#include "stdafx.h"
+#include "MySensorsMQTT.h"
+#include "../main/Logger.h"
+#include "../main/Helper.h"
+#include <iostream>
+#include "../main/localtime_r.h"
+#include "../main/mainworker.h"
+
+MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename, const int Topics):
+	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, Topics)
+{
+	m_TopicIn = "domoticz/in/MyMQTT";
+	m_TopicOut = "domoticz/out/MyMQTT";
+}
+
+MySensorsMQTT::~MySensorsMQTT(void)
+{
+}
+
+bool MySensorsMQTT::StartHardware()
+{
+	LoadDevicesFromDatabase();
+
+	bool result = MQTT::StartHardware();
+	StartSendQueue();
+
+	return result;
+}
+
+bool MySensorsMQTT::StopHardware()
+{
+	StopSendQueue();
+	return MQTT::StopHardware();
+}
+
+void MySensorsMQTT::on_message(const struct mosquitto_message *message)
+{
+	std::string topic = message->topic;
+	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
+
+	_log.Log(LOG_NORM, "MySensorsMQTT: Topic: %s, Message: %s", topic.c_str(), qMessage.c_str());
+
+	if (qMessage.empty())
+		return;
+
+	ProcessMySensorsMessage(qMessage);
+}
+
+void MySensorsMQTT::ProcessMySensorsMessage(const std::string &MySensorsMessage)
+{
+	m_bufferpos = MySensorsMessage.size();
+	memcpy(&m_buffer, MySensorsMessage.c_str(), m_bufferpos);
+	m_buffer[m_bufferpos] = 0;
+	ParseLine();
+}
+
+void MySensorsMQTT::on_connect(int rc)
+{
+	MQTT::on_connect(rc);
+
+	if (m_IsConnected)
+	{
+		_log.Log(LOG_STATUS, "MySensorsMQTT: connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
+		
+		//Request gateway version
+		std::string sRequest = "0;0;3;0;2;";
+		WriteInt(sRequest);
+	}
+}
+
+void MySensorsMQTT::SendHeartbeat()
+{
+	//Send a MySensors Heartbeat message to the gateway
+	std::string sRequest = "0;0;3;0;18;PING";
+	WriteInt(sRequest);
+}

--- a/hardware/MySensorsMQTT.cpp
+++ b/hardware/MySensorsMQTT.cpp
@@ -11,7 +11,7 @@
 #define TOPIC_OUT	"domoticz/out/MyMQTT"
 
 MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename) :
-	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, MQTT::_ePublishTopics::PT_out)
+	MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilename, (int)MQTT::PT_out)
 {
 	m_TopicInWithoutHash = TOPIC_IN;
 	m_TopicIn = m_TopicInWithoutHash + "/#";

--- a/hardware/MySensorsMQTT.h
+++ b/hardware/MySensorsMQTT.h
@@ -7,16 +7,22 @@
 class MySensorsMQTT : public MQTT
 {
 public:
-	MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename, const int Topics);
+	MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename);
 	~MySensorsMQTT(void);
 public:
 	void on_message(const struct mosquitto_message *message);
 	void on_connect(int rc);
+
+	bool AddDevice(const std::string &topicIn, const std::string &topicOut);
 private:
+	std::string m_TopicInWithoutHash;
 	void ProcessMySensorsMessage(const std::string &MySensorsMessage);
+	std::string ConvertMessageToMySensorsLine(const std::string &topic, const std::string &qMessage);
+	void ConvertMySensorsLineToMessage(const std::string &sendStr, std::string &sTopic, std::string &sPayload);
 protected:
 	bool StartHardware();
 	bool StopHardware();
 	void SendHeartbeat();
+	void WriteInt(const std::string &sendStr);
 };
 

--- a/hardware/MySensorsMQTT.h
+++ b/hardware/MySensorsMQTT.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <deque>
+#include <iostream>
+#include "MQTT.h"
+
+class MySensorsMQTT : public MQTT
+{
+public:
+	MySensorsMQTT(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password, const std::string &CAfilename, const int Topics);
+	~MySensorsMQTT(void);
+public:
+	void on_message(const struct mosquitto_message *message);
+	void on_connect(int rc);
+private:
+	void ProcessMySensorsMessage(const std::string &MySensorsMessage);
+protected:
+	bool StartHardware();
+	bool StopHardware();
+	void SendHeartbeat();
+};
+

--- a/hardware/MySensorsMQTT.h
+++ b/hardware/MySensorsMQTT.h
@@ -12,8 +12,6 @@ public:
 public:
 	void on_message(const struct mosquitto_message *message);
 	void on_connect(int rc);
-
-	bool AddDevice(const std::string &topicIn, const std::string &topicOut);
 private:
 	std::string m_TopicInWithoutHash;
 	void ProcessMySensorsMessage(const std::string &MySensorsMessage);

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -192,6 +192,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_EVOHOME_SCRIPT, "Evohome via script" },
 		{ HTYPE_MySensorsUSB, "MySensors Gateway USB" },
 		{ HTYPE_MySensorsTCP, "MySensors Gateway with LAN interface" },
+		{ HTYPE_MySensorsMQTT, "MySensors Gateway with MQTT interface" },
 		{ HTYPE_MQTT, "MQTT Client Gateway with LAN interface" },
 		{ HTYPE_FRITZBOX, "Fritzbox Callmonitor via LAN interface" },
 		{ HTYPE_ETH8020, "ETH8020 Relay board with LAN interface" },

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -172,6 +172,7 @@ enum _eHardwareTypes {
 	HTYPE_ZIBLUEUSB,			//89
 	HTYPE_ZIBLUETCP,			//90
 	HTYPE_Yeelight,				//91
+	HTYPE_MySensorsMQTT,		//92
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1030,7 +1030,7 @@ namespace http {
 			}
 			else if (
 				(htype == HTYPE_RFXLAN) || (htype == HTYPE_P1SmartMeterLAN) || (htype == HTYPE_YouLess) || (htype == HTYPE_RazberryZWave) || (htype == HTYPE_OpenThermGatewayTCP) || (htype == HTYPE_LimitlessLights) ||
-				(htype == HTYPE_SolarEdgeTCP) || (htype == HTYPE_WOL) || (htype == HTYPE_ECODEVICES) || (htype == HTYPE_Mochad) || (htype == HTYPE_MySensorsTCP) || (htype == HTYPE_MQTT) || (htype == HTYPE_FRITZBOX) ||
+				(htype == HTYPE_SolarEdgeTCP) || (htype == HTYPE_WOL) || (htype == HTYPE_ECODEVICES) || (htype == HTYPE_Mochad) || (htype == HTYPE_MySensorsTCP) || (htype == HTYPE_MySensorsMQTT) || (htype == HTYPE_MQTT) || (htype == HTYPE_FRITZBOX) ||
 				(htype == HTYPE_ETH8020) || (htype == HTYPE_Sterbox) || (htype == HTYPE_KMTronicTCP) || (htype == HTYPE_SOLARMAXTCP) || (htype == HTYPE_SatelIntegra) || (htype == HTYPE_RFLINKTCP) || (htype == HTYPE_Comm5TCP) || (htype == HTYPE_CurrentCostMeterLAN) ||
 				(htype == HTYPE_NefitEastLAN) || (htype == HTYPE_DenkoviSmartdenLan) || (htype == HTYPE_Ec3kMeterTCP) || (htype == HTYPE_MultiFun) || (htype == HTYPE_ZIBLUETCP)
 				) {
@@ -1317,7 +1317,7 @@ namespace http {
 				(htype == HTYPE_RFXLAN) || (htype == HTYPE_P1SmartMeterLAN) ||
 				(htype == HTYPE_YouLess) || (htype == HTYPE_RazberryZWave) || (htype == HTYPE_OpenThermGatewayTCP) || (htype == HTYPE_LimitlessLights) ||
 				(htype == HTYPE_SolarEdgeTCP) || (htype == HTYPE_WOL) || (htype == HTYPE_S0SmartMeterTCP) || (htype == HTYPE_ECODEVICES) || (htype == HTYPE_Mochad) ||
-				(htype == HTYPE_MySensorsTCP) || (htype == HTYPE_MQTT) || (htype == HTYPE_FRITZBOX) || (htype == HTYPE_ETH8020) || (htype == HTYPE_Sterbox) ||
+				(htype == HTYPE_MySensorsTCP) || (htype == HTYPE_MySensorsMQTT) || (htype == HTYPE_MQTT) || (htype == HTYPE_FRITZBOX) || (htype == HTYPE_ETH8020) || (htype == HTYPE_Sterbox) ||
 				(htype == HTYPE_KMTronicTCP) || (htype == HTYPE_SOLARMAXTCP) || (htype == HTYPE_SatelIntegra) || (htype == HTYPE_RFLINKTCP) ||
 				(htype == HTYPE_Comm5TCP || (htype == HTYPE_CurrentCostMeterLAN)) ||
 				(htype == HTYPE_NefitEastLAN) || (htype == HTYPE_DenkoviSmartdenLan) || (htype == HTYPE_Ec3kMeterTCP) || (htype == HTYPE_MultiFun) || (htype == HTYPE_ZIBLUETCP)
@@ -10019,7 +10019,7 @@ namespace http {
 							else
 								root["result"][ii]["version"] = sd[11];
 						}
-						else if ((pHardware->HwdType == HTYPE_MySensorsUSB) || (pHardware->HwdType == HTYPE_MySensorsTCP))
+						else if ((pHardware->HwdType == HTYPE_MySensorsUSB) || (pHardware->HwdType == HTYPE_MySensorsTCP) || (pHardware->HwdType == HTYPE_MySensorsMQTT))
 						{
 							MySensorsBase *pMyHardware = reinterpret_cast<MySensorsBase*>(pHardware);
 							root["result"][ii]["version"] = pMyHardware->GetGatewayVersion();

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -63,6 +63,7 @@
 #include "../hardware/evohome.h"
 #include "../hardware/MySensorsSerial.h"
 #include "../hardware/MySensorsTCP.h"
+#include "../hardware/MySensorsMQTT.h"
 #include "../hardware/MQTT.h"
 #include "../hardware/FritzboxTCP.h"
 #include "../hardware/ETH8020.h"
@@ -710,6 +711,10 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_MySensorsTCP:
 		//LAN
 		pHardware = new MySensorsTCP(ID, Address, Port);
+		break;
+	case HTYPE_MySensorsMQTT:
+		//LAN
+		pHardware = new MySensorsMQTT(ID, Address, Port, Username, Password, Filename, Mode1);
 		break;
 	case HTYPE_RFLINKTCP:
 		//LAN

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -714,7 +714,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_MySensorsMQTT:
 		//LAN
-		pHardware = new MySensorsMQTT(ID, Address, Port, Username, Password, Filename, Mode1);
+		pHardware = new MySensorsMQTT(ID, Address, Port, Username, Password, Filename);
 		break;
 	case HTYPE_RFLINKTCP:
 		//LAN

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -44,6 +44,7 @@
     <LinkIncremental>true</LinkIncremental>
     <IntDir>$(Configuration)_Build\</IntDir>
     <PreBuildEventUseInBuild>true</PreBuildEventUseInBuild>
+    <IncludePath>$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>true</LinkIncremental>
@@ -453,6 +454,7 @@
     <ClInclude Include="..\hardware\MySensorsBase.h" />
     <ClInclude Include="..\hardware\MySensorsSerial.h" />
     <ClInclude Include="..\hardware\MySensorsTCP.h" />
+    <ClInclude Include="..\hardware\MySensorsMQTT.h" />
     <ClInclude Include="..\hardware\NefitEasy.h" />
     <ClInclude Include="..\hardware\Nest.h" />
     <ClInclude Include="..\hardware\Netatmo.h" />
@@ -676,6 +678,7 @@
     <ClCompile Include="..\hardware\MySensorsBase.cpp" />
     <ClCompile Include="..\hardware\MySensorsSerial.cpp" />
     <ClCompile Include="..\hardware\MySensorsTCP.cpp" />
+    <ClCompile Include="..\hardware\MySensorsMQTT.cpp" />
     <ClCompile Include="..\hardware\NefitEasy.cpp" />
     <ClCompile Include="..\hardware\Nest.cpp" />
     <ClCompile Include="..\hardware\Netatmo.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -1933,6 +1933,9 @@
     <ClInclude Include="..\hardware\Yeelight.h">
       <Filter>Devices\YeeLight</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\MySensorsMQTT.h">
+      <Filter>Devices\MySensors</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\webserver\Base64.cpp">
@@ -2543,6 +2546,9 @@
     </ClCompile>
     <ClCompile Include="..\hardware\Yeelight.cpp">
       <Filter>Devices\YeeLight</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\MySensorsMQTT.cpp">
+      <Filter>Devices\MySensors</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -327,8 +327,11 @@ define(['app'], function (app) {
                 var username=$("#hardwarecontent #divlogin #username").val();
                 var password=$("#hardwarecontent #divlogin #password").val();
                 var extra="";
-                var Mode1="";
-                if ((text.indexOf("MQTT") >= 0)) {
+                var Mode1 = "";
+                if ((text.indexOf("MySensors Gateway with MQTT") >= 0)) {
+                    extra = $("#hardwarecontent #divmysensorsmqtt #filename").val();
+                }
+                else if ((text.indexOf("MQTT") >= 0)) {
 					extra=$("#hardwarecontent #divmqtt #filename").val();
 					Mode1 = $("#hardwarecontent #divmqtt #combotopicselect").val();
 				}
@@ -1136,10 +1139,13 @@ define(['app'], function (app) {
                 var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
                 var extra = "";
                 var mode1 = "";
-				if (text.indexOf("MQTT") >= 0) {
-					extra = encodeURIComponent($("#hardwarecontent #divmqtt #filename").val());
-					mode1 = $("#hardwarecontent #divmqtt #combotopicselect").val();
-				}
+                if (text.indexOf("MySensors Gateway with MQTT") >= 0) {
+                    extra = encodeURIComponent($("#hardwarecontent #divmysensorsmqtt #filename").val());
+                }
+                else if (text.indexOf("MQTT") >= 0) {
+                    extra = encodeURIComponent($("#hardwarecontent #divmqtt #filename").val());
+                    mode1 = $("#hardwarecontent #divmqtt #combotopicselect").val();
+                }
                 if ((text.indexOf("Harmony") >= 0) && (username == "")) {
                     ShowNotify($.t('Please enter a username!'), 2500, true);
                     return;
@@ -4395,7 +4401,7 @@ define(['app'], function (app) {
 
                     var SerialName="Unknown!?";
                     var intport=0;
-                    if ((HwTypeStr.indexOf("LAN") >= 0)||(HwTypeStr.indexOf("Domoticz") >= 0) ||(HwTypeStr.indexOf("Harmony") >= 0)||(HwTypeStr.indexOf("Philips Hue") >= 0))
+                    if ((HwTypeStr.indexOf("LAN") >= 0)||(HwTypeStr.indexOf("MySensors Gateway with MQTT") >= 0)||(HwTypeStr.indexOf("Domoticz") >= 0) ||(HwTypeStr.indexOf("Harmony") >= 0)||(HwTypeStr.indexOf("Philips Hue") >= 0))
                     {
                         SerialName=item.Port;
                     }
@@ -4686,7 +4692,7 @@ define(['app'], function (app) {
                                 }
                             }
                         }
-                        else if (((data["Type"].indexOf("LAN") >= 0) && (data["Type"].indexOf("YouLess") == -1) && (data["Type"].indexOf("Denkovi") == -1) && (data["Type"].indexOf("Satel Integra") == -1)) ||(data["Type"].indexOf("Domoticz") >= 0) ||(data["Type"].indexOf("Harmony") >= 0)) {
+                        else if ((((data["Type"].indexOf("LAN") >= 0) || data["Type"].indexOf("MySensors Gateway with MQTT") >= 0) && (data["Type"].indexOf("YouLess") == -1) && (data["Type"].indexOf("Denkovi") == -1) && (data["Type"].indexOf("Satel Integra") == -1)) || (data["Type"].indexOf("Domoticz") >= 0) || (data["Type"].indexOf("Harmony") >= 0)) {
                             $("#hardwarecontent #hardwareparamsremote #tcpaddress").val(data["Address"]);
                             $("#hardwarecontent #hardwareparamsremote #tcpport").val(data["Port"]);
                             if (data["Type"].indexOf("P1 Smart Meter") >= 0)
@@ -4694,7 +4700,7 @@ define(['app'], function (app) {
                                 $("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked",data["Mode2"]==0);
                             }
                         }
-                        else if (((data["Type"].indexOf("LAN") >= 0) && (data["Type"].indexOf("YouLess") >= 0)) || (data["Type"].indexOf("Domoticz") >= 0) || (data["Type"].indexOf("Denkovi") >= 0) ||(data["Type"].indexOf("Harmony") >= 0) ||(data["Type"].indexOf("Satel Integra") >= 0) ||(data["Type"].indexOf("Logitech Media Server") >= 0) ||(data["Type"].indexOf("HEOS by DENON") >= 0)) {
+                        else if ((((data["Type"].indexOf("LAN") >= 0) || data["Type"].indexOf("MySensors Gateway with MQTT") >= 0) && (data["Type"].indexOf("YouLess") >= 0)) || (data["Type"].indexOf("Domoticz") >= 0) || (data["Type"].indexOf("Denkovi") >= 0) || (data["Type"].indexOf("Harmony") >= 0) || (data["Type"].indexOf("Satel Integra") >= 0) || (data["Type"].indexOf("Logitech Media Server") >= 0) || (data["Type"].indexOf("HEOS by DENON") >= 0)) {
                             $("#hardwarecontent #hardwareparamsremote #tcpaddress").val(data["Address"]);
                             $("#hardwarecontent #hardwareparamsremote #tcpport").val(data["Port"]);
                             $("#hardwarecontent #hardwareparamslogin #password").val(data["Password"]);
@@ -4738,7 +4744,10 @@ define(['app'], function (app) {
 			else if (data["Type"].indexOf("Goodwe solar inverter via Web") >= 0) {
 			    $("#hardwarecontent #hardwareparamsgoodweweb #username").val(data["Username"]);
 			}
-                        if (data["Type"].indexOf("MQTT") >= 0) {
+                        if (data["Type"].indexOf("MySensors Gateway with MQTT") >= 0) {
+                            $("#hardwarecontent #hardwareparamsmysensorsmqtt #filename").val(data["Extra"]);
+                        }
+                        else if (data["Type"].indexOf("MQTT") >= 0) {
                             $("#hardwarecontent #hardwareparamsmqtt #filename").val(data["Extra"]);
                             $("#hardwarecontent #hardwareparamsmqtt #combotopicselect").val(data["Mode1"]);
                         }
@@ -4755,8 +4764,8 @@ define(['app'], function (app) {
                             (data["Type"].indexOf("Sterbox") >= 0)||
                             (data["Type"].indexOf("Anna") >= 0)||
                             (data["Type"].indexOf("KMTronic") >= 0)||
-                            (data["Type"].indexOf("MQTT") >= 0)||
-                            (data["Type"].indexOf("Netatmo") >= 0)||
+                            (data["Type"].indexOf("MQTT") >= 0) ||
+                            (data["Type"].indexOf("Netatmo") >= 0) ||
                             (data["Type"].indexOf("Fitbit") >= 0)||
 							(data["Type"].indexOf("HTTP") >= 0)||
                             (data["Type"].indexOf("Thermosmart") >= 0) ||
@@ -4831,6 +4840,7 @@ define(['app'], function (app) {
             $("#hardwarecontent #divphilipshue").hide();
             $("#hardwarecontent #divwinddelen").hide();
             $("#hardwarecontent #divmqtt").hide();
+            $("#hardwarecontent #divmysensorsmqtt").hide();
             $("#hardwarecontent #divsolaredgeapi").hide();
             $("#hardwarecontent #divenecotoon").hide();
             $("#hardwarecontent #div1wire").hide();
@@ -4877,7 +4887,7 @@ define(['app'], function (app) {
                 $("#hardwarecontent #divunderground").hide();
                 $("#hardwarecontent #divhttppoller").hide();
             }
-            else if (text.indexOf("LAN") >= 0 && text.indexOf("YouLess") == -1 && text.indexOf("Denkovi") == -1 && text.indexOf("Satel Integra") == -1)
+            else if ((text.indexOf("LAN") >= 0 || text.indexOf("MySensors Gateway with MQTT") >= 0) && text.indexOf("YouLess") == -1 && text.indexOf("Denkovi") == -1 && text.indexOf("Satel Integra") == -1)
             {
                 $("#hardwarecontent #divserial").hide();
                 $("#hardwarecontent #divremote").show();
@@ -4889,7 +4899,7 @@ define(['app'], function (app) {
                     $("#hardwarecontent #divcrcp1").show();
                 }
             }
-            else if (text.indexOf("LAN") >= 0 && (text.indexOf("YouLess") >= 0 || text.indexOf("Denkovi") >= 0 || text.indexOf("Satel Integra") >= 0))
+            else if ((text.indexOf("LAN") >= 0 || text.indexOf("MySensors Gateway with MQTT") >= 0) && (text.indexOf("YouLess") >= 0 || text.indexOf("Denkovi") >= 0 || text.indexOf("Satel Integra") >= 0))
             {
                 $("#hardwarecontent #divserial").hide();
                 $("#hardwarecontent #divremote").show();
@@ -5074,7 +5084,11 @@ define(['app'], function (app) {
 				) {
                 $("#hardwarecontent #divlogin").show();
             }
-            if (text.indexOf("MQTT") >= 0)
+            if (text.indexOf("MySensors Gateway with MQTT") >= 0)
+            {
+                $("#hardwarecontent #divmysensorsmqtt").show();
+            }
+            else if (text.indexOf("MQTT") >= 0)
             {
                 $("#hardwarecontent #divmqtt").show();
             }

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1349,6 +1349,14 @@
 				</tr>
 			</table>
 		</div>
+		<div id="divmysensorsmqtt">
+			<table class="display" id="hardwareparamsmysensorsmqtt" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label id="lbfilename" for="filename"><span data-i18n="CA Filename">CA Filename</span>:</label></td>
+					<td><input type="text" id="filename" style="width: 300px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+				</tr>
+			</table>
+		</div>
 		<div>
 			<br>
 			<table border="0" cellpadding="0" cellspacing="14">


### PR DESCRIPTION
Instead of using the default [MQTT device](https://www.domoticz.com/wiki/MQTT) in Domoticz, I've added a specialized hardware device that supports the message coming in  (and going out) to a [MySensors MQTT gateway](https://www.mysensors.org/build/mqtt_gateway).

With the default MQTT device in Domoticz almost the same functionality can be created with a Node-RED installation that transforms each message coming out of Domoticz into a MySensors message the MySensors MQTT gateway understands. The only thing that won't work is generating ID's for the sensor-nodes. This problem is fixed with this new 'hardware device' and Node-RED is not required any more. The MQTT messages coming out of Domoticz can go straight into the MySensors MQTT gateway.

I've re-used all the standard code that was already there for MySensors, and inherited from the existing MQTT code. I've tested my code with a ESP8266 running MySensors gateway 2.0 and 2 MySensors nodes running [Humidity](https://www.mysensors.org/build/humidity) and [Relay](https://www.mysensors.org/build/relay).

All test and builds were done on Windows. I've tried to update the makefile as best I can, but haven't tested a build for a different OS.