### PR TITLE
Allow scripts to set Evohome setpoints

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2367,8 +2367,25 @@ bool CEventSystem::parseBlocklyActions(const std::string &Actions, const std::st
 		else if (deviceName.find("SetSetpoint:") == 0)
 		{
 			int idx = atoi(deviceName.substr(12).c_str());
-			m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5f, idx, doWhat));
-			actionsDone = true;
+			std::string temp, mode, until;
+			std::vector<std::string> aParam;
+			StringSplit(doWhat, "#", aParam);
+			switch (aParam.size()) {
+			case 3:
+				until = ParseBlocklyString(aParam[2]);
+			case 2:
+				mode = ParseBlocklyString(aParam[1]);
+			case 1:
+				temp = ParseBlocklyString(aParam[0]);
+				m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5f, idx, temp, mode, until));
+				actionsDone = true;
+				break;
+
+			default:
+				//Invalid
+				_log.Log(LOG_ERROR, "EventSystem: EvohomeSetPoint, not enough parameters!");
+				break;
+			}
 			continue;
 		}
 		else if (deviceName.find("SendEmail") != std::string::npos)
@@ -3473,10 +3490,27 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 	else if (lCommand.find("SetSetPoint:") == 0)
 	{
 		std::string SetPointIdx = lCommand.substr(12);
-		std::string SetPointValue = lua_tostring(lua_state, -1);
+		std::string luaString = lua_tostring(lua_state, -1);
+		std::string temp, mode, until;
+		std::vector<std::string> aParam;
+		int idx;
+		StringSplit(luaString, "#", aParam);
+		switch (aParam.size()) {
+		case 3:
+			until = aParam[2];
+		case 2:
+			mode = aParam[1];
+		case 1:
+			idx = atoi(SetPointIdx.c_str());
+			temp = aParam[0];
+			m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5f, idx, temp, mode, until));
+			break;
 
-		int idx = atoi(SetPointIdx.c_str());
-		m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5f, idx, SetPointValue));
+		default:
+			//Invalid
+			_log.Log(LOG_ERROR, "EventSystem: EvohomeSetPoint, incorrect parameters!");
+			return false;
+		}
 	}
 	else
 	{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3144,7 +3144,7 @@ void CSQLHelper::Do_Work()
 				sstr << itt->_idx;
 				std::string idx = sstr.str();
 				float fValue = (float)atof(itt->_sValue.c_str());
-				m_mainworker.SetSetPoint(idx, fValue);
+				m_mainworker.SetSetPoint(idx, fValue, itt->_command, itt->_sUntil);
 			}
 			else if (itt->_ItemType == TITEM_SEND_NOTIFICATION)
 			{

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -65,6 +65,7 @@ struct _tTaskItem
 	int _nValue;
 	std::string _sValue;
 	std::string _command;
+	std::string _sUntil;
 	unsigned char _level;
 	int _Hue;
 	std::string _relatedEvent;
@@ -226,13 +227,15 @@ struct _tTaskItem
 			getclock(&tItem._DelayTimeBegin);
 		return tItem;
 	}
-	static _tTaskItem SetSetPoint(const float DelayTime, const uint64_t idx, const std::string &varvalue)
+	static _tTaskItem SetSetPoint(const float DelayTime, const uint64_t idx, const std::string &varvalue, const std::string &mode = std::string(), const std::string &until = std::string())
 	{
 		_tTaskItem tItem;
 		tItem._ItemType = TITEM_SET_SETPOINT;
 		tItem._DelayTime = DelayTime;
 		tItem._idx = idx;
 		tItem._sValue = varvalue;
+		tItem._command = mode;
+		tItem._sUntil = until;
 		if (DelayTime)
 			getclock(&tItem._DelayTimeBegin);
 		return tItem;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -12150,8 +12150,6 @@ namespace http {
 			//unsigned char dSubType=atoi(sd[1].c_str());
 			//int HwdID = atoi(sd[2].c_str());
 
-			int nEvoMode = 0;
-
 			if (setPoint != "" || state != "")
 			{
 				double tempcelcius = atof(setPoint.c_str());
@@ -12161,14 +12159,8 @@ namespace http {
 					tempcelcius = ConvertToCelsius(tempcelcius);
 				}
 				sprintf(szTmp, "%.2f", tempcelcius);
-				if (dType == pTypeEvohomeZone || dType == pTypeEvohomeWater)//sql update now done in setsetpoint for evohome devices
-				{
-					if (mode == "PermanentOverride")
-						nEvoMode = 1;
-					else if (mode == "TemporaryOverride")
-						nEvoMode = 2;
-				}
-				else
+
+				if (dType != pTypeEvohomeZone && dType != pTypeEvohomeWater)//sql update now done in setsetpoint for evohome devices
 				{
 					m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, sValue='%q' WHERE (ID == '%q')",
 						used, szTmp, idx.c_str());
@@ -12217,9 +12209,9 @@ namespace http {
 				if (urights < 1)
 					return;
 				if (dType == pTypeEvohomeWater)
-					m_mainworker.SetSetPoint(idx, (state == "On") ? 1.0f : 0.0f, nEvoMode, until);//FIXME float not guaranteed precise?
+					m_mainworker.SetSetPoint(idx, (state == "On") ? 1.0f : 0.0f, mode, until);//FIXME float not guaranteed precise?
 				else if (dType == pTypeEvohomeZone)
-					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())), nEvoMode, until);
+					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())), mode, until);
 				else
 					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())));
 			}

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -69,7 +69,7 @@ public:
 	bool DoesDeviceActiveAScene(const uint64_t DevRowIdx, const int Cmnd);
 
 	bool SetSetPoint(const std::string &idx, const float TempValue);
-	bool SetSetPoint(const std::string &idx, const float TempValue, const int newMode, const std::string &until);
+	bool SetSetPoint(const std::string &idx, const float TempValue, const std::string &newMode, const std::string &until);
 	bool SetSetPointInt(const std::vector<std::string> &sd, const float TempValue);
 	bool SetThermostatState(const std::string &idx, const int newState);
 	bool SetClock(const std::string &idx, const std::string &clockstr);


### PR DESCRIPTION
... and clean up the polymorphism in MainWorker:SetSetPoint() somewhat. The
three-argument version of SetSetPoint() only worked for Evohome devices,
while the one-argument version worked for everything, by calling through
to the Evohome version where necessary. I'm not convinced I would have
given those functions the same name, but OK. If the intent is that this
interface will be used to handle Domoticz-based scheduling for currently
"dumb" devices at some point in the future, that makes some sense.

Fix up the three-argument version to call through to SetSetPointInt() for
devices that it doesn't support, and then change the script invocations
so that they can handle up to three arguments.

Also sift the string matching on PermanentOverride/TemporaryOverride into
SetSetPoint() from the web server code, to avoid duplicating it.

Now with a little bit of scripting and a virtual switch, I can say
'Alexa, turn on bathtime" and ths kids' radiators all turn up to 23°C
for the next hour.