### PR TITLE
GPIO polling option (new), add-hardware fix

### DIFF
--- a/hardware/Gpio.h
+++ b/hardware/Gpio.h
@@ -33,7 +33,7 @@ Source: http://wiringpi.com
 class CGpio : public CDomoticzHardwareBase
 {
 public:
-	explicit CGpio(const int ID, const int debounce, const int period);
+	explicit CGpio(const int ID, const int debounce, const int period, const int pollinterval);
 	~CGpio();
 
 	bool WriteToHardware(const char *pdata, const unsigned char length);
@@ -45,12 +45,12 @@ public:
 private:
 	bool StartHardware();
 	bool StopHardware();
-
 	void Do_Work();
+	void Poller();
 	void DelayedStartup();
-	void CopyDeviceStates(bool forceUpdate);
+	void UpdateDeviceStates(bool forceUpdate);
 	void ProcessInterrupt(int gpioId);
-	void SetupInitialState(int gpioId, bool forceUpdate);
+	void UpdateState(int gpioId, bool forceUpdate);
 
 	// List of GPIO pin numbers, ordered as listed
 	static std::vector<CGpioPin> pins;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -939,7 +939,7 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RaspberryGPIO:
 		//Raspberry Pi GPIO port access
 #ifdef WITH_GPIO
-		pHardware = new CGpio(ID, Mode1, Mode2);
+		pHardware = new CGpio(ID, Mode1, Mode2, Mode3);
 #endif
 		break;
 	case HTYPE_Comm5TCP:

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -142,7 +142,8 @@ define(['app'], function (app) {
                 if (text.indexOf("GPIO") >= 0)
                 {
                     var gpiodebounce=$("#hardwareparamsgpio #gpiodebounce").val();
-                    var gpioperiod=$("#hardwareparamsgpio #gpioperiod").val();
+                    var gpioperiod = $("#hardwareparamsgpio #gpioperiod").val();
+                    var gpiopollinterval = $("#hardwareparamsgpio #gpiopollinterval").val();
                     if (gpiodebounce=="")
                     {
                         gpiodebounce = "50";
@@ -151,8 +152,13 @@ define(['app'], function (app) {
                     {
                         gpioperiod = "50";
                     }
+                    if (gpiopollinterval=="")
+                    {
+                        gpiopollinterval = "0";
+                    }
                     Mode1 = gpiodebounce;
                     Mode2 = gpioperiod;
+                    Mode3 = gpiopollinterval;
                 }
             	$.ajax({
                      url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
@@ -1052,7 +1058,8 @@ define(['app'], function (app) {
             else if (text.indexOf("GPIO") >= 0)
             {
                 var gpiodebounce=$("#hardwarecontent #hardwareparamsgpio #gpiodebounce").val();
-                var gpioperiod=$("#hardwarecontent #hardwareparamsgpio #gpioperiod").val();
+                var gpioperiod = $("#hardwarecontent #hardwareparamsgpio #gpioperiod").val();
+                var gpiopollinterval = $("#hardwarecontent #hardwareparamsgpio #gpiopollinterval").val();
                 if (gpiodebounce=="")
                 {
                     gpiodebounce = "50";
@@ -1061,19 +1068,31 @@ define(['app'], function (app) {
                 {
                     gpioperiod = "50";
                 }
+                if (gpiopollinterval == "")
+                {
+                    gpiopollinterval = "0";
+                }
                 Mode1 = gpiodebounce;
                 Mode2 = gpioperiod;
+                Mode3 = gpiopollinterval;
                 $.ajax({
-                     url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout + "&Mode1=" + Mode1 + "&Mode2=" + Mode2,
-                     async: false,
-                     dataType: 'json',
-                     success: function(data) {
-                        RefreshHardwareTable();
-                     },
-                     error: function(){
+                    url: "json.htm?type=command&param=addhardware&htype="
+                    + hardwaretype
+                    + "&name=" + encodeURIComponent(name)
+                    + "&enabled=" + bEnabled
+                    + "&datatimeout=" + datatimeout
+                    + "&Mode1=" + Mode1 + "&Mode2=" + Mode2 + "&Mode3=" + Mode3,
+                    async: false,
+                        dataType: 'json',
+                        success: function (data)
+                        {
+                            RefreshHardwareTable();
+                        },
+                        error: function ()
+                        {
                             ShowNotify($.t('Problem adding hardware!'), 2500, true);
-                     }
-                });
+                        }
+                    });
         }
 	    else if (text.indexOf("I2C ") >= 0 && text.indexOf("I2C sensor PIO 8bit expander PCF8574") < 0)
 	    {
@@ -4998,6 +5017,7 @@ define(['app'], function (app) {
                         else if (data["Type"].indexOf("GPIO") >= 0) {
                             $("#hardwareparamsgpio #gpiodebounce").val(data["Mode1"]);
                             $("#hardwareparamsgpio #gpioperiod").val(data["Mode2"]);
+                            $("#hardwareparamsgpio #gpiopollinterval").val(data["Mode3"]);
                         }
                         else if (data["Type"].indexOf("USB") >= 0) {
                             $("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1377
+# ref 1378
 
 CACHE:
 # CSS


### PR DESCRIPTION
[Change1]
New feature: GPIO polling has been added as a safety net to keep track of input states in case interrupts are missed. This could happen when misconfigured or in error cases. The polling interval is disabled by default by setting the poll interval to zero. This is the recommended setting for less critical environments. When poll interval is set to a integer value larger the zero then GPIO inputs are captured every poll interval. Domoticz is updated when state mismatches are detected. A typical setting is 60 seconds, faster polling intervals are not recommended to prevent unneeded overhead.

[Change2] 
Fix: Since de-bounce settings where introduced, at 22-march-2017, GPIO hardware could not be added anymore. This has been fixed. (existing configurations kept working) 