### PR TITLE
Lots of fixes and improvements on Teleinfo support thanks to forum feedback

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -835,7 +835,7 @@ void CDomoticzHardwareBase::SendAlertSensor(const int NodeID, const int BatteryL
 	gDevice.subtype = sTypeAlert;
 	gDevice.id = (unsigned char)NodeID;
 	gDevice.intval1 = alertLevel;
-        gDevice.text = message;
+        sprintf(gDevice.text, "%.199s", message.c_str());
 	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel);
 }
 

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -151,10 +151,7 @@ void CEcoDevices::DecodeXML2Teleinfo(const std::string &sResult, Teleinfo &telei
 	teleinfo.IINST1 = i_xpath_int(XMLdoc.RootElement(),"/response/IINST1/text()");
 	teleinfo.IINST2 = i_xpath_int(XMLdoc.RootElement(),"/response/IINST2/text()");
 	teleinfo.IINST3 = i_xpath_int(XMLdoc.RootElement(),"/response/IINST3/text()");
-	teleinfo.IMAX = i_xpath_int(XMLdoc.RootElement(),"/response/IMAX/text()");
-	teleinfo.IMAX1 =i_xpath_int(XMLdoc.RootElement(),"/response/IMAX1/text()");
-	teleinfo.IMAX2 = i_xpath_int(XMLdoc.RootElement(),"/response/IMAX2/text()");
-	teleinfo.IMAX3 = i_xpath_int(XMLdoc.RootElement(),"/response/IMAX3/text()");
+	teleinfo.PPOT = i_xpath_int(XMLdoc.RootElement(),"/response/PPOT/text()");
 	teleinfo.ADPS = i_xpath_int(XMLdoc.RootElement(),"/response/ADPS/text()");
 
 	#ifdef DEBUG_EcoDevices

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -2,16 +2,17 @@
 Domoticz Software : http://domoticz.com/
 File : TeleinfoBase.cpp
 Author : Blaise Thauvin
-Version : 1.1
+Version : 1.2
 Description : This class is used by various Teleinfo hardware decoders to process and display data
 		  It is currently used by EcoDevices, TeleinfoSerial
 		  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
-			  http://www.enedis.fr/sites/default/files/ERDF-NOI-CPT_02E.pdf
+	          http://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
 
 History :
 0.1 2017-03-03 : Creation
 1.0 2017-03-15 : Release candidate
 1.1 2017-03-18 : Updated to benefit from new messages in Alert sensors rather than simple text sensors
+1.2 2017-03-21 : Various bug fix and reverting to using P1SmartMeter as users requested
 */
 
 #include "stdafx.h"
@@ -19,6 +20,10 @@ History :
 #include "../main/Logger.h"
 #include "../main/localtime_r.h"
 
+
+#ifdef _DEBUG
+#define DEBUG_TeleinfoBase
+#endif
 
 CTeleinfoBase::CTeleinfoBase()
 {
@@ -35,30 +40,40 @@ void CTeleinfoBase::ProcessTeleinfo(Teleinfo &teleinfo)
 }
 
 
-// Alert level is 1 up to 100% usage, 2 then 3 above 100% load and 4 for maximum load (IMAX)
-int CTeleinfoBase::AlertLevel(int Iinst, int Imax, int Isousc)
+// Alert level is 1 up to 80% usage, 2 between 80% and 90%, 3 between 90% and 98%, 4 above
+int CTeleinfoBase::AlertLevel(int Iinst, int Isousc, char* text)
 {
 	int level;
-	double flevel;
+	float flevel;
 
-	if ((Imax - Isousc) == 0)
-		return 0;
-	if ((Imax - Iinst ) <=0)
-		level = 4;
-	else
-		flevel = (3.0 * Iinst + Imax- 4.0 * Isousc) / (Imax - Isousc);
-	if (flevel > 4) flevel = 4;
-	if (flevel < 1) flevel = 1;
-	level = (int)round(flevel + 0.49);
+	flevel = Iinst*100 / Isousc;
+        level = 1;
+	sprintf(text, " < 80%% de %iA souscrits", Isousc);
+	if (flevel > 80) 
+	{ 
+		level = 2;
+		sprintf(text, ">80%% et <90%% de %iA souscrits", Isousc);
+	}
+        if (level > 90) 
+        {
+                level = 3;
+                sprintf(text, ">90%% et <98%% de %iA souscrits", Isousc);
+        }
+        if (level > 98)
+        {
+                level = 3;
+                sprintf(text, ">98%% de %iA souscrits", Isousc);
+        } 
 	return level;
 }
 
 
 void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo &teleinfo)
 {
-	uint32_t m_pappHC, m_pappHP, m_pappHCJB, m_pappHPJB, m_pappHCJW, m_pappHPJW, m_pappHCJR, m_pappHPJR, checksum;
-	int  rate_alert = 0, color_alert = 0, demain = 0;
-	std::stringstream ss;
+	uint32_t m_pappHC, m_pappHP, m_pappHCJB, m_pappHPJB, m_pappHCJW, m_pappHPJW, m_pappHCJR, m_pappHPJR;
+	int rate_alert = 0, color_alert = 0, demain_alert = 0;
+	int alertI1, alertI2, alertI3, alertEJP, alertRate, alertPPOT; 
+	char szTmp[100];
 	std::string message;
 	time_t atime = mytime(NULL);
 
@@ -68,12 +83,13 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 		_log.Log(LOG_ERROR,"TeleinfoBase: Invalid rank passed to function (%i), must be between 1 and 4", rank);
 		return;
 	}
-	rank = rank -1;				 // Now it is 0 to 3
+	rank = rank -1;	 // Now it is 0 to 3
 
 	// Guess if we are running with one phase or three
-	// (some devices like EcoDevices always send all variables regardless or the real setting)
-	if ((teleinfo.triphase == true) || (teleinfo.IINST2 > 0) || (teleinfo.IINST3 > 0) || (teleinfo.IMAX2 > 0) || (teleinfo.IMAX3 > 0))
-		teleinfo.triphase=true;
+	// some devices like EcoDevices always send all variables so presence/absence of IINSTx is not significant
+	// Also, EcoDevices sends always sends the same value for IINST and IINST1, so check must be done on IINST2 and IINST3
+	if ((teleinfo.triphase == true) || (teleinfo.IINST2 > 0) || (teleinfo.IINST3 > 0))
+		teleinfo.triphase  = true;
 
 	// PAPP only exist on some meter versions. If not present, we can approximate it as (current x 230V)
 	if ((teleinfo.PAPP == 0) && ((teleinfo.IINST > 0)||(teleinfo.IINST1 > 0)||(teleinfo.IINST2 > 0)||(teleinfo.IINST3 > 0)))
