### PR TITLE
Logitech Media Server: Add option to remove unused nodes

### DIFF
--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -12,12 +12,12 @@
 #include "../webserver/cWebem.h"
 #include "../httpclient/HTTPClient.h"
 
-CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms) : 
-m_IP(IPAddress),
-m_User(User),
-m_Pwd(Pwd),
-m_stoprequested(false),
-m_iThreadsRunning(0)
+CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms) :
+	m_IP(IPAddress),
+	m_User(User),
+	m_Pwd(Pwd),
+	m_stoprequested(false),
+	m_iThreadsRunning(0)
 {
 	m_HwdID = ID;
 	m_Port = Port;
@@ -67,7 +67,7 @@ Json::Value CLogitechMediaServer::Query(const std::string &sIP, const int iPort,
 		sURL << "http://" << sIP << ":" << iPort << "/jsonrpc.js";
 
 	sPostData << sPostdata;
-	
+
 	HTTPClient::SetTimeout(m_iPingTimeoutms / 1000);
 	bool bRetVal = HTTPClient::POST(sURL.str(), sPostData.str(), ExtraHeaders, sResult);
 
@@ -249,7 +249,7 @@ void CLogitechMediaServer::Do_Node_Work(const LogitechMediaServerNode &Node)
 					nStatus = MSTAT_OFF;
 				else {
 					std::string sMode = root["mode"].asString();
-					if (sMode == "play") 
+					if (sMode == "play")
 						if ((nOldStatus == MSTAT_OFF) || (nOldStatus == MSTAT_DISCONNECTED))
 							nStatus = MSTAT_ON;
 						else
@@ -323,6 +323,9 @@ void CLogitechMediaServer::Do_Work()
 
 	ReloadNodes();
 	ReloadPlaylists();
+
+	//Mark devices as 'Unused'
+	m_sql.safe_query("UPDATE WOLNodes SET Timeout=-1 WHERE (HardwareID==%d)", m_HwdID);
 
 	while (!m_stoprequested)
 	{
@@ -405,7 +408,7 @@ void CLogitechMediaServer::GetPlayerInfo()
 						(model == "transporter") ||			//Transporter
 						(model == "receiver") ||			//Squeezebox Receiver
 						(model == "boom") ||				//Squeezebox Boom
-						//(model == "softsqueeze") ||		//Softsqueeze
+															//(model == "softsqueeze") ||		//Softsqueeze
 						(model == "controller") ||			//Squeezebox Controller
 						(model == "squeezeplay") ||			//SqueezePlay
 						(model == "squeezeplayer") ||		//SqueezePlay
@@ -416,7 +419,7 @@ void CLogitechMediaServer::GetPlayerInfo()
 						(model == "squeezelite")			//Max2Play SqueezePlug
 						)
 					{
-						InsertUpdatePlayer(name, ip, macaddress);
+						UpsertPlayer(name, ip, macaddress);
 					}
 					else {
 						if (!m_bShowedStartupMessage)
@@ -436,17 +439,20 @@ void CLogitechMediaServer::GetPlayerInfo()
 	}
 }
 
-void CLogitechMediaServer::InsertUpdatePlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress)
+void CLogitechMediaServer::UpsertPlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress)
 {
 	std::vector<std::vector<std::string> > result;
 
 	//Check if exists...
-	//1) Check on MacAddress (default); Update Name in case it has been changed
+	//1) Check on MacAddress (default)
 	result = m_sql.safe_query("SELECT Name FROM WOLNodes WHERE (HardwareID==%d) AND (MacAddress=='%q')", m_HwdID, MacAddress.c_str());
 	if (result.size() > 0) {
-		if (result[0][0].c_str() != Name) {
-			m_sql.safe_query("UPDATE WOLNodes SET Name='%q' WHERE (HardwareID==%d) AND (MacAddress=='%q')", Name.c_str(), m_HwdID, MacAddress.c_str());
+		if (result[0][0].c_str() != Name) { //Update Name in case it has been changed
+			m_sql.safe_query("UPDATE WOLNodes SET Name='%q', Timeout=0 WHERE (HardwareID==%d) AND (MacAddress=='%q')", Name.c_str(), m_HwdID, MacAddress.c_str());
 			_log.Log(LOG_STATUS, "Logitech Media Server: Player '%s' renamed to '%s'", result[0][0].c_str(), Name.c_str());
+		}
+		else { //Mark device as 'Active'
+			m_sql.safe_query("UPDATE WOLNodes SET Timeout=0 WHERE (HardwareID==%d) AND (MacAddress=='%q')", m_HwdID, MacAddress.c_str());
 		}
 		return;
 	}
@@ -847,6 +853,27 @@ namespace http {
 			pHardware->Restart();
 		}
 
+		void CWebServer::Cmd_LMSDeleteUnusedDevices(WebEmSession & session, const request& req, Json::Value &root)
+		{
+			if (session.rights != 2)
+			{
+				session.reply_status = reply::forbidden;
+				return; //Only admin user allowed
+			}
+			std::string hwid = request::findValue(&req, "idx");
+			if (hwid == "")
+				return;
+			int iHardwareID = atoi(hwid.c_str());
+			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
+			if (pBaseHardware == NULL)
+				return;
+			if (pBaseHardware->HwdType != HTYPE_LogitechMediaServer)
+				return;
+			CLogitechMediaServer *pHardware = reinterpret_cast<CLogitechMediaServer*>(pBaseHardware);
+
+			m_sql.safe_query("DELETE FROM WOLNodes WHERE ((HardwareID==%d) AND (Timeout==-1))", iHardwareID);
+		}
+
 		void CWebServer::Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			if (session.rights != 2)
@@ -868,7 +895,7 @@ namespace http {
 			root["title"] = "LMSGetNodes";
 
 			std::vector<std::vector<std::string> > result;
-			result = m_sql.safe_query("SELECT ID,Name,MacAddress FROM WOLNodes WHERE (HardwareID==%d)", iHardwareID);
+			result = m_sql.safe_query("SELECT ID,Name,MacAddress,(CASE Timeout WHEN -1 THEN 'Unused' ELSE 'Active' END) as Status FROM WOLNodes WHERE (HardwareID==%d)", iHardwareID);
 			if (result.size() > 0)
 			{
 				std::vector<std::vector<std::string> >::const_iterator itt;
@@ -880,6 +907,7 @@ namespace http {
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["Mac"] = sd[2];
+					root["result"][ii]["Status"] = sd[3];
 					ii++;
 				}
 			}
@@ -899,7 +927,7 @@ namespace http {
 			CLogitechMediaServer *pHardware = reinterpret_cast<CLogitechMediaServer*>(pBaseHardware);
 
 			root["status"] = "OK";
-			root["title"] = "Cmd_LMSGetPlaylists";
+			root["title"] = "LMSGetPlaylists";
 
 			std::vector<CLogitechMediaServer::LMSPlaylistNode> m_nodes = pHardware->GetPlaylists();
 			std::vector<CLogitechMediaServer::LMSPlaylistNode>::const_iterator itt;

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -12,12 +12,12 @@
 #include "../webserver/cWebem.h"
 #include "../httpclient/HTTPClient.h"
 
-CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms) :
-	m_IP(IPAddress),
-	m_User(User),
-	m_Pwd(Pwd),
-	m_stoprequested(false),
-	m_iThreadsRunning(0)
+CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms) : 
+m_IP(IPAddress),
+m_User(User),
+m_Pwd(Pwd),
+m_stoprequested(false),
+m_iThreadsRunning(0)
 {
 	m_HwdID = ID;
 	m_Port = Port;
@@ -67,7 +67,7 @@ Json::Value CLogitechMediaServer::Query(const std::string &sIP, const int iPort,
 		sURL << "http://" << sIP << ":" << iPort << "/jsonrpc.js";
 
 	sPostData << sPostdata;
-
+	
 	HTTPClient::SetTimeout(m_iPingTimeoutms / 1000);
 	bool bRetVal = HTTPClient::POST(sURL.str(), sPostData.str(), ExtraHeaders, sResult);
 
@@ -249,7 +249,7 @@ void CLogitechMediaServer::Do_Node_Work(const LogitechMediaServerNode &Node)
 					nStatus = MSTAT_OFF;
 				else {
 					std::string sMode = root["mode"].asString();
-					if (sMode == "play")
+					if (sMode == "play") 
 						if ((nOldStatus == MSTAT_OFF) || (nOldStatus == MSTAT_DISCONNECTED))
 							nStatus = MSTAT_ON;
 						else
@@ -323,9 +323,6 @@ void CLogitechMediaServer::Do_Work()
 
 	ReloadNodes();
 	ReloadPlaylists();
-
-	//Mark devices as 'Unused'
-	m_sql.safe_query("UPDATE WOLNodes SET Timeout=-1 WHERE (HardwareID==%d)", m_HwdID);
 
 	while (!m_stoprequested)
 	{
@@ -408,7 +405,7 @@ void CLogitechMediaServer::GetPlayerInfo()
 						(model == "transporter") ||			//Transporter
 						(model == "receiver") ||			//Squeezebox Receiver
 						(model == "boom") ||				//Squeezebox Boom
-															//(model == "softsqueeze") ||		//Softsqueeze
+						//(model == "softsqueeze") ||		//Softsqueeze
 						(model == "controller") ||			//Squeezebox Controller
 						(model == "squeezeplay") ||			//SqueezePlay
 						(model == "squeezeplayer") ||		//SqueezePlay
@@ -419,7 +416,7 @@ void CLogitechMediaServer::GetPlayerInfo()
 						(model == "squeezelite")			//Max2Play SqueezePlug
 						)
 					{
-						UpsertPlayer(name, ip, macaddress);
+						InsertUpdatePlayer(name, ip, macaddress);
 					}
 					else {
 						if (!m_bShowedStartupMessage)
@@ -439,20 +436,17 @@ void CLogitechMediaServer::GetPlayerInfo()
 	}
 }
 
-void CLogitechMediaServer::UpsertPlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress)
+void CLogitechMediaServer::InsertUpdatePlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress)
 {
 	std::vector<std::vector<std::string> > result;
 
 	//Check if exists...
-	//1) Check on MacAddress (default)
+	//1) Check on MacAddress (default); Update Name in case it has been changed
 	result = m_sql.safe_query("SELECT Name FROM WOLNodes WHERE (HardwareID==%d) AND (MacAddress=='%q')", m_HwdID, MacAddress.c_str());
 	if (result.size() > 0) {
-		if (result[0][0].c_str() != Name) { //Update Name in case it has been changed
-			m_sql.safe_query("UPDATE WOLNodes SET Name='%q', Timeout=0 WHERE (HardwareID==%d) AND (MacAddress=='%q')", Name.c_str(), m_HwdID, MacAddress.c_str());
+		if (result[0][0].c_str() != Name) {
+			m_sql.safe_query("UPDATE WOLNodes SET Name='%q' WHERE (HardwareID==%d) AND (MacAddress=='%q')", Name.c_str(), m_HwdID, MacAddress.c_str());
 			_log.Log(LOG_STATUS, "Logitech Media Server: Player '%s' renamed to '%s'", result[0][0].c_str(), Name.c_str());
-		}
-		else { //Mark device as 'Active'
-			m_sql.safe_query("UPDATE WOLNodes SET Timeout=0 WHERE (HardwareID==%d) AND (MacAddress=='%q')", m_HwdID, MacAddress.c_str());
 		}
 		return;
 	}
@@ -853,27 +847,6 @@ namespace http {
 			pHardware->Restart();
 		}
 
-		void CWebServer::Cmd_LMSDeleteUnusedDevices(WebEmSession & session, const request& req, Json::Value &root)
-		{
-			if (session.rights != 2)
-			{
-				session.reply_status = reply::forbidden;
-				return; //Only admin user allowed
-			}
-			std::string hwid = request::findValue(&req, "idx");
-			if (hwid == "")
-				return;
-			int iHardwareID = atoi(hwid.c_str());
-			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
-			if (pBaseHardware == NULL)
-				return;
-			if (pBaseHardware->HwdType != HTYPE_LogitechMediaServer)
-				return;
-			CLogitechMediaServer *pHardware = reinterpret_cast<CLogitechMediaServer*>(pBaseHardware);
-
-			m_sql.safe_query("DELETE FROM WOLNodes WHERE ((HardwareID==%d) AND (Timeout==-1))", iHardwareID);
-		}
-
 		void CWebServer::Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			if (session.rights != 2)
@@ -895,7 +868,7 @@ namespace http {
 			root["title"] = "LMSGetNodes";
 
 			std::vector<std::vector<std::string> > result;
-			result = m_sql.safe_query("SELECT ID,Name,MacAddress,(CASE Timeout WHEN -1 THEN 'Unused' ELSE 'Active' END) as Status FROM WOLNodes WHERE (HardwareID==%d)", iHardwareID);
+			result = m_sql.safe_query("SELECT ID,Name,MacAddress FROM WOLNodes WHERE (HardwareID==%d)", iHardwareID);
 			if (result.size() > 0)
 			{
 				std::vector<std::vector<std::string> >::const_iterator itt;
@@ -907,7 +880,6 @@ namespace http {
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["Mac"] = sd[2];
-					root["result"][ii]["Status"] = sd[3];
 					ii++;
 				}
 			}
@@ -927,7 +899,7 @@ namespace http {
 			CLogitechMediaServer *pHardware = reinterpret_cast<CLogitechMediaServer*>(pBaseHardware);
 
 			root["status"] = "OK";
-			root["title"] = "LMSGetPlaylists";
+			root["title"] = "Cmd_LMSGetPlaylists";
 
 			std::vector<CLogitechMediaServer::LMSPlaylistNode> m_nodes = pHardware->GetPlaylists();
 			std::vector<CLogitechMediaServer::LMSPlaylistNode>::const_iterator itt;

--- a/hardware/LogitechMediaServer.h
+++ b/hardware/LogitechMediaServer.h
@@ -46,7 +46,7 @@ private:
 	_eNotificationTypes	NotificationType(_eMediaStatus nStatus);
 	void Do_Work();
 	void GetPlayerInfo();
-	void InsertUpdatePlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress);
+	void UpsertPlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress);
 
 	bool StartHardware();
 	bool StopHardware();

--- a/hardware/LogitechMediaServer.h
+++ b/hardware/LogitechMediaServer.h
@@ -46,7 +46,7 @@ private:
 	_eNotificationTypes	NotificationType(_eMediaStatus nStatus);
 	void Do_Work();
 	void GetPlayerInfo();
-	void UpsertPlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress);
+	void InsertUpdatePlayer(const std::string &Name, const std::string &IPAddress, const std::string &MacAddress);
 
 	bool StartHardware();
 	bool StopHardware();

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -434,6 +434,7 @@ namespace http {
 			RegisterCommandCode("lmsgetnodes", boost::bind(&CWebServer::Cmd_LMSGetNodes, this, _1, _2, _3));
 			RegisterCommandCode("lmsgetplaylists", boost::bind(&CWebServer::Cmd_LMSGetPlaylists, this, _1, _2, _3));
 			RegisterCommandCode("lmsmediacommand", boost::bind(&CWebServer::Cmd_LMSMediaCommand, this, _1, _2, _3));
+			RegisterCommandCode("lmsdeleteunuseddevices", boost::bind(&CWebServer::Cmd_LMSDeleteUnusedDevices, this, _1, _2, _3));
 
 			RegisterCommandCode("savefibarolinkconfig", boost::bind(&CWebServer::Cmd_SaveFibaroLinkConfig, this, _1, _2, _3));
 			RegisterCommandCode("getfibarolinkconfig", boost::bind(&CWebServer::Cmd_GetFibaroLinkConfig, this, _1, _2, _3));

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -84,39 +84,39 @@ struct _tGuiLanguage {
 static const _tGuiLanguage guiLanguage[] =
 {
 	{ "en", "English" },
-	{ "ar", "Arabic" },
-	{ "bg", "Bulgarian" },
-	{ "ca", "Catalan" },
-	{ "zh", "Chinese" },
-	{ "cs", "Czech" },
-	{ "da", "Danish" },
-	{ "nl", "Dutch" },
-	{ "et", "Estonian" },
-	{ "de", "German" },
-	{ "el", "Greek" },
-	{ "fr", "French" },
-	{ "fi", "Finnish" },
-	{ "he", "Hebrew" },
-	{ "hu", "Hungarian" },
-	{ "is", "Icelandic" },
-	{ "it", "Italian" },
-	{ "lt", "Lithuanian" },
-	{ "lv", "Latvian" },
-	{ "mk", "Macedonian" },
-	{ "no", "Norwegian" },
-	{ "fa", "Persian" },
-	{ "pl", "Polish" },
-	{ "pt", "Portuguese" },
-	{ "ro", "Romanian" },
-	{ "ru", "Russian" },
-	{ "sr", "Serbian" },
-	{ "sk", "Slovak" },
-	{ "sl", "Slovenian" },
-	{ "es", "Spanish" },
-	{ "sv", "Swedish" },
-	{ "tr", "Turkish" },
-	{ "uk", "Ukrainian" },
-	{ NULL, NULL }
+{ "ar", "Arabic" },
+{ "bg", "Bulgarian" },
+{ "ca", "Catalan" },
+{ "zh", "Chinese" },
+{ "cs", "Czech" },
+{ "da", "Danish" },
+{ "nl", "Dutch" },
+{ "et", "Estonian" },
+{ "de", "German" },
+{ "el", "Greek" },
+{ "fr", "French" },
+{ "fi", "Finnish" },
+{ "he", "Hebrew" },
+{ "hu", "Hungarian" },
+{ "is", "Icelandic" },
+{ "it", "Italian" },
+{ "lt", "Lithuanian" },
+{ "lv", "Latvian" },
+{ "mk", "Macedonian" },
+{ "no", "Norwegian" },
+{ "fa", "Persian" },
+{ "pl", "Polish" },
+{ "pt", "Portuguese" },
+{ "ro", "Romanian" },
+{ "ru", "Russian" },
+{ "sr", "Serbian" },
+{ "sk", "Slovak" },
+{ "sl", "Slovenian" },
+{ "es", "Spanish" },
+{ "sv", "Swedish" },
+{ "tr", "Turkish" },
+{ "uk", "Ukrainian" },
+{ NULL, NULL }
 };
 
 extern http::server::CWebServerHelper m_webservers;
@@ -431,6 +431,7 @@ namespace http {
 			RegisterCommandCode("bleboxupdatefirmware", boost::bind(&CWebServer::Cmd_BleBoxUpdateFirmware, this, _1, _2, _3));
 
 			RegisterCommandCode("lmssetmode", boost::bind(&CWebServer::Cmd_LMSSetMode, this, _1, _2, _3));
+			RegisterCommandCode("lmsdeleteunuseddevices", boost::bind(&CWebServer::Cmd_LMSDeleteUnusedDevices, this, _1, _2, _3));
 			RegisterCommandCode("lmsgetnodes", boost::bind(&CWebServer::Cmd_LMSGetNodes, this, _1, _2, _3));
 			RegisterCommandCode("lmsgetplaylists", boost::bind(&CWebServer::Cmd_LMSGetPlaylists, this, _1, _2, _3));
 			RegisterCommandCode("lmsmediacommand", boost::bind(&CWebServer::Cmd_LMSMediaCommand, this, _1, _2, _3));
@@ -997,7 +998,7 @@ namespace http {
 					}
 #endif
 
-		}
+				}
 #endif
 #endif
 #ifndef WITH_OPENZWAVE
@@ -1019,7 +1020,7 @@ namespace http {
 					bDoAdd = false;
 				if (bDoAdd)
 					_htypes[Hardware_Type_Desc(ii)] = ii;
-	}
+			}
 			//return a sorted hardware list
 			std::map<std::string, int>::const_iterator itt;
 			int ii = 0;
@@ -1034,7 +1035,7 @@ namespace http {
 			// Append Plugin list as well
 			PluginList(root["result"]);
 #endif
-}
+		}
 
 		void CWebServer::Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root)
 		{
@@ -1106,7 +1107,7 @@ namespace http {
 					m_sql.UpdatePreferencesVar("SmartMeterType", 0);
 				}
 			}
-			else if (IsNetworkDevice(htype)) 
+			else if (IsNetworkDevice(htype))
 			{
 				//Lan
 				if (address.empty() || port == 0)
@@ -3065,9 +3066,9 @@ namespace http {
 				{
 					_log.Log(LOG_ERROR, "Error executing script command (%s). returned: %d", lscript.c_str(), ret);
 					return;
-			}
+				}
 #endif
-		}
+			}
 			else
 			{
 				//add script to background worker
@@ -3246,7 +3247,7 @@ namespace http {
 				return true;
 			if (pSession->rights == 0)
 				return false; //viewer
-			//User
+							  //User
 			int iUser = FindUser(pSession->username.c_str());
 			if ((iUser < 0) || (iUser >= (int)m_users.size()))
 				return false;
@@ -3735,8 +3736,8 @@ namespace http {
 						root["result"][ii]["idx"] = pin.GetPin();
 						root["result"][ii]["Name"] = pin.ToString();
 						ii++;
-			}
-		}
+					}
+				}
 #else
 				root["status"] = "OK";
 				root["result"][0]["idx"] = 0;
