### PR TITLE
Changed topic of mail which contains error log

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12076,7 +12076,8 @@ void MainWorker::HandleLogNotifications()
 	else
 	{
 		itt = _loglines.begin();
-		sTopic = "Domoticz: " + itt->logmessage;
+		sTopic = "Domoticz: Error received";
+		sstr << "The following error is received:<br><br>";
 	}
 
 	for (itt = _loglines.begin(); itt != _loglines.end(); ++itt)


### PR DESCRIPTION
Notification for errors #832
Changed topic of mail which contains error log to "Domoticz: Error received". The topic of the mail contained the complete error, just as in the body of the mail. Formatting is now the same as for mails which contains errors received in the last 5 minutes.