### PR TITLE
Rtl433: fix regression on restarting failed subprocess

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -331,7 +331,9 @@ void CRtl433::Do_Work()
 				{
 					_log.Log(LOG_STATUS, "Rtl433: Unhandled sensor type, please report: (%s)", line);
 				}
-			} //fgets
+			} else { //fgets
+			  break; // bail out, subprocess has failed
+			}
 		} // while !m_stoprequested
 		if (m_hPipe)
 		{


### PR DESCRIPTION
When rtl_433 subprocess dies, it won't be restarted but remains as &lt;defunct&gt;.

I think cdbdf79 takes the fgets failure case out of the while loop condition. The failed pipe never gets closed and reopened again.
