### PR TITLE
Invalid sessions on password update

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -5962,6 +5962,14 @@ namespace http {
 					idx.c_str()
 					);
 				LoadUsers();
+
+				// Invalid user's sessions if password has changed
+				std::vector<std::vector<std::string> > result;
+				result = m_sql.safe_query("SELECT Password FROM Users WHERE (ID == '%q')", idx.c_str());
+				if (result.size() == 1 && password != result[0][0])
+				{
+					m_sql.safe_query("DELETE FROM UserSessions WHERE (Username == '%s')", base64_encode((const unsigned char*) username.c_str(), username.size()).c_str());
+				}
 			}
 			else if (cparam == "deleteuser")
 			{

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -5948,13 +5948,27 @@ namespace http {
 						return;
 					}
 				}
+				std::string sHashedUsername = base64_encode((const unsigned char*)username.c_str(), username.size()).c_str();
+
+				// Invalid user's sessions if username or password has changed
+				std::vector<std::vector<std::string> > result;
+				std::string sOldUsername;
+				std::string sOldPassword;
+				result = m_sql.safe_query("SELECT Username, Password FROM Users WHERE (ID == '%q')", idx.c_str());
+				if (result.size() == 1)
+				{
+					sOldUsername = result[0][0];
+					sOldPassword = result[0][1];
+				}
+				if ((sHashedUsername != sOldUsername) || (password != sOldPassword))
+					RemoveUsersSessions(sOldUsername, session);
 
 				root["status"] = "OK";
 				root["title"] = "UpdateUser";
 				m_sql.safe_query(
 					"UPDATE Users SET Active=%d, Username='%q', Password='%q', Rights=%d, RemoteSharing=%d, TabsEnabled=%d WHERE (ID == '%q')",
 					(senabled == "true") ? 1 : 0,
-					base64_encode((const unsigned char*)username.c_str(), username.size()).c_str(),
+					sHashedUsername.c_str(),
 					password.c_str(),
 					rights,
 					(sRemoteSharing == "true") ? 1 : 0,
@@ -5963,13 +5977,7 @@ namespace http {
 					);
 				LoadUsers();
 
-				// Invalid user's sessions if password has changed
-				std::vector<std::vector<std::string> > result;
-				result = m_sql.safe_query("SELECT Password FROM Users WHERE (ID == '%q')", idx.c_str());
-				if (result.size() == 1 && password != result[0][0])
-				{
-					m_sql.safe_query("DELETE FROM UserSessions WHERE (Username == '%s')", base64_encode((const unsigned char*) username.c_str(), username.size()).c_str());
-				}
+
 			}
 			else if (cparam == "deleteuser")
 			{
@@ -5985,6 +5993,15 @@ namespace http {
 
 				root["status"] = "OK";
 				root["title"] = "DeleteUser";
+
+				// Remove user's sessions
+				std::vector<std::vector<std::string> > result;
+				result = m_sql.safe_query("SELECT Username FROM Users WHERE (ID == '%q')", idx.c_str());
+				if (result.size() == 1)
+				{
+					RemoveUsersSessions(result[0][0], session);
+				}
+
 				m_sql.safe_query("DELETE FROM Users WHERE (ID == '%q')", idx.c_str());
 
 				m_sql.safe_query("DELETE FROM SharedDevices WHERE (SharedUserID == '%q')",
@@ -7231,6 +7248,17 @@ namespace http {
 			{
 				WebPassword = GenerateMD5Hash(WebPassword);
 			}
+
+			// Invalid sessions of WebUser when his username or password has been changed
+			int nUnusedValue = 0;
+			std::string sOldWebLogin;
+			std::string sOldWebPassword;
+			if (((m_sql.GetPreferencesVar("WebUserName", nUnusedValue, sOldWebLogin)) && (sOldWebLogin != WebUserName))
+			|| ((m_sql.GetPreferencesVar("WebPassword", nUnusedValue, sOldWebPassword)) && (sOldWebPassword != WebPassword)))
+			{
+				RemoveUsersSessions(sOldWebLogin, session);
+			}
+
 			m_sql.UpdatePreferencesVar("WebUserName", WebUserName.c_str());
 			m_sql.UpdatePreferencesVar("WebPassword", WebPassword.c_str());
 			m_sql.UpdatePreferencesVar("WebLocalNetworks", WebLocalNetworks.c_str());
@@ -16427,6 +16455,17 @@ namespace http {
 			//_log.Log(LOG_STATUS, "SessionStore : clean...");
 			m_sql.safe_query(
 					"DELETE FROM UserSessions WHERE ExpirationDate < datetime('now', 'localtime')");
+		}
+
+		/**
+		 * Delete all user's session, except the session used to modify the username or password.
+		 * username must have been hashed
+		 *
+		 * Note : on the WebUserName modification, this method will not delete the session, but the session will be deleted anyway
+		 * because the username will be unknown (see cWebemRequestHandler::checkAuthToken).
+		 */
+		void CWebServer::RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession) {
+			m_sql.safe_query("DELETE FROM UserSessions WHERE (Username=='%q') and (SessionID!='%q')", username.c_str(), exceptSession.id.c_str());
 		}
 
 	} //server

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -98,6 +98,7 @@ public:
 	void StoreSession(const WebEmStoredSession & session);
 	void RemoveSession(const std::string & sessionId);
 	void CleanSessions();
+	void RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession);
 
 private:
 	void HandleCommand(const std::string &cparam, WebEmSession & session, const request& req, Json::Value &root);

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1748,7 +1748,7 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 		session.id = generateSessionID();
 		session.expires = session.timeout;
 		if (session.rememberme) {
-			// Extend session by a year
+			// Extend session by 30 days
 			session.expires += (86400 * 30);
 		}
 		session.auth_token = generateAuthToken(session, req); // do it after expires to save it also


### PR DESCRIPTION
Hello, here is a new pull request.

I have notice that I had changed the password of my GF, but she did not had to log again.

This pull request fix it, and other security issues.
Sometimes it could seem overkill, as when a user is deleted, but you could always imagine use case where you delete a user and then create a user with the same login.

Feel free to rename method or variables if you prefer, or event to reject it, I will not be upset !

You should add in contributing.md your favorites coding rules, I tried to guess it looking at the code, but it's not always that easy.

One more thing, why session are limited in time ? Would you accept a pull request to extend their validity, or to make it configurable ?