### PR TITLE
SQLHelper: lessen rounding errors for computed energy

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3427,7 +3427,7 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 			StringSplit(result[0][5].c_str(), ";", parts);
 			nEnergy = static_cast<float>(strtof(parts[0].c_str(), NULL)*interval / 3600 + strtof(parts[1].c_str(), NULL)); //Rob: whats happening here... strtof ?
 			StringSplit(sValue, ";", parts);
-			sprintf(sCompValue, "%s;%.0f", parts[0].c_str(), nEnergy);
+			sprintf(sCompValue, "%s;%.1f", parts[0].c_str(), nEnergy);
 			sValue = sCompValue;
 		}
 	        //~ use different update queries based on the device type


### PR DESCRIPTION
The power sensors I have (Ubiquiti mFi) don't have a total Energy
counter, only a monthly one, so I used the 'computed energy' features in
domoticz.
The problem is that for low power devices the %.0f format specifier
introduces big rounding errors:

* For a device that alternates between 14 and 17 Watt the computed
  energy is between 19 and 27 Watthour:
<img width="1222" alt="overreported" src="https://cloud.githubusercontent.com/assets/259525/26760653/eaaed8f6-491e-11e7-8167-e2242fb5a3f5.png">

* For a device that alternates between 10 and 15 Watt the computed
  energy is 0 and 2 Watthour:
<img width="1221" alt="underreported" src="https://cloud.githubusercontent.com/assets/259525/26760655/ef1f843a-491e-11e7-81f5-9efb2103e6c8.png">

After this patch (about 23:00 on june 3rd in the above screenshots) the first devices gets 14-15Wh and the second device
12-13Wh.
