### PR TITLE
Let Blockly "If Else" work as expected

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1857,6 +1857,7 @@ void CEventSystem::EvaluateBlockly(const std::string &reason, const uint64_t Dev
 							if (m_sql.m_bLogEventScriptTrigger)
 								_log.Log(LOG_NORM, "EventSystem: Event triggered: %s", it->Name.c_str());
 							parseBlocklyActions(it->Actions, it->Name, it->ID);
+							break;
 						}
 					}
 				}
@@ -1914,6 +1915,7 @@ void CEventSystem::EvaluateBlockly(const std::string &reason, const uint64_t Dev
 						if (m_sql.m_bLogEventScriptTrigger)
 							_log.Log(LOG_NORM, "EventSystem: Event triggered: %s", it->Name.c_str());
 						parseBlocklyActions(it->Actions, it->Name, it->ID);
+						break;
 					}
 				}
 			}
@@ -1965,6 +1967,7 @@ void CEventSystem::EvaluateBlockly(const std::string &reason, const uint64_t Dev
 							if (m_sql.m_bLogEventScriptTrigger)
 								_log.Log(LOG_NORM, "EventSystem: Event triggered: %s", it->Name.c_str());
 							parseBlocklyActions(it->Actions, it->Name, it->ID);
+							break;
 						}
 					}
 				}
@@ -2020,6 +2023,7 @@ void CEventSystem::EvaluateBlockly(const std::string &reason, const uint64_t Dev
 						if (m_sql.m_bLogEventScriptTrigger)
 							_log.Log(LOG_NORM, "EventSystem: Event triggered: %s", it->Name.c_str());
 						parseBlocklyActions(it->Actions, it->Name, it->ID);
+						break;
 					}
 				}
 			}


### PR DESCRIPTION
This is a pull request based on the comment by Ash77 here:
https://www.domoticz.com/forum/viewtopic.php?f=31&t=22320&p=172288#p172288

He claims that in order for blockly's "If Else" functionality to work as most users would expect it to, adding these 4 break statements would suffice as a fix.

Now, pay in mind:
- I have no idea what I'm doing here. I am not a C coder, so I don't know if this really is the fix. I'm just the messenger, don't shoot!
- More importantly: adding this change might mean that existing blockly's, where users have worked around this issue, might behave differently.


Still, my opinion is that it's worth it to fix this.

1. Change is good:
- Beta users accept that they can expect small changes in how Domoticz works.
- Following standards and conventions is a good practice.

2. Impact might be limited:
- Since most users don't use the "else" because it is broken, it may be fair to assume that they haven't used it that much in their scripts.
- The scripts of users that created 'else' functionality in other ways (for example by using variables) would still work fine.

3. There is a big demand:
- Many users, me included, run into this problem when they start using Domoticz. Here are just a few thread on the forum:
https://www.domoticz.com/forum/viewtopic.php?f=62&t=16535&p=123167
https://www.domoticz.com/forum/viewtopic.php?f=28&t=15908&p=119285
https://www.domoticz.com/forum/viewtopic.php?f=62&t=14802&p=108423
https://www.domoticz.com/forum/viewtopic.php?f=23&t=10911&p=78158
https://www.domoticz.com/forum/viewtopic.php?f=23&t=10706&p=76394
etc..

4. Blockly is worth the effort:
- For many users Blockly is a core reason they like Domoticz. Me included. Even if this patch is not the fix, having a blockly system that works as most people would expect it to would be a worthy cause.