### PR TITLE
OnkyoAVTCP: Various improvements (raw EISCP command, net playback status, non-MRIQSTN support, compatibility fix)

### DIFF
--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -12,6 +12,7 @@ public:
 	bool isConnected(){ return mIsConnected; };
 	bool WriteToHardware(const char *pdata, const unsigned char length);
 	bool SendPacket(const char *pdata);
+	bool SendPacket(const char *pCmd, const char *pArg);
 
 public:
 	// signals
@@ -25,7 +26,7 @@ private:
 	void ReceiveMessage(const char *pData, int Len);
 	void ReceiveSwitchMsg(const char *pData, int Len, bool muting, int ID);
 	bool ReceiveXML(const char *pData, int Len);
-	void EnsureDevice(int Unit, const char *options = NULL);
+	void EnsureSwitchDevice(int Unit, const char *options = NULL);
 	std::string BuildSelectorOptions(const std::string & names, const std::string & ids);
 
  protected:

--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -11,6 +11,7 @@ public:
 	~OnkyoAVTCP(void);
 	bool isConnected(){ return mIsConnected; };
 	bool WriteToHardware(const char *pdata, const unsigned char length);
+	bool SendPacket(const char *pdata);
 
 public:
 	// signals
@@ -21,7 +22,6 @@ private:
 	bool StopHardware();
 	unsigned char *m_pPartialPkt;
 	int m_PPktLen;
-	bool SendPacket(const char *pdata);
 	void ReceiveMessage(const char *pData, int Len);
 	void ReceiveSwitchMsg(const char *pData, int Len, bool muting, int ID);
 	bool ReceiveXML(const char *pData, int Len);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -417,6 +417,8 @@ namespace http {
 			RegisterCommandCode("heossetmode", boost::bind(&CWebServer::Cmd_HEOSSetMode, this, _1, _2, _3));
 			RegisterCommandCode("heosmediacommand", boost::bind(&CWebServer::Cmd_HEOSMediaCommand, this, _1, _2, _3));
 
+			RegisterCommandCode("onkyoeiscpcommand", boost::bind(&CWebServer::Cmd_OnkyoEiscpCommand, this, _1, _2, _3));
+
 			RegisterCommandCode("bleboxsetmode", boost::bind(&CWebServer::Cmd_BleBoxSetMode, this, _1, _2, _3));
 			RegisterCommandCode("bleboxgetnodes", boost::bind(&CWebServer::Cmd_BleBoxGetNodes, this, _1, _2, _3));
 			RegisterCommandCode("bleboxaddnode", boost::bind(&CWebServer::Cmd_BleBoxAddNode, this, _1, _2, _3));

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -261,6 +261,7 @@ private:
 	void Cmd_DeleteMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_HEOSSetMode(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_HEOSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_OnkyoEiscpCommand(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_AddYeeLight(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_AddArilux(WebEmSession & session, const request& req, Json::Value &root);
 


### PR DESCRIPTION
We don't probe for these at startup, and maybe we should. But it's fairly
forthcoming with spontaneous updates anyway, so this is a good start.

![textinfo](https://user-images.githubusercontent.com/911239/33330745-9b81b75c-d457-11e7-9ad7-557c168eae33.png)

Also support sending raw commands such as for radio presets:
```
http://${DOMOTICZ}/json.htm?type=command&param=onkyoeiscpcommand&idx=${IDX}&action=NPR04
```

