### PR TITLE
Sysfs GPIO: Added debounce parameter on hardware config screen

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -335,7 +335,7 @@ void CSysfsGpio::Do_Work()
 		}
 	}
 
-	_log.Log(LOG_STATUS, "Sysfs GPIO: Input poller stopped");
+	_log.Log(LOG_STATUS, "Sysfs GPIO: Worker stopped");
 }
 
 void CSysfsGpio::EdgeDetectThread()

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -104,8 +104,9 @@
 	for "rising" and "falling" edges will follow this
 	setting.
 
-	3-june-2017	HvB Add interrupt support for edge = rising, falling or both.
-
+	History:
+	03-jun-2017	HvB	Add interrupt support for edge = rising, falling or both.
+	24-jun-2017	HvB	Add hardware debounce parameter, range 10..750 milli sec.
 */
 
 #include "stdafx.h"
@@ -157,7 +158,7 @@ vector<gpio_info> CSysfsGpio::m_saved_state;
 int CSysfsGpio::m_sysfs_hwdid;
 int CSysfsGpio::m_sysfs_req_update;
 
-CSysfsGpio::CSysfsGpio(const int ID, const int AutoConfigureDevices)
+CSysfsGpio::CSysfsGpio(const int ID, const int AutoConfigureDevices, const int Debounce)
 {
 	m_stoprequested = false;
 	m_bIsStarted = false;
@@ -166,6 +167,7 @@ CSysfsGpio::CSysfsGpio(const int ID, const int AutoConfigureDevices)
 	m_HwdID = ID;
 	m_sysfs_hwdid = ID;
 	m_auto_configure_devices = AutoConfigureDevices;
+	m_debounce_msec = Debounce;
 }
 
 CSysfsGpio::~CSysfsGpio(void)
@@ -273,8 +275,8 @@ void CSysfsGpio::Do_Work()
 
 	UpdateDomoticzInputs(false); /* Make sure database inputs are in sync with actual hardware */
 
