### PR TITLE
Remove RFXCom specifics from CDomoticzHardwareBase

### DIFF
--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -51,7 +51,6 @@ bool Comm5SMTCP::StartHardware()
 
 	//force connect the next first time
 	m_bIsStarted = true;
-	m_rxbufferpos = 0;
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Comm5SMTCP::Do_Work, this);
@@ -100,7 +99,6 @@ void Comm5SMTCP::Do_Work()
 			bFirstTime = false;
 			if (!mIsConnected)
 			{
-				m_rxbufferpos = 0;
 				connect(m_szIPAddress, m_usIPPort);
 			}
 		}
@@ -173,7 +171,6 @@ bool Comm5SMTCP::WriteToHardware(const char* /*pdata*/, const unsigned char /*le
 
 void Comm5SMTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData, length);
 }
 

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -172,8 +172,6 @@ void Comm5Serial::enableNotificationResponseHandler(const std::string & /*mframe
 
 void Comm5Serial::readCallBack(const char * data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
@@ -324,12 +322,6 @@ void Comm5Serial::enableNotifications()
 	//                  id    op   on/off  mask
 	std::string data("\x04\x02\x01\xFF");
 	writeFrame(data);
-}
-
-void Comm5Serial::OnData(const unsigned char *pData, size_t length)
-{
-	std::lock_guard<std::mutex> l(readQueueMutex);
-	ParseData(pData, length);
 }
 
 void Comm5Serial::OnError(const std::exception e)

--- a/hardware/Comm5Serial.h
+++ b/hardware/Comm5Serial.h
@@ -32,7 +32,6 @@ private:
 	void enableNotificationResponseHandler(const std::string& mframe);
 	void readCallBack(const char* data, size_t len);
 protected:
-	void OnData(const unsigned char *pData, size_t length);
 	void OnError(const std::exception e);
 
 	void Do_Work();

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -55,7 +55,6 @@ bool Comm5TCP::StartHardware()
 
 	//force connect the next first time
 	m_bIsStarted = true;
-	m_rxbufferpos = 0;
 
 	//Start worker thread
 	m_thread = std::make_shared<std::thread>(&Comm5TCP::Do_Work, this);
@@ -107,7 +106,6 @@ void Comm5TCP::Do_Work()
 			bFirstTime = false;
 			if (!mIsConnected)
 			{
-				m_rxbufferpos = 0;
 				connect(m_szIPAddress, m_usIPPort);
 			}
 		}
@@ -216,7 +214,6 @@ bool Comm5TCP::WriteToHardware(const char *pdata, const unsigned char /*length*/
 
 void Comm5TCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData, length);
 }
 

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -87,8 +87,6 @@ bool CurrentCostMeterSerial::StopHardware()
 
 void CurrentCostMeterSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 

--- a/hardware/CurrentCostMeterTCP.cpp
+++ b/hardware/CurrentCostMeterTCP.cpp
@@ -172,7 +172,6 @@ void CurrentCostMeterTCP::Do_Work()
 			}
 			else
 			{
-				std::lock_guard<std::mutex> l(readQueueMutex);
 				ParseData(data, bread);
 			}
 		}

