### PR TITLE
Prevent plugin start / stop races

### DIFF
--- a/hardware/plugins/PluginMessages.h
+++ b/hardware/plugins/PluginMessages.h
@@ -337,37 +337,43 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 	// Base directive message class
 	class CDirectiveBase : public CPluginMessageBase
 	{
+	protected:
+		virtual void ProcessLocked() = 0;
 	public:
 		CDirectiveBase(CPlugin* pPlugin) : CPluginMessageBase(pPlugin) {};
-		virtual void Process() { throw "Base directive class Handle called"; };
+		virtual void Process() {
+			boost::lock_guard<boost::mutex> l(PythonMutex);
+			m_pPlugin->RestoreThread();
+			ProcessLocked();
+		};
 	};
 
 	class ProtocolDirective : public CDirectiveBase, public CHasConnection
 	{
 	public:
 		ProtocolDirective(CPlugin* pPlugin, PyObject* Connection) : CDirectiveBase(pPlugin), CHasConnection(Connection) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->ConnectionProtocol(this); };
+		virtual void ProcessLocked() { m_pPlugin->ConnectionProtocol(this); };
 	};
 
 	class ConnectDirective : public CDirectiveBase, public CHasConnection
 	{
 	public:
 		ConnectDirective(CPlugin* pPlugin, PyObject* Connection) : CDirectiveBase(pPlugin), CHasConnection(Connection) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->ConnectionConnect(this); };
+		virtual void ProcessLocked() { m_pPlugin->ConnectionConnect(this); };
 	};
 
 	class ListenDirective : public CDirectiveBase, public CHasConnection
 	{
 	public:
 		ListenDirective(CPlugin* pPlugin, PyObject* Connection) : CDirectiveBase(pPlugin), CHasConnection(Connection) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->ConnectionListen(this); };
+		virtual void ProcessLocked() { m_pPlugin->ConnectionListen(this); };
 	};
 
 	class DisconnectDirective : public CDirectiveBase, public CHasConnection
 	{
 	public:
 		DisconnectDirective(CPlugin* pPlugin, PyObject* Connection) : CDirectiveBase(pPlugin), CHasConnection(Connection) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->ConnectionDisconnect(this); };
+		virtual void ProcessLocked() { m_pPlugin->ConnectionDisconnect(this); };
 	};
 
 	class WriteDirective : public CDirectiveBase, public CHasConnection
@@ -388,14 +394,14 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 				Py_DECREF(m_Object);
 		}
 
-		virtual void Process() { m_pPlugin->ConnectionWrite(this); };
+		virtual void ProcessLocked() { m_pPlugin->ConnectionWrite(this); };
 	};
 
 	class SettingsDirective : public CDirectiveBase
 	{
 	public:
 		SettingsDirective(CPlugin* pPlugin) : CDirectiveBase(pPlugin) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->LoadSettings(); };
+		virtual void ProcessLocked() { m_pPlugin->LoadSettings(); };
 	};
 
 	class PollIntervalDirective : public CDirectiveBase
@@ -403,7 +409,7 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 	public:
 		PollIntervalDirective(CPlugin* pPlugin, const int PollInterval) : CDirectiveBase(pPlugin), m_Interval(PollInterval) { m_Name = __func__; };
 		int						m_Interval;
-		virtual void Process() {m_pPlugin->PollInterval(m_Interval); };
+		virtual void ProcessLocked() {m_pPlugin->PollInterval(m_Interval); };
 	};
 
 	class NotifierDirective : public CDirectiveBase
@@ -411,15 +417,22 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 	public:
 		NotifierDirective(CPlugin* pPlugin, const char* Name) : CDirectiveBase(pPlugin), m_NotifierName(Name) { m_Name = __func__; };
 		std::string		m_NotifierName;
-		virtual void Process() { m_pPlugin->Notifier(m_NotifierName); };
+		virtual void ProcessLocked() { m_pPlugin->Notifier(m_NotifierName); };
 	};
 
 	// Base event message class
 	class CEventBase : public CPluginMessageBase
 	{
+	protected:
+		virtual void ProcessLocked() = 0;
 	public:
 		CEventBase(CPlugin* pPlugin) : CPluginMessageBase(pPlugin) {};
-		virtual void Process() { throw "Base event class Handle called"; };
+		virtual void Process()
+		{
+			boost::lock_guard<boost::mutex> l(PythonMutex);
+			m_pPlugin->RestoreThread();
+			ProcessLocked();
+		}
 	};
 
 	class ReadEvent : public CEventBase, public CHasConnection
