### PR TITLE
Fix regression on notification extradata due to commit c786427bafa417…

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3074,7 +3074,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 		if (aParam.size() > 4) {
 			extraData = "|Device=" + aParam[4];
 		}
-		m_sql.AddTaskItem(_tTaskItem::SendNotification(1, subject, body, std::string(""), atoi(priority.c_str()), sound));
+		m_sql.AddTaskItem(_tTaskItem::SendNotification(1, subject, body, extraData, atoi(priority.c_str()), sound));
 		scriptTrue = true;
 	}
 	else if (lCommand == "SendEmail") {


### PR DESCRIPTION
…03b3860f1782525886a45a29db.

Do not know if it's still used but the given commit removed the extradata from the notification.
Want to do an additional pull request with the choice of the subsystem within lua. Need to fix that before.
But at the end the format will be something like:
commandArray['SendNotification']='subject#body#0#sound#extradata#gcm'.

Tell me if it's ok.