### PR TITLE
Fix Google Cloud Messaging appearing two times in setup.

### DIFF
--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -598,7 +598,7 @@
 							</div>
 							<div class="row-fluid">
 								<div class="span6">
-									<h2><span data-i18n="Google Cloud Messaging"></span>Google Cloud Messaging:</h2>
+									<h2><span data-i18n="Google Cloud Messaging"></span>:</h2>
 									<table class="display" id="gcmtable" border="0" cellpadding="0" cellspacing="0">
 									<tr>
 										<td align="right" style="width:80px"><label for="GCMEnabled"><span data-i18n="Enabled"></span>: </label></td>


### PR DESCRIPTION
Because of the last ':', "Google Cloud Messaging" is appearing two times in the setup page.
i fix it like for the others:
` <h2><span data-i18n="Google Cloud Messaging"></span>Google Cloud Messaging:</h2>`
`<h2><span data-i18n="Google Cloud Messaging"></span>:</h2>`
like the others:
`<h2><span data-i18n="Logitech Media Server"></span>:</h2>`
Best regards,
U.
