### PR TITLE
Add generic CustomCommand handling for scripts

### DIFF
--- a/dzVents/runtime/device-adapters/onkyo_device.lua
+++ b/dzVents/runtime/device-adapters/onkyo_device.lua
@@ -17,9 +17,7 @@ return {
     process = function (device, data, domoticz, utils, adapterManager)
 
         function device.onkyoEISCPCommand(cmd)
-            local url = domoticz.settings['Domoticz url'] ..
-                    '/json.htm?param=onkyoeiscpcommand&type=command&idx=' .. device.id .. '&action=' .. tostring (cmd)
-            return domoticz.openURL(url)
+            return TimedCommand(domoticz, 'CustomCommand:' .. device.id, tostring(cmd), 'device')
         end
     end
 }

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -36,6 +36,11 @@ CDomoticzHardwareBase::~CDomoticzHardwareBase()
 {
 }
 
+bool CDomoticzHardwareBase::CustomCommand(const uint64_t idx, const std::string &sCommand)
+{
+	return false;
+}
+
 bool CDomoticzHardwareBase::Start()
 {
 	m_iHBCounter = 0;

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -16,6 +16,7 @@ public:
 	bool Start();
 	bool Stop();
 	virtual bool WriteToHardware(const char *pdata, const unsigned char length)=0;
+	virtual bool CustomCommand(const uint64_t idx, const std::string &sCommand);
 
 	void EnableOutputLog(const bool bEnableLog);
 

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -676,6 +676,10 @@ void OnkyoAVTCP::ParseData(const unsigned char *pData, int Len)
 	m_pPartialPkt = new_partial;
 }
 
+bool OnkyoAVTCP::CustomCommand(const uint64_t idx, const std::string &sCommand)
+{
+	return SendPacket(sCommand.c_str());
+}
 
 //Webserver helpers
 namespace http {

--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -21,6 +21,7 @@ private:
 	int m_retrycntr;
 	bool StartHardware();
 	bool StopHardware();
+	bool CustomCommand(uint64_t idx, const std::string &sCommand);
 	unsigned char *m_pPartialPkt;
 	int m_PPktLen;
 	void ReceiveMessage(const char *pData, int Len);

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -131,6 +131,7 @@ public:
 	bool GetEventTrigger(const uint64_t ulDevID, const _eReason reason, const bool bEventTrigger);
 	void SetEventTrigger(const uint64_t ulDevID, const _eReason reason, const float fDelayTime);
 	void UpdateDevice(const uint64_t idx, const int nValue, const std::string &sValue, const int Protected, const bool bEventTrigger = false);
+	bool CustomCommand(const uint64_t idx, const std::string &sCommand);
 
 	void TriggerURL(const std::string &result, const std::vector<std::string> &headerData, const std::string &callback);
 

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3401,6 +3401,10 @@ void CSQLHelper::Do_Work()
 			{
 				m_mainworker.m_eventsystem.UpdateDevice(itt->_idx, itt->_nValue, itt->_sValue, itt->_HardwareID, (itt->_switchtype ? true : false));
 			}
+			else if (itt->_ItemType == TITEM_CUSTOM_COMMAND)
+			{
+				m_mainworker.m_eventsystem.CustomCommand(itt->_idx, itt->_command);
+			}
 
 			++itt;
 		}

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -49,7 +49,8 @@ enum _eTaskItemType
 	TITEM_SEND_NOTIFICATION,
 	TITEM_SET_SETPOINT,
 	TITEM_SEND_IFTTT_TRIGGER,
-	TITEM_UPDATEDEVICE
+	TITEM_UPDATEDEVICE,
+	TITEM_CUSTOM_COMMAND,
 };
 
 struct _tTaskItem
@@ -261,6 +262,18 @@ struct _tTaskItem
 		tItem._sValue = varvalue;
 		tItem._command = mode;
 		tItem._sUntil = until;
+
+		if (DelayTime)
+			getclock(&tItem._DelayTimeBegin);
+		return tItem;
+	}
+	static _tTaskItem CustomCommand(const float DelayTime, const uint64_t idx, const std::string &cmdstr)
+	{
+		_tTaskItem tItem;
+		tItem._ItemType = TITEM_CUSTOM_COMMAND;
+		tItem._DelayTime = DelayTime;
+		tItem._idx = idx;
+		tItem._command = cmdstr;
 		if (DelayTime)
 			getclock(&tItem._DelayTimeBegin);
 		return tItem;


### PR DESCRIPTION
The Onkyo-specific support in JSON and dzVents isn't really sufficient,
because it (quite rightly) needs authentication. But dzVents just assumes
it can make unauthenticated calls to localhost:8080, and doesn't work.

I've been working around this by spawning an external script to invoke
curl, but *that* only works over HTTPS not HTTP for some reason (without
HTTPS I just get an 'Unauthorized' response). And that takes literally
*seconds* to work, on the slow machine I'm using.

Fix it up so that the script command arrays can have a 'CustomCommand',
done generically so that it can easily cover devices other than Onkyo.