### PR TITLE
Add API for managed meters

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -114,6 +114,7 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(long, PyLong_AsLong, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyUnicode_AsUTF8String, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyImport_AddModule, const char*);
+		DECLARE_PYTHON_SYMBOL(double, PyFloat_AsDouble, PyObject*);
 
 #ifdef _DEBUG
 		// In a debug build dealloc is a function but for release builds its a macro
@@ -225,6 +226,7 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyLong_AsLong);
 					RESOLVE_PYTHON_SYMBOL(PyUnicode_AsUTF8String);
 					RESOLVE_PYTHON_SYMBOL(PyImport_AddModule);
+					RESOLVE_PYTHON_SYMBOL(PyFloat_AsDouble);
 				}
 			}
 			_Py_NoneStruct.ob_refcnt = 1;
@@ -396,4 +398,5 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyLong_AsLong			pythonLib->PyLong_AsLong
 #define PyUnicode_AsUTF8String	pythonLib->PyUnicode_AsUTF8String
 #define PyImport_AddModule		pythonLib->PyImport_AddModule
+#define PyFloat_AsDouble		pythonLib->PyFloat_AsDouble
 }

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -933,6 +933,45 @@ namespace Plugins {
 		return Py_None;
 	}
 
+	PyObject* CDevice_updateMeter(CDevice *self, PyObject *args, PyObject *kwds)
+	{
+		if (self->pPlugin)
+		{
+			float		value = 0.0;
+			char*		date = NULL;
+			float		counter = 0.0;
+			float		usage = 0.0;
+			float		min = 0.0;
+			float		max = 0.0;
+			bool		dayCalendar = false;
+			char*		clearAfterDate = NULL;
+			char*		clearBeforeDate = NULL;
+
+			std::string	sName = PyUnicode_AsUTF8(self->Name);
+			std::string	sDeviceID = PyUnicode_AsUTF8(self->DeviceID);
+			std::string	sDescription = PyUnicode_AsUTF8(self->Description);
+			static char *kwlist[] =   { "value", "date", "usage", "counter", "min", "max", "day", "clearafterdate", "clearbeforedate", NULL };
+
+			// Try to extract parameters needed to update device settings
+			if (!PyArg_ParseTupleAndKeywords(args, kwds, "fs|ffffps", kwlist, &value, &date, &usage, &counter, &min, &max, &dayCalendar, &clearAfterDate, &clearBeforeDate))
+				{
+				_log.Log(LOG_ERROR, "(%s) %s: Failed to parse parameters: 'value', 'date', ['usage', 'counter', 'min', 'max', 'day', 'clearafterdate', 'clearbeforedate'] expected.", __func__, sName.c_str());
+				LogPythonException(self->pPlugin, __func__);
+				Py_INCREF(Py_None);
+				return Py_None;
+			}
+
+			m_sql.UpdateCalendarMeter(self->HwdID, sDeviceID.c_str(), (const unsigned char)self->Unit, (const unsigned char)self->Type, (const unsigned char)self->SubType, value, date, usage, counter, min, max, dayCalendar, clearAfterDate, clearBeforeDate);
+		}
+		else
+		{
+			_log.Log(LOG_ERROR, "Meter update failed, Device object is not associated with a plugin.");
+		}
+
+		Py_INCREF(Py_None);
+		return Py_None;
+	}
+
 	PyObject* CDevice_delete(CDevice* self)
 	{
 		if (self->pPlugin)

--- a/hardware/plugins/PythonObjects.h
+++ b/hardware/plugins/PythonObjects.h
@@ -110,6 +110,7 @@ namespace Plugins {
 	PyObject* CDevice_refresh(CDevice* self);
 	PyObject* CDevice_insert(CDevice* self);
 	PyObject* CDevice_update(CDevice *self, PyObject *args, PyObject *kwds);
+	PyObject* CDevice_updateMeter(CDevice *self, PyObject *args, PyObject *kwds);
 	PyObject* CDevice_delete(CDevice* self);
 	PyObject* CDevice_str(CDevice* self);
 
@@ -138,6 +139,7 @@ namespace Plugins {
 		{ "Refresh", (PyCFunction)CDevice_refresh, METH_NOARGS, "Refresh device details" },
 		{ "Create", (PyCFunction)CDevice_insert, METH_NOARGS, "Create the device in Domoticz." },
 		{ "Update", (PyCFunction)CDevice_update, METH_VARARGS | METH_KEYWORDS, "Update the device values in Domoticz." },
+		{ "UpdateMeter", (PyCFunction)CDevice_updateMeter, METH_VARARGS | METH_KEYWORDS, "Update the device meter values in Domoticz." },
 		{ "Delete", (PyCFunction)CDevice_delete, METH_NOARGS, "Delete the device in Domoticz." },
 		{ NULL }  /* Sentinel */
 	};

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5178,7 +5178,6 @@ bool CSQLHelper::UpdateCalendarMeter(const int HardwareID, const char* DeviceID,
 	if (dayCalendar)
 	{
 		if((clearBeforeDate != NULL) && (clearBeforeDate[0] != '\0') && (clearAfterDate != NULL) && (clearAfterDate[0] != '\0')) {
-			_log.Log(LOG_ERROR,"DELETE FROM Meter WHERE (DeviceRowID=='%" PRIu64 "') AND (Date>='%s') AND (Date<='%s')", DeviceRowID, clearAfterDate, clearBeforeDate);
 			safe_query("DELETE FROM Meter WHERE (DeviceRowID=='%" PRIu64 "') AND (Date>='%q') AND (Date<='%q')", DeviceRowID, clearAfterDate, clearBeforeDate);
 		}
 
@@ -5227,7 +5226,6 @@ bool CSQLHelper::UpdateCalendarMeter(const int HardwareID, const char* DeviceID,
 		if (!isMultiMeter(devType, subType))
 		{
 			if((clearBeforeDate != NULL) && (clearBeforeDate[0] != '\0') && (clearAfterDate != NULL) && (clearAfterDate[0] != '\0')) {
-				_log.Log(LOG_ERROR,"DELETE FROM Meter WHERE (DeviceRowID=='%" PRIu64 "') AND (Date>='%s') AND (Date<='%s')", DeviceRowID, clearAfterDate, clearBeforeDate);
 				safe_query("DELETE FROM Meter_Calendar WHERE (DeviceRowID=='%" PRIu64 "') AND (Date>='%q') AND (Date<='%q')", DeviceRowID, clearAfterDate, clearBeforeDate);
 			}
 

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -286,7 +286,7 @@ public:
 	bool RestoreDatabase(const std::string &dbase);
 
 	//Returns DeviceRowID
-	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const float value, const char* date, float usage, float counter, float min, float max, const bool dayCalendar, const char* clearAfterDate, const char* clearBeforeDate);
+	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const bool validValue, const float value, const char* date, float usage, float counter, float min, float max, const bool dayCalendar, const char* clearAfterDate, const char* clearBeforeDate);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, std::string &devname, const bool bUseOnOffAction=true);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -286,6 +286,7 @@ public:
 	bool RestoreDatabase(const std::string &dbase);
 
 	//Returns DeviceRowID
+	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const float value, const char* date, float usage, float counter, float min, float max, const bool dayCalendar, const char* clearAfterDate, const char* clearBeforeDate);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, std::string &devname, const bool bUseOnOffAction=true);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
 	uint64_t UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction=true);