@@ -119,14 +135,14 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 		rate_alert = 3;
 	}
 
-	// Checksum to detect changes between measures
-	checksum=teleinfo.BASE + teleinfo.HCHC + teleinfo.HCHP + teleinfo.EJPHN + teleinfo.EJPHPM + teleinfo.BBRHCJB + teleinfo.PEJP\
-		+ teleinfo.BBRHPJB + teleinfo.BBRHCJW + teleinfo.BBRHPJB + teleinfo.BBRHCJR + teleinfo.BBRHPJR + teleinfo.PAPP;
-
 	//Send data if value changed, at most every minute and at least every 5 minutes
-	if (((teleinfo.previous != checksum) && (difftime(atime, teleinfo.last) >= 60)) || (difftime(atime, teleinfo.last) >= 300))
+	if (((teleinfo.pAlertPAPP != teleinfo.PAPP) && (difftime(atime, teleinfo.last) >= 60)) || (difftime(atime, teleinfo.last) >= 300))
 	{
-		teleinfo.previous = checksum;
+ 	#ifdef DEBUG_TeleinfoBase
+        _log.Log(LOG_STATUS,"Triphase=%s, I=%i, I1=%i, I2=%i, I3=%i", (teleinfo.triphase)?"True":"False", 
+		teleinfo.IINST, teleinfo.IINST1, teleinfo.IINST2, teleinfo.IINST3);
+        #endif
+		teleinfo.pAlertPAPP = teleinfo.PAPP;
 		teleinfo.last = atime;
 		m_p1power.usagecurrent = teleinfo.PAPP;
 		if (teleinfo.OPTARIF == "BASE")
@@ -134,29 +150,34 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 			teleinfo.tariff="Tarif de Base";
 			m_p1power.powerusage1 = teleinfo.BASE;
 			m_p1power.powerusage2 = 0;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " Total").c_str(), 255);
-			SendKwhMeter(m_HwdID, 32*rank + 2, 255, teleinfo.PAPP, teleinfo.BASE/1000.0, name + " Index kWh");
+			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
+		//	SendKwhMeter(m_HwdID, 32*rank + 2, 255, teleinfo.PAPP, teleinfo.BASE/1000.0, name + " kWh Total");
 		}
 		else if (teleinfo.OPTARIF == "HC..")
 		{
 			teleinfo.tariff="Tarif option Heures Creuses";
 			SendKwhMeter(m_HwdID, 32*rank + 3, 255, m_pappHC, teleinfo.HCHC/1000.0, name + " kWh Heures Creuses");
 			SendKwhMeter(m_HwdID, 32*rank + 4, 255, m_pappHP, teleinfo.HCHP/1000.0, name + " kWh Heures Pleines");
-			m_p1power.powerusage1 = teleinfo.HCHC;
-			m_p1power.powerusage2 = teleinfo.HCHP;
+			m_p1power.powerusage1 = teleinfo.HCHP;
+			m_p1power.powerusage2 = teleinfo.HCHC;
 			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
-			//	SendKwhMeter(m_HwdID, 32*rank + 5, 255, teleinfo.PAPP, (teleinfo.HCHP + teleinfo.HCHC)/1000.0, name + " kWh Total");
+		//	SendKwhMeter(m_HwdID, 32*rank + 5, 255, teleinfo.PAPP, (teleinfo.HCHP + teleinfo.HCHC)/1000.0, name + " kWh Total");
 		}
 		else if (teleinfo.OPTARIF == "EJP.")
 		{
 			teleinfo.tariff="Tarif option EJP";
 			SendKwhMeter(m_HwdID, 32*rank + 6, 255, m_pappHC, teleinfo.EJPHN/1000.0, name + " kWh Heures Normales");
 			SendKwhMeter(m_HwdID, 32*rank + 7, 255, m_pappHP, teleinfo.EJPHPM/1000.0, name + " kWh Pointe Mobile");
-			m_p1power.powerusage1 = teleinfo.EJPHN;
-			m_p1power.powerusage2 = teleinfo.EJPHPM;
+			m_p1power.powerusage1 = teleinfo.EJPHPM;
+			m_p1power.powerusage2 = teleinfo.EJPHN;
 			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh EJP").c_str(), 255);
-			//		SendKwhMeter(m_HwdID, 32*rank + 8, 255, teleinfo.PAPP, (teleinfo.EJPHN + teleinfo.EJPHPM)/1000.0, name + " Total");
-			SendAlertSensor(32*rank + 2, 255, ((teleinfo.PEJP == 30) ? 4 : 1), teleinfo.rate, (name + " Preannonce Pointe Mobile"));
+		//	SendKwhMeter(m_HwdID, 32*rank + 8, 255, teleinfo.PAPP, (teleinfo.EJPHN + teleinfo.EJPHPM)/1000.0, name + "kWh  Total");
+			alertEJP =  (teleinfo.PEJP == 30) ? 4 : 1;
+			if (alertEJP != teleinfo.pAlertEJP)
+			{
+				SendAlertSensor(32*rank + 2, 255, alertEJP, teleinfo.rate, (name + " Preannonce Pointe Mobile"));
+				teleinfo.pAlertEJP = alertEJP;
+			}
 		}
 		else if (teleinfo.OPTARIF.substr(0,3) == "BBR")
 		{
@@ -207,71 +228,100 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 			//SendKwhMeter(m_HwdID, 32*rank + 15, 255, m_pappHPJR, teleinfo.BBRHCJR/1000.0, name + " Jour Rouge, Plein");
 			SendKwhMeter(m_HwdID, 32*rank + 16, 255, teleinfo.PAPP, (teleinfo.BBRHCJB + teleinfo.BBRHPJB + teleinfo.BBRHCJW
 				+ teleinfo.BBRHPJW + teleinfo.BBRHCJR + teleinfo.BBRHPJR)/1000.0, name + " kWh Total");
-			m_p1power.powerusage1 = teleinfo.BBRHCJB;
-			m_p1power.powerusage2 = teleinfo.BBRHPJB;
+			m_p1power.powerusage1 = teleinfo.BBRHPJB;
+			m_p1power.powerusage2 = teleinfo.BBRHCJB;
 			m_p1power.usagecurrent = m_pappHCJB + m_pappHPJB;
-			m_p2power.powerusage1 = teleinfo.BBRHCJW;
-			m_p2power.powerusage2 = teleinfo.BBRHPJW;
+			m_p2power.powerusage1 = teleinfo.BBRHPJW;
+			m_p2power.powerusage2 = teleinfo.BBRHCJW;
 			m_p2power.usagecurrent = m_pappHCJW + m_pappHPJW;
-			m_p3power.powerusage1 = teleinfo.BBRHCJR;
-			m_p3power.powerusage2 = teleinfo.BBRHPJR;
+			m_p3power.powerusage1 = teleinfo.BBRHPJR;
+			m_p3power.powerusage2 = teleinfo.BBRHCJR;
 			m_p3power.usagecurrent = m_pappHCJR + m_pappHPJR;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + "Jours Bleus").c_str(), 255);
