### PR TITLE
Add DST aware time constructs

### DIFF
--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -170,26 +170,12 @@ void SolarEdgeAPI::GetMeterDetails()
 	if (ActHourMin - 60 > sunSet)
 		return;
 
-	struct tm ltime_min5;
- 	time_t atime_min5;
-	int isdst = ltime.tm_isdst;
-	bool goodtime = false;
-	while (!goodtime) {
-		ltime_min5.tm_isdst = isdst;
-		ltime_min5.tm_year = ltime.tm_year;
-		ltime_min5.tm_mon = ltime.tm_mon;
-		ltime_min5.tm_mday = ltime.tm_mday;
-		ltime_min5.tm_hour = ltime.tm_hour;
-		ltime_min5.tm_min = ltime.tm_min - 60;
-		ltime_min5.tm_sec = ltime.tm_sec;
-		atime_min5 = mktime(&ltime_min5);
-		goodtime = (ltime_min5.tm_isdst == isdst);
-		isdst = ltime_min5.tm_isdst;
-	}
-
+	struct tm ltime_min10;
+ 	time_t atime_min10;
+	constructTime(atime_min10,ltime_min10,ltime.tm_year,ltime.tm_mon,ltime.tm_mday,ltime.tm_hour,ltime.tm_min-10,ltime.tm_sec,ltime.tm_isdst);
 
 	char szTmp[100];
