### PR TITLE
EventSystem disable on initialization

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -120,7 +120,7 @@ static const _tJsonMap JsonMap[] =
 CEventSystem::CEventSystem(void)
 {
 	m_stoprequested = false;
-	m_bEnabled = true;
+	m_bEnabled = false;
 }
 
 


### PR DESCRIPTION
Prevent the Event System being enabled on initialization while not yet started, should fix the rare (though multiple times reported) issue of printing dzVents instead of Lua on script execution. 