### PR TITLE
Make daemonize compatible with Systemd forking type

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -3,6 +3,7 @@ Version 3.xxxx (January xth 2017)
 - Fixed: Devices could become invisible when a scene/group was added to the 'hidden devices' room plan with the same idx
 - Fixed: JSon float/nan value, solved by upgrading JSonCPP
 - Fixed: OZW, when a value is updated and the sensor did not exists before (for example a kWh sensor), it is created (saves a restart)
+- Fixed: Deamonize compatible with Systemd forking type
 - Changed: Blinds T5 till T13 new DeviceID generation, could cause new sensors
 - Changed: Switch type 'Door Lock' renamed to 'Door Contact'
 - Changed: Minimized On/Off/Script execution time

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -227,13 +227,6 @@ void daemonize(const char *rundir, const char *pidfile)
 	struct sigaction newSigAction;
 	sigset_t newSigSet;
 
-	/* Check if parent process id is set */
-	if (getppid() == 1)
-	{
-		/* PPID exists, therefore we are already a daemon */
-		return;
-	}
-
 	/* Set signal mask - signals we want to block */
 	sigemptyset(&newSigSet);
 	sigaddset(&newSigSet, SIGCHLD);  /* ignore child - i.e. we don't need to wait for it */


### PR DESCRIPTION
When using Systemd service with type set to forking, the parent PID is Systemd itself, thus fails on this check and deamonize will return instead of forking.