### PR TITLE
Added support for MCP23017: 16bit I2C GPIO expander

### DIFF
--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -11,6 +11,7 @@ This code supports:
 - PCF8574, PCF8574A
 - HTU21D
 - TSL2561
+- MCP23017
 
 PS there are better density and QNH formulas.
 
@@ -18,6 +19,7 @@ Authors:
 - GizMoCuz
 - Eric Maasdorp
 - Ondrej Lycka (ondrej.lycka@seznam.cz)
+- Guillermo Estevez (gestevezluka@gmail.com)
 */
 
 #include "stdafx.h"
@@ -38,6 +40,7 @@ Authors:
 #include "../main/RFXtrx.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
+#include "../main/SQLHelper.h"
 
 #define round(a) ( int ) ( a + .5 )
 
@@ -93,6 +96,43 @@ const unsigned char BMPx8x_OverSampling = 3;
 #define TSL2561_Channel0	0xAC	// IR+Visible lux
 #define TSL2561_Channel1	0xAE	// IR only lux
 
+// MCP23017 registers
+#define MCP23x17_IODIRA         0x00
+#define MCP23x17_IPOLA          0x02
+#define MCP23x17_GPINTENA       0x04
+#define MCP23x17_DEFVALA        0x06
+#define MCP23x17_INTCONA        0x08
+#define MCP23x17_IOCON          0x0A
+#define MCP23x17_GPPUA          0x0C
+#define MCP23x17_INTFA          0x0E
+#define MCP23x17_INTCAPA        0x10
+#define MCP23x17_GPIOA          0x12
+#define MCP23x17_OLATA          0x14
+
+#define MCP23x17_IODIRB         0x01
+#define MCP23x17_IPOLB          0x03
+#define MCP23x17_GPINTENB       0x05
+#define MCP23x17_DEFVALB        0x07
+#define MCP23x17_INTCONB        0x09
+#define MCP23x17_IOCONB         0x0B
+#define MCP23x17_GPPUB          0x0D
+#define MCP23x17_INTFB          0x0F
+#define MCP23x17_INTCAPB        0x11
+#define MCP23x17_GPIOB          0x13
+#define MCP23x17_OLATB          0x15
+
+// MCP23x17 - Bits in the IOCON register
+#define IOCON_UNUSED    0x01
+#define IOCON_INTPOL    0x02
+#define IOCON_ODR       0x04
+#define IOCON_HAEN      0x08
+#define IOCON_DISSLW    0x10
+#define IOCON_SEQOP     0x20
+#define IOCON_MIRROR    0x40
+#define IOCON_BANK_MODE 0x80
+
+
+
 const char* szI2CTypeNames[] = {
 	"I2C_Unknown",
 	"I2C_BMP085/180",
@@ -100,12 +140,13 @@ const char* szI2CTypeNames[] = {
 	"I2C_TSL2561",
 	"I2C_PCF8574",
 	"I2C_BME280",
+	"I2C_MCP23017",
 };
 
 I2C::I2C(const int ID, const _eI2CType DevType, const int Port):
 m_dev_type(DevType)
 {
-	if (m_dev_type == I2CTYPE_PCF8574) {
+	if ((m_dev_type == I2CTYPE_PCF8574) || (m_dev_type == I2CTYPE_MCP23017)) {
 		i2c_addr = Port;
 	}
 
@@ -134,6 +175,9 @@ bool I2C::StartHardware()
 		m_LastSendForecast = baroForecastNoInfo;
 	}
 
+	if (m_dev_type == I2CTYPE_MCP23017)
+		MCP23017_Init();
+
 	//Start worker thread
 	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&I2C::Do_Work, this)));
 	sOnConnected(this);
