### PR TITLE
Allow remote proxy

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -328,6 +328,20 @@ namespace http {
 				}
 			}
 
+			std::string WebRemoteProxyIPs;
+			int nValue;
+			if (m_sql.GetPreferencesVar("WebRemoteProxyIPs", nValue, WebRemoteProxyIPs))
+			{
+				std::vector<std::string> strarray;
+				StringSplit(WebRemoteProxyIPs, ";", strarray);
+				std::vector<std::string>::const_iterator itt;
+				for (itt = strarray.begin(); itt != strarray.end(); ++itt)
+				{
+					std::string ipaddr = *itt;
+					m_pWebEm->AddRemoteProxyIPs(ipaddr);
+				}
+			}
+
 			//register callbacks
 			m_pWebEm->RegisterIncludeCode("switchtypes", boost::bind(&CWebServer::DisplaySwitchTypesCombo, this, _1));
 			m_pWebEm->RegisterIncludeCode("metertypes", boost::bind(&CWebServer::DisplayMeterTypesCombo, this, _1));
@@ -7631,9 +7645,11 @@ namespace http {
 			std::string WebUserName = request::findValue(&req, "WebUserName");
 			std::string WebPassword = request::findValue(&req, "WebPassword");
 			std::string WebLocalNetworks = request::findValue(&req, "WebLocalNetworks");
+			std::string WebRemoteProxyIPs = request::findValue(&req, "WebRemoteProxyIPs");
 			WebUserName = CURLEncode::URLDecode(WebUserName);
 			WebPassword = CURLEncode::URLDecode(WebPassword);
 			WebLocalNetworks = CURLEncode::URLDecode(WebLocalNetworks);
+			WebRemoteProxyIPs = CURLEncode::URLDecode(WebRemoteProxyIPs);
 
 			if ((WebUserName.empty()) || (WebPassword.empty()))
 			{
@@ -7659,19 +7675,28 @@ namespace http {
 			m_sql.UpdatePreferencesVar("WebUserName", WebUserName.c_str());
 			m_sql.UpdatePreferencesVar("WebPassword", WebPassword.c_str());
 			m_sql.UpdatePreferencesVar("WebLocalNetworks", WebLocalNetworks.c_str());
+			m_sql.UpdatePreferencesVar("WebRemoteProxyIPs", WebRemoteProxyIPs.c_str());
 
 			LoadUsers();
 			m_pWebEm->ClearLocalNetworks();
 			std::vector<std::string> strarray;
 			StringSplit(WebLocalNetworks, ";", strarray);
-			std::vector<std::string>::const_iterator itt;
-			for (itt = strarray.begin(); itt != strarray.end(); ++itt)
+			for (std::vector<std::string>::const_iterator itt = strarray.begin(); itt != strarray.end(); ++itt)
 			{
 				std::string network = *itt;
 				m_pWebEm->AddLocalNetworks(network);
 			}
 			//add local hostname
 			m_pWebEm->AddLocalNetworks("");
+
+			m_pWebEm->ClearRemoteProxyIPs();
+			strarray.clear();
+			StringSplit(WebRemoteProxyIPs, ";", strarray);
+			for (std::vector<std::string>::const_iterator itt = strarray.begin(); itt != strarray.end(); ++itt)
+			{
+				std::string ipaddr = *itt;
+				m_pWebEm->AddRemoteProxyIPs(ipaddr);
+			}
 
 			if (session.username.empty())
 			{
@@ -12600,6 +12625,10 @@ namespace http {
 				else if (Key == "WebLocalNetworks")
 				{
 					root["WebLocalNetworks"] = sValue;
+				}
+				else if (Key == "WebRemoteProxyIPs")
+				{
+					root["WebRemoteProxyIPs"] = sValue;
 				}
 				else if (Key == "RandomTimerFrame")
 				{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -28,27 +28,10 @@
 #define SHORT_SESSION_TIMEOUT 600 // 10 minutes
 #define LONG_SESSION_TIMEOUT (30 * 86400) // 30 days
 
-//GB
-#include<stdio.h>
-#include<stdlib.h>
-#ifndef _WIN32
-#define sprintf_s(buffer, buffer_size, stringbuffer, ...) (sprintf(buffer, stringbuffer, __VA_ARGS__))
-#endif
-
 int m_failcounter=0;
 
 namespace http {
 	namespace server {
-
-//GB
-std::string time2str(const time_t gtime)
-{
-	struct tm ltime;
-	localtime_r(&gtime, &ltime);
-	char c_until[40];
-	sprintf_s(c_until,40,"%04d-%02d-%02d %02d:%02d:%02d",ltime.tm_year+1900,ltime.tm_mon+1,ltime.tm_mday,ltime.tm_hour,ltime.tm_min,ltime.tm_sec);
-	return std::string(c_until);
-}
 
 /**
 Webem constructor

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1494,9 +1494,10 @@ bool cWebemRequestHandler::CheckAuthentication(WebEmSession & session, const req
 		{
 			if (!sSID.empty()) {
 				WebEmSession* oldSession = myWebem->GetSession(sSID);
-				if ((oldSession == NULL) || (oldSession->expires < now)) {
+				if ((oldSession == NULL) || (oldSession->expires < now))
 					expired = true;
-				}
+				else
+					session = *oldSession;
 			}
 			if (sSID.empty() || expired)
 				session.isnew = true;

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -198,6 +198,11 @@ namespace http {
 			std::string m_DigistRealm;
 			void SetZipPassword(const std::string &password);
 
+			//IPs that are allowed to pass proxy headers
+			std::vector < std::string > myRemoteProxyIPs;
+			void AddRemoteProxyIPs(const std::string ipaddr);
+			void ClearRemoteProxyIPs();
+
 			// Session store manager
 			void SetSessionStore(session_store_impl_ptr sessionStore);
 			session_store_impl_ptr GetSessionStore();

--- a/webserver/connection_manager.cpp
+++ b/webserver/connection_manager.cpp
@@ -41,7 +41,7 @@ void connection_manager::start(connection_ptr c)
 	{
 		//ok, this could get a very long list when running for years
 		connectedips_.insert(s);
-		_log.Log(LOG_STATUS,"Incoming connection from: %s", s.c_str());
+		//_log.Log(LOG_STATUS,"Incoming connection from: %s", s.c_str());
 	}
 
 	c->start();

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -605,12 +605,12 @@ define(['app'], function (app) {
 					if (typeof data.EnableEventScriptSystem != 'undefined') {
 						$("#eventsystemtable #EnableEventScriptSystem").prop('checked', data.EnableEventScriptSystem == 1);
 					}
-                    if (typeof data.DisableDzVentsSystem != 'undefined') {
-                        $("#DisableDzVentsSystem").prop('checked', data.DisableDzVentsSystem == 0);
-                    }
-                    if (typeof data.DzVentsLogLevel != 'undefined') {
-                        $("#comboDzVentsLogLevel").val(data.DzVentsLogLevel);
-                    }
+					if (typeof data.DisableDzVentsSystem != 'undefined') {
+						$("#DisableDzVentsSystem").prop('checked', data.DisableDzVentsSystem == 0);
+					}
+					if (typeof data.DzVentsLogLevel != 'undefined') {
+						$("#comboDzVentsLogLevel").val(data.DzVentsLogLevel);
+					}
 					if (typeof data.LogEventScriptTrigger != 'undefined') {
 						$("#eventsystemtable #LogEventScriptTrigger").prop('checked', data.LogEventScriptTrigger == 1);
 					}
@@ -686,6 +686,9 @@ define(['app'], function (app) {
 					}
 					if (typeof data.IFTTTAPI != 'undefined') {
 						$("#ifttttable #IFTTTAPI").val(atob(data.IFTTTAPI));
+					}
+					if (typeof data.WebRemoteProxyIPs != 'undefined') {
+						$("#webproxytable #WebRemoteProxyIPs").val(data.WebRemoteProxyIPs);
 					}
 				}
 			});

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1487
+# ref 1488
 
 CACHE:
 # CSS

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -208,6 +208,21 @@
 								</div>
 							</div>
 							<div class="row-fluid">
+								<div class="span12">
+									<h2><span data-i18n="RemoteProxyIPs">Remote Proxy IPs</span>:</h2>
+									<table class="display" id="webproxytable" border="0" cellpadding="0" cellspacing="0">
+									<tr>
+										<td align="right" style="width:60px"><label><span data-i18n="IP Address"></span>: </label></td>
+										<td>
+											<input type="input" id="WebRemoteProxyIPs" name="WebRemoteProxyIPs" style="width: 300px; padding: .2em$
+											<span data-i18n="(Separate by a semicolon, For Example"></span>: 127.0.0.1;192.168.0.12)
+										</td>
+									</tr>
+									</table>
+									<br>
+								</div>
+							</div>
+							<div class="row-fluid">
 								<div class="span6">
 									<div id="SoftwareUpdates">
 										<h2><span data-i18n="SoftwareUpdates"></span>:</h2>


### PR DESCRIPTION
In response to issue #1823: AreWeInLocalNetwork and Nginx

This update allows users to specify a list of IPs that are allowed to act as a proxy. The additional logging patch will show the originating (proxied) IP when a new session is started rather than just once for each unique IP.