### PR TITLE
Raspberry-Pi GPIO capture input state on startup

### DIFF
--- a/hardware/Gpio.h
+++ b/hardware/Gpio.h
@@ -48,9 +48,9 @@ private:
 
 	void Do_Work();
 	void DelayedStartup();
-	void CopyDeviceStates();
+	void CopyDeviceStates(bool forceUpdate);
 	void ProcessInterrupt(int gpioId);
-	void SetupInitialState(int gpioId);
+	void SetupInitialState(int gpioId, bool forceUpdate);
 	
 	// List of GPIO pin numbers, ordered as listed
 	static std::vector<CGpioPin> pins;

--- a/hardware/Gpio.h
+++ b/hardware/Gpio.h
@@ -47,7 +47,10 @@ private:
 	bool StopHardware();
 
 	void Do_Work();
+	void DelayedStartup();
+	void CopyDeviceStates();
 	void ProcessInterrupt(int gpioId);
+	void SetupInitialState(int gpioId);
 	
 	// List of GPIO pin numbers, ordered as listed
 	static std::vector<CGpioPin> pins;


### PR DESCRIPTION
When Domoticz currently starts up, on Raspberry Pi, the actual input state is not reflected correctly. Only after an input state transition Domoticz on Raspberry sees the correct input status. This is a problem when for example door or window sensors are monitored. The state would in that case only be correct after all doors and windows have been opened/closed or vise versa. To fix this problem this modification captures the actual input state on startup and updates the corresponding switches. Also after 30 seconds input state is captured again. The latter is done to support Raspberry Pi being used as a slave device providing its inputs to the master. The master usually quickly connects (assumed to do so within 30 seconds). Then Raspberry input states are then captured and updated one more time. As a result of this input states are correctly reflected on the Domoticz Master also. Note: I have build the code on Windows, Ubuntu and Raspberry Pi model3. I have tested it on Raspberry only as this feature is only applicable on the system.