@@ -3762,7 +3763,7 @@ namespace http {
 						root["status"] = "OK";
 						root["result"][ii]["idx"] = gpio_ids[ii];
 						root["result"][ii]["Name"] = gpio_names[ii];
-			}
+					}
 				}
 #else
 				root["status"] = "OK";
@@ -3964,7 +3965,7 @@ namespace http {
 					}
 				}//end light/switches
 
-				//Add Scenes
+				 //Add Scenes
 				result = m_sql.safe_query("SELECT ID, Name FROM Scenes ORDER BY Name");
 				if (result.size() > 0)
 				{
@@ -4189,7 +4190,7 @@ namespace http {
 					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
 					if (pBaseHardware == NULL)
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) 
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3)
 						&& (pBaseHardware->HwdType != HTYPE_USBtinGateway) )
 						return;
 					unsigned long rID = 0;
@@ -4252,7 +4253,7 @@ namespace http {
 						root["status"] = "ERROR";
 						root["message"] = "Given pin is not configured for output";
 						return;
-			}
+					}
 #else
 					root["status"] = "ERROR";
 					root["message"] = "GPIO support is disabled";
@@ -4745,7 +4746,7 @@ namespace http {
 					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
 					if (pBaseHardware == NULL)
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) 
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3)
 						&& (pBaseHardware->HwdType != HTYPE_USBtinGateway) )
 						return;
 					unsigned long rID = 0;
