### PR TITLE
EventSystem make threaded / match Lua and Python file name on devicename 

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2150,7 +2150,7 @@ bool CEventSystem::parseBlocklyActions(const std::string &Actions, const std::st
                         {
 				subsystem = aParam[4];
 			}
-			m_sql.AddTaskItem(_tTaskItem::SendNotification(1, subject, body, std::string(""), atoi(priority.c_str()), sound, subsystem));
+			m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, std::string(""), atoi(priority.c_str()), sound, subsystem));
 			actionsDone = true;
 			continue;
 		}
@@ -3012,7 +3012,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			subsystem = aParam[5];
 		}
 
-		m_sql.AddTaskItem(_tTaskItem::SendNotification(1, subject, body, extraData, atoi(priority.c_str()), sound, subsystem));
+		m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, extraData, atoi(priority.c_str()), sound, subsystem));
 		scriptTrue = true;
 	}
 	else if (lCommand == "SendEmail") {

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1216,7 +1216,6 @@ void CEventSystem::EvaluateEventPython(const std::string &reason, const uint64_t
 	if (!m_bEnabled)
 		return;
 
-	boost::unique_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	std::vector<std::string> FileEntries;
 	std::vector<std::string>::const_iterator itt;
 	std::string filename;
@@ -2303,9 +2302,11 @@ void CEventSystem::EvaluatePython(const std::string &reason, const std::string &
 	//_log.Log(LOG_NORM, "EventSystem: Already scheduled this event, skipping");
 	// _log.Log(LOG_STATUS, "EventSystem: script %s trigger, file: %s, script: %s, deviceName: %s" , reason.c_str(), filename.c_str(), PyString.c_str(), devname.c_str());
 
-    Plugins::PythonEventsProcessPython(reason, filename, PyString, DeviceID, m_devicestates, m_uservariables, getSunRiseSunSetMinutes("Sunrise"),
-        getSunRiseSunSetMinutes("Sunset"));
+	boost::unique_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
+	boost::unique_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 
+	Plugins::PythonEventsProcessPython(reason, filename, PyString, DeviceID, m_devicestates, m_uservariables, getSunRiseSunSetMinutes("Sunrise"),
+		getSunRiseSunSetMinutes("Sunset"));
 
 	//Py_Finalize();
 }

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1084,6 +1084,7 @@ void CEventSystem::ProcessDevice(const int HardwareID, const uint64_t ulDevID, c
 		std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][4].c_str());
 
 		std::string nValueWording = UpdateSingleState(ulDevID, devname, nValue, sValue, devType, subType, switchType, sd[2], atoi(sd[3].c_str()), options);
+		GetCurrentUserVariables();
 		boost::thread EvaluateEvent(boost::bind(&CEventSystem::EvaluateEvent, this, "device", ulDevID, devname, nValue, sValue, nValueWording, 0));
 #ifdef ENABLE_PYTHON
 		EvaluateEventPython("device", ulDevID, devname, nValue, sValue, nValueWording, 0);
@@ -1097,6 +1098,7 @@ void CEventSystem::ProcessDevice(const int HardwareID, const uint64_t ulDevID, c
 void CEventSystem::ProcessMinute()
 {
 	GetCurrentScenesGroups();
+	GetCurrentUserVariables();
 	EvaluateEvent("time");
 #ifdef ENABLE_PYTHON
 	EvaluateEventPython("time", 0, "", 0, "", "", 0);
@@ -1107,6 +1109,7 @@ void CEventSystem::ProcessUserVariable(const uint64_t varId)
 {
 	if (!m_bEnabled)
 		return;
+	GetCurrentUserVariables();
 	EvaluateEvent("uservariable", varId);
 #ifdef ENABLE_PYTHON
 	EvaluateEventPython("uservariable", 0, "", 0, "", "", varId);
@@ -1127,7 +1130,6 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 {
 	if (!m_bEnabled)
 		return;
-	GetCurrentUserVariables();
 
 	std::vector<std::string> FileEntries;
 	std::vector<std::string>::const_iterator itt;
@@ -1213,7 +1215,6 @@ void CEventSystem::EvaluateEventPython(const std::string &reason, const uint64_t
 {
 	if (!m_bEnabled)
 		return;
-	GetCurrentUserVariables();
 
 	boost::unique_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	std::vector<std::string> FileEntries;

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3129,6 +3129,12 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			variableValue = variableType.substr(5);
 			varTypeNum = "4";
 		}
+		else
+		{
+			// defaults to string
+			variableValue = variableType;
+			varTypeNum = "2";
+		}
 		m_sql.SaveUserVariable(variableName, varTypeNum, variableValue);
 		scriptTrue = true;
 	}

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1136,6 +1136,7 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 		{
 			if (reason == "device" && filename.find("_device_") != std::string::npos)
 			{
+				bDeviceFileFound = false;
 				boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 				std::map<uint64_t, _tDeviceStatus>::const_iterator itt2;
 				for (itt2 = m_devicestates.begin(); itt2 != m_devicestates.end(); ++itt2)
@@ -1177,7 +1178,6 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 #ifdef ENABLE_PYTHON
 	try
 	{
-		bDeviceFileFound = false;
 		FileEntries.clear();
 
 		DirectoryListing(FileEntries, python_Dir, false, true);
@@ -1191,6 +1191,7 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 			{
 				if (reason == "device" && filename.find("_device_") != std::string::npos)
 				{
+					bDeviceFileFound = false;
 					boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 					std::map<uint64_t, _tDeviceStatus>::const_iterator itt2;
 					for (itt2 = m_devicestates.begin(); itt2 != m_devicestates.end(); ++itt2)

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1314,6 +1314,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "device");
+	devicestatesMutexLock.unlock();
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	lua_createtable(lua_state, (int)m_uservariables.size(), 0);
@@ -1345,8 +1346,6 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 
 	boost::lock_guard<boost::mutex> measurementStatesMutexLock(m_measurementStatesMutex);
 	GetCurrentMeasurementStates();
-
-	devicestatesMutexLock.unlock();
 
 	if (m_tempValuesByID.size() > 0) {
 		lua_createtable(lua_state, (int)m_tempValuesByID.size(), 0);

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2271,6 +2271,7 @@ void CEventSystem::EvaluatePython(const std::string &reason, const std::string &
 	// _log.Log(LOG_STATUS, "EventSystem: script %s trigger, file: %s, script: %s, deviceName: %s" , reason.c_str(), filename.c_str(), PyString.c_str(), devname.c_str());
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
+	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 
     Plugins::PythonEventsProcessPython(reason, filename, PyString, DeviceID, m_devicestates, m_uservariables, getSunRiseSunSetMinutes("Sunrise"),
         getSunRiseSunSetMinutes("Sunset"));

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3097,6 +3097,41 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			scriptTrue = true;
 		}
 	}
+	else if (lCommand.find("AddVariable:") == 0)
+	{
+		std::string variableName = lCommand.substr(12);
+		std::string variableType = lua_tostring(lua_state, -1);
+		std::string variableValue;
+		std::string varTypeNum;
+
+		if (variableType.find("Integer:") == 0)
+		{
+			variableValue = variableType.substr(8);
+			varTypeNum = "0";
+		}
+		else if (variableType.find("Float:") == 0)
+		{
+			variableValue = variableType.substr(6);
+			varTypeNum = "1";
+		}
+		else if (variableType.find("String:") == 0)
+		{
+			variableValue = variableType.substr(7);
+			varTypeNum = "2";
+		}
+		else if (variableType.find("Date:") == 0)
+		{
+			variableValue = variableType.substr(5);
+			varTypeNum = "3";
+		}
+		else if (variableType.find("Time:") == 0)
+		{
+			variableValue = variableType.substr(5);
+			varTypeNum = "4";
+		}
+		m_sql.SaveUserVariable(variableName, varTypeNum, variableValue);
+		scriptTrue = true;
+	}
 	else if (lCommand.find("SetSetPoint:") == 0)
 	{
 		std::string SetPointIdx = lCommand.substr(12);

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -189,4 +189,7 @@ private:
 	void report_errors(lua_State *L, int status, std::string filename);
 	unsigned char calculateDimLevel(int deviceID, int percentageLevel);
 	void StripQuotes(std::string &sString);
+	std::string SpaceToUnderscore(std::string sResult);
+	std::string LowerCase(std::string sResult);
+
 };

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -125,6 +125,7 @@ private:
 	bool parseBlocklyActions(const std::string &Actions, const std::string &eventName, const uint64_t eventID);
 	std::string ProcessVariableArgument(const std::string &Argument);
 #ifdef ENABLE_PYTHON
+	void EvaluateEventPython(const std::string &reason, const uint64_t DeviceID, const std::string &devname, const int nValue, const char* sValue, std::string nValueWording, const uint64_t varId);
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString, const uint64_t varId);
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString);
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString, const uint64_t DeviceID, const std::string &devname, const int nValue, const char* sValue, std::string nValueWording, const uint64_t varId);


### PR DESCRIPTION
- Threading the EvaluateEvent function prevents Domoticz to stall on Lua / Blockly / ~~Python~~ processing, makes multi-core processing very efficient. 

- Matching device name on file name. E.g. script_device_devicename.lua (or .py for Python) will only be executed when DeviceName is processed (case insensitive, DeviceName is lower cased and spaces are replaced with underscores). On the other hand script_device_somenamethatdoesntexist.lua will just be matched on ALL devices, just as the current behavior. The logic inside the scripts (devicechanged / otherdevices etc) hasn't changed. Executing Lua is a costly process, so this saves a lot (system load reduced considerably).

- Added AddVariable for Lua, which allows to do something like this in your scripts:
```
local variable = uservariables['SomeVariable']
if (variable == nil) then
commandArray['AddVariable:SomeVariable'] = tostring("Float:12.12")}
else
commandArray['Variable:SomeVariable'] = tostring("12.12")}
end
```

By implementing the threaded / file match concept with unique_lock / shared_lock mutexes, multiple scripts can run fast simultaneously when reading, without the risk of lockups/races. Timing has become much more predictable now. On my RPi 1, all my switches now respond almost instantaneously, despite the fairly high number of Lua scripts I have. I can only imagine the latency reduction on multi-core systems ;)