-			sDecodeRXMessage(this, (const unsigned char *)&m_p2power, (name + "Jours Blancs").c_str(), 255);
-			sDecodeRXMessage(this, (const unsigned char *)&m_p3power, (name + "Jours Rouges").c_str(), 255);
-			SendAlertSensor(32*rank + 2, 255, color_alert, ("Jour " + teleinfo.color), (name + " Couleur du jour"));
+			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + "kWh Jours Bleus").c_str(), 255);
+			sDecodeRXMessage(this, (const unsigned char *)&m_p2power, (name + "kWh Jours Blancs").c_str(), 255);
+			sDecodeRXMessage(this, (const unsigned char *)&m_p3power, (name + "kWh Jours Rouges").c_str(), 255);
+			if (color_alert != teleinfo.pAlertColor) 
+			{
+				SendAlertSensor(32*rank + 2, 255, color_alert, ("Jour " + teleinfo.color), (name + " Couleur du jour"));
+				teleinfo.pAlertColor = color_alert;
+			}
 			if (teleinfo.DEMAIN == "BLEU")
-				demain = 1;
+				demain_alert = 1;
 			else if  (teleinfo.DEMAIN == "BLANC")
-				demain = 2;
+				demain_alert = 2;
 			else if  (teleinfo.DEMAIN == "ROUG")
 			{
-				demain = 3;
+				demain_alert = 3;
 				teleinfo.DEMAIN = "ROUGE";
 			}
-			else demain = 0;
-			SendAlertSensor(32*rank + 3, 255, demain, ("Demain, jour " + teleinfo.DEMAIN) , (name + " Couleur demain"));
+			else demain_alert = 0;
+			if (demain_alert != teleinfo.pAlertDemain)
+			{
+				SendAlertSensor(32*rank + 3, 255, demain_alert, ("Demain, jour " + teleinfo.DEMAIN) , (name + " Couleur demain"));
+				teleinfo.pAlertDemain = demain_alert;
+			} 
 		}
 		// Common sensors for all rates
-		SendAlertSensor(32*rank + 1, 255, rate_alert, teleinfo.rate, (name + " Tarif en cours"));
+		if (rate_alert != teleinfo.pAlertRate)
+		{
+			SendAlertSensor(32*rank + 1, 255, rate_alert, teleinfo.rate, name + " Tarif en cours");
+			teleinfo.pAlertRate = rate_alert;
+		}	
 		if (teleinfo.triphase == false)
 		{
 			SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST, 0, 0, name + " Courant");
-			ss.clear();
-			ss << teleinfo.IINST << "A, sur " << teleinfo.ISOUSC << "A souscrits";
-			message = ss.str();
-			SendAlertSensor(32*rank + 4, 255, AlertLevel(teleinfo.IINST, teleinfo.IMAX, teleinfo.ISOUSC),
-				message, (name + " Alerte courant maximal"));
-			SendPercentageSensor(32* rank + 1, 0, 255, (teleinfo.IINST*100)/float(teleinfo.IMAX), name + " Intensite souscrite");
+			alertI1 =  AlertLevel(teleinfo.IINST, teleinfo.ISOUSC, szTmp);
+			if (alertI1 != teleinfo.pAlertI1)
+			{
+				SendAlertSensor(32*rank + 4, 255, alertI1, szTmp, name + " Alerte courant");
+				teleinfo.pAlertI1 = alertI1;
+			}
+			SendPercentageSensor(32* rank + 1, 0, 255, (teleinfo.IINST*100)/float(teleinfo.ISOUSC), name + " Pourcentage de Charge");
 		}
 		else
 		{
 			SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST1, (float)teleinfo.IINST2, (float)teleinfo.IINST3,
 				name + " Courant");
-			ss.clear();
-			ss << teleinfo.IINST1 << "A, sur " << teleinfo.ISOUSC << "A souscrits";
-			message = ss.str();
-			SendAlertSensor(32*rank + 4, 255, AlertLevel(teleinfo.IINST1, teleinfo.IMAX1, teleinfo.ISOUSC),
-				message, (name + " Alerte courant phase 1"));
-			ss.clear();
-			ss << teleinfo.IINST2 << "A, sur " << teleinfo.ISOUSC << "A souscrits";
-			message = ss.str();
-			SendAlertSensor(32*rank + 5, 255, AlertLevel(teleinfo.IINST2, teleinfo.IMAX2, teleinfo.ISOUSC),
-				message, (name + " Alerte courant phase 2"));
-			ss.clear();
-			ss << teleinfo.IINST3 << "A, sur " << teleinfo.ISOUSC << "A souscrits";
-			message = ss.str();
-			SendAlertSensor(32*rank + 6, 255, AlertLevel(teleinfo.IINST3, teleinfo.IMAX3, teleinfo.ISOUSC),
-				message, (name + " Alerte courant phase 3"));
-			if (teleinfo.IMAX1 > 0)
-				SendPercentageSensor(32 * rank + 1, 0, 255, (teleinfo.IINST1*100)/float(teleinfo.IMAX1),
+			alertI1 = AlertLevel(teleinfo.IINST1, teleinfo.ISOUSC, szTmp);
+                        if (alertI1 != teleinfo.pAlertI1)
+                        {
+                                SendAlertSensor(32*rank + 4, 255, alertI1, szTmp, name + " Alerte phase 1");
+                                teleinfo.pAlertI1 = alertI1;
+                        }
+			alertI2 = AlertLevel(teleinfo.IINST2, teleinfo.ISOUSC, szTmp);
+                        if (alertI2 != teleinfo.pAlertI2)
+                        {
+                                SendAlertSensor(32*rank + 5, 255, alertI2, szTmp, name + " Alerte phase 2");
+                                teleinfo.pAlertI2 = alertI2;
+                        }
+			alertI3 = AlertLevel(teleinfo.IINST3, teleinfo.ISOUSC, szTmp);
+                        if (alertI3 != teleinfo.pAlertI3)
+                        {
+                                SendAlertSensor(32*rank + 6, 255, alertI3, szTmp, name + " Alerte phase 3");
+                                teleinfo.pAlertI3 = alertI3;
+                        }
+			if (teleinfo.PPOT != teleinfo.pAlertPPOT) 
+			{
+				if (teleinfo.PPOT !=0)
+					alertPPOT = 4;
+				else
+					alertPPOT = 1;
+				teleinfo.pAlertPPOT = teleinfo.PPOT;
+				teleinfo.PPOT>>=1;
+				std::stringstream ss;
+                                ss << "Bitmap phases: " <<std::bitset<3>(~teleinfo.PPOT);
+                                message = ss.str();
+				SendAlertSensor(32*rank+7, 255, alertPPOT, message, " Alerte Potentiels");
+			}
+			if (teleinfo.ISOUSC > 0) 
+			{
+				SendPercentageSensor(32 * rank + 1, 0, 255, (teleinfo.IINST1*100)/float(teleinfo.ISOUSC),
 					name + " Charge phase 1");
-			if (teleinfo.IMAX2 > 0)
-				SendPercentageSensor(32 * rank + 2, 0, 255, (teleinfo.IINST2*100)/float(teleinfo.IMAX2),
+				SendPercentageSensor(32 * rank + 2, 0, 255, (teleinfo.IINST2*100)/float(teleinfo.ISOUSC),
 					name + " Charge phase 2");
-			if (teleinfo.IMAX3 > 0)
-				SendPercentageSensor(32 * rank + 3, 0, 255, (teleinfo.IINST3*100)/float(teleinfo.IMAX3),
+				SendPercentageSensor(32 * rank + 3, 0, 255, (teleinfo.IINST3*100)/float(teleinfo.ISOUSC),
 					name + " charge phase 3");
+			}
 		}
 	}
 }

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -6,7 +6,7 @@ Version : 1.2
 Description : This class is used by various Teleinfo hardware decoders to process and display data
 		  It is currently used by EcoDevices, TeleinfoSerial
 		  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