@@ -4803,7 +4804,7 @@ namespace http {
 					CGpioPin *pPin = CGpio::GetPPinById(atoi(sunitcode.c_str()));
 					if (pPin == NULL) {
 						return;
-			}
+					}
 #else
 					return;
 #endif
@@ -6442,9 +6443,9 @@ namespace http {
 				std::string until = request::findValue(&req, "until");//optional until date / time as applicable
 				std::string action = request::findValue(&req, "action");//Run action or not (update status only)
 				std::string onlyonchange = request::findValue(&req, "ooc");//No update unless the value changed (check if updated)
-				//The on action is used to call a script to update the real device so we only want to use it when altering the status in the Domoticz Web Client
-				//If we're posting the status from the real device to domoticz we don't want to run the on action script ("action"!=1) to avoid loops and contention
-				//""... we only want to log a change (and trigger an event) when the status has actually changed ("ooc"==1) i.e. suppress non transient updates
+																		   //The on action is used to call a script to update the real device so we only want to use it when altering the status in the Domoticz Web Client
+																		   //If we're posting the status from the real device to domoticz we don't want to run the on action script ("action"!=1) to avoid loops and contention
+																		   //""... we only want to log a change (and trigger an event) when the status has actually changed ("ooc"==1) i.e. suppress non transient updates
 				if ((idx.empty()) || (switchcmd.empty()))
 					return;
 
@@ -8109,7 +8110,7 @@ namespace http {
 							" LEFT OUTER JOIN DeviceToPlansMap as B ON (B.DeviceRowID==a.ID) AND (B.DevSceneType==1)"
 							" ORDER BY ");
 						szQuery += szOrderBy;
-                                                result = m_sql.safe_query(szQuery.c_str(), order.c_str());
+						result = m_sql.safe_query(szQuery.c_str(), order.c_str());
 					}
 
 					if (result.size() > 0)
@@ -9055,7 +9056,7 @@ namespace http {
 						//Rob: Dont know who did this, but this should be solved in GetLightCommand
 						//Now we had double Set Level/Level notations
 						//if (llevel != 0)
-							//sprintf(szData, "%s, Level: %d %%", lstatus.c_str(), llevel);
+						//sprintf(szData, "%s, Level: %d %%", lstatus.c_str(), llevel);
 						//else
 						sprintf(szData, "%s", lstatus.c_str());
 						root["result"][ii]["Data"] = szData;
@@ -17115,8 +17116,8 @@ namespace http {
 		}
 
 		/**
-		 * Retrieve user session from store, without remote host.
-		 */
+		* Retrieve user session from store, without remote host.
+		*/
 		const WebEmStoredSession CWebServer::GetSession(const std::string & sessionId) {
 			//_log.Log(LOG_STATUS, "SessionStore : get...");
 			WebEmStoredSession session;
@@ -17146,8 +17147,8 @@ namespace http {
 		}
 
 		/**
-		 * Save user session.
-		 */
+		* Save user session.
+		*/
 		void CWebServer::StoreSession(const WebEmStoredSession & session) {
 			//_log.Log(LOG_STATUS, "SessionStore : store...");
 			if (session.id.empty()) {
@@ -17184,8 +17185,8 @@ namespace http {
 		}
 
 		/**
-		 * Remove user session and expired sessions.
-		 */
+		* Remove user session and expired sessions.
+		*/
 		void CWebServer::RemoveSession(const std::string & sessionId) {
 			//_log.Log(LOG_STATUS, "SessionStore : remove...");
 			if (sessionId.empty()) {
@@ -17197,8 +17198,8 @@ namespace http {
 		}
 
 		/**
-		 * Remove all expired user sessions.
-		 */
+		* Remove all expired user sessions.
+		*/
 		void CWebServer::CleanSessions() {
 			//_log.Log(LOG_STATUS, "SessionStore : clean...");
 			m_sql.safe_query(
@@ -17206,12 +17207,12 @@ namespace http {
 		}
 
 		/**
-		 * Delete all user's session, except the session used to modify the username or password.
-		 * username must have been hashed
-		 *
-		 * Note : on the WebUserName modification, this method will not delete the session, but the session will be deleted anyway
-		 * because the username will be unknown (see cWebemRequestHandler::checkAuthToken).
-		 */
+		* Delete all user's session, except the session used to modify the username or password.
+		* username must have been hashed
+		*
+		* Note : on the WebUserName modification, this method will not delete the session, but the session will be deleted anyway
+		* because the username will be unknown (see cWebemRequestHandler::checkAuthToken).
+		*/
 		void CWebServer::RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession) {
 			m_sql.safe_query("DELETE FROM UserSessions WHERE (Username=='%q') and (SessionID!='%q')", username.c_str(), exceptSession.id.c_str());
 		}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -84,39 +84,39 @@ struct _tGuiLanguage {
 static const _tGuiLanguage guiLanguage[] =
 {
 	{ "en", "English" },
-{ "ar", "Arabic" },
-{ "bg", "Bulgarian" },
-{ "ca", "Catalan" },
-{ "zh", "Chinese" },
-{ "cs", "Czech" },
-{ "da", "Danish" },
-{ "nl", "Dutch" },
-{ "et", "Estonian" },
-{ "de", "German" },
-{ "el", "Greek" },
-{ "fr", "French" },
-{ "fi", "Finnish" },
-{ "he", "Hebrew" },
-{ "hu", "Hungarian" },
-{ "is", "Icelandic" },
-{ "it", "Italian" },
-{ "lt", "Lithuanian" },
-{ "lv", "Latvian" },
-{ "mk", "Macedonian" },
-{ "no", "Norwegian" },
-{ "fa", "Persian" },
-{ "pl", "Polish" },
-{ "pt", "Portuguese" },
-{ "ro", "Romanian" },
-{ "ru", "Russian" },
-{ "sr", "Serbian" },
-{ "sk", "Slovak" },
-{ "sl", "Slovenian" },
-{ "es", "Spanish" },
-{ "sv", "Swedish" },
-{ "tr", "Turkish" },
-{ "uk", "Ukrainian" },
-{ NULL, NULL }
+	{ "ar", "Arabic" },
+	{ "bg", "Bulgarian" },
+	{ "ca", "Catalan" },
+	{ "zh", "Chinese" },
+	{ "cs", "Czech" },
+	{ "da", "Danish" },
+	{ "nl", "Dutch" },
+	{ "et", "Estonian" },
+	{ "de", "German" },
+	{ "el", "Greek" },
+	{ "fr", "French" },
+	{ "fi", "Finnish" },
+	{ "he", "Hebrew" },
+	{ "hu", "Hungarian" },
+	{ "is", "Icelandic" },
+	{ "it", "Italian" },
+	{ "lt", "Lithuanian" },
+	{ "lv", "Latvian" },
+	{ "mk", "Macedonian" },
+	{ "no", "Norwegian" },
+	{ "fa", "Persian" },
+	{ "pl", "Polish" },
+	{ "pt", "Portuguese" },
+	{ "ro", "Romanian" },
+	{ "ru", "Russian" },
+	{ "sr", "Serbian" },
+	{ "sk", "Slovak" },
+	{ "sl", "Slovenian" },
+	{ "es", "Spanish" },
+	{ "sv", "Swedish" },
+	{ "tr", "Turkish" },
+	{ "uk", "Ukrainian" },
+	{ NULL, NULL }
 };
 
 extern http::server::CWebServerHelper m_webservers;
@@ -431,7 +431,6 @@ namespace http {
 			RegisterCommandCode("bleboxupdatefirmware", boost::bind(&CWebServer::Cmd_BleBoxUpdateFirmware, this, _1, _2, _3));
 
 			RegisterCommandCode("lmssetmode", boost::bind(&CWebServer::Cmd_LMSSetMode, this, _1, _2, _3));
-			RegisterCommandCode("lmsdeleteunuseddevices", boost::bind(&CWebServer::Cmd_LMSDeleteUnusedDevices, this, _1, _2, _3));
 			RegisterCommandCode("lmsgetnodes", boost::bind(&CWebServer::Cmd_LMSGetNodes, this, _1, _2, _3));
 			RegisterCommandCode("lmsgetplaylists", boost::bind(&CWebServer::Cmd_LMSGetPlaylists, this, _1, _2, _3));
 			RegisterCommandCode("lmsmediacommand", boost::bind(&CWebServer::Cmd_LMSMediaCommand, this, _1, _2, _3));
@@ -998,7 +997,7 @@ namespace http {
 					}
 #endif
 
-				}
+		}
 #endif
 #endif
 #ifndef WITH_OPENZWAVE
@@ -1020,7 +1019,7 @@ namespace http {
 					bDoAdd = false;
 				if (bDoAdd)
 					_htypes[Hardware_Type_Desc(ii)] = ii;
-			}
+	}
 			//return a sorted hardware list
 			std::map<std::string, int>::const_iterator itt;
 			int ii = 0;
@@ -1035,7 +1034,7 @@ namespace http {
 			// Append Plugin list as well
 			PluginList(root["result"]);
 #endif
-		}
+}
 
 		void CWebServer::Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root)
 		{
@@ -1107,7 +1106,7 @@ namespace http {
 					m_sql.UpdatePreferencesVar("SmartMeterType", 0);
 				}
 			}
-			else if (IsNetworkDevice(htype))
+			else if (IsNetworkDevice(htype)) 
 			{
 				//Lan
 				if (address.empty() || port == 0)
@@ -3066,9 +3065,9 @@ namespace http {
 				{
 					_log.Log(LOG_ERROR, "Error executing script command (%s). returned: %d", lscript.c_str(), ret);
 					return;
-				}
-#endif
 			}
+#endif
+		}
 			else
 			{
 				//add script to background worker
@@ -3247,7 +3246,7 @@ namespace http {
 				return true;
 			if (pSession->rights == 0)
 				return false; //viewer
-							  //User
+			//User
 			int iUser = FindUser(pSession->username.c_str());
 			if ((iUser < 0) || (iUser >= (int)m_users.size()))
 				return false;
@@ -3736,8 +3735,8 @@ namespace http {
 						root["result"][ii]["idx"] = pin.GetPin();
 						root["result"][ii]["Name"] = pin.ToString();
 						ii++;
-					}
-				}
+			}
+		}
 #else
 				root["status"] = "OK";
 				root["result"][0]["idx"] = 0;
@@ -3763,7 +3762,7 @@ namespace http {
 						root["status"] = "OK";
 						root["result"][ii]["idx"] = gpio_ids[ii];
 						root["result"][ii]["Name"] = gpio_names[ii];
-					}
+			}
 				}
 #else
 				root["status"] = "OK";
@@ -3965,7 +3964,7 @@ namespace http {
 					}
 				}//end light/switches
 
