### PR TITLE
Correction in pTypePower, sTypePercentage, pTypeUsage + silently ignore update notifications for general devices

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3900,6 +3900,17 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, const char* ID, const uns
 	return devRowID;
 }
 
+bool CSQLHelper::DoesDeviceExist(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType) {
+	std::vector<std::vector<std::string> > result;
+	result = safe_query("SELECT ID,Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",HardwareID, ID, unit, devType, subType);
+	if (result.size()==0) {
+		return false;
+	}
+	else {
+		return true;
+	}
+}
+
 uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction)
 		//TODO: 'unsigned char unit' only allows 256 devices / plugin
 {

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -291,6 +291,8 @@ public:
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
 	uint64_t UpdateValueLighting2GroupCmd(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction = true);
 	uint64_t UpdateValueHomeConfortGroupCmd(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction = true);
+	
+	bool DoesDeviceExist(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType);
 
 	bool GetLastValue(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, int &nvalue, std::string &sValue, struct tm &LastUpdateTime);
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12919,9 +12919,6 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	std::stringstream s_strid;
 	s_strid << std::hex << DeviceID;
 	s_strid >> ID;
-	uint64_t dID = 0;
-	std::string dName = "";
-
 
 	if (pHardware)
 	{
@@ -12931,6 +12928,9 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 			"SELECT ID,Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
 			HardwareID, DeviceID.c_str(), unit, devType, subType);
 
+		uint64_t dID = 0;
+		std::string dName = "";
+		
 		if (!result.empty())
 		{
 			std::vector<std::string> sd = result[0];
@@ -13025,7 +13025,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	}
 	else if (pHardware) {
 		//Handle Notification
-		m_notifications.CheckAndHandleNotification(dID, HardwareID, DeviceID, dName, unit, devType, subType, nValue, sValue);
+		m_notifications.CheckAndHandleNotification(devidx, HardwareID, DeviceID, devname, unit, devType, subType, nValue, sValue);
 	}
 	return true;
 }

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12919,6 +12919,9 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	std::stringstream s_strid;
 	s_strid << std::hex << DeviceID;
 	s_strid >> ID;
+	uint64_t dID = 0;
+	std::string dName = "";
+
 
 	if (pHardware)
 	{
@@ -12927,9 +12930,6 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 		result = m_sql.safe_query(
 			"SELECT ID,Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
 			HardwareID, DeviceID.c_str(), unit, devType, subType);
-
-		uint64_t dID = 0;
-		std::string dName = "";
 
 		if (!result.empty())
 		{
@@ -12972,9 +12972,6 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 			DecodeRXMessage(pHardware, (const unsigned char *)&lcmd.LIGHTING2, NULL, batterylevel);
 			return true;
 		}
-
-		//Handle Notification
-		m_notifications.CheckAndHandleNotification(dID, HardwareID, DeviceID, dName, unit, devType, subType, nValue, sValue);
 	}
 
 	std::string devname = "Unknown";