-	          http://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
+			  http://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
 
 History :
 0.1 2017-03-03 : Creation
@@ -19,7 +19,7 @@ History :
 #include "TeleinfoBase.h"
 #include "../main/Logger.h"
 #include "../main/localtime_r.h"
-
+#include <bitset>				 // This is necessary to compile on Windows
 
 #ifdef _DEBUG
 #define DEBUG_TeleinfoBase
@@ -31,6 +31,7 @@ CTeleinfoBase::CTeleinfoBase()
 	m_p2power.ID = 2;
 	m_p3power.ID = 3;
 }
+
 
 CTeleinfoBase::~CTeleinfoBase() {}
 
@@ -47,23 +48,23 @@ int CTeleinfoBase::AlertLevel(int Iinst, int Isousc, char* text)
 	float flevel;
 
 	flevel = Iinst*100 / Isousc;
-        level = 1;
+	level = 1;
 	sprintf(text, " < 80%% de %iA souscrits", Isousc);
-	if (flevel > 80) 
-	{ 
+	if (flevel > 80)
+	{
 		level = 2;
 		sprintf(text, ">80%% et <90%% de %iA souscrits", Isousc);
 	}
-        if (level > 90) 
-        {
-                level = 3;
-                sprintf(text, ">90%% et <98%% de %iA souscrits", Isousc);
-        }
-        if (level > 98)
-        {
-                level = 3;
-                sprintf(text, ">98%% de %iA souscrits", Isousc);
-        } 
+	if (level > 90)
+	{
+		level = 3;
+		sprintf(text, ">90%% et <98%% de %iA souscrits", Isousc);
+	}
+	if (level > 98)
+	{
+		level = 3;
+		sprintf(text, ">98%% de %iA souscrits", Isousc);
+	}
 	return level;
 }
 
@@ -72,7 +73,7 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 {
 	uint32_t m_pappHC, m_pappHP, m_pappHCJB, m_pappHPJB, m_pappHCJW, m_pappHPJW, m_pappHCJR, m_pappHPJR;
 	int rate_alert = 0, color_alert = 0, demain_alert = 0;
-	int alertI1, alertI2, alertI3, alertEJP, alertRate, alertPPOT; 
+	int alertI1, alertI2, alertI3, alertEJP, alertRate, alertPPOT;
 	char szTmp[100];
 	std::string message;
 	time_t atime = mytime(NULL);
@@ -83,7 +84,7 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 		_log.Log(LOG_ERROR,"TeleinfoBase: Invalid rank passed to function (%i), must be between 1 and 4", rank);
 		return;
 	}
-	rank = rank -1;	 // Now it is 0 to 3
+	rank = rank -1;				 // Now it is 0 to 3
 
 	// Guess if we are running with one phase or three
 	// some devices like EcoDevices always send all variables so presence/absence of IINSTx is not significant
@@ -135,172 +136,192 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 		rate_alert = 3;
 	}
 
