### PR TITLE
Add pTypeManaged/sTypeManagedCounter devices for plugins and JSON

### DIFF
--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -84,6 +84,7 @@ namespace http {
 			{ 16,  0xF3, 0x04 }, //Leaf Wetness
 			{ 246, 0xF6, 0x01 }, //Lux
 			{ 250, 0xFA, 0x01 }, //P1 Smart Meter (Electric)
+			{ 1005,0xEF, 0x01 }, //Managed Counter
 			{ 2,   0xF3, 0x06 }, //Percentage
 			{ 1,   0xF3, 0x09 }, //Pressure (Bar)
 			{ 85,  0x55, 0x03 }, //Rain

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -84,7 +84,7 @@ namespace http {
 			{ 16,  0xF3, 0x04 }, //Leaf Wetness
 			{ 246, 0xF6, 0x01 }, //Lux
 			{ 250, 0xFA, 0x01 }, //P1 Smart Meter (Electric)
-			{ 1005,0xF3, 0x01 }, //Managed Counter
+			{ 1005,0xF3, 0x21 }, //Managed Counter
 			{ 2,   0xF3, 0x06 }, //Percentage
 			{ 1,   0xF3, 0x09 }, //Pressure (Bar)
 			{ 85,  0x55, 0x03 }, //Rain

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -84,7 +84,7 @@ namespace http {
 			{ 16,  0xF3, 0x04 }, //Leaf Wetness
 			{ 246, 0xF6, 0x01 }, //Lux
 			{ 250, 0xFA, 0x01 }, //P1 Smart Meter (Electric)
-			{ 1005,0xEF, 0x01 }, //Managed Counter
+			{ 1005,0xF3, 0x01 }, //Managed Counter
 			{ 2,   0xF3, 0x06 }, //Percentage
 			{ 1,   0xF3, 0x09 }, //Pressure (Bar)
 			{ 85,  0x55, 0x03 }, //Rain

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -29,6 +29,9 @@
 #define bmpbaroforecast_unknown			0x05
 #define bmpbaroforecast_rain			0x06 //when forecast was cloudy and pressure is below 1010 we have 50%+ change of rain
 
+#define pTypeManaged				0xEF
+#define sTypeManagedCounter			0x00
+
 #define pTypeThermostat			0xF2
 #define sTypeThermSetpoint		0x01
 #define sTypeThermTemperature	0x02

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -29,9 +29,6 @@
 #define bmpbaroforecast_unknown			0x05
 #define bmpbaroforecast_rain			0x06 //when forecast was cloudy and pressure is below 1010 we have 50%+ change of rain
 
-#define pTypeManaged				0xEF
-#define sTypeManagedCounter			0x00
-
 #define pTypeThermostat			0xF2
 #define sTypeThermSetpoint		0x01
 #define sTypeThermTemperature	0x02
@@ -64,6 +61,7 @@
 #define sTypeWaterflow				0x1E
 #define sTypeCustom					0x1F
 #define sTypeZWaveAlarm				0x20
+#define sTypeManagedCounter			0x21
 
 //General Switch
 #define pTypeGeneralSwitch			0xF4

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -941,6 +941,44 @@ void CEventSystem::GetCurrentMeasurementStates()
 						isUtility = true;
 					}
 				}
+				else if (sitem.subType == sTypeManagedCounter)
+				{
+					if (splitresults.size() > 1) {
+						float usage = static_cast<float>(atof(splitresults[1].c_str()));
+                                                
+						if (usage < 0.0) {
+							usage = 0.0;
+						}
+
+						char szTmp[100];
+						sprintf(szTmp, "%.02f", usage);
+
+						float musage = 0;
+						_eMeterType metertype = (_eMeterType)sitem.switchtype;
+						switch (metertype)
+						{
+						case MTYPE_ENERGY:
+						case MTYPE_ENERGY_GENERATED:
+							musage = usage / EnergyDivider;
+							sprintf(szTmp, "%.03f kWh", musage);
+							break;
+						case MTYPE_GAS:
+							musage = usage / GasDivider;
+							sprintf(szTmp, "%.02f m3", musage);
+							break;
+						case MTYPE_WATER:
+							musage = usage / WaterDivider;
+							sprintf(szTmp, "%.02f m3", musage);
+							break;
+						case MTYPE_COUNTER:
+							break;
+						default:
+							continue; //not handled
+						}
+						utilityval = static_cast<float>(atof(szTmp));
+						isUtility = true;
+					}
+				}
 			}
 		}
 		break;
@@ -1059,13 +1097,6 @@ void CEventSystem::GetCurrentMeasurementStates()
 					utilityval = static_cast<float>(atof(szTmp));
 					isUtility = true;
 				}
-			}
-			break;
-		case pTypeManaged:
-			if (sitem.subType == sTypeManagedCounter)
-			{
-				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
-				isUtility = true;
 			}
 			break;
 		default:

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1061,6 +1061,13 @@ void CEventSystem::GetCurrentMeasurementStates()
 				}
 			}
 			break;
