### PR TITLE
GPIO-wiringpi: fix hang on disable hardware

### DIFF
--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -58,7 +58,8 @@ Connection information:
 #include "../main/SQLHelper.h"
 
 #define NO_INTERRUPT	-1
-#define MAX_GPIO	31
+#define MAX_GPIO		31
+#define	DELAYED_STARTUP_SECONDS 30
 
 bool m_bIsInitGPIOPins=false;
 bool interruptHigh[MAX_GPIO+1]={ false };
@@ -191,6 +192,9 @@ bool CGpio::StartHardware()
 #endif
 	m_stoprequested=false;
 
+	//  Read all exported GPIO ports and set the device status accordingly.
+	UpdateDeviceStates(false);
+
 	//  Start worker thread that will be responsible for interrupt handling
 	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CGpio::Do_Work, this)));
 
@@ -238,26 +242,7 @@ bool CGpio::StartHardware()
 		}
 	}
 
-	//  Read all exported GPIO ports and set the device status accordingly.
-	UpdateDeviceStates(false);
-
-	//  No need for delayed startup and force update when no masters are able to connect.
-	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT ID FROM Users WHERE (RemoteSharing==1) AND (Active==1)");
-	if (result.size()>0)
-	{
-		//  Wait 250 milli seconds to make sure all are set before initialising
-		//  the remainder of domoticz.
-		sleep_milliseconds(250);
-
-		//  Start thread to do a delayed setup of initial state
-		m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CGpio::DelayedStartup, this)));
-	}
-
-	if (m_pollinterval > 0)
-	{
-		m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CGpio::Poller, this)));
-	}
+	m_thread_poller = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CGpio::Poller, this)));
 
 	_log.Log(LOG_NORM, "GPIO: WiringPi is now initialized");
 #endif
@@ -266,13 +251,18 @@ bool CGpio::StartHardware()
 	return (m_thread != NULL);
 }
 
-
 bool CGpio::StopHardware()
 {
+	m_stoprequested = true;
+
 	if (m_thread != NULL) {
-		m_stoprequested=true;
 		interruptCondition.notify_one();
 		m_thread->join();
+	}
+
+	if (m_thread_poller != NULL) 
+	{
+		m_thread_poller->join();
 	}
 
 	m_bIsStarted=false;
@@ -405,6 +395,14 @@ void CGpio::Poller()
 	//	missed this code will make up for it.
 	//
 	int sec_counter = 0;
+	bool delayed_startup = false;
+
+	std::vector<std::vector<std::string> > result = 
+		m_sql.safe_query("SELECT ID FROM Users WHERE (RemoteSharing==1) AND (Active==1)");
+	if (result.size() > 0)
+	{
+		delayed_startup = true;
+	}
 
 	_log.Log(LOG_STATUS, "GPIO: %d-second poller started", m_pollinterval);
 
@@ -413,9 +411,27 @@ void CGpio::Poller()
 		sleep_seconds(1);
 		sec_counter++;
 
-		if ((sec_counter % m_pollinterval == 0) && (!m_stoprequested))
+		if (m_stoprequested)
 		{
+			break;
+		}
+
+		if (delayed_startup && (sec_counter == DELAYED_STARTUP_SECONDS))
+		{
+			_log.Log(LOG_NORM, "GPIO: Update Master Domoticz GPIO status");
 			UpdateDeviceStates(false);
+
+			if (m_pollinterval == 0)
+			{
+				break;
+			}
+		}
+		else
+		{
+			if ((m_pollinterval > 0) && (sec_counter % m_pollinterval == 0))
+			{
+				UpdateDeviceStates(false);
+			}
 		}
 	}
 
@@ -607,22 +623,6 @@ CGpioPin* CGpio::GetPPinById(int id)
 		}
 	}
 	return NULL;
-}
-
-void CGpio::DelayedStartup()
-{
-	//
-	//	This runs to better support Raspberry Pi as domoticz slave device.
-	//
-	//  Delay 30 seconds to make sure master domoticz has connected. Then
-	//	copy the GPIO ports states to the switches one more time so the
-	//	master will see the actual states also after it has connected.
-	//
-	sleep_milliseconds(30000);
-	_log.Log(LOG_NORM, "GPIO: Optional connected Master Domoticz now updates its status");
-	UpdateDeviceStates(true);
-
-	// _log.Log(LOG_NORM, "GPIO: DelayedStartup - done");
 }
 
 void CGpio::UpdateDeviceStates(bool forceUpdate)

--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -404,7 +404,10 @@ void CGpio::Poller()
 		delayed_startup = true;
 	}
 
-	_log.Log(LOG_STATUS, "GPIO: %d-second poller started", m_pollinterval);
+	if (m_pollinterval)
+	{
+		_log.Log(LOG_STATUS, "GPIO: %d-second poller started", m_pollinterval);
+	}
 
 	while (!m_stoprequested)
 	{
@@ -435,7 +438,10 @@ void CGpio::Poller()
 		}
 	}
 
-	_log.Log(LOG_STATUS, "GPIO: %d-second poller stopped", m_pollinterval);
+	if (m_pollinterval)
+	{
+		_log.Log(LOG_STATUS, "GPIO: %d-second poller stopped", m_pollinterval);
+	}
 }
 
 /*

--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -422,7 +422,7 @@ void CGpio::Poller()
 		if (delayed_startup && (sec_counter == DELAYED_STARTUP_SECONDS))
 		{
 			_log.Log(LOG_NORM, "GPIO: Update Master Domoticz GPIO status");
-			UpdateDeviceStates(false);
+			UpdateDeviceStates(true);
 
 			if (m_pollinterval == 0)
 			{

--- a/hardware/Gpio.h
+++ b/hardware/Gpio.h
@@ -47,7 +47,6 @@ private:
 	bool StopHardware();
 	void Do_Work();
 	void Poller();
-	void DelayedStartup();
 	void UpdateDeviceStates(bool forceUpdate);
 	void ProcessInterrupt(int gpioId);
 	void UpdateState(int gpioId, bool forceUpdate);
@@ -56,6 +55,7 @@ private:
 	static std::vector<CGpioPin> pins;
 
 	boost::shared_ptr<boost::thread> m_thread;
+	boost::shared_ptr<boost::thread> m_thread_poller;
 	volatile bool m_stoprequested;
 	tRBUF IOPinStatusPacket;
 };


### PR DESCRIPTION
Fix possible hang when GPIO-wiringpi enabled checkbox is turned off, and the update button is pressed,
 on the domoticz hardware page. The fix was made based on test feedback from Lenard Kaptein (see  #1471).