### PR TITLE
bind to ipv4 and ipv6 sockets if net.inet6.ip6.v6only is set to 1

### DIFF
--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -41,8 +41,10 @@ void server_base::init(init_connectionhandler_func init_connection_handler, acce
 	boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
 	acceptor_.open(endpoint.protocol());
 	acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
-	// bind to both ipv6 and ipv4 sockets
-	acceptor_.set_option(boost::asio::ip::v6_only(false));
+	// bind to both ipv6 and ipv4 sockets for the "::" address only
+	if (settings_.listening_address == "::") {
+		acceptor_.set_option(boost::asio::ip::v6_only(false));
+	}
 	// bind to our port
 	acceptor_.bind(endpoint);
 	// listen for incoming requests

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -41,6 +41,8 @@ void server_base::init(init_connectionhandler_func init_connection_handler, acce
 	boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query);
 	acceptor_.open(endpoint.protocol());
 	acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true));
+	// bind to both ipv6 and ipv4 sockets
+	acceptor_.set_option(boost::asio::ip::v6_only(false));
 	// bind to our port
 	acceptor_.bind(endpoint);
 	// listen for incoming requests


### PR DESCRIPTION
I am using domoticz on the FreeBSD 11. It was found that with default settings it binds only to ipv6 socket. Netstat shows that domoticz is listening only on ipv6 address. It is possible to force using v4 address, but in this case i will loose ipv6 connectivity. So i looked at the source and found that:

1. In FreeBSD there is a sysctl variable `net.inet6.ip6.v6only` and it is set to 1. This disabling support for the "mapped v4 addresses" globally, so v4 connections will not be accepted on v6 sockets.  
```
root@rpi-b:# netstat -an|grep 8080|grep LIST
tcp6       0      0 *.8080                 *.*                    LISTEN
```
2. It is possible to enable this globally (not recommended, could be security risk) or per socket (recommended). 
3. I tried to so this using boost and it works just fine. After this patch netstat shows:
```
root@rpi-b:# netstat -an|grep 8080|grep LIST
tcp46       0      0 *.8080                 *.*                    LISTEN
```
and domoticz accepting connections on the both ports