### PR TITLE
UI improvements for ColorSwitch type devices

### DIFF
--- a/hardware/Limitless.h
+++ b/hardware/Limitless.h
@@ -5,13 +5,13 @@
 
 class CLimitLess : public CDomoticzHardwareBase
 {
+public:
 	enum _eLimitlessBridgeType
 	{
 		LBTYPE_V4 = 0,
 		LBTYPE_V5,
 		LBTYPE_V6
 	};
-public:
 	CLimitLess(const int ID, const int LedType, const int BridgeType, const std::string &IPAddress, const unsigned short usIPPort);
 	~CLimitLess(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length);

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -267,6 +267,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 
 			std::string hex = root["hex"].asString();
 			std::string hue = root["hue"].asString();
+			std::string sat = root["sat"].asString();
 			std::string brightness = root["level"].asString();
 			std::string iswhite;
 			if (!root["isWhite"].empty())
@@ -352,7 +353,9 @@ void MQTT::on_message(const struct mosquitto_message *message)
 
 				//convert hue to RGB
 				float iHue = float(atof(hue.c_str()));
-				hsb2rgb(iHue, 1.0f, 1.0f, r, g, b, 255);
+				float iSat = 100.0f;
+				if (!sat.empty()) iSat = float(atof(sat.c_str()));
+				hsb2rgb(iHue, iSat/100.0f, 1.0f, r, g, b, 255);
 
 				color = _tColor(r, g, b, 0, 0, ColorModeRGB);
 				if (iswhite == "true") color.mode = ColorModeWhite;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -23,6 +23,7 @@
 #include "../hardware/AccuWeather.h"
 #include "../hardware/OpenWeatherMap.h"
 #include "../hardware/Kodi.h"
+#include "../hardware/Limitless.h"
 #include "../hardware/LogitechMediaServer.h"
 #include "../hardware/MySensorsBase.h"
 #include "../hardware/RFXBase.h"
@@ -6741,6 +6742,7 @@ namespace http {
 				std::string json = request::findValue(&req, "color");
 				std::string hex = request::findValue(&req, "hex");
 				std::string hue = request::findValue(&req, "hue");
+				std::string sat = request::findValue(&req, "sat");
 				std::string brightness = request::findValue(&req, "brightness");
 				std::string iswhite = request::findValue(&req, "iswhite");
 
@@ -6818,7 +6820,9 @@ namespace http {
 
 					//convert hue to RGB
 					float iHue = float(atof(hue.c_str()));
-					hsb2rgb(iHue, 1.0f, 1.0f, r, g, b, 255);
+					float iSat = 100.0f;
+					if (!sat.empty()) iSat = float(atof(sat.c_str()));
+					hsb2rgb(iHue, iSat/100.0f, 1.0f, r, g, b, 255);
 
 					color = _tColor(r, g, b, 0, 0, ColorModeRGB);
 					if (iswhite == "true") color.mode = ColorModeWhite;
@@ -8053,6 +8057,8 @@ namespace http {
 			int HardwareTypeVal;
 			std::string HardwareType;
 			bool Enabled;
+			std::string Mode1; // Used to flag DimmerType as relative for some old LimitLessLight type bulbs
+			std::string Mode2; // Used to flag DimmerType as relative for some old LimitLessLight type bulbs
 		} tHardwareList;
 
 		void CWebServer::GetJSonDevices(
@@ -8085,7 +8091,7 @@ namespace http {
 
 			//Get All Hardware ID's/Names, need them later
 			std::map<int, _tHardwareListInt> _hardwareNames;
-			result = m_sql.safe_query("SELECT ID, Name, Enabled, Type FROM Hardware");
+			result = m_sql.safe_query("SELECT ID, Name, Enabled, Type, Mode1, Mode2 FROM Hardware");
 			if (result.size() > 0)
 			{
 				std::vector<std::vector<std::string> >::const_iterator itt;
@@ -8110,6 +8116,8 @@ namespace http {
 						tlist.HardwareType = PluginHardwareDesc(ID);
 					}
 #endif
+					tlist.Mode1 = sd[4];
+					tlist.Mode2 = sd[5];
 					_hardwareNames[ID] = tlist;
 				}
 			}
@@ -9000,6 +9008,24 @@ namespace http {
 							root["result"][ii]["LevelInt"] = atoi(sValue.c_str());
 						}
 						root["result"][ii]["HaveDimmer"] = bHaveDimmer;
+						std::string DimmerType = "none";
+						if (bHaveDimmer)
+						{
+							DimmerType = "abs";
+							if (_hardwareNames.find(hardwareID) != _hardwareNames.end())
+							{
+								// Milight V4/V5 bridges do not support absolute dimming for RGB or CW_WW lights
+								if (_hardwareNames[hardwareID].HardwareTypeVal == HTYPE_LimitlessLights &&
+								    atoi(_hardwareNames[hardwareID].Mode2.c_str()) != CLimitLess::LBTYPE_V6 &&
+									(atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_RGB ||
+									 atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_White ||
+									 atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_CW_WW))
+								{
+									DimmerType = "rel";
+								}
+							}
+						}
+						root["result"][ii]["DimmerType"] = DimmerType;
 						root["result"][ii]["MaxDimLevel"] = maxDimLevel;
 						root["result"][ii]["HaveGroupCmd"] = bHaveGroupCmd;
 						root["result"][ii]["SwitchType"] = Switch_Type_Desc(switchtype);

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -759,7 +759,7 @@ define(['app'], function (app) {
 												(item.Status.indexOf('Set ') == 0)
 											) {
 												if (isLED(item.SubType)) {
-													img = '<img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="40" width="40">';
+													img = '<img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
 												}
 												else {
 													img = '<img src="images/' + item.Image + '48_On.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',RefreshFavorites,' + item.Protected + ');" class="lcursor" height="40" width="40">';
@@ -767,7 +767,7 @@ define(['app'], function (app) {
 											}
 											else {
 												if (isLED(item.SubType)) {
-													img = '<img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="40" width="40">';
+													img = '<img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
 												}
 												else {
 													img = '<img src="images/' + item.Image + '48_Off.png" title="' + $.t("Turn On") + '" onclick="SwitchLight(' + item.idx + ',\'On\',RefreshFavorites,' + item.Protected + ');" class="lcursor" height="40" width="40">';
@@ -2562,7 +2562,7 @@ define(['app'], function (app) {
 											(item.Status.indexOf('Disco ') == 0)
 										) {
 											if (isLED(item.SubType)) {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="40" width="40"></td>\n';
+												xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
 											}
 											else {
 												xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_On.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',RefreshFavorites,' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
@@ -2570,7 +2570,7 @@ define(['app'], function (app) {
 										}
 										else {
 											if (isLED(item.SubType)) {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="40" width="40"></td>\n';
+												xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshFavorites\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
 											}
 											else {
 												xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_Off.png" title="' + $.t("Turn On") + '" onclick="SwitchLight(' + item.idx + ',\'On\',RefreshFavorites,' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
@@ -2662,11 +2662,11 @@ define(['app'], function (app) {
 										'\t      <td id="status" class="status">' + status + '</td>\n' +
 										'\t      <td id="lastupdate" class="lastupdate"><span>' + item.LastUpdate + '</span></td>\n';
 									if (item.SwitchType == "Dimmer") {
-										if (isLED(item.SubType)) {
-											//TODO: Why not show dimmer slider for LED type?
+										if (item.DimmerType && item.DimmerType!="abs") {
+											// Don't show dimmer slider if the device does not support absolute dimming
 										}
 										else {
-											xhtm += '<td class="input"><div style="margin-left:50px; margin-top: 0.2em;" class="dimslider dimslidernorm" id="slider" data-idx="' + item.idx + '" data-type="norm" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
+											xhtm += '<td class="input"><div style="margin-left:50px; margin-top: 0.2em;" class="dimslider dimslidernorm" id="slider" data-idx="' + item.idx + '" data-type="norm" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '" data-isled="' + isLED(item.SubType) + '"></div></td>';
 										}
 									}
 									else if (item.SwitchType == "TPI") {
@@ -3982,6 +3982,7 @@ define(['app'], function (app) {
 					clearInterval($.setDimValue);
 					var maxValue = $(this).slider("option", "max");
 					var dtype = $(this).slider("option", "type");
+					var isled = $(this).data('isled');
 					var isProtected = $(this).slider("option", "isprotected");
 					var fPercentage = parseInt((100.0 / maxValue) * ui.value);
 					var idx = $(this).data('idx');
@@ -3995,6 +3996,10 @@ define(['app'], function (app) {
 						if (dtype == "blinds") {
 							TxtOn = "Open";
 							TxtOff = "Close";
+						}
+						else if (dtype == "blinds_inv") {
+							TxtOn = "Close";
+							TxtOff = "Open";
 						}
 						if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
 							if (fPercentage == 0) {
@@ -4022,7 +4027,7 @@ define(['app'], function (app) {
 								img = '<img src="images/' + imgname + 'n.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + idx + ',\'Off\',RefreshFavorites,' + isProtected + ');" class="lcursor" height="40" width="40">';
 								status = fPercentage + " %";
 							}
-							if (dtype != "blinds") {
+							if ((dtype != "blinds") && (dtype != "blinds_inv") && !isled) {
 								if ($(id + " #img").html() != img) {
 									$(id + " #img").html(img);
 								}

--- a/www/app/DeviceLightEdit.js
+++ b/www/app/DeviceLightEdit.js
@@ -61,14 +61,16 @@ define(['app'], function (app) {
             var $ctrl = this;
 
             $ctrl.$onInit = init;
-            $ctrl.isBrightnessAvailable = isBrightnessAvailable;
-            $ctrl.isLightControlAvailable = isLightControlAvailable;
+            $ctrl.isRelativeDimmer = isRelativeDimmer;
+            $ctrl.isRelativeColorTemperature = isRelativeColorTemperature;
             $ctrl.brightnessUp = withDevice(deviceLightApi.brightnessUp);
             $ctrl.brightnessDown = withDevice(deviceLightApi.brightnessDown);
             $ctrl.nightLight = withDevice(deviceLightApi.nightLight);
             $ctrl.fullLight = withDevice(deviceLightApi.fullLight);
             $ctrl.switchOn = withDevice(deviceLightApi.switchOn);
             $ctrl.switchOff = withDevice(deviceLightApi.switchOff);
+            $ctrl.colorWarmer = withDevice(deviceLightApi.colorWarmer);
+            $ctrl.colorColder = withDevice(deviceLightApi.colorColder);
 
             function init() {
                 var maxDimLevel = 100;
@@ -83,6 +85,7 @@ define(['app'], function (app) {
                     $ctrl.device.LevelInt || 0,
                     $ctrl.device.Color,
                     $ctrl.device.SubType,
+                    $ctrl.device.DimmerType,
                     updateColor
                 )
             }
@@ -93,20 +96,16 @@ define(['app'], function (app) {
                 }
             }
 
-            function isBrightnessAvailable() {
-                var ledType = getLEDType($ctrl.device.SubType);
-                var isColorSwitch = $ctrl.device.Type === 'Color Switch';
-
-                return ledType.bHasRGB && $ctrl.device.Unit === 0 && isColorSwitch
+            // returns true if the light does not support absolute dimming, used to control display of Brightness Up / Brightness Down buttons
+            function isRelativeDimmer() {
+                return $ctrl.device.DimmerType && $ctrl.device.DimmerType === "rel";
             }
 
-            function isLightControlAvailable() {
+            // returns true if the light does not support absolute color temperature, used to control display of Warmer White / Colder White buttons
+            function isRelativeColorTemperature() {
                 var ledType = getLEDType($ctrl.device.SubType);
-                var isColorSwitch = $ctrl.device.Type === 'Color Switch';
 
-                return (ledType.bHasRGB === true && $ctrl.device.Unit === 0 && isColorSwitch)
-                    || (ledType.bHasTemperature && isColorSwitch)
-                    || (ledType.bHasWhite && !ledType.bHasTemperature && isColorSwitch)
+                return $ctrl.device.DimmerType && $ctrl.device.DimmerType === "rel" && ledType.bHasTemperature;
             }
 
             function updateColor(deviceIdx, JSONColor, dimlevel) {
@@ -116,29 +115,6 @@ define(['app'], function (app) {
                         $ctrl.device.Color = JSONColor;
                         $ctrl.device.LevelInt = dimlevel;
                     });
-            }
-        }
-    });
-
-    app.component('whitePicker', {
-        templateUrl: 'views/whitePicker.html',
-        bindings: {
-            deviceIdx: '<'
-        },
-        controller: function (deviceLightApi) {
-            var $ctrl = this;
-
-            $ctrl.brightnessUp = withDevice(deviceLightApi.brightnessUp);
-            $ctrl.brightnessDown = withDevice(deviceLightApi.brightnessDown);
-            $ctrl.nighLight = withDevice(deviceLightApi.nighLight);
-            $ctrl.fullLight = withDevice(deviceLightApi.fullLight);
-            $ctrl.colorWarmer = withDevice(deviceLightApi.colorWarmer);
-            $ctrl.colorColder = withDevice(deviceLightApi.colorColder);
-
-            function withDevice(fn) {
-                return function () {
-                    fn($ctrl.deviceIdx);
-                }
             }
         }
     });

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -600,7 +600,7 @@ define(['app'], function (app) {
 										(item.Status.indexOf('Set ') == 0)
 									) {
 										if (isLED(item.SubType)) {
-											img = '<img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="48" width="48">';
+											img = '<img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="48" width="48">';
 										}
 										else {
 											img = '<img src="images/' + item.Image + '48_On.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',RefreshLights,' + item.Protected + ');" class="lcursor" height="48" width="48">';
@@ -608,7 +608,7 @@ define(['app'], function (app) {
 									}
 									else {
 										if (isLED(item.SubType)) {
-											img = '<img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ',\'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="48" width="48">';
+											img = '<img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ',\'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="48" width="48">';
 										}
 										else {
 											img = '<img src="images/' + item.Image + '48_Off.png" title="' + $.t("Turn On") + '" onclick="SwitchLight(' + item.idx + ',\'On\',RefreshLights,' + item.Protected + ');" class="lcursor" height="48" width="48">';
@@ -1192,7 +1192,7 @@ define(['app'], function (app) {
 									(item.Status.indexOf('Disco ') == 0)
 								) {
 									if (isLED(item.SubType)) {
-										xhtm += '\t      <td id="img"><img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="48" width="48"></td>\n';
+										xhtm += '\t      <td id="img"><img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="48" width="48"></td>\n';
 									}
 									else {
 										xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_On.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',\'RefreshLights\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
@@ -1200,7 +1200,7 @@ define(['app'], function (app) {
 								}
 								else {
 									if (isLED(item.SubType)) {
-										xhtm += '\t      <td id="img"><img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\');" class="lcursor" height="48" width="48"></td>\n';
+										xhtm += '\t      <td id="img"><img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', \'RefreshLights\',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="48" width="48"></td>\n';
 									}
 									else {
 										xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_Off.png" title="' + $.t("Turn On") + '" onclick="SwitchLight(' + item.idx + ',\'On\',RefreshLights,' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
@@ -1287,11 +1287,11 @@ define(['app'], function (app) {
 								'\t      <td id="lastupdate">' + item.LastUpdate + '</td>\n' +
 								'\t      <td id="type">' + item.Type + ', ' + item.SubType + ', ' + item.SwitchType;
 							if (item.SwitchType == "Dimmer") {
-								if (isLED(item.SubType)) {
-									//TODO: Why not show dimmer slider for LED type?
+								if (item.DimmerType && item.DimmerType!="abs") {
+									// Don't show dimmer slider if the device does not support absolute dimming
 								}
 								else {
-									xhtm += '<br><br><div style="margin-left:60px;" class="dimslider" id="slider" data-idx="' + item.idx + '" data-type="norm" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
+									xhtm += '<br><br><div style="margin-left:60px;" class="dimslider" id="slider" data-idx="' + item.idx + '" data-type="norm" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '" data-isled="' + isLED(item.SubType) + '"></div>';
 								}
 							}
 							else if (item.SwitchType == "TPI") {
@@ -1473,6 +1473,7 @@ define(['app'], function (app) {
 					clearInterval($.setDimValue);
 					var maxValue = $(this).slider("option", "max");
 					var dtype = $(this).slider("option", "type");
+					var isled = $(this).data('isled');
 					var isProtected = $(this).slider("option", "isprotected");
 					var fPercentage = parseInt((100.0 / maxValue) * ui.value);
 					var idx = $(this).data('idx');
@@ -1501,7 +1502,7 @@ define(['app'], function (app) {
 							img = '<img src="images/' + imgname + 'n.png" title="' + $.t("Turn Off") + '" onclick="SwitchLight(' + idx + ',\'Off\',RefreshLights,' + isProtected + ');" class="lcursor" height="48" width="48">';
 							bigtext = fPercentage + " %";
 						}
-						if ((dtype != "blinds") && (dtype != "blinds_inv")) {
+						if ((dtype != "blinds") && (dtype != "blinds_inv") && !isled) {
 							if ($(id + " #img").html() != img) {
 								$(id + " #img").html(img);
 							}

--- a/www/app/ScenesController.js
+++ b/www/app/ScenesController.js
@@ -458,14 +458,16 @@ define(['app'], function (app) {
 						$("#scenecontent #combolevel").val(level);
 						
 						var SubType = "";
+						var DimmerType = "";
 						$.each($.LightsAndSwitches, function (i, item) {
 							if (item.idx == devidx) {
 								SubType = item.SubType;
+								DimmerType = item.DimmerType;
 							}
 						});
 						var MaxDimLevel = 100; // Always 100 for LED type
 						if (isLED(SubType))
-							ShowRGBWPicker('#scenecontent #ScenesLedColor', devidx, 0, MaxDimLevel, level, data["Color"], SubType);
+							ShowRGBWPicker('#scenecontent #ScenesLedColor', devidx, 0, MaxDimLevel, level, data["Color"], SubType, DimmerType);
 
 						$("#scenecontent #ondelaytime").val(data["OnDelay"]);
 						$("#scenecontent #offdelaytime").val(data["OffDelay"]);
@@ -676,14 +678,16 @@ define(['app'], function (app) {
 				var DeviceIdx = $("#scenecontent #combodevice option:selected").val();
 				if (typeof DeviceIdx != 'undefined') {
 					var SubType = "";
+					var DimmerType = "";
 					$.each($.LightsAndSwitches, function (i, item) {
 						if (item.idx == DeviceIdx) {
 							SubType = item.SubType;
+							DimmerType = item.DimmerType;
 						}
 					});
 					var MaxDimLevel = 100; // Always 100 for LED type
 					if (isLED(SubType))
-						ShowRGBWPicker('#scenecontent #ScenesLedColor', DeviceIdx, 0, MaxDimLevel, 50, "", SubType);
+						ShowRGBWPicker('#scenecontent #ScenesLedColor', DeviceIdx, 0, MaxDimLevel, 50, "", SubType, DimmerType);
 				}
 			});
 			$('#scenecontent #combodevice').keypress(function () {

--- a/www/app/timers/DeviceTimersController.js
+++ b/www/app/timers/DeviceTimersController.js
@@ -19,6 +19,7 @@ define(['app', 'timers/factories', 'timers/components'], function (app) {
                 vm.isLoaded = true;
                 vm.itemName = device.Name;
                 vm.colorSettingsType = device.SubType;
+                vm.dimmerType = device.DimmerType;
 
                 vm.isDimmer = ['Dimmer', 'Blinds Percentage', 'Blinds Percentage Inverted', 'TPI'].includes(device.SwitchType);
                 vm.isSelector = device.SubType === "Selector Switch";

--- a/www/app/timers/components.js
+++ b/www/app/timers/components.js
@@ -156,6 +156,7 @@ define(['app', 'timers/factories'], function (app) {
                         vm.timerSettings.level || 0,
                         vm.timerSettings.color,
                         vm.colorSettingsType,
+                        vm.dimmerType,
                         onColorChange
                     );
                 });

--- a/www/html5.appcache
+++ b/www/html5.appcache
@@ -1,6 +1,6 @@
 CACHE MANIFEST
 
-# ref 1504
+# ref 1506
 
 CACHE:
 # CSS
@@ -484,7 +484,6 @@ app/CustomIconsController.js
 app/DashboardController.js
 app/DeviceLightEdit.js
 app/DevicesController.js
-app/DeviceTimers.js
 app/DPFibaroController.js
 app/DPHttpController.js
 app/DPInfluxController.js

--- a/www/index.html
+++ b/www/index.html
@@ -506,6 +506,22 @@ $(document).ready(function() {
 						<tr>
 							<td align="left" style="width:200px">
 								<input type="text" id="popup_picker"  data-wheelcolorpicker="" data-wcp-layout="block" data-wcp-sliders="wvkl"/>
+								<div class="btn-group">
+									<button id="popup_bright_up" class="btn btn-small" type="button">
+										Brightness Up
+									</button>
+									<button id="popup_bright_down" class="btn btn-small" type="button">
+										Brightness Down
+									</button>
+								</div>
+								<div class="btn-group">
+									<button id="popup_warmer" class="btn btn-small" type="button">
+										Warmer White
+									</button>
+									<button id="popup_colder" class="btn btn-small" type="button">
+										Colder White
+									</button>
+								</div>
 							</td>
 							<td align="left" style="vertical-align: center;">
 								<a id="popup_switch_on"><img src="images/pushon48.png" class="lcursor" height="48" width="48"></a><br>

--- a/www/views/device_light_edit.html
+++ b/www/views/device_light_edit.html
@@ -136,14 +136,6 @@
                     <label for="protected"></label>
                 </td>
             </tr>
-            <tr ng-if="vm.isWhiteSettingsAvailable()">
-                <td>
-                    <label>{{ :: 'Color' | translate}}:</label>
-                </td>
-                <td>
-                    <white-picker device-idx="vm.device.idx"></white-picker>
-                </td>
-            </tr>
             <tr ng-if="vm.isColorSettingsAvailable()">
                 <td>
                     <label>{{ :: 'Color' | translate}}:</label>
@@ -410,7 +402,24 @@
                 </table>
             </td>
             <td align="left" style="vertical-align: top;">
-                <div class="btn-group" ng-show="$ctrl.isBrightnessAvailable()">
+                <div class="btn-group">
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.switchOn()">
+                        {{:: 'On' | translate }}
+                    </button>
+                    <!-- TODO: Domoticz back-end should report if the light implements fulllight -->
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.fullLight()">
+                        {{:: 'Full Light' | translate }}
+                    </button>
+                    <!-- TODO: Domoticz back-end should report if the light implements nightlight -->
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.nightLight()">
+                        {{:: 'Night Light' | translate }}
+                    </button>
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.switchOff()">
+                        {{:: 'Off' | translate }}
+                    </button>
+                </div>
+                <br><br>
+                <div class="btn-group" ng-show="$ctrl.isRelativeDimmer()">
                     <button class="btn btn-small" type="button" ng-click="$ctrl.brightnessUp()">
                         {{:: 'Brightness Up' | translate }}
                     </button>
@@ -419,32 +428,15 @@
                     </button>
                 </div>
                 <br><br>
-                <div class="btn-group" ng-show="$ctrl.isLightControlAvailable()">
-                    <button class="btn btn-small" type="button" ng-click="$ctrl.switchOn()">
-                        {{:: 'On' | translate }}
+                <div class="btn-group" ng-show="$ctrl.isRelativeColorTemperature()">
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.colorWarmer()">
+                        {{:: 'Warmer White' | translate }}
                     </button>
-                    <button class="btn btn-small" type="button" ng-click="$ctrl.fullLight()">
-                        {{:: 'Full Light' | translate }}
-                    </button>
-                    <button class="btn btn-small" type="button" ng-click="$ctrl.nightLight()">
-                        {{:: 'Night Light' | translate }}
-                    </button>
-                    <button class="btn btn-small" type="button" ng-click="$ctrl.switchOff()">
-                        {{:: 'Off' | translate }}
+                    <button class="btn btn-small" type="button" ng-click="$ctrl.colorColder()">
+                        {{:: 'Colder White' | translate }}
                     </button>
                 </div>
             </td>
         </tr>
     </table>
-</script>
-
-<script type="text/ng-template" id="views/whitePicker.html">
-    <button type="button" ng-click="$ctrl.brightnessUp()">{{:: 'Brightness Up' | translate }}</button>
-    <button type="button" ng-click="$ctrl.brightnessUp()">{{:: 'Brightness Down' | translate }}</button>
-    <br/>
-    <button type="button" ng-click="$ctrl.colorWarmer()">{{:: 'Warm White' | translate }}</button>
-    <button type="button" ng-click="$ctrl.colorColder()">{{:: 'Cold White' | translate }}</button>
-    <br/>
-    <button type="button" ng-click="$ctrl.fullLight()">{{:: 'Full Light' | translate }}</button>
-    <button type="button" ng-click="$ctrl.nighLight()">{{:: 'Night Light' | translate }}</button>
 </script>


### PR DESCRIPTION
- Show dimmer slider on dashboard and lights view
- Show "Brightness Up" / "Brightness Down" buttons instead of master level slider for MiLight v4/v5 devices that don't support absolute dimming
- Show "Warmer" / "Colder" buttons instead of color temeperature picker for MiLight v4/v5 devices that don't support absolute setting of color temperature