### PR TITLE
Update XiaomiGateway.cpp

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -528,7 +528,7 @@ void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::str
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, NULL, BatteryLevel);
 			}
 		}
-		if (Name == "Xiaomi Smart Plug") {
+		if ((Name == "Xiaomi Smart Plug") || (Name == "Xiaomi Smart Wall Plug")) {
 			if (load_power != "" && power_consumed != "") {
 				int power = atoi(load_power.c_str());
 				int consumed = atoi(power_consumed.c_str()) / 1000;


### PR DESCRIPTION
Commented here: https://github.com/domoticz/domoticz/issues/2470

Aqara wall plug recognized as ctrl_86plug.aq1 doesnt show power usage:

So i guess that a better way to solve it is just change on line 531:
if (Name == "Xiaomi Smart Plug") {
if ((Name == "Xiaomi Smart Plug") || (Name == "Xiaomi Smart Wall Plug")) {