### PR TITLE
New attempt to enable C++11 build and fix build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,14 @@
 #set to minimum version that supports clean build on cygwin
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.1.0)
 
 project(domoticz)
 
 ## required min. libBoost version
 SET(DOMO_MIN_LIBBOOST_VERSION 105500)
 ##
+
+set(CMAKE_CXX_STANDARD 11)
+set(CXX_STANDARD_REQUIRED ON)
 
 MACRO(Gitversion_GET_REVISION dir variable)
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} --git-dir ./.git rev-list HEAD --count
@@ -235,10 +238,10 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
     LIST(APPEND _compiler_FLAGS ${_directory_flags})
 
     SEPARATE_ARGUMENTS(_compiler_FLAGS)
-    MESSAGE("${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_compiler_FLAGS} -x c++-header -o ${_output} ${_source}")
+    MESSAGE("${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_compiler_FLAGS} -x c++-header -std=gnu++11 -o ${_output} ${_source}")
     ADD_CUSTOM_COMMAND(
       OUTPUT ${_output}
-      COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_compiler_FLAGS} -x c++-header -o ${_output} ${_source}
+      COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} ${_compiler_FLAGS} -x c++-header -std=gnu++11 -o ${_output} ${_source}
       DEPENDS ${_source} )
     ADD_CUSTOM_TARGET(${_targetName}_gch DEPENDS ${_output})
     ADD_DEPENDENCIES(${_targetName} ${_targetName}_gch)

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -52,7 +52,7 @@ Version history
 #define MINOR_RT2 0
 #define RELEASE_RT2 29
 
-CEcoDevices::CEcoDevices(const int ID, const std::string &IPAddress, const unsigned short usIPPort, 
+CEcoDevices::CEcoDevices(const int ID, const std::string &IPAddress, const unsigned short usIPPort,
 	const std::string &username, const std::string &password, const int datatimeout, const int model, const int ratelimit):
 m_szIPAddress(IPAddress),
 m_username(username),
@@ -62,16 +62,16 @@ m_password(password)
 	m_usIPPort = usIPPort;
 	m_stoprequested = false;
 	m_iModel = model;
-        
-        // Updates must be at least every 5mn in order to keep consistent historical data
+
+	// Updates must be at least every 5mn in order to keep consistent historical data
 	m_iDataTimeout = (datatimeout >= 300 || datatimeout == 0) ? 300 : datatimeout;
-	
+
  	// system seems unstable if going too fast
 	m_iRateLimit = (ratelimit < 2) ? 2 : ratelimit;
 
-        // RateLimit > DataTimeout is an inconsistent setting. In that case, decrease RateLimit (which increases update rate) 
+	// RateLimit > DataTimeout is an inconsistent setting. In that case, decrease RateLimit (which increases update rate)
 	// down to Timeout in order to avoir watchdog errors due to this user configuration mistake.
-        if (m_iRateLimit > m_iDataTimeout)   m_iRateLimit = m_iDataTimeout;
+	if (m_iRateLimit > m_iDataTimeout)   m_iRateLimit = m_iDataTimeout;
 
 	Init();
 }
@@ -90,11 +90,11 @@ void CEcoDevices::Init()
 	// Is the device we poll password protected?
 	m_ssURL.str("");
 	if ((m_username.size() > 0) && (m_password.size() > 0))
-        	m_ssURL << "http://" << m_username << ":" << m_password << "@";
-        else
-                m_ssURL <<"http://";
+		m_ssURL << "http://" << m_username << ":" << m_password << "@";
+	else
+		m_ssURL <<"http://";
 
-        m_ssURL << m_szIPAddress << ":" << m_usIPPort;
+	m_ssURL << m_szIPAddress << ":" << m_usIPPort;
 
 }
 
@@ -208,7 +208,7 @@ void CEcoDevices::GetMeterDetails()
 
 	// Check EcoDevices firmware version and process pulse counters
 	sstr << m_ssURL.str() << "/status.xml";
