### PR TITLE
Fixed python-interpreter not terminated properly.

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -83,6 +83,9 @@ void CEventSystem::StopEventSystem()
 		m_stoprequested = true;
 		m_thread->join();
 	}
+#ifdef ENABLE_PYTHON
+    Plugins::PythonEventsStop();
+#endif
 }
 
 void CEventSystem::SetEnabled(const bool bEnabled)

--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -150,8 +150,13 @@
         }
         
         bool PythonEventsStop() {
-            if (m_PyInterpreter) Py_EndInterpreter((PyThreadState*)m_PyInterpreter);
-            return true;
+            if (m_PyInterpreter) {
+                PyEval_RestoreThread((PyThreadState*)m_PyInterpreter);
+                Py_EndInterpreter((PyThreadState*)m_PyInterpreter);
+                _log.Log(LOG_STATUS, "EventSystem - Python stopped...");
+                return true;
+            } else
+                return false;
         }
         
         PyObject* PythonEventsGetModule (void) {


### PR DESCRIPTION
The event-python interpreter wasn't being terminated when stopping the event system, fixed.

M