### PR TITLE
XiaomiGateway enhancements

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -33,6 +33,10 @@ XiaomiGateway::~XiaomiGateway(void)
 bool XiaomiGateway::WriteToHardware(const char * pdata, const unsigned char length)
 {
 	_tGeneralSwitch *xcmd = (_tGeneralSwitch*)pdata;
+	if (xcmd->subtype == sSwitchTypeSelector) {
+		//_log.Log(LOG_STATUS, "WriteToHardware: Ignoring sSwitchTypeSelector");
+		return true;
+	}
 	char szTmp[50];
 	sprintf(szTmp, "%08X", (unsigned int)xcmd->id);
 	std::string ID = szTmp;
@@ -59,7 +63,6 @@ bool XiaomiGateway::WriteToHardware(const char * pdata, const unsigned char leng
 	}
 	std::string gatewaykey = GetGatewayKey();
 	std::string message = "{\"cmd\":\"write\",\"model\":\"plug\",\"sid\":\"" + sid + "\",\"short_id\":9844,\"data\":\"{\\\"channel_0\\\":\\\"" + command + "\\\",\\\"key\\\":\\\"" + gatewaykey + "\\\"}\" }";
-
 	boost::asio::io_service io_service;
 	boost::asio::ip::udp::socket socket_(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0));
 	boost::shared_ptr<std::string> message1(new std::string(message));
@@ -308,8 +311,6 @@ std::string XiaomiGateway::GetGatewayKey()
 		sprintf(&gatewaykey[i * 2], "%02X", ciphertext[i]);
 	}
 
-	//EVP_cleanup();
-	//ERR_free_strings();
 	return gatewaykey;
 }
 

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -314,15 +314,15 @@ std::string XiaomiGateway::GetGatewayKey()
 }
 
 XiaomiGateway::xiaomi_udp_server::xiaomi_udp_server(boost::asio::io_service& io_service, int m_HwdID, XiaomiGateway *parent)
-	: socket_(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 9898))
+	: socket_(io_service, boost::asio::ip::udp::v4())
 {
 	m_gatewayip = "127.0.0.1";
 	socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
+	socket_.bind(boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 0));
 	boost::shared_ptr<std::string> message(new std::string("{\"cmd\":\"whois\"}"));
 	boost::asio::ip::udp::endpoint remote_endpoint;
 	remote_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string("224.0.0.50"), 4321);
 	socket_.send_to(boost::asio::buffer(*message), remote_endpoint);
-
 	socket_.set_option(boost::asio::ip::multicast::join_group(boost::asio::ip::address::from_string("224.0.0.50")));
 
 	m_HardwareID = m_HwdID;

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -115,7 +115,7 @@ void XiaomiGateway::InsertUpdateHumidity(const std::string &nodeid, const std::s
 	SendHumiditySensor(sID, 255, Humidity, Name.c_str());
 }
 
-void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, _eSwitchType subtype, int level)
+void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, const _eSwitchType subtype, const int level)
 {
 	// Make sure the ID supplied fits with what is expected ie 158d0000fd32c2
 	if (nodeid.length() < 14) {
@@ -401,12 +401,15 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 						}
 						else if ((status == "click")) {
 							level = 10;
+							on = true;
 						}
 						else if ((status == "long_click_press") || (status == "long_click_release")) {
 							level = 20;
+							on = true;
 						}
 						else if ((status == "double_click")) {
 							level = 30;
+							on = true;
 						}
 						std::string battery = root2["battery"].asString();
 						if (battery != "") {

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -317,13 +317,12 @@ XiaomiGateway::xiaomi_udp_server::xiaomi_udp_server(boost::asio::io_service& io_
 	: socket_(io_service, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), 9898))
 {
 	m_gatewayip = "127.0.0.1";
-
+	socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
 	boost::shared_ptr<std::string> message(new std::string("{\"cmd\":\"whois\"}"));
 	boost::asio::ip::udp::endpoint remote_endpoint;
 	remote_endpoint = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string("224.0.0.50"), 4321);
 	socket_.send_to(boost::asio::buffer(*message), remote_endpoint);
 
-	socket_.set_option(boost::asio::ip::udp::socket::reuse_address(true));
 	socket_.set_option(boost::asio::ip::multicast::join_group(boost::asio::ip::address::from_string("224.0.0.50")));
 
 	m_HardwareID = m_HwdID;

--- a/hardware/XiaomiGateway.h
+++ b/hardware/XiaomiGateway.h
@@ -13,7 +13,7 @@ public:
 	XiaomiGateway(const int ID);
 	~XiaomiGateway(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);
-	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, const bool bIsOn, const _eSwitchType subtype, const int level);
+	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, const _eSwitchType subtype, const int level);
 	void InsertUpdateVoltage(const std::string &nodeid, const std::string &Name, const int BatteryLevel);
 	void InsertUpdateTemperature(const std::string &nodeid, const std::string &Name, const float Temperature);
 	void InsertUpdateHumidity(const std::string &nodeid, const std::string &Name, const int Humidity);

--- a/hardware/XiaomiGateway.h
+++ b/hardware/XiaomiGateway.h
@@ -13,7 +13,7 @@ public:
 	XiaomiGateway(const int ID);
 	~XiaomiGateway(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);
-	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, _eSwitchType subtype);
+	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, _eSwitchType subtype, int level);
 	void InsertUpdateVoltage(const std::string &nodeid, const std::string &Name, const int BatteryLevel);
 	void InsertUpdateTemperature(const std::string &nodeid, const std::string &Name, const float Temperature);
 	void InsertUpdateHumidity(const std::string &nodeid, const std::string &Name, const int Humidity);

--- a/hardware/XiaomiGateway.h
+++ b/hardware/XiaomiGateway.h
@@ -13,7 +13,7 @@ public:
 	XiaomiGateway(const int ID);
 	~XiaomiGateway(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);
-	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, bool bIsOn, _eSwitchType subtype, int level);
+	void InsertUpdateSwitch(const std::string &nodeid, const std::string &Name, const bool bIsOn, const _eSwitchType subtype, const int level);
 	void InsertUpdateVoltage(const std::string &nodeid, const std::string &Name, const int BatteryLevel);
 	void InsertUpdateTemperature(const std::string &nodeid, const std::string &Name, const float Temperature);
 	void InsertUpdateHumidity(const std::string &nodeid, const std::string &Name, const int Humidity);


### PR DESCRIPTION
Changed wireless switch to use selector type with extra options for click/long click/double click.
Added try/catch around socket connector to handle port 9898 already bound.
Stopped WriteToHardware sending commands for wireless switch as not necessary.