### PR TITLE
Name all threads to aid debugging

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -75,9 +75,11 @@ bool C1Wire::StartHardware()
 	// Start worker thread
 	if (m_sensorThreadPeriod != 0) {
 		m_threadSensors = std::make_shared<std::thread>(&C1Wire::SensorThread, this);
+		SetThreadName(m_threadSensors->native_handle(), "1WireSensors");
 	}
 	if (m_switchThreadPeriod != 0) {
 		m_threadSwitches = std::make_shared<std::thread>(&C1Wire::SwitchThread, this);
+		SetThreadName(m_threadSwitches->native_handle(), "1WireSwitches");
 	}
 	m_bIsStarted=true;
 	sOnConnected(this);

--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -28,6 +28,7 @@ C1WireByKernel::C1WireByKernel() :
 	m_stoprequested(false)
 {
 	m_thread = std::make_shared<std::thread>(&C1WireByKernel::ThreadFunction, this);
+	SetThreadName(m_thread->native_handle(), "1WireByKernel");
 	_log.Log(LOG_STATUS, "Using 1-Wire support (kernel W1 module)...");
 }
 

--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -52,7 +52,7 @@ class AsyncSerialImpl
 {
 public:
     AsyncSerialImpl(): io(), port(io), backgroundThread(), open(false),
-		error(false), writeBufferSize(0) {}
+		error(false), writeBufferSize(0) {SetThreadName(backgroundThread.native_handle(), "AsyncSer_Background");}
 
     boost::asio::io_service io; ///< Io service object
     boost::asio::serial_port port; ///< Serial port object
@@ -122,6 +122,7 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
     pimpl->io.post(boost::bind(&AsyncSerial::doRead, this));
 
     boost::thread t(boost::bind(&boost::asio::io_service::run, &pimpl->io));
+	SetThreadName(t.native_handle(), "AsyncSer_Background");
     pimpl->backgroundThread.swap(t);
     setErrorStatus(false);//If we get here, no error
     pimpl->open=true; //Port is now open
@@ -154,6 +155,7 @@ void AsyncSerial::openOnlyBaud(const std::string& devname, unsigned int baud_rat
 	pimpl->io.post(boost::bind(&AsyncSerial::doRead, this));
 
 	boost::thread t(boost::bind(&boost::asio::io_service::run, &pimpl->io));
+	SetThreadName(t.native_handle(), "AsyncSer_Background");
 	pimpl->backgroundThread.swap(t);
 	setErrorStatus(false);//If we get here, no error
 	pimpl->open=true; //Port is now open

--- a/hardware/AccuWeather.cpp
+++ b/hardware/AccuWeather.cpp
@@ -71,6 +71,7 @@ bool CAccuWeather::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CAccuWeather::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "AccuWeather");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -75,6 +75,7 @@ bool CAnnaThermostat::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CAnnaThermostat::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "AnnaThermostat");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -46,6 +46,7 @@ bool Arilux::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Arilux::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Arilux");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -96,6 +96,7 @@ bool CAtagOne::StartHardware()
 	m_LastMinute = -1;
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CAtagOne::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "AtagOne");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/BleBox.cpp
+++ b/hardware/BleBox.cpp
@@ -52,6 +52,7 @@ bool BleBox::StartHardware()
 
 	LoadNodes();
 	m_thread = std::make_shared<std::thread>(&BleBox::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "BleBox");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);
@@ -1189,7 +1190,9 @@ void BleBox::SearchNodes(const std::string &ipmask)
 		std::map<const std::string, const int>::const_iterator itt = m_devices.find(IPAddress);
 		if (itt == m_devices.end())
 		{
-			searchingThreads.push_back(std::make_shared<std::thread>(&BleBox::AddNode, this, "unknown", IPAddress));
+			auto thread = std::make_shared<std::thread>(&BleBox::AddNode, this, "unknown", IPAddress);
+			SetThreadName(thread->native_handle(), "BleBox_Search");
+			searchingThreads.push_back(thread);
 		}
 	}
 

--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -55,6 +55,7 @@ bool Comm5SMTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Comm5SMTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Comm5SMTCP");
 
 	_log.Log(LOG_STATUS, "Comm5 SM-XXXX: Started");
 

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -63,6 +63,7 @@ bool Comm5Serial::StartHardware()
 {
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&Comm5Serial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Comm5Serial");
 
 	//Try to open the Serial Port
 	try

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -59,6 +59,7 @@ bool Comm5TCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Comm5TCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Comm5TCP");
 
 	_log.Log(LOG_STATUS, "Comm5 MA-5XXX: Started");
 

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -34,6 +34,7 @@ bool CurrentCostMeterSerial::StartHardware()
 {
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CurrentCostMeterSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "CurrentCostMeterSerial");
 
 	//Try to open the Serial Port
 	try

--- a/hardware/CurrentCostMeterTCP.cpp
+++ b/hardware/CurrentCostMeterTCP.cpp
@@ -57,6 +57,7 @@ bool CurrentCostMeterTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CurrentCostMeterTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "CurrentCostMeterTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -104,6 +104,7 @@ bool CDaikin::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDaikin::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Daikin");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "Daikin: Started hardware %s ...", m_szIPAddress.c_str());

--- a/hardware/DarkSky.cpp
+++ b/hardware/DarkSky.cpp
@@ -69,6 +69,7 @@ bool CDarkSky::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDarkSky::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Darksky");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -47,6 +47,7 @@ bool CDavisLoggerSerial::StartHardware()
 	m_stoprequested = false;
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDavisLoggerSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "DavisLoggerSerial");
 
 	return (m_thread != nullptr);
 

