### PR TITLE
Update temperature_humidity_barometer_device.lua

### DIFF
--- a/scripts/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
+++ b/scripts/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
@@ -6,6 +6,13 @@ local constMapping = {
 	['rain'] = 4
 }
 
+local constHumStatus = {
+	['Normal'] = 0,
+	['Comfortable'] = 1,
+	['Dry'] = 2,
+	['Wet'] = 3
+}
+
 return {
 
 	baseType = 'device',
@@ -33,6 +40,10 @@ return {
 				return
 			end
 
+			if (type(forecast)=='string') then forecast=constMapping[forecast]
+				elseif (type(forecast)=='nil') then forecast=0
+			end
+			
 			forecast = forecast ~= nil and constMapping[forecast] or 5
 
 			local value = tostring(temperature) .. ';' ..


### PR DESCRIPTION
Unlike the humidity status, the forecast in the THB device contains a string instead of a numerical code when assigned to a variable. As it is, dzVents only supports using  the numerical code, making copying the data from one device to another not possible, causing this code to return an error when run:

		local t =   math.floor(domoticz.devices('Meteo terraza').temperature*10)/10
		local hum = domoticz.devices('Meteo terraza').humidity
		local hs =  domoticz.devices('Meteo terraza').humidityStatus
		local p0 =  domoticz.devices('Meteo terraza').barometer
		local fcst = domoticz.devices('WU THB LG').forecast
		local h = 240
		local p = p0 * (1 + h * 0.0065 / (t + 273.15)) ^ 5.257
		domoticz.devices('Meteo terraza corregido').updateTempHumBaro(t, hum, hs, p, fcst)

This small update allows the THB device to support the assignment of the forecast data using both the numerical code or the string.

I hope this helps.-