### PR TITLE
dzVents 2.1.0

### DIFF
--- a/scripts/dzVents/documentation/README.md
+++ b/scripts/dzVents/documentation/README.md
@@ -1291,6 +1291,7 @@ On the other hand, you have to make sure that dzVents can access the json withou
  - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
  - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
  - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
+ - Use different api command for setting setPoints in the Thermostat setpoint device adapter.
 
 [2.0.0] Domoticz integration
 

--- a/scripts/dzVents/documentation/README.md
+++ b/scripts/dzVents/documentation/README.md
@@ -1,6 +1,6 @@
 **For people working with dzVents prior to version 2.0: Please read the [change log](#Change_log) below as there are a couple of (easy-to-fix) breaking changes. Or check [Migrating from version 1.x.x](#Migrating_from_version_1.x.x)**
 
-# About dzVents 2.0.0
+# About dzVents 2.1.0
 dzVents (|diː ziː vɛnts| short for Domoticz Easy Events) brings Lua scripting in Domoticz to a whole new level. Writing scripts for Domoticz has never been so easy. Not only can you define triggers more easily, and have full control over timer-based scripts with extensive scheduling support, dzVents presents you with an easy to use API to all necessary information in Domoticz. No longer do you have to combine all kinds of information given to you by Domoticzs in many different data tables. You don't have to construct complex commandArrays anymore. dzVents encapsulates all the Domoticz peculiarities regarding controlling and querying your devices. And on top of that, script performance has increased a lot if you have many scripts because Domoticz will fetch all device information only once for all your device scripts and timer scripts.
 
 Let's start with an example. Let's say you have a switch that when activated, it should activate another switch but only if the room temperature is above a certain level. And when done, it should send a notification. This is how it looks like in dzVents:
@@ -415,7 +415,16 @@ Note that if you do not find your specific device type here you can always inspe
   - **updateAirQuality(ppm)**: Pass the CO2 concentration.
 
 #### Alert sensor
+ - **color**: *Number*. Color of the alert. See domoticz color constants for possible values.
  - **updateAlertSensor(level, text)**: *Function*. Level can be domoticz.ALERTLEVEL_GREY, ALERTLEVEL_GREEN, ALERTLEVEL_YELLOW, ALERTLEVEL_ORANGE, ALERTLEVEL_RED
+
+#### Ampère, 1-phase
+ - **current**: *Number*. Ampère.
+ - **updateCurrent(current)**: *Function*. Current in Ampère.
+
+#### Ampère, 3-phase
+ - **current1**, **current2**, **current3** : *Number*. Ampère.
+ - **updateCurrent(current1, current2, current3)**: *Function*. Currents in Ampère.
 
 #### Barometer sensor
  - **barometer**. *Number*. Barometric pressure.
@@ -441,6 +450,7 @@ Note that if you do not find your specific device type here you can always inspe
 
 #### Electric usage
  - **WActual**: *Number*. Current Watt usage.
+ - **updateEnergy(energy)**: *Function*. In Watt.
 
 #### Evohome
  - **setPoint**: *Number*.
@@ -476,6 +486,12 @@ Note that if you do not find your specific device type here you can always inspe
  - **updateElectricity(power, energy)**: *Function*.
  - **usage**: *Number*.
  - **WhToday**: *Number*. Total Wh usage of the day. Note the unit is Wh and not kWh!
+ - **WhTotal**: *Number*. Total Wh usage.
+ - **WhActual**: *Number*. Actual reading.
+
+#### Leaf wetness
+ - **wetness**: *Number*. Wetness value
+ - **updateWetness(wetness)**: *Function*.
 
 #### Lux sensor
  - **lux**: *Number*. Lux level for light sensors.
@@ -515,6 +531,10 @@ Note that if you do not find your specific device type here you can always inspe
  - **rainRate**: *Number*
  - **updateRain(rate, counter)**: *Function*.
 
+#### Scale weight
+ - **weight**: *Number*
+ - **udateWeight()**: *Function*.
+
 #### Scene
  - **switchOn()**: *Function*. Supports timing options. See [below](#Switch_timing_options_.28delay.2C_duration.29).
 
@@ -524,14 +544,23 @@ Note that if you do not find your specific device type here you can always inspe
  - **disarm()**: Disarms a security device.
 
 #### Solar radiation
- - **radiation**. *Number*
+ - **radiation**. *Number*. In Watt/m2.
  - **updateRadiation(radiation)**: *Function*.
+
+#### Soil moisture
+ - **moisture**. *Number*. In centibars (cB).
+ - **updateSoilMoisture(moisture)**: *Function*.
+
+#### Sound level
+ - **level**. *Number*. In dB.
+ - **updateSoundLevel(level)**: *Function*.
 
 #### Switch (dimmer, selector etc.)
 There are many switch-like devices. Not all methods are applicable for all switch-like devices. You can always use the generic `setState(newState)` method.
 
  - **close()**: *Function*. Set device to Close if it supports it. Supports timing options. See [below](#Switch_timing_options_.28delay.2C_duration.29).
  - **dimTo(percentage)**: *Function*. Switch a dimming device on and/or dim to the specified level. Supports timing options. See [below](#Switch_timing_options_.28delay.2C_duration.29).
+ - **lastLevel**: Number. The level of a dimmer just before it was switched off.
  - **level**: *Number*. For dimmers and other 'Set Level..%' devices this holds the level like selector switches.
  - **levelActions**: *String*. |-separated list of url actions for selector switches.
  - **levelName**: *Table*. Table holding the level names for selector switch devices.
@@ -573,12 +602,20 @@ There are many switch-like devices. Not all methods are applicable for all switc
 - **updateSetPoint(setPoint)**:*Function*.
 
 #### UV sensor
- - **uv**: *Number*.
- - **updateUV(uv)**: *Function*.
+ - **uv**: *Number*. UV index.
+ - **updateUV(uv)**: *Function*. UV index.
+
+#### Visibility
+ - **visibility**: *Number*. In km.
+ - **updateVisibility(distance)**:Function*. In km.
 
 #### Voltage
  - **voltage**: *Number*.
  - **updateVoltage(voltage)**:Function*.
+
+#### Waterflow
+ - **flow**: *Number*. In L/m.
+ - **updateWaterflow(flow)**:Function*. In L/m.
 
 #### Wind
  - **chill**: *Number*.
@@ -587,7 +624,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **gust**: *Number*.
  - **temperature**: *Number*
  - **speed**: *Number*.
- - **updateWind(bearing, direction, speed, gust, temperature, chill)**: *Function*. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius.
+ - **updateWind(bearing, direction, speed, gust, temperature, chill)**: *Function*. Bearing in degrees, direction in N, S, NNW etc, speed in m/s, gust in m/s, temperature and chill in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius.
 
 #### Zone heating
  - **setPoint**: *Number*.
@@ -1026,14 +1063,14 @@ Of course, if you don't intend to use any of these statistical functions you can
 
 ###### Functions
 
- - **avg( [fromIdx], [toIdx], [default] )**: Calculates the average of all item values within the range `fromIdx` to `toIdx`. You can specify a `default` value for when there is no data in the set.
- - **avgSince( [timeAgo](#Time_specification_.28timeAgo.29), default )**: Calculates the average of all data points since `timeAgo`. Returns `default` if there is no data. E.g.: `local avg = myVar.avgSince('00:30:00')` returns the average over the past 30 minutes.
+ - **avg( [fromIdx], [toIdx], [default] )**: Calculates the average of all item values within the range `fromIdx` to `toIdx`. You can specify a `default` value for when there is no data in the set otherwise it returns 0.
+ - **avgSince( [timeAgo](#Time_specification_.28timeAgo.29), default )**: Calculates the average of all data points since `timeAgo`. Returns `default` if there is no data otherwise 0. E.g.: `local avg = myVar.avgSince('00:30:00')` returns the average over the past 30 minutes.
  - **min( [fromIdx], [toIdx] )**: Returns the lowest value in the range defined by fromIdx and toIdx.
  - **minSince( [timeAgo](#Time_specification_.28timeAgo.29) )**: Same as **min** but now within the `timeAgo` interval.
  - **max( [fromIdx], [toIdx] )**: Returns the highest value in the range defined by fromIdx and toIdx.
  - **maxSince( [timeAgo](#Time_specification_.28timeAgo.29) )**: Same as **max** but now within the `timeAgo` interval.
- - **sum( [fromIdx], [toIdx] )**: Returns the summation of all values in the range defined by fromIdx and toIdx.
- - **sumSince( [timeAgo](#Time_specification_.28timeAgo.29) )**: Same as **sum** but now within the `timeAgo` interval.
+ - **sum( [fromIdx], [toIdx] )**: Returns the summation of all values in the range defined by fromIdx and toIdx. It will return 0 when there is no data.
+ - **sumSince( [timeAgo](#Time_specification_.28timeAgo.29) )**: Same as **sum** but now within the `timeAgo` interval.  It will return 0 when there is no data in the interval.
  - **delta( fromIdx, toIdx, [smoothRange], [default] )**: Returns the delta (difference) between items specified by `fromIdx` and `toIdx`. You have to provide a valid range (no `nil` values). [Supports data smoothing](#About_data_smoothing) when providing a `smoothRange` value. Returns `default` if there is not enough data.
  - **deltaSince( [timeAgo](#Time_specification_.28timeAgo.29),  [smoothRange], [default] )**: Same as **delta** but now within the `timeAgo` interval.
  - **localMin( [smoothRange], default )**: Returns the first minimum value (and the item holding the minimal value) in the past. [Supports data smoothing](#About_data_smoothing) when providing a `smoothRange` value. So if you have this range of values in the data set (from new to old): `10 8 7 5 3 4 5 6`.  Then it will return `3` because older values *and* newer values are higher: a local minimum. You can use this if you want to know at what time a temperature started to rise after have been dropping. E.g.:
@@ -1235,9 +1272,25 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # Change log
-[2.0.1] Domoticz integration
- - Added support for switching Lighting Limitless/Applamp (Hue etc) devices.
+[2.1.0]
+ - Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
+ - Added support for Ampère 1 and 3-phase devices
+ - Added support for leaf wetness devices
+ - Added support for scale weight devices
+ - Added support for soil moisture devices
+ - Added support for sound level devices
+ - Added support for visibility devices
+ - Added support for waterflow devices
+ - Added missing color attribute to alert sensor devices
+ - Added updateEnergy() to electric usage devices
+ - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
  - Added toCelsius() helper method to domoticz object as the various update temperature methods all need celsius.
+ - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
+ - Added integration tests for full round-trip Domoticz > dzVents > Domoticz > dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
+ - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
+ - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
+ - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
+ - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
 
 [2.0.0] Domoticz integration
 

--- a/scripts/dzVents/documentation/README.wiki
+++ b/scripts/dzVents/documentation/README.wiki
@@ -1,6 +1,6 @@
 '''For people working with dzVents prior to version 2.0: Please read the [[#Change_log|change log]] below as there are a couple of (easy-to-fix) breaking changes. Or check [[#Migrating_from_version_1.x.x|Migrating from version 1.x.x]]'''
 
-= About dzVents 2.0.0 =
+= About dzVents 2.1.0 =
 
 dzVents (|diː ziː vɛnts| short for Domoticz Easy Events) brings Lua scripting in Domoticz to a whole new level. Writing scripts for Domoticz has never been so easy. Not only can you define triggers more easily, and have full control over timer-based scripts with extensive scheduling support, dzVents presents you with an easy to use API to all necessary information in Domoticz. No longer do you have to combine all kinds of information given to you by Domoticzs in many different data tables. You don't have to construct complex commandArrays anymore. dzVents encapsulates all the Domoticz peculiarities regarding controlling and querying your devices. And on top of that, script performance has increased a lot if you have many scripts because Domoticz will fetch all device information only once for all your device scripts and timer scripts.
 
@@ -65,7 +65,7 @@ Just to give you an idea! Everything in your Domoticz system is now logically av
 
 = Using dzVents with Domoticz =
 
-In Domoticz go to '''Setup &gt; Settings &gt; Other''' and in the section EventSystem make sure the checkbox 'dzVents disabled' is not checked. Also make sure that in the Security section in the settings you allow <code>127.0.0.1</code> to not need a password. dzVents uses that port to send certain commands to Domoticz.
+In Domoticz go to '''Setup &gt; Settings &gt; Other''' and in the section EventSystem make sure the checkbox 'dzVents disabled' is not checked. Also make sure that in the Security section in the settings you allow <code>127.0.0.1</code> to not need a password. dzVents uses that port to send certain commands to Domoticz. Finally make sure you have set your current location in '''Setup &gt; Settings &gt; System &gt; Location''' otherwise there is no way to determine nighttime/daytime state.
 
 There are two ways of creating dzVents event script in Domoticz:
 
@@ -250,19 +250,25 @@ So this object structure contains all the information logically arranged where y
 
 One tip: '''Make sure that all your devices have unique names!! dzVents doesn't check for duplicates!!'''
 
-== Domoticz object API ==
+== dzVents API ==
 
 The domoticz object holds all information about your Domoticz system. It has a couple of global attributes and methods to query and manipulate your system. It also has a collection of '''devices''', '''variables''' (user variables in Domoticz), '''scenes''', '''groups''' and when applicable, a collection of '''changedDevices''' and '''changedVariables'''. All these collections each have three iterator functions: <code>forEach(function)</code>, <code>filter(function)</code> and <code>reduce(function)</code> to make searching for devices easier. See [[#Iterators|iterators]] below.
 
-=== Domoticz attributes: ===
+=== Domoticz object API: ===
 
 * '''changedDevices(id/name)''': ''Function''. A function returning the device by id (or name). To iterate over all changed devices do: <code>domoticz.changedDevices().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.changedDevices()) do .. end</code>.
 * '''changedVariables(id/name)''': ''Function''. A function returning the user variable by id or name. To iterate over all changed variables do: <code>domoticz.changedVariables().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.changedVariables()) do .. end</code>.
 * '''devices(id/name)''': ''Function''. A function returning a device by id or name: <code>domoticz.devices(123)</code> or <code>domoticz.devices('My switch')</code>. See [[#Device_object_API|Device object API]] below. To iterate over all devices do: <code>domoticz.devices().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.devices()) do .. end</code>.
+* '''email(subject, message, mailTo)''': ''Function''. Send email.
 * '''groups(id/name)''': ''Function'': A function returning a group by name or id. Each group has the same interface as a device. To iterate over all groups do: <code>domoticz.groups().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.groups()) do .. end</code>.
 * '''helpers''': ''Table''. Collection of shared helper functions available to all your dzVents scripts. See [[#Creating_shared_helper_functions|Creating shared helper functions]].
+* '''log(message, [level])''': ''Function''. Creates a logging entry in the Domoticz log but respects the log level settings. You can provide the loglevel: <code>domoticz.LOG_INFO</code>, <code>domoticz.LOG_DEBUG</code>, <code>domoticz.LOG_ERROR</code> or <code>domoticz.LOG_FORCE</code>. In Domoticz settings you can set the log level for dzVents.
+* '''notify(subject, message, priority, sound, extra, subsystem)''': ''Function''. Send a notification (like Prowl). Priority can be like <code>domoticz.PRIORITY_LOW, PRIORITY_MODERATE, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_EMERGENCY</code>. For sound see the SOUND constants below. <code>subsystem</code> can be a table containing one or more notification subsystems. See <code>domoticz.NSS_xxx</code> types.
+* '''openURL(url)''': ''Function''. Have Domoticz 'call' a URL.
 * '''scenes(id/name)''': ''Function'': A function returning a scene by name or id. Each scene has the same interface as a device. See [[#Device_object_API|Device object API]]. To iterate over all scenes do: <code>domoticz.scenes().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.scenes()) do .. end</code>.
 * '''security''': Holds the state of the security system e.g. <code>Armed Home</code> or <code>Armed Away</code>.
+* '''sendCommand(command, value)''': Generic (low-level)command method (adds it to the commandArray) to the list of commands that are being sent back to domoticz. ''There is likely no need to use this directly. Use any of the device methods instead (see below).''
+* '''sms(message)''': ''Function''. Sends an sms if it is configured in Domoticz.
 * '''time''': Current system time:
 ** '''day''': ''Number''
 ** '''getISO''': ''Function''. Returns the ISO 8601 formatted date.
@@ -280,18 +286,8 @@ The domoticz object holds all information about your Domoticz system. It has a c
 ** '''sunriseInMinutes'''
 ** '''wday''': ''Number''. Day of the week ( 0 == sunday)
 ** '''year''': ''Number''
+* '''toCelsius(f, relative)''': ''Function''. Converts temperature from Fahrenheit to Celsius along the temperature scale or when relative==true it uses the fact that 1F==0.56C. So <code>toCelsius(5, true)</code> returns 5F*(1/1.8) = 2.78C.
 * '''variables(id/name)''': ''Function''. A function returning a variable by it's name or id. See [[#Variable_object_API|Variable object API]] for the attributes. To iterate over all variables do: <code>domoticz.variables().forEach(..)</code>. See [[#Iterators|Iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.variables()) do .. end</code>.
-
-=== Domoticz methods ===
-
-* '''email(subject, message, mailTo)''': Send email.
-* '''log(message, [level])''': Creates a logging entry in the Domoticz log but respects the log level settings. You can provide the loglevel: <code>domoticz.LOG_INFO</code>, <code>domoticz.LOG_DEBUG</code>, <code>domoticz.LOG_ERROR</code> or <code>domoticz.LOG_FORCE</code>. In Domoticz settings you can set the log level for dzVents.
-* '''notify(subject, message, priority, sound, extra, subsystem)''': Send a notification (like Prowl). Priority can be like <code>domoticz.PRIORITY_LOW, PRIORITY_MODERATE, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_EMERGENCY</code>. For sound see the SOUND constants below. <code>subsystem</code> can be a table containing one or more notification subsystems. See <code>domoticz.NSS_xxx</code> types.
-* '''openURL(url)''': Have Domoticz 'call' a URL.
-* '''sendCommand(command, value)''': Generic (low-level)command method (adds it to the commandArray) to the list of commands that are being sent back to domoticz. ''There is likely no need to use this directly. Use any of the device methods instead (see below).''
-* '''setScene(scene, value)''': E.g. <code>domoticz.setScene('My scene', 'On')</code>. Supports timing options. See below.
-* '''sms(message)''': Sends an sms if it is configured in Domoticz.
-* '''switchGroup(group, value)''': E.g. <code>domoticz.switchGroup('My group', 'Off')</code>. Supports timing options. See below.
 
 === Iterators ===
 
@@ -362,7 +358,7 @@ dzVents already recognizes most of the devices and creates the proper attributes
 
 Most of the time when your device is not recognized you can always use the <code>rawData</code> attribute as that will almost always hold all the data that is available in Domoticz.
 
-=== Device attributes for all devices ===
+=== Device attributes and methods for all devices ===
 
 * '''batteryLevel''': ''Number'' If applicable for that device then it will be from 0-100.
 * '''bState''': ''Boolean''. Is true for some common states like 'On' or 'Open' or 'Motion'.
@@ -403,7 +399,7 @@ Most of the time when your device is not recognized you can always use the <code
 * '''timedOut''': ''Boolean''. Is true when the device couldn't be reached.
 * '''update(&lt; params &gt;)''': ''Function''. Generic update method. Accepts any number of parameters that will be sent back to Domoticz. There is no need to pass the device.id here. It will be passed for you. Example to update a temperature: <code>device.update(0,12)</code>. This will eventually result in a commandArray entry <code>['UpdateDevice']='&lt;idx&gt;|0|12'</code>
 
-=== Device attributes for specific devices ===
+=== Device attributes and methods for specific devices ===
 
 Note that if you do not find your specific device type here you can always inspect what is in the <code>rawData</code> attribute. Please lets us know that it is missing so we can write an adapter for it (or you can write your own and submit it). You can dump all attributes for your device by calling <code>myDevice.dump()</code>. That will show you all the attributes and their values in the Domoticz. log.
 
@@ -415,7 +411,18 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Alert sensor ====
 
+* '''color''': ''Number''. Color of the alert. See domoticz color constants for possible values.
 * '''updateAlertSensor(level, text)''': ''Function''. Level can be domoticz.ALERTLEVEL_GREY, ALERTLEVEL_GREEN, ALERTLEVEL_YELLOW, ALERTLEVEL_ORANGE, ALERTLEVEL_RED
+
+==== Ampère, 1-phase ====
+
+* '''current''': ''Number''. Ampère.
+* '''updateCurrent(current)''': ''Function''. Current in Ampère.
+
+==== Ampère, 3-phase ====
+
+* '''current1''', '''current2''', '''current3''' : ''Number''. Ampère.
+* '''updateCurrent(current1, current2, current3)''': ''Function''. Currents in Ampère.
 
 ==== Barometer sensor ====
 
@@ -446,6 +453,7 @@ Note that if you do not find your specific device type here you can always inspe
 ==== Electric usage ====
 
 * '''WActual''': ''Number''. Current Watt usage.
+* '''updateEnergy(energy)''': ''Function''. In Watt.
 
 ==== Evohome ====
 
@@ -487,6 +495,13 @@ Note that if you do not find your specific device type here you can always inspe
 * '''updateElectricity(power, energy)''': ''Function''.
 * '''usage''': ''Number''.
 * '''WhToday''': ''Number''. Total Wh usage of the day. Note the unit is Wh and not kWh!
+* '''WhTotal''': ''Number''. Total Wh usage.
+* '''WhActual''': ''Number''. Actual reading.
+
+==== Leaf wetness ====
+
+* '''wetness''': ''Number''. Wetness value
+* '''updateWetness(wetness)''': ''Function''.
 
 ==== Lux sensor ====
 
@@ -532,6 +547,11 @@ Note that if you do not find your specific device type here you can always inspe
 * '''rainRate''': ''Number''
 * '''updateRain(rate, counter)''': ''Function''.
 
+==== Scale weight ====
+
+* '''weight''': ''Number''
+* '''udateWeight()''': ''Function''.
+
 ==== Scene ====
 
 * '''switchOn()''': ''Function''. Supports timing options. See [[#Switch_timing_options_.28delay.2C_duration.29|below]].
@@ -544,8 +564,18 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Solar radiation ====
 
-* '''radiation'''. ''Number''
+* '''radiation'''. ''Number''. In Watt/m2.
 * '''updateRadiation(radiation)''': ''Function''.
+
+==== Soil moisture ====
+
+* '''moisture'''. ''Number''. In centibars (cB).
+* '''updateSoilMoisture(moisture)''': ''Function''.
+
+==== Sound level ====
+
+* '''level'''. ''Number''. In dB.
+* '''updateSoundLevel(level)''': ''Function''.
 
 ==== Switch (dimmer, selector etc.) ====
 
@@ -553,6 +583,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 
 * '''close()''': ''Function''. Set device to Close if it supports it. Supports timing options. See [[#Switch_timing_options_.28delay.2C_duration.29|below]].
 * '''dimTo(percentage)''': ''Function''. Switch a dimming device on and/or dim to the specified level. Supports timing options. See [[#Switch_timing_options_.28delay.2C_duration.29|below]].
+* '''lastLevel''': Number. The level of a dimmer just before it was switched off.
 * '''level''': ''Number''. For dimmers and other 'Set Level..%' devices this holds the level like selector switches.
 * '''levelActions''': ''String''. |-separated list of url actions for selector switches.
 * '''levelName''': ''Table''. Table holding the level names for selector switch devices.
@@ -567,7 +598,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 ==== Temperature sensor ====
 
 * '''temperature''': ''Number''
-* '''updateTemperature(temperature)''': ''Function''.
+* '''updateTemperature(temperature)''': ''Function''. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius.
 
 ==== Temperature, Humidity, Barometer sensor ====
 
@@ -578,7 +609,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidity''': ''Number''
 * '''humidityStatus''': ''String''
 * '''temperature''': ''Number''
-* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN
+* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius.
 
 ==== Temperature, Humidity ====
 
@@ -586,7 +617,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidity''': ''Number''
 * '''humidityStatus''': ''String''
 * '''temperature''': ''Number''
-* '''updateTempHum(temperature, humidity, status)''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET.
+* '''updateTempHum(temperature, humidity, status)''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius.
 
 ==== Text ====
 
@@ -600,13 +631,23 @@ There are many switch-like devices. Not all methods are applicable for all switc
 
 ==== UV sensor ====
 
-* '''uv''': ''Number''.
-* '''updateUV(uv)''': ''Function''.
+* '''uv''': ''Number''. UV index.
+* '''updateUV(uv)''': ''Function''. UV index.
+
+==== Visibility ====
+
+* '''visibility''': ''Number''. In km.
+* '''updateVisibility(distance)''':Function*. In km.
 
 ==== Voltage ====
 
 * '''voltage''': ''Number''.
 * '''updateVoltage(voltage)''':Function*.
+
+==== Waterflow ====
+
+* '''flow''': ''Number''. In L/m.
+* '''updateWaterflow(flow)''':Function*. In L/m.
 
 ==== Wind ====
 
@@ -616,7 +657,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''gust''': ''Number''.
 * '''temperature''': ''Number''
 * '''speed''': ''Number''.
-* '''updateWind(bearing, direction, speed, gust, temperature, chill)''': ''Function''.
+* '''updateWind(bearing, direction, speed, gust, temperature, chill)''': ''Function''. Bearing in degrees, direction in N, S, NNW etc, speed in m/s, gust in m/s, temperature and chill in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius.
 
 ==== Zone heating ====
 
@@ -1032,14 +1073,14 @@ Of course, if you don't intend to use any of these statistical functions you can
 ====== Functions ======
 
 <ul>
-<li>'''avg( [fromIdx], [toIdx], [default] )''': Calculates the average of all item values within the range <code>fromIdx</code> to <code>toIdx</code>. You can specify a <code>default</code> value for when there is no data in the set.</li>
-<li>'''avgSince( [[#Time_specification_.28timeAgo.29|timeAgo]], default )''': Calculates the average of all data points since <code>timeAgo</code>. Returns <code>default</code> if there is no data. E.g.: <code>local avg = myVar.avgSince('00:30:00')</code> returns the average over the past 30 minutes.</li>
+<li>'''avg( [fromIdx], [toIdx], [default] )''': Calculates the average of all item values within the range <code>fromIdx</code> to <code>toIdx</code>. You can specify a <code>default</code> value for when there is no data in the set otherwise it returns 0.</li>
+<li>'''avgSince( [[#Time_specification_.28timeAgo.29|timeAgo]], default )''': Calculates the average of all data points since <code>timeAgo</code>. Returns <code>default</code> if there is no data otherwise 0. E.g.: <code>local avg = myVar.avgSince('00:30:00')</code> returns the average over the past 30 minutes.</li>
 <li>'''min( [fromIdx], [toIdx] )''': Returns the lowest value in the range defined by fromIdx and toIdx.</li>
 <li>'''minSince( [[#Time_specification_.28timeAgo.29|timeAgo]] )''': Same as '''min''' but now within the <code>timeAgo</code> interval.</li>
 <li>'''max( [fromIdx], [toIdx] )''': Returns the highest value in the range defined by fromIdx and toIdx.</li>
 <li>'''maxSince( [[#Time_specification_.28timeAgo.29|timeAgo]] )''': Same as '''max''' but now within the <code>timeAgo</code> interval.</li>
-<li>'''sum( [fromIdx], [toIdx] )''': Returns the summation of all values in the range defined by fromIdx and toIdx.</li>
-<li>'''sumSince( [[#Time_specification_.28timeAgo.29|timeAgo]] )''': Same as '''sum''' but now within the <code>timeAgo</code> interval.</li>
+<li>'''sum( [fromIdx], [toIdx] )''': Returns the summation of all values in the range defined by fromIdx and toIdx. It will return 0 when there is no data.</li>
+<li>'''sumSince( [[#Time_specification_.28timeAgo.29|timeAgo]] )''': Same as '''sum''' but now within the <code>timeAgo</code> interval. It will return 0 when there is no data in the interval.</li>
 <li>'''delta( fromIdx, toIdx, [smoothRange], [default] )''': Returns the delta (difference) between items specified by <code>fromIdx</code> and <code>toIdx</code>. You have to provide a valid range (no <code>nil</code> values). [[#About_data_smoothing|Supports data smoothing]] when providing a <code>smoothRange</code> value. Returns <code>default</code> if there is not enough data.</li>
 <li>'''deltaSince( [[#Time_specification_.28timeAgo.29|timeAgo]], [smoothRange], [default] )''': Same as '''delta''' but now within the <code>timeAgo</code> interval.</li>
 <li><p>'''localMin( [smoothRange], default )''': Returns the first minimum value (and the item holding the minimal value) in the past. [[#About_data_smoothing|Supports data smoothing]] when providing a <code>smoothRange</code> value. So if you have this range of values in the data set (from new to old): <code>10 8 7 5 3 4 5 6</code>. Then it will return <code>3</code> because older values ''and'' newer values are higher: a local minimum. You can use this if you want to know at what time a temperature started to rise after have been dropping. E.g.:</p>
@@ -1315,6 +1356,8 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you're good to go.
 
 = Change log =
+
+[2.1.0] Domoticz integration - Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute. - Added support for Ampère 1 and 3-phase devices - Added support for leaf wetness devices - Added support for scale weight devices - Added support for soil moisture devices - Added support for sound level devices - Added support for visibility devices - Added support for waterflow devices - Added missing color attribute to alert sensor devices - Added updateEnergy() to electric usage devices - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?) - Added toCelsius() helper method to domoticz object as the various update temperature methods all need celsius. - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on). - Added integration tests for full round-trip Domoticz &gt; dzVents &gt; Domoticz &gt; dzVents tests (100 tests). Total tests (unit+integration) now counts 395! - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents. - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat. - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense. - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
 
 [2.0.0] Domoticz integration
 

--- a/scripts/dzVents/documentation/history.md
+++ b/scripts/dzVents/documentation/history.md
@@ -17,6 +17,7 @@
  - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
  - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
  - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
+ - Use different api command for setting setPoints in the Thermostat setpoint device adapter.
 
 [2.0.0] Domoticz integration
 

--- a/scripts/dzVents/documentation/history.md
+++ b/scripts/dzVents/documentation/history.md
@@ -1,6 +1,22 @@
-[2.0.1] Domoticz integration
- - Added support for switching Lighting Limitless/Applamp (Hue etc) devices.
+[2.1.0]
+ - Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
+ - Added support for Ampère 1 and 3-phase devices
+ - Added support for leaf wetness devices
+ - Added support for scale weight devices
+ - Added support for soil moisture devices
+ - Added support for sound level devices
+ - Added support for visibility devices
+ - Added support for waterflow devices
+ - Added missing color attribute to alert sensor devices
+ - Added updateEnergy() to electric usage devices
+ - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
  - Added toCelsius() helper method to domoticz object as the various update temperature methods all need celsius.
+ - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
+ - Added integration tests for full round-trip Domoticz > dzVents > Domoticz > dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
+ - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
+ - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
+ - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
+ - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
 
 [2.0.0] Domoticz integration
 

--- a/scripts/dzVents/documentation/pandoc.md
+++ b/scripts/dzVents/documentation/pandoc.md
@@ -1,0 +1,5 @@
+#How to generate wiki docs based on README.md so it can be pasted in Domoticz wiki?
+
+Make sure you have pandoc installed, then run in this folder:
+
+pandoc -r markdown README.md -t mediawiki -o README.wiki

--- a/scripts/dzVents/runtime/HistoricalStorage.lua
+++ b/scripts/dzVents/runtime/HistoricalStorage.lua
@@ -292,7 +292,7 @@ local function HistoricalStorage(data, maxItems, maxHours, maxMinutes, getData)
 		local subset, length = self.subset(from, to)
 
 		if (length == 0) then
-			return default
+			return default or 0
 		else
 			return _avg(subset)
 		end
@@ -301,7 +301,7 @@ local function HistoricalStorage(data, maxItems, maxHours, maxMinutes, getData)
 	function self.avgSince(timeAgo, default)
 		local subset, length = self.subsetSince(timeAgo)
 		if (length == 0) then
-			return default
+			return default or 0
 		else
 			return _avg(subset)
 		end
@@ -386,7 +386,7 @@ local function HistoricalStorage(data, maxItems, maxHours, maxMinutes, getData)
 	function self.sum(from, to)
 		local subset, length = self.subset(from, to)
 		if (length==0) then
-			return nil
+			return 0
 		else
 			return _sum(subset)
 		end
@@ -395,7 +395,7 @@ local function HistoricalStorage(data, maxItems, maxHours, maxMinutes, getData)
 	function self.sumSince(timeAgo)
 		local subset, length = self.subsetSince(timeAgo)
 		if (length==0) then
-			return nil
+			return 0
 		else
 			return _sum(subset)
 		end

--- a/scripts/dzVents/runtime/Utils.lua
+++ b/scripts/dzVents/runtime/Utils.lua
@@ -26,6 +26,16 @@ function self.print(msg)
 	print(msg)
 end
 
+function self.urlEncode(str)
+	if (str) then
+		str = string.gsub(str, "\n", "\r\n")
+		str = string.gsub(str, "([^%w %-%_%.%~])",
+			function(c) return string.format("%%%02X", string.byte(c)) end)
+		str = string.gsub(str, " ", "+")
+	end
+	return str
+end
+
 function self.log(msg, level)
 
 	if (level == nil) then level = self.LOG_INFO end

--- a/scripts/dzVents/runtime/Variable.lua
+++ b/scripts/dzVents/runtime/Variable.lua
@@ -1,6 +1,14 @@
 local Time = require('Time')
-
+local utils = require('Utils')
 --local function Variable(domoticz, name, value)
+
+local typeLookup = {
+	['integer'] = 0,
+	['float'] = 1,
+	['string'] = 2,
+	['date'] = 3,
+	['time'] = 4
+}
 
 local function Variable(domoticz, data)
 
@@ -39,10 +47,21 @@ local function Variable(domoticz, data)
 
 	-- send an update to domoticz
 	function self.set(value)
---		domoticz.sendCommand('Variable:' .. data.name, tostring(value))
+		-- domoticz.sendCommand('Variable:' .. data.name, tostring(value))
+		-- using url call otherwise no follow-up event is triggered for this variable
+
+		if (data.variableType == 'string') then
+			value = utils.urlEncode(value)
+		end
 
 		local url = domoticz.settings['Domoticz url'] ..
-				'/json.htm?type=command&param=updateuservariable&vname=' .. data.name ..'&vtype=' .. data.variableType .. '&vvalue=' .. tostring(value)
+				'/json.htm?type=command&param=updateuservariable&vname='
+				.. data.name
+				..'&vtype='
+				.. typeLookup[data.variableType]
+				.. '&vvalue='
+				.. tostring(value)
+				.. '&idx=' .. data.id
 
 		domoticz.openURL(url)
 	end

--- a/scripts/dzVents/runtime/device-adapters/Adapters.lua
+++ b/scripts/dzVents/runtime/device-adapters/Adapters.lua
@@ -3,6 +3,8 @@ local genericAdapter = require('generic_device')
 local deviceAdapters = {
 	'airquality_device',
 	'alert_device',
+	'ampere_1_phase_device',
+	'ampere_3_phase_device',
 	'barometer_device',
 	'counter_device',
 	'custom_sensor_device',
@@ -11,18 +13,22 @@ local deviceAdapters = {
 	'evohome_device',
 	'gas_device',
 	'group_device',
-	'hue_light_device',
 	'humidity_device',
 	'kwh_device',
+	'leafwetness_device',
 	'lux_device',
 	'opentherm_gateway_device',
 	'p1_smartmeter_device',
 	'percentage_device',
 	'pressure_device',
 	'rain_device',
+	'rgbw_device',
+	'scaleweight_device',
 	'scene_device',
 	'security_device',
 	'solar_radiation_device',
+	'soilmoisture_device',
+	'soundlevel_device',
 	'switch_device',
 	'thermostat_setpoint_device',
 	'temperature_device',
@@ -30,7 +36,9 @@ local deviceAdapters = {
 	'temperature_humidity_barometer_device',
 	'text_device',
 	'uv_device',
+	'visibility_device',
 	'voltage_device',
+	'waterflow_device',
 	'wind_device',
 	'zone_heating_device',
 	'kodi_device'
@@ -124,6 +132,11 @@ local function DeviceAdapters(dummyLogger)
 		if (device[name] == nil) then
 			device[name] = self.getDummyMethod(device, name)
 		end
+	end
+
+	function self.round(num, numDecimalPlaces)
+		local mult = 10 ^ (numDecimalPlaces or 0)
+		return math.floor(num * mult + 0.5) / mult
 	end
 
 	self.states = {

--- a/scripts/dzVents/runtime/device-adapters/alert_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/alert_device.lua
@@ -16,6 +16,8 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
+		device.color = data.data._nValue
+
 		function device.updateAlertSensor(level, text)
 			--[[ level can be
 				domoticz.ALERTLEVEL_GREY

--- a/scripts/dzVents/runtime/device-adapters/ampere_1_phase_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/ampere_1_phase_device.lua
@@ -1,0 +1,22 @@
+return {
+
+	baseType = 'device',
+
+	name = '1-phase Ampere device adapter',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceType == 'General' and device.deviceSubType == 'Current')
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		-- current from data.data
+
+		function device.updateCurrent(current)
+			device.update(0, current)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/ampere_3_phase_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/ampere_3_phase_device.lua
@@ -1,0 +1,18 @@
+return {
+	baseType = 'device',
+	name = '3-phase Ampere device adapter',
+	matches = function(device, adapterManager)
+		local res = (device.deviceType == 'Current' and device.deviceSubType == 'CM113, Electrisave')
+		return res
+	end,
+	process = function(device, data, domoticz, utils, adapterManager)
+
+		device.current1 = tonumber(device.rawData[1])
+		device.current2 = tonumber(device.rawData[2])
+		device.current3 = tonumber(device.rawData[3])
+
+		function device.updateCurrent(current1, current2, current3)
+			device.update(0, tostring(current1) .. ';' .. tostring(current2) .. ';' .. tostring(current3) )
+		end
+	end
+}

--- a/scripts/dzVents/runtime/device-adapters/electric_usage_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/electric_usage_device.lua
@@ -11,7 +11,11 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device['WhActual'] = device.rawData[1]  or 0
+		device['WhActual'] = tonumber(device.rawData[1]  or 0)
+
+		function device.updateEnergy(energy)
+			device.update(0, energy)
+		end
 
 	end
 

--- a/scripts/dzVents/runtime/device-adapters/kwh_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/kwh_device.lua
@@ -13,6 +13,9 @@ return {
 	end,
 
 	process = function (device, data, domoticz, utils, adapterManager)
+
+		-- from data: whAtual, whTotal
+
 		local formatted = device.counterToday or ''
 		local info = adapterManager.parseFormatted(formatted, domoticz['radixSeparator'])
 
@@ -20,6 +23,13 @@ return {
 		-- so we have to multiply it with 1000 to get it in W
 
 		device['WhToday'] = info['value'] * 1000
+
+		-- fix casing
+		device['whTotal'] = nil
+		device['WhTotal'] = data.data.whTotal
+		device['whActual'] = nil
+		device['WhActual'] = data.data.whActual
+
 		device['counterToday'] = info['value']
 
 		formatted = device.usage or ''

--- a/scripts/dzVents/runtime/device-adapters/leafwetness_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/leafwetness_device.lua
@@ -1,0 +1,27 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Leaf wetness device adapter',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceSubType == 'Leaf Wetness')
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateWetness')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.wetness = data.data._nValue
+
+		function device.updateWetness(wetness)
+			-- /json.htm?type=command&param=udevice&idx=14&nvalue=10&svalue=0
+			local url = domoticz.settings['Domoticz url'] .. '/json.htm?type=command&param=udevice&idx=' .. device.id .. '&nvalue=' .. tonumber(wetness)
+			domoticz.openURL(url)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/rain_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/rain_device.lua
@@ -17,6 +17,7 @@ return {
 		-- from data: rainRate, rain
 
 		device['updateRain'] = function (rate, counter)
+			-- note that the updates are not directly visible in the gui (and data)
 			device.update(0, tostring(rate) .. ';' .. tostring(counter))
 		end
 

--- a/scripts/dzVents/runtime/device-adapters/rgbw_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/rgbw_device.lua
@@ -4,7 +4,7 @@ return {
 
 	baseType = 'device',
 
-	name = 'Hue light device adapter',
+	name = 'RGB(W) device adapter',
 
 	matches = function (device, adapterManager)
 		local res = (device.deviceType == 'Lighting 2' or device.deviceType == 'Lighting Limitless/Applamp')
@@ -33,6 +33,11 @@ return {
 				end
 			end
 			return nil
+		end
+
+		if (device.level == nil and data.data._nValue ~= nil) then
+			-- rgb devices get their level in _nValue
+			device.level = data.data._nValue
 		end
 
 		function device.switchOn()

--- a/scripts/dzVents/runtime/device-adapters/scaleweight_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/scaleweight_device.lua
@@ -1,0 +1,25 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Scale weight device adapter',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceType == 'Weight')
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateWeight')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.weight = tonumber(device.rawData[1])
+
+		function device.updateWeight(weight)
+			device.update(0, tostring(weight))
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/soilmoisture_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/soilmoisture_device.lua
@@ -1,0 +1,26 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Soil Moisture device',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceSubType == "Soil Moisture")
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateSoilMoisture')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.moisture = data.data._nValue --cB centibar
+
+		device['updateSoilMoisture'] = function (moisture)
+			local url = domoticz.settings['Domoticz url'] .. '/json.htm?type=command&param=udevice&idx=' .. device.id .. '&nvalue=' .. tonumber(moisture)
+			domoticz.openURL(url)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/soundlevel_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/soundlevel_device.lua
@@ -1,0 +1,25 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Sound level device',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceSubType == "Sound Level")
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateSoundLevel')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.level = tonumber(device.state)
+
+		device['updateSoundLevel'] = function (level)
+			device.update(0, level)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/switch_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/switch_device.lua
@@ -23,7 +23,12 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		-- from data: levelnName, levelOffHidden, levelActions, maxDimLevel
+		-- from data: levelName, levelOffHidden, levelActions, maxDimLevel
+
+		if (data.lastLevel ~= nil) then
+			-- dimmers that are switched off have a last level
+			device.lastLevel = data.lastLevel
+		end
 
 		function device.toggleSwitch()
 			local current, inv
@@ -68,7 +73,10 @@ return {
 		end
 
 		if (device.switchType == 'Selector') then
-			device.levelNames = device.levelName and string.split(device.levelName, '|') or {}
+			device.levelNames = device.levelNames and string.split(device.levelNames, '|') or {}
+			device.level = tonumber(device.rawData[1])
+			device.levelName = device.state
+
 		end
 
 	end

--- a/scripts/dzVents/runtime/device-adapters/thermostat_setpoint_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/thermostat_setpoint_device.lua
@@ -5,7 +5,7 @@ return {
 	name = 'Thermostat setpoint device adapter',
 
 	matches = function (device, adapterManager)
-		local res = device.deviceSubType == 'SetPoint'
+		local res = device.deviceSubType == 'SetPoint' and device.hardwareTypeValue ~= 20
 		if (not res) then
 			adapterManager.addDummyMethod(device, 'updateSetPoint')
 		end
@@ -18,8 +18,8 @@ return {
 
 		function device.updateSetPoint(setPoint)
 			-- send the command using openURL otherwise, due to a bug in Domoticz, you will get a timeout on the script
-			local url = domoticz.settings['Domoticz url']..
-					'/json.htm?type=command&param=udevice&idx=' .. device.id .. '&nvalue=0&svalue=' .. setPoint
+			local url = domoticz.settings['Domoticz url'] ..
+					'/json.htm?type=command&param=setsetpoint&idx=' .. device.id .. '&setpoint=' .. setPoint
 			utils.log('Setting setpoint using openURL ' .. url, utils.LOG_DEBUG)
 			domoticz.openURL(url)
 		end

--- a/scripts/dzVents/runtime/device-adapters/visibility_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/visibility_device.lua
@@ -1,0 +1,25 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Visibility device',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceSubType == "Visibility")
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateVisibility')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.visbility = adapterManager.round(data.data.visibility, 1)
+
+		device['updateVisibility'] = function (visibility)
+			device.update(0, visibility)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/device-adapters/waterflow_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/waterflow_device.lua
@@ -1,0 +1,25 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Waterflow device',
+
+	matches = function (device, adapterManager)
+		local res = (device.deviceSubType == "Waterflow")
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateWaterflow')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		device.flow = tonumber(device.rawData[1])
+
+		device['updateWaterflow'] = function (flow) -- l/m
+			device.update(0, flow)
+		end
+
+	end
+
+}

--- a/scripts/dzVents/runtime/integration-tests/File.lua
+++ b/scripts/dzVents/runtime/integration-tests/File.lua
@@ -1,0 +1,107 @@
+--
+-- # file
+--
+-- Basic file functions for Lua.
+--
+-- **License:** MIT
+--  **Source:** [GitHub](https://github.com/gummesson/file.lua)
+--
+
+-- ## References
+
+local io, os, error = io, os, error
+
+-- ## file
+--
+-- The namespace.
+--
+local file = {}
+
+-- ### file.exists
+--
+-- Determine if the file in the `path` exists.
+--
+-- - `path` is a string.
+--
+function file.exists(path)
+	local file = io.open(path, 'rb')
+	if file then
+		file:close()
+	end
+	return file ~= nil
+end
+
+-- ### file.read
+--
+-- Return the content of the file by reading the given `path` and `mode`.
+--
+-- - `path` is a string.
+-- - `mode` is a string.
+--
+function file.read(path, mode)
+	mode = mode or '*a'
+	local file, err = io.open(path, 'rb')
+	if err then
+		error(err)
+	end
+	local content = file:read(mode)
+	file:close()
+	return content
+end
+
+-- ### file.write
+--
+-- Write to the file with the given `path`, `content` and `mode`.
+--
+-- - `path`    is a string.
+-- - `content` is a string.
+-- - `mode`    is a string.
+--
+function file.write(path, content, mode)
+	mode = mode or 'w'
+	local file, err = io.open(path, mode)
+	if err then
+		error(err)
+	end
+	file:write(content)
+	file:close()
+end
+
+-- ### file.copy
+--
+-- Copy the file by reading the `src` and writing it to the `dest`.
+--
+-- - `src`  is a string.
+-- - `dest` is a string.
+--
+function file.copy(src, dest)
+	local content = file.read(src)
+	file.write(dest, content)
+end
+
+-- ### file.move
+--
+-- Move the file from `src` to the `dest`.
+--
+-- - `src`  is a string.
+-- - `dest` is a string.
+--
+function file.move(src, dest)
+	os.rename(src, dest)
+end
+
+-- ### file.remove
+--
+-- Remove the file from the given `path`.
+--
+-- - `path` is a string.
+--
+function file.remove(path)
+	os.remove(path)
+end
+
+-- ## Exports
+--
+-- Export `file` as a Lua module.
+--
+return file

--- a/scripts/dzVents/runtime/integration-tests/README.md
+++ b/scripts/dzVents/runtime/integration-tests/README.md
@@ -1,0 +1,23 @@
+In order to run the integration tests from the command line you have to
+
+* Install lua 5.2
+* Install luarocks
+* Install busted: `luarocks install busted`
+* Install lodash: `luarocks install lodash`
+
+Make sure you have Domoticz running with an empty database from the commandline so you can see the log files.
+
+DO NOT RUN THIS SCRIPT ON YOUR PRODUCTION DATABASE AS IT WILL DELETE EVERYTHING IN YOUR DATABASE!!!!!
+
+Then go to the test folder and run the tests:
+
+```
+cd runtime/integration-tests
+busted *
+```
+
+When all tests pass you should see this in the logs:
+
+```
+dzVents: Info:  Results stage 2: SUCCEEDED
+```

--- a/scripts/dzVents/runtime/integration-tests/README.md
+++ b/scripts/dzVents/runtime/integration-tests/README.md
@@ -1,9 +1,10 @@
 In order to run the integration tests from the command line you have to
 
 * Install lua 5.2
-* Install luarocks
+* Install luarocks (for 5.2 !! Google on how to make this work! or see below)
 * Install busted: `luarocks install busted`
 * Install lodash: `luarocks install lodash`
+* Install luasocket: `luarocks install luasocket`
 
 Make sure you have Domoticz running with an empty database from the commandline so you can see the log files.
 
@@ -21,3 +22,18 @@ When all tests pass you should see this in the logs:
 ```
 dzVents: Info:  Results stage 2: SUCCEEDED
 ```
+
+
+## luarocks 5.2 on da Pi
+
+* sudo apt-get install liblua5.2-dev
+* sudo apt-get install lua5.2
+* git clone https://github.com/luarocks/luarocks
+* cd luarocks
+* git checkout tags/v2.4.2
+* ./configure --lua-version=5.2 --versioned-rocks-dir
+* make build
+* sudo make install
+* sudo luarocks-5.2 install busted
+* sudo luarocks-5.2 install lodash
+* sudo luarocks-5.2 install luasocket

--- a/scripts/dzVents/runtime/integration-tests/stage1.lua
+++ b/scripts/dzVents/runtime/integration-tests/stage1.lua
@@ -1,0 +1,1069 @@
+local log
+local dz
+
+local err = function(msg)
+	log(msg, dz.LOG_ERROR)
+end
+
+local expectEql = function (attr, test, marker)
+	if (attr ~= test) then
+		local msg = tostring(attr) .. '~=' .. tostring(test)
+		if (marker ~= nil) then
+			msg = msg .. ' (' .. tostring(marker) ..')'
+		end
+		err(msg)
+		print(debug.traceback())
+		return false
+	end
+	return true
+end
+
+local checkAttributes = function(dev, attributes)
+	local res = true
+	for attr, value in pairs(attributes) do
+		res = res and expectEql(dev[attr], value, attr)
+	end
+	return res
+end
+
+local testAirQuality = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 2,
+		["name"] = name,
+		["quality"] = 'Excellent',
+		["co2"] = 0,
+		["deviceSubType"] = "Voltcraft CO-20";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "Air Quality";
+	})
+	dev.updateAirQuality(1234)
+	return res
+end
+
+local testSwitch = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 1,
+		["name"] = name,
+		["maxDimLevel"] = 100,
+		["state"] = "Off",
+		["deviceSubType"] = "Switch";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "Light/Switch";
+		["description"] = 'desc vdSwitch'
+	})
+	dev.switchOn().afterSec(1)
+	return res
+end
+
+local testDimmer = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 39,
+		["name"] = name,
+		["maxDimLevel"] = 100,
+		["lastLevel"] = 0,
+		["state"] = "Off",
+		["deviceSubType"] = "Switch";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["switchType"] = "Dimmer",
+		["switchTypeValue"] = 7,
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "Light/Switch";
+		["description"] = "desc vdSwitchDimmer"
+	})
+	dev.dimTo(75).afterSec(1)
+	return res
+end
+
+local testAlert = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 3,
+		["name"] = name,
+		["state"] = "No Alert!",
+		["color"] = 0,
+		["deviceSubType"] = "Alert";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "General";
+	})
+	dev.updateAlertSensor(dz.ALERTLEVEL_RED, 'Hey I am red')
+	return res
+end
+
+local testAmpere3 = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 4,
+		['current1'] = 0,
+		['current2'] = 0,
+		['current3'] = 0,
+		["name"] = name,
+		["deviceSubType"] = "CM113, Electrisave";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "Current";
+	})
+
+	dev.updateCurrent(123, 456, 789)
+
+	return res
+end
+
+local testAmpere1 = function(name)
+	local dev = dz.devices(name)
+	local res = true
+
+	res = res and expectEql(64, math.floor(dev.current * 10))
+
+	res = res and checkAttributes(dev, {
+		["id"] = 5,
+		["name"] = name,
+		["state"] = "6.4",
+		["deviceSubType"] = "Current";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "General";
+	})
+
+	dev.updateCurrent(123)
+
+	return res
+end
+
+local testBarometer = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 6,
+		["name"] = name,
+		["forecastString"] = "Stable";
+		["forecast"] = 0;
+		["deviceSubType"] = "Barometer";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+		["deviceType"] = "General";
+	})
+	dev.updateBarometer(1234, dz.BARO_THUNDERSTORM)
+	return res
+end
+
+local testCounter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 7,
+		["name"] = name,
+		["counterToday"] = 0;
+		["valueUnits"] = "";
+		["valueQuantity"] = "";
+		["counter"] = 0.000;
+		["deviceSubType"] = "RFXMeter counter";
+		["deviceType"] = "RFXMeter";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateCounter(1234)
+	return res
+end
+
+local testCounterIncremental = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 8,
+		["name"] = name,
+		["counterToday"] = 0;
+		["valueUnits"] = "";
+		["valueQuantity"] = "";
+		["counter"] = 0.000;
+		["deviceSubType"] = "Counter Incremental";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateCounter(1234)
+	return res
+end
+
+local testCustomSensor = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 9,
+		["name"] = name,
+		["sensorUnit"] = "axis";
+		["sensorType"] = 1;
+		["state"] = "0.0";
+		["deviceSubType"] = "Custom Sensor";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateCustomSensor(1234)
+	return res
+end
+
+local testDistance = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 10,
+		["name"] = name,
+		["state"] = '123.4',
+		["distance"] = 123.4,
+		["deviceSubType"] = "Distance";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateDistance(42.44)
+	return res
+end
+
+local testElectricInstanceCounter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 11,
+		["name"] = name,
+		['WhTotal'] = 0,
+		['WhActual'] = 0,
+		['counterToday'] = 0,
+		['usage'] = 0.0,
+		["deviceSubType"] = "kWh";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateElectricity(10, 20)
+	return res
+end
+
+local testGas = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 12,
+		["name"] = name,
+		['counterToday'] = 0,
+		['counter'] = 0,
+		["deviceSubType"] = "Gas";
+		["deviceType"] = "P1 Smart Meter";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateGas(6000) -- this won't have a direct effect
+	return res
+end
+
+local testHumidity = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 13,
+		["name"] = name,
+		["humidityStatus"] = "Comfortable";
+		["humidity"] = 50;
+		["deviceSubType"] = "LaCrosse TX3";
+		["deviceType"] = "Humidity";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateHumidity(88, dz.HUM_WET)
+	return res
+end
+
+local testLeafWetness = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 14,
+		["name"] = name,
+		['wetness'] = 2,
+		["deviceSubType"] = "Leaf Wetness";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateWetness(55)
+	return res
+end
+
+local testLux = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 15,
+		["name"] = name,
+		['lux'] = 0,
+		["deviceSubType"] = "Lux";
+		["deviceType"] = "Lux";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateLux(355)
+	return res
+end
+
+local testP1SmartMeter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 16,
+		["name"] = name,
+		["WhActual"] = 0,
+		['usage1'] = 0,
+		['usage2'] = 0,
+		['return1'] = 0,
+		['return2'] = 0,
+		['usage'] = 0,
+		['usageDelivered'] = 0,
+		['counterDeliveredToday'] = 0,
+		['counterToday'] = 0,
+		["deviceSubType"] = "Energy";
+		["deviceType"] = "P1 Smart Meter";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateP1(10, 20, 100, 200, 666, 777)
+	return res
+end
+
+local testPercentage = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 17,
+		["name"] = name,
+		['percentage'] = 0,
+		["deviceSubType"] = "Percentage";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updatePercentage(99.99)
+	return res
+end
+
+local testPressureBar = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 18,
+		["name"] = name,
+		["pressure"] = 0,
+		["deviceSubType"] = "Pressure";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updatePressure(88)
+	return res
+end
+
+local testRain = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 19,
+		["name"] = name,
+		["rain"] = 0,
+		["rainRate"] = 0,
+		["deviceSubType"] = "TFA";
+		["deviceType"] = "Rain";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateRain(3000, 6660)
+	return res
+end
+
+local testRGB = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 20,
+		["name"] = name,
+		["maxDimLevel"] = 100,
+		["state"] = "On",
+		["deviceSubType"] = "RGB";
+		["deviceType"] = "Lighting Limitless/Applamp";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.dimTo(15)
+	return res
+end
+
+local testRGBW = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 21,
+		["name"] = name,
+		["maxDimLevel"] = 100,
+		["state"] = "On",
+		["deviceSubType"] = "RGBW";
+		["deviceType"] = "Lighting Limitless/Applamp";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.dimTo(15)
+	return res
+end
+
+local testScaleWeight = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 22,
+		["name"] = name,
+		['weight'] = 0,
+		["deviceSubType"] = "BWR102";
+		["deviceType"] = "Weight";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+	dev.updateWeight(33.5)
+	return res
+end
+
+local testSelectorSwitch = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 23,
+		["name"] = name,
+		['levelName'] = 'Off',
+		['level'] = 0,
+		["state"] = 'Off',
+		["deviceSubType"] = "Selector Switch";
+		["deviceType"] = "Light/Switch";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	res = res and expectEql('Off',  dev.levelNames[1])
+	res = res and expectEql('Level1', dev.levelNames[2])
+	res = res and expectEql('Level2', dev.levelNames[3])
+	res = res and expectEql('Level3', dev.levelNames[4])
+
+	dev.switchSelector(30) -- level3
+	return res
+end
+
+local testSoilMoisture = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 24,
+		["name"] = name,
+		["moisture"] = 3,
+		["deviceSubType"] = "Soil Moisture";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateSoilMoisture(34)
+	return res
+end
+
+local testSolarRadiation = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 25,
+		["name"] = name,
+		["radiation"] = 1,
+		["deviceSubType"] = "Solar Radiation";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateRadiation(34)
+	return res
+end
+
+local testSoundLevel = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 26,
+		["name"] = name,
+		["level"] = 65,
+		["deviceSubType"] = "Sound Level";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateSoundLevel(120)
+	return res
+end
+
+local testTemperature = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 27,
+		["name"] = name,
+		["temperature"] = 0,
+		["deviceSubType"] = "LaCrosse TX3";
+		["deviceType"] = "Temp";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateTemperature(120)
+	return res
+end
+
+local testTempHum = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 28,
+		["name"] = name,
+		["temperature"] = 0,
+		["humidity"] = 50,
+		["humidityStatus"] = "Comfortable";
+		["deviceSubType"] = "THGN122/123, THGN132, THGR122/228/238/268";
+		--["deviceType"] = 'Temp + Humidity';
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateTempHum(34, 88, dz.HUM_WET)
+	return res
+end
+
+local testTempHumBaro = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 29,
+		["name"] = name,
+		["temperature"] = 0,
+		["humidity"] = 50,
+		["barometer"] = 1010,
+		["forecastString"] = "Sunny";
+		["forecast"] = 1;
+		["humidityStatus"] = "Comfortable";
+		["deviceSubType"] = "THB1 - BTHR918, BTHGN129";
+		--["deviceType"] = 'Temp + Humidity';
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateTempHumBaro(34, 88, dz.HUM_WET, 1033, dz.BARO_PARTLYCLOUDY)
+	return res
+end
+
+local testText = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 30,
+		["name"] = name,
+		["text"] = 'Hello World',
+		["deviceSubType"] = "Text";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateText("Oh my Darwin, what a lot of tests!")
+	return res
+end
+
+local testThermostatSetpoint = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 31,
+		["name"] = name,
+		["setPoint"] = 20.5,
+		["deviceSubType"] = "SetPoint";
+		["deviceType"] = "Thermostat";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateSetPoint(22)
+	return res
+end
+
+local testUsageElectric = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 32,
+		["name"] = name,
+		["WhActual"] = 0,
+		["deviceSubType"] = "Electric";
+		["deviceType"] = "Usage";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateEnergy(1922)
+	return res
+end
+
+local testUV = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 33,
+		["name"] = name,
+		["uv"] = 0,
+		["deviceSubType"] = "UVN128,UV138";
+		["deviceType"] = "UV";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateUV(12.33)
+	return res
+end
+
+local testVisibility = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and expectEql(103, math.floor(dev.visibility * 10))
+	res = res and checkAttributes(dev, {
+		["id"] = 34,
+		["name"] = name,
+		["deviceSubType"] = "Visibility";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateVisibility(1)
+	return res
+end
+
+local testVoltage = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 35,
+		["name"] = name,
+		["voltage"] = 0,
+		["deviceSubType"] = "Voltage";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateVoltage(220)
+	return res
+end
+
+local testWaterflow = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 36,
+		["name"] = name,
+		["flow"] = 0,
+		["deviceSubType"] = "Waterflow";
+		["deviceType"] = "General";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateWaterflow(15)
+	return res
+end
+
+local testWind = function(name, id, subType)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = id,
+		["name"] = name,
+		["gust"] = 0,
+		["temperature"] = 0,
+		["speed"] = 0,
+		["direction"] = 0,
+		['directionString'] = "N",
+		['chill'] = 0,
+		["deviceSubType"] = subType,
+		["deviceType"] = "Wind";
+		["hardwareType"] = "Dummy (Does nothing, use for virtual switches only)";
+		["hardwareName"] = "dummy";
+		["hardwareTypeValue"] = 15;
+		["hardwareId"] = 2;
+		["batteryLevel"] = nil; -- 255 == nil
+		["changed"] = false;
+		["timedOut"] = false;
+	})
+
+	dev.updateWind(120, 'SW', 55, 66, 77, 88)
+	return res
+end
+
+local testScene = function(name)
+	local scene = dz.scenes(name)
+	local res = true
+	res = res and checkAttributes(scene, {
+		["id"] = 1,
+		["name"] = name,
+		['state'] = 'On',
+		['baseType'] = 'scene'
+	})
+
+	scene.switchOn()
+	return res
+end
+
+local testGroup = function(name)
+	local group = dz.groups(name)
+	local res = true
+	res = res and checkAttributes(group, {
+		["id"] = 2,
+		["name"] = name,
+		['state'] = 'On',
+		['baseType'] = 'group'
+	})
+
+	group.switchOff()
+	return res
+end
+
+local testVariableInt = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		["id"] = 1,
+		["name"] = name,
+		['value'] = 42
+	})
+
+	var.set(43)
+	return res
+end
+
+local testVariableFloat = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		["id"] = 2,
+		["name"] = name,
+		['value'] = 42.11
+	})
+
+	var.set(43)
+	return res
+end
+
+local testVariableString = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		["id"] = 3,
+		["name"] = name,
+		['value'] = 'Somestring'
+	})
+
+	var.set('Zork is a dork')
+	return res
+end
+
+local testVariableDate = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		["id"] = 4,
+		["name"] = name,
+	})
+
+	res = res and expectEql(var.date.month, 12)
+	res = res and expectEql(var.date.day, 31)
+	res = res and expectEql(var.date.year, 2017)
+	var.set('20/11/2016');
+	return res
+end
+
+local testVariableTime = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		["id"] = 5,
+		["name"] = name,
+	})
+
+	res = res and expectEql(var.time.hour, 23)
+	res = res and expectEql(var.time.min, 59)
+	var.set('09:54');
+	return res
+end
+
+return {
+	active = true,
+	on = {
+		devices = {'stage1Trigger' }
+	},
+	execute = function(domoticz, trigger)
+		local res = true
+		dz = domoticz
+		log = dz.log
+
+		log('Starting stage 1')
+
+		res = res and testAirQuality('vdAirQuality')
+		res = res and testSwitch('vdSwitch')
+		res = res and testAlert('vdAlert')
+		res = res and testAmpere3('vdAmpere3')
+		res = res and testAmpere1('vdAmpere1')
+		res = res and testDimmer('vdSwitchDimmer')
+		res = res and testBarometer('vdBarometer')
+		res = res and testCounter('vdCounter')
+		res = res and testCounterIncremental('vdCounterIncremental')
+		res = res and testCustomSensor('vdCustomSensor')
+		res = res and testDistance('vdDistance')
+		res = res and testElectricInstanceCounter('vdElectricInstanceCounter')
+		res = res and testGas('vdGas')
+		res = res and testHumidity('vdHumidity')
+		res = res and testLeafWetness('vdLeafWetness')
+		res = res and testLux('vdLux')
+		res = res and testP1SmartMeter('vdP1SmartMeterElectric')
+		res = res and testPercentage('vdPercentage')
+		res = res and testPressureBar('vdPressureBar')
+		res = res and testRain('vdRain')
+		res = res and testRGB('vdRGBSwitch')
+		res = res and testRGBW('vdRGBWSwitch')
+		res = res and testScaleWeight('vdScaleWeight')
+		res = res and testSelectorSwitch('vdSelectorSwitch')
+		res = res and testSoilMoisture('vdSoilMoisture')
+		res = res and testSolarRadiation('vdSolarRadiation')
+		res = res and testSoundLevel('vdSoundLevel')
+		res = res and testTemperature('vdTemperature')
+		res = res and testTempHum('vdTempHum')
+		res = res and testTempHumBaro('vdTempHumBaro')
+		res = res and testText('vdText')
+		res = res and testThermostatSetpoint("vdThermostatSetpoint")
+		res = res and testUsageElectric("vdUsageElectric")
+		res = res and testUV("vdUV")
+		res = res and testVisibility("vdVisibility")
+		res = res and testVoltage("vdVoltage")
+		res = res and testWaterflow("vdWaterflow")
+		res = res and testWind('vdWind', 37, "WTGR800")
+		res = res and testWind('vdWindTempChill', 38, "TFA")
+--		res = res and testScene('scScene')
+--		res = res and testGroup('gpGroup')
+		res = res and testVariableInt('varInteger')
+		res = res and testVariableFloat('varFloat')
+		res = res and testVariableString('varString')
+		res = res and testVariableDate('varDate')
+		res = res and testVariableTime('varTime')
+
+		log('Finishing stage 1')
+		if (not res) then
+			log('Results stage 1: FAILED!!!!', dz.LOG_ERROR)
+		else
+			log('Results stage 1: SUCCEEDED')
+		end
+
+		dz.devices('stage2Trigger').switchOn().afterSec(2)
+	end
+}

--- a/scripts/dzVents/runtime/integration-tests/stage2.lua
+++ b/scripts/dzVents/runtime/integration-tests/stage2.lua
@@ -1,0 +1,557 @@
+local log
+local dz
+
+local err = function(msg)
+	log(msg, dz.LOG_ERROR)
+end
+
+local expectEql = function(attr, test, marker)
+	if (attr ~= test) then
+		local msg = tostring(attr) .. '~=' .. tostring(test)
+		if (marker ~= nil) then
+			msg = msg .. ' (' .. tostring(marker) .. ')'
+		end
+		err(msg)
+		print(debug.traceback())
+		return false
+	end
+	return true
+end
+
+local checkAttributes = function(dev, attributes)
+	local res = true
+	for attr, value in pairs(attributes) do
+		res = res and expectEql(dev[attr], value, attr)
+	end
+	return res
+end
+
+local testAirQuality = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["quality"] = 'Mediocre',
+		["co2"] = 1234,
+	})
+	return res
+end
+
+local testSwitch = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = "On",
+	})
+	return res
+end
+
+local testDimmer = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["id"] = 39,
+		["state"] = "On",
+		["lastLevel"] = 75;
+	})
+	return res
+end
+
+local testAlert = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = "Hey I am red",
+		["color"] = 4,
+	})
+	return res
+end
+
+local testBarometer = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["forecastString"] = "Thunderstorm";
+		["forecast"] = 4;
+		["barometer"] = 1234
+	})
+	return res
+end
+
+local testCounter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["counterToday"] = 0;
+		["counter"] = 1.234;
+	})
+	return res
+end
+
+local testCounterIncremental = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["counter"] = 1.234;
+		["counterToday"] = 0;
+	})
+	return res
+end
+
+local testCustomSensor = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = "1234";
+	})
+	return res
+end
+
+local testDistance = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = '42.44',
+		["distance"] = 42.44,
+	})
+	return res
+end
+
+local testElectricInstanceCounter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['WhTotal'] = 20,
+		['WhActual'] = 10,
+		['counterToday'] = 0.020,
+		['usage'] = 10.0,
+	})
+	return res
+end
+
+local testGas = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	-- this doesn't have a direct effect so we cannot test this unfortunately
+	--	res = res and checkAttributes(dev, {
+	--		['counterToday'] = 66,
+	--		['counter'] = 66,
+	--	})
+	return res
+end
+
+local testHumidity = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["humidityStatus"] = "Wet";
+		["humidity"] = 88;
+	})
+	return res
+end
+
+local testLeafWetness = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['wetness'] = 55,
+	})
+	return res
+end
+
+local testLux = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['lux'] = 355,
+	})
+	return res
+end
+
+local testP1SmartMeter = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["WhActual"] = 666,
+		['usage1'] = 10,
+		['usage2'] = 20,
+		['return1'] = 100,
+		['return2'] = 200,
+		['usage'] = 666,
+		['usageDelivered'] = 777,
+		['counterDeliveredToday'] = 0,
+		['counterToday'] = 0,
+	})
+	return res
+end
+
+local testPercentage = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['percentage'] = 99.99,
+	})
+	return res
+end
+
+local testPressureBar = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["pressure"] = 88,
+	})
+	return res
+end
+
+local testRain = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	expectEql(3000, tonumber(dev.rawData[1]))
+	expectEql(6660, tonumber(dev.rawData[2]))
+	return res
+end
+
+local testRGB = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = "On",
+		["level"] = 15,
+	})
+	return res
+end
+
+local testRGBW = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["state"] = "On",
+		["level"] = 15,
+	})
+	return res
+end
+
+local testScaleWeight = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['weight'] = 33.5,
+	})
+	return res
+end
+
+local testSelectorSwitch = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['levelName'] = 'Level3',
+		["state"] = 'Level3',
+		['level'] = 30
+	})
+
+	return res
+end
+
+local testSoilMoisture = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["moisture"] = 34,
+	})
+
+	return res
+end
+
+local testSolarRadiation = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["radiation"] = 34,
+	})
+
+	return res
+end
+
+local testSoundLevel = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["level"] = 120,
+	})
+	return res
+end
+
+local testTemperature = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["temperature"] = 120,
+	})
+
+	return res
+end
+
+local testTempHum = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["temperature"] = 34,
+		["humidity"] = 88,
+		["humidityStatus"] = "Wet";
+	})
+
+	return res
+end
+
+local testTempHumBaro = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["temperature"] = 34,
+		["humidity"] = 88,
+		["barometer"] = 1033,
+		["forecastString"] = "Partly Cloudy";
+		["forecast"] = 2;
+		["humidityStatus"] = "Wet";
+	})
+
+	return res
+end
+
+local testText = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["text"] = "Oh my Darwin, what a lot of tests!"
+	})
+
+	return res
+end
+
+local testThermostatSetpoint = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["setPoint"] = 22,
+	})
+
+	return res
+end
+
+local testUsageElectric = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["WhActual"] = 1922,
+	})
+
+	return res
+end
+
+local testUV = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["uv"] = 12.33,
+	})
+
+	return res
+end
+
+local testVisibility = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and expectEql(1, dev.visibility)
+
+	return res
+end
+
+local testVoltage = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["voltage"] = 220,
+	})
+
+	return res
+end
+
+local testWaterflow = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["flow"] = 15,
+	})
+
+	return res
+end
+
+local testWind = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		["gust"] = 66,
+		["temperature"] = 77,
+		["speed"] = 55,
+		["direction"] = 120,
+		['directionString'] = "SW",
+		['chill'] = 88,
+	})
+	return res
+end
+
+local testGroup = function(name)
+	local group = dz.groups(name)
+	local res = true
+	res = res and checkAttributes(group, {
+		["id"] = 2,
+		["name"] = name,
+		['state'] = 'Off',
+		['baseType'] = 'group'
+	})
+
+	return res
+end
+
+local testVariableInt = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		['value'] = 43
+	})
+
+	return res
+end
+
+local testVariableFloat = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		['value'] = 43
+	})
+
+	return res
+end
+
+local testVariableString = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and checkAttributes(var, {
+		['value'] = 'Zork is a dork'
+	})
+
+	return res
+end
+
+local testVariableDate = function(name)
+	local var = dz.variables(name)
+	local res = true
+	res = res and expectEql(var.date.month, 11)
+	res = res and expectEql(var.date.day, 20)
+	res = res and expectEql(var.date.year, 2016)
+	var.set('20/11/2016');
+	return res
+end
+
+local testVariableTime = function(name)
+	local var = dz.variables(name)
+	local res = true
+
+	res = res and expectEql(var.time.hour, 9)
+	res = res and expectEql(var.time.min, 54)
+	return res
+end
+
+local testAmpere1 = function(name)
+	local dev = dz.devices(name)
+	local res = true
+
+	res = res and checkAttributes(dev, {
+		['current'] = 123,
+	})
+
+	return res
+end
+
+local testAmpere3 = function(name)
+	local dev = dz.devices(name)
+	local res = true
+	res = res and checkAttributes(dev, {
+		['current1'] = 123,
+		['current2'] = 456,
+		['current3'] = 789,
+	})
+
+	return res
+end
+
+
+return {
+	active = true,
+	on = {
+		devices = { 'stage2Trigger' }
+	},
+	execute = function(domoticz, trigger)
+
+		local res = true
+		dz = domoticz
+		log = dz.log
+
+		log('Starting stage 2')
+
+		res = res and testAirQuality('vdAirQuality')
+		res = res and testSwitch('vdSwitch')
+		res = res and testAlert('vdAlert')
+		res = res and testBarometer('vdBarometer')
+		res = res and testCounter('vdCounter')
+		res = res and testCounterIncremental('vdCounterIncremental')
+		res = res and testCustomSensor('vdCustomSensor')
+		res = res and testDistance('vdDistance')
+		res = res and testElectricInstanceCounter('vdElectricInstanceCounter')
+		res = res and testGas('vdGas')
+		res = res and testHumidity('vdHumidity')
+		res = res and testLeafWetness('vdLeafWetness')
+		res = res and testLux('vdLux')
+		res = res and testP1SmartMeter('vdP1SmartMeterElectric')
+		res = res and testPercentage('vdPercentage')
+		res = res and testPressureBar('vdPressureBar')
+		res = res and testRain('vdRain')
+		res = res and testRGB('vdRGBSwitch')
+		res = res and testRGBW('vdRGBWSwitch')
+		res = res and testScaleWeight('vdScaleWeight')
+		res = res and testSelectorSwitch('vdSelectorSwitch')
+		res = res and testSoilMoisture('vdSoilMoisture')
+		res = res and testSolarRadiation('vdSolarRadiation')
+		res = res and testSoundLevel('vdSoundLevel')
+		res = res and testTemperature('vdTemperature')
+		res = res and testTempHum('vdTempHum')
+		res = res and testTempHumBaro('vdTempHumBaro')
+		res = res and testText('vdText')
+		res = res and testThermostatSetpoint("vdThermostatSetpoint")
+		res = res and testUsageElectric("vdUsageElectric")
+		res = res and testUV("vdUV")
+		res = res and testVisibility("vdVisibility")
+		res = res and testVoltage("vdVoltage")
+		res = res and testWaterflow("vdWaterflow")
+		res = res and testWind('vdWind')
+		res = res and testWind('vdWindTempChill')
+--		res = res and testGroup('gpGroup')
+		res = res and testVariableInt('varInteger')
+		res = res and testVariableFloat('varFloat')
+		res = res and testVariableString('varString')
+		res = res and testVariableDate('varDate')
+		res = res and testVariableTime('varTime')
+		res = res and testAmpere1('vdAmpere1')
+		res = res and testAmpere3('vdAmpere3')
+		res = res and testDimmer('vdSwitchDimmer')
+
+		if (not res) then
+			log('Results stage 2: FAILED!!!!', dz.LOG_ERROR)
+			dz.devices('endResult').updateText('FAILED')
+		else
+			log('Results stage 2: SUCCEEDED')
+			dz.devices('endResult').updateText('SUCCEEDED')
+		end
+
+		log('Finishing stage 2')
+	end
+}

