### PR TITLE
Added Evohome HGI80 HR80 battery info and fixed 0 demand bug 

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -40,11 +40,11 @@
 extern std::string szUserDataFolder;
 
 std::ofstream *CEvohome::m_pEvoLog=NULL;
-#ifdef _DEBUG
+//#ifdef _DEBUG
 bool CEvohome::m_bDebug=true;
-#else
-bool CEvohome::m_bDebug=false;
-#endif
+//#else
+//bool CEvohome::m_bDebug=false;
+//#endif
 
 const char CEvohome::m_szControllerMode[7][20]={"Normal","Economy","Away","Day Off","Custom","Heating Off","Unknown"};
 const char CEvohome::m_szWebAPIMode[7][20]={"Auto","AutoWithEco","Away","DayOff","Custom","HeatingOff","Unknown"};
@@ -1606,9 +1606,11 @@ bool CEvohome::DecodeBatteryInfo(CEvohomeMsg &msg)
 	RFX_SETID3(msg.GetID(0),tsen.EVOHOME2.id1,tsen.EVOHOME2.id2,tsen.EVOHOME2.id3)
 	tsen.EVOHOME2.updatetype = updBattery;
 	
-	double dbCharge=0;
-	if(nBattery!=0xFF)
-		dbCharge=(double)nBattery/2.0; //Presumed to be the charge level where sent
+	if (nBattery == 0xFF)
+		nBattery = 100; // recode full battery (0xFF) to 100 for consistency across device types
+	else
+		nBattery = nBattery / 2;  // recode battery level values to 0-100 from original 0-200 values
+
 	if(nLowBat==0)
 		nBattery=0;
 	tsen.EVOHOME2.battery_level=nBattery;
@@ -1659,7 +1661,7 @@ bool CEvohome::DecodeBatteryInfo(CEvohomeMsg &msg)
 		tsen.EVOHOME2.zone=nDevNo;
 		sDecodeRXMessage(this, (const unsigned char *)&tsen.EVOHOME2, NULL, nBattery);
 	}
-	Log(true,LOG_STATUS,"evohome: %s: %s=%d charge=%d (%.1f %%) level=%d (%s)",tag,szType.c_str(),nDevNo,nBattery,dbCharge,nLowBat,(nLowBat==0)?"Low":"OK");
+	Log(true,LOG_STATUS,"evohome: %s: %s=%d charge=%d(%%) level=%d (%s)",tag,szType.c_str(),nDevNo,nBattery,nLowBat,(nLowBat==0)?"Low":"OK");
 	
 	return true;
 }

--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -40,11 +40,11 @@
 extern std::string szUserDataFolder;
 
 std::ofstream *CEvohome::m_pEvoLog=NULL;
-//#ifdef _DEBUG
+#ifdef _DEBUG
 bool CEvohome::m_bDebug=true;
-//#else
-//bool CEvohome::m_bDebug=false;
-//#endif
+#else
+bool CEvohome::m_bDebug=false;
+#endif
 
 const char CEvohome::m_szControllerMode[7][20]={"Normal","Economy","Away","Day Off","Custom","Heating Off","Unknown"};
 const char CEvohome::m_szWebAPIMode[7][20]={"Auto","AutoWithEco","Away","DayOff","Custom","HeatingOff","Unknown"};

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -825,14 +825,17 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 #endif
 	case HTYPE_RaspberryBMP085:
-		pHardware = new I2C(ID,1);
+		pHardware = new I2C(ID,1,0);
 		break;
 	case HTYPE_RaspberryHTU21D:
-		pHardware = new I2C(ID,2);
+		pHardware = new I2C(ID,2,0);
 		break;
 	case HTYPE_RaspberryTSL2561:
-		pHardware = new I2C(ID,3);
+		pHardware = new I2C(ID,3,0);
 		break;
+	case HTYPE_RaspberryPCF8574:
+		pHardware = new I2C(ID,4,Port);
+		break; 
 	case HTYPE_Wunderground:
 		pHardware = new CWunderground(ID,Username,Password);
 		break;
@@ -6267,6 +6270,12 @@ void MainWorker::decode_evohome3(const int HwdID, const _eHardwareTypes HwdType,
 			return;
 		unsigned char cur_cmnd=atoi(result[0][5].c_str());
 		BatteryLevel = atoi(result[0][7].c_str());
+		
+		if (pEvo->EVOHOME3.updatetype == CEvohome::updBattery)
+		{
+			BatteryLevel = pEvo->EVOHOME3.battery_level;
+			szDemand = result[0][6];
+		}
 		if(Unit==0xFF)
 		{
 			Unit=atoi(result[0][2].c_str());
@@ -6286,10 +6295,9 @@ void MainWorker::decode_evohome3(const int HwdID, const _eHardwareTypes HwdType,
 		bNewDev=true;
 		if(pEvo->EVOHOME3.demand==0xFF)//0418 allows us to associate unit and deviceid but no state information other messages only contain one or the other
 			szDemand="0";
+		if (pEvo->EVOHOME3.updatetype == CEvohome::updBattery)
+			BatteryLevel = pEvo->EVOHOME3.battery_level;
 	}
-
-	if (pEvo->EVOHOME3.updatetype == CEvohome::updBattery)
-		BatteryLevel = pEvo->EVOHOME3.battery_level;
 
 	uint64_t DevRowIdx=m_sql.UpdateValue(HwdID, ID.c_str(),Unit,devType,subType,SignalLevel,BatteryLevel,cmnd,szDemand.c_str(), procResult.DeviceName);
 	if (DevRowIdx == -1)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -6275,6 +6275,7 @@ void MainWorker::decode_evohome3(const int HwdID, const _eHardwareTypes HwdType,
 		{
 			BatteryLevel = pEvo->EVOHOME3.battery_level;
 			szDemand = result[0][6];
+			cmnd=(atoi(szDemand.c_str())>0)?light1_sOn:light1_sOff;
 		}
 		if(Unit==0xFF)
 		{


### PR DESCRIPTION
Added support for battery info for HR80 device. Standardised battery levels to 0-100 across Evohome devices.  Fixed bug which caused heat demand switch devices demand to display Off - 0 following a battery_level message.