### PR TITLE
URGENT: Revert "Log messages flagged as errors by the hardware interface"

### DIFF
--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -692,7 +692,7 @@ int CEvohome::ProcessBuf(char * buf, int size)
 	for (int i = 0; i < size; ++i) 
 	{
 		if(buf[i]==0x11)//this appears to be a break character?
-			buf[i]=0x20; // replace with printable char and continue; next stage will log error
+			start=i+1;
 		else if(buf[i]==0x0A)//this is the end of packet marker...not sure if there is a CR before this?
 		{
 			if (i - start >= 2048) {


### PR DESCRIPTION
This reverts commit 17774019c416d078c98467ce78e984e7bc1c1e32.

This commit broke Domoticz Evohome integration for users with genuine Honeywell HGI80 devices. It is important that this PR gets merged to master before the next Domoticz release is made.