### PR TITLE
Update subtype of Hue, Yeelight and ZWave devices when subtype is not matching

### DIFF
--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -440,15 +440,22 @@ void CPhilipsHue::InsertUpdateSwitch(const int NodeID, const _eHueLightType LTyp
 
 		//Get current nValue if exist
 		vector<vector<string> > result;
-		result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d) AND (SubType==%d) AND (DeviceID=='%q')",
-			m_HwdID, int(unitcode), pTypeColorSwitch, sType, szID);
+		result = m_sql.safe_query("SELECT nValue, SubType, ID FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d) AND (DeviceID=='%q')",
+			m_HwdID, int(unitcode), pTypeColorSwitch, szID);
 
 		if (!result.empty())
 		{
 			//Already in the system
 			//Update state
 			nvalue = atoi(result[0][0].c_str());
-			tIsOn = (nvalue != 0);					
+			tIsOn = (nvalue != 0);
+			unsigned sTypeOld = atoi(result[0][1].c_str());
+			std::string sID = result[0][2];
+			if (sTypeOld != sType)
+			{
+				_log.Log(LOG_STATUS, "Philips Hue: Updating SubType of light '%s' from %u to %u", szID, sTypeOld, sType);
+				m_sql.UpdateDeviceValue("SubType", (int)sType, sID);
+			}
 		}
 		
 		// TODO: Update color stored in database

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -140,7 +140,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 	int nvalue = 0;
 	bool tIsOn = !(bIsOn);
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT nValue, LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (SubType==%d)", m_HwdID, szDeviceID, pTypeColorSwitch, YeeType);
+	result = m_sql.safe_query("SELECT nValue, LastLevel, SubType, ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d)", m_HwdID, szDeviceID, pTypeColorSwitch);
 	int yeelightColorMode = atoi(syeelightColorMode.c_str());
 	if (yeelightColorMode > 0) {
 		if (_log.isTraceEnabled()) _log.Log(LOG_TRACE, "Yeelight::InsertUpdateSwitch colorMode: %u, Bri: %s, Hue: %s, Sat: %s, RGB: %s, CT: %s", yeelightColorMode, yeelightBright.c_str(), syeelightHue.c_str(), syeelightSat.c_str(), syeelightRGB.c_str(), syeelightCT.c_str());
@@ -166,6 +166,14 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', SwitchType=%d, LastLevel=%d WHERE(HardwareID == %d) AND (DeviceID == '%q')", lightName.c_str(), (STYPE_Dimmer), value, m_HwdID, szDeviceID);
 	}
 	else {
+		// Make sure subtype is correct
+		unsigned sTypeOld = atoi(result[0][2].c_str());
+		std::string sIdx = result[0][3];
+		if (sTypeOld != YeeType)
+		{
+			_log.Log(LOG_STATUS, "YeeLight: Updating SubType of light (%s/%s) from %u to %u", Location.c_str(), lightName.c_str(), sTypeOld, YeeType);
+			m_sql.UpdateDeviceValue("SubType", (int)YeeType, sIdx);
+		}
 
 		nvalue = atoi(result[0][0].c_str());
 		tIsOn = (nvalue != 0);


### PR DESCRIPTION
There were changes in Hue, Yeelight and ZWave integration as part of the color switch changes:
- Philips Hue: Exact device capability is discovered and mapped to matching color switch subtype
- Yeelight: Exact device capability is discovered and mapped to matching color switch subtype
- ZWave: Legacy RGBW switch mapped to sTypeColor_RGB_W_Z, color switch mapped to sTypeColor_RGB_CW_WW_Z

This PR makes sure that if subtype is no longer matching after upgrade, subtype will be changed instead of creating duplicate devices.

@gizmocuz:
- I can test with Philips Hue only, please help to review (it's the same code for Yeelight and ZWave)
- Possible improvements, please let me know if I should add either of them:
  - If duplicate devices are present, print a warning message to alert the user
  - If duplicate devices are present, remove the newest one(s) from database and alert the user