-	_log.Log(LOG_STATUS, "Sysfs GPIO: Worker startup, polling=%s interrupts=%s inputs:%d outputs:%d", 
-		m_polling_enabled ? "yes":"no", m_interrupts_enabled ? "yes":"no", input_count, output_count);
+	_log.Log(LOG_STATUS, "Sysfs GPIO: Worker startup, polling:%s interrupts:%s debounce:%d inputs:%d outputs:%d", 
+		m_polling_enabled ? "yes":"no", m_interrupts_enabled ? "yes":"no", m_debounce_msec, input_count, output_count);
 
 	if (m_interrupts_enabled)
 	{
@@ -393,7 +395,7 @@ void CSysfsGpio::EdgeDetectThread()
 
 		if (retval > 0)
 		{
-			sleep_milliseconds(50); /* debounce */
+			sleep_milliseconds(m_debounce_msec); /* debounce */
 
 			for (int i = 0; i < m_saved_state.size(); i++)
 			{

--- a/hardware/SysfsGpio.h
+++ b/hardware/SysfsGpio.h
@@ -29,7 +29,7 @@ class CSysfsGpio : public CDomoticzHardwareBase
 
 public:
 
-	CSysfsGpio(const int ID, const int ManualDevices);
+	CSysfsGpio(const int ID, const int ManualDevices, const int Debounce);
 	~CSysfsGpio();
 
 	bool WriteToHardware(const char *pdata, const unsigned char length);
@@ -64,6 +64,7 @@ private:
 	bool m_polling_enabled;
 	bool m_interrupts_enabled;
 	volatile bool m_stoprequested;
+	int m_debounce_msec;
 	int m_auto_configure_devices;
 	int m_maxfd;
 	fd_set m_rfds;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -944,7 +944,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_SysfsGpio:
 #ifdef WITH_GPIO
-		pHardware = new CSysfsGpio(ID, Mode1);
+		pHardware = new CSysfsGpio(ID, Mode1, Mode2);
 #endif
 		break;
 	case HTYPE_Comm5TCP:

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -154,6 +154,7 @@ define(['app'], function (app) {
 				}
 				if (text.indexOf("sysfs GPIO") >= 0) {
 					Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+					Mode2 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsdebounce').val();
 				}
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
@@ -1127,13 +1128,15 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("sysfs GPIO") >= 0) {
 				Mode1 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure').prop("checked") ? 1 : 0;
+				Mode2 = $('#hardwarecontent #hardwareparamssysfsgpio #sysfsdebounce').val();
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype="
 					+ hardwaretype
 					+ "&name=" + encodeURIComponent(name)
 					+ "&enabled=" + bEnabled
 					+ "&datatimeout=" + datatimeout
-					+ "&Mode1=" + Mode1,
+					+ "&Mode1=" + Mode1
+					+ "&Mode2=" + Mode2,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -5008,6 +5011,7 @@ define(['app'], function (app) {
 						}
 						else if (data["Type"].indexOf("sysfs GPIO") >= 0) {
 							$("#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure").prop("checked", data["Mode1"] == 1);
+							$("#hardwarecontent #hardwareparamssysfsgpio #sysfsdebounce").val(data["Mode2"]);
 						}
 						else if (data["Type"].indexOf("USB") >= 0 || data["Type"].indexOf("Teleinfo EDF") >= 0) {
 							$("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1396
+# ref 1397
 
 CACHE:
 # CSS

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1196,7 +1196,10 @@
 				<tr valign="top">
 					<td align="right" style="width:110px"><label for="sysfsdebounce"><span data-i18n="sysfsdebounce">Debounce</span>:</label></td>
 					<td><select id="sysfsdebounce" style="width:110" class="combobox ui-corner-all">
-						<option data-i18n="Default"  value="50">default</option>
+						<option data-i18n="Default" value="50">default</option>
+						<option data-i18n="1 msec" value="1">1 msec</option>						
+						<option data-i18n="2 msec" value="2">2 msec</option>						
+						<option data-i18n="5 msec" value="5">5 msec</option>						
 						<option data-i18n="10 msec" value="10">10 msec</option>
 						<option data-i18n="25 msec" value="25">25 msec</option>
 						<option data-i18n="50 msec" value="50">50 msec</option>
@@ -1209,12 +1212,7 @@
 						<option data-i18n="350 msec" value="350">350 msec</option>					
 						<option data-i18n="400 msec" value="400">400 msec</option>					
 						<option data-i18n="450 msec" value="450">450 msec</option>					
-						<option data-i18n="500 msec" value="500">500 msec</option>					
-						<option data-i18n="550 msec" value="550">550 msec</option>					
-						<option data-i18n="600 msec" value="600">600 msec</option>
-						<option data-i18n="650 msec" value="650">650 msec</option>						
-						<option data-i18n="700 msec" value="700">700 msec</option>
-						<option data-i18n="750 msec" value="750">750 msec</option>						
+						<option data-i18n="500 msec" value="500">500 msec</option>										
 					</select>
 					</td>
 				</tr>				

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1193,6 +1193,31 @@
                     <td align="right" style="width:110px"><label><span data-i18n="Auto configure devices">Auto configure devices</span>:</label></td>
                     <td><input type="checkbox" id="sysfsautoconfigure" checked > </td>
                 </tr>
+				<tr valign="top">
+					<td align="right" style="width:110px"><label for="sysfsdebounce"><span data-i18n="sysfsdebounce">Debounce</span>:</label></td>
+					<td><select id="sysfsdebounce" style="width:110" class="combobox ui-corner-all">
+						<option data-i18n="Default"  value="50">default</option>
+						<option data-i18n="10 msec" value="10">10 msec</option>
+						<option data-i18n="25 msec" value="25">25 msec</option>
+						<option data-i18n="50 msec" value="50">50 msec</option>
+						<option data-i18n="75 msec" value="75">75 msec</option>						
+						<option data-i18n="100 msec" value="100">100 msec</option>
+						<option data-i18n="150 msec" value="150">150 msec</option>
+						<option data-i18n="200 msec" value="200">200 msec</option>
+						<option data-i18n="250 msec" value="250">250 msec</option>
+						<option data-i18n="300 msec" value="300">300 msec</option>					
+						<option data-i18n="350 msec" value="350">350 msec</option>					
+						<option data-i18n="400 msec" value="400">400 msec</option>					
+						<option data-i18n="450 msec" value="450">450 msec</option>					
+						<option data-i18n="500 msec" value="500">500 msec</option>					
+						<option data-i18n="550 msec" value="550">550 msec</option>					
+						<option data-i18n="600 msec" value="600">600 msec</option>
+						<option data-i18n="650 msec" value="650">650 msec</option>						
+						<option data-i18n="700 msec" value="700">700 msec</option>
+						<option data-i18n="750 msec" value="750">750 msec</option>						
+					</select>
+					</td>
+				</tr>				
             </table>
         </div>
         <div id="divevohome">


### PR DESCRIPTION
The SysfsGPIO input de-bounce value can now be selected . This setting is only applicable when interrupt based gpio input handling is used, i.e. when the gpio pin "edge" is set to "rising", "falling" or "both". The value can be selected using the dropdown box, ranging from 1 msec up to 500 msec, on the hardware configuration screen. The default value is set to 50 msec. This value as was previously fixed. When gpio pin "edge" is set to "none" (polling mode) this setting is not used. During startup the domoticz logfile will indicate the selected de-bounce value.