### PR TITLE
Changed authorization from url to basic authentication header

### DIFF
--- a/push/DataPush.cpp
+++ b/push/DataPush.cpp
@@ -8,6 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/RFXtrx.h"
 #include "../main/SQLHelper.h"
+#include "../webserver/Base64.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
 #define __STDC_FORMAT_MACROS
@@ -147,10 +148,17 @@ void CDataPush::DoFibaroPush()
 				std::stringstream sPostData;
 				std::stringstream Url;
 				std::vector<std::string> ExtraHeaders;
-					sendValue = CURLEncode::URLEncode(sendValue);
+
+				// Create basic authentication header
+				std::stringstream sstr;
+				sstr << fibaroUsername << ":" << fibaroPassword;
+				std::string m_AccessToken = base64_encode((const unsigned char *)(sstr.str().c_str()), strlen(sstr.str().c_str()));
+				ExtraHeaders.push_back("Authorization:Basic " + m_AccessToken);
+
+				sendValue = CURLEncode::URLEncode(sendValue);
 					
 				if (targetType==0) {
-					Url << "http://" << fibaroUsername << ":" << fibaroPassword << "@" << fibaroIP << "/api/globalVariables";
+					Url << "http://" << fibaroIP << "/api/globalVariables";
 
 					if (bIsV4)
 						Url << "/" << targetVariable;
@@ -172,22 +180,22 @@ void CDataPush::DoFibaroPush()
 					}
 				}	
 				else if (targetType==1) {
-					Url << "http://" << fibaroUsername << ":" << fibaroPassword << "@" << fibaroIP << "/api/callAction?deviceid=" << targetDeviceID << "&name=setProperty&arg1=" << targetProperty << "&arg2=" << sendValue;
+					Url << "http://" << fibaroIP << "/api/callAction?deviceid=" << targetDeviceID << "&name=setProperty&arg1=" << targetProperty << "&arg2=" << sendValue;
 					if (fibaroDebugActive) {
 						_log.Log(LOG_NORM,"FibaroLink: sending value %s to property %s of virtual device id %d",sendValue.c_str(),targetProperty.c_str(),targetDeviceID);
 					}
-					if (!HTTPClient::GET(Url.str(),sResult))
+					if (!HTTPClient::GET(Url.str(), ExtraHeaders, sResult))
 					{
 						_log.Log(LOG_ERROR,"Error sending data to Fibaro!");
 					}
 				}
 				else if (targetType==2) {
 					if (((delpos==0)&&(lstatus=="Off"))||((delpos==1)&&(lstatus=="On"))) {
-						Url << "http://" << fibaroUsername << ":" << fibaroPassword << "@" << fibaroIP << "/api/sceneControl?id=" << targetDeviceID << "&action=start";
+						Url << "http://" << fibaroIP << "/api/sceneControl?id=" << targetDeviceID << "&action=start";
 						if (fibaroDebugActive) {
 							_log.Log(LOG_NORM,"FibaroLink: activating scene %d",targetDeviceID);
 						}
-						if (!HTTPClient::GET(Url.str(),sResult))
+						if (!HTTPClient::GET(Url.str(), ExtraHeaders, sResult))
 						{
 							_log.Log(LOG_ERROR,"Error sending data to Fibaro!");
 						}
@@ -195,7 +203,7 @@ void CDataPush::DoFibaroPush()
 				}
 				else if (targetType==3) {
 					if (((delpos==0)&&(lstatus=="Off"))||((delpos==1)&&(lstatus=="On"))) {
-						Url << "http://" << fibaroUsername << ":" << fibaroPassword << "@" << fibaroIP << "/api/settings/reboot";
+						Url << "http://" << fibaroIP << "/api/settings/reboot";
 						if (fibaroDebugActive) {
 							_log.Log(LOG_NORM,"FibaroLink: reboot");
 						}

--- a/push/DataPush.cpp
+++ b/push/DataPush.cpp
@@ -149,16 +149,25 @@ void CDataPush::DoFibaroPush()
 				std::stringstream Url;
 				std::vector<std::string> ExtraHeaders;
 
-				// Create basic authentication header
-				std::stringstream sstr;
-				sstr << fibaroUsername << ":" << fibaroPassword;
-				std::string m_AccessToken = base64_encode((const unsigned char *)(sstr.str().c_str()), strlen(sstr.str().c_str()));
-				ExtraHeaders.push_back("Authorization:Basic " + m_AccessToken);
+				Url << "http://";
+
+				if (bIsV4) {
+					// Create basic authentication header
+					std::stringstream sstr;
+					sstr << fibaroUsername << ":" << fibaroPassword;
+					std::string m_AccessToken = base64_encode((const unsigned char *)(sstr.str().c_str()), strlen(sstr.str().c_str()));
+					ExtraHeaders.push_back("Authorization:Basic " + m_AccessToken);
+				} 
+				else {
+					Url << fibaroUsername << ":" << fibaroPassword << "@"; // Add user name in url for earlier than V4
+				}
+
+				Url << fibaroIP << "/";
 
 				sendValue = CURLEncode::URLEncode(sendValue);
-					
+				
 				if (targetType==0) {
-					Url << "http://" << fibaroIP << "/api/globalVariables";
+					Url << "api/globalVariables";
 
 					if (bIsV4)
 						Url << "/" << targetVariable;
@@ -180,7 +189,7 @@ void CDataPush::DoFibaroPush()
 					}
 				}	
 				else if (targetType==1) {
-					Url << "http://" << fibaroIP << "/api/callAction?deviceid=" << targetDeviceID << "&name=setProperty&arg1=" << targetProperty << "&arg2=" << sendValue;
+					Url << "api/callAction?deviceid=" << targetDeviceID << "&name=setProperty&arg1=" << targetProperty << "&arg2=" << sendValue;
 					if (fibaroDebugActive) {
 						_log.Log(LOG_NORM,"FibaroLink: sending value %s to property %s of virtual device id %d",sendValue.c_str(),targetProperty.c_str(),targetDeviceID);
 					}
@@ -191,7 +200,7 @@ void CDataPush::DoFibaroPush()
 				}
 				else if (targetType==2) {
 					if (((delpos==0)&&(lstatus=="Off"))||((delpos==1)&&(lstatus=="On"))) {
-						Url << "http://" << fibaroIP << "/api/sceneControl?id=" << targetDeviceID << "&action=start";
+						Url << "api/sceneControl?id=" << targetDeviceID << "&action=start";
 						if (fibaroDebugActive) {
 							_log.Log(LOG_NORM,"FibaroLink: activating scene %d",targetDeviceID);
 						}
@@ -203,7 +212,7 @@ void CDataPush::DoFibaroPush()
 				}
 				else if (targetType==3) {
 					if (((delpos==0)&&(lstatus=="Off"))||((delpos==1)&&(lstatus=="On"))) {
-						Url << "http://" << fibaroIP << "/api/settings/reboot";
+						Url << "api/settings/reboot";
 						if (fibaroDebugActive) {
 							_log.Log(LOG_NORM,"FibaroLink: reboot");
 						}


### PR DESCRIPTION
Changed authorization from url to basic authentication header in DataPush FibaroLink. Username and password is no longer supported by Fibaro API. These changes are tested on Fibaro HC2 controller with software version 4.104 Beta (which is the latest version per 2. january 2017).