@@ -470,6 +471,9 @@ private:
 	std::vector<std::vector<std::string> > query(const std::string &szQuery);
 	std::vector<std::vector<std::string> > queryBlob(const std::string &szQuery);
 	void LogQueryResult(TSqlQueryResult &result);
+	
+	bool isMultiMeter(const unsigned char devType, const unsigned char subType);
+	std::string getMeterFilter();
 };
 
 extern CSQLHelper m_sql;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -511,7 +511,6 @@ namespace http {
 			RegisterCommandCode("emailcamerasnapshot", boost::bind(&CWebServer::Cmd_EmailCameraSnapshot, this, _1, _2, _3));
 			RegisterCommandCode("udevice", boost::bind(&CWebServer::Cmd_UpdateDevice, this, _1, _2, _3));
 			RegisterCommandCode("udevices", boost::bind(&CWebServer::Cmd_UpdateDevices, this, _1, _2, _3));
-			RegisterCommandCode("umeter", boost::bind(&CWebServer::Cmd_UpdateCalendarMeter, this, _1, _2, _3));
 			RegisterCommandCode("thermostatstate", boost::bind(&CWebServer::Cmd_SetThermostatState, this, _1, _2, _3));
 			RegisterCommandCode("system_shutdown", boost::bind(&CWebServer::Cmd_SystemShutdown, this, _1, _2, _3));
 			RegisterCommandCode("system_reboot", boost::bind(&CWebServer::Cmd_SystemReboot, this, _1, _2, _3));
@@ -2856,80 +2855,6 @@ namespace http {
 			root["title"] = "Email Camera Snapshot";
 		}
 
-		void CWebServer::Cmd_UpdateCalendarMeter(WebEmSession & session, const request& req, Json::Value &root)
-		{
-			if (session.rights < 1)
-			{
-				session.reply_status = reply::forbidden;
-				return; //only user or higher allowed
-			}
-
-			std::string idx = request::findValue(&req, "idx");
-
-			if (!IsIdxForUser(&session, atoi(idx.c_str())))
-			{
-				_log.Log(LOG_ERROR, "User: %s tried to update an Unauthorized device!", session.username.c_str());
-				session.reply_status = reply::forbidden;
-				return;
-			}
-
-			std::string hid = request::findValue(&req, "hid");
-			std::string did = request::findValue(&req, "did");
-			std::string dunit = request::findValue(&req, "dunit");
-			std::string dtype = request::findValue(&req, "dtype");
-			std::string dsubtype = request::findValue(&req, "dsubtype");
-
-			bool validValue = !request::findValue(&req, "value").empty();
-			float value = atof(request::findValue(&req, "value").c_str());
-			std::string date = request::findValue(&req, "date");
-			float usage = atof(request::findValue(&req, "usage").c_str());
-			float counter = atof(request::findValue(&req, "counter").c_str());
-			float min = atof(request::findValue(&req, "min").c_str());
-			float max = atof(request::findValue(&req, "max").c_str());
-			bool dayCalendar = !request::findValue(&req, "day").empty();
-			std::string clearafter = request::findValue(&req, "clearafterdate");
-			std::string clearbefore = request::findValue(&req, "clearbeforedate");
-
-			if (idx.empty())
-			{
-				//No index supplied, check if raw parameters where supplied
-				if (
-					(hid.empty()) ||
-					(did.empty()) ||
-					(dunit.empty()) ||
-					(dtype.empty()) ||
-					(dsubtype.empty())
-					)
-					return;
-			}
-			else
-			{
-				//Get the raw device parameters
-				std::vector<std::vector<std::string> > result;
-				result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID=='%q')",
-					idx.c_str());
-				if (result.empty())
-					return;
-				hid = result[0][0];
-				did = result[0][1];
-				dunit = result[0][2];
-				dtype = result[0][3];
-				dsubtype = result[0][4];
-			}
-
-			int HardwareID = atoi(hid.c_str());
-			std::string DeviceID = did;
-			int unit = atoi(dunit.c_str());
-			int devType = atoi(dtype.c_str());
-			int subType = atoi(dsubtype.c_str());
-
-			if (m_sql.UpdateCalendarMeter(HardwareID, DeviceID.c_str(), unit, devType, subType, validValue, value, date.c_str(), usage, counter, min, max, dayCalendar, clearafter.c_str(), clearbefore.c_str()))
-			{
-				root["status"] = "OK";
-				root["title"] = "Update Device";
-			}
-		}
-
 		void CWebServer::Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			if (session.rights < 1)
