### PR TITLE
defeat possible memory access error due to oversized timestamp value

### DIFF
--- a/hardware/P1MeterBase.h
+++ b/hardware/P1MeterBase.h
@@ -48,4 +48,6 @@ private:
 	void ParseData(const unsigned char *pData, const int Len, const bool disable_crc, int ratelimit);
 
 	bool CheckCRC();
+
+	bool hflogonce;
 };


### PR DESCRIPTION
Somewhat running in the dark here, but this seems like the most likely cause for issue #1556