### PR TITLE
Allow linking to external JsonCPP library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,28 @@ set (domoticz_VERSION_MAJOR 3)
 set (domoticz_VERSION_MINOR 0)
 set (domoticz_VERSION_PATCH ${ProjectRevision})
 
+option(USE_BUILTIN_JSONCPP "Use builtin JsonCPP" YES)
+IF(USE_BUILTIN_JSONCPP)
+  MESSAGE(STATUS "Using builtin JsonCPP")
+  set (domoticz_jsoncpp_SRCS 
+       json/json_reader.cpp
+       json/json_value.cpp
+       json/json_writer.cpp
+      )
+ELSE(USE_BUILTIN_JSONCPP)
+  MESSAGE(STATUS "Using external JsonCPP")
+  find_package(PkgConfig)
+  pkg_check_modules(JSONCPP jsoncpp)
+  IF(JSONCPP_FOUND)
+    INCLUDE_DIRECTORIES(${JSONCPP_INCLUDE_DIRS})
+    add_definitions(-DWITH_EXTERNAL_JSONCPP)
+    link_directories(${JSONCPP_LIBRARY_DIRS})
+    MESSAGE(STATUS "JsonCPP Found at ${JSONCPP_INCLUDE_DIRS} and ${JSONCPP_LIBRARY_DIRS}")
+  ELSE(JSONCPP_FOUND)
+    MESSAGE(FATAL_ERROR "JsonCPP not found but USE_BUILTIN_LUA=NO")
+  ENDIF(JSONCPP_FOUND)
+ENDIF(USE_BUILTIN_JSONCPP)
+
 option(USE_BUILTIN_LUA "Use builtin lua library" YES)
 IF(USE_BUILTIN_LUA)
   IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
@@ -438,9 +460,6 @@ webserver/request_parser.cpp
 webserver/server.cpp
 webserver/proxycommon.cpp
 webserver/proxyclient.cpp
-json/json_reader.cpp
-json/json_value.cpp
-json/json_writer.cpp
 tinyxpath/action_store.cpp
 tinyxpath/htmlutil.cpp
 tinyxpath/lex_util.cpp
@@ -458,7 +477,7 @@ tinyxpath/xpath_stack.cpp
 tinyxpath/xpath_static.cpp
 tinyxpath/xpath_syntax.cpp
 )
-add_executable(domoticz ${domoticz_SRCS})
+add_executable(domoticz ${domoticz_SRCS} ${domoticz_jsoncpp_SRCS})
 
 # explicitly say that the executable depends on the revisiontag
 add_dependencies(domoticz revisiontag)
@@ -680,9 +699,9 @@ else()
 endif (TELLDUSCORE_INCLUDE)
 
 IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  target_link_libraries(domoticz ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${CURL_LIBRARIES} pthread ${LUA_LIBRARIES} ${MQTT_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES})
+  target_link_libraries(domoticz ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${CURL_LIBRARIES} pthread ${LUA_LIBRARIES} ${MQTT_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES} ${JSONCPP_LIBRARIES})
 else()
-  target_link_libraries(domoticz -lrt ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${CURL_LIBRARIES} pthread ${LUA_LIBRARIES} ${MQTT_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES} ${EXECINFO_LIBRARIES})
+  target_link_libraries(domoticz -lrt ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${CURL_LIBRARIES} pthread ${LUA_LIBRARIES} ${MQTT_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES} ${EXECINFO_LIBRARIES} ${JSONCPP_LIBRARIES})
 ENDIF()
 
 ADD_PRECOMPILED_HEADER(domoticz "main/stdafx.h")

--- a/hardware/1Wire/1WireForWindows.h
+++ b/hardware/1Wire/1WireForWindows.h
@@ -1,7 +1,7 @@
 #pragma once
 #ifdef WIN32
 #include "1WireSystem.h"
-#include "../../json/json.h"
+#include "../../main/json.h"
 
 #include <boost/asio.hpp>
 

--- a/hardware/AccuWeather.cpp
+++ b/hardware/AccuWeather.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../ma../main.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 

--- a/hardware/AccuWeather.cpp
+++ b/hardware/AccuWeather.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../ma../main.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 

--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -8,7 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../ma../main.h"
 #include <numeric>
 
 

--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -8,7 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../ma../main.h"
+#include "../main/json.h"
 #include <numeric>
 
 

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -9,7 +9,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../ma../main.h"
 
 extern http::server::CWebServerHelper m_webservers;
 

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -9,7 +9,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../ma../main.h"
+#include "../main/json.h"
 
 extern http::server::CWebServerHelper m_webservers;
 

