### PR TITLE
HardwareMonitor Domoticz process memory usage

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -723,18 +723,19 @@ void CDomoticzHardwareBase::SendWaterflowSensor(const int NodeID, const int Chil
 
 void CDomoticzHardwareBase::SendCustomSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float Dust, const std::string &defaultname, const std::string &defaultLabel)
 {
-	std::vector<std::vector<std::string> > result;
-	char szTmp[30];
-	sprintf(szTmp, "0000%02X%02X", NodeID, ChildID);
-	result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
-		m_HwdID, szTmp, int(pTypeGeneral), int(sTypeCustom));
-	bool bDoesExists = !result.empty();
 
 	_tGeneralDevice gDevice;
 	gDevice.subtype = sTypeCustom;
 	gDevice.id = ChildID;
 	gDevice.intval1 = (NodeID << 8) | ChildID;
 	gDevice.floatval1 = Dust;
+
+	char szTmp[9];
+	sprintf(szTmp, "%08X", gDevice.intval1);
+	std::vector<std::vector<std::string> > result;
+	result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
+		m_HwdID, szTmp, int(pTypeGeneral), int(sTypeCustom));
+	bool bDoesExists = !result.empty();
 
 	if (bDoesExists)
 		sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel);
@@ -1023,7 +1024,7 @@ int CDomoticzHardwareBase::CalculateBaroForecast(const double pressure)
 
 	m_baro_minuteCount++;
 
-	if (m_baro_minuteCount < 36) //if time is less than 35 min 
+	if (m_baro_minuteCount < 36) //if time is less than 35 min
 		return wsbaroforcast_unknown; // Unknown, more time needed
 	else if (m_dP_dt < (-0.25))
 		return wsbaroforcast_heavy_rain; // Quickly falling LP, Thunderstorm, not stable

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -72,7 +72,6 @@ extern std::string szInternalVoltageCommand;
 extern bool bHasInternalCurrent;
 extern std::string szInternalCurrentCommand;
 
-
 #define round(a) ( int ) ( a + .5 )
 
 CHardwareMonitor::CHardwareMonitor(const int ID)
@@ -367,6 +366,14 @@ void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int di
 		float curr = static_cast<float>(atof(devValue.c_str()));
 		SendCurrent(doffset + dindex, curr, devName);
 	}
+#if defined (__linux__)
+	else if (qType == "Process")
+	{
+		doffset = 1500;
+		float usage = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, usage, devName, "MB");
+	}
+#endif
 	return;
 }
 
@@ -532,6 +539,32 @@ void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string &qType)
 			(((double) tp.tv_usec) * 0.000001 );
 	}
 
+#if defined(__linux__)
+	float CHardwareMonitor::GetProcessMemUsage()
+	{
+		pid_t pid = getpid();
+		std::stringstream sPid;
+		sPid << pid;
+		std::ifstream mfile("/proc/" + sPid.str() + "/status");
+		if (!mfile.is_open())
+			return -1;
+		uint32_t VmRSS = -1;
+		uint32_t VmSwap = -1;
+		std::string token;
+		while (mfile >> token)
+		{
+			if (token == "VmRSS:")
+				mfile >> VmRSS;
+			else if (token == "VmSwap:")
+				mfile >> VmSwap;
+
+			// ignore rest of the line
+			mfile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+		}
+		return (VmRSS + VmSwap) / 1000.f;
+	}
+#endif
+
 	float GetMemUsageLinux()
 	{
 #if defined(__FreeBSD__)
@@ -629,6 +662,14 @@ void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string &qType)
 #endif
 		sprintf(szTmp,"%.2f",memusedpercentage);
 		UpdateSystemSensor("Load", 0, "Memory Usage", szTmp);
+#ifdef __linux__
+		float memProcess = GetProcessMemUsage();
+		if (memProcess != -1)
+		{
+			sprintf(szTmp, "%.2f", memProcess);
+			UpdateSystemSensor("Process", 0, "Process Usage", szTmp);
+		}
+#endif
 	}
 
 	void CHardwareMonitor::FetchUnixCPU()

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -43,5 +43,8 @@ private:
 	int m_totcpu;
 	std::string m_dfcommand;
 #endif
+#if defined (__linux__)
+	float GetProcessMemUsage();
+#endif
 };
 


### PR DESCRIPTION
This will monitor process usage for the Domoticz process on Linux (unfortunately other platforms are much harder to monitor, but I think 99% of the users with memory issues use Linux anyway) by getting the relevant VmRSS + VmSwap values from it's status file. This way reports of memory leakages etc are much clearer, because we now know for sure whether it's generic memory usage or specific to Domoticz without having to dig too deep.

Changes to SendCustomSensor are needed to work correctly with child id > 255