### PR TITLE
Revert "bugfix: return 'nvalue' iso 'svalue' for humidity levels in d…

### DIFF
--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -491,7 +491,7 @@ std::string CBasePush::ProcessSendValue(const std::string &rawsendValue, const i
 	}
 	else if (vType == "Humidity")
 	{
-		sprintf(szData,"%d", nValue);
+		sprintf(szData,"%d", atoi(rawsendValue.c_str()));
 	}
 	else if (vType == "Humidity Status")
 	{


### PR DESCRIPTION
…atapush handling"

While this fixes the issue with dummy devices it breaks real devices because of inconsistancies in data storage and data parsing in the datapush module between dummy devices and real devices.
see issue #1656 for details on the issue and a possible fix for both situations.
Please revert this fix as it breaks more than it fixes.

This reverts commit f24fa115bff3cd6948b2ad306ed14e35f6645483.