### PR TITLE
Rewritten GCM Specific phone selection method

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3422,7 +3422,12 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			sound = aParam[3];
 		}
 		if (aParam.size() > 4) {
-			extraData = "|Device=" + aParam[4];
+			if (aParam[4].find("midx_") != std::string::npos) {
+				extraData = aParam[4];
+			}
+			else {
+				extraData = "|Device=" + aParam[4];
+			}
 		}
 		if (aParam.size() > 5) {
 			subsystem = aParam[5];

--- a/notifications/NotificationGCM.cpp
+++ b/notifications/NotificationGCM.cpp
@@ -36,22 +36,19 @@ bool CNotificationGCM::SendMessageImplementation(
 
 	std::string sMidx;
 	std::vector<std::string> vDevices;
-	//std::string sDevice = "";
-	if (ExtraData.find("midx_") != std::string::npos)
+	if (ExtraData.find("midx_") != std::string::npos) {
 		sMidx = ExtraData.substr(5);
-	if (ExtraData.find("|Device=") != std::string::npos) {
-		std::string sDevice = ExtraData.substr(8);
-		if (!sDevice.empty())
-			boost::split(vDevices, sDevice, boost::is_any_of(";"));
+		boost::split(vDevices, sMidx, boost::is_any_of(";"));
 	}
 
 	std::string szQuery("SELECT SenderID, DeviceType FROM MobileDevices");
-	if (!sMidx.empty())
-		szQuery += " WHERE (ID == " + sMidx + ")";
-	else if (!vDevices.empty())
+	if (!vDevices.empty()) {
 		szQuery += " WHERE (ID IN (" + boost::algorithm::join(vDevices, ",") + "))";
-	else
+	}
+	else {
 		szQuery += " WHERE (Active == 1)";
+	}
+
 	result = m_sql.safe_query(szQuery.c_str());
 	if (result.empty())
 		return true;


### PR DESCRIPTION
Rewritten GCM Specific phone selection method

Just now you need to do the following:
table.insert(commandArray, {['SendNotification'] = "Subject#Message###midx_7;8#gcm"})

instead of:
table.insert(commandArray, {['SendNotification'] = "Subject#Message###7;8#gcm"})

I think, because I build it and I did not change the wiki's, this wasn't used, so no (much) problems for other users.

midx_ was introduced by @gizmocuz to do a single test message from the mobile devices overview