--- a/hardware/DenkoviDevices.cpp
+++ b/hardware/DenkoviDevices.cpp
@@ -66,6 +66,7 @@ bool CDenkoviDevices::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDenkoviDevices::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "DenkoviDevices");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	switch (m_iModel) {

--- a/hardware/DenkoviSmartdenIPInOut.cpp
+++ b/hardware/DenkoviSmartdenIPInOut.cpp
@@ -60,6 +60,7 @@ bool CDenkoviSmartdenIPInOut::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDenkoviSmartdenIPInOut::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "DenkoviSmartdenIPInOut");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "Denkovi_IP_In: Started");

--- a/hardware/DenkoviSmartdenLan.cpp
+++ b/hardware/DenkoviSmartdenLan.cpp
@@ -40,6 +40,7 @@ bool CDenkoviSmartdenLan::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CDenkoviSmartdenLan::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "DenkoviSmartdenLAN");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "Denkovi: Started");

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -81,6 +81,7 @@ void CDomoticzHardwareBase::StartHeartbeatThread()
 {
 	m_stopHeartbeatrequested = false;
 	m_Heartbeatthread = std::make_shared<std::thread>(&CDomoticzHardwareBase::Do_Heartbeat_Work, this);
+	SetThreadName(m_Heartbeatthread->native_handle(), "Domoticz_HBWork");
 }
 
 void CDomoticzHardwareBase::StopHeartbeatThread()

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -117,6 +117,7 @@ bool DomoticzTCP::StartHardwareTCP()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&DomoticzTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "DomoticzTCP");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/ETH8020.cpp
+++ b/hardware/ETH8020.cpp
@@ -36,6 +36,7 @@ bool CETH8020::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CETH8020::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ETH8020");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "ETH8020: Started");

--- a/hardware/Ec3kMeterTCP.cpp
+++ b/hardware/Ec3kMeterTCP.cpp
@@ -69,6 +69,7 @@ bool Ec3kMeterTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Ec3kMeterTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Ec3kMeterTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/EcoCompteur.cpp
+++ b/hardware/EcoCompteur.cpp
@@ -49,6 +49,7 @@ bool CEcoCompteur::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CEcoCompteur::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EcoCompteur");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -103,6 +103,7 @@ bool CEcoDevices::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CEcoDevices::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EcoDevices");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -647,6 +647,7 @@ bool CEnOceanESP2::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CEnOceanESP2::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EnOceanESP2");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -432,6 +432,7 @@ bool CEnOceanESP3::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CEnOceanESP3::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EnOceanESP3");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -55,6 +55,7 @@ bool EnphaseAPI::StartHardware()
 {
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&EnphaseAPI::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EnphaseAPI");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -182,6 +182,7 @@ bool CEvohomeRadio::StartHardware()
 	m_bDoRestart = false;
 	m_retrycntr = EVOHOME_RETRY_DELAY; //will force reconnect first thing
 	m_thread = std::make_shared<std::thread>(&CEvohomeRadio::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EvohomeRadio");
 	m_bIsStarted = true;
 
 	return (m_thread != nullptr);

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -165,6 +165,7 @@ bool CEvohomeWeb::StartHardware()
 		return false;
 	Init();
 	m_thread = std::make_shared<std::thread>(&CEvohomeWeb::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EvohomeWeb");
 	if (!m_thread)
 		return false;
 	m_stoprequested = false;

--- a/hardware/FritzboxTCP.cpp
+++ b/hardware/FritzboxTCP.cpp
@@ -61,6 +61,7 @@ bool FritzboxTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&FritzboxTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "FritzboxTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/GoodweAPI.cpp
+++ b/hardware/GoodweAPI.cpp
@@ -107,6 +107,7 @@ bool GoodweAPI::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&GoodweAPI::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "GoodweAPI");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -254,10 +254,12 @@ bool CGpio::StartHardware()
 			m_stoprequested=true;
 		 }*/
 		m_thread_updatestartup = std::make_shared<std::thread>(&CGpio::UpdateStartup, this);
+		SetThreadName(m_thread_updatestartup->native_handle(), "GPIO_UpdStartup");
 
 		if (m_pollinterval > 0)
 		{
 			m_thread_poller = std::make_shared<std::thread>(&CGpio::Poller, this);
+			SetThreadName(m_thread_poller->native_handle(), "GPIO_Poller");
 		}
 	}
 	else
@@ -512,6 +514,7 @@ bool CGpio::InitPins()
 			{
 				pinPass = gpio_pin;
 				m_thread_interrupt[gpio_pin] = std::make_shared<std::thread>(&CGpio::InterruptHandler, this);
+				SetThreadName(m_thread_interrupt[gpio_pin]->native_handle(), "GPIO_Interrupt");
 				while (pinPass != -1)
 					sleep_milliseconds(1);
 			}

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -585,6 +585,7 @@ bool CHEOS::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CHEOS::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "HEOS");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -114,6 +114,7 @@ bool CHardwareMonitor::StartHardware()
 	m_stoprequested = false;
 	m_lastquerytime = 0;
 	m_thread = std::make_shared<std::thread>(&CHardwareMonitor::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "HardwareMonitor");
 	m_bIsStarted = true;
 	sOnConnected(this);
 #if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -142,6 +142,7 @@ bool CHarmonyHub::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CHarmonyHub::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "HarmonyHub");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Honeywell.cpp
