### PR TITLE
Correctly refresh Evohome parameters when switching between hardware

### DIFF
--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -5002,6 +5002,10 @@ define(['app'], function (app) {
                         }
                         else if (data["Type"].indexOf("USB") >= 0) {
                             $("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);
+                            if (data["Type"].indexOf("Evohome") >= 0)
+                            {
+                                $("#hardwarecontent #divbaudrateevohome #combobaudrateevohome").val(data["Mode1"]);
+                            }
                             if (data["Type"].indexOf("MySensors") >= 0)
                             {
                                 $("#hardwarecontent #divbaudratemysensors #combobaudrate").val(data["Mode1"]);


### PR DESCRIPTION
I missed this from my previous Evohome baud rate PR. When switching between hardware drivers on the table view, the Evohome parameters were not correctly loaded into the controls.