### PR TITLE
Python Events - Removed misleading log entry on startup

### DIFF
--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -171,7 +171,6 @@
                 // _log.Log(LOG_STATUS, "Python Event System: Module found");
                 return pModule;
             } else {
-                _log.Log(LOG_STATUS, "Python EventSystem: Module not found - Trying to initialize.");
                 Plugins::PyRun_SimpleStringFlags("import DomoticzEvents", NULL);
                 pModule = PyState_FindModule(&DomoticzEventsModuleDef);
 


### PR DESCRIPTION
Minor change, removed a unnecessary and misleading log message when the python event system starts.