### PR TITLE
Sysfs gpio: Support to add devices manually

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -385,7 +385,7 @@ hardware/serial/impl/unix.cpp
 hardware/SolarEdgeAPI.cpp
 hardware/SolarMaxTCP.cpp
 hardware/Sterbox.cpp
-hardware/SysfsGPIO.cpp
+hardware/SysfsGpio.cpp
 hardware/TCPProxy/tcpproxy_server.cpp
 hardware/TE923.cpp
 hardware/TE923Tool.cpp
@@ -663,10 +663,10 @@ else()
 ENDIF(WiringPi)
 
 IF(EXISTS /sys/class/gpio)
-	message(STATUS "Sysfs GPIO available")
+	message(STATUS "Sysfs gpio is available")
 	add_definitions(-DWITH_SYSFS_GPIO)
 ELSE()
-	message(STATUS "Sysfs GPIO not available")
+	message(STATUS "Sysfs gpio is not available")
 ENDIF()
 
 

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -129,6 +129,7 @@ const _tRFLinkStringIntHelper rfswitches[] =
 	{ "RFCustom", sSwitchTypeRFCustom },
 	{ "YW_Sensor", sSwitchTypeYW_Sensor },
 	{ "LEGRANDCAD", sSwitchTypeLegrandcad },
+	{ "SysfsGpio", sSwitchTypeSysfsGpio },
 	{ "", -1 }
 };
 

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -131,6 +131,7 @@ master occurs once, 30 seconds after startup.
 */
 #define HEARTBEAT_COUNT		40
 #define UPDATE_MASTER_COUNT 120
+#define DB_UPDATE_DELAY		4
 #define GPIO_POLL_MSEC		250
 
 #define GPIO_IN				0
@@ -146,12 +147,20 @@ master occurs once, 30 seconds after startup.
 #define GPIO_MAX_VALUE_SIZE	16		
 #define GPIO_MAX_PATH		64
 #define GPIO_PATH			"/sys/class/gpio/gpio"
+#define GPIO_DEVICE_ID_BASE	0x030E0E00
+using namespace std;
 
-CSysfsGPIO::CSysfsGPIO(const int ID)
+vector<gpio_info> CSysfsGPIO::GpioSavedState;
+int CSysfsGPIO::sysfs_hwdid;
+int CSysfsGPIO::sysfs_req_update;
+
+CSysfsGPIO::CSysfsGPIO(const int ID, const int AutoConfigureDevices)
 {
 	m_stoprequested = false;
 	m_bIsStarted = false;
 	m_HwdID = ID;
+	sysfs_hwdid = ID;
+	m_auto_configure_devices = AutoConfigureDevices;
 }
 
 CSysfsGPIO::~CSysfsGPIO(void)
@@ -160,8 +169,6 @@ CSysfsGPIO::~CSysfsGPIO(void)
 
 bool CSysfsGPIO::StartHardware()
 {
-	GpioSavedState.clear();
-
 	Init();
 
 	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CSysfsGPIO::Do_Work, this)));
@@ -203,14 +210,10 @@ bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
 			(GpioSavedState[i].direction == GPIO_OUT) && 
 			(packettype == pTypeLighting2))
 		{
-			if (pSen->LIGHTING2.cmnd == light2_sOn)
-			{
-				GPIOWrite(gpio_pin, true);
-			}
-			else
-			{
-				GPIOWrite(gpio_pin, false);
-			}
+			int state = pSen->LIGHTING2.cmnd == light2_sOn ? GPIO_HIGH : GPIO_LOW;
+			GPIOWrite(gpio_pin, state);
+			GpioSavedState[i].db_state = state;
+			GpioSavedState[i].value = state;
 			bOk = true;
 			break;
 		}
@@ -221,32 +224,18 @@ bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
 void CSysfsGPIO::Do_Work()
 {
 	char path[GPIO_MAX_PATH];
-	char value_str[3];
-	int fd;
+	int counter = 0;
 	int input_count = 0;
 	int output_count = 0;
-
+	
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
-		if (GpioSavedState[i].direction == 0)
-		{
-			input_count++;
-		}
+		if ((GpioSavedState[i].direction == GPIO_IN) ? input_count++ : output_count++);
 
-		if (GpioSavedState[i].direction == 1)
-		{
-			output_count++;
-		}
-	}
-
-	/* create fd's used for fast reads */
-	for (int i = 0; i < GpioSavedState.size(); i++)
-	{
 		snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, GpioSavedState[i].pin_number);
 		GpioSavedState[i].read_value_fd = open(path, O_RDONLY);
 	}
 
-	int counter = 0;
 	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller started, inputs:%d outputs:%d", input_count, output_count);
 
 	while (!m_stoprequested)
@@ -267,7 +256,7 @@ void CSysfsGPIO::Do_Work()
 
 		if (counter == UPDATE_MASTER_COUNT)	/* only executes when master/slave configuration*/
 		{
-			std::vector<std::vector<std::string> > result;
+			vector<vector<string> > result;
 			result = m_sql.safe_query("SELECT ID FROM Users WHERE (RemoteSharing==1) AND (Active==1)");
 
 			if (result.size() > 0)
@@ -276,13 +265,26 @@ void CSysfsGPIO::Do_Work()
 				UpdateDomoticzInputs(true);
 			}
 		}
+
+		if (sysfs_req_update)
+		{
+			sysfs_req_update--;
+
+			if (sysfs_req_update == 0)
+			{
+				UpdateDomoticzDatabase();
+			}
+		}
 	}
 
-	for (int i = 0; i < GpioSavedState.size(); i++) /* close all fast read fd's */
+	/* termination, close all open fd's */
+	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
-		snprintf(path, GPIO_MAX_PATH, "%s%d/value", GPIO_PATH, GpioSavedState[i].pin_number);
-		close(GpioSavedState[i].read_value_fd);
-		GpioSavedState[i].read_value_fd = -1;
+		if (GpioSavedState[i].read_value_fd != -1)
+		{
+			close(GpioSavedState[i].read_value_fd);
+			GpioSavedState[i].read_value_fd = -1;
+		}
 	}
 
 	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller stopped");
@@ -290,39 +292,34 @@ void CSysfsGPIO::Do_Work()
 
 void CSysfsGPIO::Init()
 {
-	BYTE id1 = 0x03;
-	BYTE id2 = 0x0E;
-	BYTE id3 = 0x0E;
-	BYTE id4 = m_HwdID & 0xFF;
+	int id = GPIO_DEVICE_ID_BASE + m_HwdID;
+	GpioSavedState.clear();
+	memset(&m_Packet, 0, sizeof(tRBUF));
+	sysfs_req_update = 0;
 
-	memset(&m_Packet, 0, sizeof(tRBUF)); /* Prepare packet for LIGHTING2 relay status packet */
-
-	if (m_HwdID > 0xFF)
-	{
-		id3 = (m_HwdID >> 8) & 0xFF;
-	}
-
-	if (m_HwdID > 0xFFFF)
-	{
-		id3 = (m_HwdID >> 16) & 0xFF;
-	}
-
+	/* default ligthing2 packet */
 	m_Packet.LIGHTING2.packetlength = sizeof(m_Packet.LIGHTING2) - 1;
 	m_Packet.LIGHTING2.packettype = pTypeLighting2;
 	m_Packet.LIGHTING2.subtype = sTypeAC;
 	m_Packet.LIGHTING2.unitcode = 0;
-	m_Packet.LIGHTING2.id1 = id1;
-	m_Packet.LIGHTING2.id2 = id2;
-	m_Packet.LIGHTING2.id3 = id3;
-	m_Packet.LIGHTING2.id4 = id4;
+	m_Packet.LIGHTING2.id1 = (id >> 24) & 0xFF;
+	m_Packet.LIGHTING2.id2 = (id >> 16) & 0xFF;
+	m_Packet.LIGHTING2.id3 = (id >> 8)  & 0xFF;
+	m_Packet.LIGHTING2.id4 = (id >> 0)  & 0xFF;
 	m_Packet.LIGHTING2.cmnd = 0;
 	m_Packet.LIGHTING2.level = 0;
 	m_Packet.LIGHTING2.filler = 0;
 	m_Packet.LIGHTING2.rssi = 12;
 
 	FindGpioExports();
-	CreateDomoticzDevices();
+	
+	if (m_auto_configure_devices)
+	{
+		CreateDomoticzDevices();
+	}
+
 	UpdateDomoticzInputs(false);
+	UpdateGpioOutputs();
 }
 
 void CSysfsGPIO::FindGpioExports()
@@ -331,8 +328,8 @@ void CSysfsGPIO::FindGpioExports()
 
 	for (int gpio_pin = GPIO_PIN_MIN; gpio_pin <= GPIO_PIN_MAX; gpio_pin++)
 	{
-		int fd;
 		char path[GPIO_MAX_PATH];
+		int fd;
 
 		snprintf(path, GPIO_MAX_PATH, "%s%d", GPIO_PATH, gpio_pin);
 		fd = open(path, O_RDONLY);
@@ -340,19 +337,26 @@ void CSysfsGPIO::FindGpioExports()
 		if (-1 != fd) /* GPIO export found */
 		{
 			gpio_info gi;
+			memset(&gi, 0, sizeof(gi));
+
 			gi.pin_number = gpio_pin;
 			gi.value = GPIORead(gpio_pin, "value");
 			gi.direction = GPIORead(gpio_pin, "direction");
 			gi.active_low = GPIORead(gpio_pin, "active_low");
 			gi.edge = GPIORead(gpio_pin, "edge");
 			gi.read_value_fd = -1;
-			GpioSavedState.push_back(gi);
+			gi.db_state = -1;
+			gi.id_valid = -1;
+			gi.id1 = 0;
+			gi.id2 = 0;
+			gi.id3 = 0;
+			gi.id4 = 0;
+			gi.request_update = -1;
 
+			GpioSavedState.push_back(gi);
 			close(fd);
 		}
 	}