--- a/hardware/DarkSky.cpp
+++ b/hardware/DarkSky.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -6,7 +6,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "hardwaretypes.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/hardware/Ec3kMeterTCP.cpp
+++ b/hardware/Ec3kMeterTCP.cpp
@@ -6,7 +6,7 @@
 #include "../main/localtime_r.h"
 //#include "../main/mainworker.h"
 #include "../hardware/hardwaretypes.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <sstream>
 

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -35,7 +35,7 @@ Version history
 #include "../httpclient/HTTPClient.h"
 #include <../tinyxpath/xpath_static.h>
 #include "../webserver/Base64.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include <sstream>
 
 #ifdef _DEBUG

--- a/hardware/Fitbit.cpp
+++ b/hardware/Fitbit.cpp
@@ -7,7 +7,7 @@
 #include "../main/RFXtrx.h"
 #include "hardwaretypes.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/GoodweAPI.cpp
+++ b/hardware/GoodweAPI.cpp
@@ -7,7 +7,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 #if defined(_WIN32) || defined(_WIN64) 

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -39,7 +39,7 @@ History:
 #include "../main/mainworker.h"
 #include "../webserver/Base64.h"
 #include "csocket.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define CONNECTION_ID								"21345678-1234-5678-1234-123456789012-1"
 #define GET_CONFIG_COMMAND							"get_config"

--- a/hardware/HttpPoller.cpp
+++ b/hardware/HttpPoller.cpp
@@ -7,7 +7,7 @@
 #include "../main/RFXtrx.h"
 #include "hardwaretypes.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../webserver/Base64.h"
 #include "../main/WebServer.h"
 #include "../main/LuaHandler.h"

