### PR TITLE
Timer corrections (retry)

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -212,6 +212,7 @@ MainWorker::MainWorker()
 	m_ScheduleLastMinuteTime = 0;
 	m_ScheduleLastHourTime = 0;
 	m_ScheduleLastDayTime = 0;
+        m_LastSunriseSet = "";
 
 	m_bHaveDownloadedDomoticzUpdate=false;
 	m_bHaveDownloadedDomoticzUpdateSuccessFull=false;
@@ -517,6 +518,7 @@ bool MainWorker::GetSunSettings()
 	sprintf(szRiseSet,"%02d:%02d:00",sresult.SunSetHour,sresult.SunSetMin);
 	sunset=szRiseSet;
 
+	m_scheduler.SetSunRiseSetTimers(sunrise, sunset);
 	std::string riseset=sunrise.substr(0, sunrise.size()-3)+";"+sunset.substr(0, sunrise.size() - 3); //make a short version
 	if (m_LastSunriseSet != riseset)
 	{
@@ -525,8 +527,9 @@ bool MainWorker::GetSunSettings()
 
 		// ToDo: add here some condition to avoid double events loading on application startup. check if m_LastSunriseSet was empty?
 		m_eventsystem.LoadEvents(); // reloads all events from database to refresh blocky events sunrise/sunset what are already replaced with time
+
+                m_scheduler.ReloadSchedules(); // force reload of all schedules to adjust for changed sunrise/sunset values
 	}
-	m_scheduler.SetSunRiseSetTimers(sunrise, sunset);
 	return true;
 }
 


### PR DESCRIPTION
1. Next firing time calculation is wrong for sunset/sunrise timers because it takes today's sun values to set tomorrow's scheduled time. https://github.com/domoticz/domoticz/pull/1429/commits/f7e131409918a0d647955a0b67d226cfcf872da7 fixes this by reloading the schedules when sunset/sunrise values change

2. Next firing time calculation contains a default routine that adds 24 hours to the calculated time, either enforced by the caller or because the time references the past. In time zones that have DST this is wrong twice a year. https://github.com/domoticz/domoticz/pull/1429/commits/62e37ba3b0c55e672f560d0284028cf3db1d8b5b fixes this by using a sane time calculation.