### PR TITLE
RelayNet: Create both relay and input devices disabled

### DIFF
--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -382,7 +382,7 @@ void RelayNet::SetupDevices()
 
 				m_sql.safe_query(
 					"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue) "
-					"VALUES (%d,'%q',%d, %d, %d, %d, 1, 12, 255, '%q', 0, ' ')",
+					"VALUES (%d,'%q',%d, %d, %d, %d, 0, 12, 255, '%q', 0, ' ')",
 					m_HwdID, szIdx, 100+inputNumber, pTypeLighting2, sTypeAC, int(STYPE_Contact), "Input");
 			}
 		}


### PR DESCRIPTION
Minor change: Input devices are now created disabled. This was already the case for the relays. The user will enable and rename them before actual use.