### PR TITLE
EventSystem Lua Classic use queued item value for otherdevices tables

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2570,7 +2570,8 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQu
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
 		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
-		lua_pushstring(lua_state, iterator->second.nValueWording.c_str());
+		lua_pushstring(lua_state, (iterator->first == item.DeviceID && item.reason == REASON_DEVICE) ?
+			item.nValueWording.c_str() : iterator->second.nValueWording.c_str());
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices");

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2542,7 +2542,7 @@ bool CEventSystem::PythonScheduleEvent(std::string ID, const std::string &Action
 				_log.Log(LOG_ERROR, "EventSystem: SetPoint, not enough parameters!");
 				return false;
 		}
-		
+
 		return true;
 	}
 	return ScheduleEvent(ID, Action,eventName);
@@ -2561,16 +2561,16 @@ void CEventSystem::EvaluatePython(const _tEventQueue &item, const std::string &f
 
 #endif // ENABLE_PYTHON
 
-void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state)
+void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQueue &item)
 {
-	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock2(m_devicestatesMutex);
+	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 	lua_createtable(lua_state, (int)m_devicestates.size(), 0);
+
 	std::map<uint64_t, _tDeviceStatus>::iterator iterator;
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
-		_tDeviceStatus sitem = iterator->second;
-		lua_pushstring(lua_state, sitem.deviceName.c_str());
-		lua_pushstring(lua_state, sitem.nValueWording.c_str());
+		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
+		lua_pushstring(lua_state, iterator->second.nValueWording.c_str());
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices");
@@ -2578,9 +2578,9 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state)
 	lua_createtable(lua_state, (int)m_devicestates.size(), 0);
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
-		_tDeviceStatus sitem = iterator->second;
-		lua_pushstring(lua_state, sitem.deviceName.c_str());
-		lua_pushstring(lua_state, sitem.lastUpdate.c_str());
+		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
+		lua_pushstring(lua_state, (iterator->first == item.DeviceID && item.reason == REASON_DEVICE) ?
+			item.lastUpdate.c_str() : iterator->second.lastUpdate.c_str());
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices_lastupdate");
@@ -2588,18 +2588,17 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state)
 	lua_createtable(lua_state, (int)m_devicestates.size(), 0);
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
-		_tDeviceStatus sitem = iterator->second;
-		lua_pushstring(lua_state, sitem.deviceName.c_str());
-		lua_pushstring(lua_state, sitem.sValue.c_str());
+		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
+		lua_pushstring(lua_state, (iterator->first == item.DeviceID && item.reason == REASON_DEVICE) ?
+			 item.sValue.c_str() : iterator->second.sValue.c_str());
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices_svalues");
 	lua_createtable(lua_state, (int)m_devicestates.size(), 0);
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
-		_tDeviceStatus sitem = iterator->second;
-		lua_pushstring(lua_state, sitem.deviceName.c_str());
-		lua_pushnumber(lua_state, (lua_Number)sitem.ID);
+		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
+		lua_pushnumber(lua_state, (lua_Number)iterator->second.ID);
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices_idx");
@@ -2607,13 +2606,12 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state)
 	lua_createtable(lua_state, (int)m_devicestates.size(), 0);
 	for (iterator = m_devicestates.begin(); iterator != m_devicestates.end(); ++iterator)
 	{
-		_tDeviceStatus sitem = iterator->second;
-		lua_pushstring(lua_state, sitem.deviceName.c_str());
-		lua_pushnumber(lua_state, sitem.lastLevel);
+		lua_pushstring(lua_state, iterator->second.deviceName.c_str());
+		lua_pushnumber(lua_state, (iterator->first == item.DeviceID && item.reason == REASON_DEVICE) ?
+			item.lastLevel : iterator->second.lastLevel);
 		lua_rawset(lua_state, -3);
 	}
 	lua_setglobal(lua_state, "otherdevices_lastlevel");
-	devicestatesMutexLock2.unlock();
 }
 
 void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &item, const int secStatus)
@@ -2946,7 +2944,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 	}
 
-	ExportDeviceStatesToLua(lua_state);
+	ExportDeviceStatesToLua(lua_state, item);
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	lua_createtable(lua_state, (int)m_uservariables.size(), 0);

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -22,6 +22,7 @@ extern "C" {
 class CEventSystem : public CLuaCommon
 {
 	friend class CdzVents;
+	friend class CLuaHandler;
 	typedef struct lua_State lua_State;
 
 	struct _tEventItem
@@ -126,7 +127,6 @@ public:
 	void GetCurrentUserVariables();
 	bool UpdateSceneGroup(const uint64_t ulDevID, const int nValue, const std::string &lastUpdate);
 	void UpdateUserVariable(const uint64_t ulDevID, const std::string &varName, const std::string &varValue, const int varType, const std::string &lastUpdate);
-	void ExportDeviceStatesToLua(lua_State *lua_state);
 	bool PythonScheduleEvent(std::string ID, const std::string &Action, const std::string &eventName);
 	bool GetEventTrigger(const uint64_t ulDevID, const _eReason reason, const bool bEventTrigger);
 	void SetEventTrigger(const uint64_t ulDevID, const _eReason reason, const float fDelayTime);
@@ -226,8 +226,8 @@ private:
 	void UpdateJsonMap(_tDeviceStatus &item, const uint64_t ulDevID);
 	void EventQueueThread();
 	void UnlockEventQueueThread();
+	void ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQueue &item);
 	void EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &item, const int secStatus);
-
 
 	//std::string reciprocalAction (std::string Action);
 	std::vector<_tEventItem> m_events;

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -187,7 +187,9 @@ bool CLuaHandler::executeLuaScript(const std::string &script, const std::string 
 	lua_rawset(lua_state, -3);
 	lua_setglobal(lua_state, "request");
 
-	m_mainworker.m_eventsystem.ExportDeviceStatesToLua(lua_state);
+	CEventSystem::_tEventQueue item;
+	item.DeviceID = 0;
+	m_mainworker.m_eventsystem.ExportDeviceStatesToLua(lua_state, item);
 
 	// Push all url parameters as a map indexed by the parameter name
 	// Each entry will be uri[<param name>] = <param value>


### PR DESCRIPTION
Had fixed the lastupdate / lastlevel issue before, but after changes for dzVents 2.4 the old (faulty) behaviour came back for classic. See https://www.domoticz.com/forum/viewtopic.php?t=22157
This will make sure the item's queued values for lastupdate, lastlevel and svalue are being evaluated.