### PR TITLE
JS: Add myglobals.DateFormat and honour it for all datepickers

### DIFF
--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -1097,7 +1097,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1169,7 +1169,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1267,9 +1267,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1372,9 +1372,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1542,7 +1542,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1604,9 +1604,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1700,9 +1700,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1870,7 +1870,7 @@ namespace http {
 						int Year = atoi(sdate.substr(0, 4).c_str());
 						int Month = atoi(sdate.substr(5, 2).c_str());
 						int Day = atoi(sdate.substr(8, 2).c_str());
-						sprintf(szTmp, "%02d-%02d-%04d", Month, Day, Year);
+						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
 					else
@@ -1938,9 +1938,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -2041,9 +2041,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Month = atoi(sdate.substr(0, 2).c_str());
-					Day = atoi(sdate.substr(3, 2).c_str());
-					Year = atoi(sdate.substr(6, 4).c_str());
+					Year = atoi(sdate.substr(0, 4).c_str());
+					Month = atoi(sdate.substr(5, 2).c_str());
+					Day = atoi(sdate.substr(8, 2).c_str());
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)

--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -74,7 +74,9 @@ define(['app'], function (app) {
 				$(":button:contains('Cancel Override')").attr("disabled", "d‌​isabled").addClass('ui-state-disabled');
 			else
 				$(":button:contains('Cancel Override')").removeAttr("disabled").removeClass('ui-state-disabled');
-			$("#dialog-editsetpoint #until").datetimepicker();
+			$("#dialog-editsetpoint #until").datetimepicker({
+				dateFormat: window.myglobals.DateFormat,
+			});
 			if (until != "")
 				$("#dialog-editsetpoint #until").datetimepicker("setDate", (new Date(until)));
 			$("#dialog-editsetpoint").i18n();
@@ -94,7 +96,9 @@ define(['app'], function (app) {
 				$(":button:contains('Cancel Override')").attr("disabled", "d‌​isabled").addClass('ui-state-disabled');
 			else
 				$(":button:contains('Cancel Override')").removeAttr("disabled").removeClass('ui-state-disabled');
-			$("#dialog-editstate #until_state").datetimepicker();
+			$("#dialog-editstate #until_state").datetimepicker({
+				dateFormat: window.myglobals.DateFormat,
+			});
 			if (until != "")
 				$("#dialog-editstate #until_state").datetimepicker("setDate", (new Date(until)));
 			$("#dialog-editstate").i18n();

--- a/www/app/TemperatureCustomLogController.js
+++ b/www/app/TemperatureCustomLogController.js
@@ -12,7 +12,7 @@ define(['app'], function (app) {
                     $('#customlog').i18n();
 
                     $('.datepick').datepicker({
-                        dateFormat: 'yy-mm-dd',
+                        dateFormat: window.myglobals.DateFormat,
                         onClose: function () {
                             ctrl.datePickerChanged(this);
                         }

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -856,6 +856,7 @@ define(['angularAMD', 'angular-route', 'angular-animate', 'ng-grid', 'ng-grid-fl
 			}
 
 			$.myglobals.DashboardType = $rootScope.config.DashboardType;
+			$.myglobals.DateFormat = $rootScope.config.DateFormat;
 
 			if (typeof $rootScope.config.WindScale != 'undefined') {
 				$.myglobals.windscale = parseFloat($rootScope.config.WindScale);
@@ -902,7 +903,8 @@ define(['angularAMD', 'angular-route', 'angular-animate', 'ng-grid', 'ng-grid-fl
 			appdate: 0,
 			pythonversion: "",
 			versiontooltip: "",
-			ShowUpdatedEffect: true
+			ShowUpdatedEffect: true,
+			DateFormat: "yy-mm-dd"
 		};
 
 		$rootScope.GetGlobalConfig = function () {

--- a/www/app/timers/components.js
+++ b/www/app/timers/components.js
@@ -49,7 +49,7 @@ define(['app', 'timers/factories'], function (app) {
                 element.datepicker({
                     minDate: now,
                     defaultDate: now,
-                    dateFormat: "mm/dd/yy",
+                    dateFormat: window.myglobals.DateFormat,
                     showWeek: true,
                     firstDay: 1,
                     onSelect: function (date) {

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1514
+# ref 1515
 
 CACHE:
 # CSS


### PR DESCRIPTION
As requested in #1965, this makes the date format configurable — instead of hard-coding it in various places, we now have it in `myglobals.DateFormat` so it can be tweaked.

This still doesn't yet allow you to *change* it; that will require more work on the UI side to perform conversions, as discussed. But it's a step in that direction, which can be built on in future commits. And it does fix the immediate issue that Domoticz isn't consistent.