### PR TITLE
Move Evohome Web installation parameters to where mainworker expects …

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -33,7 +33,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 120
+#define DB_VERSION 121
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -2319,6 +2319,24 @@ bool CSQLHelper::OpenDatabase()
 				if (int returncode = RemoveDir(dzv_rm_Dir1 + "|" + dzv_rm_Dir2, errorPath))
 					_log.Log(LOG_ERROR, "EventSystem: (%d) Could not remove %s, please remove manually!", returncode, errorPath.c_str());
 			}
+		}
+		if (dbversion < 121)
+		{
+			// incorrect call to hardware class from mainworker: move Evohome installation parameters from Mode5 to unused Mode3
+			std::stringstream szQuery2;
+			std::vector<std::vector<std::string> > result;
+			szQuery2 << "SELECT ID, Mode5 FROM Hardware WHERE([Type]==" << HTYPE_EVOHOME_WEB << ")";
+			result = query(szQuery2.str());
+			if (result.size() > 0)
+			{
+				std::vector<std::vector<std::string> >::const_iterator itt;
+				for (itt = result.begin(); itt != result.end(); ++itt)
+				{
+					std::vector<std::string> sd = *itt;
+					safe_query("UPDATE Hardware SET Mode3='%q', Mode5='' WHERE (ID=%s)", sd[1].c_str(), sd[0].c_str());
+				}
+			}
+			
 		}
 	}
 	else if (bNewInstall)

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -918,7 +918,7 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&Mode1=" + Pollseconds +
 					"&Mode2=" + UseFlags +
-					"&Mode5=" + evo_installation,
+					"&Mode3=" + evo_installation,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -1782,7 +1782,7 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&Mode1=" + Pollseconds +
 					"&Mode2=" + UseFlags +
-					"&Mode5=" + evo_installation,
+					"&Mode3=" + evo_installation,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -5224,7 +5224,7 @@ define(['app'], function (app) {
 							$("#hardwarecontent #divevohomeweb #showlocationevohomeweb").prop("checked",((UseFlags & 4) >>> 2));
 							$("#hardwarecontent #divevohomeweb #comboevoprecision").val((UseFlags & 24));
 
-							var Location = parseInt(data["Mode5"]);
+							var Location = parseInt(data["Mode3"]);
 							for (var i=1;i<10;i++){
 								$("#hardwarecontent #divevohomeweb #comboevolocation")[0].options[i]=new Option(i,i);
 								$("#hardwarecontent #divevohomeweb #comboevogateway")[0].options[i]=new Option(i,i);

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1453
+# ref 1454
 
 CACHE:
 # CSS


### PR DESCRIPTION
…them to be

Refactoring/code cleanup in mainworker caused the Evohome via Web API hardware class to always be called with installation parameters [0,0,0] regardless of what the user specified.