### PR TITLE
Fix Travis build on macos x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ matrix:
     dist: trusty
     sudo: required
     compiler: gcc
-    env: 
+    env:
           - TARGET_ARCHITECTURE=x86_64
           - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
     addons:
@@ -78,8 +78,7 @@ matrix:
       - brew install openssl
       - brew link openssl --force
       - brew install md5sha1sum
-      - brew install python3
-      - brew linkapps python3
+      - brew upgrade python
       - export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
     script:
       - CPPFLAGS="-std=c++11" cmake -DCMAKE_BUILD_TYPE=Release -DPYTHON_INCLUDE_DIR=$(python3-config --prefix)/Headers -DPYTHON_LIBRARY=$(python3-config --prefix)/lib/libpython3.6.dylib


### PR DESCRIPTION
As explained in the homebrew blog, the formula for python was changed. https://brew.sh/2018/01/19/homebrew-1.5.0/

This is also discussed in this issue https://github.com/Homebrew/homebrew-core/issues/24702