### PR TITLE
hardware: TeleinfoSerial: Fix bad strlen argument

### DIFF
--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -158,7 +158,7 @@ void CTeleinfoSerial::MatchLine()
 	#endif
 
 	// Is the line we got worth analysing any further?
-	if ((strlen((const char*)&line)<4) || (line[0] == 0x0a))
+	if ((strlen((const char*)line)<4) || (line[0] == 0x0a))
 		return;
 
 	// Extract the elements, return if not enough and line is invalid


### PR DESCRIPTION
In MatchLine() method, call to strlen() to do some sanity check on line
length is buggy. Since line is char pointer, "line" should be passed to
strlen().

Signed-off-by: Jean-Nicolas Graux <nicogrx@gmail.com>