### PR TITLE
Sysfs GPIO: Log new gpio-state after state-change

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -762,6 +762,10 @@ void CSysfsGpio::UpdateDomoticzInputs(bool forceUpdate)
 					m_Packet.LIGHTING2.unitcode = (char)m_saved_state[i].pin_number;
 					m_Packet.LIGHTING2.seqnbr++;
 					sDecodeRXMessage(this, (const unsigned char *)&m_Packet.LIGHTING2, "Input", 255);
+
+					_log.Log(LOG_STATUS, "Sysfs GPIO: State change gpio%d:%s",
+						m_saved_state[i].pin_number,
+						state ? "on" : "off");
 				}
 			}
 		}


### PR DESCRIPTION
Added log message as requested on forum to indicate the new state of the gpio-pin after state change. Example: Sysfs GPIO: State change gpio20:off