### PR TITLE
HTTPClient added security options function / Notification set back priority to 0

### DIFF
--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -89,8 +89,8 @@ void HTTPClient::SetTimeout(const long timeout)
 
 void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1)
 {
-	m_iVerifyPeer = peer;
-	m_iVerifyHost = host;
+	m_iVerifyPeer = verifypeer;
+	m_iVerifyHost = verifyhost;
 	m_iEnforceTLSv1 = tlsv1;
 }
 

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -13,7 +13,6 @@
 extern std::string szUserDataFolder;
 
 bool		HTTPClient::m_bCurlGlobalInitialized = false;
-bool		HTTPClient::m_bEnforceTLSv1 = false;
 bool		HTTPClient::m_bVerifyHost = false;
 bool		HTTPClient::m_bVerifyPeer = false;
 long		HTTPClient::m_iConnectionTimeout = 10;
@@ -62,7 +61,7 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_DIGEST);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
-	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, (m_bVerifyPeer ? 0 : 1L));
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);
@@ -72,7 +71,6 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	std::string domocookie = szUserDataFolder + "domocookie.txt";
 	curl_easy_setopt(curl, CURLOPT_COOKIEFILE, domocookie.c_str());
 	curl_easy_setopt(curl, CURLOPT_COOKIEJAR, domocookie.c_str());
-	curl_easy_setopt(curl, CURLOPT_SSLVERSION, (m_bEnforceTLSv1 ? CURL_SSLVERSION_TLSv1 : CURL_SSLVERSION_DEFAULT));
 }
 
 //Configuration functions
@@ -86,11 +84,10 @@ void HTTPClient::SetTimeout(const long timeout)
 	m_iTimeout = timeout;
 }
 
-void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1)
+void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost)
 {
 	m_bVerifyPeer = verifypeer;
 	m_bVerifyHost = verifyhost;
-	m_bEnforceTLSv1 = tlsv1;
 }
 
 void HTTPClient::SetUserAgent(const std::string &useragent)

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -59,7 +59,7 @@ void HTTPClient::Cleanup()
 void HTTPClient::SetGlobalOptions(void *curlobj)
 {
 	CURL *curl=(CURL *)curlobj;
-	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC|CURLAUTH_DIGEST);
+	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_DIGEST);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
@@ -72,8 +72,7 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	std::string domocookie = szUserDataFolder + "domocookie.txt";
 	curl_easy_setopt(curl, CURLOPT_COOKIEFILE, domocookie.c_str());
 	curl_easy_setopt(curl, CURLOPT_COOKIEJAR, domocookie.c_str());
-	if (m_iEnforceTLSv1)
-		curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+	curl_easy_setopt(curl, CURLOPT_SSLVERSION, (m_iEnforceTLSv1 ? CURL_SSLVERSION_TLSv1 : CURL_SSLVERSION_DEFAULT));
 }
 
 //Configuration functions

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -236,7 +236,6 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 		{
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 		}
-//		SetCustomOptions(curl);
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -13,31 +13,37 @@
 extern std::string szUserDataFolder;
 
 bool		HTTPClient::m_bCurlGlobalInitialized = false;
-long		HTTPClient::m_iConnectionTimeout=10;
-long		HTTPClient::m_iTimeout=90; //max, time that a download has to be finished?
-std::string	HTTPClient::m_sUserAgent="domoticz/1.0";
+bool		HTTPClient::m_iVerifyPeer = false;
+bool		HTTPClient::m_iVerifyHost = false;
+bool		HTTPClient::m_iEnforceTLSv1 = false;
+long		HTTPClient::m_iConnectionTimeout = 10;
+long		HTTPClient::m_iTimeout = 90; //max, time that a download has to be finished?
+std::string	HTTPClient::m_sUserAgent = "domoticz/1.0";
 
