### PR TITLE
Webserver: Revert recent change to fix problem reported on forum

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -12106,56 +12106,8 @@ namespace http {
 			}
 			else
 			{
-				//Fix 'SubType' when device change
-				if (switchtype == -1)
-				{
-					m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q' WHERE (ID == '%q')",
-						used, name.c_str(), description.c_str(), idx.c_str());
-				}
-				else
-				{
-					switch (switchtype)
-					{
-						case STYPE_OnOff:					//0
-						case STYPE_Doorbell:				//1
-						case STYPE_Contact:					//2
-						case STYPE_Blinds:					//3
-						case STYPE_X10Siren:				//4
-						case STYPE_SMOKEDETECTOR:			//5
-						case STYPE_BlindsInverted:			//6
-						case STYPE_Dimmer:					//7
-						case STYPE_Motion:					//8
-						case STYPE_PushOn:					//9
-						case STYPE_PushOff:					//10
-						case STYPE_DoorContact:				//11
-						case STYPE_Dusk:					//12
-						case STYPE_BlindsPercentage:		//13
-						case STYPE_VenetianBlindsUS:		//14
-						case STYPE_VenetianBlindsEU:		//15
-						case STYPE_BlindsPercentageInverted://16
-						case STYPE_Media:					//17
-						case STYPE_DoorLock:				//19
-						{
-							m_sql.safe_query(
-							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
-							used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
-							break;
-						}
-						case STYPE_Selector:	//18
-						{
-							m_sql.safe_query(
-							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
-							used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
-							break;
-						}
-						default:
-						{
-							m_sql.safe_query(
-							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
-							used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
-						}
-					}
-				}
+				m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q' WHERE (ID == '%q')",
+					used, name.c_str(), description.c_str(), idx.c_str());
 			}
 
 			if (bHasstrParam1)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -12106,8 +12106,17 @@ namespace http {
 			}
 			else
 			{
-				m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q' WHERE (ID == '%q')",
-					used, name.c_str(), description.c_str(), idx.c_str());
+				if (switchtype == -1)
+				{
+					m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q' WHERE (ID == '%q')",
+						used, name.c_str(), description.c_str(), idx.c_str());
+				}
+				else
+				{
+					m_sql.safe_query(
+						"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
+						used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
+				}
 			}
 
 			if (bHasstrParam1)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -12114,8 +12114,7 @@ namespace http {
 				}
 				else
 				{
-					_eSwitchType switchsubtype = (_eSwitchType)switchtype;
-					switch (switchsubtype)
+					switch (switchtype)
 					{
 						case STYPE_OnOff:					//0
 						case STYPE_Doorbell:				//1
@@ -12138,14 +12137,14 @@ namespace http {
 						case STYPE_DoorLock:				//19
 						{
 							m_sql.safe_query(
-							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SubType=73, SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
+							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
 							used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
 							break;
 						}
 						case STYPE_Selector:	//18
 						{
 							m_sql.safe_query(
-							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SubType=62, SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
+							"UPDATE DeviceStatus SET Used=%d, Name='%q', Description='%q', SwitchType=%d, CustomImage=%d WHERE (ID == '%q')",
 							used, name.c_str(), description.c_str(), switchtype, CustomImage, idx.c_str());
 							break;
 						}


### PR DESCRIPTION
Workaround for problem reported on forum by several people. See forum bugs and problems "On/Off Switch becoming unusable after modification".

Note: I know the intended subtype change wont work any more (as that code is removed by this PR). If still needed this will be re-addressed and tested by DT27 I assume.