### PR TITLE
Harmony Hub bugfixes + user requests

### DIFF
--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -108,7 +108,12 @@ bool CHarmonyHub::WriteToHardware(const char *pdata, const unsigned char length)
 	}
 	else if ((pCmd->LIGHTING2.packettype == pTypeLighting2) && (pCmd->LIGHTING2.cmnd==0))
 	{
-		if (!SubmitCommand(START_ACTIVITY_COMMAND, "-1",""))
+		if (m_szCurActivityID == "-1") // already powered off
+		{
+			SubmitCommand(START_ACTIVITY_COMMAND, "-1", ""); // send it anyway, user may be trying to correct a wrong state
+			return false; // should I do something else here to prevent making this look like an error?
+		}
+		if (!SubmitCommand(START_ACTIVITY_COMMAND, "-1", ""))
 		{
 			_log.Log(LOG_ERROR,"Harmony Hub: Error sending the power-off command");
 			return false;

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -122,8 +122,8 @@ void CHarmonyHub::Init()
 {
 	m_stoprequested = false;
 	m_bDoLogin = true;
-	m_szCurActivityID="";
-	m_bIsChangingActivity=false;
+	m_szCurActivityID = "";
+	m_bIsChangingActivity = false;
 	m_hubSwVersion = "";
 }
 
@@ -210,7 +210,7 @@ void CHarmonyHub::Do_Work()
 				if (Login() && SetupCommandSocket())
 				{
 					m_bDoLogin=false;
-					if (!UpdateCurrentActivity() || !UpdateActivities())
+					if (!UpdateActivities() || !UpdateCurrentActivity())
 					{
 						_log.Log(LOG_ERROR, "Harmony Hub: Error updating activities.. Resetting connection.");
 						ResetCommandSocket();
@@ -318,8 +318,9 @@ void CHarmonyHub::ResetCommandSocket()
 	if (m_commandcsocket)
 		delete m_commandcsocket;
 	m_commandcsocket = NULL;
-	m_bIsChangingActivity=false;
-	m_bDoLogin=true;
+	m_bIsChangingActivity = false;
+	m_bDoLogin = true;
+	m_szCurActivityID = "";
 }
 
 
@@ -399,13 +400,6 @@ bool CHarmonyHub::UpdateActivities()
 			std::string aLabel = root["activity"][ii]["label"].asString();
 			m_mapActivities[aID] = aLabel;
 		}
-
-		std::map< std::string, std::string>::const_iterator itt;
-		int cnt = 0;
-		for (itt = m_mapActivities.begin(); itt != m_mapActivities.end(); ++itt)
-		{
-			UpdateSwitch(cnt++, itt->first.c_str(), (m_szCurActivityID == itt->first), itt->second);
-		}
 	}
 	catch (...)
 	{
@@ -424,14 +418,22 @@ bool CHarmonyHub::UpdateCurrentActivity()
 	}
 
 	//check if changed
-	if (m_szCurActivityID!=m_szResultString)
+	if (m_szCurActivityID != m_szResultString) 
 	{
-		if (!m_szCurActivityID.empty())
+		if (m_szCurActivityID.empty()) // initialize all switches
 		{
-			//need to set the old activity to off
-			CheckSetActivity(m_szCurActivityID,false );
+			std::map< std::string, std::string>::const_iterator itt;
+			int cnt = 0;
+			for (itt = m_mapActivities.begin(); itt != m_mapActivities.end(); ++itt)
+			{
+				UpdateSwitch(cnt++, itt->first.c_str(), (m_szResultString == itt->first), itt->second);
+			}
 		}
-		CheckSetActivity(m_szResultString,true);
+		else
+		{
+			CheckSetActivity(m_szCurActivityID, false);
+			CheckSetActivity(m_szResultString, true);
+		}
 		m_szCurActivityID = m_szResultString;
 	}
 


### PR DESCRIPTION
Bug: when communication is lost, switches can be in an impossible state of multiple activities running at the same time

Bug: possibility to power off the PowerOff state lead to a state where you cannot see the current activity

Bug: sending a switch off request on any activity would activate PowerOff activity regardless of whether the associated activity was running

Added: when we are disconnected from the Hub, do an instant connect if user sends a switch command

Added: allow silencing the error message when Hub cannot be reached after a Domoticz restart (by sending disallowed PowerOff `off` request)