### PR TITLE
Fix non threadsafe HW shutdown

### DIFF
--- a/hardware/CurrentCostMeterTCP.cpp
+++ b/hardware/CurrentCostMeterTCP.cpp
@@ -68,6 +68,12 @@ bool CurrentCostMeterTCP::isConnected()
 
 bool CurrentCostMeterTCP::StopHardware()
 {
+	m_stoprequested=true;
+	if (m_thread)
+	{
+		m_thread->join();
+		m_thread.reset();
+	}
 	if (isConnected())
 	{
 		try {
@@ -111,16 +117,10 @@ bool CurrentCostMeterTCP::ConnectInternal()
 
 void CurrentCostMeterTCP::disconnect()
 {
-	m_stoprequested=true;
 	if (m_socket==INVALID_SOCKET)
 		return;
 	closesocket(m_socket);
 	m_socket=INVALID_SOCKET;
-	sleep_seconds(1);
-	if (m_thread)
-	{
-		m_thread->join();
-	}
 }
 
 

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -142,16 +142,6 @@ bool DomoticzTCP::StopHardware()
 
 bool DomoticzTCP::StopHardwareTCP()
 {
-	if (isConnected())
-	{
-		try {
-			disconnectTCP();
-		}
-		catch (...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -163,6 +153,16 @@ bool DomoticzTCP::StopHardwareTCP()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnectTCP();
+		}
+		catch (...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 	m_bIsStarted = false;
 	return true;
@@ -213,17 +213,11 @@ bool DomoticzTCP::ConnectInternal()
 
 void DomoticzTCP::disconnectTCP()
 {
-	m_stoprequested = true;
 	if (m_socket != INVALID_SOCKET)
 	{
 		shutdown(m_socket, SHUT_RDWR);
 		closesocket(m_socket);
 		m_socket = INVALID_SOCKET;
-		sleep_seconds(1);
-	}
-	if (m_thread)
-	{
-		m_thread->join();
 	}
 }
 

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -591,16 +591,6 @@ bool CHEOS::StartHardware()
 bool CHEOS::StopHardware()
 {
 	m_stoprequested = true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-		}
-		catch (...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -611,6 +601,16 @@ bool CHEOS::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+		}
+		catch (...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted = false;

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -108,6 +108,17 @@ bool MochadTCP::StartHardware()
 bool MochadTCP::StopHardware()
 {
 	m_stoprequested = true;
+	try {
+		if (m_thread)
+		{
+			m_thread->join();
+			m_thread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
 	if (isConnected())
 	{
 		try {

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -46,16 +46,6 @@ bool MySensorsTCP::StopHardware()
 {
 	m_stoprequested = true;
 	StopSendQueue();
-	if (isConnected())
-	{
-		try {
-			disconnect();
-		}
-		catch (...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -66,6 +56,16 @@ bool MySensorsTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+		}
+		catch (...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted = false;

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -45,8 +45,8 @@ bool OTGWSerial::StartHardware()
 bool OTGWSerial::StopHardware()
 {
 	m_bIsStarted=false;
-	terminate();
 	StopPollerThread();
+	terminate();
 	return true;
 }
 

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -40,16 +40,6 @@ bool OTGWTCP::StartHardware()
 bool OTGWTCP::StopHardware()
 {
 	m_stoprequested=true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -60,6 +50,16 @@ bool OTGWTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		} catch(...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted=false;

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -38,17 +38,6 @@ bool P1MeterTCP::StartHardware()
 bool P1MeterTCP::StopHardware()
 {
 	m_stoprequested = true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-			close();
-		}
-		catch(...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -59,6 +48,17 @@ bool P1MeterTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		}
+		catch(...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 	m_bIsStarted = false;
 	return true;

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -36,16 +36,6 @@ bool CRFLinkTCP::StartHardware()
 bool CRFLinkTCP::StopHardware()
 {
 	m_stoprequested=true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -56,6 +46,16 @@ bool CRFLinkTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		} catch(...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted=false;

--- a/hardware/RFXComTCP.cpp
+++ b/hardware/RFXComTCP.cpp
@@ -39,16 +39,22 @@ bool RFXComTCP::StartHardware()
 bool RFXComTCP::StopHardware()
 {
 	m_stoprequested = true;
+	try {
+		if (m_thread)
+		{
+			m_thread->join();
+			m_thread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
 	if (isConnected())
 	{
 		try {
 			disconnect();
 			close();
-			if (m_thread)
-			{
-				m_thread->join();
-				m_thread.reset();
-			}
 		}
 		catch (...)
 		{

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -195,11 +195,6 @@ bool RelayNet::StopHardware()
 {
 	m_stoprequested = true;
 
-	if (isConnected())
-	{
-		disconnect();
-	}
-
 	try
 	{
 		if (m_thread)
@@ -210,6 +205,10 @@ bool RelayNet::StopHardware()
 	}
 	catch (...)
 	{
+	}
+	if (isConnected())
+	{
+		disconnect();
 	}
 
 	m_bIsStarted = false;

--- a/hardware/S0MeterSerial.cpp
+++ b/hardware/S0MeterSerial.cpp
@@ -108,8 +108,8 @@ bool S0MeterSerial::StartHardware()
 bool S0MeterSerial::StopHardware()
 {
 	m_bIsStarted=false;
-	terminate();
 	StopHeartbeatThread();
+	terminate();
 	_log.Log(LOG_STATUS, "S0 Meter: Serial Worker stopped...");
 	return true;
 }

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -43,16 +43,6 @@ bool S0MeterTCP::StartHardware()
 bool S0MeterTCP::StopHardware()
 {
 	m_stoprequested=true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -63,6 +53,16 @@ bool S0MeterTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		} catch(...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted=false;

--- a/hardware/SolarMaxTCP.cpp
+++ b/hardware/SolarMaxTCP.cpp
@@ -104,24 +104,23 @@ bool SolarMaxTCP::StartHardware()
 
 bool SolarMaxTCP::StopHardware()
 {
+	m_stoprequested = true;
+	try {
+		if (m_thread)
+		{
+			
+			m_thread->join();
+			m_thread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
 	if (isConnected())
 	{
 		try {
 			disconnect();
-		}
-		catch (...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
-	else {
-		try {
-			if (m_thread)
-			{
-				m_stoprequested = true;
-				m_thread->join();
-				m_thread.reset();
-			}
 		}
 		catch (...)
 		{
@@ -170,16 +169,10 @@ bool SolarMaxTCP::ConnectInternal()
 
 void SolarMaxTCP::disconnect()
 {
-	m_stoprequested = true;
 	if (m_socket != INVALID_SOCKET)
 	{
 		closesocket(m_socket);
 		m_socket = INVALID_SOCKET;
-		sleep_seconds(1);
-	}
-	if (m_thread)
-	{
-		m_thread->join();
 	}
 }
 

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -119,8 +119,8 @@ bool CTeleinfoSerial::StartHardware()
 
 bool CTeleinfoSerial::StopHardware()
 {
-	terminate();
 	StopHeartbeatThread();
+	terminate();
 	m_bIsStarted = false;
 	return true;
 }

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -238,7 +238,11 @@ bool CTellstick::StopHardware()
     m_bIsStarted = false;
     m_cond.notify_all();
     lock.unlock();
-    m_thread.join();
+    if (m_thread)
+	{
+		m_thread->join();
+		m_thread.reset();
+	}
     return true;
 }
 

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -238,8 +238,7 @@ bool CTellstick::StopHardware()
     m_bIsStarted = false;
     m_cond.notify_all();
     lock.unlock();
-    if (m_thread.joinable()) //TODO: Why do we only join the thread if it's joinable?
-        m_thread.join();
+    m_thread.join();
     return true;
 }
 

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -238,7 +238,7 @@ bool CTellstick::StopHardware()
     m_bIsStarted = false;
     m_cond.notify_all();
     lock.unlock();
-    if (m_thread.joinable())
+    if (m_thread.joinable()) //TODO: Why do we only join the thread if it's joinable?
         m_thread.join();
     return true;
 }

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -39,16 +39,6 @@ bool CZiBlueTCP::StartHardware()
 bool CZiBlueTCP::StopHardware()
 {
 	m_stoprequested=true;
-	if (isConnected())
-	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
-	}
 	try {
 		if (m_thread)
 		{
@@ -59,6 +49,16 @@ bool CZiBlueTCP::StopHardware()
 	catch (...)
 	{
 		//Don't throw from a Stop command
+	}
+	if (isConnected())
+	{
+		try {
+			disconnect();
+			close();
+		} catch(...)
+		{
+			//Don't throw from a Stop command
+		}
 	}
 
 	m_bIsStarted=false;


### PR DESCRIPTION
Many HW classes shuts down the connection before the worker thread. This is unsafe and causes crashes.
Also add forgotten join() of the worker in MochadTCP.