### PR TITLE
Global TimeToString function

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -526,12 +526,12 @@ std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, i
 	return ret;
 }
 
-std::string TimeToString(time_t ltime, _eTimeFormat format)
+std::string TimeToString(time_t *ltime, _eTimeFormat format)
 {
 	struct tm timeinfo;
 	struct timeval tv;
 	std::stringstream sstr;
-	if (!ltime) // current time
+	if (ltime == NULL) // current time
 	{
 #ifdef CLOCK_REALTIME
 		struct timespec ts;
@@ -551,7 +551,7 @@ std::string TimeToString(time_t ltime, _eTimeFormat format)
 #endif
 	}
 	else
-		localtime_r(&ltime, &timeinfo);
+		localtime_r(&(*ltime), &timeinfo);
 
 	if (format > TF_Time)
 	{

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -526,7 +526,7 @@ std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, i
 	return ret;
 }
 
-std::string TimeToString(time_t *ltime, _eTimeFormat format)
+std::string TimeToString(const time_t *ltime, const _eTimeFormat format)
 {
 	struct tm timeinfo;
 	struct timeval tv;
@@ -568,7 +568,7 @@ std::string TimeToString(time_t *ltime, _eTimeFormat format)
 		<< std::setw(2) << std::setfill('0') << timeinfo.tm_sec;
 	}
 
-	if (format > TF_DateTime && !ltime)
+	if (format > TF_DateTime && ltime == NULL)
 		sstr << "." << std::setw(3) << std::setfill('0') << ((int)tv.tv_usec / 1000);
 
 	return sstr.str();

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -562,7 +562,8 @@ std::string TimeToString(time_t ltime, _eTimeFormat format)
 
 	if (format != TF_Date)
 	{
-		sstr << std::setw(2) << std::setfill('0') << timeinfo.tm_hour << ":"
+		sstr
+		<< std::setw(2) << std::setfill('0') << timeinfo.tm_hour << ":"
 		<< std::setw(2) << std::setfill('0') << timeinfo.tm_min << ":"
 		<< std::setw(2) << std::setfill('0') << timeinfo.tm_sec;
 	}

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -526,50 +526,53 @@ std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, i
 	return ret;
 }
 
-//convert date string 10/12/2014 10:45:58 en  struct tm
-void DateAsciiTotmTime (std::string &sTime , struct tm &tmTime  )
+std::string TimeToString(time_t ltime, _eTimeFormat format)
 {
-		tmTime.tm_isdst=0; //dayly saving time
-		tmTime.tm_year=atoi(sTime.substr(0,4).c_str())-1900;
-		tmTime.tm_mon=atoi(sTime.substr(5,2).c_str())-1;
-		tmTime.tm_mday=atoi(sTime.substr(8,2).c_str());
-		tmTime.tm_hour=atoi(sTime.substr(11,2).c_str());
-		tmTime.tm_min=atoi(sTime.substr(14,2).c_str());
-		tmTime.tm_sec=atoi(sTime.substr(17,2).c_str());
+	struct tm timeinfo;
+	struct timeval tv;
+	std::stringstream sstr;
+	if (!ltime) // current time
+	{
+#ifdef CLOCK_REALTIME
+		struct timespec ts;
+		if (!clock_gettime(CLOCK_REALTIME, &ts))
+		{
+			tv.tv_sec = ts.tv_sec;
+			tv.tv_usec = ts.tv_nsec / 1000;
+		}
+		else
+#endif
+			gettimeofday(&tv, NULL);
+#ifdef WIN32
+		time_t tv_sec = tv.tv_sec;
+		localtime_r(&tv_sec, &timeinfo);
+#else
+		localtime_r(&tv.tv_sec, &timeinfo);
+#endif
+	}
+	else
+		localtime_r(&ltime, &timeinfo);
 
+	if (format > TF_Time)
+	{
+		sstr << (timeinfo.tm_year + 1900) << "-"
+		<< std::setw(2)	<< std::setfill('0') << (timeinfo.tm_mon + 1) << "-"
+		<< std::setw(2) << std::setfill('0') << timeinfo.tm_mday << " ";
+	}
 
+	if (format != TF_Date)
+	{
+		sstr << std::setw(2) << std::setfill('0') << timeinfo.tm_hour << ":"
+		<< std::setw(2) << std::setfill('0') << timeinfo.tm_min << ":"
+		<< std::setw(2) << std::setfill('0') << timeinfo.tm_sec;
+	}
+
+	if (format > TF_DateTime && !ltime)
+		sstr << "." << std::setw(3) << std::setfill('0') << ((int)tv.tv_usec / 1000);
+
+	return sstr.str();
 }