@@ -434,7 +447,7 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 		};
 		std::vector<byte>		m_Buffer;
 		int						m_ElapsedMs;
-		virtual void Process()
+		virtual void ProcessLocked()
 		{
 			m_pPlugin->WriteDebugBuffer(m_Buffer, true);
 			m_pPlugin->ConnectionRead(this);
@@ -446,7 +459,7 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 	public:
 		DisconnectedEvent(CPlugin* pPlugin, PyObject* Connection) : CEventBase(pPlugin), CHasConnection(Connection), bNotifyPlugin(true) { m_Name = __func__; };
 		DisconnectedEvent(CPlugin* pPlugin, PyObject* Connection, bool NotifyPlugin) : CEventBase(pPlugin), CHasConnection(Connection), bNotifyPlugin(NotifyPlugin) { m_Name = __func__; };
-		virtual void Process() { m_pPlugin->DisconnectEvent(this); };
+		virtual void ProcessLocked() { m_pPlugin->DisconnectEvent(this); };
 		bool	bNotifyPlugin;
 	};
 }

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -265,29 +265,29 @@ namespace Plugins {
 		}
 	}
 
-#define ADD_BYTES_TO_DICT(pDict, key, value)	\
-		{	\
-			PyObject*	pObj = Py_BuildValue("y#", value.c_str(), value.length());	\
-			if (PyDict_SetItemString(pDict, key, pObj) == -1)	\
-				_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", __func__, key, value.c_str());	\
-			Py_DECREF(pObj);	\
-		}
+static void AddBytesToDict(PyObject* pDict, const char* key, const std::string &value)
+{
+	PyObject*	pObj = Py_BuildValue("y#", value.c_str(), value.length());
+	if (PyDict_SetItemString(pDict, key, pObj) == -1)
+		_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", __func__, key, value.c_str());
+	Py_DECREF(pObj);
+}
 
-#define ADD_STRING_TO_DICT(pDict, key, value)	\
-		{	\
-			PyObject*	pObj = Py_BuildValue("s#", value.c_str(), value.length());	\
-			if (PyDict_SetItemString(pDict, key, pObj) == -1)	\
-				_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", __func__, key, value.c_str());	\
-			Py_DECREF(pObj);	\
-		}
+static void AddStringToDict(PyObject* pDict, const char* key, const std::string &value)
+{
+	PyObject*	pObj = Py_BuildValue("s#", value.c_str(), value.length());
+	if (PyDict_SetItemString(pDict, key, pObj) == -1)
+		_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", __func__, key, value.c_str());
+	Py_DECREF(pObj);
+}
 
-#define ADD_INT_TO_DICT(pDict, key, value)	\
-		{	\
-			PyObject*	pObj = Py_BuildValue("i", value);	\
-			if (PyDict_SetItemString(pDict, key, pObj) == -1)	\
-				_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%d' to dictionary.", __func__, key, value);	\
-			Py_DECREF(pObj);	\
-		}
+static void AddIntToDict(PyObject* pDict, const char* key, const int value)
+{
+	PyObject*	pObj = Py_BuildValue("i", value);
+	if (PyDict_SetItemString(pDict, key, pObj) == -1)
+		_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%d' to dictionary.", __func__, key, value);
+	Py_DECREF(pObj);
+}
 
 	void CPluginProtocolHTTP::ProcessInbound(const ReadEvent* Message)
 	{
@@ -902,47 +902,47 @@ namespace Plugins {
 			{
 			case MQTT_CONNACK:
 			{
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("CONNACK"));
+				AddStringToDict(pMqttDict, "Verb", std::string("CONNACK"));
 				if (iRemainingLength == 2) // check length is correct
 				{
 					switch (*it++)
 					{
 					case 0:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Accepted"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Accepted"));
 						break;
 					case 1:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Refused, unacceptable protocol version"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Refused, unacceptable protocol version"));
 						break;
 					case 2:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Refused, identifier rejected"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Refused, identifier rejected"));
 						break;
 					case 3:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Refused, Server unavailable"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Refused, Server unavailable"));
 						break;
 					case 4:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Refused, bad user name or password"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Refused, bad user name or password"));
 						break;
 					case 5:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Connection Refused, not authorized"));
