### PR TITLE
Avoid call to split function on undefined variable when editing a selector device

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     dist: trusty
     sudo: required
     compiler: gcc
-    env: 
+    env:
           - TARGET_ARCHITECTURE=x86_64
           - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
     addons:
@@ -78,8 +78,8 @@ matrix:
       - brew install openssl
       - brew link openssl --force
       - brew install md5sha1sum
-      - brew install python3
-      - brew linkapps python3
+      - brew install python
+      - brew linkapps python
       - export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
     script:
       - CPPFLAGS="-std=c++11" cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/Headers -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.6.dylib

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -698,13 +698,13 @@ define(['app'], function (app) {
 			else {
 				$("#lightcontent #optionsRGBW").hide();
 			}
-			
+
 			if (($.bIsRGBW == true) || ($.bIsRGBWW == true)) {
 				$("#lightcontent #optionsWhiteSlider").show();
 			} else {
 				$("#lightcontent #optionsWhiteSlider").hide();
 			}
-			
+
 			$cpick = $('#lightcontent #picker').colpick({
 				flat: true,
 				layout: 'hex',
@@ -758,7 +758,7 @@ define(['app'], function (app) {
 					if (white_value>255) white_value=255;
 					$.setColValue = setInterval(function () { SetColValue($.devIdx, (white_value << 16) + hsb.h, hsb.b, bIsWhite); }, 400);
 				}
-			});			
+			});
 
 			$("#lightcontent #optionRGB").prop('checked', (sat == 180));
 			$("#lightcontent #optionWhite").prop('checked', !(sat == 180));
@@ -1570,7 +1570,7 @@ define(['app'], function (app) {
 			$.isslave = isslave;
 			$.stype = stype;
 			$.strUnit = strUnit;
-			$.bIsSelectorSwitch = (devsubtype === "Selector Switch");
+			$.bIsSelectorSwitch = (devsubtype === "Selector Switch" && switchtype === 18);
 
 			ConfigureEditLightSettings();
 
@@ -1740,7 +1740,7 @@ define(['app'], function (app) {
 					if (white_value>255) white_value=255;
 					$.setColValue = setInterval(function () { SetColValue($.devIdx, (white_value << 16) + hsb.h, hsb.b, bIsWhite); }, 400);
 				}
-			});			
+			});
 			$("#lightcontent #optionRGB").prop('checked', (sat == 100));
 			$("#lightcontent #optionWhite").prop('checked', !(sat == 100));
 
@@ -1785,7 +1785,17 @@ define(['app'], function (app) {
 						$("#lightcontent #SwitchIconDiv").show();
 					}
 					if (switchtype == 18) {
+						// Add default value required to correctly display the switch options
+						//LevelNames:Off|Level1|Level2|Level3
+						$("#lightcontent #selectorlevelstable").data('levelNames', typeof $.selectorSwitchLevels !== "undefined" ? $.selectorSwitchLevels.join('|') : 'Off|Level1|Level2|Level3');
+						$("#lightcontent #selectoractionstable").data('levelActions', typeof $.selectorSwitchActions !== "undefined" ? $.selectorSwitchActions.join('|') : '|||');
+						$("#lightcontent .selector-switch-options.level-off-hidden input[type=checkbox]").prop('checked', typeof $.selectorSwitchLevelOffHidden !== "undefined" ? $.selectorSwitchLevelOffHidden : false);
+						BuildSelectorActionsTable();
+						BuildSelectorLevelsTable();
+						$.bIsSelectorSwitch = true;
+
 						$("#lightcontent .selector-switch-options").show();
+						$("#lightcontent .selector-switch-options.style input[value=0]").attr('checked', typeof $.selectorSwitchStyle !== "undefined" ? $.selectorSwitchStyle : true);
 					}
 				});
 

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1483
+# ref 1484
 
 CACHE:
 # CSS


### PR DESCRIPTION
When a new Selector Switch of type selector is created, the webserver fill the default values. When a Selector Switch or Switch devices is updated from any type to Selector type, the default values (device options) are not fill by the client side.
This caused the call the split function on undefined variable and avoir the edit page to be displayed.

To fix this, when the type is changed and set to Selector, the device is initialize with the same default values than the webserver or with the current backup values.