### PR TITLE
Add API to change events status without resending everything.

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -4109,6 +4109,21 @@ namespace http {
 					root["status"] = "OK";
 				}
 			}
+			else if (cparam == "updatestatus")
+			{
+			   std::string eventactive = request::findValue(&req, "eventstatus");
+			   if (eventactive == "")
+			      return;
+
+			   std::string eventid = request::findValue(&req, "eventid");
+			   if (eventid == "")
+			      return;
+
+			   m_sql.safe_query("UPDATE EventMaster SET Status ='%d' WHERE (ID == '%q')", atoi(eventactive.c_str()), eventid.c_str());
+			   m_mainworker.m_eventsystem.LoadEvents();
+			   root["status"] = "OK";
+
+			}
 			else if (cparam == "create")
 			{
 


### PR DESCRIPTION
Hi Gizmocuz,
Just added a new option in the event api to enable/disable without resending everything.
It has been requested by galadril for the app:
[https://www.domoticz.com/forum/viewtopic.php?t=12557](url)

param is updatestatus to avoid any confusion as it updates only the status.