### PR TITLE
Python 3.7 GIL changes

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -119,6 +119,8 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(long, PyLong_AsLong, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyUnicode_AsUTF8String, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyImport_AddModule, const char*);
+		DECLARE_PYTHON_SYMBOL(void, PyEval_SetProfile, Py_tracefunc COMMA PyObject*);
+		DECLARE_PYTHON_SYMBOL(void, PyEval_SetTrace, Py_tracefunc COMMA PyObject*);
 
 #ifdef _DEBUG
 		// In a debug build dealloc is a function but for release builds its a macro
@@ -238,6 +240,8 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyLong_AsLong);
 					RESOLVE_PYTHON_SYMBOL(PyUnicode_AsUTF8String);
 					RESOLVE_PYTHON_SYMBOL(PyImport_AddModule);
+					RESOLVE_PYTHON_SYMBOL(PyEval_SetProfile);
+					RESOLVE_PYTHON_SYMBOL(PyEval_SetTrace);
 				}
 			}
 			_Py_NoneStruct.ob_refcnt = 1;
@@ -414,4 +418,6 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyLong_AsLong			pythonLib->PyLong_AsLong
 #define PyUnicode_AsUTF8String	pythonLib->PyUnicode_AsUTF8String
 #define PyImport_AddModule		pythonLib->PyImport_AddModule
+#define PyEval_SetProfile		pythonLib->PyEval_SetProfile
+#define PyEval_SetTrace			pythonLib->PyEval_SetTrace
 }

--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -87,6 +87,7 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyObject_CallObject, PyObject* COMMA PyObject*);
 		DECLARE_PYTHON_SYMBOL(int, PyFrame_GetLineNumber, PyFrameObject*);
 		DECLARE_PYTHON_SYMBOL(void, PyEval_InitThreads, );
+		DECLARE_PYTHON_SYMBOL(int, PyEval_ThreadsInitialized, );
 		DECLARE_PYTHON_SYMBOL(PyThreadState*, PyThreadState_Get, );
 		DECLARE_PYTHON_SYMBOL(PyThreadState*, PyEval_SaveThread, void);
 		DECLARE_PYTHON_SYMBOL(void, PyEval_RestoreThread, PyThreadState*);
@@ -205,6 +206,7 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyObject_CallObject);
 					RESOLVE_PYTHON_SYMBOL(PyFrame_GetLineNumber);
 					RESOLVE_PYTHON_SYMBOL(PyEval_InitThreads);
+					RESOLVE_PYTHON_SYMBOL(PyEval_ThreadsInitialized);
 					RESOLVE_PYTHON_SYMBOL(PyThreadState_Get);
 					RESOLVE_PYTHON_SYMBOL(PyEval_SaveThread);
 					RESOLVE_PYTHON_SYMBOL(PyEval_RestoreThread);
@@ -380,6 +382,7 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyObject_CallObject		pythonLib->PyObject_CallObject
 #define PyFrame_GetLineNumber	pythonLib->PyFrame_GetLineNumber
 #define	PyEval_InitThreads		pythonLib->PyEval_InitThreads
+#define	PyEval_ThreadsInitialized	pythonLib->PyEval_ThreadsInitialized
 #define	PyThreadState_Get		pythonLib->PyThreadState_Get
 #define PyEval_SaveThread		pythonLib->PyEval_SaveThread
 #define PyEval_RestoreThread	pythonLib->PyEval_RestoreThread

--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -86,8 +86,13 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyImport_ImportModule, const char*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyObject_CallObject, PyObject* COMMA PyObject*);
 		DECLARE_PYTHON_SYMBOL(int, PyFrame_GetLineNumber, PyFrameObject*);
+		DECLARE_PYTHON_SYMBOL(void, PyEval_InitThreads, );
+		DECLARE_PYTHON_SYMBOL(PyThreadState*, PyThreadState_Get, );
 		DECLARE_PYTHON_SYMBOL(PyThreadState*, PyEval_SaveThread, void);
 		DECLARE_PYTHON_SYMBOL(void, PyEval_RestoreThread, PyThreadState*);
+		DECLARE_PYTHON_SYMBOL(void, PyEval_ReleaseLock, );
+		DECLARE_PYTHON_SYMBOL(PyThreadState*, PyThreadState_Swap, PyThreadState*);
+		DECLARE_PYTHON_SYMBOL(int, PyGILState_Check, );
 		DECLARE_PYTHON_SYMBOL(void, _Py_NegativeRefcount, const char* COMMA int COMMA PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, _PyObject_New, PyTypeObject*);
 #ifdef _DEBUG
@@ -197,8 +202,13 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyImport_ImportModule);
 					RESOLVE_PYTHON_SYMBOL(PyObject_CallObject);
 					RESOLVE_PYTHON_SYMBOL(PyFrame_GetLineNumber);
+					RESOLVE_PYTHON_SYMBOL(PyEval_InitThreads);
+					RESOLVE_PYTHON_SYMBOL(PyThreadState_Get);
 					RESOLVE_PYTHON_SYMBOL(PyEval_SaveThread);
 					RESOLVE_PYTHON_SYMBOL(PyEval_RestoreThread);
+					RESOLVE_PYTHON_SYMBOL(PyEval_ReleaseLock);
+					RESOLVE_PYTHON_SYMBOL(PyThreadState_Swap);
+					RESOLVE_PYTHON_SYMBOL(PyGILState_Check);
 					RESOLVE_PYTHON_SYMBOL(_Py_NegativeRefcount);
 					RESOLVE_PYTHON_SYMBOL(_PyObject_New);
 #ifdef _DEBUG
