### PR TITLE
GUI set correct order column

### DIFF
--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -111,7 +111,7 @@ define(['app'], function (app) {
 				}
 			}
 			$.ajax({
-				url: "json.htm?type=devices&filter=all&used=true&favorite=" + bFavorites + "&order=Name&plan=" + window.myglobals.LastPlanSelected + "&lastupdate=" + $scope.LastUpdateTime,
+				url: "json.htm?type=devices&filter=all&used=true&favorite=" + bFavorites + "&order=[Order]&plan=" + window.myglobals.LastPlanSelected + "&lastupdate=" + $scope.LastUpdateTime,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -1729,7 +1729,7 @@ define(['app'], function (app) {
 			}
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=all&used=true&favorite=" + bFavorites + "&order=Name&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=all&used=true&favorite=" + bFavorites + "&order=[Order]&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -2108,7 +2108,7 @@ define(['app'], function (app) {
 			var id = "";
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=light&used=true&order=Name&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=light&used=true&order=[Order]&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -2630,7 +2630,7 @@ define(['app'], function (app) {
 			var j = 0;
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=light&used=true&order=Name&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=light&used=true&order=[Order]&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {

--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -141,7 +141,7 @@ define(['app'], function (app) {
 			}
 			var id = "";
 			$.ajax({
-				url: "json.htm?type=devices&filter=temp&used=true&order=Name&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=temp&used=true&order=[Order]&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -192,7 +192,7 @@ define(['app'], function (app) {
 			};
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=temp&used=true&order=Name&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=temp&used=true&order=[Order]&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -911,7 +911,7 @@ define(['app'], function (app) {
 			var id = "";
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=utility&used=true&order=Name&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=utility&used=true&order=[Order]&lastupdate=" + $.LastUpdateTime + "&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -1156,7 +1156,7 @@ define(['app'], function (app) {
 
 			var i = 0;
 			$.ajax({
-				url: "json.htm?type=devices&filter=utility&used=true&order=Name&plan=" + window.myglobals.LastPlanSelected,
+				url: "json.htm?type=devices&filter=utility&used=true&order=[Order]&plan=" + window.myglobals.LastPlanSelected,
 				async: false,
 				dataType: 'json',
 				success: function (data) {

--- a/www/app/WeatherController.js
+++ b/www/app/WeatherController.js
@@ -87,7 +87,7 @@ define(['app'], function (app) {
 			var id = "";
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=weather&used=true&order=Name&lastupdate=" + $.LastUpdateTime,
+				url: "json.htm?type=devices&filter=weather&used=true&order=[Order]&lastupdate=" + $.LastUpdateTime,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -133,7 +133,7 @@ define(['app'], function (app) {
 			$('#modal').show();
 
 			$.ajax({
-				url: "json.htm?type=devices&filter=weather&used=true&order=Name",
+				url: "json.htm?type=devices&filter=weather&used=true&order=[Order]",
 				async: false,
 				dataType: 'json',
 				success: function (data) {


### PR DESCRIPTION
While working hard at fixing dzVents issues, this 'bug' also appeared after fixing code in WebServer.cpp. The default order is set to column 'Name', which in it's current state is being ignored and always falls back to column 'Order'. But there is no reason to keep this in code, it's confusing and we should also fix this in WebServer.cpp to make the order argument actually work (but I suggest to do that after all dzVents patches are merged).