### PR TITLE
EventSystem/Blockly reduced/optimized code

### DIFF
--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -201,9 +201,9 @@ private:
 	void GetCurrentMeasurementStates();
 	std::string UpdateSingleState(const uint64_t ulDevID, const std::string &devname, const int nValue, const char* sValue, const unsigned char devType, const unsigned char subType, const _eSwitchType switchType, const std::string &lastUpdate, const unsigned char lastLevel, const std::map<std::string, std::string> & options);
 	void EvaluateEvent(const std::vector<_tEventQueue> &items);
-
-	void EvaluateBlockly(const _tEventQueue &item);
-	bool parseBlocklyActions(const std::string &Actions, const std::string &eventName, const uint64_t eventID);
+	void EvaluateDatabaseEvents(const _tEventQueue &item);
+	lua_State *ParseBlocklyLua(lua_State *lua_state, const _tEventItem &item);
+	bool parseBlocklyActions(const _tEventItem &item);
 	std::string ProcessVariableArgument(const std::string &Argument);
 #ifdef ENABLE_PYTHON
 	std::string m_python_Dir;
@@ -264,7 +264,7 @@ private:
 	std::map<uint64_t, float> m_windgustValuesByID;
 	std::map<uint64_t, int> m_zwaveAlarmValuesByID;
 
-	void reportMissingDevice(const int deviceID, const std::string &EventName, const uint64_t eventID);
+	void reportMissingDevice(const int deviceID, const _tEventItem &item);
 	int getSunRiseSunSetMinutes(const std::string &what);
 	bool isEventscheduled(const std::string &eventName);
 	bool iterateLuaTable(lua_State *lua_state, const int tIndex, const std::string &filename);


### PR DESCRIPTION
- Renamed EvaluateBlockly to EvaluateDatabaseEvents
- Moved/merged DB events (m_events) evaluation to EvaluateDatabaseEvents (now m_events is iterated only once instead of twice per event)
- Moved redundant code from EvaluateBlockly to separate ParseBlocklyLua function
- Replaced some passed values with just one by reference

Tested with valgrind, no memory leaks ;)