### PR TITLE
Fix crash on stopping DomoticzTCP

### DIFF
--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -7,6 +7,10 @@
 #include "../main/WebServerHelper.h"
 #include "../webserver/proxyclient.h"
 
+#ifdef WIN32
+#define SHUT_RDWR SD_BOTH
+#endif
+
 #define RETRY_DELAY 30
 
 extern http::server::CWebServerHelper m_webservers;

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -147,19 +147,17 @@ bool DomoticzTCP::StopHardwareTCP()
 			//Don't throw from a Stop command
 		}
 	}
-	else {
-		try {
-			if (m_thread)
-			{
-				m_stoprequested = true;
-				m_thread->join();
-				m_thread.reset();
-			}
-		}
-		catch (...)
+	try {
+		if (m_thread)
 		{
-			//Don't throw from a Stop command
+			m_stoprequested = true;
+			m_thread->join();
+			m_thread.reset();
 		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
 	}
 	m_bIsStarted = false;
 	return true;
@@ -213,11 +211,11 @@ void DomoticzTCP::disconnectTCP()
 	m_stoprequested = true;
 	if (m_socket != INVALID_SOCKET)
 	{
+		shutdown(m_socket, SHUT_RDWR);
 		closesocket(m_socket);	//will terminate the thread
 		m_socket = INVALID_SOCKET;
 		sleep_seconds(1);
 	}
-	//m_thread-> join();
 }
 
 void DomoticzTCP::Do_Work()

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -214,7 +214,6 @@ void DomoticzTCP::disconnectTCP()
 		shutdown(m_socket, SHUT_RDWR);
 		closesocket(m_socket);	//will terminate the thread
 		m_socket = INVALID_SOCKET;
-		sleep_seconds(1);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/domoticz/domoticz/issues/2563#issuecomment-405197322 
Call shutdown before close on socket, so it won't hang until data is received. This way we can wait for the worker thread to quickly and cleanly finish. 