@@ -365,8 +375,13 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyImport_ImportModule	pythonLib->PyImport_ImportModule
 #define PyObject_CallObject		pythonLib->PyObject_CallObject
 #define PyFrame_GetLineNumber	pythonLib->PyFrame_GetLineNumber
+#define	PyEval_InitThreads		pythonLib->PyEval_InitThreads
+#define	PyThreadState_Get		pythonLib->PyThreadState_Get
 #define PyEval_SaveThread		pythonLib->PyEval_SaveThread
 #define PyEval_RestoreThread	pythonLib->PyEval_RestoreThread
+#define PyEval_ReleaseLock		pythonLib->PyEval_ReleaseLock
+#define PyThreadState_Swap		pythonLib->PyThreadState_Swap
+#define PyGILState_Check		pythonLib->PyGILState_Check
 #define _Py_NegativeRefcount	pythonLib->_Py_NegativeRefcount
 #define _PyObject_New			pythonLib->_PyObject_New
 #define PyArg_ParseTuple		pythonLib->PyArg_ParseTuple

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -139,10 +139,14 @@ namespace Plugins {
 			}
 
 			Py_Initialize();
-			m_InitialPythonThread = PyEval_SaveThread();
 
 			// Initialise threads. Python 3.7+ does this inside Py_Initialize so done here for compatibility
-			PyEval_InitThreads();
+			if (!PyEval_ThreadsInitialized())
+			{
+				PyEval_InitThreads();
+			}
+
+			m_InitialPythonThread = PyEval_SaveThread();
 
 			m_bEnabled = true;
 			_log.Log(LOG_STATUS, "PluginSystem: Started, Python version '%s'.", sVersion.c_str());

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -141,6 +141,9 @@ namespace Plugins {
 			Py_Initialize();
 			m_InitialPythonThread = PyEval_SaveThread();
 
+			// Initialise threads. Python 3.7+ does this inside Py_Initialize so done here for compatibility
+			PyEval_InitThreads();
+
 			m_bEnabled = true;
 			_log.Log(LOG_STATUS, "PluginSystem: Started, Python version '%s'.", sVersion.c_str());
 		}
@@ -319,7 +322,13 @@ namespace Plugins {
 					}
 				}
 				// Free the memory for the message
-				if (Message) delete Message;
+				if (Message)
+				{
+					CPlugin* pPlugin = (CPlugin*)Message->Plugin();
+					pPlugin->RestoreThread();
+					delete Message;
+					pPlugin->ReleaseThread();
+				}
 			}
 			sleep_milliseconds(50);
 		}

--- a/hardware/plugins/PluginManager.h
+++ b/hardware/plugins/PluginManager.h
@@ -36,10 +36,11 @@ namespace Plugins {
 		std::map<int, CDomoticzHardwareBase*>* GetHardware() { return &m_pPlugins; };
 		CDomoticzHardwareBase* RegisterPlugin(const int HwdID, const std::string &Name, const std::string &PluginKey);
 		void	 DeregisterPlugin(const int HwdID);
-		bool StopPluginSystem();
-		void AllPluginsStarted() { m_bAllPluginsStarted = true; };
+		bool	StopPluginSystem();
+		void	AllPluginsStarted() { m_bAllPluginsStarted = true; };
 		static void LoadSettings();
 		void	DeviceModified(uint64_t ID);
+		void*	PythonThread() { return m_InitialPythonThread; };
 	};
 };
 

--- a/hardware/plugins/PluginMessages.h
+++ b/hardware/plugins/PluginMessages.h
@@ -73,6 +73,7 @@ namespace Plugins {
 			boost::lock_guard<boost::mutex> l(PythonMutex);
 			m_pPlugin->RestoreThread();
 			ProcessLocked();
+			m_pPlugin->ReleaseThread();
 		};
 		virtual const char* PythonName() { return m_Callback.c_str(); };
 	};
@@ -367,6 +368,7 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 			boost::lock_guard<boost::mutex> l(PythonMutex);
 			m_pPlugin->RestoreThread();
 			ProcessLocked();
+			m_pPlugin->ReleaseThread();
 		};
 	};
 
@@ -454,6 +456,7 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 			boost::lock_guard<boost::mutex> l(PythonMutex);
 			m_pPlugin->RestoreThread();
 			ProcessLocked();
+			m_pPlugin->ReleaseThread();
 		}
 	};
 

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -78,6 +78,7 @@ namespace Plugins {
 		void	DisconnectEvent(CEventBase*);
 		void	Callback(std::string sHandler, void* pParams);
 		void	RestoreThread();
+		void	ReleaseThread();
 		void	Stop();
 
 		void	WriteDebugBuffer(const std::vector<byte>& Buffer, bool Incoming);

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -108,6 +108,7 @@ namespace Plugins {
 		PluginDebugMask		m_bDebug;
 		bool				m_stoprequested;
 		bool				m_bIsStarting;
+		bool				m_bTracing;
 	};
 
 	class CPluginNotifier : public CNotificationBase


### PR DESCRIPTION
Python 3.7 forces Python threading to by initialized which means that Domoticz needs to handle the Global Interpreter Lock (GIL) now.  This was avoided previously for simplicity and because its use is poorly documented for use with sub-interpreters.

This pull request turns on threading for all versions of Python (3.4+) for consistency and manages the GIL through matched 'SaveThread' and 'RestoreThread' operations on the Python threads.

To be clear, the Plugin Framework is still as single threaded as it always was and this PR is backwards compatible with existing plugins.

Tested on Python 3.5, 3.6 and 3.7 on Windows 10 and Linux (Ubuntu 18.04).

This PR also adds a new 'Trace' function that plugin developers can toggle inside plugins to get line level tracking of their code executing.  This is a 1st version with minimal details and will be built out later.