### PR TITLE
Add HttpOnly flag to cookie. Prevents client-side access to session ID

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1204,7 +1204,7 @@ void cWebemRequestHandler::send_remove_cookie(reply& rep)
 {
 	std::stringstream sstr;
 	sstr << "SID=none";
-	sstr << "; path=/; Expires=" << make_web_time(0);
+	sstr << "; HttpOnly; path=/; Expires=" << make_web_time(0);
 	reply::add_header(&rep, "Set-Cookie", sstr.str(), false);
 }
 
@@ -1263,7 +1263,7 @@ void cWebemRequestHandler::send_cookie(reply& rep, const WebEmSession & session)
 {
 	std::stringstream sstr;
 	sstr << "SID=" << session.id << "_" << session.auth_token << "." << session.expires;
-	sstr << "; path=/; Expires=" << make_web_time(session.expires);
+	sstr << "; HttpOnly; path=/; Expires=" << make_web_time(session.expires);
 	reply::add_header(&rep, "Set-Cookie", sstr.str(), false);
 }
 


### PR DESCRIPTION
Tested by compiling Domoticz on a Raspberry pi. After compilation the cookie was HttpOnly protected. This should not break things. If Domoticz uses client-side scripts to access the cookie HttpOnly might introduce issues. Searched the Domoticz code, did not find any Javascript client-side scripts to access the cookie (document.cookie).