+++ b/hardware/Honeywell.cpp
@@ -53,6 +53,7 @@ bool CHoneywell::StartHardware() {
 	mLastMinute = -1;
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CHoneywell::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Honeywell");
 	mIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/HttpPoller.cpp
+++ b/hardware/HttpPoller.cpp
@@ -62,6 +62,7 @@ bool CHttpPoller::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CHttpPoller::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "HttpPoller");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -185,6 +185,7 @@ bool I2C::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&I2C::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "I2C");
 	sOnConnected(this);
 	m_bIsStarted = true;
 	return (m_thread != nullptr);

--- a/hardware/ICYThermostat.cpp
+++ b/hardware/ICYThermostat.cpp
@@ -49,6 +49,7 @@ bool CICYThermostat::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CICYThermostat::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ICYThermostat");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/InComfort.cpp
+++ b/hardware/InComfort.cpp
@@ -54,6 +54,7 @@ bool CInComfort::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CInComfort::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "InComfort");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -43,6 +43,7 @@ bool KMTronic433::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&KMTronic433::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "KMTronic433");
 
 	return (m_thread != nullptr);
 

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -44,6 +44,7 @@ bool KMTronicSerial::StartHardware()
 	//Start worker thread
 	m_bIsStarted = true;
 	m_thread = std::make_shared<std::thread>(&KMTronicSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "KMTronicSerial");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/KMTronicTCP.cpp
+++ b/hardware/KMTronicTCP.cpp
@@ -57,6 +57,7 @@ bool KMTronicTCP::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&KMTronicTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "KMTronicTCP");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "KMTronic: Started");

--- a/hardware/KMTronicUDP.cpp
+++ b/hardware/KMTronicUDP.cpp
@@ -31,6 +31,7 @@ bool KMTronicUDP::StartHardware()
 	Init();
  	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&KMTronicUDP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "KMTronicUDP");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "KMTronic: Started");

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -918,6 +918,7 @@ bool CKodi::StartHardware()
 	//Start worker thread
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CKodi::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Kodi");
 	_log.Log(LOG_STATUS, "Kodi: Started");
 
 	return true;
@@ -964,6 +965,7 @@ void CKodi::Do_Work()
 				{
 					_log.Log(LOG_NORM, "Kodi: (%s) - Restarting thread.", (*itt)->m_Name.c_str());
 					boost::thread* tAsync = new boost::thread(&CKodiNode::Do_Work, (*itt));
+					SetThreadName(tAsync->native_handle(), "KodiNode");
 					m_ios.stop();
 				}
 				if ((*itt)->IsOn()) bWorkToDo = true;
@@ -976,6 +978,7 @@ void CKodi::Do_Work()
 				// need to worry about locking or concurrency issues when processing messages
 				_log.Log(LOG_NORM, "Kodi: Restarting I/O service thread.");
 				boost::thread bt(boost::bind(&boost::asio::io_service::run, &m_ios));
+				SetThreadName(bt.native_handle(), "KodiIO");
 			}
 		}
 		sleep_milliseconds(500);
@@ -1153,10 +1156,12 @@ void CKodi::ReloadNodes()
 		{
 			_log.Log(LOG_NORM, "Kodi: (%s) Starting thread.", (*itt)->m_Name.c_str());
 			boost::thread* tAsync = new boost::thread(&CKodiNode::Do_Work, (*itt));
+			SetThreadName(tAsync->native_handle(), "KodiNode");
 		}
 		sleep_milliseconds(100);
 		_log.Log(LOG_NORM, "Kodi: Starting I/O service thread.");
 		boost::thread bt(boost::bind(&boost::asio::io_service::run, &m_ios));
+		SetThreadName(bt.native_handle(), "KodiIO");
 	}
 }
 

--- a/hardware/Limitless.cpp
+++ b/hardware/Limitless.cpp
@@ -263,6 +263,7 @@ bool CLimitLess::StartHardware()
 	sOnConnected(this);
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CLimitLess::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Limitless");
 	_log.Log(LOG_STATUS, "AppLamp: Worker Started...");
 	return (m_thread != nullptr);
 }

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -117,6 +117,7 @@ bool CLogitechMediaServer::StartHardware()
 	//Start worker thread
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CLogitechMediaServer::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Logitech");
 
 	return (m_thread != nullptr);
 }
@@ -350,6 +351,7 @@ void CLogitechMediaServer::Do_Work()
 					{
 						m_iThreadsRunning++;
 						boost::thread t(boost::bind(&CLogitechMediaServer::Do_Node_Work, this, *itt));
+						SetThreadName(t.native_handle(), "LogitechNode");
 						t.join();
 					}
 				}

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -54,6 +54,7 @@ bool MQTT::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&MQTT::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MQTT");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -66,6 +66,7 @@ bool Meteostick::StopHardware()
 void Meteostick::StartPollerThread()
 {
 	m_thread = std::make_shared<std::thread>(&Meteostick::Do_PollWork, this);
+	SetThreadName(m_thread->native_handle(), "Meteostick");
 }
 
 void Meteostick::StopPollerThread()

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -101,6 +101,7 @@ bool MochadTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&MochadTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MochadTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/MultiFun.cpp
+++ b/hardware/MultiFun.cpp
@@ -135,6 +135,7 @@ bool MultiFun::StartHardware()
 #endif
 
 	m_thread = std::make_shared<std::thread>(&MultiFun::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MultiFun");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -2340,6 +2340,7 @@ bool MySensorsBase::StartSendQueue()
 {
 	//Start worker thread
 	m_send_thread = std::make_shared<std::thread>(&MySensorsBase::Do_Send_Work, this);
+	SetThreadName(m_send_thread->native_handle(), "MySensorsBase");
 	return (m_send_thread != NULL);
 }
 

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -52,6 +52,7 @@ bool MySensorsSerial::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&MySensorsSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MySensorsSerial");
 	StartSendQueue();
 	return (m_thread != nullptr);
 }

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -37,6 +37,7 @@ bool MySensorsTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&MySensorsTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MySensorsTCP");
 	StartSendQueue();
 	return (m_thread != nullptr);
 }

