### PR TITLE
Timer corrections

### DIFF
--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -402,6 +402,7 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	localtime_r(&atime, &ltime);
 	int isdst = ltime.tm_isdst;
 	struct tm tm1;
+	tm1.tm_isdst = -1;
 
 	unsigned long HourMinuteOffset = (pItem->startHour * 3600) + (pItem->startMin * 60);
 
@@ -558,16 +559,15 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	else
 		return false; //unknown timer type
 
-	if (bForceAddDay)
+	// Adjust timer by 1 day if item is scheduled for next day or we are in the past
+	while (bForceAddDay || (rtime < atime + 60) )
 	{
-		//item is scheduled for next day
-		rtime += (24 * 3600);
-	}
-
-	//Adjust timer by 1 day if we are in the past
-	while (rtime < atime + 60)
-	{
-		rtime += (24 * 3600);
+		if (tm1.tm_isdst == -1) // rtime was loaded from sunset/sunrise values; need to initialize tm1
+			localtime_r(&rtime, &tm1);
+		struct tm tm2;
+		tm1.tm_mday++;
+		constructTime(rtime, tm2, tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday, tm1.tm_hour, tm1.tm_min, tm1.tm_sec, isdst);
+		bForceAddDay = false;
 	}
 
 	pItem->startTime = rtime;


### PR DESCRIPTION
1. Next firing time calculation is wrong for sunset/sunrise timers because it takes today's sun values to set tomorrow's scheduled time. https://github.com/gordonb3/domoticz/commit/67f89ac66d86ea548e57be3b7366e8fec1525b43 fixes this by reloading the schedules when sunset/sunrise values change

2. Next firing time calculation contains a default routine that adds 24 hours to the calculated time, either enforced by the caller or because the time references the past. In time zones that have DST this is wrong twice a year. https://github.com/gordonb3/domoticz/commit/de3db55dc1e2e0bb8ff65435cc46ab9ac44023cd fixes this by using a sane time calculation.