@@ -152,17 +196,24 @@ bool I2C::StopHardware()
 
 bool I2C::WriteToHardware(const char *pdata, const unsigned char length)
 {
+	int rc=0;
 	//Giz: Could the author of this function please check his/her spelling!
-	if (m_dev_type != I2CTYPE_PCF8574)
+	if (m_dev_type != I2CTYPE_PCF8574 && m_dev_type != I2CTYPE_MCP23017)
 		return false;
 
 	const tRBUF *pCmd = reinterpret_cast<const tRBUF*>(pdata);
 	if ((pCmd->LIGHTING2.packettype == pTypeLighting2)) {
 		unsigned char pin_number = pCmd->LIGHTING2.unitcode; // in DB column "Unit" is used for identify pin number
 		unsigned char  value = pCmd->LIGHTING2.cmnd;
-		value=~value&0x01; // inversion value: domoticz have on=1, off=0, but in PCF8574 I have on=0, off=1
-		if (PCF8574_WritePin( pin_number, value)<0) return false;
-		else return true;
+		value=~value&0x01; // inversion value: domoticz have on=1, off=0, but in PCF8574/MCP23017 I have on=0, off=1
+		if (m_dev_type == I2CTYPE_PCF8574) {
+			if (PCF8574_WritePin( pin_number, value)<0) return false;
+			else return true;
+		}
+		else if (m_dev_type == I2CTYPE_MCP23017) {
+			if (MCP23017_WritePin( pin_number, value)<0) return false;
+			else return true;
+		}
 	}
 	else return false;
 }
@@ -198,6 +249,10 @@ void I2C::Do_Work()
 					if (m_dev_type == I2CTYPE_PCF8574)
 					{
 						PCF8574_ReadChipDetails();
+					}
+					else if (m_dev_type == I2CTYPE_MCP23017)
+					{
+						MCP23017_ReadChipDetails();
 					}
 				}
 				if (sec_counter % I2C_SENSOR_READ_INTERVAL == 0)
