### PR TITLE
fix power [kWh] usage

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13799,6 +13799,14 @@ namespace http {
 								{
 									//bars / hour
 									std::string actDateTimeHour = sd[2].substr(0, 13);
+
+									std::stringstream s_str1(sd[0]);
+									long long actValue;
+									s_str1 >> actValue;
+
+									if (actValue >= ulLastValue)
+										ulLastValue = actValue;
+
 									if (actDateTimeHour != LastDateTime || ((method == 1) && (itt + 1 == result.end())))
 									{
 										if (bHaveFirstValue)
@@ -13840,12 +13848,6 @@ namespace http {
 										LastDateTime = actDateTimeHour;
 										bHaveFirstValue = false;
 									}
-									std::stringstream s_str1(sd[0]);
-									long long actValue;
-									s_str1 >> actValue;
-
-									if (actValue >= ulLastValue)
-										ulLastValue = actValue;
 
 									if (!bHaveFirstValue)
 									{


### PR DESCRIPTION
For calculate the power usage
The laste 5 minutes are not count
The result is in log of power usage if you use 1000w during 1 h the result are 917 kwh
This patch fix it

i have report this bug
https://github.com/domoticz/domoticz/issues/1981

(I don't found how to link a issues to this pull request)