### PR TITLE
Blocky (Eventsystem) memory leak fix

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1599,8 +1599,6 @@ void CEventSystem::EvaluateEvent(const _tEventQueue &item)
 lua_State *CEventSystem::CreateBlocklyLuaState()
 {
 	lua_State *lua_state = luaL_newstate();
-	if (lua_state == NULL)
-		return NULL;
 
 	// load Lua libraries
 	static const luaL_Reg lualibs[] =


### PR DESCRIPTION
This should fix Blockly (eventsystem) memory leak as reported here: https://github.com/domoticz/domoticz/issues/2000

Original fix was by @jvandenbroek on the 24th july 2017 https://github.com/domoticz/domoticz/pull/1714/commits/c8ec141f3b998ba5ef811074cd2214a677b2a51d
But according to @gizmocuz his advice the check for allocation was put back as discussed here: https://github.com/domoticz/domoticz/pull/1714
Don't know the reason for that but we still had memory leak.

After a couple of days testing with my pull request the leak seems to be fixed.
Vmem stays stable instead if increasing insanely as before the fix.
As mentioned here https://github.com/domoticz/domoticz/issues/2000 i put my production system to the test.
Which stays stable and all eventsystems (blocky, lua, python) worked like charm.

p.s
Don't know if it's related but could it be that the python plugin system is affected by this fix also.
As before the my pull request some plugins after a reboot had a error like (hardware stopped)
After the pull request i didn't see any of them.