### PR TITLE
Fixed creation of new blinds type switch by RFLink

### DIFF
--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -3415,7 +3415,7 @@ void ConvertToGeneralSwitchType(std::string &devid, int &dtype, int &subtype)
 		s_strid >> deviceid;
 		deviceid = (unsigned long)((deviceid & 0xffffff00) >> 8);
 		char szTmp[20];
-		sprintf(szTmp, "%lx", deviceid);
+		sprintf(szTmp, "%08lX", deviceid);
 		//_log.Log(LOG_ERROR, "RFLink: deviceid: %x", deviceid);
 		devid = szTmp;
 	}


### PR DESCRIPTION
When creating switch for blinds by "Manual Light/Switch" it create it with lowercase ID and without leading zeros. Therefore, if you "click" for such device, RFLink will create another one with proper ID (uppercase with leading zeros). This change fully repair that issue.