### PR TITLE
Comm5 TCP and Serial IO driver update

### DIFF
--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -4,8 +4,6 @@
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
-#include "../httpclient/HTTPClient.h"
-#include "../httpclient/UrlEncode.h"
 
 #include <iostream>
 

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -10,26 +10,6 @@
 #include <boost/lexical_cast.hpp>
 
 #define RETRY_DELAY 30
-#define Max_Comm5_MA_Relais 16
-
-static inline std::string &rtrim(std::string &s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-	return s;
-}
-
-static inline std::vector<std::string> tokenize(const std::string &s) {
-	std::vector<std::string> tokens;
-	std::istringstream iss(s);
-	std::copy(std::istream_iterator<std::string>(iss),
-		std::istream_iterator<std::string>(),
-		std::back_inserter(tokens));
-	return tokens;
-}
-
-static inline bool startsWith(const std::string &haystack, const std::string &needle) {
-	return needle.length() <= haystack.length()
-		&& std::equal(needle.begin(), needle.end(), haystack.begin());
-}
 
 Comm5Serial::Comm5Serial(const int ID, const std::string& devname, unsigned int baudRate /*= 115200*/) :
 	m_szSerialPort(devname),

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -4,6 +4,8 @@
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
+#include "../httpclient/HTTPClient.h"
+#include "../httpclient/UrlEncode.h"
 
 #include <iostream>
 
@@ -142,20 +144,14 @@ void Comm5Serial::Do_Work()
 
 	while (!m_stoprequested)
 	{
-		sleep_milliseconds(200);
-		if (m_stoprequested)
-			break;
-		msec_counter++;
-		if (msec_counter == 5)
-		{
+		m_LastHeartbeat = mytime(NULL);
+		sleep_milliseconds(40);
+		if (msec_counter++ >= 100) {
 			msec_counter = 0;
-
-			sec_counter++;
-			if (sec_counter % 12 == 0) {
-				m_LastHeartbeat = mytime(NULL);
-			}
+			querySensorState();
 		}
 	}
+
 	_log.Log(LOG_STATUS, "Comm5 MA-42XX: Serial Worker stopped...");
 }
 

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -163,7 +163,7 @@ void Comm5Serial::requestDigitalInputResponseHandler(const std::string & frame)
 	for (int i = 0; i < 8; ++i) {
 		bool on = (sensorStatus & (1 << i)) != 0 ? true : false;
 		if (((lastKnownSensorState & (1 << i)) ^ (sensorStatus & (1 << i))) || initSensorData) {
-			SendSwitch((i + 1) << 8, 1, 255, on, 0, "Sensor " + boost::lexical_cast<std::string>(i + 1));
+			SendSwitchUnchecked((i + 1) << 8, 1, 255, on, 0, "Sensor " + boost::lexical_cast<std::string>(i + 1));
 		}
 	}
 	lastKnownSensorState = sensorStatus;

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -6,10 +6,13 @@
 #include "../main/mainworker.h"
 
 #include <iostream>
-
 #include <boost/lexical_cast.hpp>
 
-#define RETRY_DELAY 30
+/*
+	This driver allows Domoticz to control any I/O module from the MA-4xxx Family
+
+	These modules provide relays and digital sensors in the range of 5-30V DC.
+*/
 
 Comm5Serial::Comm5Serial(const int ID, const std::string& devname, unsigned int baudRate /*= 115200*/) :
 	m_szSerialPort(devname),

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -128,7 +128,7 @@ void Comm5TCP::processSensorData(const std::string& line)
 	for (int i = 0; i < 16; ++i) {
 		bool on = (sensorbitfield & (1 << i)) != 0 ? true : false;
 		if (((lastKnownSensorState & (1 << i)) ^ (sensorbitfield & (1 << i))) || initSensorData) {
-			SendSwitch((i + 1) << 8, 1, 255, on, 0, "Sensor " + boost::lexical_cast<std::string>(i + 1));
+			SendSwitchUnchecked((i + 1) << 8, 1, 255, on, 0, "Sensor " + boost::lexical_cast<std::string>(i + 1));
 		}
 	}
 	lastKnownSensorState = sensorbitfield;

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -12,6 +12,15 @@
 #define RETRY_DELAY 30
 #define Max_Comm5_MA_Relais 16
 
+/*
+   This driver allows Domoticz to control any I/O module from the MA-5xxx-2 Family, including the fiber-optics (FX)
+   variations.
+   https://www.comm5.com.br/en/products/io-modules/
+   These modules provide relays and digital sensors in the range of 5-30V DC or 70-240V AC selectable by dip switches
+   for each individual input.
+
+*/
+
 static inline std::string &rtrim(std::string &s) {
 	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
 	return s;

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -556,6 +556,46 @@ void CDomoticzHardwareBase::SendSwitchIfNotExists(const int NodeID, const int Ch
 	}
 }
 
