### PR TITLE
Fix various data races

### DIFF
--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -114,7 +114,7 @@ void CDavisLoggerSerial::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 		if (m_stoprequested)
 			break;

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -13,8 +13,8 @@
 
 CDomoticzHardwareBase::CDomoticzHardwareBase()
 {
-	mytime(&m_LastHeartbeat);
-	mytime(&m_LastHeartbeatReceive);
+	m_LastHeartbeat = mytime(NULL);
+	m_LastHeartbeatReceive = mytime(NULL);
 	mytime(&m_BaroCalcLastTime);
 };
 
@@ -111,7 +111,7 @@ void CDomoticzHardwareBase::Do_Heartbeat_Work()
 			secCounter = 0;
 			hbCounter++;
 			if (hbCounter % 12 == 0) {
-				mytime(&m_LastHeartbeat);
+				m_LastHeartbeat = mytime(NULL);
 			}
 		}
 	}
@@ -119,7 +119,7 @@ void CDomoticzHardwareBase::Do_Heartbeat_Work()
 
 void CDomoticzHardwareBase::SetHeartbeatReceived()
 {
-	mytime(&m_LastHeartbeatReceive);
+	m_LastHeartbeatReceive = mytime(NULL);
 }
 
 void CDomoticzHardwareBase::HandleHBCounter(const int iInterval)

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <boost/signals2.hpp>
 #include "../main/RFXNames.h"
 
@@ -24,8 +25,8 @@ public:
 
 	void SetHeartbeatReceived();
 
-	time_t m_LastHeartbeat = { 0 };
-	time_t m_LastHeartbeatReceive = { 0 };
+	std::atomic<time_t> m_LastHeartbeat = { 0 };
+	std::atomic<time_t> m_LastHeartbeatReceive = { 0 };
 
 	int m_HwdID = { 0 }; //must be uniquely assigned
 	bool m_bSkipReceiveCheck = { false };
@@ -100,7 +101,7 @@ protected:
 	//Barometric calculation (only for 1 sensor per hardware device!)
 	int CalculateBaroForecast(const double pressure);
 
