### PR TITLE
Update domoticz Daikin status in case changes are detected during poll

### DIFF
--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -749,6 +749,7 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx,  const bool bI
 	result = m_sql.safe_query("SELECT nValue, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='0000000%d') AND (Type==%d) AND (Unit == '%d')", m_HwdID, sID, xcmd.type, xcmd.unitcode);
 	if (result.size() < 1)
 	{
+		// New Hardware -> Create the corresponding devices Selector
 		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
 
 		if (customimage == 0) {
@@ -783,6 +784,11 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx,  const bool bI
 		}
 	
 	}
+	else
+	{
+		// Update status
+		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
+	}	
 }
 
 void CDaikin::SetModeLevel(const int NewLevel)

--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -739,19 +739,18 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx,  const bool bI
 	std::vector<std::vector<std::string> > result;
 	
 	// block this device if it is already added for another gateway hardware id
-
 	result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID!=%d) AND (DeviceID=='%d') AND (Type==%d) AND (Unit == '%d')", m_HwdID, sID, xcmd.type, xcmd.unitcode);
 	
 	if (result.size() > 0) {
 		return;
 	}
-
+	
+	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
+	
 	result = m_sql.safe_query("SELECT nValue, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='0000000%d') AND (Type==%d) AND (Unit == '%d')", m_HwdID, sID, xcmd.type, xcmd.unitcode);
-	if (result.size() < 1)
+	if (result.empty())
 	{
 		// New Hardware -> Create the corresponding devices Selector
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
-
 		if (customimage == 0) {
 			if (sID == 5) {
 				customimage = 16; //wall socket			
@@ -784,11 +783,6 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx,  const bool bI
 		}
 	
 	}
-	else
-	{
-		// Update status
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
-	}	
 }
 
 void CDaikin::SetModeLevel(const int NewLevel)


### PR DESCRIPTION
Defect #2410
In case they are some changes done on the Daikin HW via for instance remote control , we need to update the Domoticz devices (Selectors) accordingy

Up to now, those selector were created after addition of the new HW, but were never updated during the polling exercise