-size_t write_curl_data(void *contents, size_t size, size_t nmemb, void *userp) {
+size_t write_curl_data(void *contents, size_t size, size_t nmemb, void *userp)
+{
 	size_t realsize = size * nmemb;
 	std::vector<unsigned char>* pvHTTPResponse = (std::vector<unsigned char>*)userp;
-	pvHTTPResponse->insert(pvHTTPResponse->end(),(unsigned char*)contents,(unsigned char*)contents+realsize);
+	pvHTTPResponse->insert(pvHTTPResponse->end(), (unsigned char*)contents, (unsigned char*)contents + realsize);
 	return realsize;
 }
 
-size_t write_curl_data_file(void *contents, size_t size, size_t nmemb, void *userp) {
+size_t write_curl_data_file(void *contents, size_t size, size_t nmemb, void *userp)
+{
 	size_t realsize = size * nmemb;
-	std::ofstream *outfile=(std::ofstream*)userp;
-	outfile->write((const char*)contents,realsize);
+	std::ofstream *outfile = (std::ofstream*)userp;
+	outfile->write((const char*)contents, realsize);
 	return realsize;
 }
 
 bool HTTPClient::CheckIfGlobalInitDone()
 {
-	if (!m_bCurlGlobalInitialized) {
-		CURLcode res=curl_global_init(CURL_GLOBAL_ALL);
-		if (res!=CURLE_OK)
+	if (!m_bCurlGlobalInitialized)
+	{
+		CURLcode res = curl_global_init(CURL_GLOBAL_ALL);
+		if (res != CURLE_OK)
 			return false;
-		m_bCurlGlobalInitialized=true;
+		m_bCurlGlobalInitialized = true;
 	}
 	return true;
 }
@@ -59,29 +65,38 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT,m_iTimeout); 
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, false);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, false); //allow self signed certificates
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT,m_iTimeout);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_iVerifyPeer);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_iVerifyHost); //allow self signed certificates
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 	std::string domocookie = szUserDataFolder + "domocookie.txt";
 	curl_easy_setopt(curl, CURLOPT_COOKIEFILE, domocookie.c_str());
 	curl_easy_setopt(curl, CURLOPT_COOKIEJAR, domocookie.c_str());
+	if (m_iEnforceTLSv1)
+		curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 }
 
 //Configuration functions
 void HTTPClient::SetConnectionTimeout(const long timeout)
 {
-	m_iConnectionTimeout=timeout;
+	m_iConnectionTimeout = timeout;
 }
 
 void HTTPClient::SetTimeout(const long timeout)
 {
-	m_iTimeout=timeout;
+	m_iTimeout = timeout;
+}
+
+void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1)
+{
+	m_iVerifyPeer = peer;
+	m_iVerifyHost = host;
+	m_iEnforceTLSv1 = tlsv1;
 }
 
 void HTTPClient::SetUserAgent(const std::string &useragent)
 {
-	m_sUserAgent=useragent;
+	m_sUserAgent = useragent;
 }
 
 bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
@@ -90,7 +105,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 	{
 		if (!CheckIfGlobalInitDone())
 			return false;
-		CURL *curl=curl_easy_init();
+		CURL *curl = curl_easy_init();
 		if (!curl)
 			return false;
 
@@ -101,17 +116,19 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 		}
 
-		struct curl_slist *headers=NULL;
-		if (ExtraHeaders.size()>0) {
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
 			std::vector<std::string>::const_iterator itt;
-			for (itt=ExtraHeaders.begin(); itt!=ExtraHeaders.end(); ++itt)
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
 			{
 				headers = curl_slist_append(headers, (*itt).c_str());
 			}
 		}
 
-		if (headers!=NULL) {
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers); 
+		if (headers != NULL)
+		{
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
@@ -156,15 +173,15 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 
 		curl_easy_cleanup(curl);
 
-		if (headers!=NULL) {
+		if (headers != NULL) {
 			curl_slist_free_all(headers); /* free the header list */
 		}
 
-		return (res==CURLE_OK);
+		return (res == CURLE_OK);
 	}
 	catch (...)
 	{
-		return false;		
+		return false;
 	}
 }
 
@@ -177,11 +194,11 @@ bool HTTPClient::GETBinaryToFile(const std::string &url, const std::string &outp
 
 		//open the output file for writing
 		std::ofstream outfile;
-		outfile.open(outputfile.c_str(),std::ios::out|std::ios::binary|std::ios::trunc);
+		outfile.open(outputfile.c_str(), std::ios::out|std::ios::binary|std::ios::trunc);
 		if (!outfile.is_open())
 			return false;
 
-		CURL *curl=curl_easy_init();
+		CURL *curl = curl_easy_init();
 		if (!curl)
 			return false;
 
@@ -199,7 +216,7 @@ bool HTTPClient::GETBinaryToFile(const std::string &url, const std::string &outp
 	}
 	catch (...)
 	{
-		return false;		
+		return false;
 	}
 }
 
