### PR TITLE
Aqara cube

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -476,6 +476,10 @@ void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::str
 					// flip90/flip180/move/tap_twice/shake_air/swing/alert/free_fall
 					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|flip90|flip180|move|tap_twice|shake_air|swing|alert|free_fall|clock_wise|anti_clock_wise", false));
 				}
+				else if (Name == "Aqara Cube") {
+					// flip90/flip180/move/tap_twice/shake_air/swing/alert/free_fall/rotate
+					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|flip90|flip180|move|tap_twice|shake_air|swing|alert|free_fall|rotate", false));
+				}
 				else if (Name == "Xiaomi Wireless Dual Wall Switch") {
 					//for Aqara wireless switch, 2 buttons support
 					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Switch 1|Switch 2|Both_Click", false));
@@ -873,8 +877,12 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					else if (model == "weather.v1") {
 						name = "Xiaomi Aqara Weather";
 					}
-					else if ((model == "cube") || (model == "sensor_cube.aqgl01")) {
+					else if (model == "cube") {
 						name = "Xiaomi Cube";
+						type = STYPE_Selector;
+					}
+					else if (model == "sensor_cube.aqgl01") {
+						name = "Aqara Cube";
 						type = STYPE_Selector;
 					}
 					else if (model == "86sw2") {


### PR DESCRIPTION
The following information I found on this page http://docs.opencloud.aqara.cn/development/gateway-LAN-communication/
1 of the selector properties has changed from clock_wise | anti_clock_wise to rotate where rotate happens in the form of degrees. I have created a separate line for the new cube model. I do not know if this will solve the problem but we can try it. I doubt whether I should use the command rotate or Rotate_degree.

Cube Sensor
(Device type model: sensor_cube.aqgl01)
Attributes	Instructions
Cube_status	Flip90/flip180/move/tap_twice/shake_air/swing/alert/free_fall/rotate (Turn 90 degrees/Flip 180 degrees/Pan/Double click/Shake/Hold/Stay for a while)
Rotate_degree	The angle of rotation, in degrees (°), is a positive number, indicating clockwise rotation, and negative number counterclockwise rotation.
Detect_time	Rotation sampling length in milliseconds (ms)
Battery_voltage	Button battery voltage value, unit mv, range 0~3300mv, under normal circumstances, less than 2800mv indicates low battery.