-	sprintf(szTmp, "%04d-%02d-%02d %02d:%02d:%02d", ltime_min5.tm_year + 1900, ltime_min5.tm_mon + 1, ltime_min5.tm_mday, ltime_min5.tm_hour, ltime_min5.tm_min, ltime_min5.tm_sec);
+	sprintf(szTmp, "%04d-%02d-%02d %02d:%02d:%02d", ltime_min10.tm_year + 1900, ltime_min10.tm_mon + 1, ltime_min10.tm_mday, ltime_min10.tm_hour, ltime_min10.tm_min, ltime_min10.tm_sec);
 	std::string startDate= CURLEncode::URLEncode(szTmp);
 
 	sprintf(szTmp, "%04d-%02d-%02d %02d:%02d:%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -4753,27 +4753,13 @@ void CSQLHelper::AddCalendarTemperature()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -4840,27 +4826,13 @@ void CSQLHelper::AddCalendarUpdateRain()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -4963,26 +4935,13 @@ void CSQLHelper::AddCalendarUpdateMeter()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
+	localtime_r(&now,&ltime);
+	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	sprintf(szDateEnd,"%04d-%02d-%02d 00:00:00",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
-
-	//Subtract one day
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5167,26 +5126,13 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
+	localtime_r(&now,&ltime);
+	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	sprintf(szDateEnd,"%04d-%02d-%02d 00:00:00",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
-
-	//Subtract one day
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5308,27 +5254,13 @@ void CSQLHelper::AddCalendarUpdateWind()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5384,27 +5316,13 @@ void CSQLHelper::AddCalendarUpdateUV()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5452,27 +5370,13 @@ void CSQLHelper::AddCalendarUpdatePercentage()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5524,27 +5428,13 @@ void CSQLHelper::AddCalendarUpdateFan()
 	char szDateEnd[40];
 
 	time_t now = mytime(NULL);
-	struct tm tm1;
-	localtime_r(&now,&tm1);
-
 	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-	ltime.tm_hour=14;
-	ltime.tm_min=0;
-	ltime.tm_sec=0;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-
+	localtime_r(&now,&ltime);
 	sprintf(szDateEnd,"%04d-%02d-%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday);
 
-	//Subtract one day
-
-	ltime.tm_mday -= 1;
-	time_t later = mktime(&ltime);
+	time_t yesterday;
 	struct tm tm2;
-	localtime_r(&later,&tm2);
+	getNoon(yesterday,tm2,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday-1); // we only want the date
 	sprintf(szDateStart,"%04d-%02d-%02d",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday);
 
 	std::vector<std::vector<std::string> > result;
@@ -5899,21 +5789,11 @@ void CSQLHelper::CleanupLightSceneLog()
 	struct tm tm1;
 	localtime_r(&now,&tm1);
 
-//GB3:	No need to address DST jumps here
-	struct tm ltime;
-	ltime.tm_isdst=tm1.tm_isdst;
-	ltime.tm_hour=tm1.tm_hour;
-	ltime.tm_min=tm1.tm_min;
-	ltime.tm_sec=tm1.tm_sec;
-	ltime.tm_year=tm1.tm_year;
-	ltime.tm_mon=tm1.tm_mon;
-	ltime.tm_mday=tm1.tm_mday;
-	//subtract one day
-	ltime.tm_mday -= nMaxDays;
-	time_t daybefore = mktime(&ltime);
+	time_t daybefore;
 	struct tm tm2;
-	localtime_r(&daybefore,&tm2);
+	constructTime(daybefore,tm2,tm1.tm_year+1900,tm1.tm_mon+1,tm1.tm_mday-nMaxDays,tm1.tm_hour,tm1.tm_min,0,tm1.tm_isdst);
 	sprintf(szDateEnd,"%04d-%02d-%02d %02d:%02d:00",tm2.tm_year+1900,tm2.tm_mon+1,tm2.tm_mday,tm2.tm_hour,tm2.tm_min);
+
 
 	safe_query("DELETE FROM LightingLog WHERE (Date<'%q')", szDateEnd);
 	safe_query("DELETE FROM SceneLog WHERE (Date<'%q')", szDateEnd);
@@ -6391,7 +6271,7 @@ void CSQLHelper::SetUnitsAndScale()
 	if (m_tempunit==TEMPUNIT_F)
 	{
 		m_tempsign="F";
-		m_tempscale=1.0f; //*1.8 + 32
+		m_tempscale=1.0f; // *1.8 + 32
 	}
 }
 

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -370,7 +370,7 @@ void CScheduler::SetSunRiseSetTimers(const std::string &sSunRise, const std::str
 		sec = atoi(sSunRise.substr(6, 2).c_str());
 
 		struct tm tm1;
-		constructTime(temptime,tm1,ltime.tm_year,ltime.tm_mon,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
+		constructTime(temptime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
 		if ((m_tSunRise != temptime) && (temptime != 0))
 		{
 			if (m_tSunRise == 0)
@@ -382,7 +382,7 @@ void CScheduler::SetSunRiseSetTimers(const std::string &sSunRise, const std::str
 		min = atoi(sSunSet.substr(3, 2).c_str());
 		sec = atoi(sSunSet.substr(6, 2).c_str());
 
-		constructTime(temptime,tm1,ltime.tm_year,ltime.tm_mon,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
+		constructTime(temptime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
 		if ((m_tSunSet != temptime) && (temptime != 0))
 		{
 			if (m_tSunSet == 0)

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -358,7 +358,7 @@ void CScheduler::SetSunRiseSetTimers(const std::string &sSunRise, const std::str
 	bool bReloadSchedules = false;
 	{	//needed private scope for the lock
 		boost::lock_guard<boost::mutex> l(m_mutex);
-		unsigned char hour, min, sec;
+		int hour, min, sec;
 
 		time_t temptime;
 		time_t atime = mytime(NULL);
@@ -369,21 +369,8 @@ void CScheduler::SetSunRiseSetTimers(const std::string &sSunRise, const std::str
 		min = atoi(sSunRise.substr(3, 2).c_str());
 		sec = atoi(sSunRise.substr(6, 2).c_str());
 
-		int isdst = ltime.tm_isdst;
-		bool goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_hour = hour;
-			ltime.tm_min = min;
-			ltime.tm_sec = sec;
-			temptime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-			if (!goodtime){
-				localtime_r(&atime, &ltime);
-			}
-		}
-
+		struct tm tm1;
+		constructTime(temptime,tm1,ltime.tm_year,ltime.tm_mon,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
 		if ((m_tSunRise != temptime) && (temptime != 0))
 		{
 			if (m_tSunRise == 0)
@@ -391,15 +378,11 @@ void CScheduler::SetSunRiseSetTimers(const std::string &sSunRise, const std::str
 			m_tSunRise = temptime;
 		}
 
-		//GB3: no DST jump between sunrise and sunset
 		hour = atoi(sSunSet.substr(0, 2).c_str());
 		min = atoi(sSunSet.substr(3, 2).c_str());
 		sec = atoi(sSunSet.substr(6, 2).c_str());
 
-		ltime.tm_hour = hour;
-		ltime.tm_min = min;
-		ltime.tm_sec = sec;
-		temptime = mktime(&ltime);
+		constructTime(temptime,tm1,ltime.tm_year,ltime.tm_mon,ltime.tm_mday,hour,min,sec,ltime.tm_isdst);
 		if ((m_tSunSet != temptime) && (temptime != 0))
 		{
 			if (m_tSunSet == 0)
@@ -417,9 +400,8 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	time_t rtime = atime;
 	struct tm ltime;
 	localtime_r(&atime, &ltime);
-	ltime.tm_sec = 0;
 	int isdst = ltime.tm_isdst;
-	bool goodtime = false;
+	struct tm tm1;
 
 	unsigned long HourMinuteOffset = (pItem->startHour * 3600) + (pItem->startMin * 60);
 
@@ -445,35 +427,11 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 		(pItem->timerType == TTYPE_WEEKSODD) ||
 		(pItem->timerType == TTYPE_WEEKSEVEN))
 	{
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-			if (!goodtime) {
-				localtime_r(&atime, &ltime);
-			}
-		}
+		constructTime(rtime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday,pItem->startHour,pItem->startMin,roffset*60,isdst);
 	}
 	else if (pItem->timerType == TTYPE_FIXEDDATETIME)
 	{
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_year = pItem->startYear - 1900;
-			ltime.tm_mon = pItem->startMonth - 1;
-			ltime.tm_mday = pItem->startDay;
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-		}
+		constructTime(rtime,tm1,pItem->startYear,pItem->startMonth,pItem->startDay,pItem->startHour,pItem->startMin,roffset*60,isdst);
 		if (rtime < atime)
 			return false; //past date/time
 		pItem->startTime = rtime;
@@ -505,47 +463,15 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	}
 	else if (pItem->timerType == TTYPE_MONTHLY)
 	{
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_mday = pItem->MDay;
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			//if mday exceeds max days in month, find next month with this amount of days
-			while(ltime.tm_mday > boost::gregorian::gregorian_calendar::end_of_month_day(ltime.tm_year + 1900, ltime.tm_mon + 1))
-			{
-				ltime.tm_mon++;
-				if (ltime.tm_mon > 11)
-				{
-					ltime.tm_mon = 0;
-					ltime.tm_year++;
-				}
-			}
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-		}
-		if (rtime < atime) //past date/time
+		constructTime(rtime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,pItem->MDay,pItem->startHour,pItem->startMin,0,isdst);
+
+		while ( (rtime < atime) || (tm1.tm_mday != pItem->MDay) ) // past date/time OR mday exceeds max days in month
 		{
-			//schedule for next month
-			boost::gregorian::month_iterator m_itr(boost::gregorian::date(ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday));
-			++m_itr;
-			goodtime = false;
-			while (!goodtime) {
-				ltime.tm_isdst = isdst;
-				ltime.tm_year = m_itr->year() - 1900;
-				ltime.tm_mon = m_itr->month() - 1;
-				ltime.tm_mday = pItem->MDay;
-				ltime.tm_hour = pItem->startHour;
-				ltime.tm_min = pItem->startMin;
-				ltime.tm_sec = roffset * 60;
-				rtime = mktime(&ltime);
-				goodtime = (ltime.tm_isdst == isdst);
-				isdst = ltime.tm_isdst;
-			}
+			ltime.tm_mon++;
+			constructTime(rtime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,pItem->MDay,pItem->startHour,pItem->startMin,0,isdst);
 		}
 
+		rtime += roffset * 60; // add randomness
 		pItem->startTime = rtime;
 		return true;
 	}
@@ -564,20 +490,7 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 		nth_dow ndm(Occurence, Day, Month);
 		boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1900);
 
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_mday = d.day();
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-			if (!goodtime) {
-				localtime_r(&atime, &ltime);
-			}
-		}
+		constructTime(rtime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,d.day(),pItem->startHour,pItem->startMin,0,isdst);
 
 		if (rtime < atime) //past date/time
 		{
@@ -586,76 +499,25 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 			nth_dow ndm(Occurence, Day, Month);
 			boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1900);
 
-			goodtime = false;
-			while (!goodtime) {
-				ltime.tm_isdst = isdst;
-				ltime.tm_mon++;
-				ltime.tm_mday = d.day();
-				ltime.tm_hour = pItem->startHour;
-				ltime.tm_min = pItem->startMin;
-				ltime.tm_sec = roffset * 60;
-				rtime = mktime(&ltime);
-				goodtime = (ltime.tm_isdst == isdst);
-				isdst = ltime.tm_isdst;
-				if (!goodtime) {
-					localtime_r(&atime, &ltime);
-				}
-			}
+			constructTime(rtime,tm1,ltime.tm_year+1900,ltime.tm_mon+1,d.day(),pItem->startHour,pItem->startMin,0,isdst);
 		}
 
+		rtime += roffset * 60; // add randomness
 		pItem->startTime = rtime;
 		return true;
 	}
 	else if (pItem->timerType == TTYPE_YEARLY)
 	{
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_mon = pItem->Month - 1;
-			ltime.tm_mday = pItem->MDay;
-			//if mday exceeds max days in month, find next year with this amount of days
-			while (ltime.tm_mday > boost::gregorian::gregorian_calendar::end_of_month_day(ltime.tm_year + 1900, ltime.tm_mon + 1))
-			{
-				ltime.tm_year++;
-			}
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-			if (!goodtime) {
-				localtime_r(&atime, &ltime);
-			}
-		}
-		if (rtime < atime) //past date/time
+		constructTime(rtime,tm1,ltime.tm_year+1900,pItem->Month,pItem->MDay,pItem->startHour,pItem->startMin,0,isdst);
+
+		while ( (rtime < atime) || (tm1.tm_mday != pItem->MDay) ) // past date/time OR mday exceeds max days in month
 		{
 			//schedule for next year
-			boost::gregorian::year_iterator m_itr(boost::gregorian::date(ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday));
-			++m_itr;
-			goodtime = false;
-			while (!goodtime) {
-				ltime.tm_isdst = isdst;
-				ltime.tm_year = m_itr->year() - 1900;
-				ltime.tm_mon = pItem->Month - 1;
-				ltime.tm_mday = pItem->MDay;
-				//GB3: may seem silly to repeat this loop, but by doing so this should also work for Feb 29
-				while (ltime.tm_mday > boost::gregorian::gregorian_calendar::end_of_month_day(ltime.tm_year + 1900, ltime.tm_mon + 1))
-				{
-					ltime.tm_year++;
-				}
-				ltime.tm_hour = pItem->startHour;
-				ltime.tm_min = pItem->startMin;
-				ltime.tm_sec = roffset * 60;
-				rtime = mktime(&ltime);
-				goodtime = (ltime.tm_isdst == isdst);
-				isdst = ltime.tm_isdst;
-				if (!goodtime) {
-					localtime_r(&atime, &ltime);
-				}
-			}
+			ltime.tm_year++;
+			constructTime(rtime,tm1,ltime.tm_year+1900,pItem->Month,pItem->MDay,pItem->startHour,pItem->startMin,0,isdst);
 		}
 
+		rtime += roffset * 60; // add randomness
 		pItem->startTime = rtime;
 		return true;
 	}
@@ -674,45 +536,16 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 		nth_dow ndm(Occurence, Day, Month);
 		boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1900);
 
-		goodtime = false;
-		while (!goodtime) {
-			ltime.tm_isdst = isdst;
-			ltime.tm_mon = pItem->Month - 1;
-			ltime.tm_mday = d.day();
-			ltime.tm_hour = pItem->startHour;
-			ltime.tm_min = pItem->startMin;
-			ltime.tm_sec = roffset * 60;
-			rtime = mktime(&ltime);
-			goodtime = (ltime.tm_isdst == isdst);
-			isdst = ltime.tm_isdst;
-			if (!goodtime) {
-				localtime_r(&atime, &ltime);
-			}
-		}
+		constructTime(rtime,tm1,ltime.tm_year+1900,pItem->Month,d.day(),pItem->startHour,pItem->startMin,0,isdst);
 
 		if (rtime < atime) //past date/time
 		{
 			//schedule for next year
-			boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1901);
-			goodtime = false;
-			while (!goodtime) {
-				ltime.tm_isdst = isdst;
-				ltime.tm_year++;
-				ltime.tm_mon = pItem->Month - 1;
-				ltime.tm_mday = d.day();
-				ltime.tm_hour = pItem->startHour;
-				ltime.tm_min = pItem->startMin;
-				ltime.tm_sec = roffset * 60;
-				rtime = mktime(&ltime);
-				goodtime = (ltime.tm_isdst == isdst);
-				isdst = ltime.tm_isdst;
-				if (!goodtime) {
-					localtime_r(&atime, &ltime);
-				}
-			}
-			rtime = mktime(&ltime) + (roffset * 60);
+			ltime.tm_year++;
+			constructTime(rtime,tm1,ltime.tm_year+1900,pItem->Month,d.day(),pItem->startHour,pItem->startMin,0,isdst);
 		}
 
+		rtime += roffset * 60; // add randomness
 		pItem->startTime = rtime;
 		return true;
 	}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -8300,18 +8300,8 @@ namespace http {
 						{
 							//get lowest value of today, and max rate
 							time_t now = mytime(NULL);
-							struct tm tm1;
-							localtime_r(&now, &tm1);
-
 							struct tm ltime;
-							ltime.tm_isdst = tm1.tm_isdst;
-							ltime.tm_hour = 0;
-							ltime.tm_min = 0;
-							ltime.tm_sec = 0;
-							ltime.tm_year = tm1.tm_year;
-							ltime.tm_mon = tm1.tm_mon;
-							ltime.tm_mday = tm1.tm_mday;
-
+							localtime_r(&now, &ltime);
 							char szDate[40];
 							sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -8390,18 +8380,8 @@ namespace http {
 
 						//get value of today
 						time_t now = mytime(NULL);
-						struct tm tm1;
-						localtime_r(&now, &tm1);
-
 						struct tm ltime;
-						ltime.tm_isdst = tm1.tm_isdst;
-						ltime.tm_hour = 0;
-						ltime.tm_min = 0;
-						ltime.tm_sec = 0;
-						ltime.tm_year = tm1.tm_year;
-						ltime.tm_mon = tm1.tm_mon;
-						ltime.tm_mday = tm1.tm_mday;
-
+						localtime_r(&now, &ltime);
 						char szDate[40];
 						sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -8509,18 +8489,8 @@ namespace http {
 
                         //get value of today
                         time_t now = mytime(NULL);
-                        struct tm tm1;
-                        localtime_r(&now, &tm1);
-
-                        struct tm ltime;
-                        ltime.tm_isdst = tm1.tm_isdst;
-                        ltime.tm_hour = 0;
-                        ltime.tm_min = 0;
-                        ltime.tm_sec = 0;
-                        ltime.tm_year = tm1.tm_year;
-                        ltime.tm_mon = tm1.tm_mon;
-                        ltime.tm_mday = tm1.tm_mday;
-
+			struct tm ltime;
+			localtime_r(&now, &ltime);
                         char szDate[40];
                         sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -8627,18 +8597,8 @@ namespace http {
 
 						//get value of today
 						time_t now = mytime(NULL);
-						struct tm tm1;
-						localtime_r(&now, &tm1);
-
 						struct tm ltime;
-						ltime.tm_isdst = tm1.tm_isdst;
-						ltime.tm_hour = 0;
-						ltime.tm_min = 0;
-						ltime.tm_sec = 0;
-						ltime.tm_year = tm1.tm_year;
-						ltime.tm_mon = tm1.tm_mon;
-						ltime.tm_mday = tm1.tm_mday;
-
+						localtime_r(&now, &ltime);
 						char szDate[40];
 						sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -8824,18 +8784,8 @@ namespace http {
 
 						//get value of today
 						time_t now = mytime(NULL);
-						struct tm tm1;
-						localtime_r(&now, &tm1);
-
 						struct tm ltime;
-						ltime.tm_isdst = tm1.tm_isdst;
-						ltime.tm_hour = 0;
-						ltime.tm_min = 0;
-						ltime.tm_sec = 0;
-						ltime.tm_year = tm1.tm_year;
-						ltime.tm_mon = tm1.tm_mon;
-						ltime.tm_mday = tm1.tm_mday;
-
+						localtime_r(&now, &ltime);
 						char szDate[40];
 						sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -8881,18 +8831,8 @@ namespace http {
 						float GasDivider = 1000.0f;
 						//get lowest value of today
 						time_t now = mytime(NULL);
-						struct tm tm1;
-						localtime_r(&now, &tm1);
-
 						struct tm ltime;
-						ltime.tm_isdst = tm1.tm_isdst;
-						ltime.tm_hour = 0;
-						ltime.tm_min = 0;
-						ltime.tm_sec = 0;
-						ltime.tm_year = tm1.tm_year;
-						ltime.tm_mon = tm1.tm_mon;
-						ltime.tm_mday = tm1.tm_mday;
-
+						localtime_r(&now, &ltime);
 						char szDate[40];
 						sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -9016,18 +8956,8 @@ namespace http {
 							double total = atof(strarray[1].c_str()) / 1000;
 
 							time_t now = mytime(NULL);
-							struct tm tm1;
-							localtime_r(&now, &tm1);
-
 							struct tm ltime;
-							ltime.tm_isdst = tm1.tm_isdst;
-							ltime.tm_hour = 0;
-							ltime.tm_min = 0;
-							ltime.tm_sec = 0;
-							ltime.tm_year = tm1.tm_year;
-							ltime.tm_mon = tm1.tm_mon;
-							ltime.tm_mday = tm1.tm_mday;
-
+							localtime_r(&now, &ltime);
 							char szDate[40];
 							sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -9526,18 +9456,8 @@ namespace http {
 						{
 							//get value of today
 							time_t now = mytime(NULL);
-							struct tm tm1;
-							localtime_r(&now, &tm1);
-
 							struct tm ltime;
-							ltime.tm_isdst = tm1.tm_isdst;
-							ltime.tm_hour = 0;
-							ltime.tm_min = 0;
-							ltime.tm_sec = 0;
-							ltime.tm_year = tm1.tm_year;
-							ltime.tm_mon = tm1.tm_mon;
-							ltime.tm_mday = tm1.tm_mday;
-
+							localtime_r(&now, &ltime);
 							char szDate[40];
 							sprintf(szDate, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
 
@@ -10654,7 +10574,7 @@ namespace http {
 			else
 			{
 				//Update
-				time_t now = time(0);
+				time_t now = mytime(NULL);
 				struct tm ltime;
 				localtime_r(&now, &ltime);
 				m_sql.safe_query("UPDATE MobileDevices SET SenderID='%q', LastUpdate='%04d-%02d-%02d %02d:%02d:%02d' WHERE (UUID == '%q')",
@@ -12044,9 +11964,9 @@ namespace http {
 										bHaveFirstValue = true;
 										if ((ntime.tm_hour != 0) && (ntime.tm_min != 0))
 										{
-											atime -= 24 * 60 * 60;
 											struct tm ltime;
-											localtime_r(&atime, &ltime);
+											localtime_r(&atime, &tm1);
+											getNoon(atime,ltime,ntime.tm_year+1900,ntime.tm_mon+1,ntime.tm_mday-1); // We're only interested in finding the date
 											int year = ltime.tm_year+1900;
 											int mon = ltime.tm_mon+1;
 											int day = ltime.tm_mday;
@@ -12654,15 +12574,13 @@ namespace http {
 										{
 											struct tm ntime;
 											time_t atime;
-											ntime.tm_isdst = -1;
-											ntime.tm_year = atoi(actDateTimeHour.substr(0, 4).c_str()) - 1900;
-											ntime.tm_mon = atoi(actDateTimeHour.substr(5, 2).c_str()) - 1;
-											ntime.tm_mday = atoi(actDateTimeHour.substr(8, 2).c_str());
-											ntime.tm_hour = atoi(actDateTimeHour.substr(11, 2).c_str());
-											ntime.tm_min = 0;
-											ntime.tm_sec = 0;
-											ntime.tm_hour -= 1;
-											atime = mktime(&ntime);
+											constructTime(atime,ntime,
+												atoi(actDateTimeHour.substr(0, 4).c_str())-1900,
+												atoi(actDateTimeHour.substr(5, 2).c_str())-1,
+												atoi(actDateTimeHour.substr(8, 2).c_str()),
+												atoi(actDateTimeHour.substr(11, 2).c_str())-1,
+												0,0,-1);
+
 											char szTime[50];
 											sprintf(szTime, "%04d-%02d-%02d %02d:00", ntime.tm_year + 1900, ntime.tm_mon + 1, ntime.tm_mday, ntime.tm_hour);
 											root["result"][ii]["d"] = szTime;
@@ -13114,26 +13032,12 @@ namespace http {
 
 					char szDateStart[40];
 					char szDateEnd[40];
-
-					struct tm ltime;
-					ltime.tm_isdst = tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-					ltime.tm_hour = 14;
-					ltime.tm_min = 0;
-					ltime.tm_sec = 0;
-					ltime.tm_year = tm1.tm_year;
-					ltime.tm_mon = tm1.tm_mon;
-					ltime.tm_mday = tm1.tm_mday;
-
-					sprintf(szDateEnd, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
+					sprintf(szDateEnd, "%04d-%02d-%02d", tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday);
 
 					//Subtract one week
-
-					ltime.tm_mday -= 7;
-					time_t later = mktime(&ltime);
+					time_t weekbefore;
 					struct tm tm2;
-					localtime_r(&later, &tm2);
-
+					getNoon(weekbefore,tm2,tm1.tm_year+1900, tm1.tm_mon+1,tm1.tm_mday-7); // We only want the date
 					sprintf(szDateStart, "%04d-%02d-%02d", tm2.tm_year + 1900, tm2.tm_mon + 1, tm2.tm_mday);
 
 					result = m_sql.safe_query("SELECT Total, Rate, Date FROM %s WHERE (DeviceRowID==%" PRIu64 " AND Date>='%q' AND Date<='%q') ORDER BY Date ASC", dbasetable.c_str(), idx, szDateStart, szDateEnd);
@@ -13222,25 +13126,12 @@ namespace http {
 
 					char szDateStart[40];
 					char szDateEnd[40];
-
-					struct tm ltime;
-					ltime.tm_isdst = tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-					ltime.tm_hour = 14;
-					ltime.tm_min = 0;
-					ltime.tm_sec = 0;
-					ltime.tm_year = tm1.tm_year;
-					ltime.tm_mon = tm1.tm_mon;
-					ltime.tm_mday = tm1.tm_mday;
-
-					sprintf(szDateEnd, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
+					sprintf(szDateEnd, "%04d-%02d-%02d", tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday);
 
 					//Subtract one week
-
-					ltime.tm_mday -= 7;
-					time_t later = mktime(&ltime);
+					time_t weekbefore;
 					struct tm tm2;
-					localtime_r(&later, &tm2);
+					getNoon(weekbefore,tm2,tm1.tm_year+1900, tm1.tm_mon+1,tm1.tm_mday-7); // We only want the date
 					sprintf(szDateStart, "%04d-%02d-%02d", tm2.tm_year + 1900, tm2.tm_mon + 1, tm2.tm_mday);
 
 					int ii = 0;
@@ -13461,33 +13352,22 @@ namespace http {
 				}
 				else
 				{
-					struct tm ltime;
-					ltime.tm_isdst = tm1.tm_isdst;
-//GB3:	Use a midday hour to avoid a clash with possible DST jump
-					ltime.tm_hour = 14;
-					ltime.tm_min = 0;
-					ltime.tm_sec = 0;
-					ltime.tm_year = tm1.tm_year;
-					ltime.tm_mon = tm1.tm_mon;
-					ltime.tm_mday = tm1.tm_mday;
+					sprintf(szDateEnd, "%04d-%02d-%02d", tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday);
+					sprintf(szDateEndPrev, "%04d-%02d-%02d", tm1.tm_year + 1900 - 1, tm1.tm_mon + 1, tm1.tm_mday);
 
-					sprintf(szDateEnd, "%04d-%02d-%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday);
-					sprintf(szDateEndPrev, "%04d-%02d-%02d", ltime.tm_year + 1900 - 1, ltime.tm_mon + 1, ltime.tm_mday);
-
+					struct tm tm2;
 					if (srange == "month")
 					{
 						//Subtract one month
-						ltime.tm_mon -= 1;
+						time_t monthbefore;
+						getNoon(monthbefore,tm2,tm1.tm_year+1900,tm1.tm_mon,tm1.tm_mday);
 					}
 					else
 					{
 						//Subtract one year
-						ltime.tm_year -= 1;
+						time_t yearbefore;
+						getNoon(yearbefore,tm2,tm1.tm_year+1900-1,tm1.tm_mon+1,tm1.tm_mday);
 					}
-
-					time_t later = mktime(&ltime);
-					struct tm tm2;
-					localtime_r(&later, &tm2);
 
 					sprintf(szDateStart, "%04d-%02d-%02d", tm2.tm_year + 1900, tm2.tm_mon + 1, tm2.tm_mday);
 					sprintf(szDateStartPrev, "%04d-%02d-%02d", tm2.tm_year + 1900 - 1, tm2.tm_mon + 1, tm2.tm_mday);
@@ -15770,10 +15650,8 @@ namespace http {
 
 					std::string sExpirationDate = result[0][3];
 					time_t now = mytime(NULL);
-					struct tm tm1;
-					localtime_r(&now, &tm1);
 					struct tm tExpirationDate;
-					ParseSQLdatetime(session.expires, tExpirationDate, sExpirationDate, tm1.tm_isdst);
+					ParseSQLdatetime(session.expires, tExpirationDate, sExpirationDate);
 					// RemoteHost is not used to restore the session
 					// LastUpdate is not used to restore the session
 				}

--- a/main/localtime_r.cpp
+++ b/main/localtime_r.cpp
@@ -34,7 +34,7 @@ time_t mytime(time_t * _Time)
 }
 
 // GB3
-/* ParseSQLdatetime
+/* ParseSQLdatetime()
  * Sets time value and corresponding tm struct to match a localized datetime string in 
  * SQL format (YYYY-MM-DD HH:mm:dd). Corrects for DST jump by verifying if mktime
  * returned a different value of tm_isdst than assumed.
@@ -42,8 +42,10 @@ time_t mytime(time_t * _Time)
  * Note that if the SQL datetime input string falls within the DST jump range this
  * method may still produce an incorrect result. This is because default assumption for
  * the DST flag is to use the one from current time. To defeat this limitation you may
- * use the optional parameter isdst (1|0) to set either Summer or Winter time as the 
- * initial value.
+ * use the optional parameter isdst to set either Summer (1) or Winter (0) time as the 
+ * initial value, or set to -1 to accept either one.
+ *
+ * Returns false if no time can be created
  */
 bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string szSQLdate) {
 	time_t now = mytime(NULL);
@@ -71,10 +73,79 @@ bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string szSQLda
 			if (isdst == 0) { return false; }
 			isdst = 0;
 		} else {
-			goodtime = (result.tm_isdst == isdst);
+			goodtime = ((result.tm_isdst == isdst) || (isdst == -1));
 			isdst = result.tm_isdst;
 		}
 	}
 	return true;
 }
 
+
+/* constructTime()
+ * Updates a time_t value and corresponding tm struct with given datetime components
+ *
+ * Returns false if no time can be created
+ */
+
+bool constructTime(time_t &time, struct tm &result, int year, int month, int day, int hour, int minute, int second) {
+	time_t now = mytime(NULL);
+	struct tm ltime;
+	localtime_r(&now,&ltime);
+	return constructTime(time, result, year, month, day, hour, minute, second, ltime.tm_isdst);
+}
+
+bool constructTime(time_t &time, struct tm &result, int year, int month, int day, int hour, int minute, int second, int isdst) {
+	bool goodtime = false;
+	while (!goodtime) {
+		result.tm_isdst = isdst;
+		result.tm_year = year - 1900;
+		result.tm_mon = month - 1;
+		result.tm_mday = day;
+		result.tm_hour = hour;
+		result.tm_min = minute;
+		result.tm_sec = second;
+		time = mktime(&result);
+		if (time == -1) {
+			if (isdst == 0) { return false; }
+			isdst = 0;
+		} else {
+			goodtime = ((result.tm_isdst == isdst) || (isdst == -1));
+			isdst = result.tm_isdst;
+		}
+	}
+	return true;
+}
+
+/* getMidnight()
+ * Shorthand time construct to retrieve the ctime value and corresponding tm struct for midnight
+ * Accepts date components for specifying another date than today.
+ */
+
+bool getMidnight(time_t &time, struct tm &result) {
+	time_t now = mytime(NULL);
+	struct tm ltime;
+	localtime_r(&now,&ltime);
+	return constructTime(time, result, ltime.tm_year, ltime.tm_mon, ltime.tm_mday, 0, 0, 0, ltime.tm_isdst);
+}
+
+bool getMidnight(time_t &time, struct tm &result, int year, int month, int day) {
+	return constructTime(time, result, year, month, day, 0, 0, 0);
+}
+
+/* getNoon()
+ * Shorthand time construct to retrieve the ctime value and corresponding tm struct for noon.
+ * Accepts date components for specifying another date than today.
+ *
+ * While noon has no special meaning in Domoticz, you may use this function to save CPU cycles
+ * if you are only interested in the (corrected) date.
+ */
+bool getNoon(time_t &time, struct tm &result) {
+	time_t now = mytime(NULL);
+	struct tm ltime;
+	localtime_r(&now,&ltime);
+	return constructTime(time, result, ltime.tm_year, ltime.tm_mon, ltime.tm_mday, 12, 0, 0, ltime.tm_isdst);
+}
+
+bool getNoon(time_t &time, struct tm &result, int year, int month, int day) {
+	return constructTime(time, result, year, month, day, 12, 0, 0, -1);
+}

--- a/main/localtime_r.h
+++ b/main/localtime_r.h
@@ -14,3 +14,13 @@ time_t mytime(time_t * _Time);
 bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string szSQLdate);
 bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string szSQLdate, int isdst);
 
+
+// DST safe datetime constructors
+bool getMidnight(time_t &time, struct tm &result);
+bool getMidnight(time_t &time, struct tm &result, int year, int month, int day);
+
+bool getNoon(time_t &time, struct tm &result);
+bool getNoon(time_t &time, struct tm &result, int year, int month, int day);
+
+bool constructTime(time_t &time, struct tm &result, int year, int month, int day, int hour, int minute, int second);
+bool constructTime(time_t &time, struct tm &result, int year, int month, int day, int hour, int minute, int second, int isdst);


### PR DESCRIPTION
Big rebuild, sorry

Does in fact not change the resulting object files except for the three named main modules, but because localtime_r.h was changed cmake wants to rebuild all files that reference this file for inclusion. I ran a quick check for `On Time`, `Yearly` and `Monthly` schedules and they all behaved correctly.

Gordon