### PR TITLE
Evo web revision 4

### DIFF
--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -576,7 +576,7 @@ void CEvohomeWeb::DecodeZone(zone* hz)
 			// also wipe StrParam1 - we do not want a double action from the old (python) script when changing the setpoint
 			m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', StrParam1='' WHERE (ID == %" PRIu64 ")", ssnewname.str().c_str(), DevRowIdx);
 			if (sdevname.find("zone ") != std::string::npos)
-				_log.Log(LOG_STATUS, "(%s) register new zone '%c'", this->Name.c_str(), ssnewname.str().c_str());
+				_log.Log(LOG_STATUS, "(%s) register new zone '%s'", this->Name.c_str(), ssnewname.str().c_str());
 		}
 	}
 }

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -137,14 +137,17 @@ bool CEvohomeWeb::StartSession()
 	{
 		std::vector<std::vector<std::string> > result;
 		result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%q')", this->m_HwdID, m_tcs->systemId.c_str());
-		if (result.empty()) // shouldn't happen
-			return false;
-		std::vector<std::string> splitresults;
-		StringSplit(result[0][0], ";", splitresults);
-		if (splitresults.size()>0)
-			m_awaysetpoint = strtod(splitresults[0].c_str(), NULL);
-		if (m_awaysetpoint == 0)
-			m_awaysetpoint = 15; // use default 'Away' setpoint value
+		if (result.empty()) // unitialized hardware
+ 			m_awaysetpoint = 15; // use default 'Away' setpoint value
+		else
+		{
+			std::vector<std::string> splitresults;
+			StringSplit(result[0][0], ";", splitresults);
+			if (splitresults.size()>0)
+				m_awaysetpoint = strtod(splitresults[0].c_str(), NULL);
+			if (m_awaysetpoint == 0)
+				m_awaysetpoint = 15; // use default 'Away' setpoint value
+		}
 	}
 
 	if (m_showhdtemps)

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -68,10 +68,6 @@ CEvohomeWeb::CEvohomeWeb(const int ID, const std::string &Username, const std::s
 	m_showhdtemps = ((UseFlags & 8) > 0);
 	m_hdprecision = ((UseFlags & 16) > 0) ? 100 : 10;
 
-	// fixed values for now
-	m_showhdtemps = true;
-	m_hdprecision = 10;
-
 	if (m_refreshrate < 10)
 		m_refreshrate = 60;
 

--- a/hardware/EvohomeWeb.h
+++ b/hardware/EvohomeWeb.h
@@ -28,6 +28,7 @@ class CEvohomeWeb : public CEvohomeBase
 		Json::Value *installationInfo;
 		Json::Value *status;
 		Json::Value schedule;
+		std::string hdtemp;
 	};
 
 	struct temperatureControlSystem
@@ -137,6 +138,8 @@ private:
 	uint8_t m_gatewayId;
 	uint8_t m_systemId;
 	double m_awaysetpoint;
+	bool m_showhdtemps;
+	uint8_t m_hdprecision;
 
 
 	static const uint8_t m_dczToEvoWebAPIMode[7];
@@ -150,5 +153,12 @@ private:
 	std::map<int, location> m_locations;
 
 	temperatureControlSystem* m_tcs;
+
+	// Evohome v1 API
+	std::string m_v1uid;
+	std::vector<std::string> m_v1SessionHeaders;
+
+	bool v1_login(const std::string &user, const std::string &password);
+	void get_v1_temps();
 };
 

--- a/hardware/EvohomeWeb.h
+++ b/hardware/EvohomeWeb.h
@@ -76,7 +76,7 @@ private:
 	bool SetDHWState(const char *pdata);
 
 	// evohome client library - don't ask about naming convention - these are imported from another project
-	bool login(std::string user, std::string password);
+	bool login(const std::string &user, const std::string &password);
 	bool user_account();
 
 	void get_gateways(int location);
@@ -146,8 +146,7 @@ private:
 	Json::Value m_j_fi;
 	Json::Value m_j_stat;
 