-
-	int pin_count = GpioSavedState.size();
 }
 
 void CSysfsGPIO::PollGpioInputs()
@@ -371,24 +375,21 @@ void CSysfsGPIO::PollGpioInputs()
 
 void CSysfsGPIO::CreateDomoticzDevices()
 {
-	std::vector<std::vector<std::string> > result;
-	char szIdx[10];
-
-	sprintf(szIdx, "%X%02X%02X%02X",
-		m_Packet.LIGHTING2.id1,
-		m_Packet.LIGHTING2.id2,
-		m_Packet.LIGHTING2.id3,
-		m_Packet.LIGHTING2.id4);
+	vector<vector<string> > result;
+	vector<string> deviceid;
 
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
 		bool  createNewDevice = false;
+		deviceid = GetGpioDeviceId();
 
 		if (GpioSavedState[i].direction == GPIO_IN)
 		{
-			/* Inputs */
-			result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
-				m_HwdID, szIdx, GpioSavedState[i].pin_number); 
+			/* Input */
+
+			result = m_sql.safe_query("SELECT nValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+				m_HwdID, 
+				GpioSavedState[i].pin_number); 
 
 			if (result.empty())
 			{
@@ -396,34 +397,46 @@ void CSysfsGPIO::CreateDomoticzDevices()
 			}
 			else
 			{
-				if (result.size() > 0) /* input found */
+				if (result.size() > 0) /* found */
 				{
-					std::vector<std::string> sd = result[0];
+					vector<string> sd = result[0];
 
-					if (atoi(sd[0].c_str()) != 0) /* delete if previous db device was an output */
+					if (sd[1].empty())	
+					{	
+						/* update manual created device */
+						GpioSavedState[i].request_update = 1;
+						UpdateDomoticzDatabase();
+					}
+					else
 					{
-						m_sql.safe_query(
-							"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
-							m_HwdID, szIdx, GpioSavedState[i].pin_number);
+						if (atoi(sd[1].c_str()) != GPIO_IN) /* device was not an input, delete it */
+						{
+							m_sql.safe_query(
+								"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+								m_HwdID, GpioSavedState[i].pin_number);
 
-						createNewDevice = true;
+							createNewDevice = true;
+						}
 					}
 				}
 			}
 
 			if (createNewDevice)
 			{
+				/* create new input device */
 				m_sql.safe_query(
 					"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, Options) "
 					"VALUES (%d,'%q',%d, %d, %d, %d, 0, 12, 255, '%q', %d, ' ', '0')",
-					m_HwdID, szIdx, GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_Contact), "Input", GpioSavedState[i].value);
+					m_HwdID, deviceid[0].c_str(), GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_Contact), "Input", GpioSavedState[i].value);
 			}
 		}
 		else
 		{	
-			/* Outputs */
-			result = m_sql.safe_query("SELECT nValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
-				m_HwdID, szIdx, GpioSavedState[i].pin_number);
+			/* Output */
+
+			result = m_sql.safe_query("SELECT nValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+				m_HwdID, 
+				GpioSavedState[i].pin_number);
 
 			if (result.empty())
 			{
@@ -431,85 +444,116 @@ void CSysfsGPIO::CreateDomoticzDevices()
 			}
 			else
 			{
-				if (result.size() > 0) /* output found */
+				if (result.size() > 0) /* found */
 				{
-					std::vector<std::string> sd = result[0];
+					vector<string> sd = result[0];
 
-					if (atoi(sd[1].c_str()) != 1) /* delete if previous db device was an input */
-					{
-						m_sql.safe_query(
-							"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
-							m_HwdID, szIdx, GpioSavedState[i].pin_number);
-
-						createNewDevice = true;
+					if (sd[1].empty())
+					{	
+						/* update manual created output device */
+						GpioSavedState[i].request_update = 1;
+						UpdateDomoticzDatabase();
 					}
 					else
 					{
-						GPIOWrite(GpioSavedState[i].pin_number, atoi(sd[0].c_str()));
+						if ((atoi(sd[1].c_str()) != GPIO_OUT)) /* device was not an output, delete it */
+						{
+							m_sql.safe_query(
+								"DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+								m_HwdID, GpioSavedState[i].pin_number);
+
+							createNewDevice = true;
+						}
+						else
+						{
+							GPIOWrite(GpioSavedState[i].pin_number, atoi(sd[0].c_str()));
+						}
 					}
 				}
 			}
 
 			if (createNewDevice)
 			{
+				/* create new output device */
 				m_sql.safe_query(
 					"INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, Options) "
 					"VALUES (%d,'%q',%d, %d, %d, %d, 0, 12, 255, '%q', %d, ' ', '1')",
-					m_HwdID, szIdx, GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_OnOff), "Output", GpioSavedState[i].value);
+					m_HwdID, deviceid[0].c_str(), GpioSavedState[i].pin_number, pTypeLighting2, sTypeAC, int(STYPE_OnOff), "Output", GpioSavedState[i].value);
 			}
+		}
+	}
+}
+
+void CSysfsGPIO::UpdateDomoticzDatabase()
+{
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].request_update == 1)
+		{
+			vector<vector<string> > result = m_sql.safe_query("SELECT nValue,Options FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+				m_HwdID,
+				GpioSavedState[i].pin_number);
+
+			if (!result.empty())
+			{
+				vector<string> sd = result[0];
+
+				GpioSavedState[i].value = GPIORead(GpioSavedState[i].pin_number, "value");
+
+				m_sql.safe_query(
+					"UPDATE DeviceStatus SET nValue=%d,Options=%d WHERE (HardwareID==%d) AND (Unit==%d)",
+					GpioSavedState[i].value, GpioSavedState[i].direction, m_HwdID, GpioSavedState[i].pin_number);
+
+				GpioSavedState[i].db_state = GpioSavedState[i].value;
+				GpioSavedState[i].id_valid = -1;
+			}
+
+			GpioSavedState[i].request_update = -1;
 		}
 	}
 }
 
 void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
 {
-	std::vector<std::vector<std::string> > result;
-	char szIdx[10];
-
-	sprintf(szIdx, "%X%02X%02X%02X",
-		m_Packet.LIGHTING2.id1,
-		m_Packet.LIGHTING2.id2,
-		m_Packet.LIGHTING2.id3,
-		m_Packet.LIGHTING2.id4);
-
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
 		if ((GpioSavedState[i].direction == GPIO_IN) && (GpioSavedState[i].value != -1))
 		{
 			bool	updateDatabase = false;
-			int		state = 0;
+			int		state = GPIO_LOW;
 
 			if (GpioSavedState[i].active_low)
 			{
-				if (GpioSavedState[i].value == 0)
+				if (GpioSavedState[i].value == GPIO_LOW)
 				{
-					state = 1;
+					state = GPIO_HIGH;
 				}
 			}
 			else
 			{
-				if (GpioSavedState[i].value == 1)
+				if (GpioSavedState[i].value == GPIO_HIGH)
 				{
-					state = 1;
+					state = GPIO_HIGH;
 				}
 			}
 
 			if ((GpioSavedState[i].db_state != state) || (forceUpdate))
 			{
-				result = m_sql.safe_query("SELECT nValue,Used FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
-					m_HwdID, szIdx, GpioSavedState[i].pin_number);
+				vector< vector<string> > result = m_sql.safe_query("SELECT nValue,Used FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+					m_HwdID, 
+					GpioSavedState[i].pin_number);
 
 				if ((!result.empty()) && (result.size() > 0))
 				{
-					std::vector<std::string> sd = result[0];
+					vector<string> sd = result[0];
 
 					if (atoi(sd[1].c_str()) == 1) /* Check if device is used */
 					{
-						int db_state = 1;
+						int db_state = GPIO_HIGH;
 
-						if (atoi(sd[0].c_str()) == 0) /* determine database state*/
+						if (atoi(sd[0].c_str()) == GPIO_LOW) /* determine database state*/
 						{
-							db_state = 0;
+							db_state = GPIO_LOW;
 						}
 
 						if ((db_state != state) || (forceUpdate)) /* check if db update is required */
@@ -534,9 +578,9 @@ void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
 						m_Packet.LIGHTING2.level = 0;
 					}
 
+					UpdateDeviceID(GpioSavedState[i].pin_number);
 					m_Packet.LIGHTING2.unitcode = (char)GpioSavedState[i].pin_number;
 					m_Packet.LIGHTING2.seqnbr++;
-
 					sDecodeRXMessage(this, (const unsigned char *)&m_Packet.LIGHTING2, "Input", 255);
 				}
 			}
@@ -544,6 +588,107 @@ void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
 	}
 }
 
