### PR TITLE
Fix timers if location is not set in preferences

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -484,10 +484,9 @@ bool MainWorker::GetSunSettings()
 {
 	int nValue;
 	std::string sValue;
-	if (!m_sql.GetPreferencesVar("Location",nValue,sValue))
-		return false;
 	std::vector<std::string> strarray;
-	StringSplit(sValue, ";", strarray);
+	if (m_sql.GetPreferencesVar("Location",nValue,sValue))
+		StringSplit(sValue, ";", strarray);
 
 	if (strarray.size() != 2)
 	{


### PR DESCRIPTION
Timers were never scheduled when location was not set in preferences.

At start, timers are loaded from MainWorker::GetSunSettings().
It uses CScheduler::SetSunRiseSetTimers() which calls
CScheduler::ReloadSchedules() after getting sunrise/sunset times from
location.

When the location is invalid, ReloadSchedules() is called as fallback
early in GetSunSettings().
Though, it was never called when location was missing from settings.