### PR TITLE
Safe HW shutdown

### DIFF
--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -105,6 +105,7 @@ bool Comm5Serial::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -76,6 +76,7 @@ bool CurrentCostMeterSerial::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -61,6 +61,7 @@ bool CDavisLoggerSerial::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -90,6 +90,7 @@ void CDomoticzHardwareBase::StopHeartbeatThread()
 	{
 		m_Heartbeatthread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_Heartbeatthread.reset();
 	}

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -658,6 +658,7 @@ bool CEnOceanESP2::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -443,6 +443,7 @@ bool CEnOceanESP3::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/EvohomeSerial.cpp
+++ b/hardware/EvohomeSerial.cpp
@@ -31,6 +31,7 @@ bool CEvohomeSerial::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted=false;

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -58,6 +58,7 @@ bool KMTronic433::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -56,6 +56,7 @@ bool KMTronicSerial::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -1169,7 +1169,10 @@ void CKodi::UnloadNodes()
 	m_ios.stop();	// stop the service if it is running
 	sleep_milliseconds(100);
 
-	while (((!m_pNodes.empty()) || (!m_ios.stopped())) && (iRetryCounter < 15))
+	bool empty = m_pNodes.empty();
+	bool stopped = m_ios.stopped();
+
+	while ((!empty || !stopped) && (iRetryCounter < 120))
 	{
 		std::vector<std::shared_ptr<CKodiNode> >::iterator itt;
 		for (itt = m_pNodes.begin(); itt != m_pNodes.end(); ++itt)
@@ -1183,7 +1186,15 @@ void CKodi::UnloadNodes()
 			}
 		}
 		iRetryCounter++;
+		_log.Log(LOG_NORM, "Kodi: RetryCounter: %d", iRetryCounter);
 		sleep_milliseconds(500);
+		empty = m_pNodes.empty();
+		stopped = m_ios.stopped();
+	}
+	if (!empty || !stopped)
+	{
+		_log.Log(LOG_ERROR, "Kodi: Failed to stop nodes, m_pNodes.empty(): %u, m_ios.stopped(): %u", empty, stopped);
+		abort();
 	}
 	m_pNodes.clear();
 }

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -134,7 +134,7 @@ bool CLogitechMediaServer::StopHardware()
 
 			//Make sure all our background workers are stopped
 			int iRetryCounter = 0;
-			while ((m_iThreadsRunning > 0) && (iRetryCounter < 15))
+			while ((m_iThreadsRunning > 0) && (iRetryCounter < 120))
 			{
 				sleep_milliseconds(500);
 				iRetryCounter++;
@@ -144,6 +144,11 @@ bool CLogitechMediaServer::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (m_iThreadsRunning > 0)
+	{
+		_log.Log(LOG_ERROR, "Logitech Media Server: Failed to stop workers, m_iThreadsRunning: %u", m_iThreadsRunning);
+		abort();
 	}
 	m_bIsStarted = false;
 	return true;

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -66,6 +66,7 @@ bool MySensorsSerial::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -71,6 +71,7 @@ bool COpenWebNetUSB::StopHardware()
 		m_thread.reset();
 	}
 	// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -125,6 +125,7 @@ bool P1MeterSerial::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -1023,7 +1023,10 @@ void CPanasonic::UnloadNodes()
 	m_ios.stop();	// stop the service if it is running
 	sleep_milliseconds(100);
 
-	while (((!m_pNodes.empty()) || (!m_ios.stopped())) && (iRetryCounter < 15))
+	bool empty = m_pNodes.empty();
+	bool stopped = m_ios.stopped();
+
+	while ((!empty || !stopped) && (iRetryCounter < 120))
 	{
 		std::vector<std::shared_ptr<CPanasonicNode> >::iterator itt;
 		for (itt = m_pNodes.begin(); itt != m_pNodes.end(); ++itt)
@@ -1038,6 +1041,13 @@ void CPanasonic::UnloadNodes()
 		}
 		iRetryCounter++;
 		sleep_milliseconds(500);
+		empty = m_pNodes.empty();
+		stopped = m_ios.stopped();
+	}
+	if (!empty || !stopped)
+	{
+		_log.Log(LOG_ERROR, "Panasonic Plugin: Failed to stop nodes, m_pNodes.empty(): %u, m_ios.stopped(): %u", empty, stopped);
+		abort();
 	}
 	m_pNodes.clear();
 }

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -192,7 +192,7 @@ bool CPinger::StopHardware()
 
 			//Make sure all our background workers are stopped
 			int iRetryCounter = 0;
-			while ((m_iThreadsRunning > 0) && (iRetryCounter < 15))
+			while ((m_iThreadsRunning > 0) && (iRetryCounter < 120))
 			{
 				sleep_milliseconds(500);
 				iRetryCounter++;
@@ -202,6 +202,11 @@ bool CPinger::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (m_iThreadsRunning > 0)
+	{
+		_log.Log(LOG_ERROR, "Pinger: Failed to stop workers, m_iThreadsRunning: %u", m_iThreadsRunning);
+		abort();
 	}
 	m_bIsStarted = false;
 	return true;

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -35,6 +35,7 @@ bool CRFLinkSerial::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -114,6 +114,7 @@ bool RFXComSerial::StopHardware()
 		m_thread.reset();
 	}
     // Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
     sleep_milliseconds(10);
 	if (m_serial.isOpen())
 		m_serial.close();

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -151,6 +151,7 @@ bool CRego6XXSerial::StopHardware()
 		m_thread.reset();
 	}
     // Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+	// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
     sleep_milliseconds(10);
     terminate();
 	m_bIsStarted=false;

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -114,6 +114,7 @@ bool USBtin::StopHardware()
 		m_thread->join();
 		m_thread.reset();
 	}
+	//TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 	sleep_milliseconds(10);
 	terminate();
 	m_bIsStarted = false;

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -38,6 +38,7 @@ bool CZiBlueSerial::StopHardware()
 	{
 		m_thread->join();
 		// Wait a while. The read thread might be reading. Adding this prevents a pointer error in the async serial class.
+		// TODO: Add proper synchronized shutdown of read thread instead of fixed timeout
 		sleep_milliseconds(10);
 		m_thread.reset();
 	}

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -880,6 +880,7 @@ namespace Plugins {
 				if (m_bIsStarting)
 				{
 					_log.Log(LOG_ERROR, "(%s) Plugin did not finish start after %d seconds", m_Name.c_str(), timeout);
+					abort();
 				}
 			}
 
@@ -918,10 +919,8 @@ namespace Plugins {
 				}
 				if (m_bIsStarted)
 				{
-					_log.Log(LOG_ERROR, "(%s) Plugin did not stop after %d seconds, flushing event queue...", m_Name.c_str(), timeout);
-
-					ClearMessageQueue();
-					m_bIsStarted = false;
+					_log.Log(LOG_ERROR, "(%s) Plugin did not stop after %d seconds...", m_Name.c_str(), timeout);
+					abort();
 				}
 			}
 


### PR DESCRIPTION
In some HW types relying on worker threads, there there are currently timeouts waiting for the worker threads to finish when stopping or restarting the HW. If this timeout expires, Domoticz simply soldiers on.
This **will** cause the worker threads to use freed memory in case they are not truly stuck, which causes crashes and other undefined behavior.

This change:
- Increases the timeout such that a blocking call for exampleto resolve an address or do some network related operation should timeout
- Will instead print an error and then call abort() in case the timeout expires, to allow Domoticz to be restarted, e.g. by systemd or by Windows service management.