+void CSysfsGPIO::UpdateDeviceID(int pin)
+{
+	int index;
+	bool pin_found = false;
+
+	/* Note: Support each pin is allowed to have a different device id */
+
+	for (index = 0; index < GpioSavedState.size(); index++)
+	{
+		if (GpioSavedState[index].pin_number == pin)
+		{
+			pin_found = true;
+			break;
+		}
+	}
+
+	if (pin_found)
+	{
+		/* Existing pin was found */
+		
+		string sdeviceid;
+		int id1, id2, id3, id4;
+
+		if (GpioSavedState[index].id_valid == -1)
+		{
+			vector< vector<string> > result = m_sql.safe_query("SELECT DeviceID FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+				m_HwdID,
+				pin);
+
+			if ((!result.empty() && (result.size() > 0)))
+			{
+				/* use database device id */
+				vector<string> sd = result[0];
+				sdeviceid = sd[0];
+			}
+			else
+			{
+				/* use generated device id */
+				vector<string> deviceid = GetGpioDeviceId();
+				sdeviceid = deviceid[0];
+			}
+
+			/* extract hex device sub-id's */
+			GpioSavedState[index].id1 = strtol(sdeviceid.substr(0, 1).c_str(), NULL, 16) & 0xFF;
+			GpioSavedState[index].id2 = strtol(sdeviceid.substr(1, 2).c_str(), NULL, 16) & 0xFF;
+			GpioSavedState[index].id3 = strtol(sdeviceid.substr(3, 2).c_str(), NULL, 16) & 0xFF;
+			GpioSavedState[index].id4 = strtol(sdeviceid.substr(5, 2).c_str(), NULL, 16) & 0xFF;
+			GpioSavedState[index].id_valid = 1;
+		}
+
+		/* update device sub-id's in packet */
+		m_Packet.LIGHTING2.id1 = GpioSavedState[index].id1;
+		m_Packet.LIGHTING2.id2 = GpioSavedState[index].id2;
+		m_Packet.LIGHTING2.id3 = GpioSavedState[index].id3;
+		m_Packet.LIGHTING2.id4 = GpioSavedState[index].id4;
+	}
+}
+
+void CSysfsGPIO::UpdateGpioOutputs()
+{
+	/* make sure actual gpio output values match database */
+	
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].direction == GPIO_OUT)
+		{
+			vector<vector<string> > result = m_sql.safe_query("SELECT nValue,Used FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+				m_HwdID, 
+				GpioSavedState[i].pin_number);
+
+			if ((!result.empty()) && (result.size() > 0))
+			{
+				vector<string> sd = result[0];
+				GpioSavedState[i].db_state = atoi(sd[0].c_str());
+				
+				if (atoi(sd[1].c_str()))
+				{
+					/* device is used, update gpio output pin */
+					GPIOWrite(GpioSavedState[i].pin_number, GpioSavedState[i].db_state);
+					GpioSavedState[i].value = GpioSavedState[i].db_state;
+				}
+			}
+		}
+	}
+}
+
+vector<string> CSysfsGPIO::GetGpioDeviceId()
+{
+	vector<string> gpio_deviceid;
+	char szIdx[10];
+	int id = GPIO_DEVICE_ID_BASE + sysfs_hwdid;
+
+	snprintf(szIdx, sizeof(szIdx), "%7X", id);
+	gpio_deviceid.push_back(szIdx);
+
+	return gpio_deviceid;
+}
+
+//---------------------------------------------------------------------------
+//	sysfs gpio helper functions
+//
 int CSysfsGPIO::GetReadResult(int bytecount, char* value_str)
 {
 	int retval = -1;
@@ -663,5 +808,65 @@ int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 	close(fd);
 	return(0);
 }
+
+//---------------------------------------------------------------------------
+//	Called by WebServer when devices are manually configured.
+//
+vector<int> CSysfsGPIO::GetGpioIds()
+{
+	vector<int> gpio_ids;
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		vector<vector<string> > result = m_sql.safe_query("SELECT ID, Used FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+			sysfs_hwdid,
+			GpioSavedState[i].pin_number);
+
+		if (result.empty())
+		{
+			/* add pin to the list only if it does not exist in the db */
+			gpio_ids.push_back(GpioSavedState[i].pin_number);
+		}
+	}
+
+	return gpio_ids;
+}
+
+vector<string> CSysfsGPIO::GetGpioNames()
+{
+	vector<string> gpio_names;
+
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		vector<vector<string> > result = m_sql.safe_query("SELECT ID, Used FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
+			sysfs_hwdid,
+			GpioSavedState[i].pin_number);
+
+		if (result.empty())
+		{
+			/* add name to the list only if it does not exist in the db */
+			char name[32];
+			snprintf(name, sizeof(name), "gpio%d-%s", GpioSavedState[i].pin_number, GpioSavedState[i].direction ? "output" : "input");
+			gpio_names.push_back(name);
+		}
+	}
+
+	return gpio_names;
+}
+
+void CSysfsGPIO::RequestDbUpdate(int pin)
+{
+	for (int i = 0; i < GpioSavedState.size(); i++)
+	{
+		if (GpioSavedState[i].pin_number == pin)
+		{
+			GpioSavedState[i].request_update = 1;
+		}
+	}
+
+	sysfs_req_update = DB_UPDATE_DELAY;
+}
+
+//---------------------------------------------------------------------------
 
 #endif // WITH_SYSFS_GPIO

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -236,7 +236,7 @@ void CSysfsGpio::Do_Work()
 		GpioSavedState[i].read_value_fd = open(path, O_RDONLY);
 	}
 
-	_log.Log(LOG_STATUS, "CSysfsGpio: Input poller started, inputs:%d outputs:%d", input_count, output_count);
+	_log.Log(LOG_STATUS, "CSysfsGpio: Input poller started, Inputs:%d Outputs:%d", input_count, output_count);
 
 	while (!m_stoprequested)
 	{

--- a/hardware/SysfsGPIO.cpp
+++ b/hardware/SysfsGPIO.cpp
@@ -114,7 +114,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include "SysfsGPIO.h"
+#include "SysfsGpio.h"
 #include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "hardwaretypes.h"
@@ -150,11 +150,11 @@ master occurs once, 30 seconds after startup.
 #define GPIO_DEVICE_ID_BASE	0x030E0E00
 using namespace std;
 
-vector<gpio_info> CSysfsGPIO::GpioSavedState;
-int CSysfsGPIO::sysfs_hwdid;
-int CSysfsGPIO::sysfs_req_update;
+vector<gpio_info> CSysfsGpio::GpioSavedState;
+int CSysfsGpio::sysfs_hwdid;
+int CSysfsGpio::sysfs_req_update;
 
-CSysfsGPIO::CSysfsGPIO(const int ID, const int AutoConfigureDevices)
+CSysfsGpio::CSysfsGpio(const int ID, const int AutoConfigureDevices)
 {
 	m_stoprequested = false;
 	m_bIsStarted = false;
@@ -163,21 +163,21 @@ CSysfsGPIO::CSysfsGPIO(const int ID, const int AutoConfigureDevices)
 	m_auto_configure_devices = AutoConfigureDevices;
 }
 
-CSysfsGPIO::~CSysfsGPIO(void)
+CSysfsGpio::~CSysfsGpio(void)
 {
 }
 
-bool CSysfsGPIO::StartHardware()
+bool CSysfsGpio::StartHardware()
 {
 	Init();
 
-	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CSysfsGPIO::Do_Work, this)));
+	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CSysfsGpio::Do_Work, this)));
 	m_bIsStarted = true;
 
 	return (m_thread != NULL);
 }
 
-bool CSysfsGPIO::StopHardware()
+bool CSysfsGpio::StopHardware()
 {
 	m_stoprequested = true;
 
@@ -197,7 +197,7 @@ bool CSysfsGPIO::StopHardware()
 	return true;
 }
 
-bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
+bool CSysfsGpio::WriteToHardware(const char *pdata, const unsigned char length)
 {
 	bool bOk = false;
 	const tRBUF *pSen = reinterpret_cast<const tRBUF*>(pdata);
@@ -221,7 +221,7 @@ bool CSysfsGPIO::WriteToHardware(const char *pdata, const unsigned char length)
 	return bOk;
 }
 
-void CSysfsGPIO::Do_Work()
+void CSysfsGpio::Do_Work()
 {
 	char path[GPIO_MAX_PATH];
 	int counter = 0;
@@ -236,7 +236,7 @@ void CSysfsGPIO::Do_Work()
 		GpioSavedState[i].read_value_fd = open(path, O_RDONLY);
 	}
 
-	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller started, inputs:%d outputs:%d", input_count, output_count);
+	_log.Log(LOG_STATUS, "CSysfsGpio: Input poller started, inputs:%d outputs:%d", input_count, output_count);
 
 	while (!m_stoprequested)
 	{
@@ -261,7 +261,7 @@ void CSysfsGPIO::Do_Work()
 
 			if (result.size() > 0)
 			{
-				_log.Log(LOG_STATUS, "SysfsGPIO: Update master devices");
+				_log.Log(LOG_STATUS, "CSysfsGpio: Update master devices");
 				UpdateDomoticzInputs(true);
 			}
 		}
@@ -287,10 +287,10 @@ void CSysfsGPIO::Do_Work()
 		}
 	}
 
-	_log.Log(LOG_STATUS, "SysfsGPIO: Input poller stopped");
+	_log.Log(LOG_STATUS, "CSysfsGpio: Input poller stopped");
 }
 
-void CSysfsGPIO::Init()
+void CSysfsGpio::Init()
 {
 	int id = GPIO_DEVICE_ID_BASE + m_HwdID;
 	GpioSavedState.clear();
@@ -322,7 +322,7 @@ void CSysfsGPIO::Init()
 	UpdateGpioOutputs();
 }
 
-void CSysfsGPIO::FindGpioExports()
+void CSysfsGpio::FindGpioExports()
 {
 	GpioSavedState.clear();
 
@@ -359,7 +359,7 @@ void CSysfsGPIO::FindGpioExports()
 	}
 }
 
