### PR TITLE
Harmony Hub: use receive size from socket operation to copy the correct number of bytes to our resultstring

### DIFF
--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -64,6 +64,11 @@ History:
 #define DATABUFFER_SIZE  READBUFFER_SIZE + 1
 
 
+// socket timeout values
+#define TIMEOUT_WAIT_FOR_ANSWER 2.0f
+#define TIMEOUT_WAIT_FOR_NEXT_FRAME 0.4f
+
+
 
 CHarmonyHub::CHarmonyHub(const int ID, const std::string &IPAddress, const unsigned int port):
 m_harmonyAddress(IPAddress)
@@ -252,7 +257,7 @@ void CHarmonyHub::Do_Work()
 				if (m_commandcsocket->read(databuffer, READBUFFER_SIZE, false) > 0)
 				{
 					strData.append(databuffer);
-					m_commandcsocket->canRead(&bIsDataReadable, 0.4f);
+					m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_NEXT_FRAME);
 				}
 				else
 					bIsDataReadable = false;
@@ -503,7 +508,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	communicationcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
 	std::string strData;
 	bool bIsDataReadable = true;
-	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
+	communicationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	if (bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
@@ -527,7 +532,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	strAuth.append("</auth>");
 	communicationcsocket->write(strAuth.c_str(), static_cast<unsigned int>(strAuth.length()));
 
-	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
+	communicationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	if (bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
@@ -545,7 +550,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	//strReq = "<stream:stream to='connect.logitech.com' xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:client' xml:lang='en' version='1.0'>";
 	communicationcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
 
-	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
+	communicationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	if (bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
@@ -583,7 +588,7 @@ bool CHarmonyHub::GetAuthorizationToken(csocket* authorizationcsocket)
 	authorizationcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
 
 	bool bIsDataReadable = true;
-	authorizationcsocket->canRead(&bIsDataReadable, 2.0f);
+	authorizationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	if (bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
@@ -598,14 +603,14 @@ bool CHarmonyHub::GetAuthorizationToken(csocket* authorizationcsocket)
 		return false;
 	}
 
-	authorizationcsocket->canRead(&bIsDataReadable, 2.0f);
+	authorizationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	while(bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
 		if (authorizationcsocket->read(databuffer, READBUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
-			authorizationcsocket->canRead(&bIsDataReadable, 0.4f);
+			authorizationcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_NEXT_FRAME);
 		}
 		else
 			bIsDataReadable = false;
@@ -652,14 +657,14 @@ bool CHarmonyHub::SendPing()
 	m_commandcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
 
 	bool bIsDataReadable = true;
-	m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
+	m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	while (bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
 		if (m_commandcsocket->read(databuffer, READBUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
-			m_commandcsocket->canRead(&bIsDataReadable, 0.4f);
+			m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_NEXT_FRAME);
 		}
 		else
 			bIsDataReadable = false;
@@ -746,14 +751,14 @@ bool CHarmonyHub::SubmitCommand(const std::string &strCommand, const std::string
 
 	char databuffer[DATABUFFER_SIZE];
 	bool bIsDataReadable = true;
-	m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
+	m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 	while(bIsDataReadable)
 	{
 		memset(databuffer, 0, DATABUFFER_SIZE);
 		if (m_commandcsocket->read(databuffer, READBUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
-			m_commandcsocket->canRead(&bIsDataReadable, 0.4f);
+			m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_NEXT_FRAME);
 		}
 		else
 			bIsDataReadable = false;
@@ -787,14 +792,14 @@ bool CHarmonyHub::SubmitCommand(const std::string &strCommand, const std::string
 	}
 	else if (strCommand == GET_CONFIG_COMMAND)
 	{
-		m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
+		m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_ANSWER);
 		while(bIsDataReadable)
 		{
 			memset(databuffer, 0, DATABUFFER_SIZE);
 			if (m_commandcsocket->read(databuffer, READBUFFER_SIZE, false) > 0)
 			{
 				strData.append(databuffer);
-				m_commandcsocket->canRead(&bIsDataReadable, 0.4f);
+				m_commandcsocket->canRead(&bIsDataReadable, TIMEOUT_WAIT_FOR_NEXT_FRAME);
 			}
 			else
 				bIsDataReadable = false;

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -233,10 +233,10 @@ void CHarmonyHub::Do_Work()
 
 			boost::lock_guard<boost::mutex> lock(m_mutex);
 			std::string strData;
-			char databuffer[BUFFER_SIZE];
+			char databuffer[BUFFER_SIZE + 1];
 			while (bIsDataReadable)
 			{
-				memset(databuffer, 0, BUFFER_SIZE);
+				memset(databuffer, 0, BUFFER_SIZE + 1);
 				if (m_commandcsocket->read(databuffer, BUFFER_SIZE, false) > 0)
 				{
 					strData.append(databuffer);
@@ -485,7 +485,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	if (communicationcsocket == NULL || strUserName.length() == 0 || strPassword.length() == 0)
 		return false;
 
-	char databuffer[BUFFER_SIZE];
+	char databuffer[BUFFER_SIZE + 1];
 	// Start communication
 	std::string strReq = "<stream:stream to='connect.logitech.com' xmlns:stream='http://etherx.jabber.org/streams' xmlns='jabber:client' xml:lang='en' version='1.0'>";
 	communicationcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
@@ -494,7 +494,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
 	if (bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		communicationcsocket->read(databuffer, BUFFER_SIZE, false);
 		strData = databuffer;
 		/* <- Expect: <?xml version='1.0' encoding='iso-8859-1'?><stream:stream from='' id='XXXXXXXX' version='1.0' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'><stream:features><mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'><mechanism>PLAIN</mechanism></mechanisms></stream:features> */
@@ -518,7 +518,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
 	if (bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		communicationcsocket->read(databuffer, BUFFER_SIZE, false);
 		strData = databuffer;
 		/* <- Expect: <success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/> */
@@ -536,7 +536,7 @@ bool CHarmonyHub::StartCommunication(csocket* communicationcsocket, const std::s
 	communicationcsocket->canRead(&bIsDataReadable, 2.0f);
 	if (bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		communicationcsocket->read(databuffer, BUFFER_SIZE, false);
 		strData = databuffer;
 		/* <- Expect: <stream:stream from='connect.logitech.com' id='XXXXXXXX' version='1.0' xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'><stream:features><bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/><session xmlns='urn:ietf:params:xml:nx:xmpp-session'/></stream:features> */
@@ -561,7 +561,7 @@ bool CHarmonyHub::GetAuthorizationToken(csocket* authorizationcsocket)
 
 	std::string strData;
 	std::string strReq;
-	char databuffer[BUFFER_SIZE];
+	char databuffer[BUFFER_SIZE + 1];
 
 	strReq = "<iq type=\"get\" id=\"";
 	strReq.append(CONNECTION_ID);
@@ -574,7 +574,7 @@ bool CHarmonyHub::GetAuthorizationToken(csocket* authorizationcsocket)
 	authorizationcsocket->canRead(&bIsDataReadable, 2.0f);
 	if (bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		authorizationcsocket->read(databuffer, BUFFER_SIZE, false);
 		strData = databuffer;
 		/* <- Expect: <iq/> */
@@ -589,7 +589,7 @@ bool CHarmonyHub::GetAuthorizationToken(csocket* authorizationcsocket)
 	authorizationcsocket->canRead(&bIsDataReadable, 2.0f);
 	while(bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		if (authorizationcsocket->read(databuffer, BUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
@@ -628,7 +628,7 @@ bool CHarmonyHub::SendPing()
 
 	std::string strData = "";
 	std::string strReq;
-	char databuffer[BUFFER_SIZE];
+	char databuffer[BUFFER_SIZE + 1];
 
 	// GENERATE A PING REQUEST USING THE HARMONY ID AND LOGIN AUTHORIZATION TOKEN 
 	strReq = "<iq type=\"get\" id=\"";
@@ -643,7 +643,7 @@ bool CHarmonyHub::SendPing()
 	m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
 	while (bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		if (m_commandcsocket->read(databuffer, BUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
@@ -732,12 +732,12 @@ bool CHarmonyHub::SubmitCommand(const std::string &strCommand, const std::string
 
 	m_commandcsocket->write(strReq.c_str(), static_cast<unsigned int>(strReq.length()));
 
-	char databuffer[BUFFER_SIZE];
+	char databuffer[BUFFER_SIZE + 1];
 	bool bIsDataReadable = true;
 	m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
 	while(bIsDataReadable)
 	{
-		memset(databuffer, 0, BUFFER_SIZE);
+		memset(databuffer, 0, BUFFER_SIZE + 1);
 		if (m_commandcsocket->read(databuffer, BUFFER_SIZE, false) > 0)
 		{
 			strData.append(databuffer);
@@ -778,7 +778,7 @@ bool CHarmonyHub::SubmitCommand(const std::string &strCommand, const std::string
 		m_commandcsocket->canRead(&bIsDataReadable, 2.0f);
 		while(bIsDataReadable)
 		{
-			memset(databuffer, 0, BUFFER_SIZE);
+			memset(databuffer, 0, BUFFER_SIZE + 1);
 			if (m_commandcsocket->read(databuffer, BUFFER_SIZE, false) > 0)
 			{
 				strData.append(databuffer);

--- a/hardware/HarmonyHub.h
+++ b/hardware/HarmonyHub.h
@@ -102,6 +102,8 @@ private:
 	bool SendPing();
 	bool CheckIqGood(const std::string& strData);
 
+	bool ReceiveMessage(csocket* communicationcsocket, std::string &strMessage, float waitTimePrimary, float waitTimeSecondary, bool append);
+
 
 	//bool ParseAction(const std::string& strAction, std::vector<Action>& vecDeviceActions, const std::string& strDeviceID);
 	//bool ParseFunction(const std::string& strFunction, std::vector<Function>& vecDeviceFunctions, const std::string& strDeviceID);

--- a/hardware/HarmonyHub.h
+++ b/hardware/HarmonyHub.h
@@ -4,13 +4,6 @@
 #include <iosfwd>
 #include "hardwaretypes.h"
 
-// Note:
-// HarmonyHub is on Wifi and can thus send frames with a maximum payload length of 2324 bytes
-// Normal implementations will however obey the 1500 bytes MTU from the wired networks that
-// they are attached to and this may be limited even further if the router uses mechanisms like
-// PPTP for connecting the (Wireless) LAN to the internet.
-#define BUFFER_SIZE	 1500
-
 class csocket;
 
 class Action
@@ -125,7 +118,6 @@ private:
 	bool m_bIsChangingActivity;
 	std::string m_hubSwVersion;
 	boost::shared_ptr<boost::thread> m_thread;
-//	char m_databuffer[BUFFER_SIZE];
 	std::string m_szResultString;
 	bool m_bShowConnectError;
 	std::map< std::string, std::string> m_mapActivities;


### PR DESCRIPTION
using the smaller data buffer for socket operations there is a chance that it may be filled all the way to the last character and we cannot use its content as a string.