@@ -306,6 +361,146 @@ char I2C::PCF8574_WritePin(char pin_number,char  value)
 		if (writeByteI2C(fd, buf_new, i2c_addr) < 0 ) {
 			_log.Log(LOG_ERROR, "GPIO: %s: Error write to device!...", szI2CTypeNames[m_dev_type]);
 			return -3;
+		}
+	}
+	close(fd);
+	return 1;
+#endif
+}
+
+// MCP23017
+
+void I2C::MCP23017_Init()
+{
+#ifndef HAVE_LINUX_I2C
+	return;
+#else
+	int fd = i2c_Open(m_ActI2CBus.c_str()); // open i2c
+	if (fd < 0) return; // Error opening i2c device!
+	std::vector<std::vector<std::string> > result;
+	std::vector<std::vector<std::string> >::const_iterator itt;
+	unsigned char nvalue;
+	uint16_t GPIO_reg = 0xFFFF;
+	int unit;
+	bool value;
+	
+	result = m_sql.safe_query("SELECT Unit, nValue FROM DeviceStatus WHERE (HardwareID = %d) AND (DeviceID like '000%02X%%');", m_HwdID, i2c_addr);
+	if (!result.empty())
+	{
+		for (itt = result.begin(); itt != result.end(); ++itt)
+		{
+			std::vector<std::string> sd=*itt;
+			unit = atoi(sd[0].c_str());
+			nvalue = atoi(sd[1].c_str());
+
+			nvalue ^= 1;
+			//prepare new value by combinating current value, mask and new value
+			if (nvalue==1) {
+				GPIO_reg |= (0x01 << unit);
+				value = false;
+			}
+			else if (nvalue==0) {
+				GPIO_reg &= ~(0x01 << unit);
+				value = true;
+			}
+
+			int DeviceID = (i2c_addr << 8) + (unsigned char)unit; 			// DeviceID from i2c_address and pin_number
+			SendSwitch(DeviceID, unit, 255, value, 0, ""); 					// create or update switch
+			//_log.Log(LOG_NORM, "SendSwitch(DeviceID: %d, unit: %d, value: %d", DeviceID, unit, value );
+		}
+	}
+	else {
+		for (char pin_number=0; pin_number<16; pin_number++){
+			int DeviceID = (i2c_addr << 8) + pin_number; 			// DeviceID from i2c_address and pin_number
+			SendSwitch(DeviceID, pin_number, 255, value, 0, ""); 			// create switch
+		}
+	}
+	if (I2CWriteReg16(fd, MCP23x17_GPIOA, GPIO_reg) < 0 ) {	// write values from domoticz db to gpio register
+		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		return; 											// write to i2c failed
+	}
+	if (I2CWriteReg16(fd, MCP23x17_IODIRA, 0x0000) < 0 ){	// set all gpio pins on the port as output
+		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		return; 											// write to i2c failed
+	}
+	close(fd);
+#endif
+}
+
+void I2C::MCP23017_ReadChipDetails()
+{	
+#ifndef HAVE_LINUX_I2C
+	return;
+#else
+//	uint16_t data = 0;
+	uint16_t cur_iodir = 0;
+	i2c_data data;
+	int rc;
+
+
+	int fd = i2c_Open(m_ActI2CBus.c_str()); // open i2c
+	if (fd < 0) return; // Error opening i2c device!
+
+	rc = I2CReadReg16(fd, MCP23x17_IODIRA, &data); 				// get current iodir port value
+	close(fd);
+
+	if (rc < 0) {
+		_log.Log(LOG_NORM, "I2C::MCP23017_ReadChipDetails. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		return; //read from i2c failed
+	}
+	if ((data.word == 0xFFFF)){									// if oidir port is 0xFFFF means the chip has been reset
+		_log.Log(LOG_NORM, "I2C::MCP23017_ReadChipDetails, Cur_iodir: 0xFFFF, call MCP23017_Init");
+		MCP23017_Init();										// initialize gpio pins with switch status from db
+	}
+#endif
+}
+
+int I2C::MCP23017_WritePin(char pin_number,char  value)
+{	
+#ifndef HAVE_LINUX_I2C
+	return -1;
+#else
+	_log.Log(LOG_NORM, "GPIO: WRITE TO MCP23017 pin:%d, value: %d, i2c_address:%d", pin_number, value, i2c_addr);
+	uint16_t pin_mask=0, iodir_mask=0;
+	unsigned char gpio_port, iodir_port;
+	uint16_t new_data = 0;
+	i2c_data cur_data, cur_iodir;
+	int rc;
+	
+	pin_mask=0x01<<(pin_number);
+	iodir_mask &= ~(0x01 << (pin_number));
+	
+	// open i2c device
+	int fd = i2c_Open(m_ActI2CBus.c_str());
+	if (fd < 0) return -1; 								// Error opening i2c device!
+	
+	rc = I2CReadReg16(fd, MCP23x17_GPIOA, &cur_data); 		// get current gio port value
+	if (rc < 0) {
+		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		close(fd);
+		return -2; 						//read from i2c failed
+	}
+	rc = I2CReadReg16(fd, MCP23x17_IODIRA, &cur_iodir); 		// get current iodir port value
+	if (rc < 0) {						//read from i2c failed
+		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		close(fd);
+		return -2; 						//read from i2c failed
+	}
+	cur_iodir.word &= iodir_mask; 							// create mask for iodir register to set pin as output.
+	
+	if (value==1) new_data = cur_data.word | pin_mask;		//prepare new value by combinating current value, mask and new value
+	else new_data = cur_data.word & ~pin_mask;
+	
+	if (new_data!=cur_data.word) { 							// if value change write new value
+		if (I2CWriteReg16(fd, MCP23x17_GPIOA, new_data) < 0 ) {
+			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+			close(fd);
+			return -3;
+		}
+		if (I2CWriteReg16(fd, MCP23x17_IODIRA, cur_iodir.word) < 0 ) {		// write to iodir register, set gpio pin as output
+			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+			close(fd);
+			return -3;													// write to i2c failed
 		}
 	}
 	close(fd);
@@ -470,6 +665,55 @@ char I2C::writeByteI2C(int fd, char byte, char i2c_addr)
 #endif
 }
 
+int I2C::I2CWriteReg16(int fd, uint8_t reg, uint16_t value)
+{
+	#ifndef HAVE_LINUX_I2C
+		return -1;
+	#else
+		int rc;
+		struct i2c_rdwr_ioctl_data messagebuffer;
+		uint8_t datatosend[3];
+		i2c_data bytes;
+		bytes.word = value;
+		struct i2c_msg write_reg[1] = {
+			{ i2c_addr, 0, 3, datatosend } // flag absent == write, two registers, one for register address and one for the value to write
+		};
+		datatosend[0] = reg;						// address of register to write
+		datatosend[1] = bytes.byte[0];						// value to write
+		datatosend[2] = bytes.byte[1];						// value to write
+		messagebuffer.msgs = write_reg;				//load the 'write_reg' message into the buffer
+		messagebuffer.nmsgs = 1;
+		rc = ioctl(fd, I2C_RDWR, &messagebuffer); //Send the buffer to the bus and returns a send status
+		if (rc < 0) {
+//			_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+			return rc;
+		}
+		return 0;
+	#endif
+}
+
+int I2C::I2CReadReg16(int fd, unsigned char reg, i2c_data *data )
+{
+#ifndef HAVE_LINUX_I2C
+	return -1;
+#else
+	int rc;
+	//i2c_data data;
+	struct i2c_rdwr_ioctl_data messagebuffer;
+	struct i2c_msg read_reg[3] = {
+		{ i2c_addr, 0, 1, &reg },					//flag absent == write, address of register to read
+		{ i2c_addr, I2C_M_RD, 2, data->byte }		//flag I2C_M_RD == read
+	};
+	messagebuffer.nmsgs = 2;                  		//Two message/action
+	messagebuffer.msgs = read_reg;            		//load the 'read__reg' message into the buffer
+	return ioctl(fd, I2C_RDWR, &messagebuffer); 		//Send the buffer to the bus and returns a send status
+//	if (rc < 0) {
+//		_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s, Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+//		return rc;
+//	}
+	//return data.word ;	
+#endif
+}
 
 // HTU21D functions
 int I2C::HTU21D_checkCRC8(uint16_t data)

--- a/hardware/I2C.h
+++ b/hardware/I2C.h
@@ -2,6 +2,12 @@
 
 #include "DomoticzHardware.h"
 
+typedef union _i2c_data
+{
+  uint8_t  byte[2] ;
+  uint16_t word ;
+} i2c_data;
+
 class I2C : public CDomoticzHardwareBase
 {
 public:
@@ -12,7 +18,8 @@ public:
 		I2CTYPE_HTU21D,
 		I2CTYPE_TSL2561,
 		I2CTYPE_PCF8574,
-		I2CTYPE_BME280
+		I2CTYPE_BME280,
+		I2CTYPE_MCP23017
 	};
 
 	explicit I2C(const int ID, const _eI2CType DevType, const int Port);
@@ -92,4 +99,12 @@ private:
 	char			PCF8574_WritePin(char pin_number,char  value);
 	char 			readByteI2C(int fd, char *byte, char i2c_addr);
 	char 			writeByteI2C(int fd, char byte, char i2c_addr);
+
+	// MCP23017
+	void 			MCP23017_Init();
+	void			MCP23017_ReadChipDetails();
+	int			MCP23017_WritePin(char pin_number,char  value);
+	int 			I2CWriteReg16(int fd, uint8_t reg, uint16_t value);
+	int		 		I2CReadReg16(int fd, unsigned char reg, i2c_data *data);
+
 };

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -256,6 +256,7 @@ const char *Hardware_Type_Desc(int hType)
 		{ HTYPE_DenkoviSmartdenIPInOut, "Denkovi Smartden IP In with LAN interface" },
 		{ HTYPE_USBtinGateway, "USBtin Can Gateway"},
 		{ HTYPE_EnphaseAPI, "Enphase Envoy with LAN (HTTP) interface" },