-//convert struct tm time to char
-void AsciiTime (struct tm &ltime , char * pTime )
-{
-		sprintf(pTime, "%04d-%02d-%02d %02d:%02d:%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);
-}
 
-std::string  GetCurrentAsciiTime ()
-{
-	    time_t now = time(0)+1;
-		struct tm ltime;
-		localtime_r(&now, &ltime);
-		char pTime[40];
-		AsciiTime (ltime ,  pTime );
-		return pTime ;
-}
-
-void AsciiTime ( time_t DateStart, char * DateStr )
-{
-	struct tm ltime;
-	localtime_r(&DateStart, &ltime);
-	AsciiTime (ltime ,  DateStr );
-
-}
-
-time_t DateAsciiToTime_t ( std::string & DateStr )
-{
-	struct tm tmTime ;
-	DateAsciiTotmTime (DateStr , tmTime  );
-	return mktime(&tmTime);
-
-}
 std::string GenerateMD5Hash(const std::string &InputString, const std::string &Salt)
 {
 	std::string cstring = InputString + Salt;

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -40,7 +40,7 @@ double ConvertTemperature(const double tValue, const unsigned char tSign);
 
 std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode);
 
-std::string TimeToString(time_t ltime, _eTimeFormat format);
+std::string TimeToString(time_t *ltime, _eTimeFormat format);
 std::string GenerateMD5Hash(const std::string &InputString, const std::string &Salt="");
 
 void hue2rgb(const float hue, int &outR, int &outG, int &outB, const double maxValue = 100.0);

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -1,6 +1,14 @@
 
 #pragma once
 
+enum _eTimeFormat
+{
+	TF_Time = 0,	// 0
+	TF_Date,		// 1
+	TF_DateTime,	// 2
+	TF_DateTimeMs	// 3
+};
+
 void StringSplit(std::string str, const std::string &delim, std::vector<std::string> &results);
 void stdreplace(
 	std::string &inoutstring,
@@ -32,11 +40,7 @@ double ConvertTemperature(const double tValue, const unsigned char tSign);
 
 std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode);
 
-void DateAsciiTotmTime (std::string &sLastUpdate , struct tm &LastUpdateTime  );
-void AsciiTime (struct tm &ltime , char * pLastUpdate );
-std::string  GetCurrentAsciiTime ();
-void AsciiTime ( time_t DateStart, char * DateStr );
-time_t DateAsciiToTime_t ( std::string & DateStr );
+std::string TimeToString(time_t ltime, _eTimeFormat format);
 std::string GenerateMD5Hash(const std::string &InputString, const std::string &Salt="");
 
 void hue2rgb(const float hue, int &outR, int &outG, int &outB, const double maxValue = 100.0);

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -40,7 +40,7 @@ double ConvertTemperature(const double tValue, const unsigned char tSign);
 
 std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode);
 
-std::string TimeToString(time_t *ltime, _eTimeFormat format);
+std::string TimeToString(const time_t *ltime, const _eTimeFormat format);
 std::string GenerateMD5Hash(const std::string &InputString, const std::string &Salt="");
 
 void hue2rgb(const float hue, int &outR, int &outG, int &outB, const double maxValue = 100.0);

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -118,24 +118,7 @@ void CLogger::Log(const _eLogLevel level, const char* logline, ...)
 	std::stringstream sstr;
 
 	if (m_bEnableLogTimestamps)
-	{
-		char szDate[100];
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		struct tm timeinfo;
-#ifdef WIN32
-		//Thanks to the winsock header file
-		time_t tv_sec = tv.tv_sec;
-		localtime_r(&tv_sec, &timeinfo);
-#else
-		localtime_r(&tv.tv_sec, &timeinfo);
-#endif
-		// create a time stamp string for the log message
-		snprintf(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d ",
-			timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
-			timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, (int)tv.tv_usec / 1000);
-		sstr << szDate << " ";
-	}
+		sstr << TimeToString(0, TF_DateTimeMs) << "  ";
 
 	if (m_bEnableLogThreadIDs)
 	{
@@ -356,7 +339,7 @@ void CLogger::setLogVerboseLevel(int LogLevel)
 		m_mainworker.SetVerboseLevel(EVBL_None);
 }
 
