### PR TITLE
Allow Evohome USB to specify baud rate

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -72,7 +72,7 @@ const char* CEvohome::GetZoneModeName(uint8_t nZoneMode)
 	return m_szZoneMode[(std::min)(nZoneMode, (uint8_t)6)]; //parentheses around function name apparently avoids macro expansion windef.h macros will conflict here
 }
 
-CEvohome::CEvohome(const int ID, const std::string &szSerialPort) :
+CEvohome::CEvohome(const int ID, const std::string &szSerialPort, const int baudrate) :
 	m_ZoneNames(m_nMaxZones),
 	m_ZoneOverrideLocal(m_nMaxZones)
 {
@@ -91,8 +91,16 @@ CEvohome::CEvohome(const int ID, const std::string &szSerialPort) :
 	m_MaxDeviceID = 0;
 
 	AllSensors = false;
-	
-	m_iBaudRate=115200;
+
+	if(baudrate!=0)
+	{
+	  m_iBaudRate=baudrate;
+	}
+	else
+	{
+	  // allow migration of hardware created before baud rate was configurable
+	  m_iBaudRate=115200;
+	}
 	if(!szSerialPort.empty())
 	{
 		m_szSerialPort=szSerialPort;
@@ -219,8 +227,8 @@ bool CEvohome::OpenSerialDevice()
 	//Try to open the Serial Port
 	try
 	{
+		_log.Log(LOG_STATUS,"evohome: Opening serial port: %s@%d", m_szSerialPort.c_str(), m_iBaudRate);
 		open(m_szSerialPort,m_iBaudRate);
-		_log.Log(LOG_STATUS,"evohome: Using serial port: %s", m_szSerialPort.c_str());
 	}
 	catch (boost::exception & e)
 	{

--- a/hardware/evohome.h
+++ b/hardware/evohome.h
@@ -395,10 +395,10 @@ public:
 class CEvohome : public AsyncSerial, public CDomoticzHardwareBase
 {
 public:
-	CEvohome(const int ID, const std::string &szSerialPort);
+	CEvohome(const int ID, const std::string &szSerialPort, const int baudrate);
 	~CEvohome(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);
-	
+
 	std::string m_szSerialPort;
 	unsigned int m_iBaudRate;
 	bool m_bScriptOnly;
@@ -629,4 +629,3 @@ private:
 	static bool m_bDebug;//Debug mode for extra logging
 	static std::ofstream *m_pEvoLog;
 };
-

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -680,7 +680,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new Meteostick(ID, SerialPort, 115200);
 		break;
 	case HTYPE_EVOHOME_SERIAL:
-		pHardware = new CEvohome(ID,SerialPort);
+		pHardware = new CEvohome(ID,SerialPort,Mode1);
 		break;
 	case HTYPE_RFLINKUSB:
 		pHardware = new CRFLinkSerial(ID, SerialPort);
@@ -925,7 +925,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 #endif //WITH_TELLDUSCORE
 	case HTYPE_EVOHOME_SCRIPT:
-		pHardware = new CEvohome(ID,"");
+		pHardware = new CEvohome(ID,"",0);
 		break;
 	case HTYPE_PiFace:
 		pHardware = new CPiFace(ID);

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -188,6 +188,19 @@ define(['app'], function (app) {
                     }
                 }
 
+                if (text.indexOf("Evohome") >= 0)
+                {
+                    var baudrate=$("#hardwarecontent #divbaudrateevohome #combobaudrateevohome option:selected").val();
+
+                    if (typeof baudrate == 'undefined')
+                    {
+                        ShowNotify($.t('No baud rate selected!'), 2500, true);
+                        return;
+                    }
+
+                    Mode1 = baudrate;
+                }
+
                 if (text.indexOf("MySensors") >= 0)
                 {
                     var baudrate=$("#hardwarecontent #divbaudratemysensors #combobaudrate option:selected").val();
@@ -1094,6 +1107,19 @@ define(['app'], function (app) {
                 {
                     ShowNotify($.t('No serial port selected!'), 2500, true);
                     return;
+                }
+
+                if (text.indexOf("Evohome") >= 0)
+                {
+                    var baudrate=$("#hardwarecontent #divbaudrateevohome #combobaudrateevohome option:selected").val();
+
+                    if (typeof baudrate == 'undefined')
+                    {
+                        ShowNotify($.t('No baud rate selected!'), 2500, true);
+                        return;
+                    }
+
+                    Mode1 = baudrate;
                 }
 
                 if (text.indexOf("MySensors") >= 0)
@@ -5191,6 +5217,7 @@ define(['app'], function (app) {
             $("#hardwarecontent #username").show();
             $("#hardwarecontent #lblusername").show();
 
+            $("#hardwarecontent #divbaudrateevohome").hide();
             $("#hardwarecontent #divbaudratemysensors").hide();
             $("#hardwarecontent #divbaudratep1").hide();
             $("#hardwarecontent #divcrcp1").hide();
@@ -5253,6 +5280,10 @@ define(['app'], function (app) {
             }
             else if (text.indexOf("USB") >= 0)
             {
+                if (text.indexOf("Evohome") >= 0)
+                {
+                    $("#hardwarecontent #divbaudrateevohome").show();
+                }
                 if (text.indexOf("MySensors") >= 0)
                 {
                     $("#hardwarecontent #divbaudratemysensors").show();

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1192,6 +1192,18 @@
       </tr>
       </table>
     </div>
+    <div id="divbaudrateevohome">
+      <table class="display" id="hardwareparamsbaudrateevohome" border="0" cellpadding="0" cellspacing="20">
+        <tr>
+          <td align="right" style="width:110px"><label id="lblbaudrateevohome" for="name"><span data-i18n="Baudrate">Baudrate</span>: </label></td>
+          <td><select id="combobaudrateevohome" style="width:210px" class="combobox ui-corner-all">
+            <option value="115200">115200 (for genuine Honeywell HGI80/HGS80)</option>
+            <option value="76800">76800</option>
+            <option value="38400">38400</option>
+          </select></td>
+      </tr>
+      </table>
+    </div>
 		<div id="divbaudratep1">
 			<table class="display" id="hardwareparamsbaudratep1" border="0" cellpadding="0" cellspacing="20">
 				<tr>


### PR DESCRIPTION
There is an increasing community of makers who are building custom Evohome interface hardware, not all of which runs (or is capable of running) at 115,200 baud. This patch allows the Evohome USB hardware (as distinct from the Evohome Script hardware) to have its baud rate configurable, whilst allowing hardware created previously to correctly default to the previously hard-coded value of 115,200.