+void CDomoticzHardwareBase::SendSwitchUnchecked(const int NodeID, const int ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname, const int RssiLevel /* =12 */)
+{
+	double rlevel = (16.0 / 100.0)*Level;
+	int level = int(rlevel);
+
+	//make device ID
+	unsigned char ID1 = (unsigned char)((NodeID & 0xFF000000) >> 24);
+	unsigned char ID2 = (unsigned char)((NodeID & 0xFF0000) >> 16);
+	unsigned char ID3 = (unsigned char)((NodeID & 0xFF00) >> 8);
+	unsigned char ID4 = (unsigned char)NodeID & 0xFF;
+
+	//Send as Lighting 2
+	tRBUF lcmd;
+	memset(&lcmd, 0, sizeof(RBUF));
+	lcmd.LIGHTING2.packetlength = sizeof(lcmd.LIGHTING2) - 1;
+	lcmd.LIGHTING2.packettype = pTypeLighting2;
+	lcmd.LIGHTING2.subtype = sTypeAC;
+	lcmd.LIGHTING2.id1 = ID1;
+	lcmd.LIGHTING2.id2 = ID2;
+	lcmd.LIGHTING2.id3 = ID3;
+	lcmd.LIGHTING2.id4 = ID4;
+	lcmd.LIGHTING2.unitcode = ChildID;
+	if (!bOn)
+	{
+		lcmd.LIGHTING2.cmnd = light2_sOff;
+	}
+	else
+	{
+		if (level != 0)
+			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
+		else
+			lcmd.LIGHTING2.cmnd = light2_sOn;
+	}
+	lcmd.LIGHTING2.level = level;
+	lcmd.LIGHTING2.filler = 0;
+	lcmd.LIGHTING2.rssi = RssiLevel;
+	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), BatteryLevel);
+}
+
+
 void CDomoticzHardwareBase::SendSwitch(const int NodeID, const int ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname, const int RssiLevel /* =12 */)
 {
 	double rlevel = (16.0 / 100.0)*Level;
@@ -586,33 +626,7 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const int ChildID, cons
 				return;
 		}
 	}
-
-	//Send as Lighting 2
-	tRBUF lcmd;
-	memset(&lcmd, 0, sizeof(RBUF));
-	lcmd.LIGHTING2.packetlength = sizeof(lcmd.LIGHTING2) - 1;
-	lcmd.LIGHTING2.packettype = pTypeLighting2;
-	lcmd.LIGHTING2.subtype = sTypeAC;
-	lcmd.LIGHTING2.id1 = ID1;
-	lcmd.LIGHTING2.id2 = ID2;
-	lcmd.LIGHTING2.id3 = ID3;
-	lcmd.LIGHTING2.id4 = ID4;
-	lcmd.LIGHTING2.unitcode = ChildID;
-	if (!bOn)
-	{
-		lcmd.LIGHTING2.cmnd = light2_sOff;
-	}
-	else
-	{
-		if (level!=0)
-			lcmd.LIGHTING2.cmnd = light2_sSetLevel;
-		else
-			lcmd.LIGHTING2.cmnd = light2_sOn;
-	}
-	lcmd.LIGHTING2.level = level;
-	lcmd.LIGHTING2.filler = 0;
-	lcmd.LIGHTING2.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), BatteryLevel);
+	SendSwitchUnchecked(NodeID, ChildID, BatteryLevel, bOn, Level, defaultname, RssiLevel);
 }
 
 void CDomoticzHardwareBase::SendBlindSensor(const int NodeID, const int ChildID, const int BatteryLevel, const int Command, const std::string &defaultname, const int RssiLevel /* =12 */)

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -64,6 +64,7 @@ protected:
 	void SendLuxSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float Lux, const std::string &defaultname);
 	void SendAirQualitySensor(const int NodeID, const int ChildID, const int BatteryLevel, const int AirQuality, const std::string &defaultname);
 	void SendUsageSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float Usage, const std::string &defaultname);
+	void SendSwitchUnchecked(const int NodeID, const int ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname, const int RssiLevel = 12);
 	void SendSwitch(const int NodeID, const int ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname, const int RssiLevel = 12);
 	void SendSwitchIfNotExists(const int NodeID, const int ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname);
 	void SendRGBWSwitch(const int NodeID, const int ChildID, const int BatteryLevel, const double Level, const bool bIsRGBW, const std::string &defaultname);


### PR DESCRIPTION
Update the serial IO hardware to do periodic updates of the IO State.
Fix issue when updating a switch state before the database is updated from the previus change was ignored, leaving the system in an outdated state.