### PR TITLE
HardwareMonitor df exclude unused fstypes

### DIFF
--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -738,7 +738,7 @@ void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string &qType)
 		char szTmp[300];
 		std::map<std::string, _tDUsageStruct> _disks;
 		std::map<std::string, std::string> _dmounts_;
-		std::vector<std::string> _rlines=ExecuteCommandAndReturn("df");
+		std::vector<std::string> _rlines=ExecuteCommandAndReturn("df -x nfs -x tmpfs -x devtmpfs");
 		if (!_rlines.empty())
 		{
 			std::vector<std::string>::const_iterator ittDF;


### PR DESCRIPTION
Make sure NFS isn't called unnecessary to prevent lockups, also excluded other unused types (we're only looking for /dev). User with specific issue: http://www.domoticz.com/forum/viewtopic.php?f=6&t=18245