### PR TITLE
Sysfs GPIO: remove logfile trace as requested on forum

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -107,7 +107,8 @@
 	History:
 	03-jun-2017	HvB		Add interrupt support for edge = rising, falling or both.
 	24-jun-2017	HvB		Add hardware debounce parameter, range 10..750 milli sec.
-	04-jul-2017	HvB		Poll after an interrupt received to recover missed interrupts 
+	04-jul-2017	HvB		Poll after an interrupt received to recover missed interrupts
+	06-jul-2017 HvB		Removed log message for interrupt state change, forum request
 */
 
 #include "stdafx.h"
@@ -198,6 +199,7 @@ bool CSysfsGpio::StopHardware()
 	}
 	catch (...)
 	{
+		_log.Log(LOG_STATUS, "Sysfs GPIO: Worker - error during rundown");
 	}
 
 	try
@@ -209,6 +211,7 @@ bool CSysfsGpio::StopHardware()
 	}
 	catch (...)
 	{
+		_log.Log(LOG_STATUS, "Sysfs GPIO: Edge detection - error during rundown");
 	}
 
 	m_bIsStarted = false;
@@ -386,8 +389,6 @@ void CSysfsGpio::EdgeDetectThread()
 					GpioSaveState(i, value);
 					FD_CLR(m_saved_state[i].edge_fd, &tmp_fds);
 					GpioWrite(m_saved_state[i].edge_fd, 1);
-
-					_log.Log(LOG_STATUS, "Sysfs GPIO: Pin%d new state: %d", m_saved_state[i].pin_number, value);
 				}
 			}
 
@@ -486,8 +487,12 @@ void CSysfsGpio::Init()
 
 	UpdateDomoticzInputs(false); /* Make sure database inputs are in sync with actual hardware */
 
-	_log.Log(LOG_STATUS, "Sysfs GPIO: Worker startup, polling:%s interrupts:%s debounce:%d inputs:%d outputs:%d",
-		m_polling_enabled ? "yes":"no", m_interrupts_enabled ? "yes":"no", m_debounce_msec, input_count, output_count);
+	_log.Log(LOG_STATUS, "Sysfs GPIO: Startup - polling:%s interrupts:%s debounce:%d inputs:%d outputs:%d",
+		m_polling_enabled ? "yes":"no", 
+		m_interrupts_enabled ? "yes":"no", 
+		m_debounce_msec, 
+		input_count, 
+		output_count);
 
 	if (m_interrupts_enabled)
 	{


### PR DESCRIPTION
Remove logfile trace as requested on forum, at startup, for interrupt based gpio pins, when no database change has occurred. Also added some error case traces for exceptions at startup & rundown.