### PR TITLE
bugfix: return 'nvalue' iso 'svalue' for humidity levels in datapush …

### DIFF
--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -491,7 +491,7 @@ std::string CBasePush::ProcessSendValue(const std::string &rawsendValue, const i
 	}
 	else if (vType == "Humidity")
 	{
-		sprintf(szData,"%d", atoi(rawsendValue.c_str()));
+		sprintf(szData,"%d", nValue);
 	}
 	else if (vType == "Humidity Status")
 	{


### PR DESCRIPTION
…handling