### PR TITLE
EventSystem extended UpdateDevice function

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1217,9 +1217,12 @@ std::string CEventSystem::UpdateSingleState(const uint64_t ulDevID, const std::s
 		//_log.Log(LOG_STATUS,"EventSystem: update device %" PRIu64 "",ulDevID);
 		_tDeviceStatus replaceitem = itt->second;
 		replaceitem.deviceName = l_deviceName;
-		replaceitem.nValue = nValue;
-		replaceitem.sValue = l_sValue;
-		replaceitem.nValueWording = l_nValueWording;
+		if (nValue != -1)
+			replaceitem.nValue = nValue;
+		if (strlen(sValue) > 0)
+			replaceitem.sValue = l_sValue;
+		if (!l_nValueWording.empty() || l_nValueWording != "-1")
+			replaceitem.nValueWording = l_nValueWording;
 		if (!lastUpdate.empty())
 			replaceitem.lastUpdate = l_lastUpdate;
 		if (lastLevel != 255)
@@ -3823,11 +3826,18 @@ void CEventSystem::UpdateDevice(const std::string &DevParams)
 {
 	std::vector<std::string> strarray;
 	StringSplit(DevParams, "|", strarray);
-	if (strarray.size() != 3)
+	if (strarray.size() < 2 || strarray.size() > 4)
 		return; //Invalid!
 	std::string idx = strarray[0];
-	std::string nvalue = strarray[1];
-	std::string svalue = strarray[2];
+	std::string nvalue;
+	std::string svalue;
+	std::string protect;
+	if (strarray.size() > 1)
+		nvalue = strarray[1];
+	if (strarray.size() > 2)
+		svalue = strarray[2];
+	if (strarray.size() > 3)
+		protect = strarray[3];
 	//Get device parameters
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType, Name, SwitchType, LastLevel, Options FROM DeviceStatus WHERE (ID=='%q')",
@@ -3845,9 +3855,23 @@ void CEventSystem::UpdateDevice(const std::string &DevParams)
 		std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][8].c_str());
 		std::string szLastUpdate = TimeToString(NULL, TF_DateTime);
 
-		m_sql.safe_query("UPDATE DeviceStatus SET nValue='%q', sValue='%q', LastUpdate='%q' WHERE (ID = '%q')",
-			nvalue.c_str(), svalue.c_str(), szLastUpdate.c_str(), idx.c_str());
+		std::stringstream ssQuery;
+		ssQuery << "UPDATE DeviceStatus SET ";
+		if (!nvalue.empty())
+			ssQuery << 	"nValue='" << nvalue << "',";
+		if (!svalue.empty())
+			ssQuery << 	"sValue='" << svalue << "',";
+		if (!protect.empty())
+			ssQuery << 	"Protected=" << atoi(protect.c_str()) << ",";
+		ssQuery << "LastUpdate='" << szLastUpdate << "' WHERE (ID = '" << idx << "')";
 
+		m_sql.safe_query(ssQuery.str().c_str());
+
+		if (nvalue.empty() && svalue.empty())
+			return;
+
+		if (nvalue.empty())
+			nvalue = "-1";
 
 		uint64_t ulIdx = 0;
 		std::stringstream s_str(idx);
@@ -3897,25 +3921,26 @@ void CEventSystem::UpdateDevice(const std::string &DevParams)
 			if ((devType == pTypeRadiator1) && (subType != sTypeSmartwaresSwitchRadiator))
 				break;
 			//Add Lighting log
-			m_sql.safe_query("INSERT INTO LightingLog (DeviceRowID, nValue, sValue) VALUES ('%" PRIu64 "', '%d', '%q')", ulIdx, atoi(nvalue.c_str()), svalue.c_str());
+			if (nvalue != "-1")
+				m_sql.safe_query("INSERT INTO LightingLog (DeviceRowID, nValue, sValue) VALUES ('%" PRIu64 "', '%d', '%q')", ulIdx, atoi(nvalue.c_str()), !svalue.empty() ? svalue.c_str() : "0");
 			break;
 		}
 
 		//Check if it's a setpoint device, and if so, set the actual setpoint
 		if (
 			((devType == pTypeThermostat) && (subType == sTypeThermSetpoint)) ||
-			(devType == pTypeRadiator1)
+			(devType == pTypeRadiator1 && !svalue.empty())
 			)
 		{
 			_log.Log(LOG_NORM, "EventSystem: Sending SetPoint to device....");
 			m_mainworker.SetSetPoint(idx, static_cast<float>(atof(svalue.c_str())));
 		}
-		else if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatMode))
+		else if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatMode) && nvalue != "-1")
 		{
 			_log.Log(LOG_NORM, "EventSystem: Sending Thermostat Mode to device....");
 			m_mainworker.SetZWaveThermostatMode(idx, atoi(nvalue.c_str()));
 		}
-		else if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatFanMode))
+		else if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatFanMode) && nvalue != "-1")
 		{
 			_log.Log(LOG_NORM, "EventSystem: Sending Thermostat Fan Mode to device....");
 			m_mainworker.SetZWaveThermostatFanMode(idx, atoi(nvalue.c_str()));

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3862,8 +3862,10 @@ void CEventSystem::UpdateDevice(const std::string &DevParams)
 		if (!svalue.empty())
 			ssQuery << "sValue='" << svalue << "',";
 		if (!protect.empty())
-			ssQuery << "Protected=" << atoi(protect.c_str()) << ",";
-		ssQuery << "LastUpdate='" << szLastUpdate << "' WHERE (ID = '" << idx << "')";
+			ssQuery << "Protected=" << atoi(protect.c_str());
+		if (nvalue != -1 || !svalue.empty())
+			ssQuery << (!protect.empty() ? "," : "") << "LastUpdate='" << szLastUpdate << "'";
+		ssQuery << " WHERE (ID = '" << idx << "')";
 
 		m_sql.safe_query(ssQuery.str().c_str());
 


### PR DESCRIPTION
Needed a simple way to toggle protection for an item on/off (after I accidentally switched something remotely without noticing :-P), added a field for this to the UpdateDevice function. Argument value 1 will enable protection, 0 disables it.

Also changed the logic, now you can supply empty values to prevent changing current values (eg. 1||123 sets svalue to 123 for ID 1, but doesn't touch nvalue. Setting only a nvalue is as simple as just supplying 1|1, it's no longer needed to set all arguments (but of course still supported). Using -1 value for an invalid / empty nvalue, prevents updating it's value in memory (m_devicestates).

Example of usage to switch protection: 
commandArray['UpdateDevice'] = '1|||1' -> enables protection for ID 1. 
commandArray['UpdateDevice'] = '1|||0' -> disables protection for ID 1. 