### PR TITLE
EventSystem add BackupDB function Lua/dzVents

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3799,6 +3799,12 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 		int idx = atoi(SetPointIdx.c_str());
 		m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5f, idx, SetPointValue));
 	}
+	else if (lCommand == "BackupDB")
+	{
+		std::string luaString = lua_tostring(lua_state, -1);
+		BackupDatabase(luaString);
+		scriptTrue = true;
+	}
 	else
 	{
 		if (ScheduleEvent(lua_tostring(lua_state, -2), lua_tostring(lua_state, -1), filename)) {
@@ -3810,6 +3816,14 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 
 }
 
+void CEventSystem::BackupDatabase(const std::string &path)
+{
+	_log.Log(LOG_STATUS, "EventSystem: Starting database backup to %s", path.c_str());
+	if (m_sql.BackupDatabase(path))
+		_log.Log(LOG_STATUS, "EventSystem: Database backup completed successfully");
+	else
+		_log.Log(LOG_ERROR, "EventSystem: Error writing backup file to %s", path.c_str());
+}
 
 void CEventSystem::report_errors(lua_State *L, int status, std::string filename)
 {

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -227,6 +227,7 @@ private:
 	void report_errors(lua_State *L, int status, std::string filename);
 	unsigned char calculateDimLevel(int deviceID, int percentageLevel);
 	void StripQuotes(std::string &sString);
+	void BackupDatabase(const std::string &path);
 	std::string SpaceToUnderscore(std::string sResult);
 	std::string LowerCase(std::string sResult);
 };

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6501,7 +6501,11 @@ bool CSQLHelper::BackupDatabase(const std::string &OutputFile)
 	// Open the database file identified by zFilename.
 	rc = sqlite3_open(OutputFile.c_str(), &pFile);
 	if( rc!=SQLITE_OK )
+	{
+		if (pFile != NULL)
+			sqlite3_close(pFile);
 		return false;
+	}
 
 	// Open the sqlite3_backup object used to accomplish the transfer
     pBackup = sqlite3_backup_init(pFile, "main", m_dbase, "main");


### PR DESCRIPTION
Allow backups of the DB from Lua/dzVents. Also fix small memory leak in case the specified path can't be written (or some other error occurs).

Example of usage: commandArray['BackupDB'] = '/mnt/backups/domoticz/backup-' .. currentDate .. '.db'