--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -169,7 +169,6 @@ void CDavisLoggerSerial::Do_Work()
 
 void CDavisLoggerSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	try
 	{
 		//_log.Log(LOG_NORM,"Davis: received %ld bytes",len);

--- a/hardware/DenkoviTCPDevices.cpp
+++ b/hardware/DenkoviTCPDevices.cpp
@@ -111,8 +111,6 @@ void CDenkoviTCPDevices::CreateRequest(uint8_t * pData, size_t length)
  
 void CDenkoviTCPDevices::OnData(const unsigned char * pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	switch (m_iModel) {
 	case DDEV_WIFI_16R: {
 		if (m_Cmd == DAE_WIFI16_ASK_CMD) {
@@ -247,7 +245,6 @@ void CDenkoviTCPDevices::Do_Work()
 			m_bFirstTime = false;
 			if (!mIsConnected)
 			{
-				m_rxbufferpos = 0;
 				connect(m_szIPAddress, m_usIPPort);
 			}
 		}

--- a/hardware/DenkoviUSBDevices.cpp
+++ b/hardware/DenkoviUSBDevices.cpp
@@ -88,9 +88,6 @@ bool CDenkoviUSBDevices::StartHardware()
 
 void CDenkoviUSBDevices::readCallBack(const char * data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-	//boost::lock_guard<boost::mutex> l(readQueueMutex);
-
 	if (!m_bEnableReceive) {
 		m_readingNow = false;
 		return; //receiving not enabled
@@ -121,18 +118,6 @@ void CDenkoviUSBDevices::readCallBack(const char * data, size_t len)
 	}
 	m_updateIo = false;
 	m_readingNow = false;
-}
-
-
-void CDenkoviUSBDevices::OnData(const unsigned char *pData, size_t length)
-{
-	std::lock_guard<std::mutex> l(readQueueMutex);
-	//boost::lock_guard<boost::mutex> l(readQueueMutex);
-	uint8_t firstEight, secondEight;
-	if (length == 2) {
-		firstEight = (unsigned char)pData[0];
-		secondEight = (unsigned char)pData[1];
-	}
 }
 
 void CDenkoviUSBDevices::OnError(const std::exception e)

--- a/hardware/DenkoviUSBDevices.h
+++ b/hardware/DenkoviUSBDevices.h
@@ -35,6 +35,5 @@ private:
 	bool m_updateIo = false;
 
 protected:
-	void OnData(const unsigned char *pData, size_t length);
 	void OnError(const std::exception e);
 };

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -34,46 +34,12 @@ bool CDomoticzHardwareBase::Start()
 
 bool CDomoticzHardwareBase::Stop()
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	return StopHardware();
 }
 
 void CDomoticzHardwareBase::EnableOutputLog(const bool bEnableLog)
 {
 	m_bOutputLog = bEnableLog;
-}
-
-bool CDomoticzHardwareBase::onRFXMessage(const unsigned char *pBuffer, const size_t Len)
-{
-	if (!m_bEnableReceive)
-		return true; //receiving not enabled
-
-	size_t ii=0;
-	while (ii<Len)
-	{
-		if (m_rxbufferpos == 0)	//1st char of a packet received
-		{
-			if (pBuffer[ii]==0) //ignore first char if 00
-				return true;
-		}
-		m_rxbuffer[m_rxbufferpos]=pBuffer[ii];
-		m_rxbufferpos++;
-		if (m_rxbufferpos>=sizeof(m_rxbuffer))
-		{
-			//something is out of sync here!!
-			//restart
-			_log.Log(LOG_ERROR,"input buffer out of sync, going to restart!....");
-			m_rxbufferpos=0;
-			return false;
-		}
-		if (m_rxbufferpos > m_rxbuffer[0])
-		{
-			sDecodeRXMessage(this, (const unsigned char *)&m_rxbuffer, NULL, -1);
-			m_rxbufferpos = 0;    //set to zero to receive next message
-		}
-		ii++;
-	}
-	return true;
 }
 
 void CDomoticzHardwareBase::StartHeartbeatThread()

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -33,7 +33,6 @@ public:
 	std::string m_Name;
 	_eHardwareTypes HwdType;
 	unsigned char m_SeqNr = { 0 };
-	unsigned char m_rxbufferpos = { 0 };
 	bool m_bEnableReceive = { false };
 	boost::signals2::signal<void(CDomoticzHardwareBase *pHardware, const unsigned char *pRXCommand, const char *defaultName, const int BatteryLevel)> sDecodeRXMessage;
 	boost::signals2::signal<void(CDomoticzHardwareBase *pDevice)> sOnConnected;
@@ -42,7 +41,6 @@ public:
 protected:
 	virtual bool StartHardware()=0;
 	virtual bool StopHardware()=0;
-	bool onRFXMessage(const unsigned char *pBuffer, const size_t Len);
 
     //Heartbeat thread for classes that can not provide this themselves
 	void StartHeartbeatThread();
@@ -95,8 +93,6 @@ protected:
 	void SendFanSensor(const int Idx, const int BatteryLevel, const int FanSpeed, const std::string &defaultname);
 
 	int m_iHBCounter = { 0 };
-	std::mutex readQueueMutex;
-	unsigned char m_rxbuffer[RX_BUFFER_SIZE] = { 0 };
 	bool m_bIsStarted = { false };
 private:
     void Do_Heartbeat_Work();

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -280,7 +280,7 @@ void DomoticzTCP::Do_Work()
 			else
 			{
 				std::lock_guard<std::mutex> l(readQueueMutex);
-				onInternalMessage((const unsigned char *)&buf, bread);
+				onInternalMessage((const unsigned char *)&buf, bread, false); // Do not check validity, this might be non RFX-message
 			}
 		}
 

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -280,7 +280,7 @@ void DomoticzTCP::Do_Work()
 			else
 			{
 				std::lock_guard<std::mutex> l(readQueueMutex);
-				onRFXMessage((const unsigned char *)&buf, bread);
+				onInternalMessage((const unsigned char *)&buf, bread);
 			}
 		}
 
