### PR TITLE
HardwareMonitor fix for busybox df command

### DIFF
--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -118,7 +118,7 @@ bool CHardwareMonitor::StartHardware()
 #if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
 	// Busybox df doesn't support -x parameter
 	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn("df -x nfs -x tmpfs -x devtmpfs 2> /dev/null", &returncode);
+	std::vector<std::string> ret = ExecuteCommandAndReturn("df -x nfs -x tmpfs -x devtmpfs 2> /dev/null", returncode);
 	returncode == 0 ?
 		m_dfcommand = "df -x nfs -x tmpfs -x devtmpfs" :
 		m_dfcommand = "df";
@@ -236,7 +236,7 @@ void CHardwareMonitor::SendFanSensor(const int Idx, const int FanSpeed, const st
 void CHardwareMonitor::GetInternalTemperature()
 {
 	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalTemperatureCommand, &returncode);
+	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalTemperatureCommand, returncode);
 	if (ret.empty())
 		return;
 	std::string tmpline = ret[0];
@@ -262,7 +262,7 @@ void CHardwareMonitor::GetInternalTemperature()
 void CHardwareMonitor::GetInternalVoltage()
 {
 	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalVoltageCommand, &returncode);
+	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalVoltageCommand, returncode);
 	if (ret.empty())
 		return;
 	std::string tmpline = ret[0];
@@ -285,7 +285,7 @@ void CHardwareMonitor::GetInternalVoltage()
 void CHardwareMonitor::GetInternalCurrent()
 {
 	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalCurrentCommand, &returncode);
+	std::vector<std::string> ret = ExecuteCommandAndReturn(szInternalCurrentCommand, returncode);
 	if (ret.empty())
 		return;
 	std::string tmpline = ret[0];
@@ -750,7 +750,7 @@ void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string &qType)
 		std::map<std::string, _tDUsageStruct> _disks;
 		std::map<std::string, std::string> _dmounts_;
 		int returncode = 0;
-		std::vector<std::string> _rlines=ExecuteCommandAndReturn(m_dfcommand, &returncode);
+		std::vector<std::string> _rlines=ExecuteCommandAndReturn(m_dfcommand, returncode);
 		if (!_rlines.empty())
 		{
 			std::vector<std::string>::const_iterator ittDF;

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -41,6 +41,7 @@ private:
 	void FetchUnixDisk();
 	long long m_lastloadcpu;
 	int m_totcpu;
+	std::string m_dfcommand;
 #endif
 };
 

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -478,7 +478,7 @@ double ConvertTemperature(const double tValue, const unsigned char tSign)
 	return RoundDouble(ConvertToFahrenheit(tValue),1);
 }
 
-std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int *returncode)
+std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode)
 {
 	std::vector<std::string> ret;
 
@@ -502,9 +502,9 @@ std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, i
 			}
 			/* close */
 #ifdef WIN32
-			*returncode = _pclose(fp);
+			returncode = _pclose(fp);
 #else
-			*returncode = pclose(fp);
+			returncode = pclose(fp);
 #endif
 		}
 	}

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -478,7 +478,7 @@ double ConvertTemperature(const double tValue, const unsigned char tSign)
 	return RoundDouble(ConvertToFahrenheit(tValue),1);
 }
 
-std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand)
+std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int *returncode)
 {
 	std::vector<std::string> ret;
 
@@ -502,9 +502,9 @@ std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand)
 			}
 			/* close */
 #ifdef WIN32
-			_pclose(fp);
+			*returncode = _pclose(fp);
 #else
-			pclose(fp);
+			*returncode = pclose(fp);
 #endif
 		}
 	}

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -30,7 +30,7 @@ double ConvertToCelsius(const double Fahrenheit);
 double ConvertToFahrenheit(const double Celsius);
 double ConvertTemperature(const double tValue, const unsigned char tSign);
 
-std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand);
+std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int *returncode);
 
 void DateAsciiTotmTime (std::string &sLastUpdate , struct tm &LastUpdateTime  );
 void AsciiTime (struct tm &ltime , char * pLastUpdate );

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -30,7 +30,7 @@ double ConvertToCelsius(const double Fahrenheit);
 double ConvertToFahrenheit(const double Celsius);
 double ConvertTemperature(const double tValue, const unsigned char tSign);
 
-std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int *returncode);
+std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode);
 
 void DateAsciiTotmTime (std::string &sLastUpdate , struct tm &LastUpdateTime  );
 void AsciiTime (struct tm &ltime , char * pLastUpdate );


### PR DESCRIPTION
Extended function ExecuteCommandAndReturn with returncode to determine if the command errored. Busybox doesn't seem to support extra parameters, so this should fix issues on busybox based installations.