### PR TITLE
When compiling LUA, include FreeBSD as a target in addition to Linux …

### DIFF
--- a/lua/src/CMakeLists.txt
+++ b/lua/src/CMakeLists.txt
@@ -7,7 +7,7 @@ SET(CORE lapi.c lcode.c lctype.c ldebug.c ldo.c ldump.c lfunc.c lgc.c llex.c
 SET (LIB lauxlib.c lbaselib.c lbitlib.c lcorolib.c ldblib.c liolib.c
 	lmathlib.c loslib.c lstrlib.c ltablib.c loadlib.c linit.c)
 
-IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+IF(${CMAKE_SYSTEM_NAME} MATCHES "Linux|FreeBSD")
 	SET(OperatingSystem "Linux")
 	add_definitions(-DLUA_USE_LINUX)
 ENDIF(${CMAKE_SYSTEM_NAME} MATCHES "Linux")


### PR DESCRIPTION
…when adding -DLUA_USE_LINUX

This fixes dzVents not working on FreeBSD. See this forum post: http://www.domoticz.com/forum/viewtopic.php?f=59&t=23743