+						AddStringToDict(pMqttDict, "Description", std::string("Connection Refused, not authorized"));
 						break;
 					default:
-						ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Unknown status returned"));
+						AddStringToDict(pMqttDict, "Description", std::string("Unknown status returned"));
 						break;
 					}
-					ADD_INT_TO_DICT(pMqttDict, "Status", *it++);
+					AddIntToDict(pMqttDict, "Status", *it++);
 				}
 				else
 				{
-					ADD_INT_TO_DICT(pMqttDict, "Status", -1);
-					ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Invalid message length"));
+					AddIntToDict(pMqttDict, "Status", -1);
+					AddStringToDict(pMqttDict, "Description", std::string("Invalid message length"));
 				}
 				break;
 			}
 			case MQTT_SUBACK:
 			{
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("SUBACK"));
+				AddStringToDict(pMqttDict, "Verb", std::string("SUBACK"));
 				iPacketIdentifier = (*it++ << 8) + *it++;
-				ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+				AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 
 				if (iRemainingLength >= 3) // check length is acceptable
 				{
@@ -958,23 +958,23 @@ namespace Plugins {
 					{
 						PyObject*	pResponseDict = PyDict_New();
 						byte Status = *it++;
-						ADD_INT_TO_DICT(pResponseDict, "Status", Status);
+						AddIntToDict(pResponseDict, "Status", Status);
 						switch (Status)
 						{
 						case 0x00:
-							ADD_STRING_TO_DICT(pResponseDict, "Description", std::string("Success - Maximum QoS 0"));
+							AddStringToDict(pResponseDict, "Description", std::string("Success - Maximum QoS 0"));
 							break;
 						case 0x01:
-							ADD_STRING_TO_DICT(pResponseDict, "Description", std::string("Success - Maximum QoS 1"));
+							AddStringToDict(pResponseDict, "Description", std::string("Success - Maximum QoS 1"));
 							break;
 						case 0x02:
-							ADD_STRING_TO_DICT(pResponseDict, "Description", std::string("Success - Maximum QoS 2"));
+							AddStringToDict(pResponseDict, "Description", std::string("Success - Maximum QoS 2"));
 							break;
 						case 0x80:
-							ADD_STRING_TO_DICT(pResponseDict, "Description", std::string("Failure"));
+							AddStringToDict(pResponseDict, "Description", std::string("Failure"));
 							break;
 						default:
-							ADD_STRING_TO_DICT(pResponseDict, "Description", std::string("Unknown status returned"));
+							AddStringToDict(pResponseDict, "Description", std::string("Unknown status returned"));
 							break;
 						}
 						PyList_Append(pResponsesList, pResponseDict);
@@ -983,69 +983,69 @@ namespace Plugins {
 				}
 				else
 				{
-					ADD_INT_TO_DICT(pMqttDict, "Status", -1);
-					ADD_STRING_TO_DICT(pMqttDict, "Description", std::string("Invalid message length"));
+					AddIntToDict(pMqttDict, "Status", -1);
+					AddStringToDict(pMqttDict, "Description", std::string("Invalid message length"));
 				}
 				break;
 			}
 			case MQTT_PUBACK:
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("PUBACK"));
+				AddStringToDict(pMqttDict, "Verb", std::string("PUBACK"));
 				if (iRemainingLength == 2)
 				{
 					iPacketIdentifier = (*it++ << 8) + *it++;
-					ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+					AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 				}
 				break;
 			case MQTT_PUBREC:
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("PUBREC"));
+				AddStringToDict(pMqttDict, "Verb", std::string("PUBREC"));
 				if (iRemainingLength == 2)
 				{
 					iPacketIdentifier = (*it++ << 8) + *it++;
-					ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+					AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 				}
 				break;
 			case MQTT_PUBCOMP:
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("PUBCOMP"));
+				AddStringToDict(pMqttDict, "Verb", std::string("PUBCOMP"));
 				if (iRemainingLength == 2)
 				{
 					iPacketIdentifier = (*it++ << 8) + *it++;
-					ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+					AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 				}
 				break;
 			case MQTT_PUBLISH:
 			{
 				// Fixed Header
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("PUBLISH"));
-				ADD_INT_TO_DICT(pMqttDict, "DUP", ((header & 0x08) >> 3));
+				AddStringToDict(pMqttDict, "Verb", std::string("PUBLISH"));
+				AddIntToDict(pMqttDict, "DUP", ((header & 0x08) >> 3));
 				long	iQoS = (header & 0x06) >> 1;
