### PR TITLE
Added a switch indicating the current cost slot

### DIFF
--- a/hardware/Teleinfo.cpp
+++ b/hardware/Teleinfo.cpp
@@ -293,16 +293,9 @@ void Teleinfo::MatchLine()
 				m_p3power.powerusage1 = ulValue;
 			break;
 		case TELEINFO_TYPE_PTEC:
-			if (vString.substr (0,2) == "HC")
-                        {
-                                SendSwitch(5, 1, 255, true, 0, "Heures Creuses");
-                        }
-                        else if (vString.substr (0,2) == "HP")
-                        {
-                                SendSwitch(5, 1, 255, false, 0, "Heures Creuses");
-                        }
+			SendSwitch(5,1,255,(vString.substr (0,2) == "HC"),0,"Heures Creuses");
 
-			 if (vString.substr (2,2) == "JB")
+			if (vString.substr (2,2) == "JB")
                         {
                                 m_bLabel_PTEC_JB = true;
                                 m_bLabel_PTEC_JW = false;

--- a/hardware/Teleinfo.cpp
+++ b/hardware/Teleinfo.cpp
@@ -14,6 +14,7 @@ History :
 - 2016-02-05 : Fix bug power display with 'Tempo' contract (Anthony LAGUERRE)
 - 2016-02-11 : Fix power display when PAPP is missing (Anthony LAGUERRE)
 - 2016-02-17 : Fix bug power usage (Anthony LAGUERRE). Thanks to Multinet
+- 2017-01-28 : Add 'Heures Creuses' Switch (A.L)
 */
 
 #include "stdafx.h"
@@ -292,6 +293,15 @@ void Teleinfo::MatchLine()
 				m_p3power.powerusage1 = ulValue;
 			break;
 		case TELEINFO_TYPE_PTEC:
+			if (vString.substr (0,2) == "HC")
+                        {
+                                SendSwitch(5, 1, 255, true, 0, "Heures Creuses");
+                        }
+                        else if (vString.substr (0,2) == "HP")
+                        {
+                                SendSwitch(5, 1, 255, false, 0, "Heures Creuses");
+                        }
+
 			 if (vString.substr (2,2) == "JB")
                         {
                                 m_bLabel_PTEC_JB = true;


### PR DESCRIPTION
Added a switch indicating to the user whether it is currently full fare or low fare.

The data is evaluated directly from the EDF frame by the TELEINFO USB module

If the switch is on, the off-peak hours are active
If the switch is off, full working hours are active.