### PR TITLE
Add -lresolv to make open-zwave Dev link ok

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -598,7 +598,7 @@ else()
 endif()
 IF(OpenZWave)
   message(STATUS ${OpenZWave})
-  target_link_libraries(domoticz ${OpenZWave})
+  target_link_libraries(domoticz ${OpenZWave} -lresolv)
   include_directories(${CMAKE_SOURCE_DIR}/hardware/openzwave)
   add_definitions(-DWITH_OPENZWAVE)
   # open-zwave needs libudev


### PR DESCRIPTION
Latest open-zwave Dev failed to link into domoticz because of the missing -lresolv switch in CMaketLists.txt. After this update regenerate your Makefile.