--- a/hardware/NefitEasy.cpp
+++ b/hardware/NefitEasy.cpp
@@ -137,6 +137,7 @@ bool CNefitEasy::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CNefitEasy::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "NefitEasy");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -78,6 +78,7 @@ bool CNest::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CNest::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Nest");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/NestOAuthAPI.cpp
+++ b/hardware/NestOAuthAPI.cpp
@@ -55,6 +55,7 @@ bool CNestOAuthAPI::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CNestOAuthAPI::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "NestOAuthAPI");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -106,6 +106,7 @@ bool CNetatmo::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CNetatmo::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Netatmo");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -66,6 +66,7 @@ void OTGWSerial::readCallback(const char *data, size_t len)
 void OTGWSerial::StartPollerThread()
 {
 	m_thread = std::make_shared<std::thread>(&OTGWSerial::Do_PollWork, this);
+	SetThreadName(m_thread->native_handle(), "OTGWSerial");
 }
 
 void OTGWSerial::StopPollerThread()

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -33,6 +33,7 @@ bool OTGWTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&OTGWTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "OTGWTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -163,6 +163,7 @@ bool OnkyoAVTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&OnkyoAVTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "OnkyoAVTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -74,6 +74,7 @@ COpenWeatherMap::~COpenWeatherMap(void)
 bool COpenWeatherMap::StartHardware()
 {
 	m_thread = std::make_shared<std::thread>(&COpenWeatherMap::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "OpenWeatherMap");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "OpenWeatherMap: Started");

--- a/hardware/OpenWebNetTCP.cpp
+++ b/hardware/OpenWebNetTCP.cpp
@@ -91,10 +91,12 @@ bool COpenWebNetTCP::StartHardware()
 
 	//Start monitor thread
 	m_monitorThread = std::make_shared<std::thread>(&COpenWebNetTCP::MonitorFrames, this);
+	SetThreadName(m_monitorThread->native_handle(), "OpenWebNetTCPMF");
 
 	//Start worker thread
 	if (m_monitorThread != NULL) {
 		m_heartbeatThread = std::make_shared<std::thread>(&COpenWebNetTCP::Do_Work, this);
+		SetThreadName(m_heartbeatThread->native_handle(), "OpenWebNetTCPW");
 	}
 
 	return (m_monitorThread != NULL && m_heartbeatThread != NULL);

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -48,6 +48,7 @@ bool COpenWebNetUSB::StartHardware()
 
 								   //Start worker thread
 	m_thread = std::make_shared<std::thread>(&COpenWebNetUSB::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "OpenWebNetUSB");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -63,6 +63,7 @@ bool P1MeterSerial::StartHardware()
 #endif
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&P1MeterSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "P1MeterSerial");
 
 	//Try to open the Serial Port
 	try

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -59,6 +59,7 @@ bool P1MeterTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&P1MeterTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "P1MeterTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/PVOutput_Input.cpp
+++ b/hardware/PVOutput_Input.cpp
@@ -36,6 +36,7 @@ bool CPVOutputInput::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CPVOutputInput::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "PVOutputInput");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -201,6 +201,7 @@ bool CPanasonicNode::StartThread()
 {
 	StopThread();
 	m_thread = std::make_shared<std::thread>(&CPanasonicNode::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "PanasonicNode");
 	return (m_thread != nullptr);
 }
 
@@ -788,6 +789,7 @@ bool CPanasonic::StartHardware()
 	//Start worker thread
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CPanasonic::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Panasonic");
 	_log.Log(LOG_STATUS, "Panasonic Plugin: Started");
 
 	return true;

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -94,6 +94,7 @@ bool CPhilipsHue::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CPhilipsHue::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "PhilipsHue");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -724,7 +724,9 @@ bool CPiFace::StartHardware()
             }
 
 			m_thread = std::make_shared<std::thread>(&CPiFace::Do_Work, this);
+			SetThreadName(m_thread->native_handle(), "PiFace");
 			m_queue_thread = std::make_shared<std::thread>(&CPiFace::Do_Work_Queue, this);
+			SetThreadName(m_queue_thread->native_handle(), "PiFaceQueue");
         }
         else m_stoprequested=true;
     }

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -174,6 +174,7 @@ bool CPinger::StartHardware()
 	//Start worker thread
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CPinger::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Pinger");
 	_log.Log(LOG_STATUS, "Pinger: Started");
 
 	return true;
