### PR TITLE
Serial Helper : Add support for symlink /dev/serial/by-id/

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -299,6 +299,25 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 		closedir(d);
 	}
 
+        //also scan in /dev/serial/by-id
+        d=opendir("/dev/serial/by-id");
+	if (d != NULL)
+	{
+		struct dirent *de=NULL;
+		// Loop while not NULL
+		while ((de = readdir(d)))
+		{
+			std::string fname = de->d_name;
+			if (fname.find("usb")!=std::string::npos)
+			{
+				bUseDirectPath=true;
+				ret.push_back("/dev/serial/by-id/" + fname);
+			}
+		}
+		closedir(d);
+	}
+
+
 #endif
 	return ret;
 }


### PR DESCRIPTION
/dev/serial/by-id/ folder now exits that point to the real ttyUSBx device.
It is much more convenient as it is based on the USB vendorId and productID which are stable and independant of usb insertion order.

With this for each heardware, the drop down list of serial entries include those by-id devices.

Signed-off-by: Matthias Badaire <mbadaire@gmail.com>