### PR TITLE
Fix date formats

### DIFF
--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -971,7 +971,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1043,7 +1043,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1430,7 +1430,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1772,7 +1772,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -1141,9 +1141,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1246,9 +1253,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1478,9 +1492,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1574,9 +1595,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1813,9 +1841,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1916,9 +1951,16 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					if (sdate.c_str()[2] == '/' && sdate.c_str()[5] == '/') {
+					/* Legacy US-local date format */
+						Month = atoi(sdate.substr(0, 2).c_str());
+						Day = atoi(sdate.substr(3, 2).c_str());
+						Year = atoi(sdate.substr(6, 4).c_str());
+					} else {
+						Year = atoi(sdate.substr(0, 4).c_str());
+						Month = atoi(sdate.substr(5, 2).c_str());
+						Day = atoi(sdate.substr(8, 2).c_str());
+					}
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -616,7 +616,7 @@ define(['app'], function (app) {
 			$("#lightcontent #sdate").datepicker({
 				minDate: now,
 				defaultDate: now,
-				dateFormat: "mm/dd/yy",
+				dateFormat: "yy-mm-dd",
 				showWeek: true,
 				firstDay: 1
 			});

--- a/www/app/ScenesController.js
+++ b/www/app/ScenesController.js
@@ -1273,7 +1273,7 @@ define(['app'], function (app) {
 			$("#scenecontent #sdate").datepicker({
 				minDate: now,
 				defaultDate: now,
-				dateFormat: "mm/dd/yy",
+				dateFormat: "yy-mm-dd",
 				showWeek: true,
 				firstDay: 1
 			});
@@ -1318,7 +1318,7 @@ define(['app'], function (app) {
 					$("#scenecontent #timerparamstable #rdate").hide();
 					$("#scenecontent #timerparamstable #rnorm").hide();
 					$("#scenecontent #timerparamstable #rdays").hide();
-					$("#scenecontent #timerparamstable #roccurence").show();
+				$("#scenecontent #timerparamstable #roccurence").show();
 					$("#scenecontent #timerparamstable #rmonths").show();
 				}
 				else {

--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -74,7 +74,7 @@ define(['app'], function (app) {
 				$(":button:contains('Cancel Override')").attr("disabled", "d‌​isabled").addClass('ui-state-disabled');
 			else
 				$(":button:contains('Cancel Override')").removeAttr("disabled").removeClass('ui-state-disabled');
-			$("#dialog-editsetpoint #until").datetimepicker();
+		    $("#dialog-editsetpoint #until").datetimepicker({dateFormat: "yy-mm-dd"});
 			if (until != "")
 				$("#dialog-editsetpoint #until").datetimepicker("setDate", (new Date(until)));
 			$("#dialog-editsetpoint").i18n();
@@ -94,7 +94,7 @@ define(['app'], function (app) {
 				$(":button:contains('Cancel Override')").attr("disabled", "d‌​isabled").addClass('ui-state-disabled');
 			else
 				$(":button:contains('Cancel Override')").removeAttr("disabled").removeClass('ui-state-disabled');
-			$("#dialog-editstate #until_state").datetimepicker();
+			$("#dialog-editstate #until_state").datetimepicker({dateFormat: "yy-mm-dd"});
 			if (until != "")
 				$("#dialog-editstate #until_state").datetimepicker("setDate", (new Date(until)));
 			$("#dialog-editstate").i18n();

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -533,7 +533,7 @@ define(['app'], function (app) {
 			$('.datepick').datepicker({
 				minDate: now,
 				defaultDate: now,
-				dateFormat: "mm/dd/yy",
+				dateFormat: "yy-mm-dd",
 				showWeek: true,
 				firstDay: 1,
 				onSelect: function () {

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1462
+# ref 1463
 
 CACHE:
 # CSS


### PR DESCRIPTION
Use standard ISO date format YYYY-MM-DD everywhere, never the parochial local dialects.

The first commit should be fairly straightforward. The second actual changes the timer results returned on the wire, which is why I've pulled it out into a separate commit for specific consideration.

But as I note in that commit comment, it should be fine. What kind of person would see "dd/mm/yy" or "mm/dd/yy" on the wire and *not* assume that it **is** going to change?