### PR TITLE
Elemental theme: Fix selector switches to fit to a smaller area

### DIFF
--- a/www/styles/elemental/custom.css
+++ b/www/styles/elemental/custom.css
@@ -173,6 +173,20 @@ body table#itemtablenostatus tbody tr{
 	margin-top: 10px;
 }
 
+.btn-group {
+       display: block;
+       white-space: normal;
+}
+
+.btn-group > .btn-small {
+    font-size: 10px;
+}
+
+.btn-small {
+    padding: 2px 3px;
+    font-size: 10px;
+}
+
 #timesun {
 	height: 2.60em;
 	position: fixed;


### PR DESCRIPTION
With the latest changes, selector switch levels - when not fitting 100% to the area reserved for them - would skip to next line (inline-block style) and run over to the next block (white-space: nowrap style). The font size was also bit large and the padding as well. With these changes everything should once again fit more or less to the area reserved for selector levels from the actual block.