### PR TITLE
dzVents: runtime is based in szStartupFolder not szUserDataFolder

### DIFF
--- a/dzVents/runtime/dzVents.lua
+++ b/dzVents/runtime/dzVents.lua
@@ -8,22 +8,24 @@ if (_G.TESTMODE) then
 
 end
 
-local currentPath = globalvariables['script_path'] -- should be path/to/domoticz/scripts/dzVents
+local scriptPath = globalvariables['script_path'] -- should be ${szUserDataFolder}/scripts/dzVents/
+local runtimePath = globalvariables['runtime_path'] -- should be ${szStartupFolder}/dzVents/runtime/
 
-_G.scriptsFolderPath = currentPath .. 'scripts' -- global
-_G.generatedScriptsFolderPath = currentPath .. 'generated_scripts' -- global
-_G.dataFolderPath = currentPath .. 'data' -- global
+_G.scriptsFolderPath = scriptPath .. 'scripts' -- global
+_G.generatedScriptsFolderPath = scriptPath .. 'generated_scripts' -- global
+_G.dataFolderPath = scriptPath .. 'data' -- global
 
-package.path = package.path .. ';' .. currentPath .. '?.lua'
-package.path = package.path .. ';' .. currentPath .. '../../dzVents/runtime/?.lua'
-package.path = package.path .. ';' .. currentPath .. '../../dzVents/runtime/device-adapters/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'dzVents/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'scripts/?.lua'
-package.path = package.path .. ';' .. currentPath .. '../lua/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'scripts/modules/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'generated_scripts/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'data/?.lua'
-package.path = package.path .. ';' .. currentPath .. 'modules/?.lua'
+package.path = package.path .. ';' .. scriptPath .. '?.lua'
+package.path = package.path .. ';' .. runtimePath .. '?.lua'
+package.path = package.path .. ';' .. runtimePath .. 'device-adapters/?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'dzVents/?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'scripts/?.lua'
+package.path = package.path .. ';' .. scriptPath .. '../lua/?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'scripts/modules/?.lua'
+package.path = package.path .. ';' .. scriptPath .. '?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'generated_scripts/?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'data/?.lua'
+package.path = package.path .. ';' .. scriptPath .. 'modules/?.lua'
 
 local EventHelpers = require('EventHelpers')
 local helpers = EventHelpers()
@@ -31,9 +33,9 @@ local utils = require('Utils')
 
 
 if (tonumber(globalvariables['dzVents_log_level']) == utils.LOG_DEBUG or TESTMODE) then
-	print('Debug: Dumping domoticz data to ' .. currentPath .. 'domoticzData.lua')
+	print('Debug: Dumping domoticz data to ' .. scriptPath .. 'domoticzData.lua')
 	local persistence = require('persistence')
-	persistence.store(currentPath .. 'domoticzData.lua', domoticzData)
+	persistence.store(scriptPath .. 'domoticzData.lua', domoticzData)
 
 	local events, length = helpers.getEventSummary()
 	if (length > 0) then

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -35,7 +35,7 @@ extern "C" {
 }
 
 extern time_t m_StartTime;
-extern std::string szUserDataFolder;
+extern std::string szUserDataFolder, szStartupFolder;
 extern http::server::CWebServerHelper m_webservers;
 
 static std::string m_printprefix;
@@ -202,12 +202,12 @@ void CEventSystem::LoadEvents()
 	m_lua_Dir = szUserDataFolder + "scripts\\lua\\";
 	dzv_Dir = szUserDataFolder + "scripts\\dzVents\\generated_scripts\\";
 	dzvents->m_scriptsDir = szUserDataFolder + "scripts\\dzVents\\scripts\\";
-	dzvents->m_runtimeDir = szUserDataFolder + "dzVents\\runtime\\";
+	dzvents->m_runtimeDir = szStartupFolder + "dzVents\\runtime\\";
 #else
 	m_lua_Dir = szUserDataFolder + "scripts/lua/";
 	dzv_Dir = szUserDataFolder + "scripts/dzVents/generated_scripts/";
 	dzvents->m_scriptsDir = szUserDataFolder + "scripts/dzVents/scripts/";
-	dzvents->m_runtimeDir = szUserDataFolder + "dzVents/runtime/";
+	dzvents->m_runtimeDir = szStartupFolder + "dzVents/runtime/";
 #endif
 
 	boost::unique_lock<boost::shared_mutex> eventsMutexLock(m_eventsMutex);

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -8,7 +8,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-extern std::string szUserDataFolder, szWebRoot;
+extern std::string szUserDataFolder, szWebRoot, szStartupFolder;
 extern http::server::CWebServerHelper m_webservers;
 static std::string m_printprefix;
 
@@ -414,7 +414,7 @@ int CdzVents::l_domoticz_print(lua_State* lua_state)
 
 void CdzVents::SetGlobalVariables(lua_State *lua_state, const bool reasonTime, const int secStatus)
 {
-	std::stringstream lua_DirT;
+	std::stringstream lua_DirT, runtime_DirT;
 
 	lua_DirT << szUserDataFolder <<
 #ifdef WIN32
@@ -423,12 +423,22 @@ void CdzVents::SetGlobalVariables(lua_State *lua_state, const bool reasonTime, c
 	"scripts/dzVents/";
 #endif
 
+	runtime_DirT << szStartupFolder <<
+#ifdef WIN32
+	"dzVents\\runtime\\";
+#else
+	"dzVents/runtime/";
+#endif
+
 	lua_createtable(lua_state, 0, 0);
 	lua_pushstring(lua_state, "Security");
 	lua_pushstring(lua_state, m_mainworker.m_eventsystem.m_szSecStatus[secStatus].c_str());
 	lua_rawset(lua_state, -3);
 	lua_pushstring(lua_state, "script_path");
 	lua_pushstring(lua_state, lua_DirT.str().c_str());
+	lua_rawset(lua_state, -3);
+	lua_pushstring(lua_state, "runtime_path");
+	lua_pushstring(lua_state, runtime_DirT.str().c_str());
 	lua_rawset(lua_state, -3);
 	lua_pushstring(lua_state, "isTimeEvent");
 	lua_pushboolean(lua_state, reasonTime);


### PR DESCRIPTION
It doesn't matter in the "normal" Domoticz setup where everything lives
in /opt/domoticz, but for packaged builds we really care about read-only
bits (szStartupFolder or /usr/share/domoticz) vs. editable data (which
is szUserDataFolder or /var/lib/domoticz).