### PR TITLE
Change Devices view to add Zwave Nodeid to the Hardware column for ZWAVE devices.

### DIFF
--- a/www/app/DevicesController.js
+++ b/www/app/DevicesController.js
@@ -384,6 +384,15 @@ define(['app'], function (app) {
 								itemSubIcons += '&nbsp;<img src="images/empty16.png">';
 							}
 							var ID = item.ID;
+              if (typeof(item.HardwareTypeVal) != 'undefined' && item.HardwareTypeVal == 21) {
+                var ZWID = item.ID.substr(-4, 2);
+                if (ZWID == '00') {
+                  ZWID = item.ID.substr(-2, 2);
+                }
+                ZWID = '0x' + ZWID;
+                var ZWIDdec =  ("00" + parseInt(ZWID)).slice(-3);
+                item.HardwareName = item.HardwareName + " " + ZWIDdec + ' (' + ZWID + ')';
+              }
 							if (item.Type == "Lighting 1") {
 								ID = String.fromCharCode(item.ID);
 							}


### PR DESCRIPTION
This change will modify the Domoticz devices view and adds the ZWAVE device Nodeid to the Hardware field for the ZWAVE devices. This allows to sort the ZWAVE Domoticz devices on their ZWAVE Nodeid to determine which Domoticz devices belong to which physical ZWAVE device.
![domoticz z-wave id](https://user-images.githubusercontent.com/13818504/34497792-46d45a66-efff-11e7-92ea-d1858c6fc444.PNG)