### PR TITLE
Adding CharSize:8bits fallback to TeleinfoSerial (default is 7bits)

### DIFF
--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -98,11 +98,19 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
 
     setErrorStatus(true);//If an exception is thrown, error_ remains true
     pimpl->port.open(devname);
-    pimpl->port.set_option(boost::asio::serial_port_base::baud_rate(baud_rate));
-    pimpl->port.set_option(opt_parity);
-    pimpl->port.set_option(opt_csize);
-    pimpl->port.set_option(opt_flow);
-    pimpl->port.set_option(opt_stop);
+	try {
+		pimpl->port.set_option(boost::asio::serial_port_base::baud_rate(baud_rate));
+		pimpl->port.set_option(opt_parity);
+		pimpl->port.set_option(opt_csize);
+		pimpl->port.set_option(opt_flow);
+		pimpl->port.set_option(opt_stop);
+	}
+	catch (...)
+	{
+		_log.Log(LOG_ERROR, "ASyncSerial: Error setting options!");
+		pimpl->port.close();
+		throw;
+	}
 
 	pimpl->io.reset();
 
@@ -125,13 +133,17 @@ void AsyncSerial::openOnlyBaud(const std::string& devname, unsigned int baud_rat
 
 	setErrorStatus(true);//If an exception is thrown, error_ remains true
 	pimpl->port.open(devname);
-	pimpl->port.set_option(boost::asio::serial_port_base::baud_rate(baud_rate));
-/*
-	pimpl->port.set_option(opt_parity);
-	pimpl->port.set_option(opt_csize);
-	pimpl->port.set_option(opt_flow);
-	pimpl->port.set_option(opt_stop);
-*/
+
+	try {
+		pimpl->port.set_option(boost::asio::serial_port_base::baud_rate(baud_rate));
+	}
+	catch (...)
+	{
+		_log.Log(LOG_ERROR, "ASyncSerial: Error setting options!");
+		pimpl->port.close();
+		throw;
+	}
+
 	pimpl->io.reset();
 
 	//This gives some work to the io_service before it is started

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -84,23 +84,27 @@ bool CTeleinfoSerial::StartHardware()
 	//Try to open the Serial Port
 	try
 	{
-		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate);
-		open(
-			m_szSerialPort,
-			m_iBaudRate,
-			m_iOptParity,
-			m_iOptCsize
-			);
+		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds, Parity:%i CharSize:%i", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate, m_iOptParity, m_iOptCsize);
+		open(m_szSerialPort, m_iBaudRate, m_iOptParity, m_iOptCsize);
 	}
 	catch (boost::exception & e)
 	{
-		_log.Log(LOG_ERROR, "Teleinfo: Error opening serial port!");
-		#ifdef DEBUG_TeleinfoSerial
+		
+#ifdef DEBUG_TeleinfoSerial
 		_log.Log(LOG_ERROR, "-----------------\n%s\n-----------------", boost::diagnostic_information(e).c_str());
-		#else
+#else
 		(void)e;
-		#endif
-		return false;
+#endif
+		_log.Log(LOG_STATUS, "Teleinfo: Serial port open failed, let's retry with CharSize:8 ...");
+
+		try	{
+			open(m_szSerialPort,m_iBaudRate,m_iOptParity,boost::asio::serial_port_base::character_size(8));
+			_log.Log(LOG_STATUS, "Teleinfo: Serial port open successfully with CharSize:8 ...");
+		}
+		catch (...) {
+			_log.Log(LOG_ERROR, "Teleinfo: Error opening serial port, even with CharSize:8 !");
+			return false;
+		}
 	}
 	catch (...)
 	{

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -84,7 +84,7 @@ bool CTeleinfoSerial::StartHardware()
 	//Try to open the Serial Port
 	try
 	{
-		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds, Parity:%i CharSize:%i", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate, m_iOptParity.value, m_iOptCsize.value);
+		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate);
 		open(m_szSerialPort, m_iBaudRate, m_iOptParity, m_iOptCsize);
 	}
 	catch (boost::exception & e)

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -84,7 +84,7 @@ bool CTeleinfoSerial::StartHardware()
 	//Try to open the Serial Port
 	try
 	{
-		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds, Parity:%i CharSize:%i", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate, m_iOptParity, m_iOptCsize);
+		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds, Parity:%i CharSize:%i", Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate, m_iOptParity.value, m_iOptCsize.value);
 		open(m_szSerialPort, m_iBaudRate, m_iOptParity, m_iOptCsize);
 	}
 	catch (boost::exception & e)


### PR DESCRIPTION
I've added a fallback to 8bits if serial.open fail with the default 7bits value.
This feature is usefull to use any virtual device (like pseudo-terminal) to feed TeleinfoSerial.

I've also corrected a bug in ASyncSerial : if an exception occured while opening, the serial port will never be correctly closed.