-				ADD_INT_TO_DICT(pMqttDict, "QoS", (int) iQoS);
+				AddIntToDict(pMqttDict, "QoS", (int) iQoS);
 				PyDict_SetItemString(pMqttDict, "Retain", PyBool_FromLong(header & 0x01));
 				// Variable Header
 				int		topicLen = (*it++ << 8) + *it++;
 				std::string	sTopic((char const*)&*it, topicLen);
-				ADD_STRING_TO_DICT(pMqttDict, "Topic", sTopic);
+				AddStringToDict(pMqttDict, "Topic", sTopic);
 				it += topicLen;
 				if (iQoS)
 				{
 					iPacketIdentifier = (*it++ << 8) + *it++;
-					ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+					AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 				}
 				// Payload
 				const char*	pPayload = (it==pktend)?0:(const char*)&*it;
 				std::string	sPayload(pPayload, std::distance(it, pktend));
-				ADD_BYTES_TO_DICT(pMqttDict, "Payload", sPayload);
+				AddBytesToDict(pMqttDict, "Payload", sPayload);
 				break;
 			}
 			case MQTT_UNSUBACK:
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("UNSUBACK"));
+				AddStringToDict(pMqttDict, "Verb", std::string("UNSUBACK"));
 				if (iRemainingLength == 2)
 				{
 					iPacketIdentifier = (*it++ << 8) + *it++;
-					ADD_INT_TO_DICT(pMqttDict, "PacketIdentifier", iPacketIdentifier);
+					AddIntToDict(pMqttDict, "PacketIdentifier", iPacketIdentifier);
 				}
 				break;
 			case MQTT_PINGRESP:
-				ADD_STRING_TO_DICT(pMqttDict, "Verb", std::string("PINGRESP"));
+				AddStringToDict(pMqttDict, "Verb", std::string("PINGRESP"));
 				break;
 			default:
 				_log.Log(LOG_ERROR, "(%s) MQTT response invalid '%d' is unknown.", __func__, bResponseType);

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -408,13 +408,11 @@ namespace Plugins {
 		Name = sName;
 		m_bIsStarted = false;
 		m_bIsStarting = false;
-		_log.Log(LOG_STATUS, "(%s) CPlugin::CPlugin()", Name.c_str());
 	}
 
 	CPlugin::~CPlugin(void)
 	{
 		m_bIsStarted = false;
-		_log.Log(LOG_STATUS, "(%s) CPlugin::~CPlugin()", Name.c_str());
 	}
 
 	void CPlugin::LogPythonException()