+		case pTypeManaged:
+			if (sitem.subType == sTypeManagedCounter)
+			{
+				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
+				isUtility = true;
+			}
+			break;
 		default:
 			//Unknown device
 			continue;

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -496,6 +496,7 @@ const char *RFX_Type_Desc(const unsigned char i, const unsigned char snum)
 		{ pTypeWATER, "Water" , "counter" },
 		{ pTypeWEIGHT, "Weight" , "scale" },
 		{ pTypeRFXSensor, "RFXSensor" , "unknown" },
+		{ pTypeManaged, "Managed Device" , "counter" },
 		{ pTypeRFXMeter, "RFXMeter" , "counter" },
 		{ pTypeP1Power, "P1 Smart Meter" , "counter" },
 		{ pTypeP1Gas, "P1 Smart Meter" , "counter" },
@@ -712,6 +713,8 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeRFXSensor, sTypeRFXSensorVolt, "Voltage" },
 
 		{ pTypeRFXMeter, sTypeRFXMeterCount, "RFXMeter counter" },
+
+		{ pTypeManaged, sTypeManagedCounter, "Managed Counter" },
 
 		{ pTypeP1Power, sTypeP1Power, "Energy" },
 		{ pTypeP1Gas, sTypeP1Gas, "Gas" },

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -496,7 +496,6 @@ const char *RFX_Type_Desc(const unsigned char i, const unsigned char snum)
 		{ pTypeWATER, "Water" , "counter" },
 		{ pTypeWEIGHT, "Weight" , "scale" },
 		{ pTypeRFXSensor, "RFXSensor" , "unknown" },
-		{ pTypeManaged, "Managed Device" , "counter" },
 		{ pTypeRFXMeter, "RFXMeter" , "counter" },
 		{ pTypeP1Power, "P1 Smart Meter" , "counter" },
 		{ pTypeP1Gas, "P1 Smart Meter" , "counter" },
@@ -714,8 +713,6 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 
 		{ pTypeRFXMeter, sTypeRFXMeterCount, "RFXMeter counter" },
 
-		{ pTypeManaged, sTypeManagedCounter, "Managed Counter" },
-
 		{ pTypeP1Power, sTypeP1Power, "Energy" },
 		{ pTypeP1Gas, sTypeP1Gas, "Gas" },
 
@@ -759,6 +756,7 @@ const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeGeneral, sTypeWaterflow, "Waterflow" },
 		{ pTypeGeneral, sTypeCustom, "Custom Sensor" },
 		{ pTypeGeneral, sTypeZWaveAlarm, "Alarm" },
+		{ pTypeGeneral, sTypeManagedCounter, "Managed Counter" },
 
 		{ pTypeThermostat, sTypeThermSetpoint, "SetPoint" },
 		{ pTypeThermostat, sTypeThermTemperature, "Temperature" },

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -443,7 +443,7 @@ private:
 	//Returns DeviceRowID
 	uint64_t UpdateValueInt(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction);
 
-	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, bool dayCalendar, float value, float usageCounter, const char* date);
+	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, bool dayCalendar, float counter, float usage, const char* date);
 
 	void CheckAndUpdateDeviceOrder();
 	void CheckAndUpdateSceneDeviceOrder();

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -443,7 +443,7 @@ private:
 	//Returns DeviceRowID
 	uint64_t UpdateValueInt(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction);
 
-	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, bool dayCalendar, float counter, float usage, const char* date);
+	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, bool shortLog, float counter, float usage, const char* date);
 
 	void CheckAndUpdateDeviceOrder();
 	void CheckAndUpdateSceneDeviceOrder();
@@ -470,6 +470,8 @@ private:
 	std::string CheckUserVariable(const int vartype, const std::string &varvalue);
 	std::string CheckUserVariableName(const std::string &varname);
 	bool CheckDate(const std::string &sDate, int &d, int &m, int &y);
+	bool CheckDateSQL(const std::string &sDate);
+	bool CheckDateTimeSQL(const std::string &sDateTime);
 	bool CheckTime(const std::string &sTime);
 
 	std::vector<std::vector<std::string> > query(const std::string &szQuery);

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -443,6 +443,8 @@ private:
 	//Returns DeviceRowID
 	uint64_t UpdateValueInt(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string &devname, const bool bUseOnOffAction);
 
+	bool UpdateCalendarMeter(const int HardwareID, const char* DeviceID, const unsigned char unit, const unsigned char devType, const unsigned char subType, bool dayCalendar, float value, float usageCounter, const char* date);
+
 	void CheckAndUpdateDeviceOrder();
 	void CheckAndUpdateSceneDeviceOrder();
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -394,6 +394,9 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeP1Gas:
 			// ignore, notification is done day by day in SQLHelper
 			return false;
