### PR TITLE
Generic sysfs gpio: Cleanup unused db selects. // removed

### DIFF
--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -418,7 +418,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 		else
 		{	
 			/* Outputs */
-			result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
+			result = m_sql.safe_query("SELECT nValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
 				m_HwdID, szIdx, GpioSavedState[i].pin_number);
 
 			if (result.empty())
@@ -431,7 +431,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[0].c_str()) != 1) /* check if previous db device was an output */
+					if (atoi(sd[1].c_str()) != 1) /* check if previous db device was an output */
 					{
 						m_sql.safe_query(
 							"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
@@ -441,7 +441,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 					}
 					else
 					{
-						if (atoi(sd[1].c_str()) == 1) /* write actual db state to hardware */
+						if (atoi(sd[0].c_str()) == 1) /* write actual db state to hardware */
 						{
 							GPIOWrite(GpioSavedState[i].pin_number, GpioSavedState[i].active_low ? false : true);
 						}

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -192,25 +192,33 @@ bool CSysfsGPIO::StopHardware()
 
 bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
 {
-	bool bOk = true;
+	bool bOk = false;
 
 	const tRBUF *pSen = reinterpret_cast<const tRBUF*>(pdata);
 	unsigned char packettype = pSen->ICMND.packettype;
+	int output_pin = pSen->LIGHTING2.unitcode;
 
-	if (packettype == pTypeLighting2)
+	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
-		int output_pin = pSen->LIGHTING2.unitcode;
+		if ((GpioSavedState[i].direction == GPIO_OUT) && (GpioSavedState[i].pin_number == output_pin))
+		{
+			if (packettype == pTypeLighting2)
+			{
+				if (pSen->LIGHTING2.cmnd == light2_sOn)
+				{
+					GPIOWrite(output_pin, true);
+				}
+				else
+				{
+					GPIOWrite(output_pin, false);
+				}
+			}
 
-		if (pSen->LIGHTING2.cmnd == light2_sOn)
-		{
-			GPIOWrite(output_pin, true);
-		}
-		else
-		{
-			GPIOWrite(output_pin, false);
+			bOk = true;
+			break;
 		}
 	}
-
+	
 	return bOk;
 }
 

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -383,7 +383,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 		if (GpioSavedState[i].direction == GPIO_IN)
 		{
 			/* Inputs */
-			result = m_sql.safe_query("SELECT Name,nValue,sValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
+			result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
 				m_HwdID, szIdx, GpioSavedState[i].pin_number);
 
 			if (result.empty())
@@ -396,7 +396,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[3].c_str()) != 0) /* check if previous db device was an input */
+					if (atoi(sd[0].c_str()) != 0) /* check if previous db device was an input */
 					{
 						m_sql.safe_query(
 							"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
@@ -418,7 +418,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 		else
 		{	
 			/* Outputs */
-			result = m_sql.safe_query("SELECT Name,nValue,sValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
+			result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", 
 				m_HwdID, szIdx, GpioSavedState[i].pin_number);
 
 			if (result.empty())
@@ -431,10 +431,10 @@ void CSysfsGPIO::CreateDomoticzDevices()
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[3].c_str()) != 1) /* check if previous db device was an output */
+					if (atoi(sd[0].c_str()) != 1) /* check if previous db device was an output */
 					{
 						m_sql.safe_query(
-							"DELETE FROM DeviceStatus  WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
+							"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
 							m_HwdID, szIdx, GpioSavedState[i].pin_number);
 
 						createNewDevice = true;
@@ -499,18 +499,18 @@ void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
 
 			if ((GpioSavedState[i].db_state != state) || (forceUpdate))
 			{
-				result = m_sql.safe_query("SELECT Name,nValue,sValue,Used FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
+				result = m_sql.safe_query("SELECT nValue,Used FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
 					m_HwdID, szIdx, GpioSavedState[i].pin_number);
 
 				if ((!result.empty()) && (result.size() > 0))
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[3].c_str()) == 1) /* Check if device is used */
+					if (atoi(sd[1].c_str()) == 1) /* Check if device is used */
 					{
 						int db_state = 1;
 
-						if (atoi(sd[1].c_str()) == 0) /* determine database state*/
+						if (atoi(sd[0].c_str()) == 0) /* determine database state*/
 						{
 							db_state = 0;
 						}


### PR DESCRIPTION
Cleanup: Do not waste cycles to SELECT unused database entries. No functional change.