### PR TITLE
Made other energy rates possible in report views

### DIFF
--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -34,11 +34,13 @@ enum _eSwitchType
 enum _eMeterType
 {
 	MTYPE_ENERGY = 0,			//0
-	MTYPE_GAS,				//1
-	MTYPE_WATER,			//2
-	MTYPE_COUNTER,			//3
-	MTYPE_ENERGY_GENERATED,	//4
-	MTYPE_TIME,				//5
+	MTYPE_GAS,					//1
+	MTYPE_WATER,				//2
+	MTYPE_COUNTER,				//3
+	MTYPE_ENERGY_GENERATED,		//4
+	MTYPE_TIME,					//5
+	MTYPE_ENERGY_T2,			//6
+	MTYPE_ENERGY_GENERATED_R2,	//7
 	MTYPE_END
 };
 

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -3722,7 +3722,7 @@ define(['app'], function (app) {
 										}
 									}
 									else if ((item.Type == "Energy") || (item.Type == "Power") || (item.SubType == "kWh")) {
-										if (((item.Type == "Energy") || (item.Type == "Power") || (item.SubType == "kWh")) && (item.SwitchTypeVal == 4)) {
+										if (((item.Type == "Energy") || (item.Type == "Power") || (item.SubType == "kWh")) && ((item.SwitchTypeVal == 4) || (item.SwitchTypeVal == 7))) {
 											imagehtml += 'PV48.png" class="lcursor" onclick="ShowCounterLogSpline(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\', ' + item.SwitchTypeVal + ');" height="40" width="40"></td>\n';
 										}
 										else {

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -620,7 +620,7 @@ define(['app'], function (app) {
 								status = "";
 							}
 							else if ((item.Type == "Energy") || (item.Type == "Current/Energy") || (item.Type == "Power") || (item.SubType == "kWh")) {
-								if (((item.Type == "Energy") || (item.SubType == "kWh")) && (item.SwitchTypeVal == 4)) {
+								if (((item.Type == "Energy") || (item.SubType == "kWh")) && ((item.SwitchTypeVal == 4) || (item.SwitchTypeVal == 7))) {
 									xhtm += 'PV48.png" height="48" width="48"></td>\n';
 								}
 								else {

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1514
+# ref 1502
 
 CACHE:
 # CSS

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1501
+# ref 1514
 
 CACHE:
 # CSS

--- a/www/index.html
+++ b/www/index.html
@@ -1226,30 +1226,32 @@ $(document).ready(function() {
 		<h1 id="theader" data-i18n="Usage this Month">Usage this Month</h1>
 		<br>
 		<span data-i18n="Total Usage" id="spanmonthgastotalusage">Total Usage</span>: <span id="tu">-</span> <span id="munit">m3</span><br>
+		<span data-i18n="Costs">Costs</span>: <span id="costsperunit">-</span><br>
 		<span data-i18n="Monthly Cost">Monthly Cost</span>: <span id="mc">-</span><br>
 		<br>
 	</div>
 	<div id="toptextyeargas" style="display:none;">
 		<table class="display" border="0" cellpadding="0" cellspacing="0">
-		<tr>
-			<a id="backbutton" class="btnstylerev" onclick="ShowUtilities()" data-i18n="Back">Back</a>&nbsp;
-			<h1 id="theader" data-i18n="Usage this Year">Usage this Year</h1>
-		  <td align="right">
-				<span data-i18n="Year">Year</span>:
-				<select id="comboyear" style="width:74px" class="combobox ui-corner-all">
-					<option value="2012">2012</option>
-					<option value="2013">2013</option>
-					<option value="2014">2014</option>
-					<option value="2015">2015</option>
-					<option value="2016">2016</option>
-					<option value="2017">2017</option>
-					<option value="2018">2018</option>
-				</select>
-		  </td>
-		</tr>
+			<tr>
+				<a id="backbutton" class="btnstylerev" onclick="ShowUtilities()" data-i18n="Back">Back</a>&nbsp;
+				<h1 id="theader" data-i18n="Usage this Year">Usage this Year</h1>
+				<td align="right">
+					<span data-i18n="Year">Year</span>:
+					<select id="comboyear" style="width:74px" class="combobox ui-corner-all">
+						<option value="2012">2012</option>
+						<option value="2013">2013</option>
+						<option value="2014">2014</option>
+						<option value="2015">2015</option>
+						<option value="2016">2016</option>
+						<option value="2017">2017</option>
+						<option value="2018">2018</option>
+					</select>
+				</td>
+			</tr>
 		</table>
 		<br>
 		<span data-i18n="Total Usage" id="spanyeargastotalusage">Total Usage</span>: <span id="tu">-</span> <span id="munit">m3</span><br>
+		<span data-i18n="Costs">Costs</span>: <span id="costsperunit">-</span><br>
 		<span data-i18n="Counter">Counter</span>: <span id="cntr">-</span><br>
 		<span data-i18n="Year Cost">Year Cost</span>: <span id="mc">-</span><br>
 		<br>

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -7605,7 +7605,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 	});
 
 	var series;
-	if ((switchtype == 0) || (switchtype == 4)) {
+	if ((switchtype == 0) || (switchtype == 4) || (switchtype == 6) || (switchtype == 7)) {
 
 		//Electra Usage/Return
 		if ((chart == $.DayChart) || (chart == $.WeekChart)) {
@@ -7627,7 +7627,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 						pointRange: 3600 * 1000, // 1 hour in ms
 						zIndex: 5,
 						animation: false,
-						name: (switchtype == 0) ? $.t('Energy Usage') : $.t('Energy Generated'),
+						name: (switchtype == 0 || switchtype == 6) ? $.t('Energy Usage') : $.t('Energy Generated'),
 						tooltip: {
 							valueSuffix: (chart == $.WeekChart) ? ' kWh' : ' Wh',
 							valueDecimals: totDecimals
@@ -7679,7 +7679,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 						// counter type (no power)
 						chart.highcharts().addSeries({
 							id: 'usage1',
-							name: (switchtype == 0) ? $.t('Energy Usage') : $.t('Energy Generated'),
+							name: (switchtype == 0 || switchtype == 6) ? $.t('Energy Usage') : $.t('Energy Generated'),
 							tooltip: {
 								valueSuffix: (chart == $.DayChart) ? ' Wh' : ' kWh',
 								valueDecimals: totDecimals
@@ -7692,7 +7692,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 						// instant + counter type
 						chart.highcharts().addSeries({
 							id: 'usage1',
-							name: (switchtype == 0) ? $.t('Power Usage') : $.t('Power Generated'),
+							name: (switchtype == 0 || switchtype == 6) ? $.t('Power Usage') : $.t('Power Generated'),
 							zIndex: 10,
 							type: (chart == $.DayChart) ? 'spline' : 'column', // power vs energy
 							tooltip: {
@@ -7775,7 +7775,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 			if (datatableTotalUsage.length > 0) {
 				chart.highcharts().addSeries({
 					id: 'usage',
-					name: (switchtype == 0) ? $.t('Total Usage') : ((switchtype == 4) ? $.t('Total Generated') : $.t('Total Return')),
+					name: (switchtype == 0 || switchtype == 6) ? $.t('Total Usage') : ((switchtype == 4 || switchtype == 7) ? $.t('Total Generated') : $.t('Total Return')),
 					zIndex: 2,
 					tooltip: {
 						valueSuffix: ' kWh',
@@ -7795,7 +7795,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 
 					chart.highcharts().addSeries({
 						id: 'usage_trendline',
-						name: $.t('Trendline') + ' ' + ((switchtype == 0) ? $.t('Usage') : ((switchtype == 4) ? $.t('Generated') : $.t('Return'))),
+						name: $.t('Trendline') + ' ' + ((switchtype == 0 || switchtype == 6) ? $.t('Usage') : ((switchtype == 4 || switchtype == 7) ? $.t('Generated') : $.t('Return'))),
 						zIndex: 1,
 						tooltip: {
 							valueSuffix: ' kWh',
@@ -7853,7 +7853,7 @@ function AddDataToUtilityChart(data, chart, switchtype) {
 			if (datatableTotalUsagePrev.length > 0) {
 				chart.highcharts().addSeries({
 					id: 'usageprev',
-					name: $.t('Past') + ' ' + ((switchtype == 0) ? $.t('Usage') : ((switchtype == 4) ? $.t('Generated') : $.t('Return'))),
+					name: $.t('Past') + ' ' + ((switchtype == 0 || switchtype == 6) ? $.t('Usage') : ((switchtype == 4 || switchtype == 7) ? $.t('Generated') : $.t('Return'))),
 					tooltip: {
 						valueSuffix: ' kWh',
 						valueDecimals: 3
@@ -8377,13 +8377,26 @@ function ShowP1MonthReportGas(actMonth, actYear) {
 	$($.content).i18n();
 
 	$($.content + ' #theader').html(unescape($.devName) + " " + $.t($.monthNames[actMonth - 1]) + " " + actYear);
-	$($.content + ' #spanmonthgastotalusage').html(($.devSwitchType == 4) ? $.t('Total Generated') : $.t('Total Usage'));
+	$($.content + ' #spanmonthgastotalusage').html(($.devSwitchType == 4 || $.devSwitchType == 7) ? $.t('Total Generated') : $.t('Total Usage'));
 
 	var yAxisTitle = $.t('Energy') + ' (kWh)';
-	if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+	if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 		//Electra
 		$($.content + ' #munit').html("kWh");
-		$($.content + ' #thmonthgasusage').html(($.devSwitchType == 4) ? $.t('Generated') : $.t('Usage'));
+		$($.content + ' #thmonthgasusage').html(($.devSwitchType == 4 || $.devSwitchType == 7) ? $.t('Generated') : $.t('Usage'));
+		
+		if ($.devSwitchType == 0) {
+			$($.content + ' #costsperunit').html($.costsT1 + "/kWh (T1)");
+		}
+		else if ($.devSwitchType == 4) {
+			$($.content + ' #costsperunit').html($.costsR1 + "/kWh (R1)");
+		}
+		else if ($.devSwitchType == 6) {
+			$($.content + ' #costsperunit').html($.costsT2 + "/kWh (T2)");
+		}
+		else if ($.devSwitchType == 7) {
+			$($.content + ' #costsperunit').html($.costsR2 + "/kWh (R2)");
+		}
 	}
 	else if ($.devSwitchType == 1) {
 		//Gas
@@ -8481,9 +8494,22 @@ function ShowP1MonthReportGas(actMonth, actYear) {
 					datachart.push([cdate, parseFloat(item.v)]);
 
 					var rcost;
-					if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+					if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 						//Electra
 						rcost = Usage * $.costsT1;
+						
+						if ($.devSwitchType == 0) {
+							rcost = Usage * $.costsT1;
+						}
+						else if ($.devSwitchType == 4) {
+							rcost = Usage * $.costsR1;
+						}
+						else if ($.devSwitchType == 6) {
+							rcost = Usage * $.costsT2;
+						}
+						else if ($.devSwitchType == 7) {
+							rcost = Usage * $.costsR2;
+						}
 					}
 					else if ($.devSwitchType == 1) {
 						//Gas
@@ -8499,14 +8525,14 @@ function ShowP1MonthReportGas(actMonth, actYear) {
 						img = '<img src="images/equal.png"></img>';
 					}
 					else if (Usage < lastTotal) {
-						if ($.devSwitchType == 4) {
+						if ($.devSwitchType == 4 || $.devSwitchType == 7) {
 							img = '<img src="images/up.png" class="vflip"></img>';
 						} else {
 							img = '<img src="images/down.png"></img>';
 						}
 					}
 					else {
-						if ($.devSwitchType == 4) {
+						if ($.devSwitchType == 4 || $.devSwitchType == 7) {
 							img = '<img src="images/down.png" class="vflip"></img>';
 						} else {
 							img = '<img src="images/up.png"></img>';
@@ -8528,12 +8554,12 @@ function ShowP1MonthReportGas(actMonth, actYear) {
 			$($.content + ' #tu').html(total.toFixed(3));
 
 			var montlycosts;
-			if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+			if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 				//Electra
 				montlycosts = (total * $.costsT1)
 				$.UsageChart.highcharts().addSeries({
 					id: 'energy',
-					name: ($.devSwitchType == 0) ? $.t('Usage') : $.t('Generated'),
+					name: ($.devSwitchType == 0 || $.devSwitchType == 6) ? $.t('Usage') : $.t('Generated'),
 					showInLegend: false,
 					color: 'rgba(3,190,252,0.8)',
 					yAxis: 0
@@ -8596,9 +8622,20 @@ function addLeadingZeros(n, length) {
 
 function Add2YearTableP1ReportGas(oTable, total, lastTotal, lastMonth, actYear) {
 	var rcost;
-	if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+	if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 		//Electra
-		rcost = total * $.costsT1;
+		if ($.devSwitchType == 0) {
+			rcost = total * $.costsT1;
+		}
+		else if ($.devSwitchType == 4) {
+			rcost = total * $.costsR1;
+		}
+		else if ($.devSwitchType == 6) {
+			rcost = total * $.costsT2;
+		}
+		else if ($.devSwitchType == 7) {
+			rcost = total * $.costsR2;
+		}
 	}
 	else if ($.devSwitchType == 1) {
 		//Gas
@@ -8614,14 +8651,14 @@ function Add2YearTableP1ReportGas(oTable, total, lastTotal, lastMonth, actYear) 
 		img = '<img src="images/equal.png"></img>';
 	}
 	else if (total < lastTotal) {
-		if ($.devSwitchType == 4) {
+		if ($.devSwitchType == 4 || $.devSwitchType == 7) {
 			img = '<img src="images/up.png" class="vflip"></img>';
 		} else {
 			img = '<img src="images/down.png"></img>';
 		}
 	}
 	else {
-		if ($.devSwitchType == 4) {
+		if ($.devSwitchType == 4 || $.devSwitchType == 7) {
 			img = '<img src="images/down.png" class="vflip"></img>';
 		} else {
 			img = '<img src="images/up.png"></img>';
@@ -8658,23 +8695,38 @@ function ShowP1YearReportGas(actYear) {
 	$($.content).i18n();
 
 	$($.content + ' #theader').html(unescape($.devName) + " " + actYear);
-	$($.content + ' #spanyeargastotalusage').html(($.devSwitchType == 4) ? $.t('Total Generated') : $.t('Total Usage'));
+	$($.content + ' #spanyeargastotalusage').html(($.devSwitchType == 4 || $.devSwitchType == 7) ? $.t('Total Generated') : $.t('Total Usage'));
 
 	var yAxisTitle = $.t('Energy') + ' (kWh)';
-	if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+	if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 		//Electra
 		$($.content + ' #munit').html("kWh");
-		$($.content + ' #thyeargasusage').html(($.devSwitchType == 4) ? $.t('Generated') : $.t('Usage'));
+		$($.content + ' #thyeargasusage').html(($.devSwitchType == 4 || $.devSwitchType == 7) ? $.t('Generated') : $.t('Usage'));
+		
+		if ($.devSwitchType == 0) {
+			$($.content + ' #costsperunit').html($.costsT1 + "/kWh (T1)");
+		}
+		else if ($.devSwitchType == 4) {
+			$($.content + ' #costsperunit').html($.costsR1 + "/kWh (R1)");
+		}
+		else if ($.devSwitchType == 6) {
+			$($.content + ' #costsperunit').html($.costsT2 + "/kWh (T2)");
+		}
+		else if ($.devSwitchType == 7) {
+			$($.content + ' #costsperunit').html($.costsR2 + "/kWh (R2)");
+		}
 	}
 	else if ($.devSwitchType == 1) {
 		//Gas
 		$($.content + ' #munit').html("m3");
 		yAxisTitle = $.t('Usage') + ' (m3)';
+		$($.content + ' #costsperunit').html($.costsGas + "/m3");
 	}
 	else {
 		//Water
 		$($.content + ' #munit').html("m3");
 		yAxisTitle = $.t('Usage') + ' (m3)';
+		$($.content + ' #costsperunit').html($.costsWater + "/m3");
 	}
 
 	$($.content + ' #comboyear').val(actYear);
@@ -8805,12 +8857,25 @@ function ShowP1YearReportGas(actYear) {
 
 			$($.content + ' #tu').html(global.toFixed(3));
 			var montlycosts = 0;
-			if (($.devSwitchType == 0) || ($.devSwitchType == 4)) {
+			if (($.devSwitchType == 0) || ($.devSwitchType == 4) || ($.devSwitchType == 6) || ($.devSwitchType == 7)) {
 				//Electra
-				montlycosts = (global * $.costsT1);
+				
+				if ($.devSwitchType == 0) {
+					montlycosts = (global * $.costsT1);
+				}
+				else if ($.devSwitchType == 4) {
+					montlycosts = (global * $.costsR1);
+				}
+				else if ($.devSwitchType == 6) {
+					montlycosts = (global * $.costsT2);
+				}
+				else if ($.devSwitchType == 7) {
+					montlycosts = (global * $.costsR2);
+				}
+				
 				$.UsageChart.highcharts().addSeries({
 					id: 'energy',
-					name: ($.devSwitchType == 0) ? $.t('Usage') : $.t('Generated'),
+					name: ($.devSwitchType == 0 || $.devSwitchType == 6) ? $.t('Usage') : $.t('Generated'),
 					showInLegend: false,
 					color: 'rgba(3,190,252,0.8)',
 					yAxis: 0
@@ -9849,7 +9914,7 @@ function ShowCounterLogSpline(contentdiv, backfunction, id, name, switchtype) {
 	htmlcontent = '<p><center><h2>' + unescape(name) + '</h2></center></p>\n';
 	htmlcontent += $('#dayweekmonthyearlog').html();
 
-	if ((switchtype == 0) || (switchtype == 1) || (switchtype == 2) || (switchtype == 4)) {
+	if ((switchtype == 0) || (switchtype == 1) || (switchtype == 2) || (switchtype == 4) || (switchtype == 6) || (switchtype == 7)) {
 		$.costsT1 = 0.2389;
 		$.costsT2 = 0.2389;
 		$.costsR1 = 0.08;
@@ -9884,7 +9949,7 @@ function ShowCounterLogSpline(contentdiv, backfunction, id, name, switchtype) {
 	}
 	$($.content).i18n();
 
-	var graph_title = (switchtype == 4) ? $.t('Generated') : $.t('Usage');
+	var graph_title = (switchtype == 4 || switchtype == 7) ? $.t('Generated') : $.t('Usage');
 	graph_title += ' ' + Get5MinuteHistoryDaysGraphTitle();
 
 	$.DayChart = $($.content + ' #daygraph');

--- a/www/views/utility.html
+++ b/www/views/utility.html
@@ -83,8 +83,10 @@
         <tr>
           <td align="right"><label for="combometertype"><span data-i18n="Type">Type</span>: </label></td>
           <td><select id="combometertype" style="width:150px" class="combobox ui-corner-all">
-            <option value="0" data-i18n="Usage">Usage</option>
-            <option value="4" data-i18n="Return">Return</option>
+            <option value="0" data-i18n="Usage T1">Usage T1</option>
+            <option value="4" data-i18n="Return R1">Return R1</option>
+            <option value="6" data-i18n="Usage T2">Usage T2</option>
+            <option value="7" data-i18n="Return R2">Return R2</option>
           </select></td>
 		</tr>
         <tr>


### PR DESCRIPTION
You can edit a General kWh device and select the belonging rate
(T1/T2/R1/R2). This is now also calculated in the report views. Needed
this because my Z-Wave P1 dongle created two general kWh devices and
they used both T1 as costs by default. Now you can choose.