### PR TITLE
Add support for InterTechno GW and two common switch types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ hardware/AccuWeather.cpp
 hardware/AnnaThermostat.cpp
 hardware/ASyncSerial.cpp
 hardware/ASyncTCP.cpp
+hardware/ASyncUDP.cpp
 hardware/AtagOne.cpp
 hardware/BleBox.cpp
 hardware/Comm5TCP.cpp
@@ -322,6 +323,10 @@ hardware/HEOS.cpp
 hardware/I2C.cpp
 hardware/ICYThermostat.cpp
 hardware/InComfort.cpp
+hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+hardware/itgw/ITGWSwitchIntertechno.cpp
+hardware/ITGWBase.cpp
+hardware/ITGWUDP.cpp
 hardware/KMTronicBase.cpp
 hardware/KMTronic433.cpp
 hardware/KMTronicSerial.cpp

--- a/hardware/ASyncUDP.cpp
+++ b/hardware/ASyncUDP.cpp
@@ -1,0 +1,299 @@
+#include "stdafx.h"
+#include "ASyncUDP.h"
+#include "../main/Logger.h"
+
+#ifndef WIN32
+	#include <unistd.h> //gethostbyname
+#endif
+
+/*
+#ifdef WIN32
+	#include <Mstcpip.h>
+#elif defined(__FreeBSD__)
+	#include <netinet/tcp.h>
+#endif
+*/
+
+#define RECONNECT_TIME 30
+
+ASyncUDP::ASyncUDP()
+	: mIsConnected(false), mIsClosing(false),
+	mSocket(mIos), mReconnectTimer(mIos),
+	mDoReconnect(true), mIsReconnecting(false)
+{
+}
+
+ASyncUDP::~ASyncUDP(void)
+{
+	disconnect();
+}
+
+void ASyncUDP::update()
+{
+	if (mIsClosing)
+		return;
+	// calls the poll() function to process network messages
+	mIos.poll();
+}
+
+void ASyncUDP::connect(const std::string &ip, unsigned short port)
+{
+	// connect socket
+	try
+	{
+		std::string fip = ip;
+
+		unsigned long ipn = inet_addr(fip.c_str());
+		// if we have a error in the ip, it means we have entered a string
+		if (ipn == INADDR_NONE)
+		{
+			// change Hostname in Server Address
+			hostent *he = gethostbyname(fip.c_str());
+			if (he != NULL)
+			{
+				char szIP[20];
+				sprintf(szIP, "%d.%d.%d.%d", (uint8_t)he->h_addr_list[0][0], (uint8_t)he->h_addr_list[0][1], (uint8_t)he->h_addr_list[0][2], (uint8_t)he->h_addr_list[0][3]);
+				fip = szIP;
+			}
+			else
+			{
+				//we will fail
+				_log.Log(LOG_ERROR, "UDP: Unable to resolve '%s'", fip.c_str());
+			}
+		}
+
+		boost::asio::ip::udp::endpoint endpoint(boost::asio::ip::address::from_string(fip), port);
+
+		connect(endpoint);
+	}
+	catch(const std::exception &e)
+	{
+		OnError(e);
+		_log.Log(LOG_ERROR,"UDP: Exception: %s", e.what());
+	}
+}
+
+void ASyncUDP::connect(boost::asio::ip::udp::endpoint& endpoint)
+{
+	//if(mIsConnected) return;
+	//if(mIsClosing) return;
+
+	mEndPoint = endpoint;
+
+	// try to connect, then call handle_connect
+	mSocket.async_connect(endpoint,
+        boost::bind(&ASyncUDP::handle_connect, this, boost::asio::placeholders::error));
+}
+
+void ASyncUDP::disconnect()
+{
+	// tell socket to close the connection
+	close();
+
+	// tell the IO service to stop
+	mIos.stop();
+
+	//mIsConnected = false;
+	mIsClosing = false;
+}
+
+void ASyncUDP::close()
+{
+	//if(!mIsConnected) return;
+
+	// safe way to request the client to close the connection
+	mIos.post(boost::bind(&ASyncUDP::do_close, this));
+}
+
+// callbacks
+
+void ASyncUDP::handle_connect(const boost::system::error_code& error)
+{
+
+	if(mIsClosing) return;
+
+	if (!error) {
+
+		// we are connected!
+		//mIsConnected = true;
+
+		//Enable keep alive
+		//boost::asio::socket_base::keep_alive option(true);
+		//mSocket.set_option(option);
+
+		//set_tcp_keepalive();
+
+		OnConnect();
+
+		// Start Reading
+		//This gives some work to the io_service before it is started
+		mIos.post(boost::bind(&ASyncUDP::read, this));
+	}
+	else {
+		// there was an error :(
+		// mIsConnected = false;
+
+		OnError(error);
+		OnErrorInt(error);
+
+		if (!mDoReconnect)
+		{
+			OnDisconnect();
+			return;
+		}
+		if (!mIsReconnecting)
+		{
+			mIsReconnecting = true;
+			_log.Log(LOG_STATUS, "UDP: Reconnecting in %d seconds...", RECONNECT_TIME);
+			// schedule a timer to reconnect after 30 seconds
+			mReconnectTimer.expires_from_now(boost::posix_time::seconds(RECONNECT_TIME));
+			mReconnectTimer.async_wait(boost::bind(&ASyncUDP::do_reconnect, this, boost::asio::placeholders::error));
+		}
+	}
+}
+
+void ASyncUDP::read()
+{
+//	if (!mIsConnected) return;
+//	if (mIsClosing) return;
+
+	mSocket.async_receive_from(boost::asio::buffer(m_buffer, sizeof(m_buffer)),
+          mEndPoint,
+		boost::bind(&ASyncUDP::handle_read,
+			this,
+			boost::asio::placeholders::error,
+			boost::asio::placeholders::bytes_transferred));
+}
+
+void ASyncUDP::handle_read(const boost::system::error_code& error, size_t bytes_transferred)
+{
+	if (!error)
+	{
+		OnData(m_buffer,bytes_transferred);
+		//Read next
+		//This gives some work to the io_service before it is started
+		mIos.post(boost::bind(&ASyncUDP::read, this));
+	}
+	else
+	{
+		// try to reconnect if external host disconnects
+		if (!mIsClosing)
+		{
+			mIsConnected = false;
+
+			// let listeners know
+			OnError(error);
+			if (!mDoReconnect)
+			{
+				OnDisconnect();
+				return;
+			}
+			if (!mIsReconnecting)
+			{
+				mIsReconnecting = true;
+				_log.Log(LOG_STATUS, "UDP: Reconnecting in %d seconds...", RECONNECT_TIME);
+				// schedule a timer to reconnect after 30 seconds
+				mReconnectTimer.expires_from_now(boost::posix_time::seconds(RECONNECT_TIME));
+				mReconnectTimer.async_wait(boost::bind(&ASyncUDP::do_reconnect, this, boost::asio::placeholders::error));
+			}
+		}
+		else
+			do_close();
+	}
+}
+
+void ASyncUDP::write_end(const boost::system::error_code& error)
+{
+	if (!mIsClosing)
+	{
+		if (error)
+		{
+			// let listeners know
+			OnError(error);
+
+			mIsConnected = false;
+
+			if (!mDoReconnect)
+			{
+				OnDisconnect();
+				return;
+			}
+			if (!mIsReconnecting)
+			{
+				mIsReconnecting = true;
+				_log.Log(LOG_STATUS, "UDP: Reconnecting in %d seconds...", RECONNECT_TIME);
+				// schedule a timer to reconnect after 30 seconds
+				mReconnectTimer.expires_from_now(boost::posix_time::seconds(RECONNECT_TIME));
+				mReconnectTimer.async_wait(boost::bind(&ASyncUDP::do_reconnect, this, boost::asio::placeholders::error));
+			}
+		}
+	}
+}
+
+
+
+void ASyncUDP::write(const unsigned char *pData, size_t length)
+{
+
+	if (!mIsClosing)
+	{
+		  mSocket.async_send_to(boost::asio::buffer(pData,length),
+                            mEndPoint,
+		                        boost::bind(&ASyncUDP::write_end,
+			this,
+			boost::asio::placeholders::error));
+	}
+}
+
+void ASyncUDP::write(const std::string &msg)
+{
+	write((const unsigned char*)msg.c_str(), msg.size());
+}
+
+void ASyncUDP::do_close()
+{
+	if(mIsClosing) return;
+
+	mIsClosing = true;
+
+	mSocket.close();
+}
+
+void ASyncUDP::do_reconnect(const boost::system::error_code& error)
+{
+	//if(mIsConnected) return;
+	if(mIsClosing) return;
+
+	// close current socket if necessary
+	mSocket.close();
+
+	mReconnectTimer.cancel();
+	// try to reconnect, then call handle_connect
+	_log.Log(LOG_STATUS, "UDP: Reconnecting...");
+	mSocket.async_connect(mEndPoint,
+        boost::bind(&ASyncUDP::handle_connect, this, boost::asio::placeholders::error));
+	mIsReconnecting = false;
+}
+
+void ASyncUDP::OnErrorInt(const boost::system::error_code& error)
+{
+	if (
+		(error == boost::asio::error::address_in_use) ||
+		(error == boost::asio::error::connection_refused) ||
+		(error == boost::asio::error::access_denied) ||
+		(error == boost::asio::error::host_unreachable) ||
+		(error == boost::asio::error::timed_out)
+		)
+	{
+		_log.Log(LOG_STATUS, "UDP: Connection problem (Unable to connect to specified IP/Port)");
+	}
+	else if (
+		(error == boost::asio::error::eof) ||
+		(error == boost::asio::error::connection_reset)
+		)
+	{
+		_log.Log(LOG_STATUS, "UDP: Connection reset! (Disconnected)");
+	}
+	else
+		_log.Log(LOG_ERROR, "UDP: Error: %s", error.message().c_str());
+}