-void CSysfsGPIO::PollGpioInputs()
+void CSysfsGpio::PollGpioInputs()
 {
 	if (GpioSavedState.size())
 	{
@@ -373,7 +373,7 @@ void CSysfsGPIO::PollGpioInputs()
 	}
 }
 
-void CSysfsGPIO::CreateDomoticzDevices()
+void CSysfsGpio::CreateDomoticzDevices()
 {
 	vector<vector<string> > result;
 	vector<string> deviceid;
@@ -484,7 +484,7 @@ void CSysfsGPIO::CreateDomoticzDevices()
 	}
 }
 
-void CSysfsGPIO::UpdateDomoticzDatabase()
+void CSysfsGpio::UpdateDomoticzDatabase()
 {
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
@@ -513,7 +513,7 @@ void CSysfsGPIO::UpdateDomoticzDatabase()
 	}
 }
 
-void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
+void CSysfsGpio::UpdateDomoticzInputs(bool forceUpdate)
 {
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{
@@ -588,7 +588,7 @@ void CSysfsGPIO::UpdateDomoticzInputs(bool forceUpdate)
 	}
 }
 
-void CSysfsGPIO::UpdateDeviceID(int pin)
+void CSysfsGpio::UpdateDeviceID(int pin)
 {
 	int index;
 	bool pin_found = false;
@@ -646,7 +646,7 @@ void CSysfsGPIO::UpdateDeviceID(int pin)
 	}
 }
 
-void CSysfsGPIO::UpdateGpioOutputs()
+void CSysfsGpio::UpdateGpioOutputs()
 {
 	/* make sure actual gpio output values match database */
 	
@@ -674,7 +674,7 @@ void CSysfsGPIO::UpdateGpioOutputs()
 	}
 }
 