@@ -418,7 +418,7 @@ void DomoticzTCP::FromProxy(const unsigned char *data, size_t datalen)
 {
 	/* data received from slave */
 	std::lock_guard<std::mutex> l(readQueueMutex);
-	onRFXMessage(data, datalen);
+	onInternalMessage(data, datalen);
 }
 
 std::string DomoticzTCP::GetToken()

--- a/hardware/DomoticzTCP.h
+++ b/hardware/DomoticzTCP.h
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "DomoticzHardware.h"
+#include "RFXBase.h"
 #if defined WIN32
 #include "ws2tcpip.h"
 #endif
 
-class DomoticzTCP : public CDomoticzHardwareBase
+class DomoticzTCP : public CRFXBase
 {
 public:
 	DomoticzTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &username, const std::string &password);

--- a/hardware/Ec3kMeterTCP.cpp
+++ b/hardware/Ec3kMeterTCP.cpp
@@ -147,7 +147,6 @@ void Ec3kMeterTCP::Do_Work()
 
 void Ec3kMeterTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData,length);
 }
 

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -1005,7 +1005,6 @@ bool CEnOceanESP2::OpenSerialDevice()
 
 void CEnOceanESP2::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	size_t ii = 0;
 	while (ii < len)
 	{

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -570,7 +570,6 @@ bool CEnOceanESP3::OpenSerialDevice()
 
 void CEnOceanESP3::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	size_t ii=0;
 
 	while (ii<len)

--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -1633,7 +1633,7 @@ void CEvohomeRadio::PopSendQueue(const CEvohomeMsg &msg)
 
 void CEvohomeRadio::Send()
 {
-	std::lock_guard<std::mutex> rl(readQueueMutex);//ideally we need some way to send only if we're not in the middle of receiving a packet but as everything is buffered i'm not sure if this will be effective
+	//ideally we need some way to send only if we're not in the middle of receiving a packet but as everything is buffered i'm not sure if this will be effective
 	if (m_nBufPtr > 0)
 		return;
 	std::lock_guard<std::mutex> sl(m_mtxSend);

--- a/hardware/EvohomeSerial.cpp
+++ b/hardware/EvohomeSerial.cpp
@@ -74,7 +74,6 @@ bool CEvohomeSerial::OpenSerialDevice()
 
 void CEvohomeSerial::ReadCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	try
 	{
 		//_log.Log(LOG_NORM,"evohome: received %ld bytes",len);

--- a/hardware/EvohomeTCP.cpp
+++ b/hardware/EvohomeTCP.cpp
@@ -122,7 +122,6 @@ void CEvohomeTCP::Do_Work()
 
 void CEvohomeTCP::OnData(const unsigned char *pData, size_t length)
 {
-    std::lock_guard<std::mutex> l(readQueueMutex);
 	try
 	{
 		//_log.Log(LOG_NORM,"evohome: received %ld bytes",len);

--- a/hardware/FritzboxTCP.cpp
+++ b/hardware/FritzboxTCP.cpp
@@ -140,7 +140,6 @@ void FritzboxTCP::Do_Work()
 
 void FritzboxTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData,length);
 }
 

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -633,7 +633,6 @@ void CHEOS::OnDisconnect()
 
 void CHEOS::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData, length);
 }
 

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -146,7 +146,6 @@ bool KMTronic433::OpenSerialDevice()
 
 void KMTronic433::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -142,7 +142,6 @@ bool KMTronicSerial::OpenSerialDevice()
 
 void KMTronicSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -156,7 +156,6 @@ void Meteostick::Do_PollWork()
 
 void Meteostick::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -139,7 +139,6 @@ void MochadTCP::OnDisconnect()
 
 void MochadTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData, length);
 }
 