-	//Send data if value changed, at most every minute and at least every 5 minutes
-	if (((teleinfo.pAlertPAPP != teleinfo.PAPP) && (difftime(atime, teleinfo.last) >= 60)) || (difftime(atime, teleinfo.last) >= 300))
+	// Process only if power consumption changed. If it did not, then alerts and intensity have not changed either
+	if (teleinfo.pAlertPAPP != teleinfo.PAPP)
 	{
- 	#ifdef DEBUG_TeleinfoBase
-        _log.Log(LOG_STATUS,"Triphase=%s, I=%i, I1=%i, I2=%i, I3=%i", (teleinfo.triphase)?"True":"False", 
-		teleinfo.IINST, teleinfo.IINST1, teleinfo.IINST2, teleinfo.IINST3);
-        #endif
-		teleinfo.pAlertPAPP = teleinfo.PAPP;
-		teleinfo.last = atime;
-		m_p1power.usagecurrent = teleinfo.PAPP;
-		if (teleinfo.OPTARIF == "BASE")
+		//Send data if value changed, at most every minute and at least every 5 minutes
+		if ((difftime(atime, teleinfo.last) >= 60) || (difftime(atime, teleinfo.last) >= 300))
 		{
-			teleinfo.tariff="Tarif de Base";
-			m_p1power.powerusage1 = teleinfo.BASE;
-			m_p1power.powerusage2 = 0;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
-		//	SendKwhMeter(m_HwdID, 32*rank + 2, 255, teleinfo.PAPP, teleinfo.BASE/1000.0, name + " kWh Total");
-		}
-		else if (teleinfo.OPTARIF == "HC..")
-		{
-			teleinfo.tariff="Tarif option Heures Creuses";
-			SendKwhMeter(m_HwdID, 32*rank + 3, 255, m_pappHC, teleinfo.HCHC/1000.0, name + " kWh Heures Creuses");
-			SendKwhMeter(m_HwdID, 32*rank + 4, 255, m_pappHP, teleinfo.HCHP/1000.0, name + " kWh Heures Pleines");
-			m_p1power.powerusage1 = teleinfo.HCHP;
-			m_p1power.powerusage2 = teleinfo.HCHC;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
-		//	SendKwhMeter(m_HwdID, 32*rank + 5, 255, teleinfo.PAPP, (teleinfo.HCHP + teleinfo.HCHC)/1000.0, name + " kWh Total");
-		}
-		else if (teleinfo.OPTARIF == "EJP.")
-		{
-			teleinfo.tariff="Tarif option EJP";
-			SendKwhMeter(m_HwdID, 32*rank + 6, 255, m_pappHC, teleinfo.EJPHN/1000.0, name + " kWh Heures Normales");
-			SendKwhMeter(m_HwdID, 32*rank + 7, 255, m_pappHP, teleinfo.EJPHPM/1000.0, name + " kWh Pointe Mobile");
-			m_p1power.powerusage1 = teleinfo.EJPHPM;
-			m_p1power.powerusage2 = teleinfo.EJPHN;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh EJP").c_str(), 255);
-		//	SendKwhMeter(m_HwdID, 32*rank + 8, 255, teleinfo.PAPP, (teleinfo.EJPHN + teleinfo.EJPHPM)/1000.0, name + "kWh  Total");
-			alertEJP =  (teleinfo.PEJP == 30) ? 4 : 1;
-			if (alertEJP != teleinfo.pAlertEJP)
+			#ifdef DEBUG_TeleinfoBase
+			_log.Log(LOG_STATUS,"Triphase=%s, I=%i, I1=%i, I2=%i, I3=%i", (teleinfo.triphase)?"True":"False",
+				teleinfo.IINST, teleinfo.IINST1, teleinfo.IINST2, teleinfo.IINST3);
+			#endif
+			teleinfo.pAlertPAPP = teleinfo.PAPP;
+			teleinfo.last = atime;
+			m_p1power.usagecurrent = teleinfo.PAPP;
+			if (teleinfo.OPTARIF == "BASE")
 			{
-				SendAlertSensor(32*rank + 2, 255, alertEJP, teleinfo.rate, (name + " Preannonce Pointe Mobile"));
-				teleinfo.pAlertEJP = alertEJP;
+				teleinfo.tariff="Tarif de Base";
+				m_p1power.powerusage1 = teleinfo.BASE;
+				m_p1power.powerusage2 = 0;
+				sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
+				//	SendKwhMeter(m_HwdID, 32*rank + 2, 255, teleinfo.PAPP, teleinfo.BASE/1000.0, name + " kWh Total");
 			}
-		}
-		else if (teleinfo.OPTARIF.substr(0,3) == "BBR")
-		{
-			teleinfo.tariff="Tarif option TEMPO";
-			m_pappHCJB=0;
-			m_pappHPJB=0;
-			m_pappHCJW=0;
-			m_pappHPJW=0;
-			m_pappHCJR=0;
-			m_pappHPJR=0;
-			if (teleinfo.PTEC.substr(3,1) == "B")
+			else if (teleinfo.OPTARIF == "HC..")
 			{
-				teleinfo.color="Bleu";
-				color_alert = 1;
-				if (teleinfo.rate == "Heures Creuses")
-					m_pappHCJB=teleinfo.PAPP;
-				else
-					m_pappHPJB=teleinfo.PAPP;
+				teleinfo.tariff="Tarif option Heures Creuses";
+				SendKwhMeter(m_HwdID, 32*rank + 3, 255, m_pappHC, teleinfo.HCHC/1000.0, name + " kWh Heures Creuses");
+				SendKwhMeter(m_HwdID, 32*rank + 4, 255, m_pappHP, teleinfo.HCHP/1000.0, name + " kWh Heures Pleines");
+				m_p1power.powerusage1 = teleinfo.HCHP;
+				m_p1power.powerusage2 = teleinfo.HCHC;
+				sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh Total").c_str(), 255);
+				//	SendKwhMeter(m_HwdID, 32*rank + 5, 255, teleinfo.PAPP, (teleinfo.HCHP + teleinfo.HCHC)/1000.0, name + " kWh Total");
 			}
-			else if (teleinfo.PTEC.substr(3,1) == "W")
+			else if (teleinfo.OPTARIF == "EJP.")
 			{
-				teleinfo.color="Blanc";
-				color_alert = 2;
-				if (teleinfo.rate == "Heures Creuses")
-					m_pappHCJW=teleinfo.PAPP;
-				else
-					m_pappHPJW=teleinfo.PAPP;
+				teleinfo.tariff="Tarif option EJP";
+				SendKwhMeter(m_HwdID, 32*rank + 6, 255, m_pappHC, teleinfo.EJPHN/1000.0, name + " kWh Heures Normales");
+				SendKwhMeter(m_HwdID, 32*rank + 7, 255, m_pappHP, teleinfo.EJPHPM/1000.0, name + " kWh Pointe Mobile");
+				m_p1power.powerusage1 = teleinfo.EJPHPM;
+				m_p1power.powerusage2 = teleinfo.EJPHN;
+				sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + " kWh EJP").c_str(), 255);
+				//	SendKwhMeter(m_HwdID, 32*rank + 8, 255, teleinfo.PAPP, (teleinfo.EJPHN + teleinfo.EJPHPM)/1000.0, name + "kWh  Total");
+				alertEJP =  (teleinfo.PEJP == 30) ? 4 : 1;
+				if (alertEJP != teleinfo.pAlertEJP)
+				{
+					SendAlertSensor(32*rank + 2, 255, alertEJP, teleinfo.rate, (name + " Preannonce Pointe Mobile"));
+					teleinfo.pAlertEJP = alertEJP;
+				}
 			}
