### PR TITLE
Fix precompiled header with -Wl,… in compile flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,7 +232,8 @@ MACRO(ADD_PRECOMPILED_HEADER _targetName _input)
     SET(_output "${_outdir}/.c++")
 
     STRING(TOUPPER "CMAKE_CXX_FLAGS_${CMAKE_BUILD_TYPE}" _flags_var_name)
-    SET(_compiler_FLAGS "${CMAKE_CXX_FLAGS} ${${_flags_var_name}}")
+    # Strip out -Wl,… linker directives as they make GCC fail
+    STRING(REGEX REPLACE " -Wl,[^ ]*" " " _compiler_FLAGS " ${CMAKE_CXX_FLAGS} ${${_flags_var_name}}")
 
     GET_DIRECTORY_PROPERTY(_directory_flags INCLUDE_DIRECTORIES)
     FOREACH(item ${_directory_flags})


### PR DESCRIPTION
Arguably, GCC ought to ignore stuff like -Wl,-z,relro when it's building
a precompiled header. It doesn't, so strip it out.

Some platforms do enable relro by default, and this causes a build
failure otherwise.