### PR TITLE
Xiaomi get local IP fallback: parsing from ifconfig

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -678,16 +678,29 @@ void XiaomiGateway::Do_Work()
 		try {
 	
 			// get output from ifconfig
-			std::string ifconfigStr;	
-			FILE * stream = popen("ifconfig", "r");
-			const int max_buffer = 256;
-    			char buffer[max_buffer];
+			std::string ifconfigStr;
+                        const int max_buffer = 256;
+                        char buffer[max_buffer];
 
-	    		if (stream) {
-  				while (!feof(stream))
-    					if (fgets(buffer, max_buffer, stream) != NULL) ifconfigStr.append(buffer);
-    				pclose(stream);
-    			}
+			// compiler specific as popen/pclose does not exist on Windows
+			// fixes compilation error, but won't work on Windows (ifconfig does not exist)
+			#ifdef _WIN32
+				FILE * stream = _popen("ifconfig", "r");
+		    		if (stream) {
+  					while (!feof(stream))
+    						if (fgets(buffer, max_buffer, stream) != NULL) ifconfigStr.append(buffer);
+    					_pclose(stream);
+    				}
+                        #else
+                                FILE * stream = popen("ifconfig", "r");
+                                if (stream) {
+                                        while (!feof(stream))
+                                                if (fgets(buffer, max_buffer, stream) != NULL) ifconfigStr.append(buffer);
+                                        pclose(stream);
+                                }
+                        #endif
+
+
 	
 			// regex pattern to match ip address in ifconfig output
 			// with <ip> being a valid ip, pattern will match "inet <ip>", "inet addr:<ip>", "inet: <ip>", "inet addr <ip>"

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -674,8 +674,8 @@ void XiaomiGateway::Do_Work()
 	}
 
 	if (m_LocalIp == "") {
+		std::string ifconfigOrIpconfig;
 		try {
-			
 			// get network ip range to search for from Xiaomi gateway
 			std::string GatewayNetwork;
 			_log.Log(LOG_STATUS, "XiaomiGateway: IP of gateway: %s", m_GatewayIp.c_str());	
@@ -706,6 +706,7 @@ void XiaomiGateway::Do_Work()
     						if (fgets(buffer, max_buffer, stream) != NULL) ifconfigStr.append(buffer);
     							_pclose(stream);
     				}
+				ifconfigOrIpconfig = "ipconfig";
 			#else
 				FILE * stream = popen("ifconfig", "r");
 				if (stream) {
@@ -713,6 +714,7 @@ void XiaomiGateway::Do_Work()
 						if (fgets(buffer, max_buffer, stream) != NULL) ifconfigStr.append(buffer);
 							pclose(stream);
 				}
+				ifconfigOrIpconfig = "ifconfig";
 			#endif
 	
 			// regex pattern to match ip address in ifconfig or ipconfig output
@@ -722,15 +724,15 @@ void XiaomiGateway::Do_Work()
 
 			if (std::regex_search(ifconfigStr, match, pattern)){
         			 m_LocalIp = match[1];
-				 _log.Log(LOG_STATUS, "XiaomiGateway: Using %s for Domoticz local IP address (parsed from ifconfig).", m_LocalIp.c_str());
+				 _log.Log(LOG_STATUS, "XiaomiGateway: Using %s for Domoticz local IP address (parsed from %s).", m_LocalIp.c_str(), ifconfigOrIpconfig.c_str());
 			}
 			else {
-				_log.Log(LOG_STATUS, "XiaomiGateway: Could not detect local Domoticz IP address (parsing ifconfig).");
+				_log.Log(LOG_STATUS, "XiaomiGateway: Could not detect local Domoticz IP address (parsing %s).", ifconfigOrIpconfig.c_str());
 			}
 		}
 
 		catch (std::exception& e) {
-			_log.Log(LOG_STATUS, "XiaomiGateway: Could not detect local IP address (parsing ifconfig): %s", e.what());
+			_log.Log(LOG_STATUS, "XiaomiGateway: Could not detect local IP address (parsing %s): %s", ifconfigOrIpconfig.c_str(), e.what());
 		}
 	}
 	

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -704,7 +704,7 @@ void XiaomiGateway::Do_Work()
 	
 			// regex pattern to match ip address in ifconfig output
 			// with <ip> being a valid ip, pattern will match "inet <ip>", "inet addr:<ip>", "inet: <ip>", "inet addr <ip>"
-			std::regex pattern("[inet|inet:][ ]*[addr|addr:]*[ ]*(\\d{1,3}(\\.\\d{1,3}){3})");
+			std::regex pattern("[inet|inet:][ ]*[addr|addr:]*[ ]*(?!127)(\\d{1,3}(\\.\\d{1,3}){3})");
 			std::smatch match;
 			
 			if (std::regex_search(ifconfigStr, match, pattern)){


### PR DESCRIPTION
A fallback to determine the Domoticz local IP address for the Xiaomi gateway in case boost asio does not work. This was the case for me using an iocage FreeNas jail (based on FreeBSD), but others seem to encounter this problem as well, e.g. with NAS4Free (http://www.domoticz.com/forum/viewtopic.php?f=47&t=22813).

The fallback parses the output from ifconfig (present on almost every linux system) to determine the local IP. It can be made more robust (for example by checking if 127.0.0.1 is not given as answer), but it does the job for me.