### PR TITLE
Generic sysfs gpio, new

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ hardware/serial/impl/unix.cpp
 hardware/SolarEdgeAPI.cpp
 hardware/SolarMaxTCP.cpp
 hardware/Sterbox.cpp
+hardware/SysfsGPIO.cpp
 hardware/TCPProxy/tcpproxy_server.cpp
 hardware/TE923.cpp
 hardware/TE923Tool.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -659,6 +659,14 @@ else()
   message(STATUS "==== (Please follow http://wiringpi.com/download-and-install/ if you want to use GPIO.)")
 ENDIF(WiringPi)
 
+IF(EXISTS /sys/class/gpio)
+	message(STATUS "Sysfs GPIO available")
+	add_definitions(-DWITH_SYSFS_GPIO)
+ELSE()
+	message(STATUS "Sysfs GPIO not available")
+ENDIF()
+
+
 find_path(TELLDUSCORE_INCLUDE NAMES telldus-core.h)
 if (TELLDUSCORE_INCLUDE)
   message(STATUS "Found telldus-core (telldus-core.h) at : ${TELLDUSCORE_INCLUDE}")

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -138,23 +138,6 @@
 #define GPIO_MAX_PATH		64
 #define GPIO_PATH			"/sys/class/gpio/gpio"
 