@@ -13025,6 +13022,10 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	{
 		_log.Log(LOG_NORM, "Sending Thermostat Fan Mode to device....");
 		SetZWaveThermostatFanMode(sidx.str(), nValue);
+	}
+	else if (pHardware) {
+		//Handle Notification
+		m_notifications.CheckAndHandleNotification(dID, HardwareID, DeviceID, dName, unit, devType, subType, nValue, sValue);
 	}
 	return true;
 }

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12915,6 +12915,10 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 {
 	CDomoticzHardwareBase *pHardware = GetHardware(HardwareID);
 
+	// Prevent hazardous modification of DB from JSON calls
+	if (!m_sql.DoesDeviceExist(HardwareID, DeviceID.c_str(), unit, devType, subType))
+		return false;
+	
 	unsigned long ID = 0;
 	std::stringstream s_strid;
 	s_strid << std::hex << DeviceID;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -10421,7 +10421,7 @@ void MainWorker::decode_CartelectronicTIC(const int HwdID,
 			if (DevRowIdx == -1)
 				return;
 
-			m_notifications.CheckAndHandleNotification(DevRowIdx, HwdID, ID, procResult.DeviceName, 1, pTypeUsage, sTypeElectric, (float)apparentPower);
+			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, pTypeUsage, sTypeElectric, NTYPE_ENERGYINSTANT, (const float)apparentPower);
 		}
 
 		switch (contractType)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -8779,6 +8779,8 @@ void MainWorker::decode_Weight(const int HwdID, const _eHardwareTypes HwdType, c
 	if (DevRowIdx == -1)
 		return;
 
+	m_notifications.CheckAndHandleNotification(DevRowIdx, HwdID, ID, procResult.DeviceName, Unit, devType, subType, weight);
+	
 	if (m_verboselevel >= EVBL_ALL)
 	{
 		WriteMessageStart();

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -231,6 +231,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const int nValue, const std::string &sValue, const float fValue) {
 	float fValue2;
 	bool r1, r2, r3;
+	int nsize;
+	int nexpected = 0;
 	
 	// Notifications for switches are handled by CheckAndHandleSwitchNotification in UpdateValue() of SQLHelper
 	if (IsLightOrSwitch(cType, cSubType)) {
@@ -241,9 +243,11 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		int meterType = 0;
 		std::vector<std::string> strarray;
 		StringSplit(sValue, ";", strarray);
+		nsize = strarray.size();
 		switch(cType) {
 			case pTypeP1Power:
-				if (strarray.size() == 6) {
+				nexpected = 6;
+				if (nsize == nexpected) {
 					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)atof(strarray[4].c_str()));
 				}
 				break;
@@ -271,7 +275,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 			case pTypeHUM:
 				return CheckAndHandleTempHumidityNotification(DevRowIdx, sName, 0.0, nValue, false, true);
 			case pTypeTEMP_HUM:
-				if (strarray.size() == 3) {
+				nexpected = 3;
+				if (nsize == nexpected) {
 					float Temp = (float)atof(strarray[0].c_str());
 					int Hum = atoi(strarray[1].c_str());
 					float dewpoint = (float)CalculateDewPoint(Temp, Hum);
@@ -281,7 +286,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeTEMP_HUM_BARO:
-				if (strarray.size() == 5) {
+				nexpected = 5;
+				if (nsize == nexpected) {
 					float Temp = (float)atof(strarray[0].c_str());
 					int Hum = atoi(strarray[1].c_str());
 					float dewpoint = (float)CalculateDewPoint(Temp, Hum);
@@ -292,7 +298,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeRAIN:
-				if (strarray.size() == 2) {
+				nexpected = 2;
+				if (nsize == nexpected) {
 					fValue2 = (float)atof(strarray[1].c_str());
 					return CheckAndHandleRainNotification(DevRowIdx, sName, cType, cSubType, NTYPE_RAIN, fValue2);
 				}
@@ -307,7 +314,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeUV:
-				if (strarray.size() == 2) {
+				nexpected = 2;
+				if (nsize == nexpected) {
 					float Level = (float)atof(strarray[0].c_str());
 					float Temp = (float)atof(strarray[1].c_str());
 					if (cSubType == sTypeUV3)
@@ -321,7 +329,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeCURRENT:
-				if (strarray.size() == 3) {
+				nexpected = 3;
+				if (nsize == nexpected) {
 					float CurrentChannel1 = (float)atof(strarray[0].c_str());
 					float CurrentChannel2 = (float)atof(strarray[1].c_str());
 					float CurrentChannel3 = (float)atof(strarray[2].c_str());
@@ -329,7 +338,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeCURRENTENERGY:
-				if (strarray.size() == 4) {
+				nexpected = 4;
+				if (nsize == nexpected) {
 					float CurrentChannel1 = (float)atof(strarray[0].c_str());
 					float CurrentChannel2 = (float)atof(strarray[1].c_str());
 					float CurrentChannel3 = (float)atof(strarray[2].c_str());
@@ -337,7 +347,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeWIND:
-				if (strarray.size() == 6) {
+				nexpected = 6;
+				if (nsize == nexpected) {
 					float wspeedms = (float)(atof(strarray[2].c_str()) / 10.0f);
 					float temp = (float)atof(strarray[4].c_str());
 					r1 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_WIND, wspeedms);
@@ -346,7 +357,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeYouLess:
-				if (strarray.size() == 2) {
+				nexpected = 2;
+				if (nsize == nexpected) {
 					float usagecurrent = (float)atof(strarray[1].c_str());
 					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, usagecurrent);
 				}
@@ -358,7 +370,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 			case pTypeRego6XXTemp:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_TEMPERATURE, fValue);
 			case pTypePOWER:
-				if (strarray.size() == 2) {
+				nexpected = 2;
+				if (nsize == nexpected) {
 					fValue2 = (float)atof(strarray[0].c_str());
 					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 				}
@@ -394,7 +407,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 					case sTypeBaro:
 					case sTypeKwh:
-						if (strarray.size() == 2) {
+						nexpected = 2;
+						if (nsize == nexpected) {
 							fValue2 = (float)atof(strarray[0].c_str());
 							return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 						}
@@ -425,7 +439,12 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				break;
 		}
 	}
-	_log.Log(LOG_STATUS, "Warning: Notification NOT handled (type: %02X - %s, subtype: %d - %s), please report on GitHub!", cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	if (nexpected > 0) {
+		_log.Log(LOG_STATUS, "Warning: Expecting svalue with %d elements separated by semicolon, %d elements received, notification not sent (type: %02X - %s, subtype: %d - %s)", nexpected, nsize, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	}
+	else {
+		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (type: %02X - %s, subtype: %d - %s), please report on GitHub!", cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	}
 	return false;
 }
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -365,6 +365,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				break;
 			case pTypeAirQuality:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)nValue);
+			case pTypeWEIGHT:
 			case pTypeLux:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 			case pTypeRego6XXTemp:
@@ -387,6 +388,9 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 			case pTypeUsage:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 				break;
+			case pTypeP1Gas:
+				// ignore, notification is done day by day in SQLHelper
+				return false;
 			case pTypeGeneral:
 				switch(cSubType) {
 					case sTypeVisibility:

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -401,6 +401,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 						break;
 					case sTypeZWaveAlarm:
 						return CheckAndHandleValueNotification(DevRowIdx, sName, nValue);
+					case sTypePercentage:
+						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_PERCENTAGE, fValue);
 					case sTypeSoilMoisture:
 					case sTypeLeafWetness:
 					case sTypeAlert:
@@ -411,7 +413,6 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 					case sTypeVoltage:
 					case sTypeCurrent:
 					case sTypePressure:
-					case sTypePercentage:
 					case sTypeWaterflow:
 					case sTypeCustom:
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -360,7 +360,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 			case pTypePOWER:
 				if (strarray.size() == 2) {
 					fValue2 = (float)atof(strarray[0].c_str());
-					return CheckAndHandleRainNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
+					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 				}
 				break;
 			case pTypeRFXMeter:

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -4,6 +4,8 @@
 #include "../main/SQLHelper.h"
 #include "../main/localtime_r.h"
 #include "../main/RFXtrx.h"
+#include "../main/mainworker.h"
+#include "../hardware/DomoticzHardware.h"
 #include "../hardware/hardwaretypes.h"
 #include "NotificationHelper.h"
 #include "NotificationProwl.h"
@@ -443,12 +445,23 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				break;
 		}
 	}
-	if (nexpected > 0) {
-		_log.Log(LOG_STATUS, "Warning: Expecting svalue with %d elements separated by semicolon, %d elements received, notification not sent (ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s)", nexpected, nsize, ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	
+	std::string hName;
+	CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(HardwareID);
+	if (pHardware == NULL) {
+		hName = "";
 	}
 	else {
-		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s), please report on GitHub!", ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+		hName = pHardware->Name;
 	}
+	
+	if (nexpected > 0) {
+		_log.Log(LOG_STATUS, "Warning: Expecting svalue with %d elements separated by semicolon, %d elements received (\"%s\"), notification not sent (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s)", nexpected, nsize, sValue.c_str(), HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	}
+	else {
+		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s), please report on GitHub!", HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+	}
+	
 	return false;
 }
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -444,10 +444,10 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		}
 	}
 	if (nexpected > 0) {
-		_log.Log(LOG_STATUS, "Warning: Expecting svalue with %d elements separated by semicolon, %d elements received, notification not sent (type: %02X - %s, subtype: %d - %s)", nexpected, nsize, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+		_log.Log(LOG_STATUS, "Warning: Expecting svalue with %d elements separated by semicolon, %d elements received, notification not sent (ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s)", nexpected, nsize, ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
 	}
 	else {
-		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (type: %02X - %s, subtype: %d - %s), please report on GitHub!", cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s), please report on GitHub!", ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
 	}
 	return false;
 }

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -341,7 +341,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 					float wspeedms = (float)(atof(strarray[2].c_str()) / 10.0f);
 					float temp = (float)atof(strarray[4].c_str());
 					r1 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_WIND, wspeedms);
-					r2 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, temp, 0, true, false) && r1;
+					r2 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, temp, 0, true, false);
 					return r1 && r2;
 				}
 				break;
@@ -372,7 +372,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				}
 				break;
 			case pTypeUsage:
-				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_ENERGYINSTANT, fValue);
+				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 				break;
 			case pTypeGeneral:
 				switch(cSubType) {

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -357,6 +357,15 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 			case pTypeRego6XXTemp:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_TEMPERATURE, fValue);
+			case pTypeRego6XXValue:
+				switch(cSubType) {
+					case sTypeRego6XXCounter:
+						// silent ignore, it is handled in SQLHelper
+						return false;
+					default:
+						break;
+				}
+				break;
 			case pTypePOWER:
 				if (strarray.size() == 2) {
 					fValue2 = (float)atof(strarray[0].c_str());
@@ -416,7 +425,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 					case sTypeCustom:
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 					case sTypeTextStatus:
-						//no notification for text
+					case sTypeCounterIncremental:
+						//no notification
 						return false;
 				}
 				break;

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -357,15 +357,6 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
 			case pTypeRego6XXTemp:
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_TEMPERATURE, fValue);
-			case pTypeRego6XXValue:
-				switch(cSubType) {
-					case sTypeRego6XXCounter:
-						// silent ignore, it is handled in SQLHelper
-						return false;
-					default:
-						break;
-				}
-				break;
 			case pTypePOWER:
 				if (strarray.size() == 2) {
 					fValue2 = (float)atof(strarray[0].c_str());
@@ -424,12 +415,9 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 					case sTypeWaterflow:
 					case sTypeCustom:
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
-					case sTypeTextStatus:
-					case sTypeCounterIncremental:
-						//no notification
-						return false;
 					default:
-						break;
+						// silently ignore other general devices
+						return false;
 				}
 				break;
 			default:

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -428,6 +428,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 					case sTypeCounterIncremental:
 						//no notification
 						return false;
+					default:
+						break;
 				}
 				break;
 			default:


### PR DESCRIPTION
because it seems to be a pain for users

I improved the log when the array size is not the expected one.

Notifications tested on every dummy devices.

Currently pTypeBARO,  pTypeWeight and pTypeP1Gas are not handled, but wasn't previously

Moved call to m_notifications.CheckAndHandleNotification() in MainWorker::UpdateDevice() to prevent 2 calls to CheckAndHandleNotification() for Thermostat SetPoint