+		{ HTYPE_RaspberryMCP23017, "I2C sensor GPIO 16bit expander MCP23017" },
 		{ 0, NULL, NULL }
 	};
 	return findTableIDSingle1 (Table, hType);

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -191,6 +191,7 @@ enum _eHardwareTypes {
 	HTYPE_EVOHOME_TCP,			//106
 	HTYPE_USBtinGateway,		//107
 	HTYPE_EnphaseAPI,			//108
+	HTYPE_RaspberryMCP23017,	//109
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -972,7 +972,8 @@ namespace http {
 					(ii == HTYPE_RaspberryHTU21D) ||
 					(ii == HTYPE_RaspberryTSL2561) ||
 					(ii == HTYPE_RaspberryPCF8574) ||
-					(ii == HTYPE_RaspberryBME280)
+					(ii == HTYPE_RaspberryBME280) ||
+					(ii == HTYPE_RaspberryMPC23017)
 					)
 				{
 					bDoAdd = false;
@@ -1177,6 +1178,9 @@ namespace http {
 				//all fine here!
 			}
 			else if (htype == HTYPE_RaspberryBME280) {
+				//all fine here!
+			}
+			else if (htype == HTYPE_RaspberryMCP23017) {
 				//all fine here!
 			}
 			else if (htype == HTYPE_Dummy) {
@@ -1533,6 +1537,9 @@ namespace http {
 			}
 			else if (htype == HTYPE_RaspberryBME280) {
 				//All fine here
+			}
+			else if (htype == HTYPE_RaspberryMCP23017) {
+				//all fine here!
 			}
 			else if (htype == HTYPE_Dummy) {
 				//All fine here

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -884,6 +884,10 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RaspberryBME280:
 		pHardware = new I2C(ID, I2C::I2CTYPE_BME280, 0);
 		break;
+	case HTYPE_RaspberryMCP23017:
+		_log.Log(LOG_NORM, "MainWorker::AddHardwareFromParams HTYPE_RaspberryMCP23017");
+		pHardware = new I2C(ID, I2C::I2CTYPE_MCP23017, Port);
+		break;
 	case HTYPE_Wunderground:
 		pHardware = new CWunderground(ID, Username, Password);
 		break;

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -135,6 +135,10 @@ define(['app'], function (app) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
 					var port = "&port=" + encodeURIComponent(i2caddress);
 				}
+				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
+					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
+					var port = "&port=" + encodeURIComponent(i2caddress);
+				}
 				if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs GPIO") == -1)) {
 					var gpiodebounce = $("#hardwareparamsgpio #gpiodebounce").val();
 					var gpioperiod = $("#hardwareparamsgpio #gpioperiod").val();
@@ -1188,6 +1192,10 @@ define(['app'], function (app) {
 				var port = "";
 				var text1 = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').text();
 				if (text1.indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
+					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
+					var port = "&port=" + encodeURIComponent(i2caddress);
+				}
+				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
 					var port = "&port=" + encodeURIComponent(i2caddress);
 				}
@@ -4776,7 +4784,7 @@ define(['app'], function (app) {
 								SerialName = item.SerialPort;
 								intport = jQuery.inArray(item.SerialPort, $scope.SerialPortStr);
 							}
-							if (item.Type == 93) {
+							if (item.Type == 93 || item.Type == 109) {
 								SerialName = "I2C-" + SerialName;
 							}
 
@@ -5019,6 +5027,9 @@ define(['app'], function (app) {
 						else if (data["Type"].indexOf("I2C ") >= 0) {
 							$("#hardwareparamsi2clocal #comboi2clocal").val(jQuery.inArray(data["Type"], $.myglobals.HardwareI2CStr));
 							if (data["Type"].indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
+								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
+							}
+							else if (data["Type"].indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
 								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
 							}
 						}
@@ -5395,6 +5406,9 @@ define(['app'], function (app) {
 				$("#hardwarecontent #divi2caddress").hide();
 				var text1 = $("#hardwarecontent #divi2clocal #hardwareparamsi2clocal #comboi2clocal option:selected").text();
 				if (text1.indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
+					$("#hardwarecontent #divi2caddress").show();
+				}
+				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
 					$("#hardwarecontent #divi2caddress").show();
 				}
 			}


### PR DESCRIPTION
Details:
Added support for Microchip's MCP23017: 16 bit I2C GPIO expander:

Only output mode is supported currently.
Hardcoded to use I2C port 1 on RPI 2 and 3.
No dependency on wiringpi library.
Output value is inverted on gpio ouput pin.( switch on == 0, switch off == 1)
Restore previous output pin status after power outage or system reboot.

Thanks