### PR TITLE
Fix returning uncompressed .js file with header Content-Encoding set to gzip

### DIFF
--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -399,7 +399,7 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
   reply::add_header(&rep, "Content-Length", boost::lexical_cast<std::string>(rep.content.size()));
   reply::add_header(&rep, "Content-Type", mime_types::extension_to_type(extension));
   reply::add_header(&rep, "Access-Control-Allow-Origin", "*");
-  if (bHaveLoadedgzip)
+  if (bHaveGZipSupport && bHaveLoadedgzip)
   {
 	reply::add_header(&rep, "Content-Encoding", "gzip");
   }


### PR DESCRIPTION
Only set encoding to gzip when the caller accepts gzip and a .gz was loaded.

Retrieving a javascript file from my (pi based) domoticz with the following request headers:
```
Cache-Control: no-cache
Connection: Keep-Alive
Pragma: no-cache
Accept: */*
Accept-Language: en-GB,en-US;q=0.8,en;q=0.6
```
Returns the following:
```
HTTP/1.1 200 OK
Content-Length: 74830
Content-Type: application/javascript;charset=UTF-8
Access-Control-Allow-Origin: *
Content-Encoding: gzip
Last-Modified: Thu, 19 Jan 2017 21:24:16 GMT
Connection: Keep-Alive
Keep-Alive: max=20, timeout=20

/*
//	(c)  Kendel Boul - 2014
*/

String.prototype.setCharAt = function(idx, chr) {
	if(idx > this.length - 1){
		return this.to
snipped

```
The file contents are uncompressed but the Content-Encoding is set to 'gzip'.

This took me some time to figure out since domoticz was setup to run behind a reverse proxy. In the end the solution (as always) was simple.

Regards,
Fred