@@ -2956,7 +2881,24 @@ namespace http {
 			std::string nvalue = request::findValue(&req, "nvalue");
 			std::string svalue = request::findValue(&req, "svalue");
 
-			if ((nvalue.empty() && svalue.empty()))
+			// for meters
+			bool validValue = !request::findValue(&req, "value").empty();
+			float value = atof(request::findValue(&req, "value").c_str());
+			std::string date = request::findValue(&req, "date");
+			float usage = atof(request::findValue(&req, "usage").c_str());
+			float counter = atof(request::findValue(&req, "counter").c_str());
+			float min = atof(request::findValue(&req, "min").c_str());
+			float max = atof(request::findValue(&req, "max").c_str());
+			bool dayCalendar = !request::findValue(&req, "day").empty();
+			std::string clearafter = request::findValue(&req, "clearafterdate");
+			std::string clearbefore = request::findValue(&req, "clearbeforedate");
+
+			// check values are set or both before and after date are given
+			if (
+				(nvalue.empty() && svalue.empty() && !validValue && clearafter.empty() && clearbefore.empty())
+				|| (validValue && date.empty())
+				|| (clearafter.empty() != clearbefore.empty())
+			)
 			{
 				return;
 			}
@@ -2996,26 +2938,37 @@ namespace http {
 			int unit = atoi(dunit.c_str());
 			int devType = atoi(dtype.c_str());
 			int subType = atoi(dsubtype.c_str());
-
-			std::stringstream sstr;
-
-			uint64_t ulIdx;
-			sstr << idx;
-			sstr >> ulIdx;
-
-			int invalue = atoi(nvalue.c_str());
-
-			std::string sSignalLevel = request::findValue(&req, "rssi");
-			if (sSignalLevel != "")
+			bool resultMeter = true;
+			bool resultUpdate = true;
+			
+			if (validValue || !clearafter.empty() || !clearbefore.empty())
 			{
-				signallevel = atoi(sSignalLevel.c_str());
+				resultMeter = m_sql.UpdateCalendarMeter(HardwareID, DeviceID.c_str(), unit, devType, subType, validValue, value, date.c_str(), usage, counter, min, max, dayCalendar, clearafter.c_str(), clearbefore.c_str());
 			}
-			std::string sBatteryLevel = request::findValue(&req, "battery");
-			if (sBatteryLevel != "")
+
+			if (!nvalue.empty() || !svalue.empty())
 			{
-				batterylevel = atoi(sBatteryLevel.c_str());
+				std::stringstream sstr;
+
+				uint64_t ulIdx;
+				sstr << idx;
+				sstr >> ulIdx;
+
+				int invalue = atoi(nvalue.c_str());
+
+				std::string sSignalLevel = request::findValue(&req, "rssi");
+				if (sSignalLevel != "")
+				{
+					signallevel = atoi(sSignalLevel.c_str());
+				}
+				std::string sBatteryLevel = request::findValue(&req, "battery");
+				if (sBatteryLevel != "")
+				{
+					batterylevel = atoi(sBatteryLevel.c_str());
+				}
+				resultUpdate = m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, invalue, svalue, signallevel, batterylevel);
 			}
-			if (m_mainworker.UpdateDevice(HardwareID, DeviceID, unit, devType, subType, invalue, svalue, signallevel, batterylevel))
+			if (resultMeter || resultUpdate)
 			{
 				root["status"] = "OK";
 				root["title"] = "Update Device";

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -511,6 +511,7 @@ namespace http {
 			RegisterCommandCode("emailcamerasnapshot", boost::bind(&CWebServer::Cmd_EmailCameraSnapshot, this, _1, _2, _3));
 			RegisterCommandCode("udevice", boost::bind(&CWebServer::Cmd_UpdateDevice, this, _1, _2, _3));
 			RegisterCommandCode("udevices", boost::bind(&CWebServer::Cmd_UpdateDevices, this, _1, _2, _3));
+			RegisterCommandCode("umeter", boost::bind(&CWebServer::Cmd_UpdateCalendarMeter, this, _1, _2, _3));
 			RegisterCommandCode("thermostatstate", boost::bind(&CWebServer::Cmd_SetThermostatState, this, _1, _2, _3));
 			RegisterCommandCode("system_shutdown", boost::bind(&CWebServer::Cmd_SystemShutdown, this, _1, _2, _3));
 			RegisterCommandCode("system_reboot", boost::bind(&CWebServer::Cmd_SystemReboot, this, _1, _2, _3));
@@ -2853,6 +2854,79 @@ namespace http {
 			m_sql.AddTaskItem(_tTaskItem::EmailCameraSnapshot(1, camidx, subject));
 			root["status"] = "OK";
 			root["title"] = "Email Camera Snapshot";
+		}
+
+		void CWebServer::Cmd_UpdateCalendarMeter(WebEmSession & session, const request& req, Json::Value &root)
+		{
+			if (session.rights < 1)
+			{
+				session.reply_status = reply::forbidden;
+				return; //only user or higher allowed
+			}
+
+			std::string idx = request::findValue(&req, "idx");
+
+			if (!IsIdxForUser(&session, atoi(idx.c_str())))
+			{
+				_log.Log(LOG_ERROR, "User: %s tried to update an Unauthorized device!", session.username.c_str());
+				session.reply_status = reply::forbidden;
+				return;
+			}
+
+			std::string hid = request::findValue(&req, "hid");
+			std::string did = request::findValue(&req, "did");
+			std::string dunit = request::findValue(&req, "dunit");
+			std::string dtype = request::findValue(&req, "dtype");
+			std::string dsubtype = request::findValue(&req, "dsubtype");
+
+			float value = atof(request::findValue(&req, "value").c_str());
+			std::string date = request::findValue(&req, "date");
+			float usage = atof(request::findValue(&req, "usage").c_str());
+			float counter = atof(request::findValue(&req, "counter").c_str());
+			float min = atof(request::findValue(&req, "min").c_str());
+			float max = atof(request::findValue(&req, "max").c_str());
+			bool dayCalendar = !request::findValue(&req, "day").empty();
+			std::string clearbefore = request::findValue(&req, "clearafterdate");
+			std::string clearafter = request::findValue(&req, "clearbeforedate");
+
+			if (idx.empty())
+			{
+				//No index supplied, check if raw parameters where supplied
+				if (
+					(hid.empty()) ||
+					(did.empty()) ||
+					(dunit.empty()) ||
+					(dtype.empty()) ||
+					(dsubtype.empty())
+					)
+					return;
+			}
+			else
+			{
+				//Get the raw device parameters
+				std::vector<std::vector<std::string> > result;
+				result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID=='%q')",
+					idx.c_str());
+				if (result.empty())
+					return;
+				hid = result[0][0];
+				did = result[0][1];
+				dunit = result[0][2];
+				dtype = result[0][3];
+				dsubtype = result[0][4];
+			}
+
+			int HardwareID = atoi(hid.c_str());
+			std::string DeviceID = did;
+			int unit = atoi(dunit.c_str());
+			int devType = atoi(dtype.c_str());
+			int subType = atoi(dsubtype.c_str());
+
+			if (m_sql.UpdateCalendarMeter(HardwareID, DeviceID.c_str(), unit, devType, subType, value, date.c_str(), usage, counter, min, max, dayCalendar, clearafter.c_str(), clearbefore.c_str()))
+			{
+				root["status"] = "OK";
+				root["title"] = "Update Device";
+			}
 		}
 
 		void CWebServer::Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2879,6 +2879,7 @@ namespace http {
 			std::string dtype = request::findValue(&req, "dtype");
 			std::string dsubtype = request::findValue(&req, "dsubtype");
 
+			bool validValue = !request::findValue(&req, "value").empty();
 			float value = atof(request::findValue(&req, "value").c_str());
 			std::string date = request::findValue(&req, "date");
 			float usage = atof(request::findValue(&req, "usage").c_str());
@@ -2886,8 +2887,8 @@ namespace http {
 			float min = atof(request::findValue(&req, "min").c_str());
 			float max = atof(request::findValue(&req, "max").c_str());
 			bool dayCalendar = !request::findValue(&req, "day").empty();
-			std::string clearbefore = request::findValue(&req, "clearafterdate");
-			std::string clearafter = request::findValue(&req, "clearbeforedate");
+			std::string clearafter = request::findValue(&req, "clearafterdate");
+			std::string clearbefore = request::findValue(&req, "clearbeforedate");
 
 			if (idx.empty())
 			{
@@ -2922,7 +2923,7 @@ namespace http {
 			int devType = atoi(dtype.c_str());
 			int subType = atoi(dsubtype.c_str());
 
-			if (m_sql.UpdateCalendarMeter(HardwareID, DeviceID.c_str(), unit, devType, subType, value, date.c_str(), usage, counter, min, max, dayCalendar, clearafter.c_str(), clearbefore.c_str()))
+			if (m_sql.UpdateCalendarMeter(HardwareID, DeviceID.c_str(), unit, devType, subType, validValue, value, date.c_str(), usage, counter, min, max, dayCalendar, clearafter.c_str(), clearbefore.c_str()))
 			{
 				root["status"] = "OK";
 				root["title"] = "Update Device";

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -187,7 +187,6 @@ private:
 	void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateCalendarMeter(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);	
 	void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -187,7 +187,8 @@ private:
 	void Cmd_GetConfig(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
-	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateCalendarMeter(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);	
 	void Cmd_UpdateDevices(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SetThermostatState(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SystemShutdown(WebEmSession & session, const request& req, Json::Value &root);


### PR DESCRIPTION
This PR add JSON RPC calls and a new Python plugin function to add directly data to Meter and Meter_Calendar DB

Some french meters (Linky, Gazpar) grabs data that are available 24hours later, these API allows to include them in Domoticz DB without accessing it the bad way (editing domoticz.db from an external script).

JSON RPC calls:
For day view:
 json.htm?type=command&param=umeter&idx=14&value=32&date=2018-04-30&usage=2&day=1
For month/year view:
 json.htm?type=command&param=umeter&idx=14&value=32&date=2018-04-30&counter=3
And for multimeters:
 json.htm?type=command&param=umeter&idx=14&value=32&date=2018-04-30&min=2&max=4
Erase data (for day view and for month/year view):
 json.htm?type=command&param=umeter&idx=14&day=1&clearafterdate=2018-03-31&clearbeforedate=2018-06-01
 json.htm?type=command&param=umeter&idx=14&clearafterdate=2018-03-31&clearbeforedate=2018-06-01

Python calls:
For day view:
 Devices[14].UpdateMeter(Day=True, Values={'Value':12.2,'Date':'2014-04-02 18:14:30','Usage':2.0})
For month/year view:
 Devices[14].UpdateMeter(Day=False, Values={'Value':12.2,'Date':'2014-04-02 18:14:30','Counter':3.0})
And for multimeters:
 Devices[14].UpdateMeter(Day=False, Values={'Value':12.2,'Date':'2014-04-02 18:14:30'},'Min':2.0,'Max':20.0)
Erase data (for day view and for month/year view):
 Devices[self.iIndexUnit].UpdateMeter(Day=True, ClearAfterDate="2018-03-01 01:00:00", ClearBeforeDate="2018-04-30 20:00:00")
 Devices[self.iIndexUnit].UpdateMeter(Day=False, ClearAfterDate="2018-03-01 01:00:00", ClearBeforeDate="2018-04-30 20:00:00")

There will be a separate PR (#2272) to add an option on devices meter, preventing Domoticz to do average, transfer from Meter to Meter_Calendar, because it is useless for these kinds of meter.