-				 //Add Scenes
+				//Add Scenes
 				result = m_sql.safe_query("SELECT ID, Name FROM Scenes ORDER BY Name");
 				if (result.size() > 0)
 				{
@@ -4190,7 +4189,7 @@ namespace http {
 					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
 					if (pBaseHardware == NULL)
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3)
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) 
 						&& (pBaseHardware->HwdType != HTYPE_USBtinGateway) )
 						return;
 					unsigned long rID = 0;
@@ -4253,7 +4252,7 @@ namespace http {
 						root["status"] = "ERROR";
 						root["message"] = "Given pin is not configured for output";
 						return;
-					}
+			}
 #else
 					root["status"] = "ERROR";
 					root["message"] = "GPIO support is disabled";
@@ -4746,7 +4745,7 @@ namespace http {
 					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
 					if (pBaseHardware == NULL)
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3)
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) 
 						&& (pBaseHardware->HwdType != HTYPE_USBtinGateway) )
 						return;
 					unsigned long rID = 0;
@@ -4804,7 +4803,7 @@ namespace http {
 					CGpioPin *pPin = CGpio::GetPPinById(atoi(sunitcode.c_str()));
 					if (pPin == NULL) {
 						return;
-					}
+			}
 #else
 					return;
 #endif
@@ -6443,9 +6442,9 @@ namespace http {
 				std::string until = request::findValue(&req, "until");//optional until date / time as applicable
 				std::string action = request::findValue(&req, "action");//Run action or not (update status only)
 				std::string onlyonchange = request::findValue(&req, "ooc");//No update unless the value changed (check if updated)
-																		   //The on action is used to call a script to update the real device so we only want to use it when altering the status in the Domoticz Web Client
-																		   //If we're posting the status from the real device to domoticz we don't want to run the on action script ("action"!=1) to avoid loops and contention
-																		   //""... we only want to log a change (and trigger an event) when the status has actually changed ("ooc"==1) i.e. suppress non transient updates
+				//The on action is used to call a script to update the real device so we only want to use it when altering the status in the Domoticz Web Client
+				//If we're posting the status from the real device to domoticz we don't want to run the on action script ("action"!=1) to avoid loops and contention
+				//""... we only want to log a change (and trigger an event) when the status has actually changed ("ooc"==1) i.e. suppress non transient updates
 				if ((idx.empty()) || (switchcmd.empty()))
 					return;
 
@@ -8110,7 +8109,7 @@ namespace http {
 							" LEFT OUTER JOIN DeviceToPlansMap as B ON (B.DeviceRowID==a.ID) AND (B.DevSceneType==1)"
 							" ORDER BY ");
 						szQuery += szOrderBy;
-						result = m_sql.safe_query(szQuery.c_str(), order.c_str());
+                                                result = m_sql.safe_query(szQuery.c_str(), order.c_str());
 					}
 
 					if (result.size() > 0)
