### PR TITLE
MochadTCP/P1MeterBase: fix C++ One Definition Rule violations

### DIFF
--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -11,30 +11,30 @@
 
 #define RETRY_DELAY 30
 
-typedef enum { 
+enum _eMochadMatchType {
 	ID=0, 
 	STD, 
 	LINE17, 
 	LINE18, 
 	EXCLMARK 
-} MatchType;
+};
 
-typedef enum {
+enum _eMochadType {
 	MOCHAD_STATUS=0,
 	MOCHAD_UNIT,
 	MOCHAD_ACTION,
 	MOCHAD_RFSEC
-} MochadType;
+};
 
-typedef struct _tMatch {
-	MatchType matchtype;
-	MochadType type;
+typedef struct {
+	_eMochadMatchType matchtype;
+	_eMochadType type;
 	const char* key;
 	int start;
 	int width;
-} Match;
+} MochadMatch;
 
-static Match matchlist[] = {
+static MochadMatch matchlist[] = {
 	{STD,	MOCHAD_STATUS,	"House ",	6, 255},
 	{STD,	MOCHAD_UNIT,	"Tx PL HouseUnit: ",	17, 9},
 	{STD,	MOCHAD_UNIT,	"Rx PL HouseUnit: ",	17, 9},
@@ -239,13 +239,13 @@ void MochadTCP::MatchLine()
 	uint8_t i;
 	int j,k;
 	uint8_t found=0;
-	Match t;
+	MochadMatch t;
 	char value[20]="";
 	std::string vString;
 
 
 
-	for(i=0;(i<sizeof(matchlist)/sizeof(Match))&(!found);i++)
+	for(i=0;(i<sizeof(matchlist)/sizeof(MochadMatch))&(!found);i++)
 	{
 		t = matchlist[i];
 		switch(t.matchtype)

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -8,7 +8,7 @@
 #define CRC16_ARC	0x8005
 #define CRC16_ARC_REFL	0xA001
 
-typedef enum {
+enum _eP1MatchType {
 	ID=0,
 	EXCLMARK,
 	STD,
@@ -16,7 +16,7 @@ typedef enum {
 	GAS,
 	LINE17,
 	LINE18
-} MatchType;
+};
 
 #define P1SMID		"/"		// Smart Meter ID. Used to detect start of telegram.
 #define P1VER		"1-3:0.2.8"	// P1 version
@@ -37,7 +37,7 @@ typedef enum {
 #define P1MBTYPE	"0-n:24.1.0"	// M-Bus device type
 #define P1EOT		"!"		// End of telegram.
 
-typedef enum {
+enum _eP1Type {
 	P1TYPE_SMID=0,
 	P1TYPE_END,
 	P1TYPE_VERSION,
@@ -54,18 +54,18 @@ typedef enum {
 	P1TYPE_GASUSAGEDSMR4,
 	P1TYPE_GASTIMESTAMP,
 	P1TYPE_GASUSAGE
-} P1Type;
+};
 
-typedef struct _tMatch {
-	MatchType matchtype;
-	P1Type type;
+typedef struct {
+	_eP1MatchType matchtype;
+	_eP1Type type;
 	const char* key;
 	const char* topic;
 	int start;
 	int width;
-} Match;
+} P1Match;
 
-Match matchlist[] = {
+P1Match matchlist[] = {
 	{ID,		P1TYPE_SMID,			P1SMID,		"",			 0,  0},
 	{EXCLMARK,	P1TYPE_END,			P1EOT,		"",			 0,  0},
 	{STD,		P1TYPE_VERSION,			P1VER,		"version",		10,  2},
@@ -154,11 +154,11 @@ bool P1MeterBase::MatchLine()
 		return true; //null value (startup)
 	uint8_t i;
 	uint8_t found=0;
-	Match *t;
+	P1Match *t;
 	char value[20]="";
 	std::string vString;
 
-	for(i=0;(i<sizeof(matchlist)/sizeof(Match))&(!found);i++)
+	for(i=0;(i<sizeof(matchlist)/sizeof(P1Match))&(!found);i++)
 	{
 		t = &matchlist[i];
 		switch(t->matchtype)


### PR DESCRIPTION
Fix the following build warnings seen with GCC 8.
Untested as I have neither hardware, but Obviously Correct™.

```
hardware/MochadTCP.cpp:20:3: warning: type ‘MatchType’ violates the C++ One Definition Rule [-Wodr]
 } MatchType;
   ^
hardware/P1MeterBase.cpp:19:3: note: an enum with different value name is defined in another translation unit
 } MatchType;
   ^
hardware/MochadTCP.cpp:29:16: warning: type ‘struct _tMatch’ violates the C++ One Definition Rule [-Wodr]
 typedef struct _tMatch {
                ^
hardware/P1MeterBase.cpp:59:16: note: a different type is defined in another translation unit
 typedef struct _tMatch {
                ^
hardware/MochadTCP.cpp:30:12: note: the first difference of corresponding definitions is field ‘matchtype’
  MatchType matchtype;
            ^
hardware/P1MeterBase.cpp:60:12: note: a field of same name but different type is defined in another translation unit
  MatchType matchtype;
            ^
hardware/MochadTCP.cpp:20:3: note: type ‘MatchType’ itself violates the C++ One Definition Rule
 } MatchType;
   ^
hardware/P1MeterBase.cpp:19:3: note: the incompatible type is defined here
 } MatchType;
   ^
```