@@ -657,7 +655,6 @@ namespace Plugins {
 
 	bool CPlugin::StartHardware()
 	{
-		_log.Log(LOG_STATUS, "(%s) enter CPlugin::StartHardware", Name.c_str());
 		if (m_bIsStarted) StopHardware();
 
 		//	Add start command to message queue
@@ -666,7 +663,6 @@ namespace Plugins {
 
 		_log.Log(LOG_STATUS, "(%s) Started.", Name.c_str());
 
-		_log.Log(LOG_STATUS, "(%s) leave CPlugin::StartHardware", Name.c_str());
 		return true;
 	}
 
@@ -702,7 +698,6 @@ namespace Plugins {
 
 	bool CPlugin::StopHardware()
 	{
-		_log.Log(LOG_STATUS, "(%s) enter CPlugin::StopHardware", Name.c_str());
 		try
 		{
 			_log.Log(LOG_STATUS, "(%s) Stop directive received.", Name.c_str());
@@ -711,13 +706,13 @@ namespace Plugins {
 			while (m_bIsStarting)
 			{
 				int scounter = 0;
-				while (m_bIsStarting && (scounter++ < 600))
+				while (m_bIsStarting && (scounter++ < 300))
 				{
 					sleep_milliseconds(100);
 				}
 				if (m_bIsStarting)
 				{
-					_log.Log(LOG_ERROR, "(%s) Plugin did not finish start after 60 seconds", Name.c_str());
+					_log.Log(LOG_ERROR, "(%s) Plugin did not finish start after 30 seconds", Name.c_str());
 				}
 			}
 
@@ -778,7 +773,6 @@ namespace Plugins {
 		}
 
 		_log.Log(LOG_STATUS, "(%s) Stopped.", Name.c_str());
-		_log.Log(LOG_STATUS, "(%s) leave CPlugin::StopHardware", Name.c_str());
 
 		return true;
 	}

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -626,7 +626,8 @@ namespace Plugins {
 
 	void CPlugin::Notifier(std::string Notifier)
 	{
-		delete m_Notifier;
+		if (m_Notifier)
+			delete m_Notifier;
 		if (m_bDebug & PDM_PLUGIN) _log.Log(LOG_NORM, "(%s) Notifier Name set to: %s.", Name.c_str(), Notifier.c_str());
 		m_Notifier = new CPluginNotifier(this, Notifier);
 	}
@@ -764,8 +765,11 @@ namespace Plugins {
 				m_thread.reset();
 			}
 
-			delete m_Notifier;
-			m_Notifier = NULL;
+			if (m_Notifier)
+			{
+				delete m_Notifier;
+				m_Notifier = NULL;
+			}
 		}
 		catch (...)
 		{
@@ -1092,8 +1096,11 @@ Error:
 	{
 		ProtocolDirective*	pMessage = (ProtocolDirective*)pMess;
 		CConnection*		pConnection = (CConnection*)pMessage->m_pConnection;
-		delete pConnection->pProtocol;
-		pConnection->pProtocol = NULL;
+		if (m_Notifier)
+		{
+			delete pConnection->pProtocol;
+			pConnection->pProtocol = NULL;
+		}
 		std::string	sProtocol = PyUnicode_AsUTF8(pConnection->Protocol);
 		pConnection->pProtocol = CPluginProtocol::Create(sProtocol, m_Username, m_Password);
 		if (m_bDebug & PDM_CONNECTION) _log.Log(LOG_NORM, "(%s) Protocol set to: '%s'.", Name.c_str(), sProtocol.c_str());

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -830,7 +830,7 @@ namespace Plugins {
 
 		try
 		{
-			m_PyInterpreter = Py_NewInterpreter(); //TODO: Possible memory leak here according to valgrind
+			m_PyInterpreter = Py_NewInterpreter();
 			if (!m_PyInterpreter)
 			{
 				_log.Log(LOG_ERROR, "(%s) failed to create interpreter.", m_PluginKey.c_str());
@@ -864,7 +864,7 @@ namespace Plugins {
 
 			try
 			{
-				m_PyModule = PyImport_ImportModule("plugin"); //TODO: Possible memory leak here according to valgrind
+				m_PyModule = PyImport_ImportModule("plugin");
 				if (!m_PyModule)
 				{
 					_log.Log(LOG_ERROR, "(%s) failed to load 'plugin.py', Python Path used was '%S'.", m_PluginKey.c_str(), sPath.c_str());
@@ -1134,7 +1134,7 @@ Error:
 			if ((sTransport == "TLS/IP") || pConnection->pProtocol->Secure())
 				pConnection->pTransport = (CPluginTransport*) new CPluginTransportTCPSecure(m_HwdID, (PyObject*)pConnection, sAddress, sPort);
 			else
-				pConnection->pTransport = (CPluginTransport*) new CPluginTransportTCP(m_HwdID, (PyObject*)pConnection, sAddress, sPort); //TODO: Possible memory leak here according to valgrind
+				pConnection->pTransport = (CPluginTransport*) new CPluginTransportTCP(m_HwdID, (PyObject*)pConnection, sAddress, sPort);
 		}
 		else if (sTransport == "Serial")
 		{
@@ -1446,6 +1446,11 @@ Error:
 		}
 	}
 
+	void CPlugin::RestoreThread()
+	{
+		if (m_PyInterpreter) PyEval_RestoreThread((PyThreadState*)m_PyInterpreter);
+	}
+
 	void CPlugin::Callback(std::string sHandler, void * pParams)
 	{
 		try
@@ -1460,7 +1465,7 @@ Error:
 					if (m_bDebug & PDM_QUEUE) _log.Log(LOG_NORM, "(%s) Calling message handler '%s'.", Name.c_str(), sHandler.c_str());
 
 					PyErr_Clear();
-					PyObject*	pReturnValue = PyObject_CallObject(pFunc, (PyObject*)pParams); //TODO: Possible memory leak here according to valgrind
+					PyObject*	pReturnValue = PyObject_CallObject(pFunc, (PyObject*)pParams);
 					if (!pReturnValue)
 					{
 						LogPythonException(sHandler);

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -77,6 +77,7 @@ namespace Plugins {
 		void	ConnectionDisconnect(CDirectiveBase*);
 		void	DisconnectEvent(CEventBase*);
 		void	Callback(std::string sHandler, void* pParams);
+		void	RestoreThread();
 		void	Stop();
 
 		void	WriteDebugBuffer(const std::vector<byte>& Buffer, bool Incoming);

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -51,6 +51,7 @@ namespace Plugins {
 		bool StartHardware();
 		void Do_Work();
 		bool StopHardware();
+		void ClearMessageQueue();
 
 		void LogPythonException();
 		void LogPythonException(const std::string &);
@@ -104,6 +105,7 @@ namespace Plugins {
 		std::string			m_HomeFolder;
 		PluginDebugMask		m_bDebug;
 		bool				m_stoprequested;
+		bool				m_bIsStarting;
 	};
 
 	class CPluginNotifier : public CNotificationBase

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -408,12 +408,8 @@ void MainWorker::RemoveDomoticzHardware(CDomoticzHardwareBase *pHardware)
 
 	if (pOrgDevice == pHardware)
 	{
-		_log.Log(LOG_STATUS, "MainWorker: Calling pOrgDevice->Stop");
 		pOrgDevice->Stop();
-		_log.Log(LOG_STATUS, "MainWorker: Return from pOrgDevice->Stop");
-		_log.Log(LOG_STATUS, "MainWorker: Calling delete pOrgDevice");
 		delete pOrgDevice;
-		_log.Log(LOG_STATUS, "MainWorker: Return from delete pOrgDevice");
 	}
 }
 
@@ -423,10 +419,8 @@ void MainWorker::RemoveDomoticzHardware(int HwdId)
 	if (dpos == -1)
 		return;
 #ifdef ENABLE_PYTHON
-	_log.Log(LOG_STATUS, "MainWorker: Calling m_pluginsystem.DeregisterPlugin");
 	m_pluginsystem.DeregisterPlugin(HwdId);
 #endif
-	_log.Log(LOG_STATUS, "MainWorker: Return from m_pluginsystem.DeregisterPlugin");
 	RemoveDomoticzHardware(m_hardwaredevices[dpos]);
 }
 
@@ -712,15 +706,10 @@ bool MainWorker::AddHardwareFromParams(
 	const bool bDoStart
 )
 {
-	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams Calling RemoveDomoticzHardware");
 	RemoveDomoticzHardware(ID);
-	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from RemoveDomoticzHardware");
 
 	if (!Enabled)
-	{
-		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams !Enabled, return");
 		return true;
-	}
 
 	CDomoticzHardwareBase *pHardware = NULL;
 
@@ -1091,9 +1080,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_PythonPlugin:
 #ifdef ENABLE_PYTHON
-		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams call m_pluginsystem.RegisterPlugin");
 		pHardware = m_pluginsystem.RegisterPlugin(ID, Name, Filename);
-		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from m_pluginsystem.RegisterPlugin");
 #endif
 		break;
 	case HTYPE_XiaomiGateway:
@@ -1139,19 +1126,9 @@ bool MainWorker::AddHardwareFromParams(
 		AddDomoticzHardware(pHardware);
 
 		if (bDoStart)
-		{
-			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams call pHardware->Start");
 			pHardware->Start();
-			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from pHardware->Start");
-		}
-		else
-		{
-			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams !bDoStart");
-		}
-		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return true");
 		return true;
 	}
-	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return false");
 	return false;
 }
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -408,8 +408,12 @@ void MainWorker::RemoveDomoticzHardware(CDomoticzHardwareBase *pHardware)
 
 	if (pOrgDevice == pHardware)
 	{
+		_log.Log(LOG_STATUS, "MainWorker: Calling pOrgDevice->Stop");
 		pOrgDevice->Stop();
+		_log.Log(LOG_STATUS, "MainWorker: Return from pOrgDevice->Stop");
+		_log.Log(LOG_STATUS, "MainWorker: Calling delete pOrgDevice");
 		delete pOrgDevice;
+		_log.Log(LOG_STATUS, "MainWorker: Return from delete pOrgDevice");
 	}
 }
 
@@ -419,8 +423,10 @@ void MainWorker::RemoveDomoticzHardware(int HwdId)
 	if (dpos == -1)
 		return;
 #ifdef ENABLE_PYTHON
+	_log.Log(LOG_STATUS, "MainWorker: Calling m_pluginsystem.DeregisterPlugin");
 	m_pluginsystem.DeregisterPlugin(HwdId);
 #endif
+	_log.Log(LOG_STATUS, "MainWorker: Return from m_pluginsystem.DeregisterPlugin");
 	RemoveDomoticzHardware(m_hardwaredevices[dpos]);
 }
 
@@ -706,10 +712,15 @@ bool MainWorker::AddHardwareFromParams(
 	const bool bDoStart
 )
 {
+	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams Calling RemoveDomoticzHardware");
 	RemoveDomoticzHardware(ID);
+	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from RemoveDomoticzHardware");
 
 	if (!Enabled)
+	{
+		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams !Enabled, return");
 		return true;
+	}
 
 	CDomoticzHardwareBase *pHardware = NULL;
 
@@ -1080,7 +1091,9 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_PythonPlugin:
 #ifdef ENABLE_PYTHON
+		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams call m_pluginsystem.RegisterPlugin");
 		pHardware = m_pluginsystem.RegisterPlugin(ID, Name, Filename);
+		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from m_pluginsystem.RegisterPlugin");
 #endif
 		break;
 	case HTYPE_XiaomiGateway:
@@ -1126,9 +1139,19 @@ bool MainWorker::AddHardwareFromParams(
 		AddDomoticzHardware(pHardware);
 
 		if (bDoStart)
+		{
+			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams call pHardware->Start");
 			pHardware->Start();
+			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return from pHardware->Start");
+		}
+		else
+		{
+			_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams !bDoStart");
+		}
+		_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return true");
 		return true;
 	}
+	_log.Log(LOG_STATUS, "MainWorker::AddHardwareFromParams return false");
 	return false;
 }
 


### PR DESCRIPTION
Fix three races when stopping a plugin:

1. Queued messages for a stopping plugin are not always cleaned causing them to be processed after the plugin has been already been deleted
   Attempt to fix by clearing the message queue from CPlugin::Stop()
2. If a plugin is stopped before m_bIsStarted has been set, it will not be properly stopped.
  Attempt to fix by adding a "starting" state which is set before sending the `InitializeMessage` and cleared after setting m_bIsStarted in CPlugin::Start().
3. A plugin manipulating dictionaries after another plugin has just called Py_EndInterpreter().
Prevent this by calling PyEval_RestoreThread also before processing events and directives.

The first two races cause access to already freed memory, by the plugin framework and by the python parser, and are easily triggered by enabling/disabling/changing settings of a plugin from the WebUI.

The third race causes crashes in the python dictionary code.

The error handling in CPlugin::Start() and CPlugin::Initialise() might need some additional improvement to make sure the plugin does not end up in a semi started state if we fail while starting the plugin.

@dnpwwo, @gizmocuz Please review.