### PR TITLE
Sysfs GPIO: Allow poll-once for edge based inputs (fix)

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -262,7 +262,7 @@ void CSysfsGpio::Do_Work()
 		{
 			if (m_polling_enabled)
 			{
-				PollGpioInputs();
+				PollGpioInputs(false);
 				UpdateDomoticzInputs(false);
 			}
 		}
@@ -405,7 +405,7 @@ void CSysfsGpio::EdgeDetectThread()
 			//
 			if (poll_once)
 			{
-				PollGpioInputs();
+				PollGpioInputs(true);
 				UpdateDomoticzInputs(false);
 				poll_once = false;
 			}
@@ -537,7 +537,7 @@ void CSysfsGpio::FindGpioExports()
 	}
 }
 
-void CSysfsGpio::PollGpioInputs()
+void CSysfsGpio::PollGpioInputs(bool PollOnce)
 {
 	if (m_saved_state.size())
 	{
@@ -545,7 +545,7 @@ void CSysfsGpio::PollGpioInputs()
 		{
 			if ((m_saved_state[i].direction == GPIO_IN) &&
 				(m_saved_state[i].read_value_fd != -1) &&
-				((m_saved_state[i].edge == GPIO_EDGE_NONE) || m_saved_state[i].edge == GPIO_EDGE_UNKNOWN))
+				(PollOnce || (m_saved_state[i].edge == GPIO_EDGE_NONE) || (m_saved_state[i].edge == GPIO_EDGE_UNKNOWN)))
 			{
 				GpioSaveState(i, GpioReadFd(m_saved_state[i].read_value_fd));
 			}

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -487,7 +487,7 @@ void CSysfsGpio::Init()
 
 	UpdateDomoticzInputs(false); /* Make sure database inputs are in sync with actual hardware */
 
-	_log.Log(LOG_STATUS, "Sysfs GPIO: Startup - polling:%s interrupts:%s debounce:%d inputs:%d outputs:%d",
+	_log.Log(LOG_STATUS, "Sysfs GPIO: Startup - polling:%s interrupts:%s debounce:%dmsec inputs:%d outputs:%d",
 		m_polling_enabled ? "yes":"no", 
 		m_interrupts_enabled ? "yes":"no", 
 		m_debounce_msec, 

--- a/hardware/SysfsGpio.h
+++ b/hardware/SysfsGpio.h
@@ -44,7 +44,7 @@ private:
 	void Do_Work();
 	void EdgeDetectThread();
 	void Init();
-	void PollGpioInputs();
+	void PollGpioInputs(bool PollOnce);
 	void CreateDomoticzDevices();
 	void UpdateDomoticzInputs(bool forceUpdate);
 	void UpdateDomoticzDatabase();


### PR DESCRIPTION
Poll after interrupt, to avoid missing interrupts, was not working because gpio pins with edge set to rising, falling or both where bypassed by the poller. This is now fixed.