### PR TITLE
Night and day calculation

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2291,12 +2291,12 @@ void CEventSystem::EvaluatePython(const std::string &reason, const std::string &
 		int intRise = getSunRiseSunSetMinutes("Sunrise");
 		int intSet = getSunRiseSunSetMinutes("Sunset");
 
+		// Do not correct for DST change - we only need this to compare with intRise and intSet which aren't as well
 		time_t now = mytime(NULL);
-		struct tm mtime;
-		time_t tmidnight;
-		getMidnight(tmidnight,mtime);
-		int minutesSinceMidnight = (int)(difftime(now,tmidnight) / 60);
-	
+		struct tm ltime;
+		localtime_r(&now, &ltime);
+		int minutesSinceMidnight = (ltime.tm_hour * 60) + ltime.tm_min;
+
 		bool dayTimeBool = false;
 		bool nightTimeBool = false;
 		if ((minutesSinceMidnight > intRise) && (minutesSinceMidnight < intSet)) {
@@ -2499,11 +2499,12 @@ void CEventSystem::EvaluateLua(const std::string &reason, const std::string &fil
 
 	int intRise = getSunRiseSunSetMinutes("Sunrise");
 	int intSet = getSunRiseSunSetMinutes("Sunset");
-	time_t now = time(0);
-	struct tm mtime;
-	time_t tmidnight;
-	getMidnight(tmidnight,mtime);
-	int minutesSinceMidnight = (int)(difftime(now,tmidnight) / 60);
+
+	// Do not correct for DST change - we only need this to compare with intRise and intSet which aren't as well
+	time_t now = mytime(NULL);
+	struct tm ltime;
+	localtime_r(&now, &ltime);
+	int minutesSinceMidnight = (ltime.tm_hour * 60) + ltime.tm_min;
 
 	bool dayTimeBool = false;
 	bool nightTimeBool = false;

--- a/main/localtime_r.cpp
+++ b/main/localtime_r.cpp
@@ -143,7 +143,7 @@ bool getMidnight(time_t &time, struct tm &result) {
 }
 
 bool getMidnight(time_t &time, struct tm &result, int year, int month, int day) {
-	return constructTime(time, result, year, month, day, 0, 0, 0);
+	return constructTime(time, result, year, month, day, 0, 0, 0, -1);
 }
 
 /* getNoon()


### PR DESCRIPTION
There was an oversight when adding DST change awareness to the code. In EventSystem the current time is corrected for such a change, but the sunrise and sunset values are not. They should either all be corrected or none of them.