--- a/hardware/ICYThermostat.cpp
+++ b/hardware/ICYThermostat.cpp
@@ -8,7 +8,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/InComfort.cpp
+++ b/hardware/InComfort.cpp
@@ -4,12 +4,12 @@
 #include "../main/Logger.h"
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/InComfort.cpp
+++ b/hardware/InComfort.cpp
@@ -9,7 +9,6 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -62,9 +62,9 @@ Json::Value CLogitechMediaServer::Query(std::string sIP, int iPort, std::string 
 	std::stringstream sPostData;
 
 	if ((m_User != "") && (m_Pwd != ""))
-		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort <<../mainrpc.js";
+		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort <<../jsonrpc.js";
 	else
-		sURL << "http://" << sIP << ":" << iPort <<../mainrpc.js";
+		sURL << "http://" << sIP << ":" << iPort <<../jsonrpc.js";
 
 	sPostData << sPostdata;
 	

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -62,9 +62,9 @@ Json::Value CLogitechMediaServer::Query(std::string sIP, int iPort, std::string 
 	std::stringstream sPostData;
 
 	if ((m_User != "") && (m_Pwd != ""))
-		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort <<../jsonrpc.js";
+		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort << "/jsonrpc.js";
 	else
-		sURL << "http://" << sIP << ":" << iPort <<../jsonrpc.js";
+		sURL << "http://" << sIP << ":" << iPort << "/jsonrpc.js";
 
 	sPostData << sPostdata;
 	

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -62,9 +62,9 @@ Json::Value CLogitechMediaServer::Query(std::string sIP, int iPort, std::string 
 	std::stringstream sPostData;
 
 	if ((m_User != "") && (m_Pwd != ""))
-		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort << "/jsonrpc.js";
+		sURL << "http://" << m_User << ":" << m_Pwd << "@" << sIP << ":" << iPort <<../mainrpc.js";
 	else
-		sURL << "http://" << sIP << ":" << iPort << "/jsonrpc.js";
+		sURL << "http://" << sIP << ":" << iPort <<../mainrpc.js";
 
 	sPostData << sPostdata;
 	

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -6,7 +6,7 @@
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 #include "../main/SQLHelper.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../notifications/NotificationHelper.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -15,7 +15,7 @@
 #include <boost/bind.hpp>
 #include <boost/lexical_cast.hpp>
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <ctime>
 

--- a/hardware/NefitEasy.cpp
+++ b/hardware/NefitEasy.cpp
@@ -279,7 +279,7 @@ void CNefitEasy::SetUserMode(bool bSetUserModeClock)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 
 	try
 	{
@@ -308,7 +308,7 @@ void CNefitEasy::SetHotWaterMode(bool bTurnOn)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 
 	try
 	{
@@ -814,7 +814,7 @@ void CNefitEasy::SetSetpoint(const int idx, const float temp)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 
 	try
 	{

--- a/hardware/NefitEasy.cpp
+++ b/hardware/NefitEasy.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 #include "../webserver/Base64.h"
@@ -279,7 +279,7 @@ void CNefitEasy::SetUserMode(bool bSetUserModeClock)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 
 	try
 	{
@@ -308,7 +308,7 @@ void CNefitEasy::SetHotWaterMode(bool bTurnOn)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 
 	try
 	{
@@ -814,7 +814,7 @@ void CNefitEasy::SetSetpoint(const int idx, const float temp)
 	std::string sResult;
 	std::vector<std::string> ExtraHeaders;
 	//ExtraHeaders.push_back("User-Agent: NefitEasy");
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 
 	try
 	{

--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -8,7 +8,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -7,7 +7,7 @@
 #include "../main/RFXtrx.h"
 #include "hardwaretypes.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -13,7 +13,7 @@
 #include <algorithm>
 #include <iostream>
 #include <boost/bind.hpp>
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <ctime>
 

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 #include "../main/SQLHelper.h"

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -19,7 +19,7 @@
 #include "../webserver/cWebem.h"
 #include "../main/mainworker.h"
 
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/localtime_r.h"
 
 //OpenZWave includes

--- a/hardware/PVOutput_Input.cpp
+++ b/hardware/PVOutput_Input.cpp
@@ -4,7 +4,7 @@
 #include "../main/Logger.h"
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -8,7 +8,7 @@
 #include "../main/WebServer.h"
 #include "../main/mainworker.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <boost/asio.hpp>
 #include <boost/enable_shared_from_this.hpp>

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -11,7 +11,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #ifdef _DEBUG
 	#define ENABLE_LOGGING

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -7,7 +7,7 @@
 #include "../main/SQLHelper.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <string>
 #include <algorithm>

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -8,7 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "hardwaretypes.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 #include <iostream>
@@ -156,7 +156,7 @@ void SolarEdgeAPI::GetSite()
 	sResult = ReadFile("E:\\SolarEdge_sites.json");
 #else
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/sites/list?size=1&api_key=" << m_APIKey << "&format=application/json";
+	sURL << "https://monitoringapi.solaredge.com/sites/list?size=1&api_key=" << m_APIKey << "&format=applicati../main";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);
@@ -209,7 +209,7 @@ void SolarEdgeAPI::GetInverters()
 	sResult = ReadFile("E:\\SolarEdge_inverters.json");
 #else
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/list?api_key=" << m_APIKey << "&format=application/json";
+	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/list?api_key=" << m_APIKey << "&format=applicati../main";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);
@@ -310,7 +310,7 @@ void SolarEdgeAPI::GetInverterDetails(const _tInverterSettings *pInverterSetting
 	sprintf(szTmp, "%04d-%02d-%02d %02d:%02d:%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);
 	std::string endDate = CURLEncode::URLEncode(szTmp);
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/" << pInverterSettings->SN << "/data.json?startTime=" << startDate << "&endTime=" << endDate << "&api_key=" << m_APIKey << "&format=application/json";
+	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/" << pInverterSettings->SN << "/data.json?startTime=" << startDate << "&endTime=" << endDate << "&api_key=" << m_APIKey << "&format=applicati../main";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -156,7 +156,7 @@ void SolarEdgeAPI::GetSite()
 	sResult = ReadFile("E:\\SolarEdge_sites.json");
 #else
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/sites/list?size=1&api_key=" << m_APIKey << "&format=applicati../main";
+	sURL << "https://monitoringapi.solaredge.com/sites/list?size=1&api_key=" << m_APIKey << "&format=application/json";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);
@@ -209,7 +209,7 @@ void SolarEdgeAPI::GetInverters()
 	sResult = ReadFile("E:\\SolarEdge_inverters.json");
 #else
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/list?api_key=" << m_APIKey << "&format=applicati../main";
+	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/list?api_key=" << m_APIKey << "&format=application/json";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -310,7 +310,7 @@ void SolarEdgeAPI::GetInverterDetails(const _tInverterSettings *pInverterSetting
 	sprintf(szTmp, "%04d-%02d-%02d %02d:%02d:%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);
 	std::string endDate = CURLEncode::URLEncode(szTmp);
 	std::stringstream sURL;
-	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/" << pInverterSettings->SN << "/data.json?startTime=" << startDate << "&endTime=" << endDate << "&api_key=" << m_APIKey << "&format=applicati../main";
+	sURL << "https://monitoringapi.solaredge.com/equipment/" << m_SiteID << "/" << pInverterSettings->SN << "/data.json?startTime=" << startDate << "&endTime=" << endDate << "&api_key=" << m_APIKey << "&format=application/json";
 	bool bret;
 	std::string szURL = sURL.str();
 	bret = HTTPClient::GET(szURL, sResult);

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -8,7 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include <telldus-core.h>
 
 using namespace std;

--- a/hardware/Thermosmart.cpp
+++ b/hardware/Thermosmart.cpp
@@ -9,7 +9,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define round(a) ( int ) ( a + .5 )
 
@@ -436,7 +436,7 @@ void CThermosmart::SetPauseStatus(const bool bIsPause)
 	szPostdata += "}";
 
 	std::vector<std::string> ExtraHeaders;
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 	std::string sResult;
 
 	std::string sURL = THERMOSMART_SET_PAUZE;

--- a/hardware/Thermosmart.cpp
+++ b/hardware/Thermosmart.cpp
@@ -436,7 +436,7 @@ void CThermosmart::SetPauseStatus(const bool bIsPause)
 	szPostdata += "}";
 
 	std::vector<std::string> ExtraHeaders;
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 	std::string sResult;
 
 	std::string sURL = THERMOSMART_SET_PAUZE;

--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -8,7 +8,7 @@
 #include "../main/SQLHelper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <boost/uuid/uuid.hpp>            // uuid class
 #include <boost/uuid/uuid_generators.hpp> // generators

--- a/hardware/WOL.cpp
+++ b/hardware/WOL.cpp
@@ -7,7 +7,7 @@
 #include "../main/WebServer.h"
 #include "../main/mainworker.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 CWOL::CWOL(const int ID, const std::string &BroadcastAddress, const unsigned short Port):
 m_broadcast_address(BroadcastAddress)

--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -6,7 +6,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/RFXtrx.h"
 #include "../main/mainworker.h"
 

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -7,7 +7,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "XiaomiGateway.h"
 #include <openssl/aes.h>
 #include <boost/asio.hpp>

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -8,7 +8,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 /*
 Yeelight (Mi Light) is a company that created White and RGBW lights

--- a/hardware/YouLess.cpp
+++ b/hardware/YouLess.cpp
@@ -7,7 +7,7 @@
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #define YOULESS_POLL_INTERVAL 10
 

--- a/hardware/ZiBlueBase.cpp
+++ b/hardware/ZiBlueBase.cpp
@@ -10,7 +10,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include "ziblue_usb_frame_api.h"
 

--- a/hardware/evohome.cpp
+++ b/hardware/evohome.cpp
@@ -22,7 +22,7 @@
 #include "../main/mainworker.h"
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "../main/json.h"
 
 #include <string>
 #include <algorithm>

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -11,7 +11,7 @@
 #include "SQLHelper.h"
 #include "WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "json.h"
 
 #define CAMERA_POLL_INTERVAL 30
 

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -16,7 +16,7 @@
 #include "../notifications/NotificationHelper.h"
 #include "WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "json.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 

--- a/main/LuaCommon.cpp
+++ b/main/LuaCommon.cpp
@@ -17,7 +17,7 @@ extern "C" {
 }
 
 #include "../tinyxpath/xpath_processor.h"
-#include "../json/json.h"
+#include "json.h"
 #include "SQLHelper.h"
 #include "mainworker.h"
 #include "../hardware/hardwaretypes.h"

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -17,7 +17,7 @@ extern "C" {
 }
 
 #include "../tinyxpath/xpath_processor.h"
-#include "../json/json.h"
+#include "json.h"
 #include "SQLHelper.h"
 #include "mainworker.h"
 #include "../hardware/hardwaretypes.h"

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -8,7 +8,7 @@
 #include "mainworker.h"
 #include "WebServer.h"
 #include "../webserver/cWebem.h"
-#include "../json/json.h"
+#include "json.h"
 #include "boost/date_time/gregorian/gregorian.hpp"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -37,7 +37,7 @@
 #endif
 #include "../webserver/Base64.h"
 #include "../smtpclient/SMTPClient.h"
-#include "../json/json.h"
+#include "json.h"
 #include "Logger.h"
 #include "SQLHelper.h"
 #include "../push/BasePush.h"

--- a/main/json.h
+++ b/main/json.h
@@ -1,0 +1,5 @@
+#ifdef WITH_EXTERNAL_JSONCPP
+#include <json/json.h>
+#else 
+#include "../json/json.h"
+#endif

--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -59,7 +59,7 @@ bool CNotificationGCM::SendMessageImplementation(
 	std::string szPostdata = sstr.str();
 
 	std::vector<std::string> ExtraHeaders;
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 
 	sstr2 << "Authorization: key=" << GAPI;
 	ExtraHeaders.push_back(sstr2.str());

--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -3,7 +3,7 @@
 #include "../httpclient/HTTPClient.h"
 #include "../main/Logger.h"
 #include "../main/SQLHelper.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include <boost/lexical_cast.hpp>
 
 #define GAPI_POST_URL "https://gcm-http.googleapis.com/gcm/send"
@@ -59,7 +59,7 @@ bool CNotificationGCM::SendMessageImplementation(
 	std::string szPostdata = sstr.str();
 
 	std::vector<std::string> ExtraHeaders;
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 
 	sstr2 << "Authorization: key=" << GAPI;
 	ExtraHeaders.push_back(sstr2.str());

--- a/notifications/NotificationLogitechMediaServer.h
+++ b/notifications/NotificationLogitechMediaServer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "NotificationBase.h"
 
-#include "../json/json.h"
+#include "../main/json.h"
 
 class CNotificationLogitechMediaServer : public CNotificationBase {
 public:

--- a/notifications/NotificationPushbullet.cpp
+++ b/notifications/NotificationPushbullet.cpp
@@ -2,7 +2,7 @@
 #include "NotificationPushbullet.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/Logger.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../httpclient/UrlEncode.h"
 
 CNotificationPushbullet::CNotificationPushbullet() : CNotificationBase(std::string("pushbullet"), OPTIONS_URL_SUBJECT | OPTIONS_URL_BODY | OPTIONS_URL_PARAMS)
@@ -45,7 +45,7 @@ bool CNotificationPushbullet::SendMessageImplementation(
 	//Add the required Access Token and Content Type
 	sHeaderKey << "Access-Token: " << _apikey;
 	ExtraHeaders.push_back(sHeaderKey.str());
-	ExtraHeaders.push_back("Content-Type: application/json");
+	ExtraHeaders.push_back("Content-Type: applicati../main");
 	
 	//Do the request
 	bRet = HTTPClient::POST("https://api.pushbullet.com/v2/pushes",sPostData,ExtraHeaders,sResult);

--- a/notifications/NotificationPushbullet.cpp
+++ b/notifications/NotificationPushbullet.cpp
@@ -45,7 +45,7 @@ bool CNotificationPushbullet::SendMessageImplementation(
 	//Add the required Access Token and Content Type
 	sHeaderKey << "Access-Token: " << _apikey;
 	ExtraHeaders.push_back(sHeaderKey.str());
-	ExtraHeaders.push_back("Content-Type: applicati../main");
+	ExtraHeaders.push_back("Content-Type: application/json");
 	
 	//Do the request
 	bRet = HTTPClient::POST("https://api.pushbullet.com/v2/pushes",sPostData,ExtraHeaders,sResult);

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "BasePush.h"
 #include "../hardware/hardwaretypes.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "../main/RFXtrx.h"

--- a/push/FibaroPush.cpp
+++ b/push/FibaroPush.cpp
@@ -2,7 +2,7 @@
 #include "FibaroPush.h"
 #include "../hardware/hardwaretypes.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "../main/mainworker.h"

--- a/push/GooglePubSubPush.cpp
+++ b/push/GooglePubSubPush.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "GooglePubSubPush.h"
 #include "../hardware/hardwaretypes.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 #include "../main/Logger.h"

--- a/push/HttpPush.cpp
+++ b/push/HttpPush.cpp
@@ -11,7 +11,7 @@
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
 #include "../main/mainworker.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 

--- a/push/InfluxPush.cpp
+++ b/push/InfluxPush.cpp
@@ -2,7 +2,7 @@
 #include "InfluxPush.h"
 #include "../hardware/hardwaretypes.h"
 #include "../httpclient/HTTPClient.h"
-#include "../json/json.h"
+#include "../main/json.h"
 #include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "../main/mainworker.h"


### PR DESCRIPTION
Hello,

On some OS there is already JsonCPP library in the system.
To avoid duplicate code in some embedded and/or localy patched jsoncpp library I have added an option : USE_BUILTIN_JSONCPP.

CMakeFile use pkg-config to find the correct flags where the library and include files are.