@@ -163,7 +162,6 @@ void MochadTCP::Do_Work()
 			bFirstTime = false;
 			if (!mIsConnected)
 			{
-				m_rxbufferpos = 0;
 				connect(m_szIPAddress, m_usIPPort);
 			}
 		}

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -251,7 +251,6 @@ MySensorsBase::~MySensorsBase(void)
 
 void MySensorsBase::LoadDevicesFromDatabase()
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	m_nodes.clear();
 
 	std::vector<std::vector<std::string> > result, result2;

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -197,7 +197,6 @@ bool MySensorsSerial::OpenSerialDevice()
 
 void MySensorsSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -137,7 +137,6 @@ void MySensorsTCP::Do_Work()
 
 void MySensorsTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData, length);
 }
 

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -53,7 +53,6 @@ bool OTGWSerial::StopHardware()
 
 void OTGWSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -132,7 +132,6 @@ void OTGWTCP::Do_Work()
 
 void OTGWTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData,length);
 }
 

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -242,7 +242,6 @@ void OnkyoAVTCP::Do_Work()
 
 void OnkyoAVTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(pData,length);
 }
 

--- a/hardware/OpenWebNetTCP.h
+++ b/hardware/OpenWebNetTCP.h
@@ -94,4 +94,5 @@ private:
 	volatile uint32_t mask_request_status;
 	int m_heartbeatcntr;
 	csocket* m_pStatusSocket;
+	std::mutex readQueueMutex;
 };

--- a/hardware/OpenWebNetUSB.h
+++ b/hardware/OpenWebNetUSB.h
@@ -47,4 +47,5 @@ private:
 
 	volatile bool m_bWriting;
 	volatile bool m_stoprequested;
+	std::mutex readQueueMutex;
 };

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -137,8 +137,6 @@ bool P1MeterSerial::StopHardware()
 
 void P1MeterSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 	ParseData((const unsigned char*)data, static_cast<int>(len), m_bDisableCRC, m_ratelimit);

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -130,7 +130,6 @@ void P1MeterTCP::OnDisconnect()
 
 void P1MeterTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData((const unsigned char*)pData, length, m_bDisableCRC, m_ratelimit);
 }
 

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -63,7 +63,6 @@ bool RAVEn::StopHardware()
 
 void RAVEn::readCallback(const char *indata, size_t inlen)
 {
-    std::lock_guard<std::mutex> l(readQueueMutex);
     if (!m_bEnableReceive)
         return; //receiving not enabled
 

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -193,7 +193,6 @@ bool CRFLinkSerial::OpenSerialDevice()
 
 void CRFLinkSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(data, len);
 }
 

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -155,7 +155,6 @@ void CRFLinkTCP::Do_Work()
 
 void CRFLinkTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData((const char*)pData,length);
 }
 

--- a/hardware/RFXBase.cpp
+++ b/hardware/RFXBase.cpp
@@ -202,6 +202,7 @@ bool CRFXBase::SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned 
 
 void CRFXBase::SendResetCommand()
 {
+	std::lock_guard<std::mutex> l(readQueueMutex);
 	m_bEnableReceive = false;
 	m_rxbufferpos = 0;
 	//Send Reset

--- a/hardware/RFXBase.cpp
+++ b/hardware/RFXBase.cpp
@@ -14,7 +14,7 @@ CRFXBase::~CRFXBase()
 {
 }
 
-bool CRFXBase::onInternalMessage(const unsigned char *pBuffer, const size_t Len)
+bool CRFXBase::onInternalMessage(const unsigned char *pBuffer, const size_t Len, const bool checkValid/* = true*/)
 {
 	if (!m_bEnableReceive)
 		return true; //receiving not enabled
@@ -39,7 +39,7 @@ bool CRFXBase::onInternalMessage(const unsigned char *pBuffer, const size_t Len)
 		}
 		if (m_rxbufferpos > m_rxbuffer[0])
 		{
-			if (CheckValidRFXData((uint8_t*)&m_rxbuffer))
+			if (!checkValid || CheckValidRFXData((uint8_t*)&m_rxbuffer))
 				sDecodeRXMessage(this, (const unsigned char *)&m_rxbuffer, NULL, -1);
 			else
 				_log.Log(LOG_ERROR, "RFXCOM: Invalid data received!....");

--- a/hardware/RFXBase.h
+++ b/hardware/RFXBase.h
@@ -17,8 +17,12 @@ public:
 	int m_NoiseLevel;
 	bool SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned char Mode2, const unsigned char Mode3, const unsigned char Mode4, const unsigned char Mode5, const unsigned char Mode6);
 	void SendResetCommand();
-private:
+protected:
 	bool onInternalMessage(const unsigned char *pBuffer, const size_t Len);
+	std::mutex readQueueMutex;
+	unsigned char m_rxbuffer[RX_BUFFER_SIZE] = { 0 };
+	unsigned char m_rxbufferpos = { 0 };
+private:
 	static bool CheckValidRFXData(const uint8_t *pData);
 	void SendCommand(const unsigned char Cmd);
 	std::shared_ptr<std::thread> m_thread;

--- a/hardware/RFXBase.h
+++ b/hardware/RFXBase.h
@@ -18,7 +18,7 @@ public:
 	bool SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned char Mode2, const unsigned char Mode3, const unsigned char Mode4, const unsigned char Mode5, const unsigned char Mode6);
 	void SendResetCommand();
 protected:
-	bool onInternalMessage(const unsigned char *pBuffer, const size_t Len);
+	bool onInternalMessage(const unsigned char *pBuffer, const size_t Len, const bool checkValid = true);
 	std::mutex readQueueMutex;
 	unsigned char m_rxbuffer[RX_BUFFER_SIZE] = { 0 };
 	unsigned char m_rxbufferpos = { 0 };

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -317,8 +317,6 @@ bool CRego6XXSerial::OpenSerialDevice()
 
 void CRego6XXSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -760,8 +760,6 @@ void RelayNet::OnDisconnect()
 
 void RelayNet::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
-
 	if (!m_stoprequested)
 	{
 		ParseData(pData, length);

--- a/hardware/S0MeterSerial.cpp
+++ b/hardware/S0MeterSerial.cpp
@@ -117,7 +117,6 @@ bool S0MeterSerial::StopHardware()
 
 void S0MeterSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bIsStarted)
 		return;
 

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -135,7 +135,6 @@ bool S0MeterTCP::WriteToHardware(const char *pdata, const unsigned char length)
 
 void S0MeterTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData((const unsigned char*)pData,length);
 }
 

--- a/hardware/SolarMaxTCP.cpp
+++ b/hardware/SolarMaxTCP.cpp
@@ -241,7 +241,6 @@ void SolarMaxTCP::Do_Work()
 				}
 				else
 				{
-					std::lock_guard<std::mutex> l(readQueueMutex);
 					ParseData((const unsigned char *)&buf, bread);
 				}
 			}

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -134,7 +134,6 @@ bool CTeleinfoSerial::WriteToHardware(const char *pdata, const unsigned char len
 
 void CTeleinfoSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bEnableReceive)
 	{
 		_log.Log(LOG_ERROR, "(%s) Receiving is not enabled", m_Name.c_str());

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -253,7 +253,6 @@ bool USBtin::OpenSerialDevice()
 
 void USBtin::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 	if (len > sizeof(m_USBtinBuffer)){

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -150,7 +150,6 @@ bool CZiBlueSerial::OpenSerialDevice()
 
 void CZiBlueSerial::readCallback(const char *data, size_t len)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData(data, len);
 }
 

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -159,7 +159,6 @@ void CZiBlueTCP::Do_Work()
 
 void CZiBlueTCP::OnData(const unsigned char *pData, size_t length)
 {
-	std::lock_guard<std::mutex> l(readQueueMutex);
 	ParseData((const char*)pData,length);
 }
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1759,8 +1759,7 @@ void MainWorker::OnHardwareConnected(CDomoticzHardwareBase *pHardware)
 		(pHardware->HwdType != HTYPE_RFXLAN)
 		)
 	{
-		//clear buffer, and enable receive
-		pHardware->m_rxbufferpos = 0;
+		//enable receive
 		pHardware->m_bEnableReceive = true;
 		return;
 	}


### PR DESCRIPTION
Move RFXCom specifics from CDomoticzHardwareBase to CRFXBase, get rid of readQueueMutex from most HW.