@@ -392,6 +393,7 @@ void CPinger::DoPingHosts()
 		{
 			//m_iThreadsRunning++;
 			boost::thread t(boost::bind(&CPinger::Do_Ping_Worker, this, *itt));
+			SetThreadName(t.native_handle(), "PingerWorker");
 			t.join();
 		}
 	}

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -24,6 +24,7 @@ bool CRFLinkSerial::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CRFLinkSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "RFLinkSerial");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -29,6 +29,7 @@ bool CRFLinkTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CRFLinkTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "RFLinkTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -100,6 +100,7 @@ bool RFXComSerial::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&RFXComSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "RFXComSerial");
 
 	return (m_thread != nullptr);
 

--- a/hardware/RFXComTCP.cpp
+++ b/hardware/RFXComTCP.cpp
@@ -32,6 +32,7 @@ bool RFXComTCP::StartHardware()
 	m_rxbufferpos=0;
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&RFXComTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "RFXComTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -138,6 +138,7 @@ bool CRego6XXSerial::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CRego6XXSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Rego6XXSerial");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -177,6 +177,7 @@ bool RelayNet::StartHardware()
 	if (m_input_count || m_relay_count)
 	{
 		m_thread = std::make_shared<std::thread>(&RelayNet::Do_Work, this);
+		SetThreadName(m_thread->native_handle(), "RelayNet");
 	}
 
 	if (m_thread)

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -37,6 +37,7 @@ CRtl433::~CRtl433()
 bool CRtl433::StartHardware()
 {
 	m_thread = std::make_shared<std::thread>(&CRtl433::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Rtl433");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	StartHeartbeatThread();

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -36,6 +36,7 @@ bool S0MeterTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&S0MeterTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "S0MeterTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -104,6 +104,7 @@ bool CSBFSpot::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CSBFSpot::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "SBFSpot");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/SatelIntegra.cpp
+++ b/hardware/SatelIntegra.cpp
@@ -134,6 +134,7 @@ bool SatelIntegra::StartHardware()
 	}
 
 	m_thread = std::make_shared<std::thread>(&SatelIntegra::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "SatelIntegra");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -74,6 +74,7 @@ bool SolarEdgeAPI::StartHardware()
 {
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&SolarEdgeAPI::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "SolarEdgeAPI");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/SolarMaxTCP.cpp
+++ b/hardware/SolarMaxTCP.cpp
@@ -97,6 +97,7 @@ bool SolarMaxTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&SolarMaxTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "SolarMaxTCP");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/Sterbox.cpp
+++ b/hardware/Sterbox.cpp
@@ -38,6 +38,7 @@ bool CSterbox::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CSterbox::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Sterbox");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	_log.Log(LOG_STATUS, "Sterbox: Started");

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -181,6 +181,7 @@ bool CSysfsGpio::StartHardware()
 	Init();
 
 	m_thread = std::make_shared<std::thread>(&CSysfsGpio::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "SysfsGpio");
 	m_bIsStarted = true;
 
 	return (m_thread != nullptr);
@@ -497,6 +498,7 @@ void CSysfsGpio::Init()
 	if (m_interrupts_enabled)
 	{
 		m_edge_thread = std::make_shared<std::thread>(&CSysfsGpio::EdgeDetectThread, this);
+		SetThreadName(m_edge_thread->native_handle(), "SysfsGpio_Edge");
 	}
 }
 

--- a/hardware/TE923.cpp
+++ b/hardware/TE923.cpp
@@ -38,6 +38,7 @@ bool CTE923::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CTE923::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "TE923");
 	m_bIsStarted=true;
 	sOnConnected(this);
 

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -47,6 +47,7 @@ bool CTado::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CTado::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Tado");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -220,6 +220,7 @@ bool CTellstick::StartHardware()
     _log.Log(LOG_NORM, "Tellstick: StartHardware");
     //Start worker thread
 	m_thread = std::make_shared<std::thread>(&CTellstick::ThreadSendCommands, this);
+	SetThreadName(m_thread->native_handle(), "Tellstick");
 	return true;
 }
 

--- a/hardware/Thermosmart.cpp
+++ b/hardware/Thermosmart.cpp
@@ -100,6 +100,7 @@ bool CThermosmart::StartHardware()
 	m_LastMinute = -1;
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CThermosmart::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Thermosmart");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -181,6 +181,7 @@ bool CToonThermostat::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CToonThermostat::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ToonThermostat");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -96,6 +96,7 @@ bool USBtin::StartHardware()
 	m_USBtinBelErrorCount = 0;
 	m_USBtinRetrycntr=USBTIN_RETRY_DELAY*5; //will force reconnect first thing
 	m_thread = std::make_shared<std::thread>(&USBtin::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "USBtin");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/USBtin_MultiblocV8.cpp
+++ b/hardware/USBtin_MultiblocV8.cpp
@@ -200,6 +200,7 @@ bool USBtin_MultiblocV8::StartThread()
 	m_V8minCounterBase = (60*5);
 	m_V8minCounter1 = (3600*6);
 	m_thread = std::make_shared<std::thread>(&USBtin_MultiblocV8::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "USBtinMbV8");
 	_log.Log(LOG_STATUS,"MultiblocV8: thread started");
 	return (m_thread != nullptr);
 }

--- a/hardware/VolcraftCO20.cpp
+++ b/hardware/VolcraftCO20.cpp
@@ -39,6 +39,7 @@ bool CVolcraftCO20::StartHardware()
 {
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CVolcraftCO20::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "VolcraftCO20");
 	m_bIsStarted=true;
 	sOnConnected(this);
 

