### PR TITLE
Reworked GCM data to notification message

### DIFF
--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -50,8 +50,8 @@ bool CNotificationGCM::SendMessageImplementation(
 		sstr << "\"" << sd[0] << "\"";
 		ii++;
 	}
-	sstr << "], \"data\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
-	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\" } }";
+	sstr << "], \"notification\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
+	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\", \"content_available\": true } }";
 	std::string szPostdata = sstr.str();
 
 	std::vector<std::string> ExtraHeaders;


### PR DESCRIPTION
Reworked GCM data to notification message

- Data message won't display a notification on your device, should use a notification message for that instead.
- For receiving push notifications on the background on should include content_available = true inside the notification key.

new gcm json message body is going to be:

```

{
  "registration_ids" : ["senderid"],
  "notification" : {
    "subject" : "test subject",
    "body" : "test body",
    "extradata" : "test data",
    "deviceid" : "1",
    "message" : "test message",
    "priority" : "high",
    "content_available" : true,
  },
}

```