--- a/hardware/ASyncUDP.h
+++ b/hardware/ASyncUDP.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <string>
+#include <iostream>
+#include <boost/asio.hpp>
+#include <boost/bind.hpp>
+
+typedef boost::shared_ptr<class ASyncUDP> ASyncUDPRef;
+
+class ASyncUDP
+{
+public:
+	ASyncUDP();
+	virtual ~ASyncUDP(void);
+
+	void write(const std::string &msg);
+
+	void connect(const std::string &ip, unsigned short port);
+	void connect(boost::asio::ip::udp::endpoint& endpoint);
+
+	void disconnect();
+
+	bool isConnected(){ return mIsConnected; };
+
+	void update();
+protected:
+	void read();
+	void close();
+	//bool set_tcp_keepalive();
+
+	// callbacks
+	void handle_connect(const boost::system::error_code& error);
+	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
+	void write_end(const boost::system::error_code& error);
+
+	void write(const unsigned char *pData, size_t length);
+	void do_close();
+
+	void do_reconnect(const boost::system::error_code& error);
+
+	virtual void OnConnect()=0;
+	virtual void OnDisconnect()=0;
+	virtual void OnData(const unsigned char *pData, size_t length)=0;
+	virtual void OnError(const std::exception e)=0;
+	virtual void OnError(const boost::system::error_code& error)=0;
+
+	void OnErrorInt(const boost::system::error_code& error);
+
+protected:
+	bool							mIsConnected;
+	bool							mIsClosing;
+	bool							mDoReconnect;
+	bool							mIsReconnecting;
+
+	boost::asio::ip::udp::endpoint	mEndPoint;
+
+	boost::asio::io_service			mIos;
+	boost::asio::ip::udp::socket	mSocket;
+
+	unsigned char m_buffer[1024];
+
+	boost::asio::deadline_timer		mReconnectTimer;
+
+};

--- a/hardware/ITGWBase.cpp
+++ b/hardware/ITGWBase.cpp
@@ -15,6 +15,20 @@
 #include "itgw/ITGWSwitchIntertechno.h"
 #include "itgw/ITGWSwitchBrennenstuhl.h"
 
+/*Intertechno 433Mhz gateway ITGW-433 support
+ *
+ * ITGW is transmitter only, commonly sold in Bauhous brand stores
+ * in eastern parts of europe. The Wlan in the name is misleading,
+ * device requires a cable ethernet to operate and gets it's IP
+ * from DHCP only. To configure it, easyest way of finding out what it got,
+ * is using your smartphone and "Power Switch" app. It broadcasts it's presence
+ * on the network, that this app detects. Or you can listen for the broadcasts
+ * with whatever you preffer for it. You may also want to tell router
+ * to keep giving it the same ip.
+ *
+ * http://intertechno.at/front/produkte/smartphone/itgw-433/
+ */
+
 #ifdef _DEBUG
 	#define ENABLE_LOGGING
 #endif

--- a/hardware/ITGWBase.cpp
+++ b/hardware/ITGWBase.cpp
@@ -154,8 +154,6 @@ bool CITGWBase::WriteToHardware(const char *pdata, const unsigned char length)
 	if (pSwitch->type == pTypeGeneralSwitch) {
 		std::string switchcmnd = GetGeneralITGWFromInt(rfswitchcommands, pSwitch->cmnd);
 
-		_log.Log(LOG_NORM, "ITGW: switch command: %d", pSwitch->cmnd);
-
 		if (switchcmnd.empty()) {
 			_log.Log(LOG_ERROR, "ITGW: trying to send unknown switch command: %d", pSwitch->cmnd);
 			return false;
@@ -168,12 +166,9 @@ bool CITGWBase::WriteToHardware(const char *pdata, const unsigned char length)
       std::string itcmnd;
       if(pSwitch->cmnd == gswitch_sOn) {
         itcmnd = its->GetOnCommandString(ID.c_str());
-        _log.Log(LOG_NORM, "ITGW: switch on command got: %s", itcmnd);
-
       }
       else if(pSwitch->cmnd == gswitch_sOff) {
         itcmnd =  its->GetOffCommandString(ID.c_str());
-        _log.Log(LOG_NORM, "ITGW: switch off command got: %s", itcmnd);
       }
       sstr << its->GetHeader() << itcmnd << txversion << its->GetSpeed();
     }
@@ -182,21 +177,19 @@ bool CITGWBase::WriteToHardware(const char *pdata, const unsigned char length)
       std::string itcmnd;
       if(pSwitch->cmnd == gswitch_sOn) {
         itcmnd = its->GetOnCommandString(ID.c_str());
-        _log.Log(LOG_NORM, "ITGW: switch on command got: %s", itcmnd);
 
       }
       else if(pSwitch->cmnd == gswitch_sOff) {
         itcmnd =  its->GetOffCommandString(ID.c_str());
-        _log.Log(LOG_NORM, "ITGW: switch off command got: %s", itcmnd);
       }
       sstr << its->GetHeader() << itcmnd << txversion << its->GetSpeed();
     }
 
 		sstr << suffix << "\n";
 
-//#ifdef _DEBUG
+#ifdef _DEBUG
 		_log.Log(LOG_STATUS, "ITGW Sending: %s", sstr.str().c_str());
-//#endif
+#endif
 		m_bTXokay = false; // clear OK flag
 		WriteInt(sstr.str());
 		time_t atime = mytime(NULL);