--- a/hardware/Winddelen.cpp
+++ b/hardware/Winddelen.cpp
@@ -33,6 +33,7 @@ bool CWinddelen::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CWinddelen::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Winddelen");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -72,6 +72,7 @@ bool CWunderground::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CWunderground::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Wunderground");
 	if (!m_thread)
 		return false;
 	m_bIsStarted=true;

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -625,6 +625,7 @@ bool XiaomiGateway::StartHardware()
 
 		//Start worker thread
 		m_thread = std::shared_ptr<std::thread>(new std::thread(&XiaomiGateway::Do_Work, this));
+		SetThreadName(m_thread->native_handle(), "XiaomiGateway");
 	}
 
 	return (m_thread != nullptr);
@@ -676,6 +677,7 @@ void XiaomiGateway::Do_Work()
 	boost::thread bt;
 	if (m_ListenPort9898) {
 		bt = boost::thread(boost::bind(&boost::asio::io_service::run, &io_service));
+		SetThreadName(bt.native_handle(), "XiaomiGatewayIO");
 	}
 
 	int sec_counter = 0;

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -72,6 +72,7 @@ bool Yeelight::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Yeelight::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Yeelight");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/YouLess.cpp
+++ b/hardware/YouLess.cpp
@@ -58,6 +58,7 @@ bool CYouLess::StartHardware()
 	Init();
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CYouLess::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "YouLess");
 	m_bIsStarted=true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -53,6 +53,7 @@ bool ZWaveBase::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&ZWaveBase::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ZWaveBase");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -27,6 +27,7 @@ bool CZiBlueSerial::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CZiBlueSerial::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ZiBlueSerial");
 
 	return (m_thread != nullptr);
 }

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -32,6 +32,7 @@ bool CZiBlueTCP::StartHardware()
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CZiBlueTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "ZiBlueTCP");
 	return (m_thread != nullptr);
 }
 

--- a/hardware/eHouse/EhouseTcpClient.cpp
+++ b/hardware/eHouse/EhouseTcpClient.cpp
@@ -21,6 +21,7 @@
  */
 
 #include "stdafx.h"
+#include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "../eHouseTCP.h"
 #ifndef WIN32
@@ -145,6 +146,7 @@ char eHouseTCP::SendTCPEvent(const unsigned char *Events, unsigned char EventCou
 	ExecQueuedEvents();
 #else
 	EhouseTcpClientThread[tcp_client_socket_index] = std::make_shared<std::thread>(&eHouseTCP::EhouseSubmitData, this, tcp_client_socket_index);
+	SetThreadName(EhouseTcpClientThread[tcp_client_socket_index]->native_handle(), "EHouseTCPClient");
 
 	EhouseTcpClientThread[tcp_client_socket_index]->detach();
 	msl(100);

--- a/hardware/eHouseTCP.cpp
+++ b/hardware/eHouseTCP.cpp
@@ -530,6 +530,7 @@ bool eHouseTCP::StartHardware()
 
 #endif
 	m_thread = std::make_shared<std::thread>(&eHouseTCP::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "eHouseTCP");
 	m_bIsStarted = true;
 	sOnConnected(this);
 	return (m_thread != nullptr);

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -105,6 +105,7 @@ namespace Plugins {
 		BuildManifest();
 
 		m_thread = std::make_shared<std::thread>(&CPluginSystem::Do_Work, this);
+		SetThreadName(m_thread->native_handle(), "PluginMgr");
 
 		szPyVersion = Py_GetVersion();
 
@@ -260,6 +261,7 @@ namespace Plugins {
 		// Create initial IO Service thread
 		ios.reset();
 		boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+		SetThreadName(bt.native_handle(), "PluginMgr_IO");
 
 		while (!m_stoprequested)
 		{
@@ -281,6 +283,7 @@ namespace Plugins {
 					ios.reset();
 					_log.Log(LOG_NORM, "PluginSystem: Restarting I/O service thread.");
 					boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+					SetThreadName(bt.native_handle(), "PluginMgr_IO");
 				}
 			}
 

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -67,6 +67,7 @@ namespace Plugins {
 					ios.reset();
 					if (pPlugin->m_bDebug & PDM_CONNECTION) _log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 					boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+					SetThreadName(bt.native_handle(), "PluginMgr_IO");
 				}
 			}
 		}
@@ -121,6 +122,7 @@ namespace Plugins {
 				ios.reset();
 				if (pPlugin->m_bDebug & PDM_CONNECTION) _log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 				boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+				SetThreadName(bt.native_handle(), "PluginMgr_IO");
 			}
 		}
 		else
@@ -158,6 +160,7 @@ namespace Plugins {
 					if (((CConnection*)m_pConnection)->pPlugin->m_bDebug & PDM_CONNECTION)
 						_log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 					boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+					SetThreadName(bt.native_handle(), "PluginMgr_IO");
 				}
 			}
 		}
@@ -384,6 +387,7 @@ namespace Plugins {
 					if (((CConnection*)m_pConnection)->pPlugin->m_bDebug & PDM_CONNECTION)
 						_log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 					boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+					SetThreadName(bt.native_handle(), "PluginMgr_IO");
 				}
 			}
 			catch (boost::system::system_error se)
@@ -528,6 +532,7 @@ namespace Plugins {
 				if (((CConnection*)m_pConnection)->pPlugin->m_bDebug & PDM_CONNECTION)
 					_log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 				boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+				SetThreadName(bt.native_handle(), "PluginMgr_IO");
 			}
 
 			m_bConnected = true;
