### PR TITLE
EventSystem disable on initialization #2

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1135,7 +1135,6 @@ bool MainWorker::StartThread()
 
 	//Start Scheduler
 	m_scheduler.StartScheduler();
-	m_eventsystem.SetEnabled(m_sql.m_bEnableEventSystem);
 	m_cameras.ReloadCameras();
 
 	int rnvalue=0;
@@ -1516,6 +1515,7 @@ void MainWorker::Do_Work()
 				m_pluginsystem.AllPluginsStarted();
 #endif
 				ParseRFXLogFile();
+				m_eventsystem.SetEnabled(m_sql.m_bEnableEventSystem);
 				m_eventsystem.StartEventSystem();
 			}
 		}


### PR DESCRIPTION
Previous patch seemed not to be enough to prevent it from being enabled before started, also need to move the SetEnabled line just above StartEventSystem in mainworker.cpp. Tested it and now it acts as expected.