--- a/hardware/ITGWBase.cpp
+++ b/hardware/ITGWBase.cpp
@@ -1,0 +1,336 @@
+
+#include "stdafx.h"
+#include "ITGWBase.h"
+#include "../main/Logger.h"
+#include "../main/Helper.h"
+#include "../main/RFXtrx.h"
+#include "hardwaretypes.h"
+#include "../main/localtime_r.h"
+#include "../main/SQLHelper.h"
+
+#include "../main/mainworker.h"
+#include "../main/WebServer.h"
+#include "../webserver/cWebem.h"
+#include "../json/json.h"
+#include "itgw/ITGWSwitchIntertechno.h"
+#include "itgw/ITGWSwitchBrennenstuhl.h"
+
+
+#ifdef _DEBUG
+	#define ENABLE_LOGGING
+#endif
+
+
+struct _tITGWStringIntHelper
+{
+	std::string szType;
+	int gType;
+};
+
+const _tITGWStringIntHelper rfswitches[] =
+{
+	{ "Intertechno 2 Dials relay", sSwitchTypeInterTechno },               // p9
+	{ "Brennestuh Dipswith relay", sSwitchTypeBrennenstuhl },              // p3
+	{ "RFCustom", sSwitchTypeRFCustom },
+	{ "", -1 }
+};
+
+const _tITGWStringIntHelper rfswitchcommands[] =
+{
+	{ "ON", gswitch_sOn },
+	{ "OFF", gswitch_sOff },
+	{ "", -1 }
+};
+
+const _tITGWStringIntHelper rfblindcommands[] =
+{
+	{ "UP", blinds_sOpen },
+	{ "DOWN", blinds_sClose },
+	{ "STOP", blinds_sStop },
+	{ "CONFIRM", blinds_sConfirm },
+	{ "LIMIT", blinds_sLimit },
+	{ "", -1 }
+};
+
+const std::string txversion = "1,";
+const std::string suffix = "0;";
+
+int GetGeneralITGWFromString(const _tITGWStringIntHelper *pTable, const std::string &szType)
+{
+	int ii = 0;
+	while (pTable[ii].gType!=-1)
+	{
+		if (pTable[ii].szType == szType)
+			return pTable[ii].gType;
+		ii++;
+	}
+	return -1;
+}
+
+std::string GetGeneralITGWFromInt(const _tITGWStringIntHelper *pTable, const int gType)
+{
+	int ii = 0;
+	while (pTable[ii].gType!=-1)
+	{
+		if (pTable[ii].gType == gType)
+			return pTable[ii].szType;
+		ii++;
+	}
+	return "";
+}
+
+CITGWBase::CITGWBase()
+{
+	m_rfbufferpos=0;
+	memset(&m_rfbuffer,0,sizeof(m_rfbuffer));
+}
+
+CITGWBase::~CITGWBase()
+{
+}
+
+
+/*
+void CITGWBase::Add2SendQueue(const char* pData, const size_t length)
+{
+	std::string sBytes;
+	sBytes.insert(0,pData,length);
+	boost::lock_guard<boost::mutex> l(m_sendMutex);
+	m_sendqueue.push_back(sBytes);
+}
+*/
+
+void CITGWBase::ParseData(const char *data, size_t len)
+{
+  ParseLine(data);
+}
+
+#define round(a) ( int ) ( a + .5 )
+
+void GetITGWSwitchType(const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, int &switchType)
+{
+	switchType = 0;
+	std::vector<std::vector<std::string> > result;
+	result = m_sql.safe_query("SELECT SwitchType FROM DeviceStatus WHERE (DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", ID, unit, devType, subType);
+	if (result.size() != 0)
+	{
+		switchType = atoi(result[0][0].c_str());
+	}
+}
+
+
+bool CITGWBase::WriteToHardware(const char *pdata, const unsigned char length)
+{
+	const _tGeneralSwitch *pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pdata);
+
+
+//	_log.Log(LOG_ERROR, "ITGW: type: %d", pSwitch->type);
+//	_log.Log(LOG_ERROR, "ITGW: subtype: %d", pSwitch->subtype);
+
+	if ((pSwitch->type != pTypeGeneralSwitch))
+		return false; //only allowed to control regular switches
+
+//	_log.Log(LOG_ERROR, "ITGW: switch type: %d", pSwitch->subtype);
+	std::string switchtype = GetGeneralITGWFromInt(rfswitches, pSwitch->subtype);
+	if (switchtype.empty())
+	{
+		_log.Log(LOG_ERROR, "ITGW: trying to send unknown switch type: %d", pSwitch->subtype);
+		return false;
+	}
+
+	_log.Log(LOG_NORM, "ITGW: switch id %04X accessed", pSwitch->id);
+//	_log.Log(LOG_ERROR, "ITGW: subtype: %d", pSwitch->subtype);
+
+	// get SwitchType from SQL table
+	int m_SwitchType = 0;
+	char szDeviceID[20];
+	sprintf(szDeviceID, "%04X", pSwitch->id);
+	std::string ID = szDeviceID;
+	GetITGWSwitchType(ID.c_str(), pSwitch->unitcode, pSwitch->type, pSwitch->subtype, m_SwitchType);
+//	_log.Log(LOG_ERROR, "ITGW: switch type: %d", m_SwitchType);
+//  _log.Log(LOG_ERROR, "ITGW: switch cmd: %d", pSwitch->cmnd);
+
+
+	if (pSwitch->type == pTypeGeneralSwitch) {
+		std::string switchcmnd = GetGeneralITGWFromInt(rfswitchcommands, pSwitch->cmnd);
+
+		_log.Log(LOG_NORM, "ITGW: switch command: %d", pSwitch->cmnd);
+
+		if (switchcmnd.empty()) {
+			_log.Log(LOG_ERROR, "ITGW: trying to send unknown switch command: %d", pSwitch->cmnd);
+			return false;
+		}
+
+		//Build send string
+		std::stringstream sstr;
+    if(pSwitch->subtype == sSwitchTypeInterTechno){
+      ITGWSwitchIntertechno *its = new ITGWSwitchIntertechno();
+      std::string itcmnd;
+      if(pSwitch->cmnd == gswitch_sOn) {
+        itcmnd = its->GetOnCommandString(ID.c_str());
+        _log.Log(LOG_NORM, "ITGW: switch on command got: %s", itcmnd);
+
+      }
+      else if(pSwitch->cmnd == gswitch_sOff) {
+        itcmnd =  its->GetOffCommandString(ID.c_str());
+        _log.Log(LOG_NORM, "ITGW: switch off command got: %s", itcmnd);
+      }
+      sstr << its->GetHeader() << itcmnd << txversion << its->GetSpeed();
+    }
+    else if(pSwitch->subtype == sSwitchTypeBrennenstuhl){
+      ITGWSwitchBrennenstuhl *its = new ITGWSwitchBrennenstuhl();
+      std::string itcmnd;
+      if(pSwitch->cmnd == gswitch_sOn) {
+        itcmnd = its->GetOnCommandString(ID.c_str());
+        _log.Log(LOG_NORM, "ITGW: switch on command got: %s", itcmnd);
+
+      }
+      else if(pSwitch->cmnd == gswitch_sOff) {
+        itcmnd =  its->GetOffCommandString(ID.c_str());
+        _log.Log(LOG_NORM, "ITGW: switch off command got: %s", itcmnd);
+      }
+      sstr << its->GetHeader() << itcmnd << txversion << its->GetSpeed();
+    }
+
+		sstr << suffix << "\n";
+
+//#ifdef _DEBUG
+		_log.Log(LOG_STATUS, "ITGW Sending: %s", sstr.str().c_str());
+//#endif
+		m_bTXokay = false; // clear OK flag
+		WriteInt(sstr.str());
+		time_t atime = mytime(NULL);
+		time_t btime = mytime(NULL);
+
+		// Wait for an OK response(ITGW just sends a reply) from ITGW to make sure the command was executed
+		while (m_bTXokay == false) {
+			if (difftime(btime,atime) > 4) {
+				_log.Log(LOG_ERROR, "ITGW: TX time out...");
+				return false;
+			}
+			btime = mytime(NULL);
+		}
+		return true;
+	}
+}
+
+bool CITGWBase::SendSwitchInt(const unsigned char *pdata)
+{
+	sDecodeRXMessage(this, pdata, NULL, 0);
+	return true;
+}
+
+bool CITGWBase::ParseLine(const std::string &sLine)
+{
+  //ITGW only ever sends its identifier string
+	m_LastReceivedTime = mytime(NULL);
+
+	std::vector<std::string> results;
+	StringSplit(sLine, ";", results);
+
+#ifdef ENABLE_LOGGING
+		_log.Log(LOG_NORM, "ITGW: %s", sLine.c_str());
+#endif
+
+	//std::string Sensor_ID = results[1];
+	if (results.size() >2)
+	{
+		//Status reply
+		std::string Name_ID = results[0];
+		if (Name_ID.find("HCGW:VC:ITECHNO") != std::string::npos)
+		{
+			m_bTXokay = true; // variable to indicate an OK was received
+			mytime(&m_LastHeartbeatReceive);  // keep heartbeat happy
+			mytime(&m_LastHeartbeat);  // keep heartbeat happy
+			m_LastReceivedTime = m_LastHeartbeat;
+#ifdef ENABLE_LOGGING
+			_log.Log(LOG_STATUS, "ITGW identified by reply - ITGW only ever reply's its ID.");
+#endif
+		}
+    else {
+      return false;
+    }
+	}
+  return false;
+}
+
+//Webserver helpers
+namespace http {
+	namespace server {
+		void CWebServer::RType_CreateITGWDevice(WebEmSession & session, const request& req, Json::Value &root)
+		{
+			if (session.rights != 2)
+			{
+				session.reply_status = reply::forbidden;
+				return; //Only admin user allowed
+			}
+
+			std::string idx = request::findValue(&req, "idx");
+			std::string scommand = request::findValue(&req, "command");
+			if (idx.empty() || scommand.empty())
+			{
+				return;
+			}
+
+			#ifdef _DEBUG
+			_log.Log(LOG_STATUS, "ITGW Custom Command: %s", scommand.c_str());
+			_log.Log(LOG_STATUS, "ITGW Custom Command idx: %s", idx.c_str());
+			#endif
+
+			bool bCreated = false;						// flag to know if the command was a success
+			CITGWBase *pRFLINK = reinterpret_cast<CITGWBase*>(m_mainworker.GetHardware(atoi(idx.c_str())));
+			if (pRFLINK == NULL)
+				return;
+
+			if (scommand.substr(0, 14).compare("10;rfdebug=on;") == 0) {
+				pRFLINK->m_bRFDebug = true; // enable debug
+				_log.Log(LOG_STATUS, "User: %s initiated ITGW Enable Debug mode with command: %s", session.username.c_str(), scommand.c_str());
+				pRFLINK->WriteInt("10;RFDEBUG=ON;\n");
+				root["status"] = "OK";
+				root["title"] = "DebugON";
+				return;
+			}
+			if (scommand.substr(0, 15).compare("10;rfdebug=off;") == 0) {
+				pRFLINK->m_bRFDebug = false; // disable debug
+				_log.Log(LOG_STATUS, "User: %s initiated ITGW Disable Debug mode with command: %s", session.username.c_str(), scommand.c_str());
+				pRFLINK->WriteInt("10;RFDEBUG=OFF;\n");
+				root["status"] = "OK";
+				root["title"] = "DebugOFF";
+				return;
+			}
+
+			_log.Log(LOG_STATUS, "User: %s initiated a ITGW Device Create command: %s", session.username.c_str(), scommand.c_str());
+			scommand = "11;" + scommand;
+			#ifdef _DEBUG
+			_log.Log(LOG_STATUS, "User: %s initiated a ITGW Device Create command: %s", session.username.c_str(), scommand.c_str());
+			#endif
+			scommand += "\r\n";
+
+			bCreated = true;
+			pRFLINK->m_bTXokay = false; // clear OK flag
+			pRFLINK->WriteInt(scommand.c_str());
+			time_t atime = mytime(NULL);
+			time_t btime = mytime(NULL);
+
+			// Wait for an OK response from ITGW to make sure the command was executed
+			while (pRFLINK->m_bTXokay == false) {
+				if (difftime(btime,atime) > 4) {
+					_log.Log(LOG_ERROR, "ITGW: TX time out...");
+					bCreated = false;
+					break;
+				}
+				btime = mytime(NULL);
+			}
+
+			#ifdef _DEBUG
+			_log.Log(LOG_STATUS, "ITGW custom command done");
+			#endif
+
+			if (bCreated)
+			{
+				root["status"] = "OK";
+				root["title"] = "CreateITGWDevice";
+			}
+		}
+	}
+}

