### PR TITLE
Style, Element-Dark, missing comma..

### DIFF
--- a/www/styles/element-dark/custom.css
+++ b/www/styles/element-dark/custom.css
@@ -137,7 +137,7 @@ h2{
 }
 
 body table#itemtablesmall tbody tr,
-body table#itemtablesmalldoubleicon tbody tr
+body table#itemtablesmalldoubleicon tbody tr,
 body table#itemtable tbody tr,
 body table#itemtablenotype tbody tr,
 body table#itemtablenostatus tbody tr,

--- a/www/styles/element-dark/custom.css
+++ b/www/styles/element-dark/custom.css
@@ -145,7 +145,7 @@ body table#itemtabledoubleicon tbody tr,
 body table#itemtabletrippleicon tbody tr,
 body table#itemtablesmalldoubleicon tbody tr,
 body table#itemtablesmalltrippleicon tbody tr,
-body table#mobileitem tbody tr
+body table#mobileitem tbody tr,
 body table#itemtablesmall tbody tr:hover,
 body table#itemtablesmalldoubleicon tbody tr:hover,
 body table#itemtable tbody tr:hover,


### PR DESCRIPTION
missing comma made power meters and such format as default theme

Looks like this with fix
![image](https://cloud.githubusercontent.com/assets/25690871/25140501/de5dae70-2460-11e7-83ce-0847567023bb.png)
