### PR TITLE
The devices are not created correctly

### DIFF
--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -764,9 +764,8 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx,  const bool bI
 		return;
 	}
 
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
-
 	result = m_sql.safe_query("SELECT nValue, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='0000000%d') AND (Type==%d) AND (Unit == '%d')", m_HwdID, sID, xcmd.type, xcmd.unitcode);
+	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, defaultname.c_str(), 255);
 	if (result.empty())
 	{
 		// New Hardware -> Create the corresponding devices Selector


### PR DESCRIPTION
The function PushAndWaitRx must be call after the safe_query in order to have the if (result.empty(s) statement working correctly !

That is a not a great code, but this is how it was originally implemented. the latest changes which have been made in 0af09b28e215e31d726081e07ea4a63176919bbe have introduce the issue.