### PR TITLE
Prevent deadlock in DST "black hole" time calculations

### DIFF
--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -542,13 +542,13 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 		nth_dow ndm(Occurence, Day, Month);
 		boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1900);
 
-		constructTime(rtime, tm1, ltime.tm_year + 1900, pItem->Month, d.day(), pItem->startHour, pItem->startMin, 0, -1);
+		constructTime(rtime, tm1, ltime.tm_year + 1900, pItem->Month, d.day(), pItem->startHour, pItem->startMin, 0, isdst);
 
 		if (rtime < atime) //past date/time
 		{
 			//schedule for next year
 			ltime.tm_year++;
-			constructTime(rtime, tm1, ltime.tm_year + 1900, pItem->Month, d.day(), pItem->startHour, pItem->startMin, 0, -1);
+			constructTime(rtime, tm1, ltime.tm_year + 1900, pItem->Month, d.day(), pItem->startHour, pItem->startMin, 0, isdst);
 		}
 
 		rtime += roffset * 60; // add randomness


### PR DESCRIPTION
When doing calculations on times that are skipped due to a DST state change using the DST state flag to validate that our calculation is correct always returns a negative answer. The solution provided here prevents an endless loop by only allowing either state (on/off) to be checked only once and then falls back to `accept any`.

As the resulting time value turns out to be inconsistent between platforms the fallback method also shifts the time one hour ahead which should match the DST jump. For European times this produces the correct response on the platforms previously found to produce different results (Windows and Linux).