### PR TITLE
Sysfs GPIO: Poll at 1st timeout after interrupt received

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -378,9 +378,9 @@ void CSysfsGpio::EdgeDetectThread()
 
 			for (int i = 0; i < m_saved_state.size(); i++)
 			{
-				if (FD_ISSET(m_saved_state[i].edge_fd, &tmp_fds) &&
+				if ((FD_ISSET(m_saved_state[i].edge_fd, &tmp_fds) &&
 					(m_saved_state[i].direction == GPIO_IN) &&
-					(m_saved_state[i].edge != GPIO_EDGE_NONE))
+					(m_saved_state[i].edge != GPIO_EDGE_NONE)))
 				{
 					value = GpioReadFd(m_saved_state[i].edge_fd);
 					GpioSaveState(i, value);
@@ -394,9 +394,8 @@ void CSysfsGpio::EdgeDetectThread()
 			if (!m_polling_enabled)
 			{
 				UpdateDomoticzInputs(false);
+				poll_once = true;
 			}
-
-			poll_once = true;
 		}
 		else
 		{

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -325,7 +325,7 @@ void CSysfsGpio::EdgeDetectThread()
 	fd_set tmp_fds;
 	timeval tv;
 	int fd;
-	bool poll_once = true;
+	bool poll_once = false;
 
 	FD_ZERO(&m_rfds);
 	m_maxfd = 0;


### PR DESCRIPTION
	After one or more GPIO state change interrupts have been detected a poll is done to make
	sure the domoticz database reflects the actual states of all GPIO pins in all cases. A
	missed interrupt can occur when a GPIO pin changes state twice within m_debounce_msec. 