### PR TITLE
Implement IsDebuggerPresent() for other OS than Linux

### DIFF
--- a/main/Helper.h
+++ b/main/Helper.h
@@ -78,6 +78,9 @@ int GetDirFilesRecursive(const std::string &DirPath, std::map<std::string, int> 
 
 int SetThreadName(std::thread::native_handle_type thread, const char *name);
 
+#if !defined(WIN32)
+	bool IsDebuggerPresent(void);
+#endif
 #if defined(__linux__)
 	bool IsWSL(void); //Detects if running under Windows Subsystem for Linux (WSL)
 #endif

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12859,13 +12859,14 @@ void MainWorker::HeartbeatCheck()
 			_log.Log(LOG_ERROR, "%s thread seems to have ended unexpectedly (last update %f seconds ago)", itt.first.c_str(), diff);
 			if (itt.second.second) // If the stalled component is marked as critical, call abort / raise signal
 			{
-#ifndef _DEBUG
+				if (!IsDebuggerPresent())
+				{
 #ifdef WIN32
-				abort();
+					abort();
 #else
-				raise(SIGUSR1);
+					raise(SIGUSR1);
 #endif
-#endif
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For Windows: Call built in function bool IsDebuggerPresent(void);
For BSD/MacOS: Try to attach to the domoticz process, which will fail if Domoticz is already being debugged
Also: Fix/cleanup Linux implementation.