-			else if (teleinfo.PTEC.substr(3,1) == "R")
+			else if (teleinfo.OPTARIF.substr(0,3) == "BBR")
 			{
-				teleinfo.color="Rouge";
-				color_alert = 3;
-				if (teleinfo.rate == "Heures Creuses")
-					m_pappHCJR=teleinfo.PAPP;
+				teleinfo.tariff="Tarif option TEMPO";
+				m_pappHCJB=0;
+				m_pappHPJB=0;
+				m_pappHCJW=0;
+				m_pappHPJW=0;
+				m_pappHCJR=0;
+				m_pappHPJR=0;
+				if (teleinfo.PTEC.substr(3,1) == "B")
+				{
+					teleinfo.color="Bleu";
+					color_alert = 1;
+					if (teleinfo.rate == "Heures Creuses")
+						m_pappHCJB=teleinfo.PAPP;
+					else
+						m_pappHPJB=teleinfo.PAPP;
+				}
+				else if (teleinfo.PTEC.substr(3,1) == "W")
+				{
+					teleinfo.color="Blanc";
+					color_alert = 2;
+					if (teleinfo.rate == "Heures Creuses")
+						m_pappHCJW=teleinfo.PAPP;
+					else
+						m_pappHPJW=teleinfo.PAPP;
+				}
+				else if (teleinfo.PTEC.substr(3,1) == "R")
+				{
+					teleinfo.color="Rouge";
+					color_alert = 3;
+					if (teleinfo.rate == "Heures Creuses")
+						m_pappHCJR=teleinfo.PAPP;
+					else
+						m_pappHPJR=teleinfo.PAPP;
+				}
 				else
-					m_pappHPJR=teleinfo.PAPP;
+				{
+					teleinfo.color = "Unknown";
+					color_alert = 3;
+				}
+				//SendKwhMeter(m_HwdID, 32*rank + 10, 255, m_pappHCJB, teleinfo.BBRHCJB/1000.0, name + " Jour Bleu, Creux");
+				//SendKwhMeter(m_HwdID, 32*rank + 11, 255, m_pappHPJB, teleinfo.BBRHPJB/1000.0, name + " Jour Bleu, Plein");
+				//SendKwhMeter(m_HwdID, 32*rank + 12, 255, m_pappHCJW, teleinfo.BBRHCJW/1000.0, name + " Jour Blanc, Creux");
+				//SendKwhMeter(m_HwdID, 32*rank + 13, 255, m_pappHPJW, teleinfo.BBRHPJW/1000.0, name + " Jour Blanc, Plein");
+				//SendKwhMeter(m_HwdID, 32*rank + 14, 255, m_pappHCJR, teleinfo.BBRHCJR/1000.0, name + " Jour Rouge, Creux");
+				//SendKwhMeter(m_HwdID, 32*rank + 15, 255, m_pappHPJR, teleinfo.BBRHCJR/1000.0, name + " Jour Rouge, Plein");
+				SendKwhMeter(m_HwdID, 32*rank + 16, 255, teleinfo.PAPP, (teleinfo.BBRHCJB + teleinfo.BBRHPJB + teleinfo.BBRHCJW
+					+ teleinfo.BBRHPJW + teleinfo.BBRHCJR + teleinfo.BBRHPJR)/1000.0, name + " kWh Total");
+				m_p1power.powerusage1 = teleinfo.BBRHPJB;
+				m_p1power.powerusage2 = teleinfo.BBRHCJB;
+				m_p1power.usagecurrent = m_pappHCJB + m_pappHPJB;
+				m_p2power.powerusage1 = teleinfo.BBRHPJW;
+				m_p2power.powerusage2 = teleinfo.BBRHCJW;
+				m_p2power.usagecurrent = m_pappHCJW + m_pappHPJW;
+				m_p3power.powerusage1 = teleinfo.BBRHPJR;
+				m_p3power.powerusage2 = teleinfo.BBRHCJR;
+				m_p3power.usagecurrent = m_pappHCJR + m_pappHPJR;
+				sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + "kWh Jours Bleus").c_str(), 255);
+				sDecodeRXMessage(this, (const unsigned char *)&m_p2power, (name + "kWh Jours Blancs").c_str(), 255);
+				sDecodeRXMessage(this, (const unsigned char *)&m_p3power, (name + "kWh Jours Rouges").c_str(), 255);
+				if (color_alert != teleinfo.pAlertColor)
+				{
+					SendAlertSensor(32*rank + 2, 255, color_alert, ("Jour " + teleinfo.color), (name + " Couleur du jour"));
+					teleinfo.pAlertColor = color_alert;
+				}
+				if (teleinfo.DEMAIN == "BLEU")
+					demain_alert = 1;
+				else if  (teleinfo.DEMAIN == "BLANC")
+					demain_alert = 2;
+				else if  (teleinfo.DEMAIN == "ROUG")
+				{
+					demain_alert = 3;
+					teleinfo.DEMAIN = "ROUGE";
+				}
+				else demain_alert = 0;
+				if (demain_alert != teleinfo.pAlertDemain)
+				{
+					SendAlertSensor(32*rank + 3, 255, demain_alert, ("Demain, jour " + teleinfo.DEMAIN) , (name + " Couleur demain"));
+					teleinfo.pAlertDemain = demain_alert;
+				}
+			}
+			if (teleinfo.triphase == false)
+			{
+				SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST, 0, 0, name + " Courant");
+				SendPercentageSensor(32* rank + 1, 0, 255, (teleinfo.IINST*100)/float(teleinfo.ISOUSC), name + " Pourcentage de Charge");
 			}
 			else
 			{
-				teleinfo.color = "Unknown";
-				color_alert = 3;
+				SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST1, (float)teleinfo.IINST2, (float)teleinfo.IINST3,
+					name + " Courant");
+				if (teleinfo.ISOUSC > 0)
+				{
+					SendPercentageSensor(32 * rank + 1, 0, 255, (teleinfo.IINST1*100)/float(teleinfo.ISOUSC),
+						name + " Charge phase 1");
+					SendPercentageSensor(32 * rank + 2, 0, 255, (teleinfo.IINST2*100)/float(teleinfo.ISOUSC),
+						name + " Charge phase 2");
+					SendPercentageSensor(32 * rank + 3, 0, 255, (teleinfo.IINST3*100)/float(teleinfo.ISOUSC),
+						name + " charge phase 3");
+				}
 			}
