### PR TITLE
Fix for forum bug report "can't select the GPIO hardware"

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3627,7 +3627,6 @@ namespace http {
 							root["result"][ii]["idx"] = ID;
 							root["result"][ii]["Name"] = Name;
 							ii++;
-							break;
 						}
 					}
 				}


### PR DESCRIPTION
Fix for forum bug report "I can't select the GPIO hardware when adding a manual Light/Switch Device." filed on 24-5-2017. 
Note: Please review this change because I see the break was in for a long time (since it was created in 2014). So it must have been broken for a long time or I am missing something. The "break" caused to only show the first found hardware ID. I reproduced the problem & after the change I see it work correctly on my system. I see now not only the 1st device but also the others, the available ones, listed in the switch statement. (I tested on Raspberry Pi). Why was this not reported before is my question.