### PR TITLE
EventSystem fix use absolute instead of relative paths

### DIFF
--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -112,9 +112,8 @@ public:
 	void GetCurrentUserVariables();
 	void UpdateScenesGroups(const uint64_t ulDevID, const int nValue, const std::string &lastUpdate);
 	void UpdateUserVariable(const uint64_t ulDevID, const std::string &varName, const std::string varValue, const int varType, const std::string &lastUpdate);
-	void ExportDomoticzDataToLua(lua_State *lua_state, uint64_t deviceID, uint64_t varID);
 	void ExportDeviceStatesToLua(lua_State *lua_state);
-    bool PythonScheduleEvent(std::string ID, const std::string &Action, const std::string &eventName);
+	bool PythonScheduleEvent(std::string ID, const std::string &Action, const std::string &eventName);
 
 private:
 	//lua_State	*m_pLUA;
@@ -129,6 +128,8 @@ private:
 	volatile bool m_stoprequested;
 	boost::shared_ptr<boost::thread> m_thread;
 	int m_SecStatus;
+	std::string m_lua_Dir;
+	std::string m_dzv_Dir;
 
 	//our thread
 	void Do_Work();
@@ -143,12 +144,14 @@ private:
 	bool parseBlocklyActions(const std::string &Actions, const std::string &eventName, const uint64_t eventID);
 	std::string ProcessVariableArgument(const std::string &Argument);
 #ifdef ENABLE_PYTHON
+	std::string m_python_Dir;
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString, const uint64_t varId);
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString);
 	void EvaluatePython(const std::string &reason, const std::string &filename, const std::string &PyString, const uint64_t DeviceID, const std::string &devname, const int nValue, const char* sValue, std::string nValueWording, const uint64_t varId);
 #endif
 	void EvaluateLua(const std::string &reason, const std::string &filename, const std::string &LuaString, const uint64_t varId);
 	void EvaluateLua(const std::string &reason, const std::string &filename, const std::string &LuaString);
+	void ExportDomoticzDataToLua(lua_State *lua_state, uint64_t deviceID, uint64_t varID);
 	void EvaluateLua(const std::string &reason, const std::string &filename, const std::string &LuaString, const uint64_t DeviceID, const std::string &devname, const int nValue, const char* sValue, std::string nValueWording, const uint64_t varId);
 	void luaThread(lua_State *lua_state, const std::string &filename);
 	static void luaStop(lua_State *L, lua_Debug *ar);


### PR DESCRIPTION
szUserDataFolder is initiated after EventSystem's global variables, making the paths relative instead of absolute (that seems to work fine on most installations, but not all). See comment here: https://github.com/domoticz/domoticz/commit/74b59052883611b869e17b482c7fb95bbcdafad3#commitcomment-23273867

