### PR TITLE
TCPServer: Prevent log flooding for same IP-address

### DIFF
--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -52,7 +52,7 @@ void CTCPServerInt::handle_stop()
 	stopAllClients();
 }
 
-bool CTCPServerInt::logFirstTime(const std::string &ip_string)
+bool CTCPServerInt::IsUserHereFirstTime(const std::string &ip_string)
 {
 	//
 	//	Log same IP-address first time and then once per day
@@ -102,7 +102,7 @@ void CTCPServerInt::handleAccept(const boost::system::error_code& error)
 
 		new_connection_->m_endpoint=s;
 		
-		if (logFirstTime(s))
+		if (IsUserHereFirstTime(s))
 		{
 			_log.Log(LOG_STATUS, "Incoming Domoticz connection from: %s", s.c_str());
 		}

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -33,7 +33,6 @@ void CTCPServerInt::start()
 	// asynchronous operation outstanding: the asynchronous accept call waiting
 	// for new incoming connections.
 	io_service_.run();
-	m_incoming_domoticz_history.clear();
 }
 
 void CTCPServerInt::stop()

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -65,15 +65,15 @@ bool CTCPServerInt::IsUserHereFirstTime(const std::string &ip_string)
 		log_info li = m_incoming_domoticz_history[i];
 		double elapsed_seconds = now - li.time;
 
-		if (ip_string.compare(li.string) == 0)
+		if (elapsed_seconds > SECONDS_PER_DAY)
 		{
-			if (elapsed_seconds < SECONDS_PER_DAY)
+			m_incoming_domoticz_history.erase(m_incoming_domoticz_history.begin()+i);
+		}
+		else
+		{
+			if (ip_string.compare(li.string) == 0)
 			{
-				log_this = false;	
-			}
-			else
-			{
-				m_incoming_domoticz_history.erase(m_incoming_domoticz_history.begin()+i);
+				log_this = false;
 			}
 		}
 	}

--- a/tcpserver/TCPServer.h
+++ b/tcpserver/TCPServer.h
@@ -91,7 +91,7 @@ private:
 
 	CTCPClient_ptr new_connection_;
 
-	bool logFirstTime(const std::string &ip_string);
+	bool IsUserHereFirstTime(const std::string &ip_string);
 	std::vector<log_info> m_incoming_domoticz_history;
 };
 

--- a/tcpserver/TCPServer.h
+++ b/tcpserver/TCPServer.h
@@ -20,7 +20,7 @@ struct _tRemoteShareUser
 
 #define RemoteMessage_id_Low 0xE2
 #define RemoteMessage_id_High 0x2E
-
+#define SECONDS_PER_DAY 60*60*24
 
 struct _tRemoteMessage
 {
@@ -28,6 +28,12 @@ struct _tRemoteMessage
 	uint8_t ID_High;
 	int		Original_Hardware_ID;
 	//data
+};
+
+struct log_info
+{
+	time_t		time;
+	std::string string;
 };
 
 class CTCPServerIntBase
@@ -84,6 +90,9 @@ private:
 	boost::asio::ip::tcp::acceptor acceptor_;
 
 	CTCPClient_ptr new_connection_;
+
+	bool logFirstTime(const std::string &ip_string);
+	std::vector<log_info> m_incoming_domoticz_history;
 };
 
 #ifndef NOCLOUD


### PR DESCRIPTION
TCPServer logging adjustment:

To prevent logfile flooding, when domoticz reconnects for same IP-address occur, this code change will make sure that:
1. The connect for a given IP address is always logged on first the time connect.
2. After that logging connects, for the same IP-address for next 24 hours, are skipped.
3. The first connect that occurs after 24 hours of silence will be logged again.
4. When the user has debug level is set to LOG_TRACE logging will as before, i.e. unfiltered. 

NOTE:
In the future we may implement this as a logging helper class in case the functionality is needed more often in other modules. In that case that class will need more control, like duration settings (instead of a fixed 24 hours setting), a summary report creation and more. For now I like to keep it simple and just do exactly what we need right now.  

See #PR1695. That PR was closed while working on this one.