-			//SendKwhMeter(m_HwdID, 32*rank + 10, 255, m_pappHCJB, teleinfo.BBRHCJB/1000.0, name + " Jour Bleu, Creux");
-			//SendKwhMeter(m_HwdID, 32*rank + 11, 255, m_pappHPJB, teleinfo.BBRHPJB/1000.0, name + " Jour Bleu, Plein");
-			//SendKwhMeter(m_HwdID, 32*rank + 12, 255, m_pappHCJW, teleinfo.BBRHCJW/1000.0, name + " Jour Blanc, Creux");
-			//SendKwhMeter(m_HwdID, 32*rank + 13, 255, m_pappHPJW, teleinfo.BBRHPJW/1000.0, name + " Jour Blanc, Plein");
-			//SendKwhMeter(m_HwdID, 32*rank + 14, 255, m_pappHCJR, teleinfo.BBRHCJR/1000.0, name + " Jour Rouge, Creux");
-			//SendKwhMeter(m_HwdID, 32*rank + 15, 255, m_pappHPJR, teleinfo.BBRHCJR/1000.0, name + " Jour Rouge, Plein");
-			SendKwhMeter(m_HwdID, 32*rank + 16, 255, teleinfo.PAPP, (teleinfo.BBRHCJB + teleinfo.BBRHPJB + teleinfo.BBRHCJW
-				+ teleinfo.BBRHPJW + teleinfo.BBRHCJR + teleinfo.BBRHPJR)/1000.0, name + " kWh Total");
-			m_p1power.powerusage1 = teleinfo.BBRHPJB;
-			m_p1power.powerusage2 = teleinfo.BBRHCJB;
-			m_p1power.usagecurrent = m_pappHCJB + m_pappHPJB;
-			m_p2power.powerusage1 = teleinfo.BBRHPJW;
-			m_p2power.powerusage2 = teleinfo.BBRHCJW;
-			m_p2power.usagecurrent = m_pappHCJW + m_pappHPJW;
-			m_p3power.powerusage1 = teleinfo.BBRHPJR;
-			m_p3power.powerusage2 = teleinfo.BBRHCJR;
-			m_p3power.usagecurrent = m_pappHCJR + m_pappHPJR;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1power, (name + "kWh Jours Bleus").c_str(), 255);
-			sDecodeRXMessage(this, (const unsigned char *)&m_p2power, (name + "kWh Jours Blancs").c_str(), 255);
-			sDecodeRXMessage(this, (const unsigned char *)&m_p3power, (name + "kWh Jours Rouges").c_str(), 255);
-			if (color_alert != teleinfo.pAlertColor) 
-			{
-				SendAlertSensor(32*rank + 2, 255, color_alert, ("Jour " + teleinfo.color), (name + " Couleur du jour"));
-				teleinfo.pAlertColor = color_alert;
-			}
-			if (teleinfo.DEMAIN == "BLEU")
-				demain_alert = 1;
-			else if  (teleinfo.DEMAIN == "BLANC")
-				demain_alert = 2;
-			else if  (teleinfo.DEMAIN == "ROUG")
-			{
-				demain_alert = 3;
-				teleinfo.DEMAIN = "ROUGE";
-			}
-			else demain_alert = 0;
-			if (demain_alert != teleinfo.pAlertDemain)
-			{
-				SendAlertSensor(32*rank + 3, 255, demain_alert, ("Demain, jour " + teleinfo.DEMAIN) , (name + " Couleur demain"));
-				teleinfo.pAlertDemain = demain_alert;
-			} 
 		}
 		// Common sensors for all rates
+		// Alerts can be updated at every call and is not subject to the 1mn interval
 		if (rate_alert != teleinfo.pAlertRate)
 		{
 			SendAlertSensor(32*rank + 1, 255, rate_alert, teleinfo.rate, name + " Tarif en cours");
 			teleinfo.pAlertRate = rate_alert;
-		}	
+		}
 		if (teleinfo.triphase == false)
 		{
-			SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST, 0, 0, name + " Courant");
 			alertI1 =  AlertLevel(teleinfo.IINST, teleinfo.ISOUSC, szTmp);
 			if (alertI1 != teleinfo.pAlertI1)
 			{
 				SendAlertSensor(32*rank + 4, 255, alertI1, szTmp, name + " Alerte courant");
 				teleinfo.pAlertI1 = alertI1;
 			}
-			SendPercentageSensor(32* rank + 1, 0, 255, (teleinfo.IINST*100)/float(teleinfo.ISOUSC), name + " Pourcentage de Charge");
 		}
 		else
 		{
-			SendCurrentSensor(m_HwdID + rank, 255, (float)teleinfo.IINST1, (float)teleinfo.IINST2, (float)teleinfo.IINST3,
-				name + " Courant");
 			alertI1 = AlertLevel(teleinfo.IINST1, teleinfo.ISOUSC, szTmp);
-                        if (alertI1 != teleinfo.pAlertI1)
-                        {
-                                SendAlertSensor(32*rank + 4, 255, alertI1, szTmp, name + " Alerte phase 1");
-                                teleinfo.pAlertI1 = alertI1;
-                        }
+			if (alertI1 != teleinfo.pAlertI1)
+			{
+				SendAlertSensor(32*rank + 4, 255, alertI1, szTmp, name + " Alerte phase 1");
+				teleinfo.pAlertI1 = alertI1;
+			}
 			alertI2 = AlertLevel(teleinfo.IINST2, teleinfo.ISOUSC, szTmp);
-                        if (alertI2 != teleinfo.pAlertI2)
-                        {
-                                SendAlertSensor(32*rank + 5, 255, alertI2, szTmp, name + " Alerte phase 2");
-                                teleinfo.pAlertI2 = alertI2;
-                        }
+			if (alertI2 != teleinfo.pAlertI2)
+			{
+				SendAlertSensor(32*rank + 5, 255, alertI2, szTmp, name + " Alerte phase 2");
+				teleinfo.pAlertI2 = alertI2;
+			}
 			alertI3 = AlertLevel(teleinfo.IINST3, teleinfo.ISOUSC, szTmp);
-                        if (alertI3 != teleinfo.pAlertI3)
-                        {
-                                SendAlertSensor(32*rank + 6, 255, alertI3, szTmp, name + " Alerte phase 3");
-                                teleinfo.pAlertI3 = alertI3;
-                        }
-			if (teleinfo.PPOT != teleinfo.pAlertPPOT) 
+			if (alertI3 != teleinfo.pAlertI3)
+			{
+				SendAlertSensor(32*rank + 6, 255, alertI3, szTmp, name + " Alerte phase 3");
+				teleinfo.pAlertI3 = alertI3;
+			}
+			if (teleinfo.PPOT != teleinfo.pAlertPPOT)
 			{
 				if (teleinfo.PPOT !=0)
 					alertPPOT = 4;
@@ -309,18 +330,9 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 				teleinfo.pAlertPPOT = teleinfo.PPOT;
 				teleinfo.PPOT>>=1;
 				std::stringstream ss;
-                                ss << "Bitmap phases: " <<std::bitset<3>(~teleinfo.PPOT);
-                                message = ss.str();
+				ss << "Bitmap phases: " <<std::bitset<3>(~teleinfo.PPOT);
+				message = ss.str();
 				SendAlertSensor(32*rank+7, 255, alertPPOT, message, " Alerte Potentiels");
-			}
-			if (teleinfo.ISOUSC > 0) 
-			{
-				SendPercentageSensor(32 * rank + 1, 0, 255, (teleinfo.IINST1*100)/float(teleinfo.ISOUSC),
-					name + " Charge phase 1");
-				SendPercentageSensor(32 * rank + 2, 0, 255, (teleinfo.IINST2*100)/float(teleinfo.ISOUSC),
-					name + " Charge phase 2");
-				SendPercentageSensor(32 * rank + 3, 0, 255, (teleinfo.IINST3*100)/float(teleinfo.ISOUSC),
-					name + " charge phase 3");
 			}
 		}
 	}

--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -29,7 +29,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 
 	private:
 		int AlertLevel(int Iinst, int Isousc, char* text);
-		P1Power	m_p1power, m_p2power, m_p3power;
+		P1Power m_p1power, m_p2power, m_p3power;
 
 	protected:
 		typedef struct _tTeleinfo
