### PR TITLE
wunderground - Missing current_observation option

### DIFF
--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -246,6 +246,10 @@ void CWunderground::GetMeterDetails()
 			{
 				barometric_forcast=baroForecastSunny;
 			}
+			else if (forcasticon=="clear")
+			{
+				barometric_forcast=baroForecastSunny;
+			}			
 			else if (forcasticon=="rain")
 			{
 				barometric_forcast=baroForecastRain;


### PR DESCRIPTION
When Wunderground report "Clear" domoticz is taking this option....