-static int GPIORead(int pin, const char* param);
-static int GPIOReadFd(int fd);
-static int GPIOWrite(int pin, int value);
-
-struct gpio_info
-{
-	int	pin_number;		// GPIO Pin number
-	int	value;			// GPIO pin Value
-	int	db_state;		// Database Value
-	int	direction;		// GPIO IN or OUT
-	int	active_low;		// GPIO ActiveLow
-	int	edge;			// GPIO int Edge
-	int	read_value_fd;	// Fast read fd
-};
-
-static std::vector<gpio_info> GpioSavedState;
-
 CSysfsGPIO::CSysfsGPIO(const int ID)
 {
 	m_stoprequested = false;

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -1,0 +1,639 @@
+/*
+	USAGE:
+	======
+	To use "Generic sysfs gpio" you need to export the inputs and outputs you
+	are going to use. On start up "Gerenic sysfs gpio" will pick up the exports
+	that are available and starts processing them. You may want to use chmod to
+	set gpio permissions
+
+	GPIO Sysfs Interface for Userspace
+	==================================
+
+	Platforms which use the "gpiolib" implementors framework may choose to
+	configure a sysfs user interface to GPIOs. This is different from the
+	debugfs interface, since it provides control over GPIO direction and
+	value instead of just showing a gpio state summary. Plus, it could be
+	present on production systems without debugging support.
+
+	Given appropriate hardware documentation for the system, userspace could
+	know for example that GPIO #23 controls the write protect line used to
+	protect boot loader segments in flash memory. System upgrade procedures
+	may need to temporarily remove that protection, first importing a GPIO,
+	then changing its output state, then updating the code before re-enabling
+	the write protection. In normal use, GPIO #23 would never be touched,
+	and the kernel would have no need to know about it.
+
+	Again depending on appropriate hardware documentation, on some systems
+	userspace GPIO can be used to determine system configuration data that
+	standard kernels won't know about. And for some tasks, simple userspace
+	GPIO drivers could be all that the system really needs.
+
+	DO NOT ABUSE SYSFS TO CONTROL HARDWARE THAT HAS PROPER KERNEL DRIVERS.
+	PLEASE READ THE DOCUMENT NAMED "drivers-on-gpio.txt" IN THIS DOCUMENTATION
+	DIRECTORY TO AVOID REINVENTING KERNEL WHEELS IN USERSPACE. I MEAN IT.
+	REALLY.
+
+	Paths in Sysfs
+	--------------
+	There are three kinds of entries in /sys/class/gpio:
+
+	-	Control interfaces used to get userspace control over GPIOs;
+
+	-	GPIOs themselves; and
+
+	-	GPIO controllers ("gpio_chip" instances).
+
+	That's in addition to standard files including the "device" symlink.
+
+	The control interfaces are write-only:
+
+	/sys/class/gpio/
+
+	"export" ... Userspace may ask the kernel to export control of
+	a GPIO to userspace by writing its number to this file.
+
+	Example:  "echo 19 > export" will create a "gpio19" node
+	for GPIO #19, if that's not requested by kernel code.
+
+	"unexport" ... Reverses the effect of exporting to userspace.
+
+	Example:  "echo 19 > unexport" will remove a "gpio19"
+	node exported using the "export" file.
+
+	GPIO signals have paths like /sys/class/gpio/gpio42/ (for GPIO #42)
+	and have the following read/write attributes:
+
+	/sys/class/gpio/gpioN/
+
+	"direction" ... reads as either "in" or "out". This value may
+	normally be written. Writing as "out" defaults to
+	initializing the value as low. To ensure glitch free
+	operation, values "low" and "high" may be written to
+	configure the GPIO as an output with that initial value.
+
+	Note that this attribute *will not exist* if the kernel
+	doesn't support changing the direction of a GPIO, or
+	it was exported by kernel code that didn't explicitly
+	allow userspace to reconfigure this GPIO's direction.
+
+	"value" ... reads as either 0 (low) or 1 (high). If the GPIO
+	is configured as an output, this value may be written;
+	any nonzero value is treated as high.
+
+	If the pin can be configured as interrupt-generating interrupt
+	and if it has been configured to generate interrupts (see the
+	description of "edge"), you can poll(2) on that file and
+	poll(2) will return whenever the interrupt was triggered. If
+	you use poll(2), set the events POLLPRI and POLLERR. If you
+	use select(2), set the file descriptor in exceptfds. After
+	poll(2) returns, either lseek(2) to the beginning of the sysfs
+	file and read the new value or close the file and re-open it
+	to read the value.
+
+	"edge" ... reads as either "none", "rising", "falling", or
+	"both". Write these strings to select the signal edge(s)
+	that will make poll(2) on the "value" file return.
+
+	This file exists only if the pin can be configured as an
+	interrupt generating input pin.
+
+	"active_low" ... reads as either 0 (false) or 1 (true). Write
+	any nonzero value to invert the value attribute both
+	for reading and writing. Existing and subsequent
+	poll(2) support configuration via the edge attribute
+	for "rising" and "falling" edges will follow this
+	setting.
+
+*/
+
+#include "stdafx.h"
+
+#ifndef WIN32
+
+#include <sys/types.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include "SysfsGPIO.h"
+#include "../main/Helper.h"
+#include "../main/Logger.h"
+#include "hardwaretypes.h"
+#include "../main/RFXtrx.h"
+#include "../main/mainworker.h"
+#include "../main/SQLHelper.h"
+#include "../main/localtime_r.h"
+
+#define GPIO_POLL_MSEC		250
+#define GPIO_IN				0
+#define GPIO_OUT			1
+#define GPIO_LOW			0
+#define GPIO_HIGH			1
+#define GPIO_NONE			0
+#define GPIO_RISING			1
+#define GPIO_FALLING		2
+#define GPIO_BOTH			3
+#define GPIO_PIN_MIN		0
+#define GPIO_PIN_MAX		31
+#define GPIO_MAX_VALUE_SIZE	16		
+#define GPIO_MAX_PATH		64
+#define GPIO_PATH			"/sys/class/gpio/gpio"
+
+static int GPIORead(int pin, const char* param);
+static int GPIOReadFd(int fd);
+static int GPIOWrite(int pin, int value);
+
+struct gpio_info
+{
+	int	pin_number;		// GPIO Pin number
+	int	value;			// GPIO pin Value
+	int	db_state;		// Database Value
+	int	direction;		// GPIO IN or OUT
+	int	active_low;		// GPIO ActiveLow
+	int	edge;			// GPIO int Edge
+	int	read_value_fd;	// Fast read fd
+};
+
+static std::vector<gpio_info> GpioSavedState;
+
+CSysfsGPIO::CSysfsGPIO(const int ID)
+{
+	m_stoprequested = false;
+	m_bIsStarted = false;
+	m_HwdID = ID;
+}
+
+CSysfsGPIO::~CSysfsGPIO(void)
+{
+}
+
+bool CSysfsGPIO::StartHardware()
+{
+	GpioSavedState.clear();
+
+	Init();
+
+	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CSysfsGPIO::Do_Work, this)));
+	m_bIsStarted = true;
+
+	return (m_thread != NULL);
+}
+
+bool CSysfsGPIO::StopHardware()
+{
+	m_stoprequested = true;
+
+	try
+	{
+		if (m_thread)
+		{
+			m_thread->join();
+		}
+	}
+	catch (...)
+	{
+	}
+
+	m_bIsStarted = false;
+
+	return true;
+}
+
+bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
+{
+	bool bOk = true;
+
+	const tRBUF *pSen = reinterpret_cast<const tRBUF*>(pdata);
+	unsigned char packettype = pSen->ICMND.packettype;
+
+	if (packettype == pTypeLighting2)
+	{
+		int output_pin = pSen->LIGHTING2.unitcode;
+
+		if (pSen->LIGHTING2.cmnd == light2_sOn)
+		{
+			GPIOWrite(output_pin, true);
+		}
+		else
+		{
+			GPIOWrite(output_pin, false);
+		}
+	}
+
+	return bOk;
+}
+
+void CSysfsGPIO::Do_Work()
+{
+	char path[GPIO_MAX_PATH];
+	char value_str[3];
+	int fd;
+	int counter;
+	int input_count = 0;
+	int output_count = 0;
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].direction == 0)
+		{
+			input_count++;
+		}
+
+		if (GpioSavedState[i].direction == 1)
+		{
+			output_count++;
+		}
+	}
+
+	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller started, configured inputs:%d outputs:%d", input_count, output_count);
+
+	/* create fd's used for fast reads */
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, GpioSavedState[i].pin_number);
+		GpioSavedState[i].read_value_fd = open(path, O_RDONLY);
+	}
+
+	while (!m_stoprequested)
+	{
+		sleep_milliseconds(GPIO_POLL_MSEC);
+		counter++;
+
+		/*  Heartbeat maintenance  */
+		if (counter % 40 == 0)
+		{
+			m_LastHeartbeat = mytime(NULL);
+		}
+
+		if (!m_stoprequested)
+		{
+			PollGpioInputs();
+			UpdateDomoticzInputs();
+		}
+	}
+
+	/* close all fast read fd's */
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, GpioSavedState[i].pin_number);
+		close(GpioSavedState[i].read_value_fd);
+		GpioSavedState[i].read_value_fd = -1;
+	}
+
+	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller stopped");
+}
+
+void CSysfsGPIO::Init()
+{
+	BYTE id1 = 0x03;
+	BYTE id2 = 0x0E;
+	BYTE id3 = 0x0E;
+	BYTE id4 = m_HwdID & 0xFF;
+
+	/* 	Prepare packet for LIGHTING2 relay status packet  */
+	memset(&m_Packet, 0, sizeof(tRBUF));
+
+	if (m_HwdID > 0xFF)
+	{
+		id3 = (m_HwdID >> 8) & 0xFF;
+	}
+
+	if (m_HwdID > 0xFFFF)
+	{
+		id3 = (m_HwdID >> 16) & 0xFF;
+	}
+
+	m_Packet.LIGHTING2.packetlength = sizeof(m_Packet.LIGHTING2) - 1;
+	m_Packet.LIGHTING2.packettype = pTypeLighting2;
+	m_Packet.LIGHTING2.subtype = sTypeAC;
+	m_Packet.LIGHTING2.unitcode = 0;
+	m_Packet.LIGHTING2.id1 = id1;
+	m_Packet.LIGHTING2.id2 = id2;
+	m_Packet.LIGHTING2.id3 = id3;
+	m_Packet.LIGHTING2.id4 = id4;
+	m_Packet.LIGHTING2.cmnd = 0;
+	m_Packet.LIGHTING2.level = 0;
+	m_Packet.LIGHTING2.filler = 0;
+	m_Packet.LIGHTING2.rssi = 12;
+
+	FindGpioExports();
+	CreateDomoticzDevices();
+	UpdateDomoticzInputs();
+}
+
+void CSysfsGPIO::FindGpioExports()
+{
+	GpioSavedState.clear();
+
+	for (int gpio_pin = GPIO_PIN_MIN; gpio_pin <= GPIO_PIN_MAX; gpio_pin++)
+	{
+		int fd;
+		char path[GPIO_MAX_PATH];
+
+		snprintf(path, GPIO_MAX_PATH, "%s%d", GPIO_PATH, gpio_pin);
+		fd = open(path, O_RDONLY);
+
+		if (-1 != fd) 
+		{
+			/* GPIO export *found */
+			gpio_info gi;
+			gi.pin_number = gpio_pin;
+			gi.value = GPIORead(gpio_pin, "value");
+			gi.direction = GPIORead(gpio_pin, "direction");
+			gi.active_low = GPIORead(gpio_pin, "active_low");
+			gi.edge = GPIORead(gpio_pin, "edge");
+			gi.read_value_fd = -1;
+			GpioSavedState.push_back(gi);
+
+			close(fd);
+		}
+	}
+
+	int pin_count = GpioSavedState.size();
+}
+
+void CSysfsGPIO::PollGpioInputs()
+{
+	if (GpioSavedState.size())
+	{
+		for (int i = 0; i < GpioSavedState.size(); i++)
+		{
+			if ((GpioSavedState[i].direction == GPIO_IN) && (GpioSavedState[i].read_value_fd != -1))
+			{
+				GpioSavedState[i].value = GPIOReadFd(GpioSavedState[i].read_value_fd);
+			}
+		}
+	}
+}
+
+void CSysfsGPIO::CreateDomoticzDevices()
+{
+	std::vector<std::vector<std::string> > result;
+	char szIdx[10];
+
+	sprintf(szIdx, "%X%02X%02X%02X",
+		m_Packet.LIGHTING2.id1,
+		m_Packet.LIGHTING2.id2,
+		m_Packet.LIGHTING2.id3,
+		m_Packet.LIGHTING2.id4);
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].direction == GPIO_IN)
+		{
+			result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
+				m_HwdID, szIdx, GpioSavedState[i].pin_number);
+
+			if (result.empty())
+			{
+				m_sql.safe_query(
+					"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue) "
+					"VALUES (%d,'%q',%d, %d, %d, %d, 0, 12, 255, '%q', 0, ' ')",
+					m_HwdID, szIdx, GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_Contact), "Input");
+			}
+		}
+		else
+		{
+			result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
+				m_HwdID, szIdx, GpioSavedState[i].pin_number);
+			
+			if (result.empty())
+			{
+				m_sql.safe_query(
+					"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue) "
+					"VALUES (%d,'%q',%d, %d, %d, %d, 0, 12, 255, '%q', 0, ' ')",
+					m_HwdID, szIdx, GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_OnOff), "Output");
+			}
+		}
+	}
+}
+
+void CSysfsGPIO::UpdateDomoticzInputs()
+{
+	
+	std::vector<std::vector<std::string> > result;
+	char szIdx[10];
+
+	sprintf(szIdx, "%X%02X%02X%02X",
+		m_Packet.LIGHTING2.id1,
+		m_Packet.LIGHTING2.id2,
+		m_Packet.LIGHTING2.id3,
+		m_Packet.LIGHTING2.id4);
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if ((GpioSavedState[i].direction == GPIO_IN) && (GpioSavedState[i].value != -1))
+		{
+			bool	updateDatabase = false;
+			int		state = 0;
+
+			if (GpioSavedState[i].active_low)
+			{
+				if (GpioSavedState[i].value == 0)
+				{
+					state = 1;
+				}
+			}
+			else
+			{
+				if (GpioSavedState[i].value == 1)
+				{
+					state = 1;
+				}
+			}
+
+			if (GpioSavedState[i].db_state != state)
+			{
+				result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
+					m_HwdID, szIdx, GpioSavedState[i].pin_number);
+
+				if ((!result.empty()) && (result.size() > 0))
+				{
+					std::vector<std::string> sd = result[0];
+					bool db_state = true;
+
+					if (atoi(sd[1].c_str()) == 0)
+					{
+						db_state = false;
+					}
+
+					if (db_state != state)
+					{
+						updateDatabase = true;
+					}
+
+					GpioSavedState[i].db_state = state;
+				}
+
+				if (updateDatabase)
+				{
+					if (state)
+					{
+						m_Packet.LIGHTING2.cmnd = light2_sOn;
+						m_Packet.LIGHTING2.level = 100;
+					}
+					else
+					{
+						m_Packet.LIGHTING2.cmnd = light2_sOff;
+						m_Packet.LIGHTING2.level = 0;
+					}
+					m_Packet.LIGHTING2.unitcode = (char)GpioSavedState[i].pin_number;
+					m_Packet.LIGHTING2.seqnbr++;
+
+					/* send packet to Domoticz */
+					sDecodeRXMessage(this, (const unsigned char *)&m_Packet.LIGHTING2, "Input", 255);
+				}
+			}
+		}
+	}
+}
+
+static int GetReadResult(int bytecount, char* value_str)
+{
+	int retval = -1;
+
+	switch (bytecount)
+	{
+		case -1:
+		case  0:
+		case  1:
+		{
+			break;
+		}
+
+		default:
+		{
+			if ((memcmp("0", value_str, strlen("0")) == 0) || 
+				(memcmp("in", value_str, strlen("in")) == 0) ||
+				(memcmp("none", value_str, strlen("none")) == 0))
+			{
+				retval = 0;
+				break;
+			}
+
+			if ((memcmp("1", value_str, strlen("1")) == 0) ||
+				(memcmp("out", value_str, strlen("out")) == 0) ||
+				(memcmp("rising", value_str, strlen("rising")) == 0))
+			{
+				retval = 1;
+				break;
+			}
+
+			if (memcmp("falling", value_str, strlen("falling")) == 0)
+			{
+				retval = 2;
+				break;
+			}
+
+			if (memcmp("both", value_str, strlen("both")) == 0)
+			{
+				retval = 3;
+				break;
+			}
+		}
+	}
+
+	return (retval);
+}
+
+static int GPIORead(int gpio_pin, const char *param)
+{
+	char path[GPIO_MAX_PATH];
+	char value_str[GPIO_MAX_VALUE_SIZE];
+	int fd;
+	int bytecount = -1;
+	int retval = -1;
+
+	memset(value_str, GPIO_MAX_VALUE_SIZE, 0);
+
+	snprintf(path, GPIO_MAX_PATH, "%s%d/%s", GPIO_PATH, gpio_pin, param);
+	fd = open(path, O_RDONLY);
+
+	if (fd == -1)
+	{
+		return(-1);
+	}
+
+	bytecount = read(fd, value_str, GPIO_MAX_VALUE_SIZE);
+	close(fd);
+
+	if (-1 == bytecount)
+	{
+		close(fd);
+		return(-1);
+	}
+
+	return(GetReadResult(bytecount, &value_str[0]));
+}
+
+static int GPIOReadFd(int fd)
+{
+	int bytecount = -1;
+	int retval = -1;
+	char value_str[GPIO_MAX_VALUE_SIZE];
+
+	memset(value_str, GPIO_MAX_VALUE_SIZE, 0);
+
+	if (fd == -1)
+	{
+		return(-1);
+	}
+
+	if (lseek(fd, 0, SEEK_SET) == -1)
+	{
+		return (-1);
+	}
+
+	bytecount = read(fd, value_str, GPIO_MAX_VALUE_SIZE);
+
+	return(GetReadResult(bytecount, &value_str[0]));
+}
+
+static int GPIOWrite(int gpio_pin, int value)
+{
+	char path[GPIO_MAX_PATH];
+	int fd;
+	int new_state = 0;
+	int active_low = -1;
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].pin_number == gpio_pin)
+		{
+			active_low = GpioSavedState[i].active_low;
+			break;
+		}
+	}
+
+	if (active_low == -1)
+	{
+		return -1;
+	}
+
+	if (active_low == 1)
+	{
+		value ? new_state = 0 : new_state = 1;
+	}
+	else
+	{
+		value ? new_state = 1 : new_state = 0;
+	}
+
+	snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, gpio_pin);
+	fd = open(path, O_WRONLY);
+
+	if (fd == -1)
+	{
+		return(-1);
+	}
+
+	if (1 != write(fd, GPIO_LOW == new_state ? "0" : "1", 1))
+	{
+		close(fd);
+		return(-1);
+	}
+
+	close(fd);
+	return(0);
+}
+
+#endif // WIN32

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -487,7 +487,7 @@ void CSysfsGPIO::UpdateDomoticzInputs()
 	}
 }
 
