### PR TITLE
Fix crash - ensures we don't join twice the thread

### DIFF
--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -150,7 +150,7 @@ bool CHarmonyHub::StartHardware()
 
 bool CHarmonyHub::StopHardware()
 {
-	if (m_thread != NULL)
+	if (m_thread != NULL && m_thread->joinable())
 	{
 		m_stoprequested = true;
 		m_thread->join();


### PR DESCRIPTION
See https://github.com/domoticz/domoticz/issues/2549 - Makes sure we don't "join" the thread twice.