### PR TITLE
Respond correctly to CORS preflighted requests for JSON API

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1597,6 +1597,19 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	bool isPage = myWebem->IsPageOverride(req, rep);
 	bool isAction = myWebem->IsAction(req);
 
+	// Respond to CORS Preflight request (for JSON API)
+	if (req.method == "OPTIONS")
+	{
+		rep.status = reply::ok;
+		reply::add_header(&rep, "Content-Length", "0");
+		reply::add_header(&rep, "Content-Type", "text/plain");
+		reply::add_header(&rep, "Access-Control-Max-Age", "3600");
+		reply::add_header(&rep, "Access-Control-Allow-Origin", "*");
+		reply::add_header(&rep, "Access-Control-Allow-Methods", "GET, POST");
+		reply::add_header(&rep, "Access-Control-Allow-Headers", "Authorization, Content-Type");
+		return;
+	}
+
 	// Check authentication on each page or action, if it exists.
 	if ((isPage || isAction) && !CheckAuthentication(session, req, rep)) {
 		return;


### PR DESCRIPTION
Fix issue #603 

More details about preflighted requests : https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests