### PR TITLE
Blockly memory leak fix

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1544,6 +1544,8 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 lua_State *CEventSystem::CreateBlocklyLuaState()
 {
 	lua_State *lua_state = luaL_newstate();
+	if (lua_state == NULL)
+		return NULL;
 
 	// load Lua libraries
 	static const luaL_Reg lualibs[] =

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1544,10 +1544,6 @@ void CEventSystem::EvaluateEvent(const std::string &reason, const uint64_t Devic
 lua_State *CEventSystem::CreateBlocklyLuaState()
 {
 	lua_State *lua_state = luaL_newstate();
-	if (lua_state == NULL)
-		return NULL;
-
-	lua_state = luaL_newstate();
 
 	// load Lua libraries
 	static const luaL_Reg lualibs[] =


### PR DESCRIPTION
This should fix Blockly memory leak as reported here: https://www.domoticz.com/forum/viewtopic.php?f=6&t=16367

Could reproduce it with Valgrind, with this change there is no longer leakage reported.
Did a little reformatting to make reading easier.