-static int GetReadResult(int bytecount, char* value_str)
+int CSysfsGPIO::GetReadResult(int bytecount, char* value_str)
 {
 	int retval = -1;
 
@@ -535,15 +535,13 @@ static int GetReadResult(int bytecount, char* value_str)
 	return (retval);
 }
 
-static int GPIORead(int gpio_pin, const char *param)
+int CSysfsGPIO::GPIORead(int gpio_pin, const char *param)
 {
 	char path[GPIO_MAX_PATH];
 	char value_str[GPIO_MAX_VALUE_SIZE];
 	int fd;
 	int bytecount = -1;
 	int retval = -1;
-
-	memset(value_str, GPIO_MAX_VALUE_SIZE, 0);
 
 	snprintf(path, GPIO_MAX_PATH, "%s%d/%s", GPIO_PATH, gpio_pin, param);
 	fd = open(path, O_RDONLY);
@@ -565,13 +563,11 @@ static int GPIORead(int gpio_pin, const char *param)
 	return(GetReadResult(bytecount, &value_str[0]));
 }
 
-static int GPIOReadFd(int fd)
+int CSysfsGPIO::GPIOReadFd(int fd)
 {
 	int bytecount = -1;
 	int retval = -1;
 	char value_str[GPIO_MAX_VALUE_SIZE];
-
-	memset(value_str, GPIO_MAX_VALUE_SIZE, 0);
 
 	if (fd == -1)
 	{
@@ -588,7 +584,7 @@ static int GPIOReadFd(int fd)
 	return(GetReadResult(bytecount, &value_str[0]));
 }
 
-static int GPIOWrite(int gpio_pin, int value)
+int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 {
 	char path[GPIO_MAX_PATH];
 	int fd;

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -108,7 +108,7 @@
 
 #include "stdafx.h"
 
-#ifndef WIN32
+#ifdef WITH_SYSFS_GPIO
 
 #include <sys/types.h>
 #include <stdio.h>
@@ -615,4 +615,4 @@ int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 	return(0);
 }
 
-#endif // WIN32
+#endif // WITH_SYSFS_GPIO

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -24,6 +24,10 @@ private:
 	void PollGpioInputs();
 	void CreateDomoticzDevices();
 	void UpdateDomoticzInputs();
+	int GPIORead(int pin, const char* param);
+	int GPIOReadFd(int fd);
+	int GPIOWrite(int pin, int value);
+	int GetReadResult(int bytecount, char* value_str);
 	boost::shared_ptr<boost::thread> m_thread;
 	volatile bool m_stoprequested;
 	tRBUF m_Packet;

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -8,6 +8,17 @@
 
 class CSysfsGPIO : public CDomoticzHardwareBase
 {
+	struct gpio_info
+	{
+		int	pin_number;		// GPIO Pin number
+		int	value;			// GPIO pin Value
+		int	db_state;		// Database Value
+		int	direction;		// GPIO IN or OUT
+		int	active_low;		// GPIO ActiveLow
+		int	edge;			// GPIO int Edge
+		int	read_value_fd;	// Fast read fd
+	};
+
 public:
 	CSysfsGPIO(const int ID);
 	~CSysfsGPIO();
@@ -29,6 +40,7 @@ private:
 	int GPIOWrite(int pin, int value);
 	int GetReadResult(int bytecount, char* value_str);
 	boost::shared_ptr<boost::thread> m_thread;
+	std::vector<gpio_info> GpioSavedState;
 	volatile bool m_stoprequested;
 	tRBUF m_Packet;
 };

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -1,0 +1,30 @@
+/*
+	This code implements basic I/O hardware via the Raspberry Pi's GPIO port, using sysfs.
+*/
+#pragma once
+
+#include "DomoticzHardware.h"
+#include "../main/RFXtrx.h"
+
+class CSysfsGPIO : public CDomoticzHardwareBase
+{
+public:
+	CSysfsGPIO(const int ID);
+	~CSysfsGPIO();
+
+	bool WriteToHardware(const char *pdata, const unsigned char length);
+
+private:
+	bool StartHardware();
+	bool StopHardware();
+	void FindGpioExports();
+	void Do_Work();
+	void Init();
+	void Poller_thread();
+	void PollGpioInputs();
+	void CreateDomoticzDevices();
+	void UpdateDomoticzInputs();
+	boost::shared_ptr<boost::thread> m_thread;
+	volatile bool m_stoprequested;
+	tRBUF m_Packet;
+};

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -249,6 +249,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_IntergasInComfortLAN2RF, "Intergas InComfort LAN2RF Gateway" },
 		{ HTYPE_RelayNet, "Relay-Net 8 channel LAN Relay and binary Input module" },
 		{ HTYPE_KMTronicUDP, "KMTronic Gateway with LAN/UDP interface" },
