### PR TITLE
Runtime compression of .js and .html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ install_manifest.txt
 /.idea_/
 /www/images/floorplans/*.png
 /www/images/floorplans/*.jpg
+/www/.gz_cache/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,7 +547,7 @@ set(Boost_USE_STATIC_LIBS ${USE_STATIC_BOOST})
 set(Boost_USE_MULTITHREADED ON)
 unset(Boost_INCLUDE_DIR CACHE)
 unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost REQUIRED COMPONENTS thread date_time system filesystem)
+find_package(Boost REQUIRED COMPONENTS thread date_time system)
 
 if(USE_STATIC_BOOST)
    message(STATUS "Linking against boost static libraries")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,7 +547,7 @@ set(Boost_USE_STATIC_LIBS ${USE_STATIC_BOOST})
 set(Boost_USE_MULTITHREADED ON)
 unset(Boost_INCLUDE_DIR CACHE)
 unset(Boost_LIBRARY_DIRS CACHE)
-find_package(Boost REQUIRED COMPONENTS thread date_time system)
+find_package(Boost REQUIRED COMPONENTS thread date_time system filesystem)
 
 if(USE_STATIC_BOOST)
    message(STATUS "Linking against boost static libraries")

--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -204,6 +204,60 @@ void request_handler::handle_request(const request& req, reply& rep)
 	handle_request(req, rep, mInfo);
 }
 
+static bool endsWith(const std::string& str, const std::string& suffix)
+{
+    return str.size() >= suffix.size() && 0 == str.compare(str.size()-suffix.size(), suffix.size(), suffix);
+}
+
+static void validate_gzip(std::string full_path, std::string full_path_gzip)
+{
+	// Do nothing if browser requests a gzipped file
+	if (endsWith(full_path, ".gz"))
+		return;
+
+	struct stat result, resultgz;
+
+	bool gzip_valid = true;
+
+	if (stat(full_path.c_str(), &result) == 0)
+	{
+		if (stat(full_path_gzip.c_str(), &resultgz) == 0)
+		{
+			if (difftime(result.st_mtime, resultgz.st_mtime) > 0)
+			{
+				// gzipped version is old
+				gzip_valid = false;
+			}
+		}
+		else
+		{
+			// gzipped version does not exist
+			gzip_valid = false;
+		}
+	}
+
+	if (!gzip_valid)
+	{
+		std::ifstream is(full_path.c_str(), std::ios::in | std::ios::binary);
+		gzFile gzf = gzopen(full_path_gzip.c_str(), "wb");
+		if (is.is_open() && gzf != NULL)
+		{
+			std::string content((std::istreambuf_iterator<char>(is)),
+				(std::istreambuf_iterator<char>()));
+
+			bool err = false;
+			if (gzwrite(gzf, content.c_str(), content.size()) != content.size()) err = true;
+			if (gzclose(gzf) != Z_OK) err = true;
+
+			if (err){
+				std::remove(full_path_gzip.c_str());
+				_log.Log(LOG_ERROR, "Webserver: Failed to compress '%s' to '%s'", full_path.c_str(), full_path_gzip.c_str());
+			}
+			else _log.Log(LOG_STATUS, "Webserver: Compressed '%s' to '%s'", full_path.c_str(), full_path_gzip.c_str());
+		}
+	}
+}
+
 void request_handler::handle_request(const request &req, reply &rep, modify_info &mInfo)
 {
   mInfo.mtime_support = false;
@@ -272,6 +326,8 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 		  //first try gzip version
 		  if (bHaveGZipSupport)
 		  {
+			  // Validate gzipped file
+			  validate_gzip(doc_root_ + request_path, doc_root_ + request_path + ".gz");
 			  std::string full_path = doc_root_ + request_path + ".gz";
 			  // Open the file to send back.
 			  std::ifstream is(full_path.c_str(), std::ios::in | std::ios::binary);

--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -13,7 +13,6 @@
 #include <fstream>
 #include <sstream>
 #include <string>
-#include <boost/filesystem.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/scoped_array.hpp>
 #ifdef WIN32
@@ -26,6 +25,8 @@
 #include "request.hpp"
 #include "cWebem.h"
 #include "GZipHelper.h"
+
+#include "../main/Helper.h"
 
 // remove
 #include "../main/Logger.h"
@@ -240,14 +241,15 @@ static void validate_gzip(std::string full_path, std::string full_path_gzip)
 	if (!gzip_valid)
 	{
 		// Create directory
-		boost::filesystem::path p = full_path_gzip;
-		p.remove_filename();
-		try {
-			boost::filesystem::create_directories(p);
+		std::string dir = full_path_gzip;
+		std::string::size_type pos = dir.rfind('/');
+		if (pos != std::string::npos) {
+			dir.erase(pos);
 		}
-		catch (...)
+		int res = mkdir_deep(dir.c_str(), 0755);
+		if (res != 0 && errno != EEXIST)
 		{
-			_log.Log(LOG_ERROR, "Webserver: Failed to create directory '%s'", p.string().c_str());
+			_log.Log(LOG_ERROR, "Webserver: Failed to create directory '%s', errno: %d", dir.c_str(), errno);
 		}
 
 		// Compress


### PR DESCRIPTION
As discussed in #2254.

Implemented solution:
- .js and .html will be automatically compressed with gzip
- compressed version will be automatically recreated if it is outdated
- gzipped files stored separately, and ignored by git


Possible improvement points:
- Do something more advanced than just checking modification time