--- a/hardware/ITGWBase.cpp
+++ b/hardware/ITGWBase.cpp
@@ -15,7 +15,7 @@
 #include "itgw/ITGWSwitchIntertechno.h"
 #include "itgw/ITGWSwitchBrennenstuhl.h"
 
-
+#define _DEBUG
 #ifdef _DEBUG
 	#define ENABLE_LOGGING
 #endif

--- a/hardware/ITGWBase.cpp
+++ b/hardware/ITGWBase.cpp
@@ -15,7 +15,6 @@
 #include "itgw/ITGWSwitchIntertechno.h"
 #include "itgw/ITGWSwitchBrennenstuhl.h"
 
-#define _DEBUG
 #ifdef _DEBUG
 	#define ENABLE_LOGGING
 #endif

--- a/hardware/ITGWBase.h
+++ b/hardware/ITGWBase.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <vector>
+#include "ASyncSerial.h"
+#include "DomoticzHardware.h"
+
+#define RFLINK_READ_BUFFER_SIZE 65*1024
+
+class CITGWBase: public CDomoticzHardwareBase
+{
+friend class CITGWSerial;
+friend class CITGWUDP;
+public:
+	CITGWBase();
+    ~CITGWBase();
+	bool WriteToHardware(const char *pdata, const unsigned char length);
+	virtual bool WriteInt(const std::string &sendString) = 0;
+	bool m_bTXokay;
+	bool m_bRFDebug;
+	std::string m_Version;
+private:
+	void Init();
+	void ParseData(const char *data, size_t len);
+	bool ParseLine(const std::string &sLine);
+	bool SendSwitchInt(const unsigned char *pdata);
+	unsigned char m_rfbuffer[RFLINK_READ_BUFFER_SIZE];
+	int m_rfbufferpos;
+	int m_retrycntr;
+	time_t m_LastReceivedTime;
+};
+