@@ -209,7 +226,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 	{
 		if (!CheckIfGlobalInitDone())
 			return false;
-		CURL *curl=curl_easy_init();
+		CURL *curl = curl_easy_init();
 		if (!curl)
 			return false;
 
@@ -219,32 +236,37 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 		{
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 		}
+//		SetCustomOptions(curl);
+
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		curl_easy_setopt(curl, CURLOPT_POST, 1);
 
-		struct curl_slist *headers=NULL;
-		if (ExtraHeaders.size()>0) {
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
 			std::vector<std::string>::const_iterator itt;
-			for (itt=ExtraHeaders.begin(); itt!=ExtraHeaders.end(); ++itt)
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
 			{
 				headers = curl_slist_append(headers, (*itt).c_str());
 			}
 		}
 
-		if (headers!=NULL) {
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers); 
+		if (headers != NULL)
+		{
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
 
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str());
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 
-		if (headers!=NULL) {
+		if (headers != NULL)
+		{
 			curl_slist_free_all(headers); /* free the header list */
 		}
 
-		return (res==CURLE_OK);
+		return (res == CURLE_OK);
 	}
 	catch (...)
 	{
@@ -258,7 +280,7 @@ bool HTTPClient::PUTBinary(const std::string &url, const std::string &postdata, 
 	{
 		if (!CheckIfGlobalInitDone())
 			return false;
-		CURL *curl=curl_easy_init();
+		CURL *curl = curl_easy_init();
 		if (!curl)
 			return false;
 
@@ -270,28 +292,31 @@ bool HTTPClient::PUTBinary(const std::string &url, const std::string &postdata, 
 		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
 
 
-		struct curl_slist *headers=NULL;
-		if (ExtraHeaders.size()>0) {
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
 			std::vector<std::string>::const_iterator itt;
-			for (itt=ExtraHeaders.begin(); itt!=ExtraHeaders.end(); ++itt)
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
 			{
 				headers = curl_slist_append(headers, (*itt).c_str());
 			}
 		}
 
-		if (headers!=NULL) {
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers); 
+		if (headers != NULL)
+		{
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
 
 		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str());
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 
-		if (headers!=NULL) {
+		if (headers != NULL)
+		{
 			curl_slist_free_all(headers); /* free the header list */
 		}
 
-		return (res==CURLE_OK);
+		return (res == CURLE_OK);
 	}
 	catch (...)
 	{
@@ -318,7 +343,8 @@ bool HTTPClient::DeleteBinary(const std::string &url, const std::string &postdat
 
 
 		struct curl_slist *headers = NULL;
-		if (ExtraHeaders.size() > 0) {
+		if (ExtraHeaders.size() > 0)
+		{
 			std::vector<std::string>::const_iterator itt;
 			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
 			{
@@ -326,7 +352,8 @@ bool HTTPClient::DeleteBinary(const std::string &url, const std::string &postdat
 			}
 		}
 
-		if (headers != NULL) {
+		if (headers != NULL)
+		{
 			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
 
@@ -334,7 +361,8 @@ bool HTTPClient::DeleteBinary(const std::string &url, const std::string &postdat
 		res = curl_easy_perform(curl);
 		curl_easy_cleanup(curl);
 
-		if (headers != NULL) {
+		if (headers != NULL)
+		{
 			curl_slist_free_all(headers); /* free the header list */
 		}
 
@@ -351,7 +379,7 @@ bool HTTPClient::GET(const std::string &url, std::string &response, const bool b
 	response = "";
 	std::vector<unsigned char> vHTTPResponse;
 	std::vector<std::string> ExtraHeaders;
-	if (!GETBinary(url,ExtraHeaders,vHTTPResponse))
+	if (!GETBinary(url, ExtraHeaders, vHTTPResponse))
 		return false;
 	if (!bIgnoreNoDataReturned)
 	{
@@ -366,7 +394,7 @@ bool HTTPClient::GET(const std::string &url, const std::vector<std::string> &Ext
 {
 	response = "";
 	std::vector<unsigned char> vHTTPResponse;
-	if (!GETBinary(url,ExtraHeaders,vHTTPResponse))
+	if (!GETBinary(url, ExtraHeaders, vHTTPResponse))
 		return false;
 	if (!bIgnoreNoDataReturned)
 	{
@@ -381,7 +409,7 @@ bool HTTPClient::POST(const std::string &url, const std::string &postdata, const
 {
 	response = "";
 	std::vector<unsigned char> vHTTPResponse;
-	if (!POSTBinary(url,postdata,ExtraHeaders, vHTTPResponse, bFollowRedirect))
+	if (!POSTBinary(url, postdata, ExtraHeaders, vHTTPResponse, bFollowRedirect))
 		return false;
 	if (!bIgnoreNoDataReturned)
 	{
@@ -396,7 +424,7 @@ bool HTTPClient::PUT(const std::string &url, const std::string &postdata, const 
 {
 	response = "";
 	std::vector<unsigned char> vHTTPResponse;
-	if (!PUTBinary(url,postdata,ExtraHeaders, vHTTPResponse))
+	if (!PUTBinary(url, postdata, ExtraHeaders, vHTTPResponse))
 		return false;
 	if (!bIgnoreNoDataReturned)
 	{

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -65,8 +65,8 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_bVerifyPeer);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_bVerifyHost); //allow self signed certificates
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_bVerifyPeer ? 1L : 0);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_bVerifyHost ? 2L : 0); //allow self signed certificates
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 	std::string domocookie = szUserDataFolder + "domocookie.txt";
 	curl_easy_setopt(curl, CURLOPT_COOKIEFILE, domocookie.c_str());

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -13,9 +13,9 @@
 extern std::string szUserDataFolder;
 
 bool		HTTPClient::m_bCurlGlobalInitialized = false;
-bool		HTTPClient::m_iVerifyPeer = false;
-bool		HTTPClient::m_iVerifyHost = false;
-bool		HTTPClient::m_iEnforceTLSv1 = false;
+bool		HTTPClient::m_bEnforceTLSv1 = false;
+bool		HTTPClient::m_bVerifyHost = false;
+bool		HTTPClient::m_bVerifyPeer = false;
 long		HTTPClient::m_iConnectionTimeout = 10;
 long		HTTPClient::m_iTimeout = 90; //max, time that a download has to be finished?
 std::string	HTTPClient::m_sUserAgent = "domoticz/1.0";
@@ -65,14 +65,14 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT,m_iTimeout);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_iVerifyPeer);
-	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_iVerifyHost); //allow self signed certificates
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_bVerifyPeer);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_bVerifyHost); //allow self signed certificates
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
 	std::string domocookie = szUserDataFolder + "domocookie.txt";
 	curl_easy_setopt(curl, CURLOPT_COOKIEFILE, domocookie.c_str());
 	curl_easy_setopt(curl, CURLOPT_COOKIEJAR, domocookie.c_str());
-	curl_easy_setopt(curl, CURLOPT_SSLVERSION, (m_iEnforceTLSv1 ? CURL_SSLVERSION_TLSv1 : CURL_SSLVERSION_DEFAULT));
+	curl_easy_setopt(curl, CURLOPT_SSLVERSION, (m_bEnforceTLSv1 ? CURL_SSLVERSION_TLSv1 : CURL_SSLVERSION_DEFAULT));
 }
 
 //Configuration functions
@@ -88,9 +88,9 @@ void HTTPClient::SetTimeout(const long timeout)
 
 void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1)
 {
-	m_iVerifyPeer = verifypeer;
-	m_iVerifyHost = verifyhost;
-	m_iEnforceTLSv1 = tlsv1;
+	m_bVerifyPeer = verifypeer;
+	m_bVerifyHost = verifyhost;
+	m_bEnforceTLSv1 = tlsv1;
 }
 
 void HTTPClient::SetUserAgent(const std::string &useragent)

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -62,7 +62,7 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_DIGEST);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
-	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, (m_bVerifyPeer ? 0 : 1L));
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -5,6 +5,13 @@
 class HTTPClient
 {
 public:
+
+	struct _tCustomOptions
+	{
+		std::string option;
+		std::string value;
+	};
+
 	//GET functions
 	static bool GET(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
 	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
@@ -31,11 +38,15 @@ public:
 	static void SetConnectionTimeout(const long timeout);
 	static void SetTimeout(const long timeout);
 	static void SetUserAgent(const std::string &useragent);
+	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1);
 private:
 	static void SetGlobalOptions(void *curlobj);
 	static bool CheckIfGlobalInitDone();
 	//our static variables
 	static bool	m_bCurlGlobalInitialized;
+	static bool m_iVerifyPeer;
+	static bool m_iVerifyHost;
+	static bool m_iEnforceTLSv1;
 	static long	m_iConnectionTimeout;
 	static long	m_iTimeout;
 	static std::string m_sUserAgent;

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -5,13 +5,6 @@
 class HTTPClient
 {
 public:
-
-	struct _tCustomOptions
-	{
-		std::string option;
-		std::string value;
-	};
-
 	//GET functions
 	static bool GET(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
 	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -31,13 +31,12 @@ public:
 	static void SetConnectionTimeout(const long timeout);
 	static void SetTimeout(const long timeout);
 	static void SetUserAgent(const std::string &useragent);
-	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost, const bool tlsv1);
+	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost);
 private:
 	static void SetGlobalOptions(void *curlobj);
 	static bool CheckIfGlobalInitDone();
 	//our static variables
 	static bool m_bCurlGlobalInitialized;
-	static bool m_bEnforceTLSv1;
 	static bool m_bVerifyHost;
 	static bool m_bVerifyPeer;
 	static long m_iConnectionTimeout;

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -37,9 +37,9 @@ private:
 	static bool CheckIfGlobalInitDone();
 	//our static variables
 	static bool m_bCurlGlobalInitialized;
-	static bool m_iVerifyPeer;
-	static bool m_iVerifyHost;
-	static bool m_iEnforceTLSv1;
+	static bool m_bEnforceTLSv1;
+	static bool m_bVerifyHost;
+	static bool m_bVerifyPeer;
 	static long m_iConnectionTimeout;
 	static long m_iTimeout;
 	static std::string m_sUserAgent;

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -43,12 +43,12 @@ private:
 	static void SetGlobalOptions(void *curlobj);
 	static bool CheckIfGlobalInitDone();
 	//our static variables
-	static bool	m_bCurlGlobalInitialized;
+	static bool m_bCurlGlobalInitialized;
 	static bool m_iVerifyPeer;
 	static bool m_iVerifyHost;
 	static bool m_iEnforceTLSv1;
-	static long	m_iConnectionTimeout;
-	static long	m_iTimeout;
+	static long m_iConnectionTimeout;
+	static long m_iTimeout;
 	static std::string m_sUserAgent;
 };
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -94,11 +94,20 @@ bool CNotificationHelper::SendMessageEx(
 	const std::string &Subject,
 	const std::string &Text,
 	const std::string &ExtraData,
-	const int Priority,
+	int Priority,
 	const std::string &Sound,
 	const bool bFromNotification)
 {
-	bool bRet = (Priority == -100) ? false : true;
+	bool bRet = false;
+	bool bThread = true;
+
+	if (Priority == -100)
+	{
+		Priority = 0;
+		bThread = false;
+		bRet = true;
+	}
+
 #if defined WIN32
 	//Make a system tray message
 	ShowSystemTrayNotification(Subject.c_str());
@@ -119,7 +128,7 @@ bool CNotificationHelper::SendMessageEx(
 		std::map<std::string, int>::const_iterator ittSystem = ActiveSystems.find(iter->first);
 		if ((ActiveSystems.empty() || ittSystem != ActiveSystems.end()) && iter->second->IsConfigured())
 		{
-			if (Priority != -100)
+			if (bThread)
 				boost::thread SendMessageEx(boost::bind(&CNotificationBase::SendMessageEx, iter->second, Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification));
 			else
 				bRet |= iter->second->SendMessageEx(Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification);

--- a/notifications/NotificationHelper.h
+++ b/notifications/NotificationHelper.h
@@ -42,7 +42,7 @@ public:
 		const std::string &Subject,
 		const std::string &Text,
 		const std::string &ExtraData,
-		const int Priority,
+		int Priority,
 		const std::string &Sound,
 		const bool bFromNotification);
 	void LoadConfig();

--- a/notifications/NotificationPushbullet.cpp
+++ b/notifications/NotificationPushbullet.cpp
@@ -50,6 +50,7 @@ bool CNotificationPushbullet::SendMessageImplementation(
 	//Do the request
 	HTTPClient::SetSecurityOptions(true, true, true);
 	bRet = HTTPClient::POST("https://api.pushbullet.com/v2/pushes",sPostData,ExtraHeaders,sResult);
+	HTTPClient::SetSecurityOptions(false, false, false);
 	bool bSuccess = (sResult.find("\"created\":") != std::string::npos);
 	if (!bSuccess)
 		_log.Log(LOG_ERROR, "Pushbullet: %s", sResult.c_str());

--- a/notifications/NotificationPushbullet.cpp
+++ b/notifications/NotificationPushbullet.cpp
@@ -48,9 +48,9 @@ bool CNotificationPushbullet::SendMessageImplementation(
 	ExtraHeaders.push_back("Content-Type: application/json");
 
 	//Do the request
-	HTTPClient::SetSecurityOptions(true, true, true);
+	HTTPClient::SetSecurityOptions(true, true);
 	bRet = HTTPClient::POST("https://api.pushbullet.com/v2/pushes",sPostData,ExtraHeaders,sResult);
-	HTTPClient::SetSecurityOptions(false, false, false);
+	HTTPClient::SetSecurityOptions(false, false);
 	bool bSuccess = (sResult.find("\"created\":") != std::string::npos);
 	if (!bSuccess)
 		_log.Log(LOG_ERROR, "Pushbullet: %s", sResult.c_str());

--- a/notifications/NotificationPushbullet.cpp
+++ b/notifications/NotificationPushbullet.cpp
@@ -46,8 +46,9 @@ bool CNotificationPushbullet::SendMessageImplementation(
 	sHeaderKey << "Access-Token: " << _apikey;
 	ExtraHeaders.push_back(sHeaderKey.str());
 	ExtraHeaders.push_back("Content-Type: application/json");
-	
+
 	//Do the request
+	HTTPClient::SetSecurityOptions(true, true, true);
 	bRet = HTTPClient::POST("https://api.pushbullet.com/v2/pushes",sPostData,ExtraHeaders,sResult);
 	bool bSuccess = (sResult.find("\"created\":") != std::string::npos);
 	if (!bSuccess)

--- a/notifications/NotificationPushover.cpp
+++ b/notifications/NotificationPushover.cpp
@@ -49,6 +49,7 @@ bool CNotificationPushover::SendMessageImplementation(
 		sPostData << "&retry=300&expire=3600";
 	}
 	std::vector<std::string> ExtraHeaders;
+	HTTPClient::SetSecurityOptions(true, true, true);
 	bRet = HTTPClient::POST("https://api.pushover.net/1/messages.json",sPostData.str(),ExtraHeaders,sResult);
 	if (!bRet)
 		_log.Log(LOG_ERROR, "Pushover: %s", sResult.c_str());

--- a/notifications/NotificationPushover.cpp
+++ b/notifications/NotificationPushover.cpp
@@ -49,9 +49,9 @@ bool CNotificationPushover::SendMessageImplementation(
 		sPostData << "&retry=300&expire=3600";
 	}
 	std::vector<std::string> ExtraHeaders;
-	HTTPClient::SetSecurityOptions(true, true, true);
+	HTTPClient::SetSecurityOptions(true, true);
 	bRet = HTTPClient::POST("https://api.pushover.net/1/messages.json",sPostData.str(),ExtraHeaders,sResult);
-	HTTPClient::SetSecurityOptions(false, false, false);
+	HTTPClient::SetSecurityOptions(false, false);
 	if (!bRet)
 		_log.Log(LOG_ERROR, "Pushover: %s", sResult.c_str());
 	return bRet;

--- a/notifications/NotificationPushover.cpp
+++ b/notifications/NotificationPushover.cpp
@@ -51,6 +51,7 @@ bool CNotificationPushover::SendMessageImplementation(
 	std::vector<std::string> ExtraHeaders;
 	HTTPClient::SetSecurityOptions(true, true, true);
 	bRet = HTTPClient::POST("https://api.pushover.net/1/messages.json",sPostData.str(),ExtraHeaders,sResult);
+	HTTPClient::SetSecurityOptions(false, false, false);
 	if (!bRet)
 		_log.Log(LOG_ERROR, "Pushover: %s", sResult.c_str());
 	return bRet;


### PR DESCRIPTION
Added security options function for HTTP client, so verify peer, host and TLSv1 can be set / enforced. I think this will solve https://github.com/domoticz/domoticz/issues/1574, but even if not, this makes communication more secure. I only changed Pushover and Pushbullet, since those are the ones I can test.