-vector<string> CSysfsGPIO::GetGpioDeviceId()
+vector<string> CSysfsGpio::GetGpioDeviceId()
 {
 	vector<string> gpio_deviceid;
 	char szIdx[10];
@@ -689,7 +689,7 @@ vector<string> CSysfsGPIO::GetGpioDeviceId()
 //---------------------------------------------------------------------------
 //	sysfs gpio helper functions
 //
-int CSysfsGPIO::GetReadResult(int bytecount, char* value_str)
+int CSysfsGpio::GetReadResult(int bytecount, char* value_str)
 {
 	int retval = -1;
 
@@ -737,7 +737,7 @@ int CSysfsGPIO::GetReadResult(int bytecount, char* value_str)
 	return (retval);
 }
 
-int CSysfsGPIO::GPIORead(int gpio_pin, const char *param)
+int CSysfsGpio::GPIORead(int gpio_pin, const char *param)
 {
 	char path[GPIO_MAX_PATH];
 	char value_str[GPIO_MAX_VALUE_SIZE];
@@ -765,7 +765,7 @@ int CSysfsGPIO::GPIORead(int gpio_pin, const char *param)
 	return(GetReadResult(bytecount, &value_str[0]));
 }
 
-int CSysfsGPIO::GPIOReadFd(int fd)
+int CSysfsGpio::GPIOReadFd(int fd)
 {
 	int bytecount = -1;
 	int retval = -1;
@@ -786,7 +786,7 @@ int CSysfsGPIO::GPIOReadFd(int fd)
 	return(GetReadResult(bytecount, &value_str[0]));
 }
 
-int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
+int CSysfsGpio::GPIOWrite(int gpio_pin, int value)
 {
 	char path[GPIO_MAX_PATH];
 	int fd;
@@ -812,7 +812,7 @@ int CSysfsGPIO::GPIOWrite(int gpio_pin, int value)
 //---------------------------------------------------------------------------
 //	Called by WebServer when devices are manually configured.
 //
-vector<int> CSysfsGPIO::GetGpioIds()
+vector<int> CSysfsGpio::GetGpioIds()
 {
 	vector<int> gpio_ids;
 
@@ -832,7 +832,7 @@ vector<int> CSysfsGPIO::GetGpioIds()
 	return gpio_ids;
 }
 
-vector<string> CSysfsGPIO::GetGpioNames()
+vector<string> CSysfsGpio::GetGpioNames()
 {
 	vector<string> gpio_names;
 
@@ -854,7 +854,7 @@ vector<string> CSysfsGPIO::GetGpioNames()
 	return gpio_names;
 }
 
-void CSysfsGPIO::RequestDbUpdate(int pin)
+void CSysfsGpio::RequestDbUpdate(int pin)
 {
 	for (int i = 0; i < GpioSavedState.size(); i++)
 	{

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -8,19 +8,19 @@
 
 struct gpio_info
 {
-	int	pin_number;		// GPIO Pin number
-	int	value;			// GPIO pin Value
-	int	direction;		// GPIO IN or OUT
-	int	active_low;		// GPIO ActiveLow
-	int	edge;			// GPIO int Edge
+	uint8_t	value;		// GPIO pin Value
+	uint8_t	direction;	// GPIO IN or OUT
+	uint8_t	active_low;	// GPIO ActiveLow
+	uint8_t	edge;		// GPIO int Edge
+	uint8_t	db_state;	// Database Value
+	uint8_t	db_state;	// Database Value id1;			// Device id1
+	uint8_t	db_state;	// Database Value id2;			// Device id2
+	uint8_t	db_state;	// Database Valueid3;			// Device id3
+	uint8_t	db_state;	// Database Valueid4;			// Device id4
+	uint8_t	db_state;	// Database Valueid_valid;		// Device valid
+	uint8_t	db_state;	// Database Valueint request_update; // Request update
 	int	read_value_fd;	// Fast read fd
-	int	db_state;		// Database Value
-	int id1;			// Device id1
-	int id2;			// Device id2
-	int id3;			// Device id3
-	int id4;			// Device id4
-	int id_valid;		// Device valid
-	int request_update; // Request update
+	int	pin_number;		// GPIO Pin number
 };
 
 class CSysfsGPIO : public CDomoticzHardwareBase

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -9,27 +9,27 @@
 struct gpio_info
 {
 	int		pin_number;		// GPIO Pin number
-	char	value;			// GPIO pin Value
-	char	direction;		// GPIO IN or OUT
-	char	active_low;		// GPIO ActiveLow
-	char	edge;			// GPIO int Edge
-	int		read_value_fd;	// Fast read fd
-	char	db_state;		// Database Value
-	int		id1;			// Device id1
-	int		id2;			// Device id2
-	int		id3;			// Device id3
-	int		id4;			// Device id4
-	char	id_valid;		// Device valid
-	char	request_update;	// Request update
+	int		read_value_fd;	// File descriptor
+	int8_t	request_update;	// Request update
+	int8_t	db_state;		// Database Value
+	int8_t	value;			// GPIO pin Value
+	int8_t	direction;		// GPIO IN or OUT
+	int8_t	active_low;		// GPIO ActiveLow
+	int8_t	edge;			// GPIO int Edge
+	int8_t	id1;			// Device id1
+	int8_t	id2;			// Device id2
+	int8_t	id3;			// Device id3
+	int8_t	id4;			// Device id4
+	int8_t	id_valid;		// Device valid
 };
 
-class CSysfsGPIO : public CDomoticzHardwareBase
+class CSysfsGpio : public CDomoticzHardwareBase
 {
 
 public:
 
-	CSysfsGPIO(const int ID, const int ManualDevices);
-	~CSysfsGPIO();
+	CSysfsGpio(const int ID, const int ManualDevices);
+	~CSysfsGpio();
 
 	bool WriteToHardware(const char *pdata, const unsigned char length);
 	static std::vector<int> GetGpioIds();

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -8,19 +8,19 @@
 
 struct gpio_info
 {
-	uint8_t	value;		// GPIO pin Value
-	uint8_t	direction;	// GPIO IN or OUT
-	uint8_t	active_low;	// GPIO ActiveLow
-	uint8_t	edge;		// GPIO int Edge
-	uint8_t	db_state;	// Database Value
-	uint8_t	db_state;	// Database Value id1;			// Device id1
-	uint8_t	db_state;	// Database Value id2;			// Device id2
-	uint8_t	db_state;	// Database Valueid3;			// Device id3
-	uint8_t	db_state;	// Database Valueid4;			// Device id4
-	uint8_t	db_state;	// Database Valueid_valid;		// Device valid
-	uint8_t	db_state;	// Database Valueint request_update; // Request update
-	int	read_value_fd;	// Fast read fd
-	int	pin_number;		// GPIO Pin number
+	int		pin_number;		// GPIO Pin number
+	char	value;			// GPIO pin Value
+	char	direction;		// GPIO IN or OUT
+	char	active_low;		// GPIO ActiveLow
+	char	edge;			// GPIO int Edge
+	int		read_value_fd;	// Fast read fd
+	char	db_state;		// Database Value
+	int		id1;			// Device id1
+	int		id2;			// Device id2
+	int		id3;			// Device id3
+	int		id4;			// Device id4
+	char	id_valid;		// Device valid
+	char	request_update;	// Request update
 };
 
 class CSysfsGPIO : public CDomoticzHardwareBase

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -10,17 +10,17 @@ struct gpio_info
 {
 	int		pin_number;		// GPIO Pin number
 	int		read_value_fd;	// File descriptor
-	char	request_update;	// Request update
-	char	db_state;		// Database Value
-	char	value;			// GPIO pin Value
-	char	direction;		// GPIO IN or OUT
-	char	active_low;		// GPIO ActiveLow
-	char	edge;			// GPIO int Edge
-	char	id1;			// Device id1
-	char	id2;			// Device id2
-	char	id3;			// Device id3
-	char	id4;			// Device id4
-	char	id_valid;		// Device valid
+	int8_t	request_update;	// Request update
+	int8_t	db_state;		// Database Value
+	int8_t	value;			// GPIO pin Value
+	int8_t	direction;		// GPIO IN or OUT
+	int8_t	active_low;		// GPIO ActiveLow
+	int8_t	edge;			// GPIO int Edge
+	int8_t	id1;			// Device id1
+	int8_t	id2;			// Device id2
+	int8_t	id3;			// Device id3
+	int8_t	id4;			// Device id4
+	int8_t	id_valid;		// Device valid
 };
 
 class CSysfsGpio : public CDomoticzHardwareBase

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -10,17 +10,17 @@ struct gpio_info
 {
 	int		pin_number;		// GPIO Pin number
 	int		read_value_fd;	// File descriptor
-	int8_t	request_update;	// Request update
-	int8_t	db_state;		// Database Value
-	int8_t	value;			// GPIO pin Value
-	int8_t	direction;		// GPIO IN or OUT
-	int8_t	active_low;		// GPIO ActiveLow
-	int8_t	edge;			// GPIO int Edge
-	int8_t	id1;			// Device id1
-	int8_t	id2;			// Device id2
-	int8_t	id3;			// Device id3
-	int8_t	id4;			// Device id4
-	int8_t	id_valid;		// Device valid
+	char	request_update;	// Request update
+	char	db_state;		// Database Value
+	char	value;			// GPIO pin Value
+	char	direction;		// GPIO IN or OUT
+	char	active_low;		// GPIO ActiveLow
+	char	edge;			// GPIO int Edge
+	char	id1;			// Device id1
+	char	id2;			// Device id2
+	char	id3;			// Device id3
+	char	id4;			// Device id4
+	char	id_valid;		// Device valid
 };
 
 class CSysfsGpio : public CDomoticzHardwareBase

--- a/hardware/SysfsGPIO.h
+++ b/hardware/SysfsGPIO.h
@@ -6,24 +6,35 @@
 #include "DomoticzHardware.h"
 #include "../main/RFXtrx.h"
 
+struct gpio_info
+{
+	int	pin_number;		// GPIO Pin number
+	int	value;			// GPIO pin Value
+	int	direction;		// GPIO IN or OUT
+	int	active_low;		// GPIO ActiveLow
+	int	edge;			// GPIO int Edge
+	int	read_value_fd;	// Fast read fd
+	int	db_state;		// Database Value
+	int id1;			// Device id1
+	int id2;			// Device id2
+	int id3;			// Device id3
+	int id4;			// Device id4
+	int id_valid;		// Device valid
+	int request_update; // Request update
+};
+
 class CSysfsGPIO : public CDomoticzHardwareBase
 {
-	struct gpio_info
-	{
-		int	pin_number;		// GPIO Pin number
-		int	value;			// GPIO pin Value
-		int	db_state;		// Database Value
-		int	direction;		// GPIO IN or OUT
-		int	active_low;		// GPIO ActiveLow
-		int	edge;			// GPIO int Edge
-		int	read_value_fd;	// Fast read fd
-	};
 
 public:
-	CSysfsGPIO(const int ID);
+
+	CSysfsGPIO(const int ID, const int ManualDevices);
 	~CSysfsGPIO();
 
 	bool WriteToHardware(const char *pdata, const unsigned char length);
+	static std::vector<int> GetGpioIds();
+	static std::vector<std::string> GetGpioNames();
+	static void RequestDbUpdate(int pin);
 
 private:
 	bool StartHardware();
@@ -34,12 +45,19 @@ private:
 	void PollGpioInputs();
 	void CreateDomoticzDevices();
 	void UpdateDomoticzInputs(bool forceUpdate);
+	void UpdateDomoticzDatabase();
+	void UpdateGpioOutputs();
+	void UpdateDeviceID(int pin);
+	std::vector<std::string> GetGpioDeviceId();
 	int GPIORead(int pin, const char* param);
 	int GPIOReadFd(int fd);
 	int GPIOWrite(int pin, int value);
 	int GetReadResult(int bytecount, char* value_str);
 	boost::shared_ptr<boost::thread> m_thread;
-	std::vector<gpio_info> GpioSavedState;
+	static std::vector<gpio_info> GpioSavedState;
+	static int sysfs_hwdid;
+	static int sysfs_req_update;
 	volatile bool m_stoprequested;
+	int m_auto_configure_devices;
 	tRBUF m_Packet;
 };

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -179,6 +179,7 @@
 #define sSwitchTypeRFCustom			0x72
 #define sSwitchTypeYW_Sensor		0x73
 #define sSwitchTypeLegrandcad		0x74
+#define sSwitchTypeSysfsGpio		0x75
 
 //Switch commands
 #define gswitch_sOff				0x00

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -867,6 +867,7 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeGeneralSwitch, sSwitchTypeRFCustom, "RFCustom" },
 		{ pTypeGeneralSwitch, sSwitchTypeYW_Sensor, "YW_Sensor" },
 		{ pTypeGeneralSwitch, sSwitchTypeLegrandcad, "LEGRANDCAD" },
+		{ pTypeGeneralSwitch, sSwitchTypeSysfsGpio, "SysfsGpio" },
 		{  0,0,NULL }
 	};
 	return findTableID1ID2(Table, dType, sType);

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -248,7 +248,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_IntergasInComfortLAN2RF, "Intergas InComfort LAN2RF Gateway" },
 		{ HTYPE_RelayNet, "Relay-Net 8 channel LAN Relay and binary Input module" },
 		{ HTYPE_KMTronicUDP, "KMTronic Gateway with LAN/UDP interface" },
-		{ HTYPE_SysfsGPIO, "Generic sysfs gpio" },
+		{ HTYPE_SysfsGpio, "Generic sysfs gpio" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -183,7 +183,7 @@ enum _eHardwareTypes {
 	HTYPE_IntergasInComfortLAN2RF,			//99
 	HTYPE_RelayNet,				//100
 	HTYPE_KMTronicUDP,			//101
-	HTYPE_SysfsGPIO,			//102
+	HTYPE_SysfsGpio,			//102
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -26,7 +26,7 @@
 #include "../hardware/MySensorsBase.h"
 #include "../hardware/RFXBase.h"
 #include "../hardware/RFLinkBase.h"
-#include "../hardware/SysfsGPIO.h"
+#include "../hardware/SysfsGpio.h"
 #include "../hardware/HEOS.h"
 #ifdef WITH_GPIO
 #include "../hardware/Gpio.h"
@@ -993,7 +993,7 @@ namespace http {
 				}
 #endif
 #ifndef WITH_SYSFS_GPIO
-				if (ii == HTYPE_SysfsGPIO)
+				if (ii == HTYPE_SysfsGpio)
 				{
 					bDoAdd = false;
 				}
@@ -1257,7 +1257,7 @@ namespace http {
 			else if (htype == HTYPE_RaspberryGPIO) {
 				//all fine here!
 			}
-			else if (htype == HTYPE_SysfsGPIO) {
+			else if (htype == HTYPE_SysfsGpio) {
 				//all fine here!
 			}
 			else if (htype == HTYPE_OpenWebNetTCP) {
@@ -1589,7 +1589,7 @@ namespace http {
 			else if (htype == HTYPE_RaspberryGPIO) {
 				//all fine here!
 			}
-			else if (htype == HTYPE_SysfsGPIO) {
+			else if (htype == HTYPE_SysfsGpio) {
 				//all fine here!
 			}
 			else if (htype == HTYPE_Daikin) {
@@ -3618,7 +3618,7 @@ namespace http {
 							(Type == HTYPE_ZIBLUETCP) ||
 							(Type == HTYPE_OpenWebNetTCP) ||
 							(Type == HTYPE_OpenWebNetUSB) ||
-							(Type == HTYPE_SysfsGPIO))
+							(Type == HTYPE_SysfsGpio))
 						{
 							root["result"][ii]["idx"] = ID;
 							root["result"][ii]["Name"] = Name;
@@ -3660,8 +3660,8 @@ namespace http {
 				//used by Add Manual Light/Switch dialog
 				root["title"] = "GetSysfsGpio";
 #ifdef WITH_SYSFS_GPIO
-				std::vector<int> gpio_ids = CSysfsGPIO::GetGpioIds();
-				std::vector<std::string> gpio_names = CSysfsGPIO::GetGpioNames();
+				std::vector<int> gpio_ids = CSysfsGpio::GetGpioIds();
+				std::vector<std::string> gpio_names = CSysfsGpio::GetGpioNames();
 
 				if (gpio_ids.size() == 0) {
 					root["status"] = "ERROR";
@@ -4180,17 +4180,17 @@ namespace http {
 						return;
 					}
 
-					CSysfsGPIO *pSysfsGpio = (CSysfsGPIO *)m_mainworker.GetHardware(atoi(hwdid.c_str()));
+					CSysfsGpio *pSysfsGpio = (CSysfsGpio *)m_mainworker.GetHardware(atoi(hwdid.c_str()));
 
 					if (pSysfsGpio == NULL) {
 						root["status"] = "ERROR";
-						root["message"] = "Could not retrieve SysfsGPIO hardware pointer";
+						root["message"] = "Could not retrieve SysfsGpio hardware pointer";
 						return;
 					}
 
-					if (pSysfsGpio->HwdType != HTYPE_SysfsGPIO) {
+					if (pSysfsGpio->HwdType != HTYPE_SysfsGpio) {
 						root["status"] = "ERROR";
-						root["message"] = "Given hardware is not SysfsGPIO";
+						root["message"] = "Given hardware is not SysfsGpio";
 						return;
 					}
 #else
@@ -4706,7 +4706,7 @@ namespace http {
 					std::string sswitchtype = request::findValue(&req, "switchtype");
 					_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
 					std::string id = request::findValue(&req, "id");
-					CSysfsGPIO::RequestDbUpdate(unitcode);
+					CSysfsGpio::RequestDbUpdate(unitcode);
 
 					if ((id == "") || (sunitcode == ""))
 					{
@@ -4714,9 +4714,9 @@ namespace http {
 					}
 					devid = id;
 
-					CSysfsGPIO *pSysfsGPIO = (CSysfsGPIO *)m_mainworker.GetHardware(atoi(hwdid.c_str()));
+					CSysfsGpio *pSysfsGpio = (CSysfsGpio *)m_mainworker.GetHardware(atoi(hwdid.c_str()));
 					
-					if ((pSysfsGPIO == NULL) || (pSysfsGPIO->HwdType != HTYPE_SysfsGPIO))
+					if ((pSysfsGpio == NULL) || (pSysfsGpio->HwdType != HTYPE_SysfsGpio))
 					{
 						return;
 					}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -121,7 +121,7 @@
 #include "../hardware/OpenWebNetUSB.h"
 #include "../hardware/InComfort.h"
 #include "../hardware/RelayNet.h"
-#include "../hardware/SysfsGPIO.h"
+#include "../hardware/SysfsGpio.h"
 
 // load notifications configuration
 #include "../notifications/NotificationHelper.h"
@@ -940,9 +940,9 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CGpio(ID, Mode1, Mode2, Mode3);
 #endif
 		break;
-	case HTYPE_SysfsGPIO:
+	case HTYPE_SysfsGpio:
 #ifdef WITH_SYSFS_GPIO
-		pHardware = new CSysfsGPIO(ID, Mode1);
+		pHardware = new CSysfsGpio(ID, Mode1);
 #endif
 		break;
 	case HTYPE_Comm5TCP:

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -942,7 +942,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_SysfsGPIO:
 #ifdef WITH_SYSFS_GPIO
-		pHardware = new CSysfsGPIO(ID);
+		pHardware = new CSysfsGPIO(ID, Mode1);
 #endif
 		break;
 	case HTYPE_Comm5TCP:

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -439,7 +439,7 @@
     <ClInclude Include="..\hardware\FritzboxTCP.h" />
     <ClInclude Include="..\hardware\Gpio.h" />
     <ClInclude Include="..\hardware\GpioPin.h" />
-    <ClInclude Include="..\hardware\SysfsGPIO.h" />
+    <ClInclude Include="..\hardware\SysfsGpio.h" />
     <ClInclude Include="..\hardware\HarmonyHub.h" />
     <ClInclude Include="..\hardware\HEOS.h" />
     <ClInclude Include="..\hardware\HttpPoller.h" />
@@ -682,7 +682,7 @@
     <ClCompile Include="..\hardware\GoodweAPI.cpp" />
     <ClCompile Include="..\hardware\Gpio.cpp" />
     <ClCompile Include="..\hardware\GpioPin.cpp" />
-    <ClCompile Include="..\hardware\SysfsGPIO.cpp" />
+    <ClCompile Include="..\hardware\SysfsGpio.cpp" />
     <ClCompile Include="..\hardware\HarmonyHub.cpp" />
     <ClCompile Include="..\hardware\HEOS.cpp" />
     <ClCompile Include="..\hardware\HttpPoller.cpp" />

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -123,8 +123,8 @@ define(['app'], function (app) {
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
 				(text.indexOf("Arilux AL-LC0x") >= 0) ||
-				(text.indexOf("sysfs gpio") >= 0)
-			) {
+				(text.indexOf("sysfs gpio") >= 0))
+			 {
 				// if hardwaretype == 1000 => I2C sensors grouping
 				if (hardwaretype == 1000) {
 					hardwaretype = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').val();
@@ -134,7 +134,7 @@ define(['app'], function (app) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
 					var port = "&port=" + encodeURIComponent(i2caddress);
 				}
-				if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
+                if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
 					var gpiodebounce = $("#hardwareparamsgpio #gpiodebounce").val();
 					var gpioperiod = $("#hardwareparamsgpio #gpioperiod").val();
 					var gpiopollinterval = $("#hardwareparamsgpio #gpiopollinterval").val();
@@ -150,7 +150,10 @@ define(['app'], function (app) {
 					Mode1 = gpiodebounce;
 					Mode2 = gpioperiod;
 					Mode3 = gpiopollinterval;
-				}
+                }
+                if (text.indexOf("sysfs gpio") >= 0) {
+                    Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+                }
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&name=" + encodeURIComponent(name) +
@@ -1011,8 +1014,7 @@ define(['app'], function (app) {
 				(text.indexOf("Tellstick") >= 0) ||
 				(text.indexOf("Motherboard") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
-				(text.indexOf("Arilux AL-LC0x") >= 0) ||
-				(text.indexOf("sysfs gpio") >= 0)
+				(text.indexOf("Arilux AL-LC0x") >= 0)
 			) {
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + "&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout,
@@ -1026,7 +1028,7 @@ define(['app'], function (app) {
 					}
 				});
 			}
-			else if (text.indexOf("GPIO") >= 0) {
+            else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
 				var gpiodebounce = $("#hardwarecontent #hardwareparamsgpio #gpiodebounce").val();
 				var gpioperiod = $("#hardwarecontent #hardwareparamsgpio #gpioperiod").val();
 				var gpiopollinterval = $("#hardwarecontent #hardwareparamsgpio #gpiopollinterval").val();
@@ -1058,7 +1060,26 @@ define(['app'], function (app) {
 						ShowNotify($.t('Problem adding hardware!'), 2500, true);
 					}
 				});
-			}
+            }
+            else if (text.indexOf("sysfs gpio") >= 0) {
+                Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+                $.ajax({
+                    url: "json.htm?type=command&param=addhardware&htype="
+                    + hardwaretype
+                    + "&name=" + encodeURIComponent(name)
+                    + "&enabled=" + bEnabled
+                    + "&datatimeout=" + datatimeout
+                    + "&Mode1=" + Mode1,
+                    async: false,
+                    dataType: 'json',
+                    success: function (data) {
+                        RefreshHardwareTable();
+                    },
+                    error: function () {
+                        ShowNotify($.t('Problem adding hardware!'), 2500, true);
+                    }
+                });
+            }
 			else if (text.indexOf("I2C ") >= 0 && text.indexOf("I2C sensor PIO 8bit expander PCF8574") < 0) {
 				hardwaretype = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').val();
 				var port = "";
@@ -4600,7 +4621,7 @@ define(['app'], function (app) {
 							}
 							else if ((item.Type == 16) || (item.Type == 32)) {
 								SerialName = "GPIO";
-							}
+                            }
 							else if (HwTypeStr.indexOf("Evohome") >= 0 && HwTypeStr.indexOf("script") >= 0) {
 								SerialName = "Script";
 							}
@@ -4850,8 +4871,7 @@ define(['app'], function (app) {
 							(data["Type"].indexOf("PiFace") >= 0) ||
 							(data["Type"].indexOf("Tellstick") >= 0) ||
 							(data["Type"].indexOf("Yeelight") >= 0) ||
-							(data["Type"].indexOf("Arilux AL-LC0x") >= 0) ||
-							(data["Type"].indexOf("sysfs gpio") >= 0)
+							(data["Type"].indexOf("Arilux AL-LC0x") >= 0)
 						) {
 							//nothing to be set
 						}
@@ -4866,11 +4886,14 @@ define(['app'], function (app) {
 								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
 							}
 						}
-						else if (data["Type"].indexOf("GPIO") >= 0) {
+                        else if ((data["Type"].indexOf("GPIO") >= 0) && (data["Type"].indexOf("sysfs gpio") == -1)) {
 							$("#hardwareparamsgpio #gpiodebounce").val(data["Mode1"]);
 							$("#hardwareparamsgpio #gpioperiod").val(data["Mode2"]);
 							$("#hardwareparamsgpio #gpiopollinterval").val(data["Mode3"]);
-						}
+                        }
+                        else if (data["Type"].indexOf("sysfs gpio") >= 0) {
+                            $("#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure").prop("checked", data["Mode1"] == 1);
+                        }
 						else if (data["Type"].indexOf("USB") >= 0 || data["Type"].indexOf("Teleinfo EDF") >= 0) {
 							$("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);
 							if (data["Type"].indexOf("Evohome") >= 0) {
@@ -5113,18 +5136,17 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divpollinterval").hide();
 			$("#hardwarecontent #divpythonplugin").hide();
 			$("#hardwarecontent #divrelaynet").hide();
-			$("#hardwarecontent #divgpio").hide();
+            $("#hardwarecontent #divgpio").hide();
+            $("#hardwarecontent #divsysfsgpio").hide();
 
-			if (
-				(text.indexOf("TE923") >= 0) ||
+			if ((text.indexOf("TE923") >= 0) ||
 				(text.indexOf("Volcraft") >= 0) ||
 				(text.indexOf("Dummy") >= 0) ||
 				(text.indexOf("System Alive") >= 0) ||
 				(text.indexOf("PiFace") >= 0) ||
 				(text.indexOf("Yeelight") >= 0) ||
-				(text.indexOf("Arilux AL-LC0x") >= 0) ||
-				(text.indexOf("sysfs gpio") >= 0)
-			) {
+                (text.indexOf("Arilux AL-LC0x") >= 0))
+			 {
 				$("#hardwarecontent #divserial").hide();
 				$("#hardwarecontent #divremote").hide();
 				$("#hardwarecontent #divlogin").hide();
@@ -5145,15 +5167,23 @@ define(['app'], function (app) {
 					$("#hardwarecontent #divi2caddress").show();
 				}
 			}
-			else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
+			else if (text.indexOf("GPIO") >= 0) {
 				$("#hardwarecontent #divgpio").show();
 				$("#hardwarecontent #divserial").hide();
 				$("#hardwarecontent #divremote").hide();
 				$("#hardwarecontent #divlogin").hide();
 				$("#hardwarecontent #divunderground").hide();
 				$("#hardwarecontent #divhttppoller").hide();
+            }
+            else if (text.indexOf("sysfs gpio") >= 0) {
+                $("#hardwarecontent #divsysfsgpio").show();
+                $("#hardwarecontent #divserial").hide();
+                $("#hardwarecontent #divremote").hide();
+                $("#hardwarecontent #divlogin").hide();
+                $("#hardwarecontent #divunderground").hide();
+                $("#hardwarecontent #divhttppoller").hide();
 
-			}
+            }
 			else if (text.indexOf("USB") >= 0 || text.indexOf("Teleinfo EDF") >= 0) {
 				if (text.indexOf("Evohome") >= 0) {
 					$("#hardwarecontent #divevohome").show();

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -123,7 +123,8 @@ define(['app'], function (app) {
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
 				(text.indexOf("Arilux AL-LC0x") >= 0) ||
-				(text.indexOf("sysfs gpio") >= 0))
+				(text.indexOf("sysfs gpio") >= 0)
+				)
 			 {
 				// if hardwaretype == 1000 => I2C sensors grouping
 				if (hardwaretype == 1000) {
@@ -134,7 +135,7 @@ define(['app'], function (app) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
 					var port = "&port=" + encodeURIComponent(i2caddress);
 				}
-                if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
+				if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
 					var gpiodebounce = $("#hardwareparamsgpio #gpiodebounce").val();
 					var gpioperiod = $("#hardwareparamsgpio #gpioperiod").val();
 					var gpiopollinterval = $("#hardwareparamsgpio #gpiopollinterval").val();
@@ -150,10 +151,10 @@ define(['app'], function (app) {
 					Mode1 = gpiodebounce;
 					Mode2 = gpioperiod;
 					Mode3 = gpiopollinterval;
-                }
-                if (text.indexOf("sysfs gpio") >= 0) {
-                    Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
-                }
+				}
+				if (text.indexOf("sysfs gpio") >= 0) {
+					Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+				}
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&name=" + encodeURIComponent(name) +
@@ -1028,7 +1029,7 @@ define(['app'], function (app) {
 					}
 				});
 			}
-            else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
+			else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs gpio") == -1)) {
 				var gpiodebounce = $("#hardwarecontent #hardwareparamsgpio #gpiodebounce").val();
 				var gpioperiod = $("#hardwarecontent #hardwareparamsgpio #gpioperiod").val();
 				var gpiopollinterval = $("#hardwarecontent #hardwareparamsgpio #gpiopollinterval").val();
@@ -1060,26 +1061,26 @@ define(['app'], function (app) {
 						ShowNotify($.t('Problem adding hardware!'), 2500, true);
 					}
 				});
-            }
-            else if (text.indexOf("sysfs gpio") >= 0) {
-                Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
-                $.ajax({
-                    url: "json.htm?type=command&param=addhardware&htype="
-                    + hardwaretype
-                    + "&name=" + encodeURIComponent(name)
-                    + "&enabled=" + bEnabled
-                    + "&datatimeout=" + datatimeout
-                    + "&Mode1=" + Mode1,
-                    async: false,
-                    dataType: 'json',
-                    success: function (data) {
-                        RefreshHardwareTable();
-                    },
-                    error: function () {
-                        ShowNotify($.t('Problem adding hardware!'), 2500, true);
-                    }
-                });
-            }
+			}
+			else if (text.indexOf("sysfs gpio") >= 0) {
+				Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+				$.ajax({
+					url: "json.htm?type=command&param=addhardware&htype="
+					+ hardwaretype
+					+ "&name=" + encodeURIComponent(name)
+					+ "&enabled=" + bEnabled
+					+ "&datatimeout=" + datatimeout
+					+ "&Mode1=" + Mode1,
+					async: false,
+					dataType: 'json',
+					success: function (data) {
+						RefreshHardwareTable();
+					},
+					error: function () {
+						ShowNotify($.t('Problem adding hardware!'), 2500, true);
+					}
+				});
+			}
 			else if (text.indexOf("I2C ") >= 0 && text.indexOf("I2C sensor PIO 8bit expander PCF8574") < 0) {
 				hardwaretype = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').val();
 				var port = "";
@@ -4621,7 +4622,7 @@ define(['app'], function (app) {
 							}
 							else if ((item.Type == 16) || (item.Type == 32)) {
 								SerialName = "GPIO";
-                            }
+							}
 							else if (HwTypeStr.indexOf("Evohome") >= 0 && HwTypeStr.indexOf("script") >= 0) {
 								SerialName = "Script";
 							}
@@ -4886,14 +4887,14 @@ define(['app'], function (app) {
 								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
 							}
 						}
-                        else if ((data["Type"].indexOf("GPIO") >= 0) && (data["Type"].indexOf("sysfs gpio") == -1)) {
+						else if ((data["Type"].indexOf("GPIO") >= 0) && (data["Type"].indexOf("sysfs gpio") == -1)) {
 							$("#hardwareparamsgpio #gpiodebounce").val(data["Mode1"]);
 							$("#hardwareparamsgpio #gpioperiod").val(data["Mode2"]);
 							$("#hardwareparamsgpio #gpiopollinterval").val(data["Mode3"]);
-                        }
-                        else if (data["Type"].indexOf("sysfs gpio") >= 0) {
-                            $("#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure").prop("checked", data["Mode1"] == 1);
-                        }
+						}
+						else if (data["Type"].indexOf("sysfs gpio") >= 0) {
+							$("#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure").prop("checked", data["Mode1"] == 1);
+						}
 						else if (data["Type"].indexOf("USB") >= 0 || data["Type"].indexOf("Teleinfo EDF") >= 0) {
 							$("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);
 							if (data["Type"].indexOf("Evohome") >= 0) {
@@ -5114,7 +5115,6 @@ define(['app'], function (app) {
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 			$("#hardwarecontent #username").show();
 			$("#hardwarecontent #lblusername").show();
-
 			$("#hardwarecontent #divevohome").hide();
 			$("#hardwarecontent #divbaudratemysensors").hide();
 			$("#hardwarecontent #divbaudratep1").hide();
@@ -5136,8 +5136,8 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divpollinterval").hide();
 			$("#hardwarecontent #divpythonplugin").hide();
 			$("#hardwarecontent #divrelaynet").hide();
-            $("#hardwarecontent #divgpio").hide();
-            $("#hardwarecontent #divsysfsgpio").hide();
+			$("#hardwarecontent #divgpio").hide();
+			$("#hardwarecontent #divsysfsgpio").hide();
 
 			if ((text.indexOf("TE923") >= 0) ||
 				(text.indexOf("Volcraft") >= 0) ||
@@ -5145,7 +5145,7 @@ define(['app'], function (app) {
 				(text.indexOf("System Alive") >= 0) ||
 				(text.indexOf("PiFace") >= 0) ||
 				(text.indexOf("Yeelight") >= 0) ||
-                (text.indexOf("Arilux AL-LC0x") >= 0))
+				(text.indexOf("Arilux AL-LC0x") >= 0))
 			 {
 				$("#hardwarecontent #divserial").hide();
 				$("#hardwarecontent #divremote").hide();
@@ -5174,16 +5174,15 @@ define(['app'], function (app) {
 				$("#hardwarecontent #divlogin").hide();
 				$("#hardwarecontent #divunderground").hide();
 				$("#hardwarecontent #divhttppoller").hide();
-            }
-            else if (text.indexOf("sysfs gpio") >= 0) {
-                $("#hardwarecontent #divsysfsgpio").show();
-                $("#hardwarecontent #divserial").hide();
-                $("#hardwarecontent #divremote").hide();
-                $("#hardwarecontent #divlogin").hide();
-                $("#hardwarecontent #divunderground").hide();
-                $("#hardwarecontent #divhttppoller").hide();
-
-            }
+			}
+			else if (text.indexOf("sysfs gpio") >= 0) {
+				$("#hardwarecontent #divsysfsgpio").show();
+				$("#hardwarecontent #divserial").hide();
+				$("#hardwarecontent #divremote").hide();
+				$("#hardwarecontent #divlogin").hide();
+				$("#hardwarecontent #divunderground").hide();
+				$("#hardwarecontent #divhttppoller").hide();
+			}
 			else if (text.indexOf("USB") >= 0 || text.indexOf("Teleinfo EDF") >= 0) {
 				if (text.indexOf("Evohome") >= 0) {
 					$("#hardwarecontent #divevohome").show();

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -1962,6 +1962,14 @@ define(['app'], function (app) {
 				option.attr('value', item.idx).text(item.name);
 				$("#combogpio").append(option);
 			});
+			
+			RefreshSysfsGpioComboArray();
+			$("#combosysfsgpio").html("");
+			$.each($.ComboSysfsGpio, function (i, item) {
+				var option = $('<option />');
+				option.attr('value', item.idx).text(item.name);
+				$("#combosysfsgpio").append(option);
+            });
 		}
 
 		RefreshHardwareComboArray = function () {
@@ -1993,6 +2001,25 @@ define(['app'], function (app) {
 					if (typeof data.result != 'undefined') {
 						$.each(data.result, function (i, item) {
 							$.ComboGpio.push({
+								idx: item.idx,
+								name: item.Name
+							});
+						});
+					}
+				}
+			});
+		}
+		
+		RefreshSysfsGpioComboArray = function () {
+			$.ComboSysfsGpio = [];
+			$.ajax({
+				url: "json.htm?type=command&param=getsysfsgpio",
+				async: false,
+				dataType: 'json',
+				success: function (data) {
+					if (typeof data.result != 'undefined') {
+						$.each(data.result, function (i, item) {
+							$.ComboSysfsGpio.push({
 								idx: item.idx,
 								name: item.Name
 							});
@@ -3371,6 +3398,9 @@ define(['app'], function (app) {
 			else if (lighttype == 68) {
 				//Do nothing. GPIO uses a custom form
 			}
+			else if (lighttype == 69) {
+				//Do nothing. SysfsGpio uses a custom form
+			}
 			else if (lighttype == 7) {
 				tothousecodes = 16;
 				totunits = 8;
@@ -3471,6 +3501,7 @@ define(['app'], function (app) {
 			$("#dialog-addmanuallightdevice #blindsparams").hide();
 			$("#dialog-addmanuallightdevice #lightingparams_enocean").hide();
 			$("#dialog-addmanuallightdevice #lightingparams_gpio").hide();
+			$("#dialog-addmanuallightdevice #lightingparams_sysfsgpio").hide();
 			$("#dialog-addmanuallightdevice #homeconfortparams").hide();
 			$("#dialog-addmanuallightdevice #fanparams").hide();
 			$("#dialog-addmanuallightdevice #openwebnetparamsBus").hide();
@@ -3528,6 +3559,16 @@ define(['app'], function (app) {
 				$("#dialog-addmanuallightdevice #lighting2params").hide();
 				$("#dialog-addmanuallightdevice #lighting3params").hide();
 				$("#dialog-addmanuallightdevice #lightingparams_gpio").show();
+			}
+			else if (lighttype == 69) {
+				//SysfsGpio
+				$("#dialog-addmanuallightdevice #lightparams_enocean #comboid  >option").remove();
+				$("#dialog-addmanuallightdevice #lightparams_enocean #combounitcode  >option").remove();
+				$("#dialog-addmanuallightdevice #lighting1params").hide();
+				$("#dialog-addmanuallightdevice #lighting2params").show();
+				$("#dialog-addmanuallightdevice #lighting3params").hide();
+				$("#dialog-addmanuallightdevice #lighting2paramsUnitCode").hide()
+				$("#dialog-addmanuallightdevice #lightingparams_sysfsgpio").show();
 			}
 			else if ((lighttype >= 200) && (lighttype < 300)) {
 				//Blinds
@@ -3733,8 +3774,17 @@ define(['app'], function (app) {
 			}
 			else if (lighttype == 68) {
 				//GPIO
-				mParams += "&id=GPIO&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_gpio #combogpio option:selected").val();
+                mParams += "&id=GPIO&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_gpio #combogpio option:selected").val();
 			}
+			else if (lighttype == 69) {
+				//SysfsGpio
+                ID =
+                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd1 option:selected").text() +
+                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd2 option:selected").text() +
+                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd3 option:selected").text() +
+                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd4 option:selected").text();
+                mParams += "&id=" + ID + "&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_sysfsgpio #combosysfsgpio option:selected").val();
+            }
 			else if ((lighttype < 20) || (lighttype == 101)) {
 				mParams += "&housecode=" + $("#dialog-addmanuallightdevice #lightparams1 #combohousecode option:selected").val();
 				mParams += "&unitcode=" + $("#dialog-addmanuallightdevice #lightparams1 #combounitcode option:selected").val();

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1186,6 +1186,15 @@
                 </tr>
 			</table>
 		</div>
+        <div id="divsysfsgpio">
+            <br>
+            <table class="display" id="hardwareparamssysfsgpio" border="0" cellpadding="0" cellspacing="20">
+                <tr>
+                    <td align="right" style="width:110px"><label><span data-i18n="Auto configure devices">Auto configure devices</span>:</label></td>
+                    <td><input type="checkbox" id="sysfsautoconfigure" checked > </td>
+                </tr>
+            </table>
+        </div>
         <div id="divevohome">
 			<br>
 			<table class="display" id="hardwareparamsevohome" border="0" cellpadding="0" cellspacing="20">      

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1179,39 +1179,39 @@
 						<br />
 					</td>
 				</tr>
-                <tr valign="top">
-                    <td align="right" style="width:110px"><label id="lblgpiopollinterval" for="name"><span data-i18n="Pollinterval"></span>Poll interval:</label></td>
-                    <td><input type="text" id="gpiopollinterval" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="0" />&nbsp;<span data-i18n="(Seconds) 0 = Disabled"></span>
-                    </td>
-                </tr>
+				<tr valign="top">
+					<td align="right" style="width:110px"><label id="lblgpiopollinterval" for="name"><span data-i18n="Pollinterval"></span>Poll interval:</label></td>
+					<td><input type="text" id="gpiopollinterval" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="0" />&nbsp;<span data-i18n="(Seconds) 0 = Disabled"></span>
+					</td>
+				</tr>
 			</table>
 		</div>
-        <div id="divsysfsgpio">
-            <br>
-            <table class="display" id="hardwareparamssysfsgpio" border="0" cellpadding="0" cellspacing="20">
-                <tr>
-                    <td align="right" style="width:110px"><label><span data-i18n="Auto configure devices">Auto configure devices</span>:</label></td>
-                    <td><input type="checkbox" id="sysfsautoconfigure" checked > </td>
-                </tr>
-            </table>
-        </div>
-        <div id="divevohome">
+		<div id="divsysfsgpio">
 			<br>
-			<table class="display" id="hardwareparamsevohome" border="0" cellpadding="0" cellspacing="20">      
-                <tr>
-                    <td align="right" style="width:110px"><label id="lblbaudrateevohome" for="name"><span data-i18n="Baudrate">Baudrate</span>: </label></td>
-                    <td>
-                        <select id="combobaudrateevohome" style="width:210px" class="combobox ui-corner-all">
-                            <option value="115200">115200 (for genuine Honeywell HGI80/HGS80)</option>
-                            <option value="76800">76800</option>
-                            <option value="38400">38400</option>
-                        </select>
-                    </td>
-                </tr>
-                <tr>
-                    <td align="right" style="width:110px"><label><span data-i18n="Controller ID (hex)">Controller ID (hex)</span>:</label></td>
-                    <td><input type="text" id="controllerid" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
-                </tr>
+			<table class="display" id="hardwareparamssysfsgpio" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label><span data-i18n="Auto configure devices">Auto configure devices</span>:</label></td>
+					<td><input type="checkbox" id="sysfsautoconfigure" checked > </td>
+				</tr>
+			</table>
+		</div>
+		<div id="divevohome">
+			<br>
+			<table class="display" id="hardwareparamsevohome" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label id="lblbaudrateevohome" for="name"><span data-i18n="Baudrate">Baudrate</span>: </label></td>
+					<td>
+						<select id="combobaudrateevohome" style="width:210px" class="combobox ui-corner-all">
+							<option value="115200">115200 (for genuine Honeywell HGI80/HGS80)</option>
+							<option value="76800">76800</option>
+							<option value="38400">38400</option>
+						</select>
+					</td>
+				</tr>
+				<tr>
+					<td align="right" style="width:110px"><label><span data-i18n="Controller ID (hex)">Controller ID (hex)</span>:</label></td>
+					<td><input type="text" id="controllerid" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+				</tr>
 			</table>
 		</div>
     <div id="divbaudratemysensors">

--- a/www/views/lights.html
+++ b/www/views/lights.html
@@ -261,6 +261,7 @@
 						<option value="106">Blyss</option>
 						<option value="70">EnOcean</option>
 						<option value="68">GPIO</option>
+						<option value="69">SysfsGpio</option>
 						<option value="100">ByronSX</option>
 						<option value="101">Harrison Curtain</option>
 						<option value="102">RFY</option>
@@ -380,6 +381,16 @@
 						<select id="combogpio" style="width:220px" class="combobox ui-corner-all"><option value="-1">?</option></select>
 					</td>
 				</tr>
+			</table>
+		</div>
+		<div id="lightingparams_sysfsgpio">
+			<table class="display" id="lightparams_sysfsgpio" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label>SysfsGpio:</label></td>
+					<td>
+						<select id="combosysfsgpio" style="width:220px" class="combobox ui-corner-all"><option value="-1">?</option></select>
+					</td>
+				</tr>				
 			</table>
 		</div>
 		<div id="blindsparams">


### PR DESCRIPTION
Added support to add devices manually. There is a new hardware configuration option named "Auto configure devices". The option is checked by default meaning behavior is the same as was before.. When this check is removed devices are no longer created automatically. Instead devices can then be created in  the switches "Manual Light/Switch" menu. To do this select Hardware: "SysfsGPIO" and Type: "SystfsGPIO" plus the SysfsGPIO" in and or outputs. The ID: can be set to any value. Values already used for other Ligthing2 devices can best be avoided. For SysfsGPIO the ID does not matter because gpio pins have a unique unit number already.