-	std::map<std::string, std::string> m_auth_info;
-	std::map<std::string, std::string> m_account_info;
+	std::string m_evouid;
 	std::map<int, location> m_locations;
 
 	temperatureControlSystem* m_tcs;

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -880,6 +880,9 @@ define(['app'], function (app) {
 					UseFlags = UseFlags | 2;
 				}
 
+				var Precision = parseInt($("#hardwarecontent #divevohomeweb #comboevoprecision").val());
+				UseFlags += Precision;
+
 				var evo_installation = $("#hardwarecontent #divevohomeweb #comboevolocation").val()*4096;
 				evo_installation = evo_installation + $("#hardwarecontent #divevohomeweb #comboevogateway").val()*256;
 				evo_installation = evo_installation + $("#hardwarecontent #divevohomeweb #comboevotcs").val()*16;
@@ -1699,6 +1702,9 @@ define(['app'], function (app) {
 				{
 					UseFlags = UseFlags | 2;
 				}
+
+				var Precision = parseInt($("#hardwarecontent #divevohomeweb #comboevoprecision").val());
+				UseFlags += Precision;
 
 				var evo_installation = $("#hardwarecontent #divevohomeweb #comboevolocation").val()*4096;
 				evo_installation = evo_installation + $("#hardwarecontent #divevohomeweb #comboevogateway").val()*256;
@@ -5170,9 +5176,10 @@ define(['app'], function (app) {
 							$("#hardwarecontent #divevohomeweb #disableautoevohomeweb").prop("checked",((UseFlags & 1) ^ 1));
 							$("#hardwarecontent #divevohomeweb #showscheduleevohomeweb").prop("checked",((UseFlags & 2) >>> 1));
 							$("#hardwarecontent #divevohomeweb #showlocationevohomeweb").prop("checked",((UseFlags & 4) >>> 2));
+							$("#hardwarecontent #divevohomeweb #comboevoprecision").val((UseFlags & 24));
 
 							var Location = parseInt(data["Mode5"]);
-							for (var i=0;i<10;i++){
+							for (var i=1;i<10;i++){
 								$("#hardwarecontent #divevohomeweb #comboevolocation")[0].options[i]=new Option(i,i);
 								$("#hardwarecontent #divevohomeweb #comboevogateway")[0].options[i]=new Option(i,i);
 								$("#hardwarecontent #divevohomeweb #comboevotcs")[0].options[i]=new Option(i,i);

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1538,7 +1538,7 @@
 				</tr>
 			</table>
 		</div>
-		<div id="divevohomeweb">
+		<div id="divevohomeweb" style="display:none;">
 			<br />
 			<table class="display" id="hardwareparamsevohomeweb" border="0" cellpadding="0" cellspacing="20">      
 				<tr valign="top">
@@ -1583,11 +1583,24 @@
 						<label id="lblshowlocevohomeweb" for="name"><span data-i18n="Select location">Select location</span>: </label>
 					</td>
 					<td>
-						<select id="comboevolocation" name="comboevolocation" class="combobox ui-corner-all"></select>,
-						<select id="comboevogateway" name="comboevogateway" class="combobox ui-corner-all"></select>,
-						<select id="comboevotcs" name="comboevotcs" class="combobox ui-corner-all"></select>
+						<select id="comboevolocation" name="comboevolocation" class="combobox ui-corner-all"><option value="0">0</option></select>,
+						<select id="comboevogateway" name="comboevogateway" class="combobox ui-corner-all"><option value="0">0</option></select>,
+						<select id="comboevotcs" name="comboevotcs" class="combobox ui-corner-all"><option value="0">0</option></select>
+						<span data-i18n="(keep at [0,0,0] if you only have one Evohome installation)">(keep at [0,0,0] if you only have one Evohome installation)</span><br />&nbsp;<br />
 					</td>
+				</tr>
 
+				<tr valign="top">
+					<td align="right" style="width:110px">
+						<label id="lblprecisionevohomeweb" for="name"><span data-i18n="Temperature precision">Temperature precision</span>: </label>
+					</td>
+					<td><select id="comboevoprecision" style="width:200px" class="combobox ui-corner-all">
+						<option selected="selected" value="0">Same as controller (quickest)</option>
+						<option value="8">1 decimal</option>
+						<option value="24">2 decimals</option>
+						</select>
+					</td>
+				</tr>
 			</table>
 		</div>
 		<div>


### PR DESCRIPTION
Needed to round this up because there was a mistake in a previous commit that prevents detection of the evohome installation when the hardware was just added.

I've received a user request to reference a second API (the 'old' US API) for fetching actual temperatures measured by the devices. While I do see the value in that there is also a performance hit related to this and I decided the default should stay like the UK/EMEA API presents it (which is half degree precision).