### PR TITLE
Allow up to 31days in Short Log History

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13125,8 +13125,21 @@ namespace http {
 				if (sensor == "temp") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
+					int nValue=0;	
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
+					{
+						result = m_sql.safe_query("SELECT Temperature, Chill, Humidity, Barometer, Date, SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else if(nValue<=14)
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
 
-					result = m_sql.safe_query("SELECT Temperature, Chill, Humidity, Barometer, Date, SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13210,8 +13223,20 @@ namespace http {
 				else if (sensor == "Percentage") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-
-					result = m_sql.safe_query("SELECT Percentage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					int nValue=0;
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
+					{
+						result = m_sql.safe_query("SELECT Percentage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else if (nValue<=14)
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13229,8 +13254,20 @@ namespace http {
 				else if (sensor == "fan") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-
-					result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					int nValue=0;
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
+					{
+						result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else else if(nValue<=14)
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13003,7 +13003,7 @@ namespace http {
 				s_str >> idx;
 			}
 
-			std::vector<std::vector<std::string> > result;
+			std::vector<std::vector<std::string> > result,result2;
 			char szTmp[300];
 
 			std::string sensor = request::findValue(&req, "sensor");
@@ -13125,17 +13125,16 @@ namespace http {
 				if (sensor == "temp") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;	
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (result2.size() <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Temperature, Chill, Humidity, Barometer, Date, SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if(nValue<=14)
+					else if(result2.size() <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13223,17 +13222,16 @@ namespace http {
 				else if (sensor == "Percentage") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (result2.size() <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Percentage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if (nValue<=14)
+					else if (result2.size() <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13254,17 +13252,16 @@ namespace http {
 				else if (sensor == "fan") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (result2.size() <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if(nValue<=14)
+					else if (result2.size() <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else  //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13291,7 +13288,19 @@ namespace http {
 						root["title"] = "Graph " + sensor + " " + srange;
 
 						// P1 counter values can only increment, so these are more reliable for sorting than time which can decrement (when DST is turned off)
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13440,13 +13449,13 @@ namespace http {
 											int mon = ltime.tm_mon + 1;
 											int day = ltime.tm_mday;
 											sprintf(szTmp, "%04d-%02d-%02d", year, mon, day);
-											std::vector<std::vector<std::string> > result2;
-											result2 = m_sql.safe_query(
+											std::vector<std::vector<std::string> > result3;
+											result3 = m_sql.safe_query(
 												"SELECT Counter1, Counter2, Counter3, Counter4 FROM Multimeter_Calendar WHERE (DeviceRowID==%" PRIu64 ") AND (Date=='%q')",
 												idx, szTmp);
-											if (!result2.empty())
+											if (!result3.empty())
 											{
-												std::vector<std::string> sd = result2[0];
+												std::vector<std::string> sd = result3[0];
 												std::stringstream s_str1(sd[0]);
 												s_str1 >> firstUsage1;
 												std::stringstream s_str2(sd[1]);
@@ -13491,7 +13500,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13511,7 +13532,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13546,7 +13579,19 @@ namespace http {
 						{
 							vdiv = 1000.0f;
 						}
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13574,8 +13619,19 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13595,7 +13651,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13614,8 +13682,19 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13636,7 +13715,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13663,8 +13754,19 @@ namespace http {
 						m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
 						root["displaytype"] = displaytype;
-
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13739,7 +13841,19 @@ namespace http {
 
 						root["displaytype"] = displaytype;
 
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13847,7 +13961,19 @@ namespace http {
 						}
 
 						int ii = 0;
-						result = m_sql.safe_query("SELECT Value,[Usage], Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Usage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14013,7 +14139,19 @@ namespace http {
 							EnergyDivider *= 100.0f;
 
 						int ii = 0;
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14199,8 +14337,19 @@ namespace http {
 				else if (sensor == "uv") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-
-					result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (result2.size() <= 864) //Less than 3 days
+					{
+						result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else if(result2.size() <= 5184) //Less than 18 days
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else //More than 18 days
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13003,7 +13003,7 @@ namespace http {
 				s_str >> idx;
 			}
 
-			std::vector<std::vector<std::string> > result,result2;
+			std::vector<std::vector<std::string> > result;
 			char szTmp[300];
 
 			std::string sensor = request::findValue(&req, "sensor");
@@ -13125,16 +13125,17 @@ namespace http {
 				if (sensor == "temp") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-					if (result2.size() <= 864) //Less than 3 days
+					int nValue=0;	
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
 					{
 						result = m_sql.safe_query("SELECT Temperature, Chill, Humidity, Barometer, Date, SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if(result2.size() <= 5184) //Less than 18 days
+					else if(nValue<=14)
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else //More than 18 days
+					else
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13222,16 +13223,17 @@ namespace http {
 				else if (sensor == "Percentage") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-					if (result2.size() <= 864) //Less than 3 days
+					int nValue=0;
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
 					{
 						result = m_sql.safe_query("SELECT Percentage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if (result2.size() <= 5184) //Less than 18 days
+					else if (nValue<=14)
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else //More than 18 days
+					else
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13252,16 +13254,17 @@ namespace http {
 				else if (sensor == "fan") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-					if (result2.size() <= 864) //Less than 3 days
+					int nValue=0;
+					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
+					if (nValue<=7)
 					{
 						result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if (result2.size() <= 5184) //Less than 18 days
+					else if(nValue<=14)
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else  //More than 18 days
+					else
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13288,19 +13291,7 @@ namespace http {
 						root["title"] = "Graph " + sensor + " " + srange;
 
 						// P1 counter values can only increment, so these are more reliable for sorting than time which can decrement (when DST is turned off)
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13449,13 +13440,13 @@ namespace http {
 											int mon = ltime.tm_mon + 1;
 											int day = ltime.tm_mday;
 											sprintf(szTmp, "%04d-%02d-%02d", year, mon, day);
-											std::vector<std::vector<std::string> > result3;
-											result3 = m_sql.safe_query(
+											std::vector<std::vector<std::string> > result2;
+											result2 = m_sql.safe_query(
 												"SELECT Counter1, Counter2, Counter3, Counter4 FROM Multimeter_Calendar WHERE (DeviceRowID==%" PRIu64 ") AND (Date=='%q')",
 												idx, szTmp);
-											if (!result3.empty())
+											if (!result2.empty())
 											{
-												std::vector<std::string> sd = result3[0];
+												std::vector<std::string> sd = result2[0];
 												std::stringstream s_str1(sd[0]);
 												s_str1 >> firstUsage1;
 												std::stringstream s_str2(sd[1]);
@@ -13500,19 +13491,7 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13532,19 +13511,7 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13579,19 +13546,7 @@ namespace http {
 						{
 							vdiv = 1000.0f;
 						}
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13619,19 +13574,8 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13651,19 +13595,7 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13682,19 +13614,8 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13715,19 +13636,7 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13754,19 +13663,8 @@ namespace http {
 						m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
 						root["displaytype"] = displaytype;
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+
+						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13841,19 +13739,7 @@ namespace http {
 
 						root["displaytype"] = displaytype;
 
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13961,19 +13847,7 @@ namespace http {
 						}
 
 						int ii = 0;
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Usage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value,[Usage], Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14139,19 +14013,7 @@ namespace http {
 							EnergyDivider *= 100.0f;
 
 						int ii = 0;
-						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-						if (result2.size() <= 864) //Less than 3 days
-						{
-							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else if(result2.size() <= 5184) //Less than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
-						else //More than 18 days
-						{
-							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-						}
+						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14337,19 +14199,8 @@ namespace http {
 				else if (sensor == "uv") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
-					if (result2.size() <= 864) //Less than 3 days
-					{
-						result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
-					}
-					else if(result2.size() <= 5184) //Less than 18 days
-					{
-						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
-					}
-					else //More than 18 days
-					{
-						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
-					}
+
+					result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -16511,15 +16511,52 @@ namespace http {
 						sendDew = true;
 					}
 
-					if (sgraphtype == "1")
+					if ((sgraphtype == "1") || (sgraphtype == "2") || (sgraphtype == "3") || (sgraphtype == "4"))
 					{
 						// Need to get all values of the end date so 23:59:59 is appended to the date string
-						result = m_sql.safe_query(
-							"SELECT Temperature, Chill, Humidity, Barometer,"
-							" Date, DewPoint, SetPoint "
-							"FROM Temperature WHERE (DeviceRowID==%" PRIu64 ""
-							" AND Date>='%q' AND Date<='%q 23:59:59') ORDER BY Date ASC",
-							idx, szDateStart.c_str(), szDateEnd.c_str());
+						if (sgraphtype == "1")
+						{
+							result = m_sql.safe_query(
+								"SELECT Temperature, Chill, Humidity, Barometer,"
+								" Date, DewPoint, SetPoint "
+								"FROM Temperature WHERE (DeviceRowID==%" PRIu64 ""
+								" AND Date>='%q' AND Date<='%q 23:59:59') ORDER BY Date ASC",
+								idx, szDateStart.c_str(), szDateEnd.c_str());
+						}
+						else if (sgraphtype == "2")
+						{
+							result = m_sql.safe_query(
+								"SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity,"
+								" ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(DewPoint),1) AS DewPoint, ROUND(AVG(SetPoint),1) AS SetPoint "
+								"FROM Temperature WHERE (DeviceRowID==%" PRIu64 ""
+								" AND Date>='%q' AND Date<='%q 23:59:59')"
+								" GROUP BY strftime('%%Y-%%m-%%d %%H', Date), (strftime('%%M',Date)/15)"
+								" ORDER BY Date ASC",
+								idx, szDateStart.c_str(), szDateEnd.c_str());
+						}
+						else if (sgraphtype == "3")
+						{
+							result = m_sql.safe_query(
+								"SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity,"
+								" ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(DewPoint),1) AS DewPoint, ROUND(AVG(SetPoint),1) AS SetPoint "
+								"FROM Temperature WHERE (DeviceRowID==%" PRIu64 ""
+								" AND Date>='%q' AND Date<='%q 23:59:59')"
+								" GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30)"
+								" ORDER BY Date ASC",
+								idx, szDateStart.c_str(), szDateEnd.c_str());
+						}
+						else
+						{
+								result = m_sql.safe_query(
+								"SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity,"
+								" ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(DewPoint),1) AS DewPoint, ROUND(AVG(SetPoint),1) AS SetPoint "
+								"FROM Temperature WHERE (DeviceRowID==%" PRIu64 ""
+								" AND Date>='%q' AND Date<='%q 23:59:59')"
+								" GROUP BY strftime('%%Y-%%m-%%d %%H',Date)"
+								" ORDER BY Date ASC",
+								idx, szDateStart.c_str(), szDateEnd.c_str());
+						}
+
 						int ii = 0;
 						if (result.size() > 0)
 						{

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13003,7 +13003,7 @@ namespace http {
 				s_str >> idx;
 			}
 
-			std::vector<std::vector<std::string> > result;
+			std::vector<std::vector<std::string> > result,result2;
 			char szTmp[300];
 
 			std::string sensor = request::findValue(&req, "sensor");
@@ -13125,17 +13125,16 @@ namespace http {
 				if (sensor == "temp") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;	
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Temperature, Chill, Humidity, Barometer, Date, SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if(nValue<=14)
+					else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Temperature),1) AS Temperature, ROUND(AVG(Chill),1) AS Chill, ROUND(AVG(Humidity),0) AS Humidity, ROUND(AVG(Barometer),0) AS Barometer, MIN(Date) AS Date, ROUND(AVG(SetPoint),1) AS SetPoint FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13223,17 +13222,16 @@ namespace http {
 				else if (sensor == "Percentage") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Percentage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if (nValue<=14)
+					else if (atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Percentage),1) AS Percentage, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13254,17 +13252,16 @@ namespace http {
 				else if (sensor == "fan") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-					int nValue=0;
-					m_sql.GetPreferencesVar("5MinuteHistoryDays", nValue);
-					if (nValue<=7)
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
 					{
 						result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else if(nValue<=14)
+					else if (atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else
+					else  //More than 18 days
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
@@ -13291,7 +13288,19 @@ namespace http {
 						root["title"] = "Graph " + sensor + " " + srange;
 
 						// P1 counter values can only increment, so these are more reliable for sorting than time which can decrement (when DST is turned off)
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0) AS Value1, ROUND(AVG(Value2),0) AS Value2, ROUND(AVG(Value3),0) AS Value3, ROUND(AVG(Value4),0) AS Value4, ROUND(AVG(Value5),0) AS Value5, ROUND(AVG(Value6),0) AS Value5, MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Value1 ASC, Value5 ASC, Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13440,13 +13449,13 @@ namespace http {
 											int mon = ltime.tm_mon + 1;
 											int day = ltime.tm_mday;
 											sprintf(szTmp, "%04d-%02d-%02d", year, mon, day);
-											std::vector<std::vector<std::string> > result2;
-											result2 = m_sql.safe_query(
+											std::vector<std::vector<std::string> > result3;
+											result3 = m_sql.safe_query(
 												"SELECT Counter1, Counter2, Counter3, Counter4 FROM Multimeter_Calendar WHERE (DeviceRowID==%" PRIu64 ") AND (Date=='%q')",
 												idx, szTmp);
-											if (!result2.empty())
+											if (!result3.empty())
 											{
-												std::vector<std::string> sd = result2[0];
+												std::vector<std::string> sd = result3[0];
 												std::stringstream s_str1(sd[0]);
 												s_str1 >> firstUsage1;
 												std::stringstream s_str2(sd[1]);
@@ -13491,7 +13500,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13511,7 +13532,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13546,7 +13579,19 @@ namespace http {
 						{
 							vdiv = 1000.0f;
 						}
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13574,8 +13619,19 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13595,7 +13651,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13614,8 +13682,19 @@ namespace http {
 					{//day
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
-
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13636,7 +13715,19 @@ namespace http {
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13663,8 +13754,19 @@ namespace http {
 						m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
 						root["displaytype"] = displaytype;
-
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13739,7 +13841,19 @@ namespace http {
 
 						root["displaytype"] = displaytype;
 
-						result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value1, Value2, Value3, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value1),0), ROUND(AVG(Value2),0), ROUND(AVG(Value3),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 						if (result.size() > 0)
 						{
 							std::vector<std::vector<std::string> >::const_iterator itt;
@@ -13847,7 +13961,19 @@ namespace http {
 						}
 
 						int ii = 0;
-						result = m_sql.safe_query("SELECT Value,[Usage], Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (atoi(result2[0][0].c_str()) <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Usage, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(atoi(result2[0][0].c_str()) <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), ROUND(AVG(Usage),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14013,7 +14139,19 @@ namespace http {
 							EnergyDivider *= 100.0f;
 
 						int ii = 0;
-						result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+						if (result2.size() <= 864) //Less than 3 days
+						{
+							result = m_sql.safe_query("SELECT Value, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else if(result2.size() <= 5184) //Less than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
+						else //More than 18 days
+						{
+							result = m_sql.safe_query("SELECT ROUND(AVG(Value),0), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+						}
 
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
@@ -14199,8 +14337,19 @@ namespace http {
 				else if (sensor == "uv") {
 					root["status"] = "OK";
 					root["title"] = "Graph " + sensor + " " + srange;
-
-					result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					result2 = m_sql.safe_query("SELECT COUNT(*) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
+					if (result2.size() <= 864) //Less than 3 days
+					{
+						result = m_sql.safe_query("SELECT Level, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else if(result2.size() <= 5184) //Less than 18 days
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
+					else //More than 18 days
+					{
+						result = m_sql.safe_query("SELECT ROUND(AVG(Level),1), MIN(Date) FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date) ORDER BY Date ASC", dbasetable.c_str(), idx);
+					}
 					if (result.size() > 0)
 					{
 						std::vector<std::vector<std::string> >::const_iterator itt;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -13260,7 +13260,7 @@ namespace http {
 					{
 						result = m_sql.safe_query("SELECT Speed, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}
-					else else if(nValue<=14)
+					else if(nValue<=14)
 					{
 						result = m_sql.safe_query("SELECT ROUND(AVG(Speed),0) AS Speed, MIN(Date) AS Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") GROUP BY strftime('%%Y-%%m-%%d %%H',Date),(strftime('%%M',Date)/30) ORDER BY Date ASC", dbasetable.c_str(), idx);
 					}

--- a/www/app/TemperatureCustomLogController.js
+++ b/www/app/TemperatureCustomLogController.js
@@ -269,7 +269,7 @@ define(['app'], function (app) {
 
                     $.each(data.result, function(i,item)
                     {
-                        if (isday==1) {
+                        if (isday>=1) {
                             if (typeof item.te != 'undefined') {
                                 datatablete.push( [GetUTCFromString(item.d), parseFloat(item.te) ] );
                             }

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -350,6 +350,10 @@
 											<option value="5">5</option>
 											<option value="6">6</option>
 											<option value="7">7</option>
+											<option value="10">10</option>
+											<option value="14">14</option>
+											<option value="21">21</option>
+											<option value="31">31</option>
 										</select>&nbsp;&nbsp;<button data-i18n="Clear" class="btn btn-danger" ng-click="CleanupShortLog()">Clear</button></td>
 									</tr>
 									</table>

--- a/www/views/temperature_custom_temp_log.html
+++ b/www/views/temperature_custom_temp_log.html
@@ -18,6 +18,9 @@
                         <tr><td style="margin-top:7px; padding-left:10px; vertical-align:top;">
                             <span data-i18n="Select graph type"></span>:
                             <select id="combocustomgraphtype" name="CustomGraphType" style="margin-top:3px; width:200px;" class="combobox ui-corner-all" onChange="ClearCustomGraph()">
+                                <option value="4" data-i18n="Short term (1 hour values)">Short term (1 hour values)</option>
+                                <option value="3" data-i18n="Short term (30 minute values)">Short term (30 minute values)</option>
+                                <option value="2" data-i18n="Short term (15 minute values)">Short term (15 minute values)</option>
                                 <option value="1" data-i18n="Short term (5 minute values)">Short term (5 minute values)</option>
                                 <option value="0" data-i18n="Long term (daily values)">Long term (daily values)</option>
                             </select>


### PR DESCRIPTION
This change will allow to keep up to 31days in short-term history - it's a decision of user if can afford to store more data in database.
Also added new types of graphs in custom graphs to being less precise (15min, 30min and 1h).