+		{ HTYPE_SysfsGPIO, "Generic sysfs gpio" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -183,6 +183,7 @@ enum _eHardwareTypes {
 	HTYPE_IntergasInComfortLAN2RF,			//99
 	HTYPE_RelayNet,				//100
 	HTYPE_KMTronicUDP,			//101
+	HTYPE_SysfsGPIO,			//102
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -992,7 +992,7 @@ namespace http {
 					bDoAdd = false;
 				}
 #endif
-#ifdef WITH_SYSFS_GPIO
+#ifndef WITH_SYSFS_GPIO
 				if (ii == HTYPE_SysfsGPIO)
 				{
 					bDoAdd = false;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -26,6 +26,7 @@
 #include "../hardware/MySensorsBase.h"
 #include "../hardware/RFXBase.h"
 #include "../hardware/RFLinkBase.h"
+#include "../hardware/SysfsGPIO.h"
 #include "../hardware/HEOS.h"
 #ifdef WITH_GPIO
 #include "../hardware/Gpio.h"
@@ -987,7 +988,15 @@ namespace http {
 #endif
 #ifndef WITH_GPIO
 				if (ii == HTYPE_RaspberryGPIO)
+				{
 					bDoAdd = false;
+				}
+#endif
+#ifdef WIN32
+				if (ii == HTYPE_SysfsGPIO)
+				{
+					bDoAdd = false;
+				}
 #endif
 				if (((ii == HTYPE_1WIRE) && (!C1Wire::Have1WireSystem())) || (ii == HTYPE_PythonPlugin))
 					bDoAdd = false;
@@ -1236,6 +1245,9 @@ namespace http {
 					mode1 = atoi(mill_id.c_str());
 			}
 			else if (htype == HTYPE_RaspberryGPIO) {
+				//all fine here!
+			}
+			else if (htype == HTYPE_SysfsGPIO) {
 				//all fine here!
 			}
 			else if (htype == HTYPE_OpenWebNetTCP) {
@@ -1566,6 +1578,9 @@ namespace http {
 					port = 80;
 			}
 			else if (htype == HTYPE_RaspberryGPIO) {
+				//all fine here!
+			}
+			else if (htype == HTYPE_SysfsGPIO) {
 				//all fine here!
 			}
 			else if (htype == HTYPE_Daikin) {

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -992,7 +992,7 @@ namespace http {
 					bDoAdd = false;
 				}
 #endif
-#ifdef WIN32
+#ifdef WITH_SYSFS_GPIO
 				if (ii == HTYPE_SysfsGPIO)
 				{
 					bDoAdd = false;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -120,6 +120,7 @@
 #include "../hardware/OpenWebNetUSB.h"
 #include "../hardware/InComfort.h"
 #include "../hardware/RelayNet.h"
+#include "../hardware/SysfsGPIO.h"
 
 // load notifications configuration
 #include "../notifications/NotificationHelper.h"
@@ -941,6 +942,11 @@ bool MainWorker::AddHardwareFromParams(
 		//Raspberry Pi GPIO port access
 #ifdef WITH_GPIO
 		pHardware = new CGpio(ID, Mode1, Mode2, Mode3);
+#endif
+		break;
+	case HTYPE_SysfsGPIO:
+#ifndef WIN32
+		pHardware = new CSysfsGPIO(ID);
 #endif
 		break;
 	case HTYPE_Comm5TCP:

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -945,7 +945,7 @@ bool MainWorker::AddHardwareFromParams(
 #endif
 		break;
 	case HTYPE_SysfsGPIO:
-#ifndef WIN32
+#ifdef WITH_SYSFS_GPIO
 		pHardware = new CSysfsGPIO(ID);
 #endif
 		break;

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -438,6 +438,7 @@
     <ClInclude Include="..\hardware\FritzboxTCP.h" />
     <ClInclude Include="..\hardware\Gpio.h" />
     <ClInclude Include="..\hardware\GpioPin.h" />
+    <ClInclude Include="..\hardware\SysfsGPIO.h" />
     <ClInclude Include="..\hardware\HarmonyHub.h" />
     <ClInclude Include="..\hardware\HEOS.h" />
     <ClInclude Include="..\hardware\HttpPoller.h" />
@@ -679,6 +680,7 @@
     <ClCompile Include="..\hardware\GoodweAPI.cpp" />
     <ClCompile Include="..\hardware\Gpio.cpp" />
     <ClCompile Include="..\hardware\GpioPin.cpp" />
+    <ClCompile Include="..\hardware\SysfsGPIO.cpp" />
     <ClCompile Include="..\hardware\HarmonyHub.cpp" />
     <ClCompile Include="..\hardware\HEOS.cpp" />
     <ClCompile Include="..\hardware\HttpPoller.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -465,6 +465,9 @@
     <Filter Include="Devices\RelayNet">
       <UniqueIdentifier>{9882d591-40c3-4d12-8c0a-af2d53d939ff}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Devices\SysfsGPIO">
+      <UniqueIdentifier>{301fceaa-95de-4168-b336-04cadc395ff6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\CMakeLists.txt">
@@ -2002,6 +2005,9 @@
     <ClInclude Include="..\main\LuaCommon.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\SysfsGPIO.h">
+      <Filter>Devices\SysfsGPIO</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\webserver\Base64.cpp">
@@ -2663,6 +2669,9 @@
     </ClCompile>
     <ClCompile Include="..\main\LuaCommon.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\SysfsGPIO.cpp">
+      <Filter>Devices\SysfsGPIO</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -126,7 +126,8 @@ define(['app'], function (app) {
 				(text.indexOf("Kodi Media") >= 0) ||
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
-				(text.indexOf("Arilux AL-LC0x") >= 0)
+                (text.indexOf("Arilux AL-LC0x") >= 0) ||
+                (text.indexOf("sysfs gpio") >= 0)
 				)
             {
 				// if hardwaretype == 1000 => I2C sensors grouping
@@ -139,7 +140,7 @@ define(['app'], function (app) {
                 	var i2caddress=$("#hardwareparami2caddress #i2caddress").val();
                 	var port="&port=" + encodeURIComponent(i2caddress);
                 }
-                if (text.indexOf("GPIO") >= 0)
+                if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1))
                 {
                     var gpiodebounce=$("#hardwareparamsgpio #gpiodebounce").val();
                     var gpioperiod = $("#hardwareparamsgpio #gpioperiod").val();
@@ -1083,8 +1084,9 @@ define(['app'], function (app) {
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("Tellstick") >= 0) ||
 				(text.indexOf("Motherboard") >= 0) ||
-				(text.indexOf("YeeLight") >= 0) ||
-				(text.indexOf("Arilux AL-LC0x") >= 0)
+                (text.indexOf("YeeLight") >= 0) ||
+                (text.indexOf("Arilux AL-LC0x") >= 0) ||
+                (text.indexOf("sysfs gpio") >= 0)
 				)
             {
                 $.ajax({
@@ -5062,7 +5064,8 @@ define(['app'], function (app) {
 							(data["Type"].indexOf("PiFace") >= 0)||
 							(data["Type"].indexOf("Tellstick") >= 0) ||
 							(data["Type"].indexOf("Yeelight") >= 0) ||
-							(data["Type"].indexOf("Arilux AL-LC0x") >= 0)
+                            (data["Type"].indexOf("Arilux AL-LC0x") >= 0) ||
+                            (data["Type"].indexOf("sysfs gpio") >= 0)
                            )
                         {
                             //nothing to be set
@@ -5354,7 +5357,8 @@ define(['app'], function (app) {
 				(text.indexOf("System Alive") >= 0)||
 				(text.indexOf("PiFace") >= 0) ||
 				(text.indexOf("Yeelight") >= 0) ||
-				(text.indexOf("Arilux AL-LC0x") >= 0)
+                (text.indexOf("Arilux AL-LC0x") >= 0) ||
+                (text.indexOf("sysfs gpio") >= 0)
                )
             {
                 $("#hardwarecontent #divserial").hide();
@@ -5378,7 +5382,7 @@ define(['app'], function (app) {
                     $("#hardwarecontent #divi2caddress").show();
                 }
             }
-            else if (text.indexOf("GPIO") >= 0)
+            else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1))
             {
                 $("#hardwarecontent #divgpio").show();
                 $("#hardwarecontent #divserial").hide();


### PR DESCRIPTION
Generic sysfs gpio for Linux makes exported GPIO inputs and outputs available for use. Before adding the hardware within domoticz you need to export the GPIO's that you are going to use. By doing this you specify the direction of the GPIO, in or out, whether pull-ups or pull-downs are turned on etc. Then when this "Generic sysfs gpio" hardware is added it will detect the exported GPIOs and creates devices for it. After that you can fine tune the inputs and outputs for specific purposes like door-contacts etc. as always. Sysfs does not depend on any external libraries like wiringpi.