-	
+
 	if (m_status.hostname.empty()) m_status.hostname = m_szIPAddress;
 	if (HTTPClient::GET(sstr.str(), ExtraHeaders, sResult))
 	{
@@ -285,7 +285,7 @@ void CEcoDevices::GetMeterDetails()
 	else
 	{
 		message = "EcoDevices firmware needs to be at least version ";
-		message = message + static_cast<std::ostringstream*>(&(std::ostringstream() << min_major << "." << min_minor << "." << min_release))->str();
+		message = message + std::to_string(min_major) + "." + std::to_string(min_minor) + "." + std::to_string(min_release);
 		message = message + ", current version is " + m_status.version;
 		_log.Log(LOG_ERROR, "(%s) %s", Name.c_str(), message.c_str());
 		return;
@@ -323,7 +323,7 @@ void CEcoDevices::GetMeterDetails()
 	{
 		sstr.str("");
 		sstr << m_ssURL.str() << "/protect/settings/teleinfo2.xml";
-		
+
 		_log.Log(LOG_NORM, "(%s) Fetching Teleinfo 2 data", Name.c_str());
 		if (!HTTPClient::GET(sstr.str(), ExtraHeaders, sResult))
 		{
@@ -446,13 +446,13 @@ void CEcoDevices::GetMeterRT2Details()
 	if (!((major > min_major) || ((major == min_major) && (minor > min_minor)) || ((major == min_major) && (minor == min_minor) && (release >= min_release))))
 	{
 		message = "EcoDevices RT2 firmware needs to be at least version ";
-		message = message + static_cast<std::ostringstream*>(&(std::ostringstream() << min_major << "." << min_minor << "." << min_release))->str();
+		message = message + std::to_string(min_major) + "." + std::to_string(min_minor) + "." + std::to_string(min_release);
 		message = message + ", current version is " + m_status.version;
 		_log.Log(LOG_ERROR, "(%s) %s", Name.c_str(), message.c_str());
 		return;
 	}
 
-	//Measured voltage on power supply 
+	//Measured voltage on power supply
 	m_status.voltage = i_xpath_int(XMLdoc.RootElement(), "/response/vmesure/text()");
 	SendVoltageSensor(m_HwdID, 1, 255, (float)m_status.voltage, "EcoDevice RT2");
 

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -42,7 +42,7 @@ std::string	CKodiNode::CKodiStatus::LogMessage()
 		if (m_sType == "episode")
 		{
 			if (m_sShowTitle.length()) sLogText = m_sShowTitle;
-			if (m_iSeason) sLogText += " [S" + SSTR(m_iSeason) + "E" + SSTR(m_iEpisode) + "]";
+			if (m_iSeason) sLogText += " [S" + std::to_string(m_iSeason) + "E" + std::to_string(m_iEpisode) + "]";
 			if (m_sTitle.length()) sLogText += ", " + m_sTitle;
 			if ((m_sLabel != m_sTitle) && (m_sLabel.length())) sLogText += ", " + m_sLabel;
 		}

--- a/hardware/Kodi.h
+++ b/hardware/Kodi.h
@@ -10,8 +10,6 @@
 #include <boost/array.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
-#define SSTR( x ) dynamic_cast< std::ostringstream & >(( std::ostringstream() << std::dec << x ) ).str()
-
 class CKodiNode : public boost::enable_shared_from_this<CKodiNode>
 {
 	class CKodiStatus
@@ -24,7 +22,7 @@ class CKodiNode : public boost::enable_shared_from_this<CKodiNode>
 		void			Status(_eMediaStatus pStatus) { m_nStatus = pStatus; };
 		void			Status(const std::string &pStatus) { m_sStatus = pStatus; };
 		void			PlayerID(int pPlayerID) { m_iPlayerID = pPlayerID; };
-		std::string		PlayerID() { if (m_iPlayerID >= 0) return SSTR(m_iPlayerID); else return ""; };
+		std::string		PlayerID() { if (m_iPlayerID >= 0) return std::to_string(m_iPlayerID); else return ""; };
 		void			Type(const char*	pType) { m_sType = pType; };
 		std::string		Type() { return m_sType; };
 		void			Title(const char*	pTitle) { m_sTitle = pTitle; };
@@ -35,8 +33,8 @@ class CKodiNode : public boost::enable_shared_from_this<CKodiNode>
 		void			Season(int pSeason) { m_iSeason = pSeason; };
 		void			Episode(int pEpisode) { m_iEpisode = pEpisode; };
 		void			Label(const char*	pLabel) { m_sLabel = pLabel; };
-		void			Percent(float	fPercent) { m_sPercent = ""; if (fPercent > 1.0) m_sPercent = SSTR((int)round(fPercent)) + "%"; };
-		void			Year(int pYear) { m_sYear = SSTR(pYear); if (m_sYear.length() > 2) m_sYear = "(" + m_sYear + ")"; else m_sYear = ""; };
+		void			Percent(float	fPercent) { m_sPercent = ""; if (fPercent > 1.0) m_sPercent = std::to_string((int)round(fPercent)) + "%"; };
+		void			Year(int pYear) { m_sYear = std::to_string(pYear); if (m_sYear.length() > 2) m_sYear = "(" + m_sYear + ")"; else m_sYear = ""; };
 		void			Live(bool	pLive) { m_sLive = "";  if (pLive) m_sLive = "(Live)"; };
 		void			LastOK(time_t pLastOK) { m_tLastOK = pLastOK; };
 		std::string		LastOK() { std::string sRetVal;  tm ltime; localtime_r(&m_tLastOK, &ltime); char szLastUpdate[40]; sprintf(szLastUpdate, "%04d-%02d-%02d %02d:%02d:%02d", ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec); sRetVal = szLastUpdate; return sRetVal; };

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -21,8 +21,6 @@
 #include "icmp_header.hpp"
 #include "ipv4_header.hpp"
 
-#define SSTR( x ) dynamic_cast< std::ostringstream & >(( std::ostringstream() << std::dec << x ) ).str()
-
 namespace Plugins {
 
 	extern 	std::queue<CPluginMessageBase*>	PluginMessageQueue;
@@ -673,7 +671,7 @@ namespace Plugins {
 		if (!pLength && pData && PyUnicode_Check(pData))
 		{
 			Py_ssize_t iLength = PyUnicode_GetLength(pData);
-			sHttp += "Content-Length: " + SSTR(iLength) + "\r\n";
+			sHttp += "Content-Length: " + std::to_string(iLength) + "\r\n";
 		}
 
 		sHttp += "\r\n";

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -18,7 +18,6 @@
 #include "ipv4_header.hpp"
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-#define SSTR( x ) dynamic_cast< std::ostringstream & >(( std::ostringstream() << std::dec << x ) ).str()
 #define round(a) ( int ) ( a + .5 )
 
 namespace Plugins {
@@ -193,7 +192,7 @@ namespace Plugins {
 		{
 			boost::asio::ip::tcp::endpoint remote_ep = pSocket->remote_endpoint();
 			std::string sAddress = remote_ep.address().to_string();
-			std::string sPort = SSTR(remote_ep.port());
+			std::string sPort = std::to_string(remote_ep.port());
 
 			PyType_Ready(&CConnectionType);
 			CConnection* pConnection = (CConnection*)CConnection_new(&CConnectionType, (PyObject*)NULL, (PyObject*)NULL);
@@ -583,7 +582,7 @@ namespace Plugins {
 		if (!ec)
 		{
 			std::string sAddress = m_remote_endpoint.address().to_string();
-			std::string sPort = SSTR(m_remote_endpoint.port());
+			std::string sPort = std::to_string(m_remote_endpoint.port());
 
 			PyType_Ready(&CConnectionType);
 			CConnection* pConnection = (CConnection*)CConnection_new(&CConnectionType, (PyObject*)NULL, (PyObject*)NULL);

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -17,8 +17,6 @@
 #include "PluginTransports.h"
 #include <datetime.h>
 
-#define SSTR( x ) dynamic_cast< std::ostringstream & >(( std::ostringstream() << std::dec << x ) ).str()
-
 namespace Plugins {
 
 	extern boost::mutex PluginMutex;	// controls accessto the message queue
@@ -803,7 +801,7 @@ namespace Plugins {
 				m_mainworker.sOnDeviceReceived(self->pPlugin->m_HwdID, self->ID, self->pPlugin->Name, NULL);
 			}
 
-			std::string sID = SSTR(self->ID);
+			std::string sID = std::to_string(self->ID);
 
 			if (TypeName) {
 				// Reset nValue and sValue when changing device types


### PR DESCRIPTION
Enable c++11 support, builds on:
  - Ubuntu Trusty (through Travis)
  - OSX + XCode 8.3 (Through Travis)
  - VS2017 (Through appveyor)
  - Debian Jessie (x64, but needs CMake from Jessie backports)
  - Raspbian Stretch (RPi 3)
  - Ubuntu WSL (x64)

CMake minimum version stepped, CMake 3.1.0 was first version to include support for CMAKE_CXX_STANDARD