### PR TITLE
Travis OSX, removing libusb install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,8 +73,8 @@ matrix:
     env: TARGET_ARCHITECTURE=x86_64
     install:
       - brew install boost|| true
-      - brew install libusb
-      - brew install libusb-compat
+      # - brew install libusb
+      # - brew install libusb-compat
       - brew install zlib || true
       - brew install openssl
       - brew link openssl --force


### PR DESCRIPTION
Travis is currently complaining that libusb is already installed