### PR TITLE
Log error messages from python event scripts to domoticz error log

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -111,6 +111,8 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(Py_ssize_t, PyByteArray_Size, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyErr_Occurred, );
 		DECLARE_PYTHON_SYMBOL(long, PyLong_AsLong, PyObject*);
+		DECLARE_PYTHON_SYMBOL(PyObject*, PyUnicode_AsUTF8String, PyObject*);
+		DECLARE_PYTHON_SYMBOL(PyObject*, PyImport_AddModule, const char*);
 
 #ifdef _DEBUG
 		// In a debug build dealloc is a function but for release builds its a macro
@@ -219,6 +221,8 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyByteArray_Size);
 					RESOLVE_PYTHON_SYMBOL(PyErr_Occurred);
 					RESOLVE_PYTHON_SYMBOL(PyLong_AsLong);
+					RESOLVE_PYTHON_SYMBOL(PyUnicode_AsUTF8String);
+					RESOLVE_PYTHON_SYMBOL(PyImport_AddModule);
 				}
 			}
 			_Py_NoneStruct.ob_refcnt = 1;
@@ -387,4 +391,6 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyByteArray_Size		pythonLib->PyByteArray_Size
 #define PyErr_Occurred			pythonLib->PyErr_Occurred
 #define PyLong_AsLong			pythonLib->PyLong_AsLong
+#define PyUnicode_AsUTF8String	pythonLib->PyUnicode_AsUTF8String
+#define PyImport_AddModule		pythonLib->PyImport_AddModule
 }

--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -347,11 +347,16 @@
 
                    // uservariablesMutexLock2.unlock();
                    
+                   // Add __main__ module
+                   PyObject *pModule = Plugins::PyImport_AddModule("__main__");
+                   Py_INCREF(pModule);
+
+                   // Override sys.stderr
+                   Plugins::PyRun_SimpleStringFlags("import sys\nclass StdErrRedirect:\n    def __init__(self):\n        self.buffer = ''\n    def write(self, msg):\n        self.buffer += msg\nstdErrRedirect = StdErrRedirect()\nsys.stderr = stdErrRedirect\n", NULL);
 
                    if(PyString.length() > 0) {
                        // Python-string from WebEditor
                        Plugins::PyRun_SimpleStringFlags(PyString.c_str(), NULL);
-                       
                    } else {
                        // Script-file
                        FILE* PythonScriptFile = fopen(filename.c_str(), "r");
@@ -360,6 +365,39 @@
                        if (PythonScriptFile!=NULL)
                            fclose(PythonScriptFile);
                    }
+
+                   // Get message from stderr redirect
+                   PyObject *stdErrRedirect = Plugins::PyObject_GetAttrString(pModule, "stdErrRedirect");
+                   PyObject *logBuffer = Plugins::PyObject_GetAttrString(stdErrRedirect, "buffer");
+                   PyObject *logBytes = PyUnicode_AsUTF8String(logBuffer);
+                   std::string logString = PyBytes_AsString(logBytes);
+
+                   // Check for error
+                   if (PyErr_Occurred()) {
+                       _log.Log(LOG_ERROR, "EventSystem: Failed to get stderr redirect");
+                   } else {
+                       // Check if there were some errors written to stderr
+                       if (logString.length() > 0) {
+                           // Print error source
+                           _log.Log(LOG_ERROR, "EventSystem: Failed to execute python event script \"%s\"", filename.c_str());
+
+                           // Loop over all lines of the error message
+                           std::size_t lineBreakPos;
+                           while ((lineBreakPos = logString.find('\n')) != std::string::npos) {
+                               // Print line
+                               _log.Log(LOG_ERROR, "EventSystem: %s", logString.substr(0, lineBreakPos).c_str());
+
+                               // Remove line from buffer
+                               logString = logString.substr(lineBreakPos + 1);
+                           }
+                       }
+
+                       // Cleanup
+                       Py_DECREF(logBytes);
+                   }
+
+                   // Cleanup
+                   Py_DECREF(pModule);
                 } else {
                     _log.Log(LOG_ERROR, "Python EventSystem: Module not available to events");
                 }


### PR DESCRIPTION
Currently when you write a python event script, there is no way to get diagnostic informations when the script failes. The script either runs - more or less as expected - or, in case of eg. a syntax, identation, ... errors, it does not. But there is not signalling to the user, if the script execution has failed. So you start wondering if either your script logic is not working or if there are any errors in the script und you start poking around until you eventually find the reason why your script is not working.

The reason why you can't get diagnoticz informations from the python interpreter is, that the PyRun_SimpleStringFlags and PyRun_SimpleFileExFlags functions have build in error handling which will print all errors to stderr.

To solve this problem, I implemented an override for the sys.stderr stream. Before running the event script code using PyRun_SimpleStringFlags/PyRun_SimpleFileExFlags my code injects a new python class into the python interpreter that overwrites the sys.stderr stream and buffers all messages written to stderr in an internal buffer variable. After the event script has been executed, the code pulls the buffer from python interpreter and - when a message has been written to stderr - writes the error messages to the domoticz log.

This solution might also be used to redirect the sys.stdout stream, so that all print(...) messages could be written to the domoticz log. As the messages from the redirected stderr stream are pulled from the python interpreter after the script has been run, the messages of the redirected stdout stream would only appear in the domoticz log after the script has been executed.