### PR TITLE
open-zwave accepted version of TagReader500.xml

### DIFF
--- a/Config/BeNext/TagReader500.xml
+++ b/Config/BeNext/TagReader500.xml
@@ -2,52 +2,69 @@
 <!--http://www.pepper1.net/zwavedb/device/302-->
 <Product xmlns='http://code.google.com/p/open-zwave/'>
 
-  <!-- Configuration -->
-  <CommandClass id="112">
+    <!-- Configuration -->
+    <CommandClass id="112">
 
-    <Value type="byte" genre="config" instance="1" index="1" label="Set to Default" value="-86">
-      <Help>Set all configuration values to default values (factory settings).</Help>
-    </Value>
+        <Value type="list" genre="config" instance="1" index="1" label="Set to Default" size="1" value="170">
+            <Help>To configure the always awake mode.</Help>
+            <Item label="Normal" value="170"/>
+            <Item label="Set all parameters to default" value="255"/>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="2" label="Feedback Time" value="15">
-      <Help>To configure the time the beep is automatically turned off in seconds.</Help>
-    </Value>
+        <Value type="byte" genre="config" instance="1" index="2" label="Feedback Time" units="seconds" value="15">
+            <Help>To configure the time the beep is automatically turned off in seconds.
+                0x00: Disable, 0x01 - 0xFE: Value in seconds
+            </Help>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="3" label="Feedback Timeout" value="0">
-      <Help>To configure the timeout to wait for a WAKEUP_NO_MORE_INFORMATION before the error beep is automatically sound. The error beeps are fixed 8 beeps shortly after each other.</Help>
-    </Value>
+        <Value type="byte" genre="config" instance="1" index="3" label="Feedback Timeout" units="seconds" value="0">
+            <Help>
+                To configure the timeout to wait for a WAKEUP_NO_MORE_INFORMATION before the error beep
+                is automatically sound. The error beeps are fixed 8 beeps shortly after each other.
+                0x00: Disabled, 0x01 - 0xFF: Value in seconds
+            </Help>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="4" label="Feedback beeps per second" value="2">
-      <Help>To configure the number of beeps per second. Every beep is fixed about 10ms.</Help>
-    </Value>
+        <Value type="byte" genre="config" instance="1" index="4" label="Feedback beeps per second" value="2">
+            <Help>
+                To configure the number of beeps per second. Every beep is fixed about 10ms.
+                0x00 - 0xFF: Number of beeps per second
+            </Help>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="5" label="Always awake mode" value="1">
-      <Help>To configure the always awake mode.</Help>
-    </Value>
+        <Value type="list" genre="config" instance="1" index="5" label="Always awake mode" size="1" value="1">
+            <Help>To configure the always awake mode.</Help>
+            <Item label="Normal operating" value="1"/>
+            <Item label="Always awake" value="3"/>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="6" label="Not used" value="0">
-      <Help>Not used</Help>
-    </Value>	
+        <Value type="list" genre="config" instance="1" index="7" label="Operation mode" size="1" value="0">
+            <Help>The mode that the Tag Reader 500 communicates with the associated gateway.</Help>
+            <Item label="Gateway mode" value="0"/>
+            <Item label="Local mode" value="1"/>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="7" label="Operation mode" value="0">
-      <Help>The mode that the Tag Reader 500 communicates with the associated gateway.</Help>
-    </Value>
+        <Value type="list" genre="config" instance="1" index="8" label="Gateway confirmation" size="1" value="0">
+            <Help>
+                In gateway mode it is possible to let the gateway decide if the Tag Reader 500 can arm to home or away.
+                If gateway indication is disabled the Tag Reader 500 automatically assumes that it can arm and will wait
+                for a user input of RFID TAG or numeric code.
+            </Help>
+            <Item label="Disabled" value="0"/>
+            <Item label="Enabled" value="1"/>
+        </Value>
 
-    <Value type="byte" genre="config" instance="1" index="8" label="Gateway confirmation" value="0">
-      <Help>In gateway mode it is possible to let the gateway decide if the Tag Reader 500 can arm to home or away. If gateway indication is disabled the Tag Reader 500 automatically assumes that</Help>
-    </Value>
 
+    </CommandClass>
 
-  </CommandClass>
-  
-  <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
-  <CommandClass id="113" getsupported="false" />
+    <!-- COMMAND_CLASS_ALARM AlarmCmd_Get not supported -->
+    <CommandClass id="113" getsupported="false"/>
 
-  <!-- Association Groups -->
-  <CommandClass id="133">
-    <Associations num_groups="1">
-      <Group index="1" max_associations="5" label="Group 1" />
-    </Associations>
-  </CommandClass>
+    <!-- Association Groups -->
+    <CommandClass id="133">
+        <Associations num_groups="1">
+            <Group index="1" max_associations="5" label="Lifeline"/>
+        </Associations>
+    </CommandClass>
 
 </Product>


### PR DESCRIPTION
This version of the BeNext TagReader500.xml was accepted by open-zwave. Note: I first did submit a version simular to the current one in Domoticz. I got a change request, to use lists, for that one. After I made those changes it was accepted and is now part of the open-zwave Dev branch.