### PR TITLE
Add support for Netamo modules battery level

### DIFF
--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -375,65 +375,18 @@ void CNetatmo::StoreRefreshToken()
 	m_sql.safe_query("UPDATE Hardware SET Extra='%q' WHERE (ID == %d)", m_refreshToken.c_str(), m_HwdID);
 }
 
-int CNetatmo::GetBatteryLevel(const std::string &ModuleType, const int battery_vp)
+int CNetatmo::GetBatteryLevel(const std::string &ModuleType, const int battery_percent)
 {
-	int batValue = 255;
-	if (battery_vp == 0)
-		return batValue; //no battery
+    int batValue = 255;
 
-	bool bIsIndoorSensor = ((ModuleType == "NAMain") || (ModuleType == "NAModule4"));
-	bool bIsOutdoorSensor = ((ModuleType == "NAModule1") || (ModuleType == "NAModule3"));
-	bool bIsWindGaugeSensor = (ModuleType == "NAModule2");
-	bool bIsThermostatSensor = (ModuleType == "NATherm1");
-
-	if (bIsIndoorSensor)
-	{
-		/* Battery range: 6000 ... 4200
-		5640 full
-		5280 high
-		4920 medium
-		4560 low
-		Below 4560: very low */
-		if (battery_vp <= 4560)
-			batValue = 0;
-	}
-	else if (bIsOutdoorSensor)
-	{
-		/*Battery range : 6000 ... 3600 * /
-		5500 full
-		5000 high
-		4500 medium
-		4000 low
-		below 4000: very low */
-		if (battery_vp <= 4000)
-			batValue = 0;
-	}
-	else if (bIsWindGaugeSensor)
-	{
-		/* Battery range: 6000 ... 3950
-		5590 full
-		5180 high
-		4770 medium
-		4360 low
-		below 4360: very low*/
-		if (battery_vp <= 4360)
-			batValue = 0;
-	}
-	else if (bIsThermostatSensor)
-	{
-		/* Battery range: 4500 ... 3000
-		4100 full
-		3600 high
-		3300 medium
-		3000 low
-		below 3000: very low */
-		if (battery_vp <= 3000)
-			batValue = 0;
-	}
-	return batValue;
+    // Others are plugged
+    if ((ModuleType == "NAModule1") || (ModuleType == "NAModule2") || (ModuleType == "NAModule3") || (ModuleType == "NAModule4") || (ModuleType == "NATherm1"))
+        batValue = battery_percent;
+    
+    return batValue;
 }
 
-bool CNetatmo::ParseDashboard(const Json::Value &root, const int DevIdx, const int ID, const std::string &name, const std::string &ModuleType, const int battery_vp)
+bool CNetatmo::ParseDashboard(const Json::Value &root, const int DevIdx, const int ID, const std::string &name, const std::string &ModuleType, const int battery_percent)
 {
 	bool bHaveTemp = false;
 	bool bHaveHum = false;
@@ -456,7 +409,7 @@ bool CNetatmo::ParseDashboard(const Json::Value &root, const int DevIdx, const i
 	float wind_strength = 0;
 	float wind_gust = 0;
 
-	int batValue = GetBatteryLevel(ModuleType, battery_vp);
+	int batValue = GetBatteryLevel(ModuleType, battery_percent);
 
 	if (!root["Temperature"].empty())
 	{
@@ -855,19 +808,19 @@ bool CNetatmo::ParseNetatmoGetResponse(const std::string &sResult, const bool bI
 							std::string mname = module["module_name"].asString();
 							if (mname.empty())
 								mname = nDevice.ModuleName;
-							int mbattery_vp = 0;
-							if (module["battery_vp"].empty() == false)
+							int mbattery_percent = 0;
+							if (module["battery_percent"].empty() == false)
 							{
-								mbattery_vp = module["battery_vp"].asInt();
+								mbattery_percent = module["battery_percent"].asInt();
 							}
 							int crcId = Crc32(0, (const unsigned char *)mid.c_str(), mid.length());
 							if (!module["dashboard_data"].empty())
 							{
-								ParseDashboard(module["dashboard_data"], iDevIndex, crcId, mname, mtype, mbattery_vp);
+								ParseDashboard(module["dashboard_data"], iDevIndex, crcId, mname, mtype, mbattery_percent);
 							}
 							else if (!module["measured"].empty())
 							{
-								ParseDashboard(module["measured"], iDevIndex, crcId, mname, mtype, mbattery_vp);
+								ParseDashboard(module["measured"], iDevIndex, crcId, mname, mtype, mbattery_percent);
 								if (mtype == "NATherm1")
 								{
 									m_thermostatDeviceID[iDevIndex] = nDevice.ID;
@@ -885,7 +838,7 @@ bool CNetatmo::ParseNetatmoGetResponse(const std::string &sResult, const bool bI
 										//Check if setpoint was just set, and if yes, overrule the previous setpoint
 										if (!module["setpoint"]["setpoint_temp"].empty())
 										{
-											ParseDashboard(module["setpoint"], iDevIndex, crcId, mname, mtype, mbattery_vp);
+											ParseDashboard(module["setpoint"], iDevIndex, crcId, mname, mtype, mbattery_percent);
 										}
 									}
 								}
@@ -898,15 +851,15 @@ bool CNetatmo::ParseNetatmoGetResponse(const std::string &sResult, const bool bI
 			}
 			_netatmo_devices.push_back(nDevice);
 
-			int battery_vp = 0;
-			if (device["battery_vp"].empty() == false)
+			int battery_percent = 0;
+			if (device["battery_percent"].empty() == false)
 			{
-				battery_vp = device["battery_vp"].asInt();
+				battery_percent = device["battery_percent"].asInt();
 			}
 			int crcId = Crc32(0, (const unsigned char *)id.c_str(), id.length());
 			if (!device["dashboard_data"].empty())
 			{
-				ParseDashboard(device["dashboard_data"], iDevIndex, crcId, name, type, battery_vp);
+				ParseDashboard(device["dashboard_data"], iDevIndex, crcId, name, type, battery_percent);
 			}
 		}
 		iDevIndex++;
@@ -973,10 +926,10 @@ bool CNetatmo::ParseNetatmoGetResponse(const std::string &sResult, const bool bI
 			continue; //handled above
 		}
 
-		int battery_vp = 0;
-		if (!module["battery_vp"].empty())
+		int battery_percent = 0;
+		if (!module["battery_percent"].empty())
 		{
-			battery_vp = module["battery_vp"].asInt();
+			battery_percent = module["battery_percent"].asInt();
 		}
 		stdreplace(name, "'", " ");
 
@@ -988,7 +941,7 @@ bool CNetatmo::ParseNetatmoGetResponse(const std::string &sResult, const bool bI
 		int crcId = Crc32(0, (const unsigned char *)id.c_str(), id.length());
 		if (!module["dashboard_data"].empty())
 		{
-			ParseDashboard(module["dashboard_data"], iDevIndex, crcId, name, type, battery_vp);
+			ParseDashboard(module["dashboard_data"], iDevIndex, crcId, name, type, battery_percent);
 		}
 	}
 	return (!_netatmo_devices.empty());


### PR DESCRIPTION
I retrieve battery level for Netatmo modules by use the percent value of the API instead of battery_vp that is too fuzzy.