### PR TITLE
Initialize member variables

### DIFF
--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -192,8 +192,11 @@ std::string GetGeneralRFLinkFromInt(const _tRFLinkStringIntHelper *pTable, const
 
 CRFLinkBase::CRFLinkBase()
 {
-	m_rfbufferpos=0;
+	m_bTXokay = false;
+	m_bRFDebug = false;
 	memset(&m_rfbuffer,0,sizeof(m_rfbuffer));
+	m_rfbufferpos = 0;
+	m_retrycntr = RFLINK_RETRY_DELAY;
 	/*
 	ParseLine("20;4F;LIVCOL;ID=1a2b3c4;SWITCH=00;RGBW=ec5a;CMD=ON;");
 	ParseLine("20;08;NewKaku;ID=31c42a;SWITCH=2;CMD=OFF;");

--- a/hardware/RFLinkBase.h
+++ b/hardware/RFLinkBase.h
@@ -5,6 +5,7 @@
 #include "DomoticzHardware.h"
 
 #define RFLINK_READ_BUFFER_SIZE 65*1024
+#define RFLINK_RETRY_DELAY 30
 
 class CRFLinkBase: public CDomoticzHardwareBase
 {

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -4,13 +4,11 @@
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 
-#define RFLINK_RETRY_DELAY 30
-
 CRFLinkSerial::CRFLinkSerial(const int ID, const std::string& devname) :
 m_szSerialPort(devname)
 {
-	m_HwdID=ID;
-	m_stoprequested=false;
+	m_HwdID = ID;
+	m_stoprequested = false;
 	m_retrycntr = RFLINK_RETRY_DELAY * 5;
 }
 
@@ -21,7 +19,7 @@ CRFLinkSerial::~CRFLinkSerial()
 
 bool CRFLinkSerial::StartHardware()
 {
-	m_retrycntr=RFLINK_RETRY_DELAY*5; //will force reconnect first thing
+	m_retrycntr = RFLINK_RETRY_DELAY*5; //will force reconnect first thing
 
 	//Start worker thread
 	m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CRFLinkSerial::Do_Work, this)));

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -5,16 +5,13 @@
 #include <iostream>
 #include "../main/localtime_r.h"
 
-#define RFLINK_RETRY_DELAY 30
-
 CRFLinkTCP::CRFLinkTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort):
 	m_szIPAddress(IPAddress)
 {
-	m_HwdID=ID;
-	m_bDoRestart=false;
-	m_stoprequested=false;
-	m_usIPPort=usIPPort;
-	m_retrycntr = RFLINK_RETRY_DELAY;
+	m_HwdID = ID;
+	m_bDoRestart = false;
+	m_stoprequested = false;
+	m_usIPPort = usIPPort;
 }
 
 CRFLinkTCP::~CRFLinkTCP(void)
@@ -27,7 +24,7 @@ bool CRFLinkTCP::StartHardware()
 	m_bDoRestart=false;
 
 	//force connect the next first time
-	m_retrycntr=RFLINK_RETRY_DELAY;
+	m_retrycntr = RFLINK_RETRY_DELAY;
 	m_bIsStarted=true;
 
 	//Start worker thread

--- a/hardware/RFLinkTCP.h
+++ b/hardware/RFLinkTCP.h
@@ -15,7 +15,6 @@ public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;
 private:
-	int m_retrycntr;
 	bool StartHardware();
 	bool StopHardware();
 	bool WriteInt(const std::string &sendString);


### PR DESCRIPTION
Main issue is member variable `m_bRFDebug` which controls debug prints, but was not set anywhere. Hence debug prints would randomly show up or not each time RFLink HW was started.