### PR TITLE
Set LUA_USE_MACOSX for the builtin LUA on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ SET(DOMO_MIN_LIBBOOST_VERSION 105500)
 
 option(USE_BUILTIN_LUA "Use builtin lua library" YES)
 IF(USE_BUILTIN_LUA)
+  IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_definitions(-DLUA_USE_MACOSX)
+  ENDIF()
   add_subdirectory (lua)
   get_directory_property (LUA_LIBRARIES DIRECTORY lua
     DEFINITION LUA_LIBRARIES)


### PR DESCRIPTION
Currently documentation recommends to modify lua sources (see https://www.domoticz.com/wiki/Mac_OS_X#LUA_Fix), however i think that its better to just enable this define automatically for the OSX build.