### PR TITLE
Check printf format string and arguments

### DIFF
--- a/hardware/EvohomeBase.h
+++ b/hardware/EvohomeBase.h
@@ -516,7 +516,11 @@ public:
 	static const char* GetZoneModeName(uint8_t nZoneMode);
 
 	static void LogDate();
-	static void Log(bool bDebug, int nLogLevel, const char* format, ... );
+	static void Log(bool bDebug, int nLogLevel, const char* format, ... )
+#ifdef __GNUC__
+		__attribute__ ((format (printf, 3, 4)))
+#endif
+		;
 	static void Log(const char *szMsg, CEvohomeMsg &msg);
 
 private:

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -62,10 +62,17 @@ public:
 	void SetOutputFile(const char *OutputFile);
 
 	void Log(const _eLogLevel level, const std::string& sLogline);
-	void Log(const _eLogLevel level, const char* logline, ...);
+	void Log(const _eLogLevel level, const char* logline, ...)
+#ifdef __GNUC__
+		__attribute__ ((format (printf, 3, 4)))
+#endif
+	;
 	void Debug(const _eDebugLevel level, const std::string& sLogline);
-	void Debug(const _eDebugLevel level, const char* logline, ...);
-
+	void Debug(const _eDebugLevel level, const char* logline, ...)
+#ifdef __GNUC__
+		__attribute__ ((format (printf, 3, 4)))
+#endif
+	;
 	void LogSequenceStart();
 	void LogSequenceAdd(const char* logline);
 	void LogSequenceAddNoLF(const char* logline);


### PR DESCRIPTION
Notes:
- This functionality is gnu specific and not available in msvc, so no point enabling for Log function in hardware/1Wire/1WireForWindows.cpp
- The SQLHelper functions safe_query, safe_queryBlob and safe_exec_no_return do take format strings and variable amount of arguments, but the format strings do not follow same rules as printf