### PR TITLE
changes in I2C hardware module

### DIFF
--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -146,21 +146,16 @@ const char* szI2CTypeNames[] = {
 };
 
 I2C::I2C(const int ID, const _eI2CType DevType, const std::string &Address, const std::string &SerialPort, const int Mode1):
-m_dev_type(DevType)
+m_dev_type(DevType),
+m_i2c_addr((uint8_t)atoi(Address.c_str())),
+m_ActI2CBus(SerialPort),
+m_invert_data((bool) Mode1)
 {
-	if ((m_dev_type == I2CTYPE_PCF8574) || (m_dev_type == I2CTYPE_MCP23017)) {
-		
-		unsigned short i2c_addr =  (unsigned short)atoi(Address.c_str());
-		if (Mode1 == 0) invert_data=false;
-		else 			invert_data=true;
-	}
+	_log.Log(LOG_STATUS, "I2C  Start HW witf ID: %d Name: %s Address: %d Port: %s Invert:%d ", ID, szI2CTypeNames[m_dev_type], m_i2c_addr, m_ActI2CBus.c_str(), m_invert_data);
 
 	m_stoprequested = false;
 	m_HwdID = ID;
-	if ( SerialPort!="" ){ // use enterd port
-		m_ActI2CBus = SerialPort;
-	}
-	else { // autodetec port
+	if ( m_ActI2CBus=="" ){ // if empty option then autodetect i2c bus
 		m_ActI2CBus = "/dev/i2c-1";
 		if (!i2c_test(m_ActI2CBus.c_str()))
 		{
@@ -212,10 +207,10 @@ bool I2C::WriteToHardware(const char *pdata, const unsigned char length)
 
 	const tRBUF *pCmd = reinterpret_cast<const tRBUF*>(pdata);
 	if ((pCmd->LIGHTING2.packettype == pTypeLighting2)) {
-		unsigned char pin_number = pCmd->LIGHTING2.unitcode; // in DB column "Unit" is used for identify pin number
-		unsigned char  value = pCmd->LIGHTING2.cmnd;
+		uint8_t pin_number = pCmd->LIGHTING2.unitcode; // in DB column "Unit" is used for identify pin number
+		uint8_t  value = pCmd->LIGHTING2.cmnd;
 //#ifdef INVERT_PCF8574_MCP23017
-		if (invert_data == true) {
+		if (m_invert_data == true) {
 			value = ~value & 0x01; // Invert Status
 		}
 //#endif
@@ -340,19 +335,19 @@ void I2C::PCF8574_ReadChipDetails()
 #ifndef HAVE_LINUX_I2C
 	return;
 #else
-	char buf = 0;
+	uint8_t buf = 0;
 	int fd = i2c_Open(m_ActI2CBus.c_str()); // open i2c
 	if (fd < 0) return; // Error opening i2c device!
-	if ( readByteI2C(fd, &buf, i2c_addr) < 0 ) return; //read from i2c
+	if ( readByteI2C(fd, &buf, m_i2c_addr) < 0 ) return; //read from i2c
 //#ifdef INVERT_PCF8574_MCP23017
-	if (invert_data==true) {
+	if (m_invert_data==true) {
 		buf=~buf; // Invert Status
 	}
 //#endif
-	for (char pin_number=0; pin_number<8; pin_number++){
-		int DeviceID = (i2c_addr << 8) + pin_number; // DeviceID from i2c_address and pin_number
+	for (uint8_t pin_number=0; pin_number<8; pin_number++){
+		int DeviceID = (m_i2c_addr << 8) + pin_number; // DeviceID from i2c_address and pin_number
 		unsigned char Unit = pin_number;
-		char pin_mask=0x01<<pin_number;
+		uint8_t pin_mask=0x01<<pin_number;
 		bool value=(buf & pin_mask);
 		SendSwitch(DeviceID, Unit, 255, value, 0, ""); // create or update switch
 	}
@@ -361,23 +356,23 @@ void I2C::PCF8574_ReadChipDetails()
 }
 
 
-char I2C::PCF8574_WritePin(char pin_number,char  value)
+int I2C::PCF8574_WritePin(uint8_t pin_number,uint8_t  value)
 {	
 #ifndef HAVE_LINUX_I2C
 	return -1;
 #else
-	_log.Log(LOG_NORM, "GPIO: WRITE TO PCF8574 pin:%d, value: %d, i2c_address:%d", pin_number, value, i2c_addr);
-	char pin_mask=0x01<<pin_number; // create pin mask from pin number
-	char buf_act = 0;
-	char buf_new = 0;
+	_log.Log(LOG_NORM, "GPIO: WRITE TO PCF8574 pin:%d, value: %d, i2c_address:%d", pin_number, value, m_i2c_addr);
+	uint8_t pin_mask=0x01<<pin_number; // create pin mask from pin number
+	uint8_t buf_act = 0;
+	uint8_t buf_new = 0;
 	int fd = i2c_Open(m_ActI2CBus.c_str());
 	if (fd < 0) return -1; // Error opening i2c device!
-	if ( readByteI2C(fd, &buf_act, i2c_addr) < 0 ) return -2;
+	if ( readByteI2C(fd, &buf_act, m_i2c_addr) < 0 ) return -2;
 	lseek(fd,0,SEEK_SET); // after read back file cursor to begin (prepare to write new value on begin)
 	if (value==1) buf_new = buf_act | pin_mask;	//prepare new value by combinate current value, mask and new value
 	else buf_new = buf_act & ~pin_mask;
 	if (buf_new!=buf_act) { // if value change write new value
-		if (writeByteI2C(fd, buf_new, i2c_addr) < 0 ) {
+		if (writeByteI2C(fd, buf_new, m_i2c_addr) < 0 ) {
 			_log.Log(LOG_ERROR, "GPIO: %s: Error write to device!...", szI2CTypeNames[m_dev_type]);
 			return -3;
 		}
@@ -403,7 +398,7 @@ void I2C::MCP23017_Init()
 	int unit;
 	bool value;
 	
-	result = m_sql.safe_query("SELECT Unit, nValue FROM DeviceStatus WHERE (HardwareID = %d) AND (DeviceID like '000%02X%%');", m_HwdID, i2c_addr);
+	result = m_sql.safe_query("SELECT Unit, nValue FROM DeviceStatus WHERE (HardwareID = %d) AND (DeviceID like '000%02X%%');", m_HwdID, m_i2c_addr);
 	if (!result.empty())
 	{
 		for (itt = result.begin(); itt != result.end(); ++itt)
@@ -423,23 +418,23 @@ void I2C::MCP23017_Init()
 				value = true;
 			}
 
-			int DeviceID = (i2c_addr << 8) + (unsigned char)unit; 			// DeviceID from i2c_address and pin_number
+			int DeviceID = (m_i2c_addr << 8) + (unsigned char)unit; 			// DeviceID from i2c_address and pin_number
 			SendSwitch(DeviceID, unit, 255, value, 0, ""); 					// create or update switch
 			//_log.Log(LOG_NORM, "SendSwitch(DeviceID: %d, unit: %d, value: %d", DeviceID, unit, value );
 		}
 	}
 	else {
 		for (char pin_number=0; pin_number<16; pin_number++){
-			int DeviceID = (i2c_addr << 8) + pin_number; 			// DeviceID from i2c_address and pin_number
+			int DeviceID = (m_i2c_addr << 8) + pin_number; 			// DeviceID from i2c_address and pin_number
 			SendSwitch(DeviceID, pin_number, 255, value, 0, ""); 			// create switch
 		}
 	}
 	if (I2CWriteReg16(fd, MCP23x17_GPIOA, GPIO_reg) < 0 ) {	// write values from domoticz db to gpio register
-		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 		return; 											// write to i2c failed
 	}
 	if (I2CWriteReg16(fd, MCP23x17_IODIRA, 0x0000) < 0 ){	// set all gpio pins on the port as output
-		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		_log.Log(LOG_NORM, "I2C::MCP23017_Init. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 		return; 											// write to i2c failed
 	}
 	close(fd);
@@ -464,7 +459,7 @@ void I2C::MCP23017_ReadChipDetails()
 	close(fd);
 
 	if (rc < 0) {
-		_log.Log(LOG_NORM, "I2C::MCP23017_ReadChipDetails. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		_log.Log(LOG_NORM, "I2C::MCP23017_ReadChipDetails. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 		return; //read from i2c failed
 	}
 	if ((data.word == 0xFFFF)){									// if oidir port is 0xFFFF means the chip has been reset
@@ -474,12 +469,12 @@ void I2C::MCP23017_ReadChipDetails()
 #endif
 }
 
-int I2C::MCP23017_WritePin(char pin_number,char  value)
+int I2C::MCP23017_WritePin(uint8_t pin_number,uint8_t  value)
 {	
 #ifndef HAVE_LINUX_I2C
 	return -1;
 #else
-	_log.Log(LOG_NORM, "GPIO: WRITE TO MCP23017 pin:%d, value: %d, i2c_address:%d", pin_number, value, i2c_addr);
+	_log.Log(LOG_NORM, "GPIO: WRITE TO MCP23017 pin:%d, value: %d, i2c_address:%d", pin_number, value, m_i2c_addr);
 	uint16_t pin_mask=0, iodir_mask=0;
 	unsigned char gpio_port, iodir_port;
 	uint16_t new_data = 0;
@@ -495,13 +490,13 @@ int I2C::MCP23017_WritePin(char pin_number,char  value)
 	
 	rc = I2CReadReg16(fd, MCP23x17_GPIOA, &cur_data); 		// get current gio port value
 	if (rc < 0) {
-		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 		close(fd);
 		return -2; 						//read from i2c failed
 	}
 	rc = I2CReadReg16(fd, MCP23x17_IODIRA, &cur_iodir); 		// get current iodir port value
 	if (rc < 0) {						//read from i2c failed
-		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+		_log.Log(LOG_NORM, "I2C::MCP23017_WritePin. %s. Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 		close(fd);
 		return -2; 						//read from i2c failed
 	}
@@ -512,12 +507,12 @@ int I2C::MCP23017_WritePin(char pin_number,char  value)
 	
 	if (new_data!=cur_data.word) { 							// if value change write new value
 		if (I2CWriteReg16(fd, MCP23x17_GPIOA, new_data) < 0 ) {
-			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 			close(fd);
 			return -3;
 		}
 		if (I2CWriteReg16(fd, MCP23x17_IODIRA, cur_iodir.word) < 0 ) {		// write to iodir register, set gpio pin as output
-			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+			_log.Log(LOG_ERROR, "I2C::MCP23017_WritePin. %s: Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 			close(fd);
 			return -3;													// write to i2c failed
 		}
@@ -646,7 +641,7 @@ int I2C::WriteCmd(int fd, uint8_t devAction)
 #endif
 }
 
-char I2C::readByteI2C(int fd, char *byte, char i2c_addr)
+int I2C::readByteI2C(int fd, uint8_t *byte, uint8_t i2c_addr)
 {
 #ifndef HAVE_LINUX_I2C
 	return -1;
@@ -665,7 +660,7 @@ char I2C::readByteI2C(int fd, char *byte, char i2c_addr)
 #endif
 }
 
-char I2C::writeByteI2C(int fd, char byte, char i2c_addr)
+int I2C::writeByteI2C(int fd, uint8_t byte, uint8_t i2c_addr)
 {
 #ifndef HAVE_LINUX_I2C
 	return -1;
@@ -695,7 +690,7 @@ int I2C::I2CWriteReg16(int fd, uint8_t reg, uint16_t value)
 		i2c_data bytes;
 		bytes.word = value;
 		struct i2c_msg write_reg[1] = {
-			{ i2c_addr, 0, 3, datatosend } // flag absent == write, two registers, one for register address and one for the value to write
+			{ m_i2c_addr, 0, 3, datatosend } // flag absent == write, two registers, one for register address and one for the value to write
 		};
 		datatosend[0] = reg;						// address of register to write
 		datatosend[1] = bytes.byte[0];						// value to write
@@ -704,7 +699,7 @@ int I2C::I2CWriteReg16(int fd, uint8_t reg, uint16_t value)
 		messagebuffer.nmsgs = 1;
 		rc = ioctl(fd, I2C_RDWR, &messagebuffer); //Send the buffer to the bus and returns a send status
 		if (rc < 0) {
-//			_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+//			_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s. Failed to write to I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 			return rc;
 		}
 		return 0;
@@ -720,14 +715,14 @@ int I2C::I2CReadReg16(int fd, unsigned char reg, i2c_data *data )
 	//i2c_data data;
 	struct i2c_rdwr_ioctl_data messagebuffer;
 	struct i2c_msg read_reg[3] = {
-		{ i2c_addr, 0, 1, &reg },					//flag absent == write, address of register to read
-		{ i2c_addr, I2C_M_RD, 2, data->byte }		//flag I2C_M_RD == read
+		{ m_i2c_addr, 0, 1, &reg },					//flag absent == write, address of register to read
+		{ m_i2c_addr, I2C_M_RD, 2, data->byte }		//flag I2C_M_RD == read
 	};
 	messagebuffer.nmsgs = 2;                  		//Two message/action
 	messagebuffer.msgs = read_reg;            		//load the 'read__reg' message into the buffer
 	return ioctl(fd, I2C_RDWR, &messagebuffer); 		//Send the buffer to the bus and returns a send status
 //	if (rc < 0) {
-//		_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s, Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], i2c_addr);
+//		_log.Log(LOG_NORM, "I2C::I2CReadReg16. %s, Failed to read from I2C device at address: 0x%x", szI2CTypeNames[m_dev_type], m_i2c_addr);
 //		return rc;
 //	}
 	//return data.word ;	

--- a/hardware/I2C.h
+++ b/hardware/I2C.h
@@ -39,8 +39,10 @@ private:
 	boost::shared_ptr<boost::thread> m_thread;
 	volatile bool m_stoprequested;
 
-	std::string m_ActI2CBus;
 	_eI2CType m_dev_type;
+	uint8_t m_i2c_addr;
+	std::string m_ActI2CBus;
+	bool m_invert_data;
 
 
 	bool i2c_test(const char *I2CBusName);
@@ -93,20 +95,16 @@ private:
 	void TSL2561_ReadSensorDetails();
 	void TSL2561_Init();
 	
-	// PCF8574, MCP23017
-	unsigned char	i2c_addr;
-	bool 			invert_data;
-	
 	// PCF8574
 	void			PCF8574_ReadChipDetails();
-	char			PCF8574_WritePin(char pin_number,char  value);
-	char 			readByteI2C(int fd, char *byte, char i2c_addr);
-	char 			writeByteI2C(int fd, char byte, char i2c_addr);
+	int			PCF8574_WritePin(uint8_t pin_number,uint8_t  value);
+	int 			readByteI2C(int fd, uint8_t *byte, uint8_t i2c_addr);
+	int 			writeByteI2C(int fd, uint8_t byte, uint8_t i2c_addr);
 
 	// MCP23017
 	void 			MCP23017_Init();
 	void			MCP23017_ReadChipDetails();
-	int				MCP23017_WritePin(char pin_number,char  value);
+	int				MCP23017_WritePin(uint8_t pin_number,uint8_t  value);
 	int 			I2CWriteReg16(int fd, uint8_t reg, uint16_t value);
 	int		 		I2CReadReg16(int fd, unsigned char reg, i2c_data *data);
 

--- a/hardware/I2C.h
+++ b/hardware/I2C.h
@@ -22,7 +22,7 @@ public:
 		I2CTYPE_MCP23017
 	};
 
-	explicit I2C(const int ID, const _eI2CType DevType, const int Port);
+	explicit I2C(const int ID, const _eI2CType DevType, const std::string &Address, const std::string &SerialPort, const int Mode1);
 	~I2C();
 	bool WriteToHardware(const char *pdata, const unsigned char length);
 private:
@@ -93,8 +93,11 @@ private:
 	void TSL2561_ReadSensorDetails();
 	void TSL2561_Init();
 	
-	// PCF8574
+	// PCF8574, MCP23017
 	unsigned char	i2c_addr;
+	bool 			invert_data;
+	
+	// PCF8574
 	void			PCF8574_ReadChipDetails();
 	char			PCF8574_WritePin(char pin_number,char  value);
 	char 			readByteI2C(int fd, char *byte, char i2c_addr);
@@ -103,8 +106,9 @@ private:
 	// MCP23017
 	void 			MCP23017_Init();
 	void			MCP23017_ReadChipDetails();
-	int			MCP23017_WritePin(char pin_number,char  value);
+	int				MCP23017_WritePin(char pin_number,char  value);
 	int 			I2CWriteReg16(int fd, uint8_t reg, uint16_t value);
 	int		 		I2CReadReg16(int fd, unsigned char reg, i2c_data *data);
 
+	
 };

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -936,23 +936,23 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 #endif
 	case HTYPE_RaspberryBMP085:
-		pHardware = new I2C(ID, I2C::I2CTYPE_BMP085, 0);
+		pHardware = new I2C(ID, I2C::I2CTYPE_BMP085, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_RaspberryHTU21D:
-		pHardware = new I2C(ID, I2C::I2CTYPE_HTU21D, 0);
+		pHardware = new I2C(ID, I2C::I2CTYPE_HTU21D, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_RaspberryTSL2561:
-		pHardware = new I2C(ID, I2C::I2CTYPE_TSL2561, 0);
+		pHardware = new I2C(ID, I2C::I2CTYPE_TSL2561, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_RaspberryPCF8574:
-		pHardware = new I2C(ID, I2C::I2CTYPE_PCF8574, Port);
+		pHardware = new I2C(ID, I2C::I2CTYPE_PCF8574, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_RaspberryBME280:
-		pHardware = new I2C(ID, I2C::I2CTYPE_BME280, 0);
+		pHardware = new I2C(ID, I2C::I2CTYPE_BME280, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_RaspberryMCP23017:
 		_log.Log(LOG_NORM, "MainWorker::AddHardwareFromParams HTYPE_RaspberryMCP23017");
-		pHardware = new I2C(ID, I2C::I2CTYPE_MCP23017, Port);
+		pHardware = new I2C(ID, I2C::I2CTYPE_MCP23017, Address, SerialPort, Mode1);
 		break;
 	case HTYPE_Wunderground:
 		pHardware = new CWunderground(ID, Username, Password);

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -131,13 +131,21 @@ define(['app'], function (app) {
 					hardwaretype = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').val();
 				}
 				var text1 = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').text();
+				if (text1.indexOf("I2C sensor") >= 0) {
+					var i2cpath = $("#hardwareparamsi2clocal #i2cpath").val();
+					var i2caddress = "";
+					var i2cinvert = "";
+					Mode1 = "";
+				}
 				if (text1.indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
-					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
-					var port = "&port=" + encodeURIComponent(i2caddress);
+					i2caddress = $("#hardwareparami2caddress #i2caddress").val();
+					i2cinvert = $("#hardwareparami2cinvert #i2cinvert").prop("checked") ? 1 : 0;
+					Mode1 = encodeURIComponent(i2cinvert);
 				}
 				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
-					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
-					var port = "&port=" + encodeURIComponent(i2caddress);
+					i2caddress = $("#hardwareparami2caddress #i2caddress").val();
+					i2cinvert = $("#hardwareparami2cinvert #i2cinvert").prop("checked") ? 1 : 0;
+					Mode1 = encodeURIComponent(i2cinvert);
 				}
 				if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs GPIO") == -1)) {
 					var gpiodebounce = $("#hardwareparamsgpio #gpiodebounce").val();
@@ -162,12 +170,13 @@ define(['app'], function (app) {
 				}
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
+					"&address=" + encodeURIComponent(i2caddress) +
 					"&name=" + encodeURIComponent(name) +
 					"&enabled=" + bEnabled +
 					"&idx=" + idx +
 					"&datatimeout=" + datatimeout +
 					"&Mode1=" + Mode1 + "&Mode2=" + Mode2 + "&Mode3=" + Mode3 + "&Mode4=" + Mode4 + "&Mode5=" + Mode5 + "&Mode6=" + Mode6 +
-					port,
+					"&port=" + encodeURIComponent(i2cpath),
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -1214,21 +1223,27 @@ define(['app'], function (app) {
 					}
 				});
 			}
-			else if (text.indexOf("I2C ") >= 0 && text.indexOf("I2C sensor PIO 8bit expander PCF8574") < 0) {
+			else if (text.indexOf("I2C ") >= 0 ) {
 				hardwaretype = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').val();
-				var port = "";
+				var i2cpath = $("#hardwareparamsi2clocal #i2cpath").val();
+				var i2caddress = "";
+				
 				var text1 = $("#hardwareparamsi2clocal #comboi2clocal").find('option:selected').text();
 				if (text1.indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
-					var port = "&port=" + encodeURIComponent(i2caddress);
+					var i2cinvert = $("#hardwareparami2cinvert #i2cinvert").prop("checked") ? 1 : 0;
+					
 				}
 				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
 					var i2caddress = $("#hardwareparami2caddress #i2caddress").val();
-					var port = "&port=" + encodeURIComponent(i2caddress);
+					var i2cinvert = $("#hardwareparami2cinvert #i2cinvert").prop("checked") ? 1 : 0;
 				}
 
 				$.ajax({
-					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + "&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout + port,
+					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + "&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout +
+					"&address=" + encodeURIComponent(i2caddress) +
+					"&port=" + encodeURIComponent(i2cpath) +
+					"&Mode1=" + encodeURIComponent(i2cinvert),
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -4797,9 +4812,6 @@ define(['app'], function (app) {
 							else if ((item.Type == 7) || (item.Type == 11)) {
 								SerialName = "USB";
 							}
-							else if ((item.Type == 13) || (item.Type == 71) || (item.Type == 85) || (item.Type == 96)) {
-								SerialName = "I2C";
-							}
 							else if ((item.Type == 14) || (item.Type == 25) || (item.Type == 28) || (item.Type == 30) || (item.Type == 34)) {
 								SerialName = "WWW";
 							}
@@ -4826,9 +4838,6 @@ define(['app'], function (app) {
 							else {
 								SerialName = item.SerialPort;
 								intport = jQuery.inArray(item.SerialPort, $scope.SerialPortStr);
-							}
-							if (item.Type == 93 || item.Type == 109) {
-								SerialName = "I2C-" + SerialName;
 							}
 
 							var enabledstr = $.t("No");
@@ -4978,6 +4987,13 @@ define(['app'], function (app) {
 							}
 
 							var dispAddress = item.Address;
+							if ((item.Type == 13) || (item.Type == 71) || (item.Type == 85) || (item.Type == 96)) {
+								dispAddress = "I2C";
+							}
+							else if (item.Type == 93 || item.Type == 109) {
+								dispAddress = "I2C-" + dispAddress;
+							}
+							
 							var addId = oTable.fnAddData({
 								"DT_RowId": item.idx,
 								"Username": item.Username,
@@ -5434,6 +5450,7 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divgoodweweb").hide();
 			$("#hardwarecontent #divi2clocal").hide();
 			$("#hardwarecontent #divi2caddress").hide();
+			$("#hardwarecontent #divi2cinvert").hide();
 			$("#hardwarecontent #divpollinterval").hide();
 			$("#hardwarecontent #divpythonplugin").hide();
 			$("#hardwarecontent #divrelaynet").hide();
@@ -5467,12 +5484,15 @@ define(['app'], function (app) {
 				$("#hardwarecontent #divunderground").hide();
 				$("#hardwarecontent #divhttppoller").hide();
 				$("#hardwarecontent #divi2caddress").hide();
+				$("#hardwarecontent #divi2cinvert").hide();
 				var text1 = $("#hardwarecontent #divi2clocal #hardwareparamsi2clocal #comboi2clocal option:selected").text();
 				if (text1.indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
 					$("#hardwarecontent #divi2caddress").show();
+					$("#hardwarecontent #divi2cinvert").show();
 				}
 				else if (text1.indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
 					$("#hardwarecontent #divi2caddress").show();
+					$("#hardwarecontent #divi2cinvert").show();
 				}
 			}
 			else if ((text.indexOf("GPIO") >= 0) && (text.indexOf("sysfs GPIO") == -1)) {

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -5085,11 +5085,14 @@ define(['app'], function (app) {
 						}
 						else if (data["Type"].indexOf("I2C ") >= 0) {
 							$("#hardwareparamsi2clocal #comboi2clocal").val(jQuery.inArray(data["Type"], $.myglobals.HardwareI2CStr));
+							$("#hardwareparamsi2clocal #i2cpath").val(data["Port"]);
 							if (data["Type"].indexOf("I2C sensor PIO 8bit expander PCF8574") >= 0) {
-								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
+								$("#hardwareparami2caddress #i2caddress").val(data["Address"]);
+								$("#hardwareparami2cinvert #i2cinvert").prop("checked", data["Mode1"] == 1);
 							}
 							else if (data["Type"].indexOf("I2C sensor GPIO 16bit expander MCP23017") >= 0) {
-								$("#hardwareparami2caddress #i2caddress").val(data["Port"].substring(4));
+								$("#hardwareparami2caddress #i2caddress").val(data["Address"]);
+								$("#hardwareparami2cinvert #i2cinvert").prop("checked", data["Mode1"] == 1);
 							}
 						}
 						else if ((data["Type"].indexOf("GPIO") >= 0) && (data["Type"].indexOf("sysfs GPIO") == -1)) {

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1174,14 +1174,33 @@
 					<td align="right" style="width:110px"><label id="lbli2cname" for="name"><span data-i18n="SubType"></span>:</label></td>
 					<td><select id="comboi2clocal" style="width:410px" class="combobox ui-corner-all"></select></td>
 				</tr>
+				<tr>
+					<td align="right" style="width:110px"><label id="lbli2cpath" for="name"><span data-i18n="Path to I2C bus:"></span>Path to I2C bus:</label></td>
+					<td>
+						<input type="text" id="i2cpath" style="width: 250px; padding: .2em;" class="text ui-widget-content ui-corner-all" />
+						<span data-i18n="(etc. /dev/i2c-1, or empty for autodetection)">(etc. /dev/i2c-1, or empty for autodetection)</span>
+					</td>
+				</tr>
 			</table>
 		</div>
 		<div id="divi2caddress">
 			<br>
 			<table class="display" id="hardwareparami2caddress" border="0" cellpadding="0" cellspacing="20">
 				<tr>
-					<td align="right" style="width:110px"><label id="lbli2caddress" for="name"><span data-i18n="I2C address"></span>I2C address:</label></td>
-					<td><input type="text" id="i2caddress" style="width: 250px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+					<td align="right" style="width:110px"><label id="lbli2caddress" for="name"><span data-i18n="I2C address:"></span>I2C address:</label></td>
+					<td>
+						<input type="text" id="i2caddress" style="width: 250px; padding: .2em;" class="text ui-widget-content ui-corner-all" />
+						<span data-i18n="(decimal value)">(decimal value)</span>
+					</td>
+				</tr>
+			</table>
+		</div>
+		<div id="divi2cinvert">
+			<br>
+			<table class="display" id="hardwareparami2cinvert" border="0" cellpadding="0" cellspacing="20">
+				<tr>
+					<td align="right" style="width:110px"><label id="lbli2caddress" for="name"><span data-i18n="I2C address"></span>Invert GPIO:</label></td>
+					<td><input type="checkbox" id="i2cinvert" checked><label for="i2cinvert"/></td>
 				</tr>
 			</table>
 		</div>


### PR DESCRIPTION
- added configuration option invert values for sensors witch GPIO

- added configuration option "Path to I2C bus" (into column SeriaPort in hw table) for all I2C sensors. Example value "/dev/i2c-1" or empty for autodetection

- changed store "i2c addres" from column "Port" to column "Address" in hw table

- some cosmetic changes in source code of I2C hardware