### PR TITLE
EventSystem Lua match device and file name / disable dzVents when not used

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3246,7 +3246,8 @@ void CEventSystem::EvaluateLua(const std::string &reason, const std::string &fil
 
 	ExportDeviceStatesToLua(lua_state);
 
-	ExportDomoticzDataToLua(lua_state, DeviceID, varId);
+	if (!m_sql.m_bDisableDzVentsSystem)
+		ExportDomoticzDataToLua(lua_state, DeviceID, varId);
 
 	lua_createtable(lua_state, (int)m_uservariables.size(), 0);
 
@@ -3335,54 +3336,59 @@ void CEventSystem::EvaluateLua(const std::string &reason, const std::string &fil
 		secstatusw = "Disarmed";
 	}
 
-	std::stringstream lua_DirT;
-
-#ifdef WIN32
-	lua_DirT << szUserDataFolder << "scripts\\dzVents\\";
-#else
-	lua_DirT << szUserDataFolder << "scripts/dzVents/";
-#endif
-
 	lua_createtable(lua_state, 7, 0);
 	lua_pushstring(lua_state, "Security");
 	lua_pushstring(lua_state, secstatusw.c_str());
 	lua_rawset(lua_state, -3);
-	lua_pushstring(lua_state, "script_path");
-	lua_pushstring(lua_state, lua_DirT.str().c_str());
-	lua_rawset(lua_state, -3);
-	lua_pushstring(lua_state, "script_reason");
-	lua_pushstring(lua_state, reason.c_str());
-	lua_rawset(lua_state, -3);
 
-	char szTmp[10];
-	sprintf(szTmp, "%.02f", 1.23f);
-	sprintf(szTmp, "%c", szTmp[1]);
-	lua_pushstring(lua_state, "radix_separator");
-	lua_pushstring(lua_state, szTmp);
-	lua_rawset(lua_state, -3);
+	if (!m_sql.m_bDisableDzVentsSystem)
+	{
+		std::stringstream lua_DirT;
 
-	sprintf(szTmp, "%.02f", 1234.56f);
-	lua_pushstring(lua_state, "group_separator");
-	if (szTmp[1] == '2')
-	{
-		lua_pushstring(lua_state, "");
-	}
-	else
-	{
+#ifdef WIN32
+		lua_DirT << szUserDataFolder << "scripts\\dzVents\\";
+#else
+		lua_DirT << szUserDataFolder << "scripts/dzVents/";
+#endif
+
+		lua_pushstring(lua_state, "script_path");
+		lua_pushstring(lua_state, lua_DirT.str().c_str());
+		lua_rawset(lua_state, -3);
+		lua_pushstring(lua_state, "script_reason");
+		lua_pushstring(lua_state, reason.c_str());
+		lua_rawset(lua_state, -3);
+
+		char szTmp[10];
+		sprintf(szTmp, "%.02f", 1.23f);
 		sprintf(szTmp, "%c", szTmp[1]);
+		lua_pushstring(lua_state, "radix_separator");
 		lua_pushstring(lua_state, szTmp);
-	}
-	lua_rawset(lua_state, -3);
+		lua_rawset(lua_state, -3);
 
-	int rnvalue = 0;
-	m_sql.GetPreferencesVar("DzVentsLogLevel", rnvalue);
-	lua_pushstring(lua_state, "dzVents_log_level");
-	lua_pushnumber(lua_state, (lua_Number)rnvalue);
-	lua_rawset(lua_state, -3);
-	lua_pushstring(lua_state, "domoticz_listening_port");
-//	lua_pushstring(lua_state, "8080");
-	lua_pushstring(lua_state, m_webservers.our_listener_port.c_str());
-	lua_rawset(lua_state, -3);
+		sprintf(szTmp, "%.02f", 1234.56f);
+		lua_pushstring(lua_state, "group_separator");
+		if (szTmp[1] == '2')
+		{
+			lua_pushstring(lua_state, "");
+		}
+		else
+		{
+			sprintf(szTmp, "%c", szTmp[1]);
+			lua_pushstring(lua_state, szTmp);
+		}
+		lua_rawset(lua_state, -3);
+
+		int rnvalue = 0;
+		m_sql.GetPreferencesVar("DzVentsLogLevel", rnvalue);
+		lua_pushstring(lua_state, "dzVents_log_level");
+		lua_pushnumber(lua_state, (lua_Number)rnvalue);
+		lua_rawset(lua_state, -3);
+		lua_pushstring(lua_state, "domoticz_listening_port");
+	//	lua_pushstring(lua_state, "8080");
+		lua_pushstring(lua_state, m_webservers.our_listener_port.c_str());
+		lua_rawset(lua_state, -3);
+	}
+
 	lua_setglobal(lua_state, "globalvariables");
 
 	int status = 0;

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3336,7 +3336,7 @@ void CEventSystem::EvaluateLua(const std::string &reason, const std::string &fil
 		secstatusw = "Disarmed";
 	}
 
-	lua_createtable(lua_state, 7, 0);
+	lua_createtable(lua_state, 0, 0);
 	lua_pushstring(lua_state, "Security");
 	lua_pushstring(lua_state, secstatusw.c_str());
 	lua_rawset(lua_state, -3);

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2556,14 +2556,14 @@ void CEventSystem::ExportDomoticzDataToLua(lua_State *lua_state, uint64_t device
 		lua_rawset(lua_state, -3);
 
 		// Lux does not have it's own field yet.
-		if (("Lux" == dev_type) && ("Lux" == sub_type))
+		if (strcmp(dev_type, "Lux") == 0 && strcmp(sub_type, "Lux") == 0)
 		{
 			lua_pushstring(lua_state, "lux");
 			lua_pushnumber(lua_state, (lua_Number)atoi(strarray[0].c_str()));
 			lua_rawset(lua_state, -3);
 		}
 
-		if (("General" == dev_type) && ("kWh" == sub_type))
+		if (strcmp(dev_type, "General") == 0 && strcmp(sub_type, "kWh") == 0)
 		{
 			lua_pushstring(lua_state, "whTotal");
 			lua_pushnumber(lua_state, atof(strarray[1].c_str()));
@@ -2587,21 +2587,21 @@ void CEventSystem::ExportDomoticzDataToLua(lua_State *lua_state, uint64_t device
 					std::string value = tempjson["result"][0][JsonLuaMap[ii].szOriginal].asString();
 					lua_pushstring(lua_state, JsonLuaMap[ii].szNew);
 
-					if (JsonLuaMap[ii].szType == "string")
+					if (strcmp(JsonLuaMap[ii].szType, "string") == 0)
 					{
 						lua_pushstring(lua_state, value.c_str());
 					}
-					else if (JsonLuaMap[ii].szType == "float")
+					else if (strcmp(JsonLuaMap[ii].szType, "float") == 0)
 					{
 						lua_pushnumber(lua_state, atof(value.c_str()));
 					}
-					else if (JsonLuaMap[ii].szType == "integer")
+					else if (strcmp(JsonLuaMap[ii].szType, "integer") == 0)
 					{
 						lua_pushnumber(lua_state, atoi(value.c_str()));
 					}
-					else if (JsonLuaMap[ii].szType == "boolean")
+					else if (strcmp(JsonLuaMap[ii].szType, "boolean") == 0)
 					{
-						if (value.c_str() == "true")
+						if (strcmp(value.c_str(), "true") == 0)
 						{
 							lua_pushboolean(lua_state, true);
 						}

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -202,4 +202,6 @@ private:
 	void report_errors(lua_State *L, int status, std::string filename);
 	unsigned char calculateDimLevel(int deviceID, int percentageLevel);
 	void StripQuotes(std::string &sString);
+	std::string SpaceToUnderscore(std::string sResult);
+	std::string LowerCase(std::string sResult);
 };


### PR DESCRIPTION
To simplify things, I left the threaded part out as implemented in this pull: https://github.com/domoticz/domoticz/pull/1633

This pull is easier to read / debug, so let's do the basic implementation on file matching first. Also left out Python part completely, since I don't use Python scripts, I really don't care much (however I do believe that device name matching with Python would improve it's performance also considerably).

The introduction of dzVents made the execution of my Lua scripts really really slow, like 1 sec extra duration on each device update. I've disabled the dzVents code in EvaluateLua when dzVents is disabled, so things now run smoothly again.