### PR TITLE
Sysfs GPIO: Max pin number is now 1023 for Odroid C2 sysfs support

### DIFF
--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -149,7 +149,7 @@ master occurs once, 30 seconds after startup.
 #define GPIO_EDGE_BOTH		3
 #define GPIO_EDGE_UNKNOWN	-1
 #define GPIO_PIN_MIN		0
-#define GPIO_PIN_MAX		31
+#define GPIO_PIN_MAX		1023
 #define GPIO_MAX_VALUE_SIZE	16
 #define GPIO_MAX_PATH		64
 #define GPIO_PATH			"/sys/class/gpio/gpio"


### PR DESCRIPTION
On the forum it was reported by aaron that "Odroid C2 sysfs gpio"  is using sysfs gpio pin numbers higher then 31 (the raspberry 3B case). Because of this we did not detect these pins for use within domoticz. To fix this problem the number has now been increased to support pin numbers up to 1023. See forum  http://www.domoticz.com/forum/viewtopic.php?f=6&t=18323&p=142289#p142289