### PR TITLE
Prevent additional plugin start / stop race

### DIFF
--- a/hardware/plugins/PluginMessages.h
+++ b/hardware/plugins/PluginMessages.h
@@ -71,6 +71,7 @@ namespace Plugins {
 		void Process()
 		{
 			boost::lock_guard<boost::mutex> l(PythonMutex);
+			m_pPlugin->RestoreThread();
 			ProcessLocked();
 		};
 		virtual const char* PythonName() { return m_Callback.c_str(); };

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -707,13 +707,14 @@ namespace Plugins {
 			while (m_bIsStarting)
 			{
 				int scounter = 0;
-				while (m_bIsStarting && (scounter++ < 300))
+				int timeout = 30;
+				while (m_bIsStarting && (scounter++ < timeout*10))
 				{
 					sleep_milliseconds(100);
 				}
 				if (m_bIsStarting)
 				{
-					_log.Log(LOG_ERROR, "(%s) Plugin did not finish start after 30 seconds", Name.c_str());
+					_log.Log(LOG_ERROR, "(%s) Plugin did not finish start after %d seconds", Name.c_str(), timeout);
 				}
 			}
 
@@ -745,13 +746,14 @@ namespace Plugins {
 			while (m_bIsStarted)
 			{
 				int scounter = 0;
-				while (m_bIsStarted && (scounter++ < 50))
+				int timeout = 30;
+				while (m_bIsStarted && (scounter++ < timeout*10))
 				{
 					sleep_milliseconds(100);
 				}
 				if (m_bIsStarted)
 				{
-					_log.Log(LOG_ERROR, "(%s) Plugin did not stop after 5 seconds, flushing event queue...", Name.c_str());
+					_log.Log(LOG_ERROR, "(%s) Plugin did not stop after %d seconds, flushing event queue...", Name.c_str(), timeout);
 
 					ClearMessageQueue();
 					m_bIsStarted = false;

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1464,7 +1464,6 @@ Error:
 		try
 		{
 			// Callbacks MUST already have taken the PythonMutex lock otherwise bad things will happen
-			if (m_PyInterpreter) PyEval_RestoreThread((PyThreadState*)m_PyInterpreter);
 			if (m_PyModule && sHandler.length())
 			{
 				PyObject*	pFunc = PyObject_GetAttrString((PyObject*)m_PyModule, sHandler.c_str());

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -305,9 +305,21 @@ void MainWorker::StartDomoticzHardware()
 
 void MainWorker::StopDomoticzHardware()
 {
-	boost::lock_guard<boost::mutex> l(m_devicemutex);
+	// Separate the Stop() from the device removal from the vector.
+	// Some actions the hardware might take during stop (e.g updating a device) can cause deadlocks on the m_devicemutex
+	std::vector<CDomoticzHardwareBase*> OrgHardwaredevices;
 	std::vector<CDomoticzHardwareBase*>::iterator itt;
-	for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
+
+	{
+		boost::lock_guard<boost::mutex> l(m_devicemutex);
+		for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
+		{
+			OrgHardwaredevices.push_back(*itt);
+		}
+		m_hardwaredevices.clear();
+	}
+
+	for (itt = OrgHardwaredevices.begin(); itt != OrgHardwaredevices.end(); ++itt)
 	{
 #ifdef ENABLE_PYTHON
 		m_pluginsystem.DeregisterPlugin((*itt)->m_HwdID);
@@ -315,7 +327,6 @@ void MainWorker::StopDomoticzHardware()
 		(*itt)->Stop();
 		delete (*itt);
 	}
-	m_hardwaredevices.clear();
 }
 
 void MainWorker::GetAvailableWebThemes()
@@ -392,24 +403,24 @@ void MainWorker::RemoveDomoticzHardware(CDomoticzHardwareBase *pHardware)
 {
 	// Separate the Stop() from the device removal from the vector.
 	// Some actions the hardware might take during stop (e.g updating a device) can cause deadlocks on the m_devicemutex
-	CDomoticzHardwareBase *pOrgDevice = NULL;
+	CDomoticzHardwareBase *pOrgHardware = NULL;
 	{
 		boost::lock_guard<boost::mutex> l(m_devicemutex);
 		std::vector<CDomoticzHardwareBase*>::iterator itt;
 		for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
 		{
-			pOrgDevice = *itt;
-			if (pOrgDevice == pHardware) {
+			pOrgHardware = *itt;
+			if (pOrgHardware == pHardware) {
 				m_hardwaredevices.erase(itt);
 				break;
 			}
 		}
 	}
 
-	if (pOrgDevice == pHardware)
+	if (pOrgHardware == pHardware)
 	{
-		pOrgDevice->Stop();
-		delete pOrgDevice;
+		pOrgHardware->Stop();
+		delete pOrgHardware;
 	}
 }
 


### PR DESCRIPTION
Call `PyEval_RestoreThread` earlier to prevent races when restarting the Python plugin framework.
Without this change, 100% reproducible crash when restoring Domoticz database from WebUI.