@@ -94,13 +94,13 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 				BBRHPJR = 0;
 				BBRHCJR = 0;
 				pAlertPAPP = 10;
-             	           	pAlertI1 = 10;
-	                        pAlertI2 = 10;
-       	                 	pAlertI3 = 10;
+				pAlertI1 = 10;
+				pAlertI2 = 10;
+				pAlertI3 = 10;
 				pAlertPPOT = 10;
-       	                 	pAlertRate = 10;
-       		                pAlertColor = 10;
-                        	pAlertEJP = 10;
+				pAlertRate = 10;
+				pAlertColor = 10;
+				pAlertEJP = 10;
 				pAlertDemain = 10;
 				last = 0;
 				triphase = false;

--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -4,9 +4,9 @@ File : TeleinfoBase.h
 Author : Blaise Thauvin
 Version : 1.0
 Description : This class is used by various Teleinfo hardware decoders to process and display data
-			  It is currently used by EcoDevices, TeleinfoSerial
-			  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
-			  http://www.enedis.fr/sites/default/files/ERDF-NOI-CPT_02E.pdf
+		  It is currently used by EcoDevices, TeleinfoSerial
+		  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
+		  http://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
 
 History :
 0.1 2017-03-03 : Creation
@@ -28,7 +28,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 		~CTeleinfoBase();
 
 	private:
-		int AlertLevel(int Iinst, int Imax, int Isousc);
+		int AlertLevel(int Iinst, int Isousc, char* text);
 		P1Power	m_p1power, m_p2power, m_p3power;
 
 	protected:
@@ -41,10 +41,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 			uint32_t IINST1;
 			uint32_t IINST2;
 			uint32_t IINST3;
-			uint32_t IMAX;
-			uint32_t IMAX1;
-			uint32_t IMAX2;
-			uint32_t IMAX3;
+			uint32_t PPOT;
 			uint32_t ADPS;
 			uint32_t PAPP;
 			uint32_t BASE;
@@ -60,8 +57,15 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 			uint32_t BBRHPJR;
 			uint32_t BBRHCJR;
 			std::string DEMAIN;
-			uint32_t previous;
-			uint32_t checksum;
+			uint32_t pAlertPAPP;
+			uint32_t pAlertI1;
+			uint32_t pAlertI2;
+			uint32_t pAlertI3;
+			uint32_t pAlertPPOT;
+			uint32_t pAlertRate;
+			uint32_t pAlertColor;
+			uint32_t pAlertEJP;
+			uint32_t pAlertDemain;
 			std::string rate;
 			std::string tariff;
 			std::string color;
@@ -74,10 +78,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 				IINST1 = 0;
 				IINST2 = 0;
 				IINST3 = 0;
-				IMAX = 0;
-				IMAX1 = 0;
-				IMAX2 = 0;
-				IMAX3 = 0;
+				PPOT = 0;
 				ADPS = 0;
 				PAPP = 0;
 				BASE = 0;
@@ -92,7 +93,15 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 				BBRHCJW = 0;
 				BBRHPJR = 0;
 				BBRHCJR = 0;
-				previous =0;
+				pAlertPAPP = 10;
+             	           	pAlertI1 = 10;
+	                        pAlertI2 = 10;
+       	                 	pAlertI3 = 10;
+				pAlertPPOT = 10;
+       	                 	pAlertRate = 10;
+       		                pAlertColor = 10;
+                        	pAlertEJP = 10;
+				pAlertDemain = 10;
 				last = 0;
 				triphase = false;
 			}
@@ -146,7 +155,7 @@ English
 				BBRHPJR  index peak rate red day
 				PTEC     current tariff period
 				IINST    instant current
-				IMAX     maximum current
+				PPOT     Potental (tri phases only)
 				PAPP     apparent power (VA)
 				MOTDETAT status code
 */

--- a/hardware/TeleinfoSerial.h
+++ b/hardware/TeleinfoSerial.h
@@ -57,10 +57,7 @@ class CTeleinfoSerial : public CTeleinfoBase, AsyncSerial
 		TELEINFO_TYPE_IINST1,
 		TELEINFO_TYPE_IINST2,
 		TELEINFO_TYPE_IINST3,
-		TELEINFO_TYPE_IMAX,
-		TELEINFO_TYPE_IMAX1,
-		TELEINFO_TYPE_IMAX2,
-		TELEINFO_TYPE_IMAX3,
+		TELEINFO_TYPE_PPOT,
 		TELEINFO_TYPE_DEMAIN,
 		TELEINFO_TYPE_PEJP,
 		TELEINFO_TYPE_PAPP,
@@ -108,7 +105,6 @@ class CTeleinfoSerial : public CTeleinfoBase, AsyncSerial
 		bool m_bLabel_PTEC_JW;
 		bool m_bLabel_PTEC_JR;
 		bool m_bLabel_Tempo;
-		static const int NumberOfFrameToSendOne = 8;
 
 		void Init();
 		void MatchLine();

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -400,7 +400,7 @@ typedef struct _tGeneralDevice {
 	float floatval2;
 	int32_t intval1;
 	int32_t intval2;
-        std::string text;
+        char text[200];
 	_tGeneralDevice()
 	{
 		len=sizeof(_tGeneralDevice)-1;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9689,14 +9689,11 @@ void MainWorker::decode_General(const int HwdID, const _eHardwareTypes HwdType, 
 	}
 	else if (subType == sTypeAlert)
 	{
-	        std::stringstream ss;
-		if (pMeter->text ==  "")
-        		ss << pMeter->intval1;
+		if (strcmp(pMeter->text,  ""))
+			sprintf(szTmp, "(%d) %s", pMeter->intval1, pMeter->text);
 		else
-			ss << "(" << pMeter->intval1 << ") " << pMeter->text.c_str();
-		const std::string tmp = ss.str();
-		const char* cstr = tmp.c_str();
-		DevRowIdx = m_sql.UpdateValue(HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, pMeter->intval1, cstr, procResult.DeviceName);
+			sprintf(szTmp, "%d", pMeter->intval1);
+		DevRowIdx = m_sql.UpdateValue(HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, pMeter->intval1, szTmp, procResult.DeviceName);
 		if (DevRowIdx == -1)
 			return;
 		m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_USAGE, static_cast<float>(pMeter->intval1));


### PR DESCRIPTION
- Peak/OffPeak indexes swaped in P1 meters
- Update rate greatly reduced to avoid clogging database
- IMAX information now ignored
- PPOT (triphasé only) now handled
- Messages in alerts are now properly handled and will not cause crashes. Problem was with object lifetime being to short to be consumed by asynchronous thread
- Texts are (I hope) more explicit
- Wiki is updated
and more....