### PR TITLE
Fix compile with support for openzwave on macOS

### DIFF
--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -41,7 +41,7 @@
 #include <string.h>
 #include "Options.h"
 #include "Manager.h"
-#include "Node.h"
+#include "../Node.h"
 #include "Group.h"
 #include "Notification.h"
 

--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -39,11 +39,11 @@
 #include <stdlib.h>
 #include <time.h>
 #include <string.h>
-#include "Options.h"
-#include "Manager.h"
+#include "../Options.h"
+#include "../Manager.h"
 #include "../Node.h"
-#include "Group.h"
-#include "Notification.h"
+#include "../Group.h"
+#include "../Notification.h"
 
 #include <sys/stat.h>
 #include <fstream>


### PR DESCRIPTION
On macOS, since the header files are not in the same directory as ozwcp.cpp, clang seems to get confused when compiling with both openzwave and python, and imports node.h from the python-libs and not hardware/openzwave/Node.h as it should. This should fix this, and still compile under linux and win.