--- a/hardware/ITGWUDP.cpp
+++ b/hardware/ITGWUDP.cpp
@@ -1,0 +1,196 @@
+#include "stdafx.h"
+#include "ITGWUDP.h"
+#include "../main/Logger.h"
+#include "../main/Helper.h"
+#include <iostream>
+#include "../main/localtime_r.h"
+
+#define RFLINK_RETRY_DELAY 30
+
+CITGWUDP::CITGWUDP(const int ID, const std::string &IPAddress):
+	m_szIPAddress(IPAddress)
+{
+	m_HwdID=ID;
+	m_bDoRestart=false;
+	m_stoprequested=false;
+	m_usIPPort=49880;
+	m_retrycntr = RFLINK_RETRY_DELAY;
+}
+
+CITGWUDP::~CITGWUDP(void)
+{
+}
+
+bool CITGWUDP::StartHardware()
+{
+	m_stoprequested=false;
+	m_bDoRestart=false;
+
+	//force connect the next first time
+	m_retrycntr=RFLINK_RETRY_DELAY;
+	m_bIsStarted=true;
+
+	//Start worker thread
+	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CITGWUDP::Do_Work, this)));
+	return (m_thread!=NULL);
+}
+
+bool CITGWUDP::StopHardware()
+{
+	m_stoprequested=true;
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		} catch(...)
+		{
+			//Don't throw from a Stop command
+		}
+	}
+	try {
+		if (m_thread)
+		{
+			m_thread->join();
+			m_thread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
+
+	m_bIsStarted=false;
+	return true;
+}
+
+void CITGWUDP::OnConnect()
+{
+	_log.Log(LOG_STATUS,"ITGW: connected to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
+	m_bDoRestart=false;
+	m_bIsStarted=true;
+	m_rfbufferpos = 0;
+	m_LastReceivedTime = mytime(NULL);
+	sOnConnected(this);
+	write("\n");
+}
+
+void CITGWUDP::OnDisconnect()
+{
+	_log.Log(LOG_STATUS,"ITGW: disconnected");
+	m_bDoRestart = true;
+}
+
+void CITGWUDP::Do_Work()
+{
+	bool bFirstTime=true;
+	int sec_counter = 0;
+	while (!m_stoprequested)
+	{
+		sleep_seconds(1);
+		sec_counter++;
+
+		time_t atime = mytime(NULL);
+		if (sec_counter % 12 == 0) {
+			m_LastHeartbeat= atime;
+		}
+		if ((sec_counter % 20 == 0) && (mIsConnected))
+		{
+			//Send ping (keep alive)
+			if (atime - m_LastReceivedTime > 30)
+			{
+				//Timeout
+				_log.Log(LOG_ERROR, "ITGW: Nothing received for more then 30 seconds, restarting...");
+				m_retrycntr = 0;
+				m_LastReceivedTime = atime;
+				m_bDoRestart = true;
+				try {
+					disconnect();
+					close();
+				}
+				catch (...)
+				{
+					//Don't throw from a Stop command
+				}
+			}
+			else
+				write("\n");
+		}
+
+		if (bFirstTime)
+		{
+			bFirstTime=false;
+			if (mIsConnected)
+			{
+				try {
+					disconnect();
+					close();
+				}
+				catch (...)
+				{
+					//Don't throw from a Stop command
+				}
+			}
+			_log.Log(LOG_STATUS, "ITGW: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+			connect(m_szIPAddress,m_usIPPort);
+		}
+		else
+		{
+			if ((m_bDoRestart) && (sec_counter % 30 == 0))
+			{
+				_log.Log(LOG_STATUS, "ITGW: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+				try {
+					disconnect();
+					close();
+				}
+				catch (...)
+				{
+					//Don't throw from a Stop command
+				}
+				connect(m_szIPAddress, m_usIPPort);
+			}
+			update();
+		}
+	}
+	_log.Log(LOG_STATUS,"ITGW: TCP/IP Worker stopped...");
+}
+
+void CITGWUDP::OnData(const unsigned char *pData, size_t length)
+{
+	boost::lock_guard<boost::mutex> l(readQueueMutex);
+	ParseData((const char*)pData,length);
+}
+
+void CITGWUDP::OnError(const std::exception e)
+{
+	_log.Log(LOG_ERROR,"ITGW: Error: %s",e.what());
+}
+
+void CITGWUDP::OnError(const boost::system::error_code& error)
+{
+	if (
+		(error == boost::asio::error::address_in_use) ||
+		(error == boost::asio::error::connection_refused) ||
+		(error == boost::asio::error::access_denied) ||
+		(error == boost::asio::error::host_unreachable) ||
+		(error == boost::asio::error::timed_out)
+		)
+	{
+		_log.Log(LOG_ERROR, "ITGW: Can not connect to: %s:%ld", m_szIPAddress.c_str(), m_usIPPort);
+	}
+	else if (
+		(error == boost::asio::error::eof) ||
+		(error == boost::asio::error::connection_reset)
+		)
+	{
+		_log.Log(LOG_STATUS, "ITGW: Connection reset!");
+	}
+	else
+		_log.Log(LOG_ERROR, "ITGW: %s", error.message().c_str());
+}
+
+bool CITGWUDP::WriteInt(const std::string &sendString)
+{
+	write(sendString);
+	return true;
+}

--- a/hardware/ITGWUDP.h
+++ b/hardware/ITGWUDP.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <deque>
+#include <iostream>
+#include "ASyncUDP.h"
+#include "ITGWBase.h"
+
+class CITGWUDP: public CITGWBase, ASyncUDP
+{
+public:
+	CITGWUDP(const int ID, const std::string &IPAddress);
+	~CITGWUDP(void);
+	bool isConnected(){ return mIsConnected; };
+public:
+	// signals
+	boost::signals2::signal<void()>	sDisconnected;
+private:
+	int m_retrycntr;
+	bool StartHardware();
+	bool StopHardware();
+	bool WriteInt(const std::string &sendString);
+protected:
+	std::string m_szIPAddress;
+	unsigned short m_usIPPort;
+	bool m_bDoRestart;
+
+	void Do_Work();
+	void OnConnect();
+	void OnDisconnect();
+	void OnData(const unsigned char *pData, size_t length);
+	void OnError(const std::exception e);
+	void OnError(const boost::system::error_code& error);
+
+	boost::shared_ptr<boost::thread> m_thread;
+	volatile bool m_stoprequested;
+};
+

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -177,6 +177,8 @@
 #define sSwitchTypeHRCMotor			0x6e
 #define sSwitchTypeVelleman			0x6f
 #define sSwitchTypeRFCustom			0x72
+#define sSwitchTypeInterTechno	0x73
+#define sSwitchTypeBrennenstuhl	0x74
 
 //Switch commands
 #define gswitch_sOff				0x00

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
@@ -26,7 +26,9 @@ std::string ITGWSwitchBrennenstuhl::GetEncodedAddress(const char* ID){
 	std::string res = "";
   std::string _id = ID;
   std::string dipswitch_hex = _id.substr(1,3);
-  int dipswitch = std::stoi(dipswitch_hex, nullptr, 16);
+
+  char * pEnd;
+  int dipswitch = (int) std::strtol(dipswitch_hex.c_str(), &pEnd, 16);
   std::string dipswitchcode = std::bitset< 10 >( dipswitch ).to_string();
   std::string enc_addr = "";
   std::string h = B_FLOAT;

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
@@ -1,0 +1,83 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/*
+ * File:   ITGWSwitchBrennenstuhl.cpp
+ * Author: alexiade
+ *
+ * Created on March 18, 2017, 1:49 PM
+ */
+
+#include "ITGWSwitchBrennenstuhl.h"
+
+#define B_LOW "1,3,1,3,"
+#define B_FLOAT "1,3,3,1,"
+#define ON "1,3,3,1,1,3,3,1,"
+#define OFF "1,3,3,1,1,3,1,3,"
+
+ITGWSwitchBrennenstuhl::ITGWSwitchBrennenstuhl() {
+}
+
+ITGWSwitchBrennenstuhl::ITGWSwitchBrennenstuhl(const ITGWSwitchBrennenstuhl& orig) {
+}
+
+ITGWSwitchBrennenstuhl::~ITGWSwitchBrennenstuhl() {
+}
+
+std::string ITGWSwitchBrennenstuhl::GetEncodedAddress(const char* ID){
+	std::string res = "";
+  std::string _id = ID;
+  std::string dipswitch_hex = _id.substr(1,3);
+  int dipswitch = std::stoi(dipswitch_hex, nullptr, 16);
+  std::string dipswitchcode = std::bitset< 10 >( dipswitch ).to_string();
+  std::string enc_addr = "";
+  std::string h = B_FLOAT;
+  std::string l = B_LOW;
+  const char *dc = dipswitchcode.c_str();
+  //res = house+unit;
+
+  int i = 0;
+  std::stringstream sstr;
+  for(i = 0; i < 10; i++){
+    if(dc[i] == '1') {
+      sstr << l;
+    }
+    else{
+      sstr << h;
+    }
+  }
+  enc_addr =  sstr.str();
+  return enc_addr;
+}
+
+std::string ITGWSwitchBrennenstuhl::GetOnCommandString(const char* ID){
+  std::string encAddress = GetEncodedAddress(ID);
+//  _log.Log(LOG_ERROR, "ITGW: intertechno encoded address: %s", encAddress.c_str());
+  		std::stringstream sstr;
+		  sstr << encAddress;
+      sstr << ON;
+
+      return sstr.str();
+}
+
+std::string ITGWSwitchBrennenstuhl::GetOffCommandString(const char* ID){
+   std::string encAddress = GetEncodedAddress(ID);
+   std::stringstream sstr;
+	 sstr << encAddress;
+   sstr << OFF;
+
+  return sstr.str();
+}
+
+std::string ITGWSwitchBrennenstuhl::GetSpeed(){
+  const std::string speed = "32,";
+  return speed;
+}
+
+std::string ITGWSwitchBrennenstuhl::GetHeader(){
+  const std::string speed = "0,0,10,11200,350,26,0,";
+  return speed;
+}

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
@@ -29,22 +29,25 @@ std::string ITGWSwitchBrennenstuhl::GetEncodedAddress(const char* ID){
 
   char * pEnd;
   int dipswitch = (int) std::strtol(dipswitch_hex.c_str(), &pEnd, 16);
-  std::string dipswitchcode = std::bitset< 10 >( dipswitch ).to_string();
   std::string enc_addr = "";
   std::string h = B_FLOAT;
   std::string l = B_LOW;
-  const char *dc = dipswitchcode.c_str();
   //res = house+unit;
 
   int i = 0;
+  int shift = dipswitch;
   std::stringstream sstr;
   for(i = 0; i < 10; i++){
-    if(dc[i] == '1') {
+    const std::string &temp = sstr.str();
+    sstr.seekp(0);
+    if((shift % 2) == 1) {
       sstr << l;
     }
     else{
       sstr << h;
     }
+    sstr << temp;
+    shift = shift >> 1;
   }
   enc_addr =  sstr.str();
   return enc_addr;

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
@@ -13,6 +13,12 @@
 #define ON "1,3,3,1,1,3,3,1,"
 #define OFF "1,3,3,1,1,3,1,3,"
 
+/** Brennenstuhl basic 433MHz swiches support
+ * Tested with assorted RCS-1000 devices.
+ *
+ * http://www.brennenstuhl.com/index.php?module=products_downloads&index%5Bproducts_downloads%5D%5Bcategory%5D=105
+ */
+
 ITGWSwitchBrennenstuhl::ITGWSwitchBrennenstuhl() {
 }
 

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.cpp
@@ -1,17 +1,12 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
-/*
  * File:   ITGWSwitchBrennenstuhl.cpp
  * Author: alexiade
  *
  * Created on March 18, 2017, 1:49 PM
  */
-
+#include "stdafx.h"
 #include "ITGWSwitchBrennenstuhl.h"
+
 
 #define B_LOW "1,3,1,3,"
 #define B_FLOAT "1,3,3,1,"

--- a/hardware/itgw/ITGWSwitchBrennenstuhl.h
+++ b/hardware/itgw/ITGWSwitchBrennenstuhl.h
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/*
+ * File:   ITGWSwitchBrennenstuhl.h
+ * Author: alexiade
+ *
+ * Created on March 18, 2017, 1:49 PM
+ */
+
+#ifndef ITGWSWITCHBRENNENSTUHL_H
+#define ITGWSWITCHBRENNENSTUHL_H
+
+class ITGWSwitchBrennenstuhl {
+public:
+  ITGWSwitchBrennenstuhl();
+  ITGWSwitchBrennenstuhl(const ITGWSwitchBrennenstuhl& orig);
+  virtual ~ITGWSwitchBrennenstuhl();
+  std::string GetEncodedAddress(const char* ID);
+  std::string GetOnCommandString(const char* ID);
+  std::string GetOffCommandString(const char* ID);
+  std::string GetSpeed();
+  std::string GetHeader();
+private:
+
+};
+
+#endif /* ITGWSWITCHBRENNENSTUHL_H */
+

--- a/hardware/itgw/ITGWSwitchIntertechno.cpp
+++ b/hardware/itgw/ITGWSwitchIntertechno.cpp
@@ -7,6 +7,14 @@
 #include "stdafx.h"
 #include "ITGWSwitchIntertechno.h"
 
+/* Intertechno switches support
+ * Should be capable of switching any intertechno switches.
+ * for teachable ones, you need to configure the taught code
+ * as it was set with dials on the remote.
+ *
+ * http://intertechno.at/front/produkte/empfanger/einaus/
+ */
+
 #define B_LOW "4,12,4,12,"
 #define B_FLOAT "4,12,12,4,"
 #define ON "4,12,12,4,4,12,12,4,"

--- a/hardware/itgw/ITGWSwitchIntertechno.cpp
+++ b/hardware/itgw/ITGWSwitchIntertechno.cpp
@@ -1,0 +1,172 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/*
+ * File:   ITGWSwitchIntertechno.cpp
+ * Author: alexiade
+ *
+ * Created on March 18, 2017, 9:01 AM
+ */
+
+#include "ITGWSwitchIntertechno.h"
+
+#define B_LOW "4,12,4,12,"
+#define B_FLOAT "4,12,12,4,"
+#define ON "4,12,12,4,4,12,12,4,"
+#define OFF "4,12,12,4,4,12,4,12,"
+
+
+ITGWSwitchIntertechno::ITGWSwitchIntertechno() {
+}
+
+ITGWSwitchIntertechno::ITGWSwitchIntertechno(const ITGWSwitchIntertechno& orig) {
+}
+
+ITGWSwitchIntertechno::~ITGWSwitchIntertechno() {
+}
+
+std::string ITGWSwitchIntertechno::GetEncodedAddress(const char* ID){
+	std::string res = "";
+  std::string _id = ID;
+  std::string unit = _id.substr(2,2);
+  std::string house = _id.substr(0,2);
+  std::string enc_unit = "";
+  std::string enc_house = "";
+  std::string h = B_FLOAT;
+  std::string l = B_LOW;
+  //res = house+unit;
+  switch (atoi(house.c_str()) - 40) {
+            case 1:
+               enc_house =  l + l + l + l;
+                break;
+            case 2:
+               enc_house =  h + l + l + l;
+                break;
+            case 3:
+               enc_house =  l + h + l + l;
+                break;
+            case 4:
+               enc_house =  h + h + l + l;
+                break;
+            case 5:
+               enc_house =  l + l + h + l;
+                break;
+            case 6:
+               enc_house =  h + l + h + l;
+                break;
+            case 7:
+               enc_house =  l + h + h + l;
+                break;
+            case 8:
+               enc_house =  h + h + h + l;
+                break;
+            case 9:
+               enc_house =  l + l + l + h;
+                break;
+            case 10:
+               enc_house =  h + l + l + h;
+                break;
+            case 11:
+               enc_house =  l + h + l + h;
+                break;
+            case 12:
+               enc_house =  h + h + l + h;
+                break;
+            case 13:
+               enc_house =  l + l + h + h;
+                break;
+            case 14:
+               enc_house =  h + l + h + h;
+                break;
+            case 15:
+               enc_house =  l + h + h + h;
+                break;
+            case 16:
+               enc_house =  h + h + h + h;
+                break;
+  }
+
+  switch (atoi(unit.c_str())) {
+            case 1:
+               enc_unit =  l + l + l + l;
+                break;
+            case 2:
+               enc_unit =  h + l + l + l;
+                break;
+            case 3:
+               enc_unit =  l + h + l + l;
+                break;
+            case 4:
+               enc_unit =  h + h + l + l;
+                break;
+            case 5:
+               enc_unit =  l + l + h + l;
+                break;
+            case 6:
+               enc_unit =  h + l + h + l;
+                break;
+            case 7:
+               enc_unit =  l + h + h + l;
+                break;
+            case 8:
+               enc_unit =  h + h + h + l;
+                break;
+            case 9:
+               enc_unit =  l + l + l + h;
+                break;
+            case 10:
+               enc_unit =  h + l + l + h;
+                break;
+            case 11:
+               enc_unit =  l + h + l + h;
+                break;
+            case 12:
+               enc_unit =  h + h + l + h;
+                break;
+            case 13:
+               enc_unit =  l + l + h + h;
+                break;
+            case 14:
+               enc_unit =  h + l + h + h;
+                break;
+            case 15:
+               enc_unit =  l + h + h + h;
+                break;
+            case 16:
+               enc_unit =  h + h + h + h;
+                break;
+  }
+  return enc_house + enc_unit + l + h;
+}
+
+std::string ITGWSwitchIntertechno::GetOnCommandString(const char* ID){
+  std::string encAddress = GetEncodedAddress(ID);
+//  _log.Log(LOG_ERROR, "ITGW: intertechno encoded address: %s", encAddress.c_str());
+  		std::stringstream sstr;
+		  sstr << encAddress;
+      sstr << ON;
+
+      return sstr.str();
+}
+
+std::string ITGWSwitchIntertechno::GetOffCommandString(const char* ID){
+   std::string encAddress = GetEncodedAddress(ID);
+   std::stringstream sstr;
+	 sstr << encAddress;
+   sstr << OFF;
+
+  return sstr.str();
+}
+
+std::string ITGWSwitchIntertechno::GetSpeed(){
+  const std::string speed = "125,";
+  return speed;
+}
+
+std::string ITGWSwitchIntertechno::GetHeader(){
+  const std::string head = "0,0,6,11125,89,26,0,";
+  return head;
+}

--- a/hardware/itgw/ITGWSwitchIntertechno.cpp
+++ b/hardware/itgw/ITGWSwitchIntertechno.cpp
@@ -1,16 +1,10 @@
 /*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
-/*
  * File:   ITGWSwitchIntertechno.cpp
  * Author: alexiade
  *
  * Created on March 18, 2017, 9:01 AM
  */
-
+#include "stdafx.h"
 #include "ITGWSwitchIntertechno.h"
 
 #define B_LOW "4,12,4,12,"

--- a/hardware/itgw/ITGWSwitchIntertechno.h
+++ b/hardware/itgw/ITGWSwitchIntertechno.h
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+/*
+ * File:   ITGWSwitchIntertechno.h
+ * Author: alexiade
+ *
+ * Created on March 18, 2017, 9:01 AM
+ */
+
+#ifndef ITGWSWITCHINTERTECHNO_H
+#define ITGWSWITCHINTERTECHNO_H
+
+class ITGWSwitchIntertechno {
+public:
+  ITGWSwitchIntertechno();
+  ITGWSwitchIntertechno(const ITGWSwitchIntertechno& orig);
+  virtual ~ITGWSwitchIntertechno();
+  std::string GetEncodedAddress(const char* ID);
+  std::string GetOnCommandString(const char* ID);
+  std::string GetOffCommandString(const char* ID);
+  std::string GetSpeed();
+  std::string GetHeader();
+private:
+
+};
+
+#endif /* ITGWSWITCHINTERTECHNO_H */
+

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -248,6 +248,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_OpenWebNetUSB, "MyHome OpenWebNet USB" },
 		{ HTYPE_IntergasInComfortLAN2RF, "Intergas InComfort LAN2RF Gateway" },
 		{ HTYPE_RelayNet, "Relay-Net 8 channel LAN Relay and binary Input module" },
+		{ HTYPE_ITGWUDP, "Intertechno RF Transmit Gateway with LAN interface" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);
@@ -863,6 +864,8 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeGeneralSwitch, sSwitchTypeX2D, "X2D" },
 		{ pTypeGeneralSwitch, sSwitchTypeHRCMotor, "HRCMotor" },
 		{ pTypeGeneralSwitch, sSwitchTypeVelleman, "Velleman" },
+		{ pTypeGeneralSwitch, sSwitchTypeInterTechno, "InterTechno 2 dial relay" },
+		{ pTypeGeneralSwitch, sSwitchTypeBrennenstuhl, "Brennenstuhl dipswitch relay" },
 		{ pTypeGeneralSwitch, sSwitchTypeRFCustom, "RFCustom" },
 		{  0,0,NULL }
 	};

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -182,6 +182,7 @@ enum _eHardwareTypes {
 	HTYPE_OpenWebNetUSB,		//98
 	HTYPE_IntergasInComfortLAN2RF,			//99
 	HTYPE_RelayNet,				//100
+	HTYPE_ITGWUDP,				//100
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -26,6 +26,7 @@
 #include "../hardware/MySensorsBase.h"
 #include "../hardware/RFXBase.h"
 #include "../hardware/RFLinkBase.h"
+#include "../hardware/ITGWBase.h"
 #include "../hardware/HEOS.h"
 #ifdef WITH_GPIO
 #include "../hardware/Gpio.h"
@@ -574,6 +575,7 @@ namespace http {
 			RegisterRType("createevohomesensor", boost::bind(&CWebServer::RType_CreateEvohomeSensor, this, _1, _2, _3));
 			RegisterRType("bindevohome", boost::bind(&CWebServer::RType_BindEvohome, this, _1, _2, _3));
 			RegisterRType("createrflinkdevice", boost::bind(&CWebServer::RType_CreateRFLinkDevice, this, _1, _2, _3));
+			RegisterRType("createitgwdevice", boost::bind(&CWebServer::RType_CreateITGWDevice, this, _1, _2, _3));
 
 			RegisterRType("custom_light_icons", boost::bind(&CWebServer::RType_CustomLightIcons, this, _1, _2, _3));
 			RegisterRType("plans", boost::bind(&CWebServer::RType_Plans, this, _1, _2, _3));
@@ -1078,6 +1080,10 @@ namespace http {
 					}
 				}
 			}
+      else if (htype == HTYPE_ITGWUDP){
+        if (address == "")
+            return;
+      }
 			else if (htype == HTYPE_DomoticzInternal)	{
 				// DomoticzInternal cannot be added manually
 				return;
@@ -1412,7 +1418,7 @@ namespace http {
 				(htype == HTYPE_YouLess) || (htype == HTYPE_RazberryZWave) || (htype == HTYPE_OpenThermGatewayTCP) || (htype == HTYPE_LimitlessLights) ||
 				(htype == HTYPE_SolarEdgeTCP) || (htype == HTYPE_WOL) || (htype == HTYPE_S0SmartMeterTCP) || (htype == HTYPE_ECODEVICES) || (htype == HTYPE_Mochad) ||
 				(htype == HTYPE_MySensorsTCP) || (htype == HTYPE_MySensorsMQTT) || (htype == HTYPE_MQTT) || (htype == HTYPE_FRITZBOX) || (htype == HTYPE_ETH8020) || (htype == HTYPE_Sterbox) ||
-				(htype == HTYPE_KMTronicTCP) || (htype == HTYPE_SOLARMAXTCP) || (htype == HTYPE_RelayNet)  || (htype == HTYPE_SatelIntegra) || (htype == HTYPE_RFLINKTCP) ||
+				(htype == HTYPE_KMTronicTCP) || (htype == HTYPE_SOLARMAXTCP) || (htype == HTYPE_RelayNet)  || (htype == HTYPE_SatelIntegra) || (htype == HTYPE_RFLINKTCP) || (htype == HTYPE_ITGWUDP) ||
 				(htype == HTYPE_Comm5TCP || (htype == HTYPE_CurrentCostMeterLAN)) ||
 				(htype == HTYPE_NefitEastLAN) || (htype == HTYPE_DenkoviSmartdenLan) || (htype == HTYPE_Ec3kMeterTCP) || (htype == HTYPE_MultiFun) || (htype == HTYPE_ZIBLUETCP)
 				){
@@ -3564,6 +3570,7 @@ namespace http {
 						case HTYPE_RaspberryGPIO:
 						case HTYPE_RFLINKUSB:
 						case HTYPE_RFLINKTCP:
+						case HTYPE_ITGWUDP:
 						case HTYPE_ZIBLUEUSB:
 						case HTYPE_ZIBLUETCP:
 						case HTYPE_OpenWebNetTCP:
@@ -4272,6 +4279,40 @@ namespace http {
 							return;
 						devid = id;
 					}
+          else if (lighttype == 115)
+          {
+            dtype = pTypeGeneralSwitch;
+            subtype = lighttype;
+            std::string shousecode = request::findValue(&req, "housecode");
+            sunitcode = request::findValue(&req, "unitcode");
+            if (
+              (shousecode == "") ||
+              (sunitcode == "")
+              )
+              return;
+            sprintf(szTmp, "%02X", atoi(sunitcode.c_str()));
+						sunitcode = szTmp;
+						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+						shousecode = szTmp;
+						sprintf(szTmp, "%03X", switchtype);
+            devid = shousecode+sunitcode+szTmp;
+          }
+          else if (lighttype == 116)
+          {
+            dtype = pTypeGeneralSwitch;
+            subtype = lighttype;
+            std::string dipswitchcode = request::findValue(&req, "dipswitchcode");
+            sunitcode = "0";
+            std::string sdipswitchcode;
+            if (
+              (dipswitchcode == "")
+              )
+              return;
+						sprintf(szTmp, "%03X", std::stoi(dipswitchcode, nullptr, 2));
+						sdipswitchcode = szTmp;
+						sprintf(szTmp, "%02X", switchtype);
+            devid = "1"+sdipswitchcode+szTmp;
+          }
 					else if ((lighttype >= 200) && (lighttype < 300))
 					{
 						dtype = pTypeBlinds;
@@ -4439,7 +4480,7 @@ namespace http {
 				CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
 				if (pBaseHardware != NULL)
 				{
-					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP)) {
+					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP) || (pBaseHardware->HwdType == HTYPE_ITGWUDP)) {
 						ConvertToGeneralSwitchType(devid, dtype, subtype);
 					}
 				}
@@ -4725,6 +4766,40 @@ namespace http {
 						return;
 					devid = id;
 				}
+        else if (lighttype == 115)
+          {
+            dtype = pTypeGeneralSwitch;
+            subtype = lighttype;
+            std::string shousecode = request::findValue(&req, "housecode");
+            sunitcode = request::findValue(&req, "unitcode");
+            if (
+              (shousecode == "") ||
+              (sunitcode == "")
+              )
+              return;
+            sprintf(szTmp, "%02X", atoi(sunitcode.c_str()));
+						sunitcode = szTmp;
+						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+						shousecode = szTmp;
+						sprintf(szTmp, "%03X", switchtype);
+            devid = shousecode+sunitcode+szTmp;
+          }
+          else if (lighttype == 116)
+          {
+            dtype = pTypeGeneralSwitch;
+            subtype = lighttype;
+            std::string dipswitchcode = request::findValue(&req, "dipswitchcode");
+            sunitcode = "0";
+            std::string sdipswitchcode;
+            if (
+              (dipswitchcode == "")
+              )
+              return;
+						sprintf(szTmp, "%03X", std::stoi(dipswitchcode, nullptr, 2));
+						sdipswitchcode = szTmp;
+						sprintf(szTmp, "%02X", switchtype);
+            devid = "1"+sdipswitchcode+szTmp;
+          }
 				else
 				{
 					if (lighttype == 100)
@@ -4997,7 +5072,7 @@ namespace http {
 				CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
 				if (pBaseHardware != NULL)
 				{
-					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP)) {
+					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP) || (pBaseHardware->HwdType == HTYPE_ITGWUDP)) {
 						ConvertToGeneralSwitchType(devid, dtype, subtype);
 					}
 				}
@@ -10789,6 +10864,11 @@ namespace http {
 						else if ((pHardware->HwdType == HTYPE_RFLINKUSB) || (pHardware->HwdType == HTYPE_RFLINKTCP))
 						{
 							CRFLinkBase *pMyHardware = reinterpret_cast<CRFLinkBase*>(pHardware);
+							root["result"][ii]["version"] = pMyHardware->m_Version;
+						}
+            else if ((pHardware->HwdType == HTYPE_ITGWUDP))
+						{
+							CITGWBase *pMyHardware = reinterpret_cast<CITGWBase*>(pHardware);
 							root["result"][ii]["version"] = pMyHardware->m_Version;
 						}
 						else

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -4308,7 +4308,8 @@ namespace http {
               (dipswitchcode == "")
               )
               return;
-						sprintf(szTmp, "%03X", std::stoi(dipswitchcode, nullptr, 2));
+            char * pEnd;
+						sprintf(szTmp, "%03lX", std::strtol(dipswitchcode.c_str(), &pEnd, 2));
 						sdipswitchcode = szTmp;
 						sprintf(szTmp, "%02X", switchtype);
             devid = "1"+sdipswitchcode+szTmp;
@@ -4795,7 +4796,8 @@ namespace http {
               (dipswitchcode == "")
               )
               return;
-						sprintf(szTmp, "%03X", std::stoi(dipswitchcode, nullptr, 2));
+            char * pEnd;
+						sprintf(szTmp, "%03lX", std::strtol(dipswitchcode.c_str(), &pEnd, 2));
 						sdipswitchcode = szTmp;
 						sprintf(szTmp, "%02X", switchtype);
             devid = "1"+sdipswitchcode+szTmp;

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -267,7 +267,7 @@ private:
 	void Cmd_BleBoxClearNodes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_BleBoxAutoSearchingNodes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_BleBoxUpdateFirmware(WebEmSession & session, const request& req, Json::Value &root);
-	
+
 	void Cmd_GetTimerPlans(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_AddTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
@@ -314,6 +314,7 @@ private:
 	void RType_CreateEvohomeSensor(WebEmSession & session, const request& req, Json::Value &root);
 	void RType_BindEvohome(WebEmSession & session, const request& req, Json::Value &root);
 	void RType_CreateRFLinkDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CreateITGWDevice(WebEmSession & session, const request& req, Json::Value &root);
 #ifdef WITH_OPENZWAVE
 	//ZWave
 	void Cmd_ZWaveUpdateNode(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -119,6 +119,7 @@
 #include "../hardware/OpenWebNetUSB.h"
 #include "../hardware/InComfort.h"
 #include "../hardware/RelayNet.h"
+#include "../hardware/ITGWUDP.h"
 
 // load notifications configuration
 #include "../notifications/NotificationHelper.h"
@@ -979,6 +980,10 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_IntergasInComfortLAN2RF:
 		pHardware = new CInComfort(ID, Address, Port);
+		break;
+  case HTYPE_ITGWUDP:
+		//LAN
+		pHardware = new CITGWUDP(ID, Address);
 		break;
 	}
 

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -412,6 +412,7 @@
     <ClInclude Include="..\hardware\AnnaThermostat.h" />
     <ClInclude Include="..\hardware\Arilux.h" />
     <ClInclude Include="..\hardware\ASyncTCP.h" />
+    <ClInclude Include="..\hardware\ASyncUDP.h" />
     <ClInclude Include="..\hardware\AtagOne.h" />
     <ClInclude Include="..\hardware\Comm5Serial.h" />
     <ClInclude Include="..\hardware\Comm5TCP.h" />
@@ -441,6 +442,10 @@
     <ClInclude Include="..\hardware\I2C.h" />
     <ClInclude Include="..\hardware\ICYThermostat.h" />
     <ClInclude Include="..\hardware\InComfort.h" />
+    <ClInclude Include="..\hardware\itgw\ITGWSwitchBrennenstuhl.h" />
+    <ClInclude Include="..\hardware\itgw\ITGWSwitchIntertechno.h" />
+    <ClInclude Include="..\hardware\ITGWBase.h" />
+    <ClInclude Include="..\hardware\ITGWUDP.h" />
     <ClInclude Include="..\hardware\KMTronic433.h" />
     <ClInclude Include="..\hardware\KMTronicBase.h" />
     <ClInclude Include="..\hardware\KMTronicSerial.h" />
@@ -651,6 +656,7 @@
     <ClCompile Include="..\hardware\Arilux.cpp" />
     <ClCompile Include="..\hardware\ASyncSerial.cpp" />
     <ClCompile Include="..\hardware\ASyncTCP.cpp" />
+    <ClCompile Include="..\hardware\ASyncUDP.cpp" />
     <ClCompile Include="..\hardware\AtagOne.cpp" />
     <ClCompile Include="..\hardware\Comm5Serial.cpp" />
     <ClCompile Include="..\hardware\Comm5TCP.cpp" />
@@ -680,6 +686,10 @@
     <ClCompile Include="..\hardware\I2C.cpp" />
     <ClCompile Include="..\hardware\ICYThermostat.cpp" />
     <ClCompile Include="..\hardware\InComfort.cpp" />
+    <ClCompile Include="..\hardware\itgw\ITGWSwitchBrennenstuhl.cpp" />
+    <ClCompile Include="..\hardware\itgw\ITGWSwitchIntertechno.cpp" />
+    <ClCompile Include="..\hardware\ITGWBase.cpp" />
+    <ClCompile Include="..\hardware\ITGWUDP.cpp" />
     <ClCompile Include="..\hardware\KMTronic433.cpp" />
     <ClCompile Include="..\hardware\KMTronicBase.cpp" />
     <ClCompile Include="..\hardware\KMTronicSerial.cpp" />

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -1,6 +1,6 @@
 define(['app'], function (app) {
 	app.controller('LightsController', [ '$scope', '$rootScope', '$location', '$http', '$interval', 'permissions', function($scope,$rootScope,$location,$http,$interval,permissions) {
-	
+
 		$scope.HasInitializedAddManualDialog = false;
 		$scope.HasInitializedEditLightDialog = false;
 
@@ -577,7 +577,7 @@ define(['app'], function (app) {
 			$.isDimmer=isdimmer;
 			$.isSelector = (devsubtype === "Selector Switch");
 
-			$.bIsRGBWW=(devsubtype.indexOf("RGBWW") >= 0);			
+			$.bIsRGBWW=(devsubtype.indexOf("RGBWW") >= 0);
 			$.bIsRGBW=(devsubtype.indexOf("RGBW") >= 0);
 			$.bIsLED=(devsubtype.indexOf("RGB") >= 0);
 
@@ -1520,7 +1520,7 @@ define(['app'], function (app) {
 					}
 				}
 			});
-		   
+
 		}
 
 		EditLightDevice = function(idx,name,description,stype,switchtype,addjvalue,addjvalue2,isslave,customimage,devsubtype,strParam1,strParam2,bIsProtected,strUnit)
@@ -1536,7 +1536,7 @@ define(['app'], function (app) {
 			$.bIsSelectorSwitch = (devsubtype === "Selector Switch");
 
 			ConfigureEditLightSettings();
-			
+
 			var oTable;
 
 			if ($.bIsSelectorSwitch) {
@@ -1889,7 +1889,7 @@ define(['app'], function (app) {
 				}, 200);
 			}, 600);
 		}
-		
+
 		ConfigureAddManualSettings = function()
 		{
 			if ($scope.HasInitializedAddManualDialog==true) {
@@ -1955,7 +1955,7 @@ define(['app'], function (app) {
 				$('#dialog-addmanuallightdevice #homeconfortparams #combohousecode').append($('<option></option>').val(65+ii).html(String.fromCharCode(65+ii)));
 				$('#dialog-addmanuallightdevice #homeconfortparams #combounitcode').append($('<option></option>').val((ii+1)).html((ii+1)));
 			}
-			
+
 			RefreshHardwareComboArray();
 			$("#dialog-addmanuallightdevice #lighttable #combohardware").html("");
 			$.each($.ComboHardware, function(i,item){
@@ -3376,12 +3376,12 @@ define(['app'], function (app) {
 		UpdateAddManualDialog = function()
 		{
 			var lighttype=$("#dialog-addmanuallightdevice #lighttable #combolighttype option:selected").val();
-			var bIsARCType=((lighttype<20)||(lighttype==101));
+			var bIsARCType=((lighttype<20)||(lighttype==101)||(lighttype==115));
 			var bIsType5=0;
 
 			var tothousecodes=1;
 			var totunits=1;
-			if ((lighttype==0)||(lighttype==1)||(lighttype==3)||(lighttype==101)) {
+			if ((lighttype==0)||(lighttype==1)||(lighttype==3)||(lighttype==101)||(lighttype==115)) {
 				tothousecodes=16;
 				totunits=16;
 			}
@@ -3495,7 +3495,7 @@ define(['app'], function (app) {
 			    totrooms = 10;
 			    totpointofloads = 10
 			}
-            
+
 			$("#dialog-addmanuallightdevice #he105params").hide();
 			$("#dialog-addmanuallightdevice #blindsparams").hide();
 			$("#dialog-addmanuallightdevice #lightingparams_enocean").hide();
@@ -3507,6 +3507,7 @@ define(['app'], function (app) {
 			$("#dialog-addmanuallightdevice #openwebnetparamsZigbee").hide();
 			$("#dialog-addmanuallightdevice #openwebnetparamsDryContact").hide();
 			$("#dialog-addmanuallightdevice #openwebnetparamsIRdetec").hide();
+			$("#dialog-addmanuallightdevice #brennenstuhlparams").hide();
 
 			if (lighttype==104) {
 				//HE105
@@ -3514,6 +3515,12 @@ define(['app'], function (app) {
 				$("#dialog-addmanuallightdevice #lighting2params").hide();
 				$("#dialog-addmanuallightdevice #lighting3params").hide();
 				$("#dialog-addmanuallightdevice #he105params").show();
+			}if (lighttype==116) {
+				//Brennenstuhl
+				$("#dialog-addmanuallightdevice #lighting1params").hide();
+				$("#dialog-addmanuallightdevice #lighting2params").hide();
+				$("#dialog-addmanuallightdevice #lighting3params").hide();
+				$("#dialog-addmanuallightdevice #brennenstuhlparams").show();
 			}
 			else if (lighttype==303) {
 				$("#dialog-addmanuallightdevice #lighting1params").hide();
@@ -3774,12 +3781,15 @@ define(['app'], function (app) {
 				//GPIO
 				mParams+="&id=GPIO&unitcode="+$("#dialog-addmanuallightdevice #lightingparams_gpio #combogpio option:selected").val();
 			}
-			else if ((lighttype<20)||(lighttype==101)) {
+			else if ((lighttype<20)||(lighttype==101)||(lighttype==115)) {
 				mParams+="&housecode="+$("#dialog-addmanuallightdevice #lightparams1 #combohousecode option:selected").val();
 				mParams+="&unitcode="+$("#dialog-addmanuallightdevice #lightparams1 #combounitcode option:selected").val();
 			}
 			else if (lighttype==104) {
 				mParams+="&unitcode="+$("#dialog-addmanuallightdevice #he105params #combounitcode option:selected").text();
+			}
+      else if (lighttype==116) {
+				mParams+="&dipswitchcode="+$("#dialog-addmanuallightdevice #brennenstuhlparams #dipswitchcode").val();
 			}
 			else if ((lighttype>=200)&&(lighttype<300)) {
 				//Blinds
@@ -3822,7 +3832,7 @@ define(['app'], function (app) {
 			    var appID = parseInt($("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd1 option:selected").val() +
 					$("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd2 option:selected").val());
                 var ID = ("0002" + ("0000" + appID.toString(16)).slice(-4)); // WHO_AUTOMATION
-                var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd3 option:selected").val();//TODO : handle bus id (interface) in hardware 
+                var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd3 option:selected").val();//TODO : handle bus id (interface) in hardware
 				mParams+="&id="+ID.toUpperCase()+"&unitcode="+unitcode;
 			}
 			else if (lighttype==401) {
@@ -3830,7 +3840,7 @@ define(['app'], function (app) {
 			    var appID = parseInt($("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd1 option:selected").val() +
 					$("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd2 option:selected").val());
                 var ID = ("0001" + ("0000" + appID.toString(16)).slice(-4)); // WHO_LIGHTING
-                var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd3 option:selected").val();//TODO : handle bus id (interface) in hardware 
+                var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsBus #combocmd3 option:selected").val();//TODO : handle bus id (interface) in hardware
 				mParams+="&id="+ID.toUpperCase()+"&unitcode="+unitcode;
 			}
 			else if (lighttype==402) {

--- a/www/views/lights.html
+++ b/www/views/lights.html
@@ -289,6 +289,8 @@
 						<option value="404">Lights OpenWebNet Zigbee</option>
                         <option value="405">Dry Contact OpenWebNet</option>
                         <option value="406">IR Detection OpenWebNet</option>
+             <option value="115">ITGW InterTechno</option>
+             <option value="116">ITGW Brennenstuhl</option>
 			</select>
 			</td>
 		  </tr>
@@ -378,6 +380,16 @@
 					<td align="right" style="width:110px"><label>GPIO:</label></td>
 					<td>
 						<select id="combogpio" style="width:220px" class="combobox ui-corner-all"><option value="-1">?</option></select>
+					</td>
+				</tr>
+			</table>
+		</div>
+   	<div id="brennenstuhlparams">
+			<table class="display" id="brennenstuhlparams" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label><span data-i18n="Dipswitch Code">Dipswitch Code</span>:</label></td>
+          <td><input id="dipswitchcode" pattern="0|1" maxlength="10" minlength="10" style="width:160px" class="combobox ui-corner-all">
+							</input>
 					</td>
 				</tr>
 			</table>


### PR DESCRIPTION
This adds support for intertechno RF gateway(that sits on UDP) and dumb switches from both brennenstuhl and intertechno that can be commanded with it. It may be possible to use it to command many more devices, but I just happen to have samples of these two. I set it up to be easily expandable with more switch types.

P.S I have no means of fixing the visual studio build as I have no VS available and I don't seem to be able to replicate the other build bot fail(seemingly related to std c++ 11 not being available, is this deliberate? It seems to have no issue with stoi on mac, or in my own linux machine...) on Linux. It's been over a decade since I did anything in CPP :)