-	bool m_bIsStarted = { false };
+	std::atomic<bool> m_bIsStarted = { false };
 
 private:
     void Do_Heartbeat_Work();

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -237,7 +237,7 @@ void DomoticzTCP::Do_Work()
 			sec_counter++;
 
 			if (sec_counter % 12 == 0) {
-				mytime(&m_LastHeartbeat);
+				m_LastHeartbeat = mytime(NULL);
 			}
 
 			if (m_stoprequested)

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -129,7 +129,7 @@ void CEcoDevices::Do_Work()
 	{
 		sleep_seconds(1);
 		sec_counter++;
-		mytime(&m_LastHeartbeat);
+		m_LastHeartbeat = mytime(NULL);
 		if (sec_counter >= m_iRateLimit)
 		{
 			sec_counter = 0;

--- a/hardware/InComfort.cpp
+++ b/hardware/InComfort.cpp
@@ -83,7 +83,7 @@ void CInComfort::Do_Work()
 		sleep_seconds(1);
 		sec_counter++;
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 		if (sec_counter%INCOMFORT_POLL_INTERVAL == 0)
 		{

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -156,7 +156,7 @@ void MochadTCP::Do_Work()
 
 
 		if (ltime.tm_sec % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 		if (bFirstTime)
 		{

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -474,7 +474,7 @@ void MySensorsBase::UpdateNodeHeartbeat(const int nodeID)
 		return; //Not found
 
 	int intValue;
-	mytime(&m_LastHeartbeatReceive);
+	m_LastHeartbeatReceive = mytime(NULL);
 	_tMySensorNode *pNode = &ittNode->second;
 
 	for (auto & itt : pNode->m_childs)

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -82,7 +82,7 @@ void MySensorsSerial::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 
 		if (m_stoprequested)

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -103,7 +103,7 @@ void MySensorsTCP::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 
 		if (bFirstTime)

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -696,8 +696,8 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 			sstr << revision << "." << build;
 			m_Version = sstr.str();
 
-			mytime(&m_LastHeartbeatReceive);  // keep heartbeat happy
-			mytime(&m_LastHeartbeat);  // keep heartbeat happy
+			m_LastHeartbeatReceive = mytime(NULL);  // keep heartbeat happy
+			m_LastHeartbeat = mytime(NULL);  // keep heartbeat happy
 			m_LastReceivedTime = m_LastHeartbeat;
 
 			m_bTXokay = true; // variable to indicate an OK was received
@@ -705,8 +705,8 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 		}
 		if (Name_ID.find("PONG") != std::string::npos) {
 			//_log.Log(LOG_STATUS, "RFLink: PONG received!...");
-			mytime(&m_LastHeartbeatReceive);  // keep heartbeat happy
-			mytime(&m_LastHeartbeat);  // keep heartbeat happy
+			m_LastHeartbeatReceive = mytime(NULL);  // keep heartbeat happy
+			m_LastHeartbeat = mytime(NULL);  // keep heartbeat happy
 			m_LastReceivedTime = m_LastHeartbeat;
 
 			m_bTXokay = true; // variable to indicate an OK was received
@@ -714,8 +714,8 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 		}
 		if (Name_ID.find("OK") != std::string::npos) {
 			//_log.Log(LOG_STATUS, "RFLink: OK received!...");
-			mytime(&m_LastHeartbeatReceive);  // keep heartbeat happy
-			mytime(&m_LastHeartbeat);  // keep heartbeat happy
+			m_LastHeartbeatReceive = mytime(NULL);  // keep heartbeat happy
+			m_LastHeartbeat = mytime(NULL);  // keep heartbeat happy
 			m_LastReceivedTime = m_LastHeartbeat;
 
 			m_bTXokay = true; // variable to indicate an OK was received
@@ -733,8 +733,8 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 	if (results[3].find("ID=") == std::string::npos)
 		return false; //??
 
-	mytime(&m_LastHeartbeatReceive);  // keep heartbeat happy
-	mytime(&m_LastHeartbeat);  // keep heartbeat happy
+	m_LastHeartbeatReceive = mytime(NULL);  // keep heartbeat happy
+	m_LastHeartbeat = mytime(NULL);  // keep heartbeat happy
 	//_log.Log(LOG_STATUS, "RFLink: t1=%d t2=%d", m_LastHeartbeat, m_LastHeartbeatReceive);
 	m_LastReceivedTime = m_LastHeartbeat;
 

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -141,7 +141,7 @@ void CSBFSpot::Do_Work()
 			GetMeterDetails();
 		}
 		if (ltime.tm_sec % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	_log.Log(LOG_STATUS,"SBFSpot: Worker stopped...");

--- a/hardware/TE923.cpp
+++ b/hardware/TE923.cpp
@@ -66,7 +66,7 @@ void CTE923::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 
 		if (sec_counter % TE923_POLL_INTERVAL == 0)

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -215,7 +215,7 @@ void CTeleinfoSerial::MatchLine()
 		_log.Log(LOG_NORM,"(%s) Teleinfo frame complete, PAPP: %i, PTEC: %s", m_Name.c_str(), teleinfo.PAPP, teleinfo.PTEC.c_str());
 		#endif
 		ProcessTeleinfo(teleinfo);
-		mytime(&m_LastHeartbeat);// keep heartbeat happy
+		m_LastHeartbeat = mytime(NULL);// keep heartbeat happy
 	}
 }
 

--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -211,7 +211,7 @@ void CToonThermostat::Do_Work()
 		m_poll_counter--;
 		sec_counter++;
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 		if (m_poll_counter<=0)
 		{

--- a/hardware/plugins/PluginManager.h
+++ b/hardware/plugins/PluginManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 
 //
 //	Domoticz Plugin System - Dnpwwo, 2016
@@ -11,17 +12,17 @@ namespace Plugins {
 	class CPluginSystem
 	{
 	private:
-		bool	m_bEnabled;
-		bool	m_bAllPluginsStarted;
-		int		m_iPollInterval;
+		bool				m_bEnabled;
+		std::atomic<bool>	m_bAllPluginsStarted;
+		int					m_iPollInterval;
 
-		void*	m_InitialPythonThread;
+		void* 				m_InitialPythonThread;
 
 		static	std::map<int, CDomoticzHardwareBase*>	m_pPlugins;
 		static	std::map<std::string, std::string>		m_PluginXml;
 
 		std::shared_ptr<std::thread> m_thread;
-		volatile bool m_stoprequested;
+		std::atomic<bool> m_stoprequested;
 		std::mutex m_mutex;
 
 		void Do_Work();

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -106,7 +106,7 @@ namespace Plugins {
 		void*				m_SettingsDict;
 		std::string			m_HomeFolder;
 		PluginDebugMask		m_bDebug;
-		bool				m_stoprequested;
+		std::atomic<bool>	m_stoprequested;
 		bool				m_bIsStarting;
 		bool				m_bTracing;
 	};

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <boost/thread/shared_mutex.hpp>
 
@@ -186,7 +187,7 @@ private:
 	boost::shared_mutex m_eventtriggerMutex;
 	std::mutex m_measurementStatesMutex;
 	std::mutex luaMutex;
-	volatile bool m_stoprequested;
+	std::atomic<bool> m_stoprequested;
 	std::shared_ptr<std::thread> m_thread, m_eventqueuethread;
 	int m_SecStatus;
 	std::string m_lua_Dir;

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <string>
 #include "RFXNames.h"
 #include "../hardware/hardwaretypes.h"
@@ -438,7 +439,7 @@ private:
 	std::vector<_tTaskItem> m_background_task_queue;
 	std::shared_ptr<std::thread> m_background_task_thread;
 	std::mutex m_background_task_mutex;
-	bool m_stoprequested;
+	std::atomic<bool> m_stoprequested;
 	bool StartThread();
 	void Do_Work();
 

--- a/main/Scheduler.h
+++ b/main/Scheduler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include "RFXNames.h"
 #include "../hardware/hardwaretypes.h"
 #include <string>
@@ -87,7 +88,7 @@ private:
 	time_t m_tAstTwStart;
 	time_t m_tAstTwEnd;
 	std::mutex m_mutex;
-	volatile bool m_stoprequested;
+	std::atomic<bool> m_stoprequested;
 	std::shared_ptr<std::thread> m_thread;
 	std::vector<tScheduleItem> m_scheduleitems;
 

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -382,7 +382,7 @@ private:
 	void Do_Work();
 	std::vector<_tCustomIcon> m_custom_light_icons;
 	std::map<int, int> m_custom_light_icons_lookup;
-	bool m_bDoStop;
+	std::atomic<bool> m_bDoStop;
 	std::string m_server_alias;
 };
 

--- a/main/localtime_r.cpp
+++ b/main/localtime_r.cpp
@@ -3,6 +3,7 @@
 
 time_t m_lasttime=time(NULL);
 std::mutex TimeMutex_;
+std::mutex TimeMutex2_;
 
 #if defined(localtime_r) || defined(__APPLE__) || defined(__USE_POSIX)
 	#define HAVE_LOCALTIME_R
@@ -30,6 +31,7 @@ struct tm *localtime_r(const time_t *timep, struct tm *result)
 
 time_t mytime(time_t * _Time)
 {
+	std::unique_lock<std::mutex> lock(TimeMutex2_);
 	time_t acttime=time(_Time);
 	if (acttime<m_lasttime)
 		return m_lasttime;

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -169,7 +169,7 @@ private:
 #ifdef WWW_ENABLE_SSL
 	http::server::ssl_server_settings m_secure_webserver_settings;
 #endif
-	volatile bool m_stoprequested;
+	std::atomic<bool> m_stoprequested;
 	std::shared_ptr<std::thread> m_thread;
 	std::mutex m_mutex;
 
@@ -193,7 +193,7 @@ private:
 	unsigned char get_BateryLevel(const _eHardwareTypes HwdType, bool bIsInPercentage, unsigned char level);
 
 	// RxMessage queue resources
-	volatile bool m_stopRxMessageThread;
+	std::atomic<bool> m_stopRxMessageThread;
 	volatile unsigned long m_rxMessageIdx;
 	std::shared_ptr<std::thread> m_rxMessageThread;
 	void Do_Work_On_Rx_Messages();

--- a/push/InfluxPush.h
+++ b/push/InfluxPush.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include "BasePush.h"
 
 class CInfluxPush : public CBasePush
@@ -20,7 +21,7 @@ private:
 
 	std::shared_ptr<std::thread> m_thread;
 	std::mutex m_background_task_mutex;
-	bool m_stoprequested;
+	std::atomic<bool> m_stoprequested;
 	bool StartThread();
 	void StopThread();
 	void Do_Work();

--- a/webserver/server.hpp
+++ b/webserver/server.hpp
@@ -60,10 +60,10 @@ protected:
 	int timeout_;
 
 	/// indicate if the server is running
-	bool is_running;
+	std::atomic<bool> is_running;
 
 	/// indicate if the server is stopped (acceptor and connections)
-	bool is_stop_complete;
+	std::atomic<bool> is_stop_complete;
 
 private:
 	/// Handle a request to stop the server.


### PR DESCRIPTION
This PR includes changes from #2598 which are **not** critical for fixing #2541.

Reason for these changes:
1. Write of integer is NOT an atomic operation, see https://stackoverflow.com/questions/54188/are-c-reads-and-writes-of-an-int-atomic, the current way of sharing some between threads in member variables has undefined behavior
2. Make it possible to use helgrind data race detection tool without a huge number of complaints about non thread safe sharing of data