### PR TITLE
Fix Telegram notifcation setup layout

### DIFF
--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -647,13 +647,12 @@
 									</table>
 									<br>
 								</div>
-							</div>
-							<div class="span6">
+								<div class="span6">
                                                                         <h2><span data-i18n="Telegram"></span>:</h2>
                                                                         <table class="display" id="telegramtable" border="0" cellpadding="0" cellspacing="0">
                                                                         <tr>
-                                                                                <td align="right" style="width:80px"><label for="TelegramEnabled"><span data-i18n="Enabled"></span>: </label></td>
-                                                                                <td><input type="checkbox" id="TelegramEnabled" name="TelegramEnabled"/></td>
+                                                                                <td align="right" style="width:80px"><span data-i18n="Enabled"></span>:</td>
+                                                                                <td><input type="checkbox" id="TelegramEnabled" name="TelegramEnabled"/><label for="TelegramEnabled"/></td>
                                                                         </tr>
                                                                         <tr>
                                                                                 <td align="right"><label for="TelegramAPI"><span data-i18n="API Key"></span>: </label></td>
@@ -667,6 +666,7 @@
                                                                         <span data-i18n="To get a free account/API key click"></span> <a href="https://telegram.org/" class="norm-link" target="_blank"><span class="norm-link" data-i18n="Here"></span></a><br>
                                                                         <br>
                                                                 </div>
+							</div>
 							<br>
 							<div class="row-fluid">
 								<div class="span12">


### PR DESCRIPTION
Fix Telegram notifcation setup layout
`<label for="TelegramEnabled"/>` was set at the wrong place.
And there was an extra `</div>` I forgot to remove.