@@ -9056,7 +9055,7 @@ namespace http {
 						//Rob: Dont know who did this, but this should be solved in GetLightCommand
 						//Now we had double Set Level/Level notations
 						//if (llevel != 0)
-						//sprintf(szData, "%s, Level: %d %%", lstatus.c_str(), llevel);
+							//sprintf(szData, "%s, Level: %d %%", lstatus.c_str(), llevel);
 						//else
 						sprintf(szData, "%s", lstatus.c_str());
 						root["result"][ii]["Data"] = szData;
@@ -17116,8 +17115,8 @@ namespace http {
 		}
 
 		/**
-		* Retrieve user session from store, without remote host.
-		*/
+		 * Retrieve user session from store, without remote host.
+		 */
 		const WebEmStoredSession CWebServer::GetSession(const std::string & sessionId) {
 			//_log.Log(LOG_STATUS, "SessionStore : get...");
 			WebEmStoredSession session;
@@ -17147,8 +17146,8 @@ namespace http {
 		}
 
 		/**
-		* Save user session.
-		*/
+		 * Save user session.
+		 */
 		void CWebServer::StoreSession(const WebEmStoredSession & session) {
 			//_log.Log(LOG_STATUS, "SessionStore : store...");
 			if (session.id.empty()) {
@@ -17185,8 +17184,8 @@ namespace http {
 		}
 
 		/**
-		* Remove user session and expired sessions.
-		*/
+		 * Remove user session and expired sessions.
+		 */
 		void CWebServer::RemoveSession(const std::string & sessionId) {
 			//_log.Log(LOG_STATUS, "SessionStore : remove...");
 			if (sessionId.empty()) {
@@ -17198,8 +17197,8 @@ namespace http {
 		}
 
 		/**
-		* Remove all expired user sessions.
-		*/
+		 * Remove all expired user sessions.
+		 */
 		void CWebServer::CleanSessions() {
 			//_log.Log(LOG_STATUS, "SessionStore : clean...");
 			m_sql.safe_query(
@@ -17207,12 +17206,12 @@ namespace http {
 		}
 
 		/**
-		* Delete all user's session, except the session used to modify the username or password.
-		* username must have been hashed
-		*
-		* Note : on the WebUserName modification, this method will not delete the session, but the session will be deleted anyway
-		* because the username will be unknown (see cWebemRequestHandler::checkAuthToken).
-		*/
+		 * Delete all user's session, except the session used to modify the username or password.
+		 * username must have been hashed
+		 *
+		 * Note : on the WebUserName modification, this method will not delete the session, but the session will be deleted anyway
+		 * because the username will be unknown (see cWebemRequestHandler::checkAuthToken).
+		 */
 		void CWebServer::RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession) {
 			m_sql.safe_query("DELETE FROM UserSessions WHERE (Username=='%q') and (SessionID!='%q')", username.c_str(), exceptSession.id.c_str());
 		}

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -145,6 +145,7 @@ private:
 	void Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_LMSGetPlaylists(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_LMSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LMSDeleteUnusedDevices(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SaveFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetFibaroLinks(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -18,371 +18,370 @@ namespace http {
 	namespace server {
 		class cWebem;
 		struct _tWebUserPassword;
-		class CWebServer : public session_store, public boost::enable_shared_from_this<CWebServer>
-		{
-			typedef boost::function< void(WebEmSession & session, const request& req, Json::Value &root) > webserver_response_function;
-		public:
-			struct _tCustomIcon
-			{
-				int idx;
-				std::string RootFile;
-				std::string Title;
-				std::string Description;
-			};
-			CWebServer(void);
-			~CWebServer(void);
-			bool StartServer(server_settings & settings, const std::string &serverpath, const bool bIgnoreUsernamePassword);
-			void StopServer();
-			void RegisterCommandCode(const char* idname, webserver_response_function ResponseFunction, bool bypassAuthentication=false);
-			void RegisterRType(const char* idname, webserver_response_function ResponseFunction);
+class CWebServer : public session_store, public boost::enable_shared_from_this<CWebServer>
+{
+	typedef boost::function< void(WebEmSession & session, const request& req, Json::Value &root) > webserver_response_function;
+public:
+	struct _tCustomIcon
+	{
+		int idx;
+		std::string RootFile;
+		std::string Title;
+		std::string Description;
+	};
+	CWebServer(void);
+	~CWebServer(void);
+	bool StartServer(server_settings & settings, const std::string &serverpath, const bool bIgnoreUsernamePassword);
+	void StopServer();
+	void RegisterCommandCode(const char* idname, webserver_response_function ResponseFunction, bool bypassAuthentication=false);
+	void RegisterRType(const char* idname, webserver_response_function ResponseFunction);
 
-			void DisplaySwitchTypesCombo(std::string & content_part);
-			void DisplayMeterTypesCombo(std::string & content_part);
-			void DisplayTimerTypesCombo(std::string & content_part);
-			void DisplayLanguageCombo(std::string & content_part);
-			void GetJSonPage(WebEmSession & session, const request& req, reply & rep);
-			void GetAppCache(WebEmSession & session, const request& req, reply & rep);
-			void GetCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
-			void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
-			void GetDatabaseBackup(WebEmSession & session, const request& req, reply & rep);
-			void Post_UploadCustomIcon(WebEmSession & session, const request& req, reply & rep);
+	void DisplaySwitchTypesCombo(std::string & content_part);
+	void DisplayMeterTypesCombo(std::string & content_part);
+	void DisplayTimerTypesCombo(std::string & content_part);
+	void DisplayLanguageCombo(std::string & content_part);
+	void GetJSonPage(WebEmSession & session, const request& req, reply & rep);
+	void GetAppCache(WebEmSession & session, const request& req, reply & rep);
+	void GetCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
+	void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
+	void GetDatabaseBackup(WebEmSession & session, const request& req, reply & rep);
+	void Post_UploadCustomIcon(WebEmSession & session, const request& req, reply & rep);
 
-			void PostSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void RFXComUpgradeFirmware(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SetRego6XXType(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SetS0MeterType(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SetLimitlessType(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void PostSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void RFXComUpgradeFirmware(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SetRego6XXType(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SetS0MeterType(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SetLimitlessType(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-			void SetOpenThermSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void Cmd_SendOpenThermCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void SetOpenThermSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void Cmd_SendOpenThermCommand(WebEmSession & session, const request& req, Json::Value &root);
 
-			void ReloadPiFace(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void RestoreDatabase(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SBFSpotImportOldData(WebEmSession & session, const request& req, std::string & redirect_uri);
-			void SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void ReloadPiFace(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void RestoreDatabase(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SBFSpotImportOldData(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-			void EventCreate(WebEmSession & session, const request& req, std::string & redirect_uri);
+	void EventCreate(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-			cWebem *m_pWebEm;
+	cWebem *m_pWebEm;
 
-			void ReloadCustomSwitchIcons();
+	void ReloadCustomSwitchIcons();
 
-			void LoadUsers();
-			void AddUser(const unsigned long ID, const std::string &username, const std::string &password, const int userrights, const int activetabs);
-			void ClearUserPasswords();
-			bool FindAdminUser();
-			int FindUser(const char* szUserName);
-			void SetAuthenticationMethod(int amethod);
-			void SetWebTheme(const std::string &themename);
-			void SetWebRoot(const std::string &webRoot);
-			std::vector<_tWebUserPassword> m_users;
-			//JSon
-			void GetJSonDevices(
-				Json::Value &root,
-				const std::string &rused,
-				const std::string &rfilter,
-				const std::string &order,
-				const std::string &rowid,
-				const std::string &planID,
-				const std::string &floorID,
-				const bool bDisplayHidden,
-				const bool bDisplayDisabled,
-				const bool bFetchFavorites,
-				const time_t LastUpdate,
-				const std::string &username,
-				const std::string &hardwareid = ""); // OTO
+	void LoadUsers();
+	void AddUser(const unsigned long ID, const std::string &username, const std::string &password, const int userrights, const int activetabs);
+	void ClearUserPasswords();
+	bool FindAdminUser();
+	int FindUser(const char* szUserName);
+	void SetAuthenticationMethod(int amethod);
+	void SetWebTheme(const std::string &themename);
+	void SetWebRoot(const std::string &webRoot);
+	std::vector<_tWebUserPassword> m_users;
+	//JSon
+	void GetJSonDevices(
+		Json::Value &root,
+		const std::string &rused,
+		const std::string &rfilter,
+		const std::string &order,
+		const std::string &rowid,
+		const std::string &planID,
+		const std::string &floorID,
+		const bool bDisplayHidden,
+		const bool bDisplayDisabled,
+		const bool bFetchFavorites,
+		const time_t LastUpdate,
+		const std::string &username,
+		const std::string &hardwareid = ""); // OTO
 
-													 // SessionStore interface
-			const WebEmStoredSession GetSession(const std::string & sessionId);
-			void StoreSession(const WebEmStoredSession & session);
-			void RemoveSession(const std::string & sessionId);
-			void CleanSessions();
-			void RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession);
-			std::string PluginHardwareDesc(int HwdID);
+	// SessionStore interface
+	const WebEmStoredSession GetSession(const std::string & sessionId);
+	void StoreSession(const WebEmStoredSession & session);
+	void RemoveSession(const std::string & sessionId);
+	void CleanSessions();
+	void RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession);
+	std::string PluginHardwareDesc(int HwdID);
 
-		private:
-			void HandleCommand(const std::string &cparam, WebEmSession & session, const request& req, Json::Value &root);
-			void HandleRType(const std::string &rtype, WebEmSession & session, const request& req, Json::Value &root);
+private:
+	void HandleCommand(const std::string &cparam, WebEmSession & session, const request& req, Json::Value &root);
+	void HandleRType(const std::string &rtype, WebEmSession & session, const request& req, Json::Value &root);
 
-			bool IsIdxForUser(const WebEmSession *pSession, const int Idx);
+	bool IsIdxForUser(const WebEmSession *pSession, const int Idx);
 
-			//Commands
-			void Cmd_RFXComGetFirmwarePercentage(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetLanguage(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetHardwareTypes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateHardware(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteHardware(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_WOLGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_WOLAddNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_WOLUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_WOLRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_WOLClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsGetChilds(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsRemoveChild(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_MySensorsUpdateChild(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerAddNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PingerClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiAddNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_KodiMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LMSSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LMSDeleteUnusedDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LMSGetPlaylists(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_LMSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetFibaroLinks(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDevicesForFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetInfluxLinks(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDevicesForInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDeviceValueOptions(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDeviceValueOptionWording(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetUserVariables(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AllowNewHardware(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetLog(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearLog(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddPlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdatePlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeletePlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetUnusedPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddPlanActiveDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeletePlanDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SetPlanDeviceCoords(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteAllPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ChangePlanOrder(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ChangePlanDeviceOrder(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetVersion(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetAuth(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetUptime(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetActualHistory(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetNewHistory(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SystemShutdown(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SystemReboot(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ExcecuteScript(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetCosts(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_CheckForUpdate(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DownloadUpdate(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DownloadReady(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteDatePoint(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SetActiveTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_EnableTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DisableTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearTimers(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_EnableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DisableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearSceneTimers(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetSceneActivations(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddSceneCode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_RemoveSceneCode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearSceneCodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_RenameScene(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SetSetpoint(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_EnableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DisableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearSetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetSerialDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDevicesList(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetDevicesListOnOff(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueRegister(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueGetGroups(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueAddGroup(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueDeleteGroup(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueGroupAddLight(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PhilipsHueGroupRemoveLight(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetCustomIconSet(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_RenameDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SetUnused(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetHttpLinks(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveHttpLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteHttpLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_GetGooglePubSubLinks(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_SaveGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddLogMessage(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ClearShortLog(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_VacuumDatabase(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicAddNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_PanasonicMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_HEOSSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_HEOSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_OnkyoEiscpCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddYeeLight(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddArilux(WebEmSession & session, const request& req, Json::Value &root);
+	//Commands
+	void Cmd_RFXComGetFirmwarePercentage(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetLanguage(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
+        void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetHardwareTypes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateHardware(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteHardware(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_WOLGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_WOLAddNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_WOLUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_WOLRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_WOLClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsGetChilds(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsRemoveChild(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_MySensorsUpdateChild(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerAddNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PingerClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiAddNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_KodiMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LMSSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LMSGetPlaylists(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_LMSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetFibaroLinks(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDevicesForFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetInfluxLinks(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDevicesForInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDeviceValueOptions(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDeviceValueOptionWording(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetUserVariables(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AllowNewHardware(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetLog(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearLog(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddPlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdatePlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeletePlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetUnusedPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddPlanActiveDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeletePlanDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetPlanDeviceCoords(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteAllPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ChangePlanOrder(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ChangePlanDeviceOrder(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetVersion(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetAuth(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetUptime(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetActualHistory(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetNewHistory(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SystemShutdown(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SystemReboot(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ExcecuteScript(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetCosts(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_CheckForUpdate(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DownloadUpdate(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DownloadReady(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteDatePoint(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetActiveTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_EnableTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DisableTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearTimers(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_EnableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DisableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearSceneTimers(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetSceneActivations(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddSceneCode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_RemoveSceneCode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearSceneCodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_RenameScene(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetSetpoint(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_EnableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DisableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearSetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetSerialDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDevicesList(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetDevicesListOnOff(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueRegister(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueGetGroups(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueAddGroup(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueDeleteGroup(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueGroupAddLight(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PhilipsHueGroupRemoveLight(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetCustomIconSet(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_RenameDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetUnused(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetHttpLinks(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveHttpLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteHttpLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetGooglePubSubLinks(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SaveGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddLogMessage(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ClearShortLog(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_VacuumDatabase(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicAddNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PanasonicMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_HEOSSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_HEOSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_OnkyoEiscpCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddYeeLight(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddArilux(WebEmSession & session, const request& req, Json::Value &root);
 
-			void Cmd_BleBoxSetMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxAddNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxAutoSearchingNodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_BleBoxUpdateFirmware(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxSetMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxAddNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxAutoSearchingNodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_BleBoxUpdateFirmware(WebEmSession & session, const request& req, Json::Value &root);
+	
+	void Cmd_GetTimerPlans(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
 
-			void Cmd_GetTimerPlans(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_AddTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_AddCamera(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateCamera(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteCamera(WebEmSession & session, const request& req, Json::Value &root);
 
-			void Cmd_AddCamera(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_UpdateCamera(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_DeleteCamera(WebEmSession & session, const request& req, Json::Value &root);
-
-			// Plugin functions
-			void Cmd_PluginCommand(WebEmSession & session, const request& req, Json::Value &root);
-			void PluginList(Json::Value &root);
+	// Plugin functions
+	void Cmd_PluginCommand(WebEmSession & session, const request& req, Json::Value &root);
+	void PluginList(Json::Value &root);
 #ifdef ENABLE_PYTHON
-			void PluginLoadConfig();
+	void PluginLoadConfig();
 #endif
 
-			//RTypes
-			void RType_HandleGraph(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_LightLog(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_TextLog(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_SceneLog(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Settings(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Events(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Hardware(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Devices(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Cameras(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Users(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Mobiles(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Timers(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_SceneTimers(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_SetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_GetTransfers(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_TransferDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Notifications(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Schedules(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_GetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_SetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_SetUsed(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_DeleteDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_AddScene(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_DeleteScene(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_UpdateScene(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_CreateMappedSensor(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_CreateDevice(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_CustomLightIcons(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Plans(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_FloorPlans(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_Scenes(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_CreateEvohomeSensor(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_BindEvohome(WebEmSession & session, const request& req, Json::Value &root);
-			void RType_CreateRFLinkDevice(WebEmSession & session, const request& req, Json::Value &root);
+	//RTypes
+	void RType_HandleGraph(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_LightLog(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_TextLog(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_SceneLog(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Settings(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Events(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Hardware(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Devices(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Cameras(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Users(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Mobiles(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Timers(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_SceneTimers(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_SetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_GetTransfers(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_TransferDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Notifications(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Schedules(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_GetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_SetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_SetUsed(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_DeleteDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_AddScene(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_DeleteScene(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_UpdateScene(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CreateMappedSensor(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CreateDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CustomLightIcons(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Plans(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_FloorPlans(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_Scenes(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CreateEvohomeSensor(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_BindEvohome(WebEmSession & session, const request& req, Json::Value &root);
+	void RType_CreateRFLinkDevice(WebEmSession & session, const request& req, Json::Value &root);
 #ifdef WITH_OPENZWAVE
-			//ZWave
-			void Cmd_ZWaveUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveDeleteNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveInclude(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveExclude(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveHardReset(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveNetworkHeal(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveNodeHeal(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveNetworkInfo(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveRemoveGroupNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveAddGroupNode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveGroupInfo(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveCancel(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ApplyZWaveNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveStateCheck(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveRequestNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveReceiveConfigurationFromOtherController(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveSendConfigurationToSecondaryController(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveTransferPrimaryRole(WebEmSession & session, const request& req, Json::Value &root);
-			void ZWaveGetConfigFile(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPPollXml(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPIndex(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPNodeGetConf(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPNodeGetValues(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPNodeSetValue(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPNodeSetButton(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPAdminCommand(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPNodeChange(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPSaveConfig(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPGetTopo(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPGetStats(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPSetGroup(WebEmSession & session, const request& req, reply & rep);
-			void ZWaveCPSceneCommand(WebEmSession & session, const request& req, reply & rep);
-			void Cmd_ZWaveSetUserCodeEnrollmentMode(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveGetNodeUserCodes(WebEmSession & session, const request& req, Json::Value &root);
-			void Cmd_ZWaveRemoveUserCode(WebEmSession & session, const request& req, Json::Value &root);
-			void ZWaveCPTestHeal(WebEmSession & session, const request& req, reply & rep);
-			//RTypes
-			void RType_OpenZWaveNodes(WebEmSession & session, const request& req, Json::Value &root);
-			int m_ZW_Hwidx;
+	//ZWave
+	void Cmd_ZWaveUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveDeleteNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveInclude(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveExclude(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveHardReset(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveNetworkHeal(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveNodeHeal(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveNetworkInfo(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveRemoveGroupNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveAddGroupNode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveGroupInfo(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveCancel(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ApplyZWaveNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveStateCheck(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveRequestNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveReceiveConfigurationFromOtherController(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveSendConfigurationToSecondaryController(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveTransferPrimaryRole(WebEmSession & session, const request& req, Json::Value &root);
+	void ZWaveGetConfigFile(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPPollXml(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPIndex(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPNodeGetConf(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPNodeGetValues(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPNodeSetValue(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPNodeSetButton(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPAdminCommand(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPNodeChange(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPSaveConfig(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPGetTopo(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPGetStats(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPSetGroup(WebEmSession & session, const request& req, reply & rep);
+	void ZWaveCPSceneCommand(WebEmSession & session, const request& req, reply & rep);
+	void Cmd_ZWaveSetUserCodeEnrollmentMode(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveGetNodeUserCodes(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveRemoveUserCode(WebEmSession & session, const request& req, Json::Value &root);
+	void ZWaveCPTestHeal(WebEmSession & session, const request& req, reply & rep);
+	//RTypes
+	void RType_OpenZWaveNodes(WebEmSession & session, const request& req, Json::Value &root);
+	int m_ZW_Hwidx;
 #endif
 #ifdef WITH_TELLDUSCORE
-			void Cmd_TellstickApplySettings(WebEmSession &session, const request &req, Json::Value &root);
+    void Cmd_TellstickApplySettings(WebEmSession &session, const request &req, Json::Value &root);
 #endif
-			boost::shared_ptr<boost::thread> m_thread;
+	boost::shared_ptr<boost::thread> m_thread;
 
-			std::map < std::string, webserver_response_function > m_webcommands;
-			std::map < std::string, webserver_response_function > m_webrtypes;
-			void Do_Work();
-			std::vector<_tCustomIcon> m_custom_light_icons;
-			std::map<int, int> m_custom_light_icons_lookup;
-			bool m_bDoStop;
-			std::string m_server_alias;
-		};
+	std::map < std::string, webserver_response_function > m_webcommands;
+	std::map < std::string, webserver_response_function > m_webrtypes;
+	void Do_Work();
+	std::vector<_tCustomIcon> m_custom_light_icons;
+	std::map<int, int> m_custom_light_icons_lookup;
+	bool m_bDoStop;
+	std::string m_server_alias;
+};
 
-	} //server
+} //server
 }//http

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -18,370 +18,371 @@ namespace http {
 	namespace server {
 		class cWebem;
 		struct _tWebUserPassword;
-class CWebServer : public session_store, public boost::enable_shared_from_this<CWebServer>
-{
-	typedef boost::function< void(WebEmSession & session, const request& req, Json::Value &root) > webserver_response_function;
-public:
-	struct _tCustomIcon
-	{
-		int idx;
-		std::string RootFile;
-		std::string Title;
-		std::string Description;
-	};
-	CWebServer(void);
-	~CWebServer(void);
-	bool StartServer(server_settings & settings, const std::string &serverpath, const bool bIgnoreUsernamePassword);
-	void StopServer();
-	void RegisterCommandCode(const char* idname, webserver_response_function ResponseFunction, bool bypassAuthentication=false);
-	void RegisterRType(const char* idname, webserver_response_function ResponseFunction);
+		class CWebServer : public session_store, public boost::enable_shared_from_this<CWebServer>
+		{
+			typedef boost::function< void(WebEmSession & session, const request& req, Json::Value &root) > webserver_response_function;
+		public:
+			struct _tCustomIcon
+			{
+				int idx;
+				std::string RootFile;
+				std::string Title;
+				std::string Description;
+			};
+			CWebServer(void);
+			~CWebServer(void);
+			bool StartServer(server_settings & settings, const std::string &serverpath, const bool bIgnoreUsernamePassword);
+			void StopServer();
+			void RegisterCommandCode(const char* idname, webserver_response_function ResponseFunction, bool bypassAuthentication=false);
+			void RegisterRType(const char* idname, webserver_response_function ResponseFunction);
 
-	void DisplaySwitchTypesCombo(std::string & content_part);
-	void DisplayMeterTypesCombo(std::string & content_part);
-	void DisplayTimerTypesCombo(std::string & content_part);
-	void DisplayLanguageCombo(std::string & content_part);
-	void GetJSonPage(WebEmSession & session, const request& req, reply & rep);
-	void GetAppCache(WebEmSession & session, const request& req, reply & rep);
-	void GetCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
-	void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
-	void GetDatabaseBackup(WebEmSession & session, const request& req, reply & rep);
-	void Post_UploadCustomIcon(WebEmSession & session, const request& req, reply & rep);
+			void DisplaySwitchTypesCombo(std::string & content_part);
+			void DisplayMeterTypesCombo(std::string & content_part);
+			void DisplayTimerTypesCombo(std::string & content_part);
+			void DisplayLanguageCombo(std::string & content_part);
+			void GetJSonPage(WebEmSession & session, const request& req, reply & rep);
+			void GetAppCache(WebEmSession & session, const request& req, reply & rep);
+			void GetCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
+			void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
+			void GetDatabaseBackup(WebEmSession & session, const request& req, reply & rep);
+			void Post_UploadCustomIcon(WebEmSession & session, const request& req, reply & rep);
 
-	void PostSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void RFXComUpgradeFirmware(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetRego6XXType(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetS0MeterType(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetLimitlessType(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void PostSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void RFXComUpgradeFirmware(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SetRego6XXType(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SetS0MeterType(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SetLimitlessType(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-	void SetOpenThermSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void Cmd_SendOpenThermCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void SetOpenThermSettings(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void Cmd_SendOpenThermCommand(WebEmSession & session, const request& req, Json::Value &root);
 
-	void ReloadPiFace(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void RestoreDatabase(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SBFSpotImportOldData(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void ReloadPiFace(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void RestoreDatabase(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SBFSpotImportOldData(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-	void EventCreate(WebEmSession & session, const request& req, std::string & redirect_uri);
+			void EventCreate(WebEmSession & session, const request& req, std::string & redirect_uri);
 
-	cWebem *m_pWebEm;
+			cWebem *m_pWebEm;
 
-	void ReloadCustomSwitchIcons();
+			void ReloadCustomSwitchIcons();
 
-	void LoadUsers();
-	void AddUser(const unsigned long ID, const std::string &username, const std::string &password, const int userrights, const int activetabs);
-	void ClearUserPasswords();
-	bool FindAdminUser();
-	int FindUser(const char* szUserName);
-	void SetAuthenticationMethod(int amethod);
-	void SetWebTheme(const std::string &themename);
-	void SetWebRoot(const std::string &webRoot);
-	std::vector<_tWebUserPassword> m_users;
-	//JSon
-	void GetJSonDevices(
-		Json::Value &root,
-		const std::string &rused,
-		const std::string &rfilter,
-		const std::string &order,
-		const std::string &rowid,
-		const std::string &planID,
-		const std::string &floorID,
-		const bool bDisplayHidden,
-		const bool bDisplayDisabled,
-		const bool bFetchFavorites,
-		const time_t LastUpdate,
-		const std::string &username,
-		const std::string &hardwareid = ""); // OTO
+			void LoadUsers();
+			void AddUser(const unsigned long ID, const std::string &username, const std::string &password, const int userrights, const int activetabs);
+			void ClearUserPasswords();
+			bool FindAdminUser();
+			int FindUser(const char* szUserName);
+			void SetAuthenticationMethod(int amethod);
+			void SetWebTheme(const std::string &themename);
+			void SetWebRoot(const std::string &webRoot);
+			std::vector<_tWebUserPassword> m_users;
+			//JSon
+			void GetJSonDevices(
+				Json::Value &root,
+				const std::string &rused,
+				const std::string &rfilter,
+				const std::string &order,
+				const std::string &rowid,
+				const std::string &planID,
+				const std::string &floorID,
+				const bool bDisplayHidden,
+				const bool bDisplayDisabled,
+				const bool bFetchFavorites,
+				const time_t LastUpdate,
+				const std::string &username,
+				const std::string &hardwareid = ""); // OTO
 
-	// SessionStore interface
-	const WebEmStoredSession GetSession(const std::string & sessionId);
-	void StoreSession(const WebEmStoredSession & session);
-	void RemoveSession(const std::string & sessionId);
-	void CleanSessions();
-	void RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession);
-	std::string PluginHardwareDesc(int HwdID);
+													 // SessionStore interface
+			const WebEmStoredSession GetSession(const std::string & sessionId);
+			void StoreSession(const WebEmStoredSession & session);
+			void RemoveSession(const std::string & sessionId);
+			void CleanSessions();
+			void RemoveUsersSessions(const std::string& username, const WebEmSession & exceptSession);
+			std::string PluginHardwareDesc(int HwdID);
 
-private:
-	void HandleCommand(const std::string &cparam, WebEmSession & session, const request& req, Json::Value &root);
-	void HandleRType(const std::string &rtype, WebEmSession & session, const request& req, Json::Value &root);
+		private:
+			void HandleCommand(const std::string &cparam, WebEmSession & session, const request& req, Json::Value &root);
+			void HandleRType(const std::string &rtype, WebEmSession & session, const request& req, Json::Value &root);
 
-	bool IsIdxForUser(const WebEmSession *pSession, const int Idx);
+			bool IsIdxForUser(const WebEmSession *pSession, const int Idx);
 
-	//Commands
-	void Cmd_RFXComGetFirmwarePercentage(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetLanguage(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
-        void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetHardwareTypes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateHardware(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteHardware(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_WOLGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_WOLAddNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_WOLUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_WOLRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_WOLClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsGetChilds(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsRemoveChild(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_MySensorsUpdateChild(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerAddNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PingerClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiAddNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_KodiMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_LMSSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_LMSGetPlaylists(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_LMSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetFibaroLinks(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDevicesForFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetInfluxLinks(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDevicesForInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDeviceValueOptions(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDeviceValueOptionWording(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetUserVariables(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetUserVariable(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AllowNewHardware(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetLog(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearLog(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddPlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdatePlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeletePlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetUnusedPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddPlanActiveDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeletePlanDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SetPlanDeviceCoords(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteAllPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ChangePlanOrder(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ChangePlanDeviceOrder(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetVersion(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetAuth(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetUptime(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetActualHistory(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetNewHistory(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SystemShutdown(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SystemReboot(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ExcecuteScript(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetCosts(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_CheckForUpdate(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DownloadUpdate(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DownloadReady(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteDatePoint(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SetActiveTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_EnableTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DisableTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearTimers(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_EnableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DisableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearSceneTimers(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetSceneActivations(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddSceneCode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_RemoveSceneCode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearSceneCodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_RenameScene(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SetSetpoint(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_EnableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DisableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearSetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetSerialDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDevicesList(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetDevicesListOnOff(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueRegister(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueGetGroups(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueAddGroup(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueDeleteGroup(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueGroupAddLight(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PhilipsHueGroupRemoveLight(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetCustomIconSet(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_RenameDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SetUnused(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetHttpLinks(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveHttpLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteHttpLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_GetGooglePubSubLinks(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_SaveGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddLogMessage(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ClearShortLog(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_VacuumDatabase(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicAddNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_PanasonicMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_HEOSSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_HEOSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_OnkyoEiscpCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddYeeLight(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddArilux(WebEmSession & session, const request& req, Json::Value &root);
+			//Commands
+			void Cmd_RFXComGetFirmwarePercentage(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetLanguage(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetHardwareTypes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateHardware(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteHardware(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_WOLGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_WOLAddNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_WOLUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_WOLRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_WOLClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsGetChilds(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsRemoveChild(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_MySensorsUpdateChild(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerAddNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PingerClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiAddNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_KodiMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LMSSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LMSDeleteUnusedDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LMSGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LMSGetPlaylists(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_LMSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetFibaroLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetFibaroLinks(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDevicesForFibaroLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetInfluxLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetInfluxLinks(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDevicesForInfluxLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDeviceValueOptions(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDeviceValueOptionWording(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetUserVariables(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetUserVariable(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AllowNewHardware(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetLog(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearLog(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddPlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdatePlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeletePlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetUnusedPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddPlanActiveDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeletePlanDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SetPlanDeviceCoords(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteAllPlanDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ChangePlanOrder(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ChangePlanDeviceOrder(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetVersion(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetAuth(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetUptime(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetActualHistory(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetNewHistory(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SystemShutdown(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SystemReboot(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ExcecuteScript(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetCosts(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_CheckForUpdate(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DownloadUpdate(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DownloadReady(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteDatePoint(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SetActiveTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_EnableTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DisableTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearTimers(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_EnableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DisableSceneTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearSceneTimers(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetSceneActivations(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddSceneCode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_RemoveSceneCode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearSceneCodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_RenameScene(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SetSetpoint(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_EnableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DisableSetpointTimer(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearSetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetSerialDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDevicesList(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetDevicesListOnOff(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueRegister(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueGetGroups(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueAddGroup(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueDeleteGroup(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueGroupAddLight(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PhilipsHueGroupRemoveLight(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetCustomIconSet(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_RenameDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SetUnused(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetHttpLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetHttpLinks(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveHttpLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteHttpLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetGooglePubSubLinkConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetGooglePubSubLinks(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_SaveGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteGooglePubSubLink(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddLogMessage(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ClearShortLog(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_VacuumDatabase(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicAddNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_PanasonicMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteMobileDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_HEOSSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_HEOSMediaCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_OnkyoEiscpCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddYeeLight(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddArilux(WebEmSession & session, const request& req, Json::Value &root);
 
-	void Cmd_BleBoxSetMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxGetNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxAddNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxClearNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxAutoSearchingNodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_BleBoxUpdateFirmware(WebEmSession & session, const request& req, Json::Value &root);
-	
-	void Cmd_GetTimerPlans(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_AddTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxSetMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxGetNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxAddNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxRemoveNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxClearNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxAutoSearchingNodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_BleBoxUpdateFirmware(WebEmSession & session, const request& req, Json::Value &root);
 
-	void Cmd_AddCamera(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateCamera(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_DeleteCamera(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_GetTimerPlans(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_AddTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
 
-	// Plugin functions
-	void Cmd_PluginCommand(WebEmSession & session, const request& req, Json::Value &root);
-	void PluginList(Json::Value &root);
+			void Cmd_AddCamera(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_UpdateCamera(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_DeleteCamera(WebEmSession & session, const request& req, Json::Value &root);
+
+			// Plugin functions
+			void Cmd_PluginCommand(WebEmSession & session, const request& req, Json::Value &root);
+			void PluginList(Json::Value &root);
 #ifdef ENABLE_PYTHON
-	void PluginLoadConfig();
+			void PluginLoadConfig();
 #endif
 
-	//RTypes
-	void RType_HandleGraph(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_LightLog(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_TextLog(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_SceneLog(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Settings(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Events(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Hardware(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Devices(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Cameras(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Users(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Mobiles(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Timers(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_SceneTimers(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_SetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_GetTransfers(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_TransferDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Notifications(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Schedules(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_GetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_SetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_SetUsed(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_DeleteDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_AddScene(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_DeleteScene(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_UpdateScene(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_CreateMappedSensor(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_CreateDevice(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_CustomLightIcons(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Plans(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_FloorPlans(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_Scenes(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_CreateEvohomeSensor(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_BindEvohome(WebEmSession & session, const request& req, Json::Value &root);
-	void RType_CreateRFLinkDevice(WebEmSession & session, const request& req, Json::Value &root);
+			//RTypes
+			void RType_HandleGraph(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_LightLog(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_TextLog(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_SceneLog(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Settings(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Events(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Hardware(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Devices(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Cameras(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Users(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Mobiles(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Timers(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_SceneTimers(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_SetpointTimers(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_GetTransfers(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_TransferDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Notifications(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Schedules(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_GetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_SetSharedUserDevices(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_SetUsed(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_DeleteDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_AddScene(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_DeleteScene(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_UpdateScene(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_CreateMappedSensor(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_CreateDevice(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_CustomLightIcons(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Plans(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_FloorPlans(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_Scenes(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_CreateEvohomeSensor(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_BindEvohome(WebEmSession & session, const request& req, Json::Value &root);
+			void RType_CreateRFLinkDevice(WebEmSession & session, const request& req, Json::Value &root);
 #ifdef WITH_OPENZWAVE
-	//ZWave
-	void Cmd_ZWaveUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveDeleteNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveInclude(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveExclude(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveHardReset(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveNetworkHeal(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveNodeHeal(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveNetworkInfo(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveRemoveGroupNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveAddGroupNode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveGroupInfo(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveCancel(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ApplyZWaveNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveStateCheck(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveRequestNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveReceiveConfigurationFromOtherController(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveSendConfigurationToSecondaryController(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveTransferPrimaryRole(WebEmSession & session, const request& req, Json::Value &root);
-	void ZWaveGetConfigFile(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPPollXml(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPIndex(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPNodeGetConf(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPNodeGetValues(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPNodeSetValue(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPNodeSetButton(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPAdminCommand(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPNodeChange(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPSaveConfig(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPGetTopo(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPGetStats(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPSetGroup(WebEmSession & session, const request& req, reply & rep);
-	void ZWaveCPSceneCommand(WebEmSession & session, const request& req, reply & rep);
-	void Cmd_ZWaveSetUserCodeEnrollmentMode(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveGetNodeUserCodes(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_ZWaveRemoveUserCode(WebEmSession & session, const request& req, Json::Value &root);
-	void ZWaveCPTestHeal(WebEmSession & session, const request& req, reply & rep);
-	//RTypes
-	void RType_OpenZWaveNodes(WebEmSession & session, const request& req, Json::Value &root);
-	int m_ZW_Hwidx;
+			//ZWave
+			void Cmd_ZWaveUpdateNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveDeleteNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveInclude(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveExclude(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveHardReset(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveNetworkHeal(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveNodeHeal(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveNetworkInfo(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveRemoveGroupNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveAddGroupNode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveGroupInfo(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveCancel(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ApplyZWaveNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveStateCheck(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveRequestNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveReceiveConfigurationFromOtherController(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveSendConfigurationToSecondaryController(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveTransferPrimaryRole(WebEmSession & session, const request& req, Json::Value &root);
+			void ZWaveGetConfigFile(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPPollXml(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPIndex(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPNodeGetConf(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPNodeGetValues(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPNodeSetValue(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPNodeSetButton(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPAdminCommand(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPNodeChange(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPSaveConfig(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPGetTopo(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPGetStats(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPSetGroup(WebEmSession & session, const request& req, reply & rep);
+			void ZWaveCPSceneCommand(WebEmSession & session, const request& req, reply & rep);
+			void Cmd_ZWaveSetUserCodeEnrollmentMode(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveGetNodeUserCodes(WebEmSession & session, const request& req, Json::Value &root);
+			void Cmd_ZWaveRemoveUserCode(WebEmSession & session, const request& req, Json::Value &root);
+			void ZWaveCPTestHeal(WebEmSession & session, const request& req, reply & rep);
+			//RTypes
+			void RType_OpenZWaveNodes(WebEmSession & session, const request& req, Json::Value &root);
+			int m_ZW_Hwidx;
 #endif
 #ifdef WITH_TELLDUSCORE
-    void Cmd_TellstickApplySettings(WebEmSession &session, const request &req, Json::Value &root);
+			void Cmd_TellstickApplySettings(WebEmSession &session, const request &req, Json::Value &root);
 #endif
-	boost::shared_ptr<boost::thread> m_thread;
+			boost::shared_ptr<boost::thread> m_thread;
 
-	std::map < std::string, webserver_response_function > m_webcommands;
-	std::map < std::string, webserver_response_function > m_webrtypes;
-	void Do_Work();
-	std::vector<_tCustomIcon> m_custom_light_icons;
-	std::map<int, int> m_custom_light_icons_lookup;
-	bool m_bDoStop;
-	std::string m_server_alias;
-};
+			std::map < std::string, webserver_response_function > m_webcommands;
+			std::map < std::string, webserver_response_function > m_webrtypes;
+			void Do_Work();
+			std::vector<_tCustomIcon> m_custom_light_icons;
+			std::map<int, int> m_custom_light_icons_lookup;
+			bool m_bDoStop;
+			std::string m_server_alias;
+		};
 
-} //server
+	} //server
 }//http

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -3462,14 +3462,16 @@ define(['app'], function (app) {
 				success: function (data) {
 					if (typeof data.result != 'undefined') {
 						$.each(data.result, function (i, item) {
-							var addId = oTable.fnAddData({
-								"DT_RowId": item.idx,
-								"Name": item.Name,
-								"Mac": item.Mac,
-								"0": item.idx,
-								"1": item.Name,
-								"2": item.Mac
-							});
+						    var addId = oTable.fnAddData({
+						        "DT_RowId": item.idx,
+						        "Name": item.Name,
+						        "Mac": item.Mac,
+						        "Timeout": item.Status,
+						        "0": item.idx,
+						        "1": item.Name,
+						        "2": item.Mac,
+						        "3": item.Status
+						    });
 						});
 					}
 				}
@@ -3532,6 +3534,26 @@ define(['app'], function (app) {
 			$('#hardwarecontent #idx').val(idx);
 
 			RefreshLMSNodeTable();
+		}
+
+		DeleteUnusedLMSDevices = function () {
+		    bootbox.confirm($.t("Are you sure to delete all unused devices?"), function (result) {
+		        if (result == true) {
+		            $.ajax({
+		                url: "json.htm?type=command&param=lmsdeleteunuseddevices" +
+                        "&idx=" + $.devIdx,
+		                async: false,
+		                dataType: 'json',
+		                success: function (data) {
+		                    RefreshLMSNodeTable();
+		                    bootbox.alert($.t('Devices deleted'));
+		                },
+		                error: function () {
+		                    ShowNotify($.t('Problem Deleting devices!'), 2500, true);
+		                }
+		            });
+		        }
+		    });
 		}
 
 		EditSBFSpot = function (idx, name, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) {

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -3462,15 +3462,13 @@ define(['app'], function (app) {
 				success: function (data) {
 					if (typeof data.result != 'undefined') {
 						$.each(data.result, function (i, item) {
-						    var addId = oTable.fnAddData({
-						        "DT_RowId": item.idx,
-						        "Name": item.Name,
-						        "Mac": item.Mac,
-						        "Timeout": item.Status,
-						        "0": item.idx,
-						        "1": item.Name,
-						        "2": item.Mac,
-						        "3": item.Status
+							var addId = oTable.fnAddData({
+								"DT_RowId": item.idx,
+								"Name": item.Name,
+								"Mac": item.Mac,
+								"0": item.idx,
+								"1": item.Name,
+								"2": item.Mac
 							});
 						});
 					}
@@ -3501,26 +3499,6 @@ define(['app'], function (app) {
 					ShowNotify($.t('Problem Updating Settings!'), 2500, true);
 				}
 			});
-		}
-
-		DeleteUnusedLMSDevices = function () {
-		    bootbox.confirm($.t("Are you sure to delete all unused devices?"), function (result) {
-		        if (result == true) {
-		            $.ajax({
-		                url: "json.htm?type=command&param=lmsdeleteunuseddevices" +
-                        "&idx=" + $.devIdx,
-		                async: false,
-		                dataType: 'json',
-		                success: function (data) {
-		                    RefreshLMSNodeTable();
-		                    bootbox.alert($.t('Devices deleted'));
-		                },
-		                error: function () {
-		                    ShowNotify($.t('Problem Deleting devices!'), 2500, true);
-		                }
-		            });
-		        }
-		    });
 		}
 
 		EditLMS = function (idx, name, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) {

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -3462,13 +3462,15 @@ define(['app'], function (app) {
 				success: function (data) {
 					if (typeof data.result != 'undefined') {
 						$.each(data.result, function (i, item) {
-							var addId = oTable.fnAddData({
-								"DT_RowId": item.idx,
-								"Name": item.Name,
-								"Mac": item.Mac,
-								"0": item.idx,
-								"1": item.Name,
-								"2": item.Mac
+						    var addId = oTable.fnAddData({
+						        "DT_RowId": item.idx,
+						        "Name": item.Name,
+						        "Mac": item.Mac,
+						        "Timeout": item.Status,
+						        "0": item.idx,
+						        "1": item.Name,
+						        "2": item.Mac,
+						        "3": item.Status
 							});
 						});
 					}
@@ -3499,6 +3501,26 @@ define(['app'], function (app) {
 					ShowNotify($.t('Problem Updating Settings!'), 2500, true);
 				}
 			});
+		}
+
+		DeleteUnusedLMSDevices = function () {
+		    bootbox.confirm($.t("Are you sure to delete all unused devices?"), function (result) {
+		        if (result == true) {
+		            $.ajax({
+		                url: "json.htm?type=command&param=lmsdeleteunuseddevices" +
+                        "&idx=" + $.devIdx,
+		                async: false,
+		                dataType: 'json',
+		                success: function (data) {
+		                    RefreshLMSNodeTable();
+		                    bootbox.alert($.t('Devices deleted'));
+		                },
+		                error: function () {
+		                    ShowNotify($.t('Problem Deleting devices!'), 2500, true);
+		                }
+		            });
+		        }
+		    });
 		}
 
 		EditLMS = function (idx, name, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) {

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -735,14 +735,8 @@
                 <th width="70" align="center" data-i18n="ID">ID</th>
                 <th align="left" data-i18n="Name">Name</th>
                 <th width="120" align="left" data-i18n="Mac Address">Mac Address</th>
-                <th width="60" align="left" data-i18n="Status">Status</th>
             </tr>
         </thead>
-    </table>
-    <table class="display" id="lmsnodesettingstable" border="0" cellpadding="0" cellspacing="20">
-        <tr>
-            <td><a class="btn-danger sub-tabs-apply" onclick="DeleteUnusedLMSDevices();" data-i18n="Delete Unused Devices">Delete Unused Devices</a></td>
-        </tr>
     </table>
     <input type="hidden" id="idx" name="idx" value="-1">
 </div>

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -735,8 +735,14 @@
                 <th width="70" align="center" data-i18n="ID">ID</th>
                 <th align="left" data-i18n="Name">Name</th>
                 <th width="120" align="left" data-i18n="Mac Address">Mac Address</th>
+                <th width="60" align="left" data-i18n="Status">Status</th>
             </tr>
         </thead>
+    </table>
+    <table class="display" id="lmsnodesettingstable" border="0" cellpadding="0" cellspacing="20">
+        <tr>
+            <td><a class="btn-danger sub-tabs-apply" onclick="DeleteUnusedLMSDevices();" data-i18n="Delete Unused Devices">Delete Unused Devices</a></td>
+        </tr>
     </table>
     <input type="hidden" id="idx" name="idx" value="-1">
 </div>


### PR DESCRIPTION
Added an option to the LMS hardware-setup to remove unused nodes from the WolNodes table.
Unused nodes (device) are obsolete devices that are are not recognized by the LMS server.