### PR TITLE
Notification Last update SystemUptime function / check

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -22,6 +22,17 @@
 #include "RFXtrx.h"
 #include "../hardware/hardwaretypes.h"
 
+// Includes for SystemUptime()
+#if defined(__linux__) || defined(__linux) || defined(linux)
+#include <sys/sysinfo.h>
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+#include <time.h>
+#include <errno.h>
+#include <sys/sysctl.h>
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+#include <time.h>
+#endif
+
 void StringSplit(std::string str, const std::string &delim, std::vector<std::string> &results)
 {
 	results.clear();
@@ -898,4 +909,30 @@ bool IsArgumentSecure(const std::string &arg)
 		ii++;
 	}
 	return true;
+}
+
+uint32_t SystemUptime()
+{
+#if defined(WIN32)
+	return GetTickCount() / 1000u;
+#elif defined(__linux__) || defined(__linux) || defined(linux)
+	struct sysinfo info;
+	if (sysinfo(&info) != 0)
+		return -1;
+	return info.uptime;
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+	struct timeval boottime;
+	std::size_t len = sizeof(boottime);
+	int mib[2] = { CTL_KERN, KERN_BOOTTIME };
+	if (sysctl(mib, 2, &boottime, &len, NULL, 0) < 0)
+		return -1;
+	return time(NULL) - boottime.tv_sec;
+#elif (defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)) && defined(CLOCK_UPTIME)
+	struct timespec ts;
+	if (clock_gettime(CLOCK_UPTIME, &ts) != 0)
+		return -1;
+	return ts.tv_sec;
+#else
+	return 0;
+#endif
 }

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -64,4 +64,5 @@ int getclock(struct timeval *tv);
 int timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y);
 
 bool IsArgumentSecure(const std::string &arg);
+uint32_t SystemUptime();
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -1001,7 +1001,7 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 					if (bSendNotification && !bStartTime && (!bRecoveryMessage || itt2->SendAlways))
 					{
 						if (SystemUptime() < SensorTimeOut * 60 && (!bRecoveryMessage || itt2->SendAlways))
-							return;
+							continue;
 						std::vector<std::vector<std::string> > result;
 						result = m_sql.safe_query("SELECT SwitchType FROM DeviceStatus WHERE (ID=%" PRIu64 ")", Idx);
 						if (result.size() == 0)
@@ -1026,7 +1026,7 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 						CustomRecoveryMessage(itt2->ID, clearstr, true);
 					}
 					else
-						return;
+						continue;
 
 					if (bCustomMessage && !bRecoveryMessage)
 						msg = ParseCustomMessage(custommsg, itt2->DeviceName, "");

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -993,13 +993,15 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 					uint64_t Idx = itt->first;
 					int SensorTimeOut = atoi(splitresults[2].c_str());  // minutes
 					int diff = (int)round(difftime(btime, itt2->LastUpdate));
-					bool bStartTime = (difftime(btime, m_StartTime) < SensorTimeOut*60);
-					bool bSendNotification = ApplyRule(splitresults[1], (diff == SensorTimeOut*60), (diff < SensorTimeOut*60));
+					bool bStartTime = (difftime(btime, m_StartTime) < SensorTimeOut * 60);
+					bool bSendNotification = ApplyRule(splitresults[1], (diff == SensorTimeOut * 60), (diff < SensorTimeOut * 60));
 					bool bCustomMessage = false;
 					bCustomMessage = CustomRecoveryMessage(itt2->ID, custommsg, false);
 
 					if (bSendNotification && !bStartTime && (!bRecoveryMessage || itt2->SendAlways))
 					{
+						if (SystemUptime() < SensorTimeOut * 60 && (!bRecoveryMessage || itt2->SendAlways))
+							return;
 						std::vector<std::vector<std::string> > result;
 						result = m_sql.safe_query("SELECT SwitchType FROM DeviceStatus WHERE (ID=%" PRIu64 ")", Idx);
 						if (result.size() == 0)
@@ -1019,25 +1021,20 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 					}
 					else if (!bSendNotification && bRecoveryMessage)
 					{
-						bSendNotification = true;
 						msg = recoverymsg;
 						std::string clearstr = "!";
 						CustomRecoveryMessage(itt2->ID, clearstr, true);
 					}
 					else
+						return;
+
+					if (bCustomMessage && !bRecoveryMessage)
+						msg = ParseCustomMessage(custommsg, itt2->DeviceName, "");
+					SendMessageEx(Idx, itt2->DeviceName, itt2->ActiveSystems, msg, msg, szExtraData, itt2->Priority, std::string(""), true);
+					if (!bRecoveryMessage)
 					{
-						bSendNotification = false;
-					}
-					if (bSendNotification)
-					{
-						if (bCustomMessage && !bRecoveryMessage)
-							msg = ParseCustomMessage(custommsg, itt2->DeviceName, "");
-						SendMessageEx(Idx, itt2->DeviceName, itt2->ActiveSystems, msg, msg, szExtraData, itt2->Priority, std::string(""), true);
-						if (!bRecoveryMessage)
-						{
-							TouchNotification(itt2->ID);
-							CustomRecoveryMessage(itt2->ID, msg, true);
-						}
+						TouchNotification(itt2->ID);
+						CustomRecoveryMessage(itt2->ID, msg, true);
 					}
 				}
 			}


### PR DESCRIPTION
When my Pi has been down for a while, it will still send a lot of notifications after startup, because of Domoticz getting the old system time before NTP syncs the system time (so m_StartTime is much farther in the past). I've added a SystemUptime function, which I also intent to use for Lua / dzVents scripting later on, for which reason I placed it in the Helper.cpp.

Now the notification lastupdate function first checks if system uptime is less than sensor timeout and returns if true.