### PR TITLE
Increment Device Number to allow correct zone numbering. 

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -1515,7 +1515,11 @@ bool CEvohome::DecodeHeatDemand(CEvohomeMsg &msg)
 	Log(true,LOG_STATUS,"evohome: %s: %s (0x%x) DevNo 0x%02x %d (0x%x)", tag, szSourceType.c_str(), msg.GetID(0), nDevNo, nDemand, msg.command);
 
 	if(msg.command==0x0008)
+	{
+		if (nDevNo < 12)
+			nDevNo++; //Need to add 1 to give correct zone numbers
 		RXRelay(static_cast<uint8_t>(nDevNo),static_cast<uint8_t>(nDemand), msg.GetID(0));
+	}
 	return true;
 }
 


### PR DESCRIPTION
Increment the Device number for relay devices used as part of an Evohome zone to allow correct zone numbering. This is for relay devices other than the CH and DHW zone valve relays. 