### PR TITLE
Initialize tm_isdst, it is not always set by localtime_r()

### DIFF
--- a/main/localtime_r.cpp
+++ b/main/localtime_r.cpp
@@ -50,6 +50,7 @@ time_t mytime(time_t * _Time)
 bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string &szSQLdate) {
 	time_t now = mytime(NULL);
 	struct tm ltime;
+	ltime.tm_isdst = -1;
 	if (localtime_r(&now, &ltime) == NULL)
 		return false;
 	return ParseSQLdatetime(time, result, szSQLdate, ltime.tm_isdst);


### PR DESCRIPTION
ltime.tm_isdst is not always set by localtime_r()
-1 means unknown, so should be a better choice than a random value from the stack.

Valgrind complains that ltime.tm_isdst is unitialized when used:
```
==1649== Conditional jump or move depends on uninitialised value(s)
==1649==    at 0x5EB9D02: isdst_differ (mktime.c:185)
==1649==    by 0x5EB9D02: __mktime_internal (mktime.c:501)
==1649==    by 0xAF92B2: ParseSQLdatetime(long&, tm&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int) (localtime_r.cpp:75)
==1649==    by 0xAF907F: ParseSQLdatetime(long&, tm&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (localtime_r.cpp:55)
==1649==    by 0xC85C0F: http::server::CWebServer::GetSession(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (WebServer.cpp:17343)
==1649==    by 0xFF61DD: http::server::cWebemRequestHandler::checkAuthToken(http::server::_tWebEmSession&) (cWebem.cpp:1741)
==1649==    by 0xFF59D5: http::server::cWebemRequestHandler::CheckAuthentication(http::server::_tWebEmSession&, http::server::request const&, http::server::reply&) (cWebem.cpp:1643)
==1649==    by 0xFF7125: http::server::cWebemRequestHandler::handle_request(http::server::request const&, http::server::reply&) (cWebem.cpp:1936)
==1649==    by 0xFDA446: http::server::connection::handle_read(boost::system::error_code const&, unsigned long) (connection.cpp:310)
==1649==    by 0xFE3623: void boost::_mfi::mf2<void, http::server::connection, boost::system::error_code const&, unsigned long>::call<boost::shared_ptr<http::server::connection>, boost::system::error_code const, unsigned long>(boost::shared_ptr<http::server::connection>&, void const*, boost::system::error_code const&, unsigned long&) const (mem_fn_template.hpp:271)
==1649==    by 0xFE1F3C: void boost::_mfi::mf2<void, http::server::connection, boost::system::error_code const&, unsigned long>::operator()<boost::shared_ptr<http::server::connection> >(boost::shared_ptr<http::server::connection>&, boost::system::error_code const&, unsigned long) const (mem_fn_template.hpp:286)
==1649==    by 0xFE0557: void boost::_bi::list3<boost::_bi::value<boost::shared_ptr<http::server::connection> >, boost::arg<1> (*)(), boost::arg<2> (*)()>::operator()<boost::_mfi::mf2<void, http::server::connection, boost::system::error_code const&, unsigned long>, boost::_bi::list2<boost::system::error_code const&, unsigned long const&> >(boost::_bi::type<void>, boost::_mfi::mf2<void, http::server::connection, boost::system::error_code const&, unsigned long>&, boost::_bi::list2<boost::system::error_code const&, unsigned long const&>&, int) (bind.hpp:392)
==1649==    by 0xFDF578: void boost::_bi::bind_t<void, boost::_mfi::mf2<void, http::server::connection, boost::system::error_code const&, unsigned long>, boost::_bi::list3<boost::_bi::value<boost::shared_ptr<http::server::connection> >, boost::arg<1> (*)(), boost::arg<2> (*)()> >::operator()<boost::system::error_code, unsigned long>(boost::system::error_code const&, unsigned long const&) (bind_template.hpp:102)
==1649==  Uninitialised value was created by a stack allocation
==1649==    at 0xAF9038: ParseSQLdatetime(long&, tm&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (localtime_r.cpp:50)
```