### PR TITLE
fix authentication issue with clients directly accessing json.htm

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1149,9 +1149,20 @@ int cWebemRequestHandler::authorize(WebEmSession & session, const request& req, 
 		{
 			return 0;
 		}
-		size_t ulen=strlen("username=");
-		std::string tmpuname=req.uri.substr(uPos+ulen,pPos-uPos-ulen-1);
-		std::string tmpupass=req.uri.substr(pPos+strlen("username="));
+		uPos += 9; //strlen("username=")
+		pPos += 9; //strlen("password=")
+		size_t uEnd = req.uri.find("&", uPos);
+		size_t pEnd = req.uri.find("&", pPos);
+		std::string tmpuname;
+		std::string tmpupass;
+		if (uEnd == std::string::npos)
+			tmpuname = req.uri.substr(uPos);
+		else
+			tmpuname = req.uri.substr(uPos, uEnd-uPos);
+		if (pEnd == std::string::npos)
+			tmpupass = req.uri.substr(pPos);
+		else
+			tmpupass = req.uri.substr(pPos, pEnd-pPos);
 		if (request_handler::url_decode(tmpuname,uname))
 		{
 			if (request_handler::url_decode(tmpupass,upass))

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1885,7 +1885,6 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	session.isnew = false;
 	session.forcelogin = false;
 	session.rememberme = false;
-	session.username="";
 
 	rep.bIsGZIP = false;
 

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1874,6 +1874,7 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	session.isnew = false;
 	session.forcelogin = false;
 	session.rememberme = false;
+	session.username="";
 
 	rep.bIsGZIP = false;
 
@@ -2113,7 +2114,7 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	// Set timeout to make session in use
 	session.timeout = mytime(NULL) + SHORT_SESSION_TIMEOUT;
 
-	if ((session.isnew == true) && (session.rights == 2) && (req.uri.find("json.htm") != std::string::npos))
+	if ((session.isnew == true) && (session.rights == 2) && session.username.empty() && (req.uri.find("json.htm") != std::string::npos))
 	{
 		// client is possibly a script that does not send cookies - see if we have the IP address registered as a session ID
 		WebEmSession* memSession = myWebem->GetSession(session.remote_host);

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2125,7 +2125,11 @@ void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 	// Set timeout to make session in use
 	session.timeout = mytime(NULL) + SHORT_SESSION_TIMEOUT;
 
-	if ((session.isnew == true) && (session.rights == 2) && session.username.empty() && (req.uri.find("json.htm") != std::string::npos))
+	if ((session.isnew == true) &&
+	    (session.rights == 2) && 
+	    (req.uri.find("json.htm") != std::string::npos) &&
+	    (req.uri.find("logincheck") == std::string::npos)
+	)
 	{
 		// client is possibly a script that does not send cookies - see if we have the IP address registered as a session ID
 		WebEmSession* memSession = myWebem->GetSession(session.remote_host);


### PR DESCRIPTION
Clients gaining admin rights through a direct call to json.htm may never receive a session cookie if another client or script is using the same IP address