### PR TITLE
adjust for possible (hasty) clock skew in P1 gas meter

### DIFF
--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -204,9 +204,15 @@ bool P1MeterBase::MatchLine()
 					)
 				{
 					//only update gas when there is a new value, or 5 minutes are passed
-					m_lastSharedSendGas=atime;
-					m_lastgasusage=m_p1gas.gasusage;
-					sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255);
+					struct tm tma;
+					localtime_r(&atime, &tma)
+					// ...but don't accept new values in the last four minutes of the hour
+					// to correct for possible (hasty) clock skew in the gas meter.
+					if (tma.min<56){
+						m_lastSharedSendGas=atime;
+						m_lastgasusage=m_p1gas.gasusage;
+						sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255);
+					}
 				}
 			}
 			m_linecount=0;

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -205,7 +205,7 @@ bool P1MeterBase::MatchLine()
 				{
 					//only update gas when there is a new value, or 5 minutes are passed
 					struct tm tma;
-					localtime_r(&atime, &tma)
+					localtime_r(&atime, &tma);
 					// ...but don't accept new values in the last four minutes of the hour
 					// to correct for possible (hasty) clock skew in the gas meter.
 					if (tma.min<56){

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -208,7 +208,7 @@ bool P1MeterBase::MatchLine()
 					localtime_r(&atime, &tma);
 					// ...but don't accept new values in the last four minutes of the hour
 					// to correct for possible (hasty) clock skew in the gas meter.
-					if (tma.min<56){
+					if (tma.tm_min<56){
 						m_lastSharedSendGas=atime;
 						m_lastgasusage=m_p1gas.gasusage;
 						sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255);

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -198,6 +198,7 @@ bool P1MeterBase::MatchLine()
 					if (m_voltagel3)
 						SendVoltageSensor(0, 3, 255, m_voltagel3, "Voltage L3");
 				}
+				if (m_p1gas.gasusage>0){ // don't update gas if there is no gas meter
 				if (
 					(m_p1gas.gasusage!=m_lastgasusage)||
 					(difftime(atime,m_lastSharedSendGas)>=300)
@@ -208,11 +209,12 @@ bool P1MeterBase::MatchLine()
 					localtime_r(&atime, &tma);
 					// ...but don't accept new values in the last four minutes of the hour
 					// to correct for possible (hasty) clock skew in the gas meter.
-					if (tma.tm_min<56){
+					if (tma.tm_min<58){
 						m_lastSharedSendGas=atime;
 						m_lastgasusage=m_p1gas.gasusage;
 						sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255);
 					}
+				}
 				}
 			}
 			m_linecount=0;


### PR DESCRIPTION
According to [this forum topic](https://www.domoticz.com/forum/viewtopic.php?f=56&t=17357) the clock in the autonomous gas meter that is linked to the smart meter can be hasty, causing incorrect readings in Domoticz. Since the meter is only expected to change on the hour we can adjust for any hastiness by ignoring any updates during the last four minutes of the hour.