@@ -748,6 +753,7 @@ namespace Plugins {
 				if (((CConnection*)m_pConnection)->pPlugin->m_bDebug & PDM_CONNECTION)
 					_log.Log(LOG_NORM, "PluginSystem: Starting I/O service thread.");
 				boost::thread bt(boost::bind(&boost::asio::io_service::run, &ios));
+				SetThreadName(bt.native_handle(), "PluginMgr_IO");
 			}
 		}
 		catch (std::exception& e)

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1063,6 +1063,8 @@ namespace Plugins {
 			//Start worker thread
 			m_stoprequested = false;
 			m_thread = std::make_shared<std::thread>(&CPlugin::Do_Work, this);
+			std::string plugin_name = "Plugin_" + m_PluginKey;
+			SetThreadName(m_thread->native_handle(), plugin_name.c_str());
 
 			if (!m_thread)
 			{

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -153,7 +153,9 @@ void CEventSystem::StartEventSystem()
 
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CEventSystem::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "EventSystem");
 	m_eventqueuethread = std::make_shared<std::thread>(&CEventSystem::EventQueueThread, this);
+	SetThreadName(m_eventqueuethread->native_handle(), "EventSystemQueue");
 	m_szStartTime = TimeToString(&m_StartTime, TF_DateTime);
 }
 
@@ -3253,6 +3255,7 @@ void CEventSystem::EvaluateLua(const std::vector<_tEventQueue> &items, const std
 		lua_sethook(lua_state, luaStop, LUA_MASKCOUNT, 10000000);
 
 		boost::thread luaThread(boost::bind(&CEventSystem::luaThread, this, lua_state, filename));
+		SetThreadName(luaThread.native_handle(), "luaThread");
 
 		if (!luaThread.timed_join(boost::posix_time::seconds(10)))
 		{

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1082,3 +1082,58 @@ int GetDirFilesRecursive(const std::string &DirPath, std::map<std::string, int> 
 	closedir(dir);
 	return 0;
 }
+
+#ifdef WIN32
+// From https://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
+const DWORD MS_VC_EXCEPTION = 0x406D1388;
+#pragma pack(push,8)
+typedef struct tagTHREADNAME_INFO
+{
+	DWORD dwType; // Must be 0x1000.
+	LPCSTR szName; // Pointer to name (in user addr space).
+	DWORD dwThreadID; // Thread ID (-1=caller thread).
+	DWORD dwFlags; // Reserved for future use, must be zero.
+} THREADNAME_INFO;
+#pragma pack(pop)
+int SetThreadName(std::thread::native_handle_type thread, const char* threadName) {
+	DWORD dwThreadID = ::GetThreadId( static_cast<HANDLE>( thread ) );
+	THREADNAME_INFO info;
+	info.dwType = 0x1000;
+	info.szName = threadName;
+	info.dwThreadID = dwThreadID;
+	info.dwFlags = 0;
+#pragma warning(push)
+#pragma warning(disable: 6320 6322)
+	__try{
+		RaiseException(MS_VC_EXCEPTION, 0, sizeof(info) / sizeof(ULONG_PTR), (ULONG_PTR*)&info);
+	}
+	__except (EXCEPTION_EXECUTE_HANDLER){
+	}
+#pragma warning(pop)
+	return 0;
+}
+#else
+// Based on https://stackoverflow.com/questions/2369738/how-to-set-the-name-of-a-thread-in-linux-pthreads
+int SetThreadName(std::thread::native_handle_type thread, const char *name)
+{
+#if defined(__linux__) || defined(__linux) || defined(linux)
+	char name_trunc[16];
+	strncpy(name_trunc, name, sizeof(name_trunc));
+	name_trunc[sizeof(name_trunc)-1] = '\0';
+	return pthread_setname_np(thread, name_trunc);
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+	// Not possible to set name of other thread: https://stackoverflow.com/questions/2369738/how-to-set-the-name-of-a-thread-in-linux-pthreads
+#elif defined(__NetBSD__)
+	char name_trunc[PTHREAD_MAX_NAMELEN_NP];
+	strncpy(name_trunc, name, sizeof(name_trunc));
+	name_trunc[sizeof(name_trunc)-1] = '\0';
+	return pthread_setname_np(thread, name_trunc);
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+	char name_trunc[PTHREAD_MAX_NAMELEN_NP];
+	strncpy(name_trunc, name, sizeof(name_trunc));
+	name_trunc[sizeof(name_trunc)-1] = '\0';
+	pthread_setname_np(thread, name_trunc);
+	return 0;
+#endif
+}
+#endif

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -75,3 +75,5 @@ bool IsArgumentSecure(const std::string &arg);
 uint32_t SystemUptime();
 int GenerateRandomNumber(const int range);
 int GetDirFilesRecursive(const std::string &DirPath, std::map<std::string, int> &_Files);
+
+int SetThreadName(std::thread::native_handle_type thread, const char *name);

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -211,6 +211,7 @@ bool CLuaHandler::executeLuaScript(const std::string &script, const std::string 
 	{
 		lua_sethook(lua_state, luaStop, LUA_MASKCOUNT, 10000000);
 		boost::thread aluaThread(boost::bind(&CLuaHandler::luaThread, this, lua_state, fullfilename));
+		SetThreadName(aluaThread.native_handle(), "aluaThread");
 		aluaThread.timed_join(boost::posix_time::seconds(10));
 		return true;
 	}

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3040,6 +3040,7 @@ bool CSQLHelper::OpenDatabase()
 bool CSQLHelper::StartThread()
 {
 	m_background_task_thread = std::make_shared<std::thread>(&CSQLHelper::Do_Work, this);
+	SetThreadName(m_background_task_thread->native_handle(), "SQLHelper");
 	return (m_background_task_thread != NULL);
 }
 

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -35,6 +35,7 @@ CScheduler::~CScheduler(void)
 void CScheduler::StartScheduler()
 {
 	m_thread = std::make_shared<std::thread>(&CScheduler::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "Scheduler");
 }
 
 void CScheduler::StopScheduler()

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -673,6 +673,8 @@ namespace http {
 			//Start normal worker thread
 			m_bDoStop = false;
 			m_thread = std::make_shared<std::thread>(&CWebServer::Do_Work, this);
+			std::string server_name = "WebServer_" + settings.listening_port;
+			SetThreadName(m_thread->native_handle(), server_name.c_str());
 			return (m_thread != nullptr);
 		}
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1207,7 +1207,9 @@ bool MainWorker::StartThread()
 	}
 
 	m_thread = std::make_shared<std::thread>(&MainWorker::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "MainWorker");
 	m_rxMessageThread = std::make_shared<std::thread>(&MainWorker::Do_Work_On_Rx_Messages, this);
+	SetThreadName(m_rxMessageThread->native_handle(), "MainWorkerRxMsg");
 	return (m_thread != nullptr) && (m_rxMessageThread != NULL);
 }
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -135,7 +135,10 @@ bool CNotificationHelper::SendMessageEx(
 		if ((ActiveSystems.empty() || ittSystem != ActiveSystems.end()) && iter->second->IsConfigured())
 		{
 			if (bThread)
+			{
 				boost::thread SendMessageEx(boost::bind(&CNotificationBase::SendMessageEx, iter->second, Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification));
+				SetThreadName(SendMessageEx.native_handle(), "SendMessageEx");
+			}
 			else
 				bRet |= iter->second->SendMessageEx(Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification);
 		}

--- a/push/InfluxPush.cpp
+++ b/push/InfluxPush.cpp
@@ -158,6 +158,7 @@ bool CInfluxPush::StartThread()
 	StopThread();
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CInfluxPush::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "InfluxPush");
 	return (m_thread != NULL);
 }
 

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -4,6 +4,7 @@
 #include "TCPClient.h"
 #include "../main/RFXNames.h"
 #include "../main/RFXtrx.h"
