### PR TITLE
limit amount of logging of localhost scripts as incoming connections

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1995,6 +1995,13 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	session.timeout = mytime(NULL) + SHORT_SESSION_TIMEOUT;
 
 	if (session.isnew == true) {
+		bool isJson = (req.uri.find("json.htm") != std::string::npos);
+		if (isJson && (session.remote_host == "127.0.0.1"))
+		{
+			// never create sessions for script connections that originate from localhost
+			return;
+		}
+
 		_log.Log(LOG_STATUS,"Incoming connection from: %s", session.remote_host.c_str());
 		// Create a new session ID
 		session.id = generateSessionID();
@@ -2005,7 +2012,9 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 		}
 		session.auth_token = generateAuthToken(session, req); // do it after expires to save it also
 		session.isnew = false;
-		myWebem->AddSession(session);
+		//GB3 Todo: need sane way to keep track of scripts running on other hosts
+		if (!isJson)
+			myWebem->AddSession(session);
 		send_cookie(rep, session);
 
 	} else if (session.forcelogin == true) {


### PR DESCRIPTION
Because these scripts don't accept and send cookies we can currently not track them and they are always seen as new connections, causing massive logging with some users as of 6b1f93d

This is a temporary fix until I can come up with something better.