### PR TITLE
Address erroneous values in counter meter readings

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -14004,8 +14004,7 @@ namespace http {
 											char szTime[50];
 											sprintf(szTime, "%04d-%02d-%02d %02d:00", ntime.tm_year + 1900, ntime.tm_mon + 1, ntime.tm_mday, ntime.tm_hour);
 											root["result"][ii]["d"] = szTime;
-
-											float TotalValue = float(actValue - ulFirstValue);
+											float TotalValue = float((long long)actValue - (long long)ulFirstValue);
 
 											//if (TotalValue != 0)
 											{


### PR DESCRIPTION
If a counter ever takes a step back, the graph may show a huge spike
due to an overflow as described in:
https://www.domoticz.com/forum/viewtopic.php?f=6&t=14125&p=170169#p170169

More complete and sustainable approach would be to enable
warnings on sign conversions (-Wsign-conversion) and treat them as errors