### PR TITLE
Fix elemental theme's custom.css for drop down type selector switches

### DIFF
--- a/www/styles/elemental/custom.css
+++ b/www/styles/elemental/custom.css
@@ -326,7 +326,6 @@ body table#mobileitem tr td:first-child{
 
 .selectorlevels .ui-selectmenu-button.ui-widget {
 	font-size: 1em;
-	width: 200px !important;
 	height: 22px;
 }
 


### PR DESCRIPTION
Drop down list of a selector switch will align itself below the block in smaller screens if the width is forced to 200px. There does not seem to be any similar setting in other themes.