### PR TITLE
make clicking on custom weight sensor on dashboard display log graph

### DIFF
--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -3800,7 +3800,7 @@ define(['app'], function (app) {
 										statushtml = item.Data;
 									}
 									else if (item.Type == "Weight") {
-										imagehtml += 'scale48.png" height="40" width="40"></td>\n';
+										imagehtml += 'scale48.png" class="lcursor" onclick="ShowGeneralGraph(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\',\'' + item.Type + '\', \'' + item.SubType + '\');" height="40" width="40"></td>\n';
 										statushtml = item.Data;
 									}
 									else if (item.Type == "Usage") {

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1395
+# ref 1396
 
 CACHE:
 # CSS


### PR DESCRIPTION
One minor detail -- if a custom weight sensor is added to the dashboard, you can't click on the icon to show the graph like you can with every other sensor type.  This pull request fixes that.