### PR TITLE
Add data and notification info

### DIFF
--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -50,8 +50,10 @@ bool CNotificationGCM::SendMessageImplementation(
 		sstr << "\"" << sd[0] << "\"";
 		ii++;
 	}
-	sstr << "], \"notification\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
-	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\", \"content_available\": true } }";
+
+	sstr << "], \"data\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
+	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\" } , \"notification\" : { \"subject\": \""<< Subject << "\", \"body\": \""<< Text << "\", \"extradata\": \""<< ExtraData << "\", \"priority\": \""<< boost::lexical_cast<std::string>(Priority) << "\", ";
+	sstr << "\"deviceid\": \""<< boost::lexical_cast<std::string>(Idx) << "\", \"message\": \"" << Subject << "\", \"content_available\": true }  }";
 	std::string szPostdata = sstr.str();
 
 	std::vector<std::string> ExtraHeaders;


### PR DESCRIPTION
For Android we need the 'data' json object, but iOS only receives a notification when it contains a 'notification' json object. 

You need to send "data" messages to the client and then in your service, you will then always receive the callback, whether the app is in the foreground or background.

Read more here: https://firebase.google.com/docs/notifications/android/console-audience

So im changing the body to:

```

{
  "registration_ids" : ["senderid"],  
  "data" : {
    "subject" : "test subject",
    "body" : "test body",
    "extradata" : "test data",
    "deviceid" : "1",
    "message" : "test message",
    "priority" : "high",
  },
  "notification" : {
    "subject" : "test subject",
    "body" : "test body",
    "extradata" : "test data",
    "deviceid" : "1",
    "message" : "test message",
    "priority" : "high",
    "content_available" : true,
  },
}

```