--- a/scripts/dzVents/runtime/integration-tests/testIntegration.lua
+++ b/scripts/dzVents/runtime/integration-tests/testIntegration.lua
@@ -1,0 +1,692 @@
+package.path = package.path ..
+		";../?.lua;../device-adapters/?.lua;./data/?.lua;./generated_scripts/?.lua;" ..
+		"../../../lua/?.lua"
+
+local _ = require 'lodash'
+local File = require('File')
+local http = require("socket.http")
+local socket = require("socket")
+local ltn12 = require("ltn12")
+local jsonParser = require('JSON')
+
+local BASE_URL = 'http://localhost:8080'
+local API_URL = BASE_URL .. '/json.htm?'
+local DUMMY_HW = 15
+local SWITCH_TYPES = {
+	BLINDS = 3,
+	BLINDS_INVERTED= 6,
+	BLINDS_PERCENTAGE= 13,
+	BLINDS_PERCENTAGE_INVERTED= 16,
+	CONTACT= 2,
+	DIMMER= 7,
+	DOOR_CONTACT= 11,
+	DOOR_LOCK= 19,
+	DOORBELL= 1,
+	DUSK_SENSOR= 12,
+	MEDIA_PLAYER= 17,
+	MOTION_SENSOR= 8,
+	ON_OFF= 0,
+	PUSH_OFF_BUTTON= 10,
+	PUSH_ON_BUTTON= 9,
+	SELECTOR= 18,
+	SMOKE_DETECTOR= 5,
+	VENETIAN_BLINDS_EU= 15,
+	VENETIAN_BLINDS_US= 14,
+	X10_SIREN= 4
+}
+
+local VIRTUAL_DEVICES = {
+	AIR_QUALITY = {249, 'vdAirQuality'},
+	ALERT = {7, 'vdAlert'},
+	AMPERE_3_PHASE = {9, 'vdAmpere3'},
+	AMPERE_1_PHASE = {19, 'vdAmpere1'},
+	BAROMETER = {11, 'vdBarometer'},
+	COUNTER = {113, 'vdCounter'},
+	COUNTER_INCREMENTAL = {14, 'vdCounterIncremental'},
+	CUSTOM_SENSOR = {1004, 'vdCustomSensor'},
+	DISTANCE = {13, 'vdDistance'},
+	ELECTRIC_INSTANT_COUNTER = {18, 'vdElectricInstanceCounter'},
+	GAS = {3, 'vdGas'},
+	HUMIDITY = {81, 'vdHumidity'},
+	LEAF_WETNESS = {16, 'vdLeafWetness'},
+	LUX = {246, 'vdLux'},
+	P1_SMART_METER_ELECTRIC = {250, 'vdP1SmartMeterElectric'},
+	PERCENTAGE = {2, 'vdPercentage'},
+	PRESSURE_BAR = {1, 'vdPressureBar'},
+	RAIN = {85, 'vdRain'},
+	RGB_SWITCH = {241, 'vdRGBSwitch'},
+	RGBW_SWITCH = {1003, 'vdRGBWSwitch'},
+	SCALE_WEIGHT = {93, 'vdScaleWeight'},
+	SELECTOR_SWITCH = {1002, 'vdSelectorSwitch'},
+	SOIL_MOISTURE = {15, 'vdSoilMoisture'},
+	SOLAR_RADIATION = {20, 'vdSolarRadiation'},
+	SOUND_LEVEL = {10, 'vdSoundLevel'},
+	SWITCH = {6, 'vdSwitch'},
+	TEMPERATURE = {80, 'vdTemperature'},
+	TEMP_HUM = {82, 'vdTempHum'},
+	TEMP_HUM_BARO = {84, 'vdTempHumBaro'},
+	TEXT = {5, 'vdText'},
+	THERMOSTAT_SETPOINT = {8, 'vdThermostatSetpoint'},
+	USAGE_ELECTRIC = {248, 'vdUsageElectric'},
+	UV = {87, 'vdUV'},
+	VISIBILITY = {12, 'vdVisibility'},
+	VOLTAGE = {4, 'vdVoltage'},
+	WATERFLOW = {1000, 'vdWaterflow'},
+	WIND = {86, 'vdWind'},
+	WIND_TEMP_CHILL = {1001, 'vdWindTempChill'}
+}
+local VAR_TYPES = {
+	INT = {0, 'varInteger', 42},
+	FLOAT = {1, 'varFloat', 42.11},
+	STRING = {2, 'varString', 'Somestring'},
+	DATE = {3, 'varDate', '31/12/2017'},
+	TIME = {4, 'varTime', '23:59'}
+}
+
+
+function doAPICall(url)
+	local response = {}
+	local result, respcode, respheaders, respstatus = http.request {
+		method = "GET",
+		url = API_URL .. url,
+		sink = ltn12.sink.table(response)
+	}
+
+	local _json = table.concat(response)
+
+	local json = jsonParser:decode(_json)
+	local ok = json.status == 'OK'
+
+	return ok, json, result, respcode, respheaders, respstatus
+end
+
+function createHardware(name, type)
+	local url = "type=command&param=addhardware&htype=" .. tostring(type) .. "&name=" .. name .. "&enabled=true&datatimeout=0"
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	local idx = json.idx
+	return ok, idx, json, result, respcode, respheaders, respstatus
+end
+
+function createVirtualDevice(hw, name, type, options)
+	-- type=createvirtualsensor&idx=2&sensorname=s1&sensortype=6
+
+	local url = "type=createvirtualsensor&idx=" .. tostring(hw) .."&sensorname=" .. name .. "&sensortype=" .. tostring(type)
+
+	if (options) then
+		url = url .. '&sensoroptions=1;' .. tostring(options)
+	end
+
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	local idx = json.idx
+
+	return ok, idx, json, result, respcode, respheaders, respstatus
+end
+
+function createScene(name)
+	-- type=addscene&name=myScene&scenetype=0
+	local url = "type=addscene&name=" .. name .. "&scenetype=0"
+
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	local idx = json.idx
+
+	return ok, idx, json, result, respcode, respheaders, respstatus
+end
+
+function createGroup(name)
+	-- type=addscene&name=myGroup&scenetype=1
+	local url = "type=addscene&name=" .. name .. "&scenetype=1"
+
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	local idx = json.idx
+
+	return ok, idx, json, result, respcode, respheaders, respstatus
+end
+
+function createVariable(name, type, value)
+	--type=command&param=saveuservariable&vname=myint&vtype=0&vvalue=1
+	local url = "type=command&param=saveuservariable&vname=" .. name .."&vtype=" .. tostring(type) .. "&vvalue=" .. tostring(value)
+
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	local idx = json.idx
+
+	return ok, idx, json, result, respcode, respheaders, respstatus
+end
+
+function deleteDevice(idx)
+	-- type=deletedevice&idx=2;1;...
+	local url = "type=deletedevice&idx=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok, json
+end
+
+function deleteGroupScene(idx)
+	-- type=deletescene&idx=1
+	local url = "type=deletescene&idx=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok, json
+end
+
+function getDevice(idx)
+	--type=devices&rid=15
+	local url = "type=devices&rid=" .. idx
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	if (ok and json.result ~= nil and _.size(json.result) == 1) then
+		return ok, json.result[1]
+	end
+	return false, nil
+end
+
+function getAllDevices()
+	-- type=devices&displayhidden=1&displaydisabled=1&filter=all&used=all
+	local url = "type=devices&displayhidden=1&displaydisabled=1&filter=all&used=all"
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	assert.is_true(ok)
+	return ok, json, result
+end
+
+function deleteAllDevices()
+	local ok, json, result = getAllDevices()
+
+	if (ok) then
+		if (_.size(json.result) > 0) then
+			for i, device in pairs(json.result) do
+				local ok, json
+				if (device.Type == 'Scene' or device.Type == 'Group') then
+					ok, json = deleteGroupScene(device.idx)
+				else
+					ok, json = deleteDevice(device.idx)
+				end
+
+				if (not ok) then
+					print('Failed to remove device: ' .. device.Name)
+				end
+				assert.is_true(ok)
+			end
+		end
+	end
+end
+
+function deleteVariable(idx)
+	--type=command&param=deleteuservariable&idx=1
+	local url = "type=command&param=deleteuservariable&idx=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok, json
+end
+
+function deleteAllVariables()
+	-- type=command&param=getuservariables
+	local url = "type=command&param=getuservariables"
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	assert.is_true(ok)
+	if (ok) then
+		if (_.size(json.result) > 0) then
+			for i, variable in pairs(json.result) do
+				local ok, json
+				ok, json = deleteVariable(variable.idx)
+
+				if (not ok) then
+					print('Failed to remove variable: ' .. variable.Name)
+				end
+				assert.is_true(ok)
+			end
+		end
+	end
+end
+
+function deleteHardware(idx)
+	-- http://localhost:8080/json.htm?type=command&param=deletehardware&idx=2
+	local url = "type=command&param=deletehardware&idx=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok, json
+end
+
+function deleteAllHardware()
+	-- http://localhost:8080/json.htm?type=hardware
+	local url = "type=hardware"
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	assert.is_true(ok)
+	if (ok) then
+		if (_.size(json.result) > 0) then
+			for i, hw in pairs(json.result) do
+				local ok, json = deleteHardware(hw.idx)
+				if (not ok) then
+					print('Failed to remove hardware: ' .. hw.Name)
+				end
+				assert.is_true(ok)
+			end
+		end
+	end
+end
+
+function deleteScript(idx)
+	--type=events&param=delete&event=1
+	local url = "type=events&param=delete&event=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok, json
+end
+
+function deleteAllScripts()
+	-- type=events&param=list
+	local url = "type=events&param=list"
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	assert.is_true(ok)
+	if (ok) then
+		if (_.size(json.result) > 0) then
+			for i, script in pairs(json.result) do
+				local ok, json
+				ok, json = deleteScript(script.id)
+
+				if (not ok) then
+					print('Failed to remove script: ' .. script.Name)
+				end
+				assert.is_true(ok)
+			end
+		end
+	end
+end
+
+function updateSwitch(idx, name, description, switchType)
+	--http://localhost:8080/json.htm?type=setused&idx=1&name=vdSwitch&description=des&strparam1=&strparam2=&protected=false&switchtype=0&customimage=0&used=true&addjvalue=0&addjvalue2=0&options=
+	local url = "type=setused&idx=" ..
+			tostring(idx) ..
+			"&name=" .. name ..
+			"&description=" .. description ..
+			"&strparam1=&strparam2=&protected=false&" ..
+			"switchtype=" .. tostring(switchType) .. "&customimage=0&used=true&addjvalue=0&addjvalue2=0&options="
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok
+end
+
+function switch(idx, cmd)
+	--type=command&param=switchlight&idx=39&switchcmd=On&level=0&passcode=
+	local url = "type=command&param=switchlight&switchcmd=" .. cmd .. "&level=0&idx=" .. tostring(idx)
+	local ok, json, result, respcode, respheaders, respstatus = doAPICall(url)
+	return ok
+end
+
+function initSettings()
+	local response = {}
+	local reqbody = "Language=en&Themes=default&Title=Domoticz&Latitude=52.298665&Longitude=5.629619&DashboardType=0&AllowWidgetOrdering=on&MobileType=0&WebUserName=&WebPassword=d41d8cd98f00b204e9800998ecf8427e&AuthenticationMethod=0&GuestUser=0&SecPassword=d41d8cd98f00b204e9800998ecf8427e&SecOnDelay=30&ProtectionPassword=d41d8cd98f00b204e9800998ecf8427e&WebLocalNetworks=127.0.0.1&RemoteSharedPort=6144&checkforupdates=on&ReleaseChannel=0&AcceptNewHardware=on&HideDisabledHardwareSensors=on&MyDomoticzUserId=&MyDomoticzPassword=&EnableTabLights=on&EnableTabScenes=on&EnableTabTemp=on&EnableTabWeather=on&EnableTabUtility=on&EnableTabCustom=on&LightHistoryDays=30&ShortLogDays=1&ProwlAPI=&NMAAPI=&PushbulletAPI=&PushsaferAPI=&PushsaferImage=&PushoverUser=&PushoverAPI=&PushALotAPI=&ClickatellAPI=&ClickatellUser=&ClickatellPassword=&ClickatellFrom=&ClickatellTo=&HTTPField1=&HTTPField2=&HTTPField3=&HTTPField4=&HTTPTo=&HTTPURL=https%3A%2F%2Fwww.somegateway.com%2Fpushurl.php%3Fusername%3D%23FIELD1%26password%3D%23FIELD2%26apikey%3D%23FIELD3%26from%3D%23FIELD4%26to%3D%23TO%26message%3D%23MESSAGE&HTTPPostData=&HTTPPostContentType=application%2Fjson&HTTPPostHeaders=&KodiIPAddress=224.0.0.1&KodiPort=9777&KodiTimeToLive=5&LmsPlayerMac=&LmsDuration=5&NotificationSensorInterval=43200&NotificationSwitchInterval=0&EmailFrom=&EmailTo=&EmailServer=&EmailPort=25&EmailUsername=&EmailPassword=&UseEmailInNotifications=on&WindUnit=0&TempUnit=0&DegreeDaysBaseTemperature=18.0&WeightUnit=0&EnergyDivider=1000&CostEnergy=0.2149&CostEnergyT2=0.2149&CostEnergyR1=0.0800&CostEnergyR2=0.0800&GasDivider=100&CostGas=0.6218&WaterDivider=100&CostWater=1.6473&ElectricVoltage=230&CM113DisplayType=0&SmartMeterType=0&FloorplanPopupDelay=750&FloorplanAnimateZoom=on&FloorplanShowSensorValues=on&FloorplanShowSceneNames=on&FloorplanRoomColour=Blue&FloorplanActiveOpacity=25&FloorplanInactiveOpacity=5&RandomSpread=15&SensorTimeout=60&BatterLowLevel=0&LogFilter=&LogFileName=&LogLevel=0&DoorbellCommand=0&RaspCamParams=-w+800+-h+600+-t+1&UVCParams=-S80+-B128+-C128+-G80+-x800+-y600+-q100&LogEventScriptTrigger=on&DzVentsLogLevel=3"
+	local url = BASE_URL .. '/storesettings.webem'
+	local result, respcode, respheaders, respstatus = http.request {
+		method = "POST",
+		source = ltn12.source.string(reqbody),
+		url = url,
+		headers = {
+			['Connection'] = 'keep-alive',
+			['Content-Length'] = _.size(reqbody),
+			['Pragma'] = 'no-cache',
+			['Cache-Control'] = 'no-cache',
+			['Origin'] = BASE_URL,
+			['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36',
+			['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8',
+			['Accept'] = '*/*',
+			['X-Requested-With'] = 'XMLHttpRequest',
+			['DNT'] = '1',
+			['Referer'] = BASE_URL,
+		},
+		sink = ltn12.sink.table(response)
+	}
+
+	local _json = table.concat(response)
+	local ok = (respcode == 200)
+
+	return ok, result, respcode, respheaders, respstatus
+
+end
+
+function createScript(name, code)
+	local response = {}
+	local reqbody = 'name=' .. name ..'&' ..
+			'interpreter=dzVents&' ..
+			'eventtype=All&' ..
+			'xml=' .. tostring(code) .. '&' ..
+			--'xml=return%20%7B%0A%09active%20%3D%20false%2C%0A%09on%20%3D%20%7B%0A%09%09timer%20%3D%20%7B%7D%0A%09%7D%2C%0A%09execute%20%3D%20function(domoticz%2C%20device)%0A%09end%0A%7D&' ..
+			'logicarray=&' ..
+			'eventid=&' ..
+			'eventstatus=1&' ..
+			'editortheme=ace%2Ftheme%2Fxcode'
+	local url = BASE_URL .. '/event_create.webem'
+	local result, respcode, respheaders, respstatus = http.request {
+		method = "POST",
+		source = ltn12.source.string(reqbody),
+		url = url,
+		headers = {
+			['Connection'] = 'keep-alive',
+			['Pragma'] = 'no-cache',
+			['Cache-Control'] = 'no-cache',
+			['Content-Length'] = _.size(reqbody),
+			['Origin'] = BASE_URL,
+			['User-Agent'] = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.115 Safari/537.36',
+			['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8',
+			['Accept'] = '*/*',
+			['X-Requested-With'] = 'XMLHttpRequest',
+			['DNT'] = '1',
+			['Referer'] = BASE_URL,
+		},
+		sink = ltn12.sink.table(response)
+	}
+
+	local _json = table.concat(response)
+	local ok = (respcode == 200)
+
+	return ok, result, respcode, respheaders, respstatus
+
+end
+
+describe('Integration test', function ()
+
+	setup(function()
+		deleteAllDevices()
+		deleteAllVariables()
+		deleteAllHardware()
+		deleteAllScripts()
+	end)
+
+	teardown(function()
+		os.remove('../../generated_scripts/stage1.lua')
+		os.remove('../../scripts/stage2.lua')
+	end)
+
+	before_each(function()
+
+	end)
+
+	after_each(function() end)
+
+	local dummyIdx
+	local stage1TriggerIdx
+	local endResultsIdx
+
+--	it('a', function() end)
+
+	describe('Settings', function()
+
+		it('Should initialize settings', function()
+
+			local ok, result, respcode, respheaders, respstatus = initSettings()
+
+			assert.is_true(ok)
+
+		end)
+
+	end)
+
+	describe('Hardware', function()
+		it('should create dummy hardware', function()
+			local ok
+			ok, dummyIdx = createHardware('dummy', DUMMY_HW)
+			assert.is_true(ok)
+		end)
+	end)
+
+	describe('Devices', function()
+
+		it('should create a virtual switch', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SWITCH[2], VIRTUAL_DEVICES.SWITCH[1])
+			assert.is_true(ok)
+			ok = updateSwitch(idx, VIRTUAL_DEVICES.SWITCH[2], 'desc%20' .. VIRTUAL_DEVICES.SWITCH[2], SWITCH_TYPES.ON_OFF)
+			assert.is_true(ok)
+		end)
+
+		it('should create a air quality device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.AIR_QUALITY[2], VIRTUAL_DEVICES.AIR_QUALITY[1])
+			assert.is_true(ok)
+		end)
+
+		it('should create an alert device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.ALERT[2], VIRTUAL_DEVICES.ALERT[1])
+			assert.is_true(ok)
+		end)
+
+		it('should create an AMPERE_3_PHASE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.AMPERE_3_PHASE[2], VIRTUAL_DEVICES.AMPERE_3_PHASE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an AMPERE_1_PHASE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.AMPERE_1_PHASE[2], VIRTUAL_DEVICES.AMPERE_1_PHASE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an BAROMETER device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.BAROMETER[2], VIRTUAL_DEVICES.BAROMETER[1])
+			assert.is_true(ok)
+		end)
+		it('should create an COUNTER device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.COUNTER[2], VIRTUAL_DEVICES.COUNTER[1])
+			assert.is_true(ok)
+		end)
+		it('should create an COUNTER_INCREMENTAL device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.COUNTER_INCREMENTAL[2], VIRTUAL_DEVICES.COUNTER_INCREMENTAL[1])
+			assert.is_true(ok)
+		end)
+		it('should create an CUSTOM_SENSOR device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.CUSTOM_SENSOR[2], VIRTUAL_DEVICES.CUSTOM_SENSOR[1], 'axis')
+			assert.is_true(ok)
+		end)
+		it('should create an DISTANCE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.DISTANCE[2], VIRTUAL_DEVICES.DISTANCE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an ELECTRIC_INSTANT_COUNTER device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.ELECTRIC_INSTANT_COUNTER[2], VIRTUAL_DEVICES.ELECTRIC_INSTANT_COUNTER[1])
+			assert.is_true(ok)
+		end)
+		it('should create an GAS device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.GAS[2], VIRTUAL_DEVICES.GAS[1])
+			assert.is_true(ok)
+		end)
+		it('should create an HUMIDITY device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.HUMIDITY[2], VIRTUAL_DEVICES.HUMIDITY[1])
+			assert.is_true(ok)
+		end)
+		it('should create an LEAF_WETNESS device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.LEAF_WETNESS[2], VIRTUAL_DEVICES.LEAF_WETNESS[1])
+			assert.is_true(ok)
+		end)
+		it('should create an LUX device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.LUX[2], VIRTUAL_DEVICES.LUX[1])
+			assert.is_true(ok)
+		end)
+		it('should create an P1_SMART_METER_ELECTRIC device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.P1_SMART_METER_ELECTRIC[2], VIRTUAL_DEVICES.P1_SMART_METER_ELECTRIC[1])
+			assert.is_true(ok)
+		end)
+		it('should create an PERCENTAGE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.PERCENTAGE[2], VIRTUAL_DEVICES.PERCENTAGE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an PRESSURE_BAR device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.PRESSURE_BAR[2], VIRTUAL_DEVICES.PRESSURE_BAR[1])
+			assert.is_true(ok)
+		end)
+		it('should create an RAIN device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.RAIN[2], VIRTUAL_DEVICES.RAIN[1])
+			assert.is_true(ok)
+		end)
+		it('should create an RGB_SWITCH device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.RGB_SWITCH[2], VIRTUAL_DEVICES.RGB_SWITCH[1])
+			assert.is_true(ok)
+		end)
+		it('should create an RGBW_SWITCH device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.RGBW_SWITCH[2], VIRTUAL_DEVICES.RGBW_SWITCH[1])
+			assert.is_true(ok)
+		end)
+		it('should create an SCALE_WEIGHT device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SCALE_WEIGHT[2], VIRTUAL_DEVICES.SCALE_WEIGHT[1])
+			assert.is_true(ok)
+		end)
+		it('should create an SELECTOR_SWITCH device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SELECTOR_SWITCH[2], VIRTUAL_DEVICES.SELECTOR_SWITCH[1])
+			assert.is_true(ok)
+		end)
+		it('should create an SOIL_MOISTURE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SOIL_MOISTURE[2], VIRTUAL_DEVICES.SOIL_MOISTURE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an SOLAR_RADIATION device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SOLAR_RADIATION[2], VIRTUAL_DEVICES.SOLAR_RADIATION[1])
+			assert.is_true(ok)
+		end)
+		it('should create an SOUND_LEVEL device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.SOUND_LEVEL[2], VIRTUAL_DEVICES.SOUND_LEVEL[1])
+			assert.is_true(ok)
+		end)
+		it('should create an TEMPERATURE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.TEMPERATURE[2], VIRTUAL_DEVICES.TEMPERATURE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an TEMP_HUM device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.TEMP_HUM[2], VIRTUAL_DEVICES.TEMP_HUM[1])
+			assert.is_true(ok)
+		end)
+		it('should create an TEMP_HUM_BARO device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.TEMP_HUM_BARO[2], VIRTUAL_DEVICES.TEMP_HUM_BARO[1])
+			assert.is_true(ok)
+		end)
+		it('should create an TEXT device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.TEXT[2], VIRTUAL_DEVICES.TEXT[1])
+			assert.is_true(ok)
+		end)
+		it('should create an THERMOSTAT_SETPOINT device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.THERMOSTAT_SETPOINT[2], VIRTUAL_DEVICES.THERMOSTAT_SETPOINT[1])
+			assert.is_true(ok)
+		end)
+		it('should create an USAGE_ELECTRIC device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.USAGE_ELECTRIC[2], VIRTUAL_DEVICES.USAGE_ELECTRIC[1])
+			assert.is_true(ok)
+		end)
+		it('should create an UV device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.UV[2], VIRTUAL_DEVICES.UV[1])
+			assert.is_true(ok)
+		end)
+		it('should create an VISIBILITY device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.VISIBILITY[2], VIRTUAL_DEVICES.VISIBILITY[1])
+			assert.is_true(ok)
+		end)
+		it('should create an VOLTAGE device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.VOLTAGE[2], VIRTUAL_DEVICES.VOLTAGE[1])
+			assert.is_true(ok)
+		end)
+		it('should create an WATERFLOW device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.WATERFLOW[2], VIRTUAL_DEVICES.WATERFLOW[1])
+			assert.is_true(ok)
+		end)
+		it('should create an WIND device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.WIND[2], VIRTUAL_DEVICES.WIND[1])
+			assert.is_true(ok)
+		end)
+		it('should create an WIND_TEMP_CHILL device', function()
+			local ok, idx = createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.WIND_TEMP_CHILL[2], VIRTUAL_DEVICES.WIND_TEMP_CHILL[1])
+			assert.is_true(ok)
+		end)
+		it('should create a dimmer', function()
+			local ok, idx = createVirtualDevice(dummyIdx, 'vdSwitchDimmer', VIRTUAL_DEVICES.SWITCH[1])
+			assert.is_true(ok)
+			ok = updateSwitch(idx, 'vdSwitchDimmer', 'desc%20vdSwitchDimmer', SWITCH_TYPES.DIMMER)
+			assert.is_true(ok)
+		end)
+	end)
+
+	describe('Groups and scenes', function()
+
+		it('should create a scene', function()
+			local ok, idx = createScene('scScene')
+			assert.is_true(ok)
+		end)
+
+		it('should create a group', function()
+			local ok, idx = createGroup('gpGroup')
+			assert.is_true(ok)
+		end)
+
+	end)
+
+	describe('Variables', function()
+
+		it('should create an integer variable', function()
+			local ok, idx = createVariable(VAR_TYPES.INT[2], VAR_TYPES.INT[1], VAR_TYPES.INT[3])
+			assert.is_true(ok)
+		end)
+
+		it('should create an FLOAT variable', function()
+			local ok, idx = createVariable(VAR_TYPES.FLOAT[2], VAR_TYPES.FLOAT[1], VAR_TYPES.FLOAT[3])
+			assert.is_true(ok)
+		end)
+
+		it('should create an STRING variable', function()
+			local ok, idx = createVariable(VAR_TYPES.STRING[2], VAR_TYPES.STRING[1], VAR_TYPES.STRING[3])
+			assert.is_true(ok)
+		end)
+
+		it('should create an DATE variable', function()
+			local ok, idx = createVariable(VAR_TYPES.DATE[2], VAR_TYPES.DATE[1], VAR_TYPES.DATE[3])
+			assert.is_true(ok)
+		end)
+
+		it('should create an TIME variable', function()
+			local ok, idx = createVariable(VAR_TYPES.TIME[2], VAR_TYPES.TIME[1], VAR_TYPES.TIME[3])
+			assert.is_true(ok)
+		end)
+	end)
+
+
+	describe('Preparing scripts and triggers', function()
+
+		it('Should create a dzVents script', function()
+			local stage1Script = File.read('./stage1.lua')
+
+			local ok, result, respcode, respheaders, respstatus = createScript('stage1', stage1Script)
+			assert.is_true(ok)
+		end)
+
+		it('Should move stage2 script in place', function()
+
+			File.remove('../../scripts/stage2.lua')
+			File.copy('./stage2.lua', '../../scripts/stage2.lua')
+
+		end)
+
+		it('Should create the stage1 trigger switch', function()
+			local ok
+			ok, stage1TriggerIdx = createVirtualDevice(dummyIdx, 'stage1Trigger', VIRTUAL_DEVICES.SWITCH[1])
+			assert.is_true(ok)
+		end)
+
+		it('Should create the stage2 trigger switch', function()
+			local ok, idx = createVirtualDevice(dummyIdx, 'stage2Trigger', VIRTUAL_DEVICES.SWITCH[1])
+			assert.is_true(ok)
+		end)
+
+		it('Should create the final results text device', function()
+			local ok
+			ok, endResultsIdx = createVirtualDevice(dummyIdx, 'endResult', VIRTUAL_DEVICES.TEXT[1])
+			assert.is_true(ok)
+		end)
+
+	end)
+
+	describe('Start the tests', function()
+
+		it('Should all just work fine', function()
+
+			local ok = switch(stage1TriggerIdx, 'On')
+
+			assert.is_true(ok)
+
+		end)
+
+		it('Should have succeeded', function()
+
+			socket.sleep(4)
+
+			local ok, textDevice = getDevice(endResultsIdx)
+
+			assert.is_same('SUCCEEDED', textDevice['Data'])
+
+		end)
+
+
+	end)
+
+
+end);

--- a/scripts/dzVents/runtime/tests/README.md
+++ b/scripts/dzVents/runtime/tests/README.md
@@ -1,7 +1,7 @@
 In order to run the tests from the command line you have to
 
 * Install lua 5.2
-* Install luarocks 
+* Install luarocks (see below)
 * Install busted: `luarocks install busted`
 * Install luacov: `luarocks install luacov`
 * Install lodash: `luarocks install lodash`
@@ -22,3 +22,18 @@ luacov
 ```
 
 Then open `luacov.report.out`
+
+
+## luarocks 5.2 on da Pi
+
+* sudo apt-get install liblua5.2-dev
+* sudo apt-get install lua5.2
+* git clone https://github.com/luarocks/luarocks
+* cd luarocks
+* git checkout tags/v2.4.2
+* ./configure --lua-version=5.2 --versioned-rocks-dir
+* make build
+* sudo make install
+* sudo luarocks-5.2 install busted
+* sudo luarocks-5.2 install lodash
+* sudo luarocks-5.2 install luasocket

--- a/scripts/dzVents/runtime/tests/testDevice.lua
+++ b/scripts/dzVents/runtime/tests/testDevice.lua
@@ -398,7 +398,7 @@ describe('device', function()
 
 			device.updateSetPoint(14)
 
-			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=udevice&idx=1&nvalue=0&svalue=14', res)
+			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=setsetpoint&idx=1&setpoint=14', res)
 
 		end)
 

--- a/scripts/dzVents/runtime/tests/testDevice.lua
+++ b/scripts/dzVents/runtime/tests/testDevice.lua
@@ -141,7 +141,6 @@ describe('device', function()
 			return commandArray[#commandArray], command, value
 		end,
 		openURL = function(url)
-			_.print('url') --                    TODO - >> REMOVE << -
 			return table.insert(commandArray, url)
 		end
 	}
@@ -319,6 +318,24 @@ describe('device', function()
 			})
 
 			assert.is_same(12345, device.WhActual)
+			device.updateEnergy(1000)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|1000" } }, commandArray)
+		end)
+
+		it('should detect a visibility device', function()
+
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'General',
+				['subType'] = 'Visibility',
+				['additionalDataData'] = {
+					['visibility'] = 33
+				}
+			})
+
+			assert.is_same(33, device.visibility)
+			device.updateVisibility(22)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|22" } }, commandArray)
 		end)
 
 		it('should detect a p1 smart meter device', function()
@@ -409,6 +426,42 @@ describe('device', function()
 
 			device.updateRain(10, 20)
 			assert.is_same({ { ["UpdateDevice"] = "1|0|10;20" } }, commandArray)
+		end)
+
+		it('should detect a 2-phase ampere device', function()
+
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'General',
+				['subType'] = 'Current',
+				['additionalDataData'] = {
+					["current"] = 123,
+				}
+			})
+
+			assert.is_same(123, device.current)
+			device.updateCurrent(10)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|10" } }, commandArray)
+		end)
+
+		it('should detect a 3-phase ampere device', function()
+
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'Current',
+				['subType'] = 'CM113, Electrisave',
+				['rawData'] = {
+					[1] = 123,
+					[2] = 456,
+					[3] = 789,
+				}
+			})
+
+			assert.is_same(123, device.current1)
+			assert.is_same(456, device.current2)
+			assert.is_same(789, device.current3)
+			device.updateCurrent(10, 20, 30)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|10;20;30" } }, commandArray)
 		end)
 
 		it('should detect an air quality device', function()
@@ -511,14 +564,19 @@ describe('device', function()
 					"updateRadiation",
 					"updateRain",
 					"updateSetPoint",
+					"updateSoilMoisture",
+					"updateSoundLevel",
 					"updateTempHum",
 					"updateTempHumBaro",
 					"updateTemperature",
 					"updateText",
 					"updateUV",
+					"updateVisibility",
 					"updateVoltage",
+					"updateWaterflow",
+					"updateWeight",
+					"updateWetness",
 					"updateWind" }, values(dummies))
-
 			end)
 
 		end)
@@ -741,9 +799,11 @@ describe('device', function()
 		it('should detect an alert device', function()
 			local device = getDevice(domoticz, {
 				['name'] = 'myDevice',
-				['subType'] = 'Alert'
+				['subType'] = 'Alert',
+				['additionalDataData'] = { ['_nValue'] = 4 }
 			})
 
+			assert.is_same(4, device.color)
 			device.updateAlertSensor(0, 'Oh dear!')
 			assert.is_same({ { ["UpdateDevice"] = "1|0|Oh dear!" } }, commandArray)
 		end)
@@ -780,6 +840,80 @@ describe('device', function()
 			device.updateRadiation(12)
 			assert.is_same({ { ["UpdateDevice"] = "1|0|12" } }, commandArray)
 		end)
+
+		it('should detect a leaf wetness device', function()
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['subType'] = 'Leaf Wetness',
+				['additionalDataData'] = { ['_nValue'] = 4 }
+			})
+
+			local res;
+
+			domoticz.openURL = function(url)
+				res = url;
+			end
+
+			assert.is_same(4, device.wetness)
+			device.updateWetness(12)
+			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=udevice&idx=1&nvalue=12', res)
+		end)
+
+		it('should detect a scale weight device', function()
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'Weight',
+				['rawData'] = { [1] = "44" }
+			})
+
+			assert.is_same(44, device.weight)
+			device.updateWeight(12)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|12" } }, commandArray)
+		end)
+
+		it('should detect a sound level device', function()
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['subType'] = 'Sound Level',
+				['state'] = '120'
+			})
+
+			assert.is_same(120, device.level)
+			device.updateSoundLevel(33)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|33" } }, commandArray)
+		end)
+
+		it('should detect a waterflow device', function()
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['subType'] = 'Waterflow',
+				['rawData'] = { [1] = "44" }
+			})
+
+			assert.is_same(44, device.flow)
+			device.updateWaterflow(33)
+			assert.is_same({ { ["UpdateDevice"] = "1|0|33" } }, commandArray)
+		end)
+
+
+		it('should detect a soil moisture device', function()
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['subType'] = 'Soil Moisture',
+				['additionalDataData'] = { ['_nValue'] = 34 }
+			})
+
+			local res;
+
+			domoticz.openURL = function(url)
+				res = url;
+			end
+
+			assert.is_same(34, device.moisture)
+			device.updateSoilMoisture(12)
+			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=udevice&idx=1&nvalue=12', res)
+		end)
+
 
 		describe('Switch', function()
 
@@ -854,16 +988,18 @@ describe('device', function()
 					local switch = getDevice(domoticz, {
 						['type'] = 'Light/Switch',
 						['name'] = 's1',
-						['state'] = 'On',
+						['state'] = 'bb',
+						['rawData'] = { [1] = "10" },
 						['additionalRootData'] = { ['switchType'] = 'Selector'},
 						['additionalDataData'] = {
-							levelName = "aa|bb|cc"
+							levelNames = "Off|bb|cc"
 						}
 				})
-
-				assert.is_same({'aa', 'bb', 'cc'},  _.values(switch.levelNames))
+				assert.is_same(10, switch.level)
+				assert.is_same({'Off', 'bb', 'cc'},  _.values(switch.levelNames))
 
 			end)
+
 		end)
 
 		it('should detect a scene', function()

--- a/scripts/dzVents/runtime/tests/testDomoticz.lua
+++ b/scripts/dzVents/runtime/tests/testDomoticz.lua
@@ -230,7 +230,7 @@ describe('Domoticz', function()
 		end)
 	end)
 
-	describe('Interacting with the collections', function() --todo
+	describe('Interacting with the collections', function()
 
 		it('should give you a device when you need one', function()
 

--- a/scripts/dzVents/runtime/tests/testEventHelpers.lua
+++ b/scripts/dzVents/runtime/tests/testEventHelpers.lua
@@ -471,6 +471,7 @@ describe('event helpers', function()
 			local bindings = helpers.getEventBindings('security')
 
 			local modulesFound = _.pluck(bindings, {'name'})
+			modulesFound = values(modulesFound)
 
 			local scriptSecurity = _.find(bindings, function(mod)
 				return mod.name == 'script_security'

--- a/scripts/dzVents/runtime/tests/testEventHelpersStorage.lua
+++ b/scripts/dzVents/runtime/tests/testEventHelpersStorage.lua
@@ -659,7 +659,7 @@ describe('event helper storage', function()
 			assert.is_same(6, hs.avg(3,7))
 
 			hs = HS()
-			assert.is_same(nil, hs.avg(1,10))
+			assert.is_same(0, hs.avg(1,10))
 		end)
 
 		it('should return average over a time period', function()
@@ -668,7 +668,7 @@ describe('event helper storage', function()
 			assert.is_same(9, avg) -- 10,9,8
 
 			hs = HS()
-			assert.is_same(nil, hs.avgSince('0:10:1'))
+			assert.is_same(0, hs.avgSince('0:10:1'))
 		end)
 
 		it('should return the minimum value of a range', function()
@@ -768,6 +768,12 @@ describe('event helper storage', function()
 			assert.is_same(34,sum) -- 10,9,8,7
 		end)
 
+		it('should return 0 as the sum over an empty set', function()
+			local hs = HS()
+			local sum = hs.sum()
+			assert.is_same(0, sum)
+		end)
+
 		it('should return the sum over a period', function()
 			data[5].data = 20
 			local hs = HS(data)
@@ -775,7 +781,7 @@ describe('event helper storage', function()
 			assert.is_same(54,sum)
 
 			hs = HS()
-			assert.is_nil(hs.sumSince('0:0:1'))
+			assert.is_same(0, hs.sumSince('0:0:1'))
 		end)
 
 		it('should smooth an item with its neighbours', function()

--- a/scripts/dzVents/runtime/tests/testScriptdzVentsDispatching.lua
+++ b/scripts/dzVents/runtime/tests/testScriptdzVentsDispatching.lua
@@ -116,10 +116,6 @@ describe('Event dispatching', function()
 		package.loaded['dzVents'] = nil
 	end)
 
-	teardown(function()
-
-	end)
-
 	it('should dispatch device events', function()
 		_G.commandArray = {}
 		_G.globalvariables['script_reason'] = 'device'
@@ -151,7 +147,7 @@ describe('Event dispatching', function()
 		_G.globalvariables['script_reason'] = 'uservariable'
 		local main = require('dzVents')
 		assert.is_same({
-			{ ['OpenURL'] = 'http://127.0.0.1:8080/json.htm?type=command&param=updateuservariable&vname=myVar1&vtype=integer&vvalue=10' }
+			{ ['OpenURL'] = 'http://127.0.0.1:8080/json.htm?type=command&param=updateuservariable&vname=myVar1&vtype=0&vvalue=10&idx=1' }
 		}, main)
 	end)
 

--- a/scripts/dzVents/runtime/tests/testVariable.lua
+++ b/scripts/dzVents/runtime/tests/testVariable.lua
@@ -40,6 +40,10 @@ describe('variables', function()
 
 	end)
 
+	before_each(function()
+		commandArray = {}
+	end)
+
 	teardown(function()
 		Variable = nil
 	end)
@@ -62,11 +66,40 @@ describe('variables', function()
 		assert.is_same('number', type(var.nValue))
 	end)
 
-	it('should set a new value', function()
+
+	it('should set a new float value', function()
 		local var = Variable(domoticz, testData.domoticzData[yVar])
-		var.set('dzVents rocks')
+		var.set(12.5)
 		assert.is_same(1, _.size(commandArray))
-		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=y&vtype=float&vvalue=dzVents rocks' }, commandArray[1])
+		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=y&vtype=1&vvalue=12.5&idx=2' }, commandArray[1])
+	end)
+
+	it('should set a new integer value', function()
+		local var = Variable(domoticz, testData.domoticzData[xVar])
+		var.set(12)
+		assert.is_same(1, _.size(commandArray))
+		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=x&vtype=0&vvalue=12&idx=1' }, commandArray[1])
+	end)
+
+	it('should set a new string value', function()
+		local var = Variable(domoticz, testData.domoticzData[zVar])
+		var.set('dzVents')
+		assert.is_same(1, _.size(commandArray))
+		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=z&vtype=2&vvalue=dzVents&idx=3' }, commandArray[1])
+	end)
+
+	it('should set a new date value', function()
+		local var = Variable(domoticz, testData.domoticzData[aVar])
+		var.set('12/12/2012')
+		assert.is_same(1, _.size(commandArray))
+		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=a&vtype=3&vvalue=12/12/2012&idx=4' }, commandArray[1])
+	end)
+
+	it('should set a new time value', function()
+		local var = Variable(domoticz, testData.domoticzData[bVar])
+		var.set('12:34')
+		assert.is_same(1, _.size(commandArray))
+		assert.is_same({ ['OpenURL'] = 'url/json.htm?type=command&param=updateuservariable&vname=b&vtype=4&vvalue=12:34&idx=5' }, commandArray[1])
 	end)
 
 	it('should not fail when trying to cast a string', function()

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1399
+# ref 1400
 
 CACHE:
 # CSS

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1054,7 +1054,7 @@
 							</tr>
 							</table>
 							<br>
-							<h2><span data-i18n="dzVents">dzVents</span>:</h2>
+							<h2><span data-i18n="dzVents">dzVents (2.1.0)</span>:</h2>
 							<table class="display" id="dzventstable" border="0" cellpadding="0" cellspacing="0">
 							<tr>
 								<td align="right" style="width:90px"><span data-i18n="Disabled"></span>:</td>


### PR DESCRIPTION
Don't merge just yet!! Wanna check the build-bots first and do some more testing first. 

2.1.0:
- Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
 - Added support for Ampère 1 and 3-phase devices
 - Added support for leaf wetness devices
 - Added support for scale weight devices
 - Added support for soil moisture devices
 - Added support for sound level devices
 - Added support for visibility devices
 - Added support for waterflow devices
 - Added missing color attribute to alert sensor devices
 - Added updateEnergy() to electric usage devices
 - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
 - Added toCelsius() helper method to domoticz object as the various update temperature methods all need celsius.
 - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
 - Added integration tests for full round-trip Domoticz > dzVents > Domoticz > dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
 - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
 - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
 - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
 - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.