### PR TITLE
EventSystem update single instances of uservars / scenesgroups

### DIFF
--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -109,9 +109,11 @@ public:
 	void WWWGetItemStates(std::vector<_tDeviceStatus> &iStates);
 	void SetEnabled(const bool bEnabled);
 	void GetCurrentStates();
+	void GetCurrentUserVariables();
+	void UpdateScenesGroups(const uint64_t ulDevID, const int nValue, const std::string &lastUpdate);
+	void UpdateUserVariable(const uint64_t ulDevID, const std::string &varName, const std::string varValue, const int varType, const std::string &lastUpdate);
 	void ExportDomoticzDataToLua(lua_State *lua_state, uint64_t deviceID, uint64_t varID);
 	void ExportDeviceStatesToLua(lua_State *lua_state);
-
     bool PythonScheduleEvent(std::string ID, const std::string &Action, const std::string &eventName);
 
 private:
@@ -132,7 +134,6 @@ private:
 	void Do_Work();
 	void ProcessMinute();
 	void GetCurrentMeasurementStates();
-	void GetCurrentUserVariables();
 	void GetCurrentScenesGroups();
 	std::string UpdateSingleState(const uint64_t ulDevID, const std::string &devname, const int nValue, const char* sValue, const unsigned char devType, const unsigned char subType, const _eSwitchType switchType, const std::string &lastUpdate, const unsigned char lastLevel, const std::map<std::string, std::string> & options);
 	void EvaluateEvent(const std::string &reason);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12384,6 +12384,13 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 
 	_log.Log(LOG_NORM, "Activating Scene/Group: [%s]", Name.c_str());
 
+	if (!m_sql.m_bDisableEventSystem)
+	{
+		std::stringstream ssLastUpdate;
+		ssLastUpdate << (ltime.tm_year + 1900) << "-" << (ltime.tm_mon + 1) << "-" << ltime.tm_mday << " " << ltime.tm_hour << ":" << ltime.tm_min << ":" << ltime.tm_sec;
+		m_eventsystem.UpdateScenesGroups(idx, nValue, ssLastUpdate.str());
+	}
+
 	//now switch all attached devices, and only the onces that do not trigger a scene
 	result = m_sql.safe_query(
 		"SELECT DeviceRowID, Cmd, Level, Hue, OnDelay, OffDelay FROM SceneDevices WHERE (SceneRowID == %" PRIu64 ") ORDER BY [Order] ASC", idx);
@@ -12489,7 +12496,6 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 			sleep_milliseconds(50);
 		}
 	}
-
 	return true;
 }
 


### PR DESCRIPTION
Only update single instances in uservariables / scenesgroups instead of reloading complete tables every device update. Scenesgroups were only updated once a minute, now on switch scene to make sure it's up-to-date.