### PR TITLE
Partial undo of commit #f7e1314

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -528,7 +528,8 @@ bool MainWorker::GetSunSettings()
 		// ToDo: add here some condition to avoid double events loading on application startup. check if m_LastSunriseSet was empty?
 		m_eventsystem.LoadEvents(); // reloads all events from database to refresh blocky events sunrise/sunset what are already replaced with time
 
-                m_scheduler.ReloadSchedules(); // force reload of all schedules to adjust for changed sunrise/sunset values
+		// FixMe: only reload schedules relative to sunset/sunrise to prevent race conditions
+		// m_scheduler.ReloadSchedules(); // force reload of all schedules to adjust for changed sunrise/sunset values
 	}
 	return true;
 }


### PR DESCRIPTION
Undo the reload of schedules when sun times change - it may cause a race condition on schedules that are set around the same time this change occurs. Need to find a better way.