### PR TITLE
Implementation of Manual Eco mode for Nest thermostat

### DIFF
--- a/hardware/Nest.h
+++ b/hardware/Nest.h
@@ -24,6 +24,7 @@ private:
 	void UpdateSwitch(const unsigned char Idx, const bool bOn, const std::string &defaultname);
 	void UpdateSmokeSensor(const unsigned char Idx, const bool bOn, const std::string &defaultname);
 	bool SetAway(const unsigned char Idx, const bool bIsAway);
+	bool SetManualEcoMode(const unsigned char Idx, const bool bIsManualEcoMode);
 	bool Login();
 	void Logout();
 


### PR DESCRIPTION
Added functionality for the Nest thermostat device plugin. It allows switching the operation mode of the thermostat between 'manual-eco' (effectively setting the thermostat to 'do-not-heat-or-cool') and 'schedule' which is the regular schedule mode. 

The difference with 'away' mode is that 'manual-eco' forces the thermostat not to heat or cool, even when someone is home. Away mode disables itself as soon as it detects motion, this one does not.