### PR TITLE
Notification use threads

### DIFF
--- a/notifications/NotificationBase.cpp
+++ b/notifications/NotificationBase.cpp
@@ -117,6 +117,7 @@ bool CNotificationBase::SendMessageEx(
 		fText = CURLEncode::URLEncode(fText);
 	}
 
+	boost::mutex::scoped_lock SendMessageEx(SendMessageExMutex);
 	bool bRet = SendMessageImplementation(Idx, Name, fSubject, fText, ExtraData, Priority, Sound, bFromNotification);
 	if (bRet) {
 		_log.Log(LOG_NORM, std::string(std::string("Notification sent (") + _subsystemid + std::string(") => Success")).c_str());

--- a/notifications/NotificationBase.h
+++ b/notifications/NotificationBase.h
@@ -56,6 +56,7 @@ protected:
 
 	int m_IsEnabled;
 private:
+	boost::mutex SendMessageExMutex;
 	std::string _subsystemid;
 	std::map<std::string, std::string* > _configValues;
 	std::map<std::string, std::string* > _configValuesBase64;

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -98,7 +98,7 @@ bool CNotificationHelper::SendMessageEx(
 	const std::string &Sound,
 	const bool bFromNotification)
 {
-	bool bRet = (Priority != -100) ? false : true;
+	bool bRet = (Priority == -100) ? false : true;
 #if defined WIN32
 	//Make a system tray message
 	ShowSystemTrayNotification(Subject.c_str());

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -84,7 +84,7 @@ bool CNotificationHelper::SendMessage(
 	const std::string &Sound,
 	const bool bFromNotification)
 {
-	return SendMessageEx(Idx, Name, Subsystems, Subject, Text, ExtraData, 0, std::string(""), bFromNotification);
+	return SendMessageEx(Idx, Name, Subsystems, Subject, Text, ExtraData, -100, std::string(""), bFromNotification);
 }
 
 bool CNotificationHelper::SendMessageEx(
@@ -98,7 +98,7 @@ bool CNotificationHelper::SendMessageEx(
 	const std::string &Sound,
 	const bool bFromNotification)
 {
-	bool bRet = false;
+	bool bRet = (Priority != -100) ? false : true;
 #if defined WIN32
 	//Make a system tray message
 	ShowSystemTrayNotification(Subject.c_str());
@@ -114,11 +114,15 @@ bool CNotificationHelper::SendMessageEx(
 		ActiveSystems[*itt] = 1;
 	}
 
-	for (it_noti_type iter = m_notifiers.begin(); iter != m_notifiers.end(); ++iter) {
+	for (it_noti_type iter = m_notifiers.begin(); iter != m_notifiers.end(); ++iter)
+	{
 		std::map<std::string, int>::const_iterator ittSystem = ActiveSystems.find(iter->first);
-		if (ActiveSystems.empty() || (ittSystem!=ActiveSystems.end() && iter->second->IsConfigured()))
+		if ((ActiveSystems.empty() || ittSystem != ActiveSystems.end()) && iter->second->IsConfigured())
 		{
-			bRet |= iter->second->SendMessageEx(Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification);
+			if (Priority != -100)
+				boost::thread SendMessageEx(boost::bind(&CNotificationBase::SendMessageEx, iter->second, Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification));
+			else
+				bRet |= iter->second->SendMessageEx(Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification);
 		}
 	}
 	return bRet;


### PR DESCRIPTION
Spawning threads on notifications makes the interface much more responsive in case an handler is taking some time to process the notification (and reducing overal delay). There doesn't seem any code using return value of SendMessageEx, only for SendMessage. Since var priority is unused for the latter, I used value of -100 (arbitrary chosen) for it to determine it should use a thread of act as before.