### PR TITLE
Added possibility to select phones for GCM in LUA

### DIFF
--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -34,11 +34,24 @@ bool CNotificationGCM::SendMessageImplementation(
 	//Get All Devices
 	std::vector<std::vector<std::string> > result;
 
+	std::string sMidx;
+	std::vector<std::string> vDevices;
+	//std::string sDevice = "";
+	if (ExtraData.find("midx_") != std::string::npos)
+		sMidx = ExtraData.substr(5);
+	if (ExtraData.find("|Device=") != std::string::npos) {
+		std::string sDevice = ExtraData.substr(8);
+		if (!sDevice.empty())
+			boost::split(vDevices, sDevice, boost::is_any_of(";"));
+	}
+
 	std::string szQuery("SELECT SenderID, DeviceType FROM MobileDevices");
-	if ((ExtraData.empty()) || (ExtraData.find("midx_") == std::string::npos))
-		szQuery += " WHERE (Active == 1)";
+	if (!sMidx.empty())
+		szQuery += " WHERE (ID == " + sMidx + ")";
+	else if (!vDevices.empty())
+		szQuery += " WHERE (ID IN (" + boost::algorithm::join(vDevices, ",") + "))";
 	else
-		szQuery += " WHERE (ID == " + ExtraData.substr(5) + ")";
+		szQuery += " WHERE (Active == 1)";
 	result = m_sql.safe_query(szQuery.c_str());
 	if (result.empty())
 		return true;

--- a/www/app/MobileNotificationsController.js
+++ b/www/app/MobileNotificationsController.js
@@ -108,11 +108,12 @@ define(['app'], function (app) {
 								"Enabled": item.Enabled,
 								"Name": item.Name,
 								"UUID": item.UUID,
-								"0": enabledstr,
-								"1": item.Name,
-								"2": item.UUID,
-								"3": item.DeviceType,
-								"4": lUpdateItem
+								"0": item.idx,
+								"1": enabledstr,
+								"2": item.Name,
+								"3": item.UUID,
+								"4": item.DeviceType,
+								"5": lUpdateItem
 							});
 						});
 					}

--- a/www/views/mobile_notifications.html
+++ b/www/views/mobile_notifications.html
@@ -20,6 +20,7 @@
 	<table class="display" id="mobiletable" border="0" cellpadding="0" cellspacing="0" width="100%">
 		<thead>
 			<tr valign="middle">
+				<th width="30">Idx</th>
 				<th width="60" align="left" data-i18n="Enabled">Enabled</th>
 				<th align="left" data-i18n="Name">Name</th>
 				<th width="260" align="left" data-i18n="UUID">UUID</th>


### PR DESCRIPTION
You can set extraData param in lua to choose which phones would receive
a GCM push notification.
You have to give the idx value of the phone.
Now visible in the Mobile view under Setup -> More Options -> Mobile
Devices. Multiple devices could be given, seperated by a semicolon.

Example:
commandArray['SendNotification'] = "Subject#Message###1;2#gcm"

notifications\GCM
www\app\mobileNot
www\views\mobile_n