+		case pTypeManaged:
+			// ignore, notification useless for this kind of device
+			return false;
 		case pTypeGeneral:
 			switch(cSubType) {
 				case sTypeVisibility:

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -394,9 +394,6 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeP1Gas:
 			// ignore, notification is done day by day in SQLHelper
 			return false;
-		case pTypeManaged:
-			// ignore, notification useless for this kind of device
-			return false;
 		case pTypeGeneral:
 			switch(cSubType) {
 				case sTypeVisibility:

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -205,6 +205,8 @@ const char *RFX_Type_SubType_Values(const unsigned char dType, const unsigned ch
 
 		{ pTypeRFXMeter, sTypeRFXMeterCount, "Counter" },
 
+		{ pTypeManaged, sTypeManagedCounter, "Counter" },
+
 		{ pTypeP1Power, sTypeP1Power, "Usage 1,Usage 2,Delivery 1,Delivery 2,Usage current,Delivery current" },
 		{ pTypeP1Gas, sTypeP1Gas, "Gas usage" },
 

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -205,8 +205,6 @@ const char *RFX_Type_SubType_Values(const unsigned char dType, const unsigned ch
 
 		{ pTypeRFXMeter, sTypeRFXMeterCount, "Counter" },
 
-		{ pTypeManaged, sTypeManagedCounter, "Counter" },
-
 		{ pTypeP1Power, sTypeP1Power, "Usage 1,Usage 2,Delivery 1,Delivery 2,Usage current,Delivery current" },
 		{ pTypeP1Gas, sTypeP1Gas, "Gas usage" },
 
@@ -250,6 +248,7 @@ const char *RFX_Type_SubType_Values(const unsigned char dType, const unsigned ch
 		{ pTypeGeneral, sTypeWaterflow, "Percentage" },
 		{ pTypeGeneral, sTypeCustom, "Percentage" },
 		{ pTypeGeneral, sTypeZWaveAlarm, "Status" },
+		{ pTypeGeneral, sTypeManagedCounter, "Counter" },
 
 		{ pTypeThermostat, sTypeThermSetpoint, "Temperature" },
 		{ pTypeThermostat, sTypeThermTemperature, "Temperature" },

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -306,6 +306,10 @@ define(['app'], function (app) {
 										bigtext = item.CounterToday;
 									}
 									status = $.t("Today") + ': ' + item.CounterToday + ', ' + item.Counter;
+									if (item.SubType == "Managed Counter") {
+										bigtext = item.Counter;
+										status = "";
+									}
 								}
 								else if (item.Type == "Current") {
 									status = "";
@@ -540,6 +544,9 @@ define(['app'], function (app) {
 							else if ((item.SubType == "Gas") || (item.SubType == "RFXMeter counter") || (item.SubType == "Counter Incremental")) {
 								xhtm += item.CounterToday;
 							}
+							else if (item.SubType == "Managed Counter") {
+								xhtm += item.Counter;
+							}
 							else if (item.Type == "Air Quality") {
 								xhtm += item.Data;
 							}
@@ -583,7 +590,7 @@ define(['app'], function (app) {
 							xhtm += '\t      <td id="img"><img src="images/';
 							var status = "";
 							if (typeof item.Counter != 'undefined') {
-								if ((item.Type == "RFXMeter") || (item.Type == "YouLess Meter") || (item.SubType == "Counter Incremental")) {
+								if ((item.Type == "RFXMeter") || (item.Type == "YouLess Meter") || (item.SubType == "Counter Incremental") || (item.SubType == "Managed Counter")) {
 									if (item.SwitchTypeVal == 1) {
 										xhtm += 'Gas48.png" height="48" width="48"></td>\n';
 									}
@@ -611,7 +618,7 @@ define(['app'], function (app) {
 								if ((item.SubType == "Gas") || (item.SubType == "RFXMeter counter")) {
 									status = item.Counter;
 								}
-								else {
+								else if (item.SubType != "Managed Counter") {
 									status = $.t("Today") + ': ' + item.CounterToday + ', ' + item.Counter;
 								}
 							}

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1803,7 +1803,7 @@
 					<option value="0xF31F" data-i18n="Custom Sensor">Custom Sensor</option>
 					<option value="0xF31B" data-i18n="Distance">Distance</option>
 					<option value="0xF31D" data-i18n="Electric (Instant+Counter)">Electric (Instant+Counter)</option>
-					<option value="0xEF01" data-i18n="Managed counter">Managed counter</option>
+					<option value="0xF321" data-i18n="Managed counter">Managed counter</option>
 					<option value="0xFB02" data-i18n="Gas">Gas</option>
 					<option value="0x5101" data-i18n="Humidity">Humidity</option>
 					<option value="0xF304" data-i18n="Leaf Wetness">Leaf Wetness</option>

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1803,6 +1803,7 @@
 					<option value="0xF31F" data-i18n="Custom Sensor">Custom Sensor</option>
 					<option value="0xF31B" data-i18n="Distance">Distance</option>
 					<option value="0xF31D" data-i18n="Electric (Instant+Counter)">Electric (Instant+Counter)</option>
+					<option value="0xEF01" data-i18n="Managed counter">Managed counter</option>
 					<option value="0xFB02" data-i18n="Gas">Gas</option>
 					<option value="0x5101" data-i18n="Humidity">Humidity</option>
 					<option value="0xF304" data-i18n="Leaf Wetness">Leaf Wetness</option>


### PR DESCRIPTION
Mainly for counter externally managed (Linky, Gazpar) where only history can be grabbed and that will be managed by scripts

This is another implementation proposal following discussion in PR #2271 