### PR TITLE
Add SwitchType to Python Device object

### DIFF
--- a/hardware/plugins/PythonObjects.h
+++ b/hardware/plugins/PythonObjects.h
@@ -123,6 +123,7 @@ namespace Plugins {
 		{ "Image", T_INT, offsetof(CDevice, Image), READONLY, "Numeric image number" },
 		{ "Type", T_INT, offsetof(CDevice, Type), READONLY, "Numeric device type" },
 		{ "SubType", T_INT, offsetof(CDevice, SubType), READONLY, "Numeric device subtype" },
+		{ "SwitchType", T_INT, offsetof(CDevice, SwitchType), READONLY, "Numeric device subtype" },
 		{ "LastLevel", T_INT, offsetof(CDevice, LastLevel), READONLY, "Previous device level" },
 		{ "LastUpdate", T_OBJECT, offsetof(CDevice, LastUpdate), READONLY, "Last update timestamp" },
 		{ "Options", T_OBJECT, offsetof(CDevice, Options), READONLY, "Device options" },


### PR DESCRIPTION
SwitchType was already available in the C++ class, but not exposed to Python.