### PR TITLE
FIX : false positive GPIO thread seems to have ended unexpectedly

### DIFF
--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -363,12 +363,12 @@ void CGpio::Do_Work()
 	_log.Log(LOG_NORM,"GPIO: Worker started...");
 
 	while (!m_stoprequested) {
+		//_log.Log(LOG_NORM, "GPIO: Updating heartbeat");
+		mytime(&m_LastHeartbeat);
+
 #ifndef WIN32
 		boost::mutex::scoped_lock lock(interruptQueueMutex);
-		if (!interruptCondition.timed_wait(lock, duration)) {
-			//_log.Log(LOG_NORM, "GPIO: Updating heartbeat");
-			mytime(&m_LastHeartbeat);
-		} else {
+		if (interruptCondition.timed_wait(lock, duration)) {
 			while (!gpioInterruptQueue.empty()) {
 				interruptNumber = gpioInterruptQueue.front();
 				triggers.push_back(interruptNumber);


### PR DESCRIPTION
The heart-beat time was set only after 12 seconds without any interrupt. But if the GPIO see 1 interrupt every 12 seconds or less, for a minute (the heart beat timeout), you see in log "thread seems to have ended unexpectedly".
The heart-beat time is now set every 12 seconds, even if there is interrupts.