+#include "../main/Helper.h"
 #include "../main/Logger.h"
 #include "../hardware/DomoticzTCP.h"
 #include "../main/mainworker.h"
@@ -405,6 +406,7 @@ bool CTCPServer::StartServer(const std::string &address, const std::string &port
 	_log.Log(LOG_NORM, "Starting shared server on: %s:%s", listen_address.c_str(), port.c_str());
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&CTCPServer::Do_Work, this);
+	SetThreadName(m_thread->native_handle(), "TCPServer");
 	return (m_thread != nullptr);
 }
 

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -759,6 +759,7 @@ namespace http {
 		{
 			_first = first;
 			m_thread = std::make_shared<std::thread>(&CProxyManager::StartThread, shared_from_this());
+			SetThreadName(m_thread->native_handle(), "ProxyManager");
 			return 1;
 		}
 


### PR DESCRIPTION
Name threads to aid debugging, example output from gdb:
```
2018-08-01 09:40:04.524  Error: >   Id   Target Id         Frame
2018-08-01 09:40:04.524  Error: > * 1    Thread 0x7f335b100740 (LWP 29787) "domoticz" 0x00007f335a540f7b in __waitpid (pid=29803, stat_loc=0x7fffcae4fea8, options=0) at ../sysdeps/unix/sysv/linux/waitpid.c:29
2018-08-01 09:40:04.524  Error: >   2    Thread 0x7f3354580700 (LWP 29788) "Watchdog" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.524  Error: >   3    Thread 0x7f3353d70700 (LWP 29789) "SQLHelper" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.524  Error: >   4    Thread 0x7f3353560700 (LWP 29790) "PluginMgr" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.524  Error: >   5    Thread 0x7f3352ab0700 (LWP 29791) "InfluxPush" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.524  Error: >   6    Thread 0x7f3351a90700 (LWP 29793) "WebServer_8080" 0x00007f3359d47a13 in epoll_wait () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.524  Error: >   7    Thread 0x7f3350a70700 (LWP 29795) "Scheduler" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.525  Error: >   8    Thread 0x7f334bff0700 (LWP 29796) "TCPServer" 0x00007f3359d47a13 in epoll_wait () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.525  Error: >   9    Thread 0x7f334b7e0700 (LWP 29797) "MainWorker" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.538  Error: >   10   Thread 0x7f334afd0700 (LWP 29798) "MainWorkerRxMsg" pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
2018-08-01 09:40:04.538  Error: >   11   Thread 0x7f334a7c0700 (LWP 29799) "EventSystem" 0x00007f335a540c1d in nanosleep () at ../sysdeps/unix/syscall-template.S:84
2018-08-01 09:40:04.538  Error: >   12   Thread 0x7f3349fb0700 (LWP 29800) "EventSystemQueu" pthread_cond_timedwait@@GLIBC_2.3.2 () at ../sysdeps/unix/sysv/linux/x86_64/pthread_cond_timedwait.S:225
```