### PR TITLE
Upgrade GCM notification to send all the available data.

### DIFF
--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -4,6 +4,7 @@
 #include "../main/Logger.h"
 #include "../main/SQLHelper.h"
 #include "../json/json.h"
+#include <boost/lexical_cast.hpp>
 
 #define GAPI_POST_URL "https://gcm-http.googleapis.com/gcm/send"
 #define GAPI "AIzaSyBnRMroiDaXCKbwPeOmoxkNiQfjWkGMre8"
@@ -54,7 +55,8 @@ bool CNotificationGCM::SendMessageImplementation(
 			ii++;
 		}
 	}
-	sstr << "], \"data\" : { \"message\": \"" << Subject << "\" } }";
+	sstr << "], \"data\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
+	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\" } }";
 	std::string szPostdata = sstr.str();
 
 	std::vector<std::string> ExtraHeaders;


### PR DESCRIPTION
Using google cloud messaging, only a message is sent. Also the message contains only the subject.
I kept the same behavior for compatibility purpose but added other information in the json data.

The added data are:
subject
body (text)
extradata
deviceid
priority.