-//set the DEBUG option in order to allow LOG_TRACE log level 
+//set the DEBUG option in order to allow LOG_TRACE log level
 void CLogger::SetLogDebug(bool debug)
 {
 	m_debug = debug;

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -118,7 +118,7 @@ void CLogger::Log(const _eLogLevel level, const char* logline, ...)
 	std::stringstream sstr;
 
 	if (m_bEnableLogTimestamps)
-		sstr << TimeToString(0, TF_DateTimeMs) << "  ";
+		sstr << TimeToString(NULL, TF_DateTimeMs) << "  ";
 
 	if (m_bEnableLogThreadIDs)
 	{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7360,15 +7360,15 @@ std::string CSQLHelper::GetDeviceValue(const char * FieldName , const char *Idx 
 
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , std::string &Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s='%s' , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value.c_str() ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s='%s' , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value.c_str(), TimeToString(0, TF_DateTime).c_str(), Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , int Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s=%d , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s=%d , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(0, TF_DateTime).c_str(),Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , float Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s=%4.2f , LastUpdate='%s' WHERE (ID == %s )",FieldName, Value ,GetCurrentAsciiTime ().c_str(),Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s=%4.2f , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(0, TF_DateTime).c_str(),Idx.c_str());
 }
 
 //return temperature value from Svalue : is code temperature;humidity;???

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7182,28 +7182,22 @@ std::string CSQLHelper::UpdateUserVariable(const std::string &idx, const std::st
 			return "New value same as current, not updating";
 	}
 	*/
-
-	time_t now = mytime(NULL);
-	struct tm ltime;
-	localtime_r(&now, &ltime);
+	std::string szLastUpdate = TimeToString(0, TF_DateTime);
 	std::string szVarValue = CURLEncode::URLDecode(varvalue.c_str());
 	safe_query(
-		"UPDATE UserVariables SET Name='%q', ValueType='%d', Value='%q', LastUpdate='%04d-%02d-%02d %02d:%02d:%02d' WHERE (ID == '%q')",
+		"UPDATE UserVariables SET Name='%q', ValueType='%d', Value='%q', LastUpdate='%q' WHERE (ID == '%q')",
 		varname.c_str(),
 		typei,
 		szVarValue.c_str(),
-		ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec,
+		szLastUpdate.c_str(),
 		idx.c_str()
 		);
 	if (!m_bDisableEventSystem)
 	{
-		std::stringstream ssLastUpdate;
 		std::stringstream vId_str(idx);
 		uint64_t vId;
 		vId_str >> vId;
-		ssLastUpdate << (ltime.tm_year + 1900) << "-" << std::setw(2) << std::setfill('0') << (ltime.tm_mon + 1) << "-" << std::setw(2) << std::setfill('0') << ltime.tm_mday
-		<< " " << std::setw(2) << std::setfill('0') << ltime.tm_hour << ":" << std::setw(2) << std::setfill('0') << ltime.tm_min << ":" << std::setw(2) << std::setfill('0') << ltime.tm_sec;
-		m_mainworker.m_eventsystem.UpdateUserVariable(vId, varname, szVarValue, typei, ssLastUpdate.str());
+		m_mainworker.m_eventsystem.UpdateUserVariable(vId, varname, szVarValue, typei, szLastUpdate);
 	}
 	if (eventtrigger) {
 		std::stringstream vId_str(idx);
@@ -7216,22 +7210,17 @@ std::string CSQLHelper::UpdateUserVariable(const std::string &idx, const std::st
 
 bool CSQLHelper::SetUserVariable(const uint64_t idx, const std::string &varvalue, const bool eventtrigger)
 {
-	time_t now = mytime(NULL);
-	struct tm ltime;
-	localtime_r(&now, &ltime);
+	std::string szLastUpdate = TimeToString(0, TF_DateTime);
 	std::string szVarValue = CURLEncode::URLDecode(varvalue.c_str());
 	safe_query(
-		"UPDATE UserVariables SET Value='%q', LastUpdate='%04d-%02d-%02d %02d:%02d:%02d' WHERE (ID == %" PRIu64 ")",
+		"UPDATE UserVariables SET Value='%q', LastUpdate='%q' WHERE (ID == %" PRIu64 ")",
 		szVarValue.c_str(),
-		ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec,
+		szLastUpdate.c_str(),
 		idx
 		);
 	if (!m_bDisableEventSystem)
 	{
-		std::stringstream ssLastUpdate;
-		ssLastUpdate << (ltime.tm_year + 1900) << "-" << std::setw(2) << std::setfill('0') << (ltime.tm_mon + 1) << "-" << std::setw(2) << std::setfill('0') << ltime.tm_mday
-		<< " " << std::setw(2) << std::setfill('0') << ltime.tm_hour << ":" << std::setw(2) << std::setfill('0') << ltime.tm_min << ":" << std::setw(2) << std::setfill('0') << ltime.tm_sec;
-		m_mainworker.m_eventsystem.UpdateUserVariable(idx, "", szVarValue, 0, ssLastUpdate.str());
+		m_mainworker.m_eventsystem.UpdateUserVariable(idx, "", szVarValue, 0, szLastUpdate);
 	}
 	if (eventtrigger)
 	{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7182,7 +7182,7 @@ std::string CSQLHelper::UpdateUserVariable(const std::string &idx, const std::st
 			return "New value same as current, not updating";
 	}
 	*/
-	std::string szLastUpdate = TimeToString(0, TF_DateTime);
+	std::string szLastUpdate = TimeToString(NULL, TF_DateTime);
 	std::string szVarValue = CURLEncode::URLDecode(varvalue.c_str());
 	safe_query(
 		"UPDATE UserVariables SET Name='%q', ValueType='%d', Value='%q', LastUpdate='%q' WHERE (ID == '%q')",
@@ -7210,7 +7210,7 @@ std::string CSQLHelper::UpdateUserVariable(const std::string &idx, const std::st
 
 bool CSQLHelper::SetUserVariable(const uint64_t idx, const std::string &varvalue, const bool eventtrigger)
 {
-	std::string szLastUpdate = TimeToString(0, TF_DateTime);
+	std::string szLastUpdate = TimeToString(NULL, TF_DateTime);
 	std::string szVarValue = CURLEncode::URLDecode(varvalue.c_str());
 	safe_query(
 		"UPDATE UserVariables SET Value='%q', LastUpdate='%q' WHERE (ID == %" PRIu64 ")",
@@ -7349,15 +7349,15 @@ std::string CSQLHelper::GetDeviceValue(const char * FieldName , const char *Idx 
 
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , std::string &Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s='%s' , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value.c_str(), TimeToString(0, TF_DateTime).c_str(), Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s='%s' , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value.c_str(), TimeToString(NULL, TF_DateTime).c_str(), Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , int Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s=%d , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(0, TF_DateTime).c_str(),Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s=%d , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(NULL, TF_DateTime).c_str(),Idx.c_str());
 }
 void CSQLHelper::UpdateDeviceValue(const char * FieldName , float Value , std::string &Idx )
 {
-	safe_query("UPDATE DeviceStatus SET %s=%4.2f , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(0, TF_DateTime).c_str(),Idx.c_str());
+	safe_query("UPDATE DeviceStatus SET %s=%4.2f , LastUpdate='%s' WHERE (ID == %s )", FieldName, Value, TimeToString(NULL, TF_DateTime).c_str(),Idx.c_str());
 }
 
 //return temperature value from Svalue : is code temperature;humidity;???

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12350,7 +12350,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 		m_sql.HandleOnOffAction((nValue==1),onaction,offaction);
 	}
 
-	std::string szLastUpdate = TimeToString(0, TF_DateTime);
+	std::string szLastUpdate = TimeToString(NULL, TF_DateTime);
 	m_sql.safe_query("UPDATE Scenes SET nValue=%d, LastUpdate='%q' WHERE (ID == %" PRIu64 ")",
 		nValue,
 		szLastUpdate.c_str(),

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12331,10 +12331,6 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 
 	m_sql.safe_query("INSERT INTO SceneLog (SceneRowID, nValue) VALUES ('%" PRIu64 "', '%d')", idx, nValue);
 
-	time_t now = time(0);
-	struct tm ltime;
-	localtime_r(&now,&ltime);
-
 	//first set actual scene status
 	std::string Name="Unknown?";
 	_eSceneGroupType scenetype = SGTYPE_SCENE;
@@ -12354,9 +12350,10 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 		m_sql.HandleOnOffAction((nValue==1),onaction,offaction);
 	}
 
-	m_sql.safe_query("UPDATE Scenes SET nValue=%d, LastUpdate='%04d-%02d-%02d %02d:%02d:%02d' WHERE (ID == %" PRIu64 ")",
+	std::string szLastUpdate = TimeToString(0, TF_DateTime);
+	m_sql.safe_query("UPDATE Scenes SET nValue=%d, LastUpdate='%q' WHERE (ID == %" PRIu64 ")",
 		nValue,
-		ltime.tm_year+1900,ltime.tm_mon+1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec,
+		szLastUpdate.c_str(),
 		idx);
 
 	//Check if we need to email a snapshot of a Camera
@@ -12394,10 +12391,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, const std::string &switchcmd)
 
 	if (!m_sql.m_bDisableEventSystem)
 	{
-		std::stringstream ssLastUpdate;
-		ssLastUpdate << (ltime.tm_year + 1900) << "-" << std::setw(2) << std::setfill('0') << (ltime.tm_mon + 1) << "-" << std::setw(2) << std::setfill('0') << ltime.tm_mday
-		<< " " << std::setw(2) << std::setfill('0') << ltime.tm_hour << ":" << std::setw(2) << std::setfill('0') << ltime.tm_min << ":" << std::setw(2) << std::setfill('0') << ltime.tm_sec;
-		m_eventsystem.UpdateScenesGroups(idx, nValue, ssLastUpdate.str());
+		m_eventsystem.UpdateScenesGroups(idx, nValue, szLastUpdate);
 	}
 
 	//now switch all attached devices, and only the onces that do not trigger a scene

--- a/notifications/NotificationEmail.cpp
+++ b/notifications/NotificationEmail.cpp
@@ -83,9 +83,9 @@ bool CNotificationEmail::SendMessageImplementation(
 
 	std::string MessageText = Text;
 	stdreplace(MessageText, "&lt;br&gt;", "<br>");
-	
+
 	std::string HtmlBody;
-	
+
 	if (Idx != 0)
 	{
 		HtmlBody = szHTMLMail;
@@ -96,20 +96,7 @@ bool CNotificationEmail::SendMessageImplementation(
 		stdreplace(HtmlBody, "$DEVNAME", Name);
 		stdreplace(HtmlBody, "$MESSAGE", MessageText);
 
-		char szDate[100];
-		struct timeval tv;
-		gettimeofday(&tv, NULL);
-		struct tm timeinfo;
-#ifdef WIN32
-		//Thanks to the winsock header file
-		time_t tv_sec = tv.tv_sec;
-		localtime_r(&tv_sec, &timeinfo);
-#else
-		localtime_r(&tv.tv_sec, &timeinfo);
-#endif
-		snprintf(szDate, sizeof(szDate), "%04d-%02d-%02d %02d:%02d:%02d.%03d",
-			timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
-			timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, (int)tv.tv_usec / 1000);
+		std::string szDate = TimeToString(0, TF_DateTimeMs);
 		stdreplace(HtmlBody, "$DATETIME", szDate);
 	}
 	else

--- a/notifications/NotificationEmail.cpp
+++ b/notifications/NotificationEmail.cpp
@@ -96,7 +96,7 @@ bool CNotificationEmail::SendMessageImplementation(
 		stdreplace(HtmlBody, "$DEVNAME", Name);
 		stdreplace(HtmlBody, "$MESSAGE", MessageText);
 
-		std::string szDate = TimeToString(0, TF_DateTimeMs);
+		std::string szDate = TimeToString(NULL, TF_DateTimeMs);
 		stdreplace(HtmlBody, "$DATETIME", szDate);
 	}
 	else


### PR DESCRIPTION
While working on a function to get the time with ms resolution in a string for the EventSystem (dzVents), I figured out it would be better to make it a global function which you can supply different format options (time, date, datetime and datetime with ms), considering quite some functions construct a time string.

I saw that there were already a few functions added in Helper.cpp, but these are all C style and somewhat poorly formatted, so decided to use my own function and remove these.

When supplying 0 (time_t) as first argument, it will return the current time, otherwise it converts and returns the supplied time. First I had this written with a NULL pointer as valid argument, which would allow 0 as a time value, but quickly remembered how pointers are being disliked and also not needed for this purpose ;) Don't think that 0 is ever being used as time value, seems to me a good compromise.

The reason for using clock_gettime() when available, is that gettimeofday() is being depreciated, see also http://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html

If / when this gets merged, I'll do another PR for EventSystem, in which I have some more changes pending (so it's better not combine it with this PR).