### PR TITLE
Sysfs gpio: active_low output handling improved

### DIFF
--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -650,31 +650,6 @@ int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 {
 	char path[GPIO_MAX_PATH];
 	int fd;
-	int new_state = 0;
-	int active_low = -1;
-
-	for (int i = 0; i < GpioSavedState.size(); i++)
-	{
-		if (GpioSavedState[i].pin_number == gpio_pin)
-		{
-			active_low = GpioSavedState[i].active_low;
-			break;
-		}
-	}
-
-	if (active_low == -1)
-	{
-		return -1;
-	}
-
-	if (active_low == 1)
-	{
-		value ? new_state = 0 : new_state = 1;
-	}
-	else
-	{
-		value ? new_state = 1 : new_state = 0;
-	}
 
 	snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, gpio_pin);
 	fd = open(path, O_WRONLY);
@@ -684,7 +659,7 @@ int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 		return(-1);
 	}
 
-	if (1 != write(fd, GPIO_LOW == new_state ? "0" : "1", 1))
+	if (1 != write(fd, value ? "1" : "0", 1))
 	{
 		close(fd);
 		return(-1);


### PR DESCRIPTION
Removed logic that was reversing the output value based on active_low settings based on a reported issue on the forum. This will give the user direct control of active_low or not for the "Generic sysfs gpio outputs".