### PR TITLE
Teleinfo: Fix for bug reported in the forum

### DIFF
--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -22,7 +22,7 @@ History :
 #include "TeleinfoBase.h"
 #include "../main/Logger.h"
 #include "../main/localtime_r.h"
-#include <bitset>				 // This is necessary to compile on Windows
+#include <bitset>			 // This is necessary to compile on Windows
 
 #ifdef _DEBUG
 #define DEBUG_TeleinfoBase

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -2,7 +2,7 @@
 Domoticz Software : http://domoticz.com/
 File : TeleinfoBase.cpp
 Author : Blaise Thauvin
-Version : 1.3
+Version : 1.5
 Description : This class is used by various Teleinfo hardware decoders to process and display data
 		  It is currently used by EcoDevices, TeleinfoSerial
 		  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
@@ -13,7 +13,9 @@ History :
 1.0 2017-03-15 : Release candidate
 1.1 2017-03-18 : Updated to benefit from new messages in Alert sensors rather than simple text sensors
 1.2 2017-03-21 : Various bug fix and reverting to using P1SmartMeter as users requested
-1.2 2017-04-01 : Added RateLimit
+1.3 2017-04-01 : Added RateLimit
+1.4 2017-04-13 : Added DataTimeout
+1.5 2017-04-20 : Fix bug affecting "demain" for white days
 */
 
 #include "stdafx.h"
@@ -25,9 +27,6 @@ History :
 #ifdef _DEBUG
 #define DEBUG_TeleinfoBase
 #endif
-
-// Update are at least every 5 minutes
-#define MAXIMUM_UPDATE_INTERVAL 300
 
 CTeleinfoBase::CTeleinfoBase()
 {
@@ -140,25 +139,25 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string &name, int rank, Teleinfo 
 		rate_alert = 3;
 	}
 
-	// Process only if maximum time between updates has been reached or power consumption changed 
-        // If it did not, then alerts and intensity have not changed either
+	// Process only if maximum time between updates has been reached or power consumption changed
+	// If it did not, then alerts and intensity have not changed either
 	#ifdef DEBUG_TeleinfoBase
 	_log.Log(LOG_NORM,"(%s) TeleinfoBase called. Power changed: %s, last update %.f sec", Name.c_str(), (teleinfo.pAlertPAPP != teleinfo.PAPP)?"true":"false", difftime(atime, teleinfo.last));
 	#endif
-	if ((teleinfo.pAlertPAPP != teleinfo.PAPP) || (difftime(atime, teleinfo.last) >= MAXIMUM_UPDATE_INTERVAL))
+	if ((teleinfo.pAlertPAPP != teleinfo.PAPP) || (difftime(atime, teleinfo.last) >= (m_iDataTimeout -10)))
 	{
 		teleinfo.pAlertPAPP = teleinfo.PAPP;
 
-		//Send data at rate specified in settings, and at least every 5 minutes
-		if ((difftime(atime, teleinfo.last) >= m_iRateLimit) || (difftime(atime, teleinfo.last) >= MAXIMUM_UPDATE_INTERVAL))
+		//Send data at mamximum rate specified in settings, and at least 10sec less that Data Timeout
+		if ((difftime(atime, teleinfo.last) >= m_iRateLimit) || (difftime(atime, teleinfo.last) >= (m_iDataTimeout -10)))
 		{
 			teleinfo.last = atime;
 			m_p1power.usagecurrent = teleinfo.PAPP;
 			if (teleinfo.OPTARIF == "BASE")
 			{
 				#ifdef DEBUG_TeleinfoBase
-                        	_log.Log(LOG_STATUS,"Teleinfo Base: %i, PAPP: %i", teleinfo.BASE, teleinfo.PAPP);
-                        	#endif
+				_log.Log(LOG_STATUS,"Teleinfo Base: %i, PAPP: %i", teleinfo.BASE, teleinfo.PAPP);
+				#endif
 				teleinfo.tariff="Tarif de Base";
 				m_p1power.powerusage1 = teleinfo.BASE;
 				m_p1power.powerusage2 = 0;


### PR DESCRIPTION
There was a typo preventing white days to be shown in the "demain" (tomorrow) alert box.
Could only be detected recently as April 20th is the first white day for about a month.
Hope red is OK as there will not be any until next winter.
