### PR TITLE
Notifications implemented per minute Last Update check

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2673,8 +2673,8 @@ void CSQLHelper::Do_Work()
 		std::vector<_tTaskItem>::iterator itt=_items2do.begin();
 		while (itt!=_items2do.end())
 		{
-			if (_log.isTraceEnable())	  
-						_log.Log(LOG_TRACE,"SQLH: Do Task ItemType:%d Cmd:%s Value:%s ",itt->_ItemType ,itt->_command.c_str() ,itt->_sValue.c_str() ); 
+			if (_log.isTraceEnable())
+						_log.Log(LOG_TRACE,"SQLH: Do Task ItemType:%d Cmd:%s Value:%s ",itt->_ItemType ,itt->_command.c_str() ,itt->_sValue.c_str() );
 
 			if (itt->_ItemType == TITEM_SWITCHCMD)
 			{
@@ -2967,7 +2967,7 @@ std::vector<std::vector<std::string> > CSQLHelper::query(const std::string &szQu
 
 	if (_log.isTraceEnable()) {
 		_log.Log(LOG_TRACE, "SQLQ query : %s", szQuery.c_str());
-		if (!_log.TestFilter("SQLR"))	
+		if (!_log.TestFilter("SQLR"))
 			LogQueryResult(results);
 	}
 
@@ -3805,7 +3805,7 @@ bool CSQLHelper::GetPreferencesVar(const std::string &Key, std::string &sValue)
 
 bool CSQLHelper::GetPreferencesVar(const std::string &Key, double &Value)
 {
-	
+
 	std::string sValue;
 	int nValue;
 	Value = 0;
@@ -6561,133 +6561,74 @@ void CSQLHelper::CheckDeviceTimeout()
 	GetPreferencesVar("SensorTimeoutNotification", TimeoutCheckInterval);
 
 	if (TimeoutCheckInterval==0)
+		return;
+	m_sensortimeoutcounter+=1;
+	if (m_sensortimeoutcounter<TimeoutCheckInterval)
+		return;
+	m_sensortimeoutcounter=0;
+
+	int SensorTimeOut=60;
+	GetPreferencesVar("SensorTimeout", SensorTimeOut);
+	time_t now = mytime(NULL);
+	struct tm stoday;
+	localtime_r(&now,&stoday);
+	now-=(SensorTimeOut*60);
+	struct tm ltime;
+	localtime_r(&now,&ltime);
+
+	std::vector<std::vector<std::string> > result;
+	result = safe_query(
+		"SELECT ID, Name, LastUpdate FROM DeviceStatus WHERE (Used!=0 AND LastUpdate<='%04d-%02d-%02d %02d:%02d:%02d' "
+		"AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d "
+		"AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d) "
+		"ORDER BY Name",
+		ltime.tm_year+1900,ltime.tm_mon+1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec,
+		pTypeLighting1,
+		pTypeLighting2,
+		pTypeLighting3,
+		pTypeLighting4,
+		pTypeLighting5,
+		pTypeLighting6,
+		pTypeFan,
+		pTypeRadiator1,
+		pTypeLimitlessLights,
+		pTypeSecurity1,
+		pTypeCurtain,
+		pTypeBlinds,
+		pTypeRFY,
+		pTypeChime,
+		pTypeThermostat2,
+		pTypeThermostat3,
+		pTypeThermostat4,
+		pTypeRemote,
+		pTypeGeneralSwitch,
+		pTypeHomeConfort
+		);
+	if (result.size()<1)
+		return;
+
+	uint64_t ulID;
+	std::vector<std::vector<std::string> >::const_iterator itt;
+
+	//check if last timeout_notification is not sent today and if true, send notification
+	for (itt=result.begin(); itt!=result.end(); ++itt)
 	{
-		std::vector<std::vector<std::string> > result;
-		std::string ttype = Notification_Type_Desc(NTYPE_LASTUPDATE, 1);
-		result = safe_query(
-			"SELECT A.DeviceRowID, A.Params, B.Name, B.LastUpdate "
-			"FROM Notifications AS A "
-			"LEFT OUTER JOIN DeviceStatus AS B "
-			"ON A.DeviceRowID=B.ID "
-			"WHERE (A.Params LIKE '%q%%') "
-			"ORDER BY Name",
-			ttype.c_str()
-			);
-		if (result.size()<1)
-			return;
-
-		uint64_t ulID;
-		int SensorTimeOut=60;
-		time_t now = mytime(NULL);
-		struct tm ltime;
-		localtime_r(&now,&ltime); // make sure DST is set correctly
-
-		std::vector<std::vector<std::string> >::const_iterator itt;
-		std::string ltype = Notification_Type_Desc(NTYPE_LASTUPDATE, 0);
-		std::string label = Notification_Type_Label(NTYPE_LASTUPDATE);
-
-		for (itt=result.begin(); itt!=result.end(); ++itt)
+		std::vector<std::string> sd=*itt;
+		std::stringstream s_str( sd[0] );
+		s_str >> ulID;
+		bool bDoSend=true;
+		std::map<uint64_t,int>::const_iterator sitt;
+		sitt=m_timeoutlastsend.find(ulID);
+		if (sitt!=m_timeoutlastsend.end())
 		{
-			std::vector<std::string> sd=*itt;
-			std::vector<std::string> splitparams;
-			std::stringstream(sd[0]) >> ulID;
-			StringSplit(sd[1], ";", splitparams);
-			if (splitparams.size() < 3 || sd[3].size() != 19)
-				continue;
-			bool bWhenIsGreater = (splitparams[1] == ">");
-			std::stringstream(splitparams[2]) >> SensorTimeOut;
-			std::stringstream(sd[3].substr(0,4)) >> ltime.tm_year;
-			ltime.tm_year-=1900;
-			std::stringstream(sd[3].substr(5,2)) >> ltime.tm_mon;
-			ltime.tm_mon--;
-			std::stringstream(sd[3].substr(8,2)) >> ltime.tm_mday;
-			std::stringstream(sd[3].substr(11,2)) >> ltime.tm_hour;
-			std::stringstream(sd[3].substr(14,2)) >> ltime.tm_min;
-			std::stringstream(sd[3].substr(17,2)) >> ltime.tm_sec;
-//			_log.Log(LOG_STATUS, "CheckDeviceTimeout: %s tm_year: %d, tm_mon: %d, tm_mday: %d, tm_hour: %d, "
-//				"tm_min: %d, tm_sec: %d, tm_isdst: %d, bWhenIsGreater: %s, SensorTimeOut: %d",
-//				sd[2].c_str(), ltime.tm_year, ltime.tm_mon, ltime.tm_mday, ltime.tm_hour,
-//				ltime.tm_min, ltime.tm_sec, ltime.tm_isdst,	bWhenIsGreater ? "true" : "false", SensorTimeOut);
-			double diff = difftime(now,mktime(&ltime));
-			if ((diff > SensorTimeOut*60 && bWhenIsGreater)||
-				(diff < SensorTimeOut*60 && !bWhenIsGreater))
-			{
-				char szTmp[300];
-				sprintf(szTmp,"Sensor %s %s: %s [%s %d %s]",sd[2].c_str(),ltype.c_str(),sd[3].c_str(),splitparams[1].c_str(),SensorTimeOut,label.c_str());
-				m_notifications.CheckAndHandleNotification(ulID, sd[2].c_str(), NTYPE_LASTUPDATE, szTmp);
-			}
+			bDoSend=(stoday.tm_mday!=sitt->second);
 		}
-	}
-	else
-	{
-		m_sensortimeoutcounter+=1;
-		if (m_sensortimeoutcounter<TimeoutCheckInterval)
-			return;
-		m_sensortimeoutcounter=0;
-
-		int SensorTimeOut=60;
-		GetPreferencesVar("SensorTimeout", SensorTimeOut);
-		time_t now = mytime(NULL);
-		struct tm stoday;
-		localtime_r(&now,&stoday);
-		now-=(SensorTimeOut*60);
-		struct tm ltime;
-		localtime_r(&now,&ltime);
-
-		std::vector<std::vector<std::string> > result;
-		result = safe_query(
-			"SELECT ID, Name, LastUpdate FROM DeviceStatus WHERE (Used!=0 AND LastUpdate<='%04d-%02d-%02d %02d:%02d:%02d' "
-			"AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d "
-			"AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d AND Type!=%d) "
-			"ORDER BY Name",
-			ltime.tm_year+1900,ltime.tm_mon+1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec,
-			pTypeLighting1,
-			pTypeLighting2,
-			pTypeLighting3,
-			pTypeLighting4,
-			pTypeLighting5,
-			pTypeLighting6,
-			pTypeFan,
-			pTypeRadiator1,
-			pTypeLimitlessLights,
-			pTypeSecurity1,
-			pTypeCurtain,
-			pTypeBlinds,
-			pTypeRFY,
-			pTypeChime,
-			pTypeThermostat2,
-			pTypeThermostat3,
-			pTypeThermostat4,
-			pTypeRemote,
-			pTypeGeneralSwitch,
-			pTypeHomeConfort
-			);
-		if (result.size()<1)
-			return;
-
-		uint64_t ulID;
-		std::vector<std::vector<std::string> >::const_iterator itt;
-
-		//check if last timeout_notification is not sent today and if true, send notification
-		for (itt=result.begin(); itt!=result.end(); ++itt)
+		if (bDoSend)
 		{
-			std::vector<std::string> sd=*itt;
-			std::stringstream s_str( sd[0] );
-			s_str >> ulID;
-			bool bDoSend=true;
-			std::map<uint64_t,int>::const_iterator sitt;
-			sitt=m_timeoutlastsend.find(ulID);
-			if (sitt!=m_timeoutlastsend.end())
-			{
-				bDoSend=(stoday.tm_mday!=sitt->second);
-			}
-			if (bDoSend)
-			{
-				char szTmp[300];
-				sprintf(szTmp,"Sensor Timeout: %s, Last Received: %s",sd[1].c_str(),sd[2].c_str());
-				m_notifications.SendMessageEx(0, std::string(""), NOTIFYALL, szTmp, szTmp, std::string(""), 1, std::string(""), true);
-				m_timeoutlastsend[ulID]=stoday.tm_mday;
-			}
+			char szTmp[300];
+			sprintf(szTmp,"Sensor Timeout: %s, Last Received: %s",sd[1].c_str(),sd[2].c_str());
+			m_notifications.SendMessageEx(0, std::string(""), NOTIFYALL, szTmp, szTmp, std::string(""), 1, std::string(""), true);
+			m_timeoutlastsend[ulID]=stoday.tm_mday;
 		}
 	}
 }
@@ -7168,7 +7109,7 @@ void CSQLHelper::AllowNewHardwareTimer(const int iTotMinutes)
 }
 
 std::string CSQLHelper::GetDeviceValue(const char * FieldName , const char *Idx )
-{	
+{
 	TSqlQueryResult result = safe_query("SELECT %s from DeviceStatus WHERE (ID == %s )",FieldName, Idx );
   if (result.size()>0)
 	  return  result[0][0];
@@ -7177,15 +7118,15 @@ std::string CSQLHelper::GetDeviceValue(const char * FieldName , const char *Idx 
 }
 
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , std::string &Value , std::string &Idx )
-{	
+{
 	safe_query("UPDATE DeviceStatus SET %s='%s' , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value.c_str() ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , int Value , std::string &Idx )
-{	
+{
 	safe_query("UPDATE DeviceStatus SET %s=%d , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , float Value , std::string &Idx )
-{	
+{
 	safe_query("UPDATE DeviceStatus SET %s=%4.2f , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
 }
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1542,6 +1542,7 @@ void MainWorker::Do_Work()
 					m_sql.UpdatePreferencesVar("WebPassword", "");
 					std::remove(szPwdResetFile.c_str());
 				}
+				m_notifications.CheckAndHandleLastUpdateNotification();
 			}
 			if (_log.NotificationLogsEnabled())
 			{

--- a/notifications/NotificationHelper.h
+++ b/notifications/NotificationHelper.h
@@ -13,6 +13,8 @@ struct _tNotification
 	std::string Params;
 	int Priority;
 	time_t LastSend;
+	time_t LastUpdate;
+	std::string DeviceName;
 	std::string CustomMessage;
 	std::string ActiveSystems;
 	bool SendAlways;
@@ -48,6 +50,7 @@ public:
 	bool IsInConfig(const std::string &Key);
 
 	//notification functions
+	void CheckAndHandleLastUpdateNotification();
 	void ReloadNotifications();
 	bool AddNotification(const std::string &DevIdx, const std::string &Param, const std::string &CustomMessage, const std::string &ActiveSystems, const int Priority, const bool SendAlways);
 	bool RemoveDeviceNotifications(const std::string &DevIdx);
@@ -55,6 +58,7 @@ public:
 	std::vector<_tNotification> GetNotifications(const uint64_t DevIdx);
 	std::vector<_tNotification> GetNotifications(const std::string &DevIdx);
 	void TouchNotification(const uint64_t ID);
+	void TouchLastUpdate(const uint64_t ID);
 	bool HasNotifications(const uint64_t DevIdx);
 	bool HasNotifications(const std::string &DevIdx);
 
@@ -91,9 +95,9 @@ public:
 		const std::string &DeviceName,
 		const _eNotificationTypes ntype);
 	bool CheckAndHandleSwitchNotification(
-		const uint64_t Idx, 
-		const std::string & DeviceName, 
-		const _eNotificationTypes ntype, 
+		const uint64_t Idx,
+		const std::string & DeviceName,
+		const _eNotificationTypes ntype,
 		const int llevel);
 	bool CheckAndHandleRainNotification(
 		const uint64_t Idx,


### PR DESCRIPTION
Last week I implemented the per hour timeout check, however I wanted something more sophisticated and be able to check every minute. I extended the notification function to store last update values, so it doesn't have to query the DB every minute. First I extended the CheckAndHandleNotification function, this however required so much rewriting, a separate function worked out better. I've now tested this with different kind of values (greater, below combined) and it works very well.

The hourly called CheckDeviceTimeout function is now as before, so disabled by default.