### PR TITLE
Refactor ASyncTCP class

### DIFF
--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -127,7 +127,6 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
     pimpl->open=true; //Port is now open
 }
 
-//TODO: Remove this function!
 void AsyncSerial::openOnlyBaud(const std::string& devname, unsigned int baud_rate,
 	boost::asio::serial_port_base::parity /*opt_parity*/,
 	boost::asio::serial_port_base::character_size /*opt_csize*/,

--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -127,6 +127,7 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
     pimpl->open=true; //Port is now open
 }
 
+//TODO: Remove this function!
 void AsyncSerial::openOnlyBaud(const std::string& devname, unsigned int baud_rate,
 	boost::asio::serial_port_base::parity /*opt_parity*/,
 	boost::asio::serial_port_base::character_size /*opt_csize*/,

--- a/hardware/ASyncTCP.cpp
+++ b/hardware/ASyncTCP.cpp
@@ -4,6 +4,7 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/system/error_code.hpp>     // for error_code
+#include "../main/Helper.h"                // for SetThreadName
 #include "../main/Logger.h"                // for CLogger, _log, _eLogLevel:...
 struct hostent;
 
@@ -11,26 +12,39 @@ struct hostent;
 	#include <unistd.h> //gethostbyname
 #endif
 
-/*
-#ifdef WIN32
-	#include <Mstcpip.h>
-#elif defined(__FreeBSD__)
-	#include <netinet/tcp.h>
-#endif
-*/
-
 #define RECONNECT_TIME 30
 
+// TODO: Delete default constructor and require thread name to be set
 ASyncTCP::ASyncTCP()
 	: mIsConnected(false), mIsClosing(false),
 	mSocket(mIos), mReconnectTimer(mIos),
-	mDoReconnect(true), mIsReconnecting(false)
+	mDoReconnect(true), mIsReconnecting(false),
+	m_tcpwork(mIos)
 {
+	// Reset IO Service
+	mIos.reset();
+
+	//Start IO Service worker thread
+	m_tcpthread = std::make_shared<std::thread>(boost::bind(&boost::asio::io_service::run, &mIos));
+	SetThreadName(m_tcpthread->native_handle(), "ASyncTCP");
 }
 
 ASyncTCP::~ASyncTCP(void)
 {
 	disconnect();
+	// tell the IO service to stop
+	mIos.stop();
+	try {
+		if (m_tcpthread)
+		{
+			m_tcpthread->join();
+			m_tcpthread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
 }
 
 void ASyncTCP::update()
@@ -38,7 +52,7 @@ void ASyncTCP::update()
 	if (mIsClosing)
 		return;
 	// calls the poll() function to process network messages
-	mIos.poll();
+	//mIos.poll();
 }
 
 void ASyncTCP::connect(const std::string &ip, unsigned short port)
@@ -87,8 +101,8 @@ void ASyncTCP::connect(boost::asio::ip::tcp::endpoint& endpoint)
 
 	// restart IO service if it has been stopped
 	if (mIos.stopped()) {
-		_log.Log(LOG_STATUS, "ASyncTCP::connect: reset IO service");
-		mIos.reset();
+		_log.Log(LOG_ERROR, "ASyncTCP::connect: IO service stopped!");
+		//mIos.reset();
 	}
 
 	// try to connect, then call handle_connect
@@ -102,7 +116,7 @@ void ASyncTCP::disconnect()
 	close();
 
 	// tell the IO service to stop
-	mIos.stop();
+	//mIos.stop();
 
 	mIsConnected = false;
 	mIsClosing = false;
@@ -116,70 +130,6 @@ void ASyncTCP::close()
 	mIos.post(boost::bind(&ASyncTCP::do_close, this));
 }
 
-/*
-bool ASyncTCP::set_tcp_keepalive()
-{
-	int keep_alive_timeout = 10;
-
-#ifdef __OSX__
-	int native_fd = socket->native();
-	int timeout = *keep_alive_timeout;
-	int intvl = 1;
-	int on = 1;
-
-	// Set the timeout before the first keep alive message
-	int ret_sokeepalive = setsockopt(native_fd, SOL_SOCKET, SO_KEEPALIVE, (void*)&on, sizeof(int));
-	int ret_tcpkeepalive = setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPALIVE, (void*)&timeout, sizeof(int));
-	int ret_tcpkeepintvl = setsockopt(native_fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT, (void*)&intvl, sizeof(int));
-
-	if (ret_sokeepalive || ret_tcpkeepalive || ret_tcpkeepintvl)
-	{
-		string message("Failed to enable keep alive on TCP client socket!");
-		Logger::error(message, port, host);
-		return false;
-	}
-#elif defined(WIN32)
-	// Partially supported on windows
-	struct tcp_keepalive keepalive_options;
-	keepalive_options.onoff = 1;
-	keepalive_options.keepalivetime = keep_alive_timeout * 1000;
-	keepalive_options.keepaliveinterval = 2000;
-
-	BOOL keepalive_val = true;
-	SOCKET native = mSocket.native();
-	DWORD bytes_returned;
-
-	int ret_keepalive = setsockopt(native, SOL_SOCKET, SO_KEEPALIVE, (const char *)&keepalive_val, sizeof(keepalive_val));
-	int ret_iotcl = WSAIoctl(native, SIO_KEEPALIVE_VALS, (LPVOID)& keepalive_options, (DWORD) sizeof(keepalive_options), NULL, 0,
-		(LPDWORD)& bytes_returned, NULL, NULL);
-
-	if (ret_keepalive || ret_iotcl)
-	{
-		_log.Log(LOG_ERROR, "Failed to set keep alive timeout on TCP client socket!");
-		return false;
-	}
-#else
-	// For *n*x systems
-	int native_fd = mSocket.native();
-	int timeout = keep_alive_timeout;
-	int intvl = 1;
-	int probes = 10;
-	int on = 1;
-
-	int ret_keepalive = setsockopt(native_fd, SOL_SOCKET, SO_KEEPALIVE, (void*)&on, sizeof(int));
-	int ret_keepidle = setsockopt(native_fd, SOL_TCP, TCP_KEEPIDLE, (void*)&timeout, sizeof(int));
-	int ret_keepintvl = setsockopt(native_fd, SOL_TCP, TCP_KEEPINTVL, (void*)&intvl, sizeof(int));
-	int ret_keepinit = setsockopt(native_fd, SOL_TCP, TCP_KEEPCNT, (void*)&probes, sizeof(int));
-
-	if (ret_keepalive || ret_keepidle || ret_keepintvl || ret_keepinit)
-	{
-		_log.Log(LOG_ERROR, "Failed to set keep alive timeout on TCP client socket!");
-		return false;
-	}
-#endif
-	return true;
-}
-*/
 
 // callbacks
 
@@ -305,19 +255,12 @@ void ASyncTCP::write_end(const boost::system::error_code& error)
 
 void ASyncTCP::write(const uint8_t *pData, size_t length)
 {
-	if(!mIsConnected) return;
-
-	if (!mIsClosing)
-	{
-		boost::asio::async_write(mSocket,
-			boost::asio::buffer(pData,length),
-			boost::bind(&ASyncTCP::write_end, this, boost::asio::placeholders::error));
-	}
+	write(std::string((const char*)pData, length));
 }
 
 void ASyncTCP::write(const std::string &msg)
 {
-	write((const uint8_t*)msg.c_str(), msg.size());
+	mIos.post(boost::bind(&ASyncTCP::do_write, this, msg));
 }
 
 void ASyncTCP::do_close()
@@ -347,6 +290,20 @@ void ASyncTCP::do_reconnect(const boost::system::error_code& /*error*/)
 	mSocket.async_connect(mEndPoint,
         boost::bind(&ASyncTCP::handle_connect, this, boost::asio::placeholders::error));
 	mIsReconnecting = false;
+}
+
+void ASyncTCP::do_write(const std::string &msg)
+{
+	if(!mIsConnected) return;
+
+	//write((const uint8_t*)msg.c_str(), msg.size());
+
+	if (!mIsClosing)
+	{
+		boost::asio::async_write(mSocket,
+			boost::asio::buffer(msg.c_str(), msg.size()),
+			boost::bind(&ASyncTCP::write_end, this, boost::asio::placeholders::error));
+	}
 }
 
 void ASyncTCP::OnErrorInt(const boost::system::error_code& error)

--- a/hardware/ASyncTCP.h
+++ b/hardware/ASyncTCP.h
@@ -12,12 +12,12 @@ typedef std::shared_ptr<class ASyncTCP> ASyncTCPRef;
 
 class ASyncTCP
 {
-public:
+protected:
 	ASyncTCP();
 	virtual ~ASyncTCP(void);
 
 	void connect(const std::string &ip, unsigned short port);
-	void connect(boost::asio::ip::tcp::endpoint& endpoint);
+	//void connect(boost::asio::ip::tcp::endpoint& endpoint);
 	void disconnect();
 	bool isConnected() { return mIsConnected; };
 
@@ -25,16 +25,12 @@ public:
 	void write(const uint8_t *pData, size_t length);
 
 	void update();
-protected:
+//protected:
 	void read();
 	void close();
 	//bool set_tcp_keepalive();
 
 	// callbacks
-	void handle_connect(const boost::system::error_code& error);
-	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-	void write_end(const boost::system::error_code& error);
-	void do_close();
 
 	void do_reconnect(const boost::system::error_code& error);
 
@@ -61,4 +57,16 @@ protected:
 
 	boost::asio::deadline_timer		mReconnectTimer;
 
+private:
+	void connect(boost::asio::ip::tcp::endpoint& endpoint);
+
+	// Callbacks, executed from the io_service
+	void handle_connect(const boost::system::error_code& error);
+	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
+	void write_end(const boost::system::error_code& error);
+	void do_close();
+	void do_write(const std::string &msg);
+
+	std::shared_ptr<std::thread> m_tcpthread;
+	boost::asio::io_service::work m_tcpwork; // Create some work to keep IO Service alive
 };

--- a/hardware/ASyncTCP.h
+++ b/hardware/ASyncTCP.h
@@ -13,60 +13,57 @@ typedef std::shared_ptr<class ASyncTCP> ASyncTCPRef;
 class ASyncTCP
 {
 protected:
-	ASyncTCP();
+	ASyncTCP() = delete;
+	ASyncTCP(const std::string thread_name);
 	virtual ~ASyncTCP(void);
 
-	void connect(const std::string &ip, unsigned short port);
-	//void connect(boost::asio::ip::tcp::endpoint& endpoint);
-	void disconnect();
+	void connect(const std::string &hostname, unsigned short port); // Async connect to the socket, no action if mIsConnected = true. If the connection is lost, it will automatically be setup again
+	void scedule_reconnect(const int millis);         // Schedule reconnect (TODO: Implement)
+	void disconnect();                                // Async disconnect from the socket, no action if mIsConnected = false
 	bool isConnected() { return mIsConnected; };
 
-	void write(const std::string &msg);
-	void write(const uint8_t *pData, size_t length);
+	void write(const std::string &msg);               // Async write to the socket, no action if mIsConnected = false
+	void write(const uint8_t *pData, size_t length);  // Async write to the socket, no action if mIsConnected = false
 
-	void update();
-//protected:
-	void read();
-	void close();
-	//bool set_tcp_keepalive();
-
-	// callbacks
-
-	void do_reconnect(const boost::system::error_code& error);
-
+	// Callback interface to implement in derived classes
 	virtual void OnConnect()=0;
 	virtual void OnDisconnect()=0;
 	virtual void OnData(const unsigned char *pData, size_t length)=0;
 	virtual void OnError(const std::exception e)=0;
 	virtual void OnError(const boost::system::error_code& error)=0;
 
-	void OnErrorInt(const boost::system::error_code& error);
-
 protected:
+	boost::asio::io_service			mIos; // protected to allow derived classes to attach timers etc.
+
+private:
+	// Internal helper function
+	void connect(boost::asio::ip::tcp::endpoint& endpoint);
+	void OnErrorInt(const boost::system::error_code& error);
+	void close();
+	void read(); // Start async read from the socket, data is delivered in OnData(), no action if mIsConnected = false
+
+	// Callbacks for the io_service, executed from the io_service worker thread context
+	void handle_connect(const boost::system::error_code& error);
+	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
+	void write_end(const boost::system::error_code& error);
+	void do_close();
+	void do_reconnect(const boost::system::error_code& error);
+	void do_write(const std::string &msg);
+
+	// State variables
 	bool							mIsConnected;
 	bool							mIsClosing;
 	bool							mDoReconnect;
 	bool							mIsReconnecting;
 
-	boost::asio::ip::tcp::endpoint	mEndPoint;
-
-	boost::asio::io_service			mIos;
-	boost::asio::ip::tcp::socket	mSocket;
-
-	unsigned char m_buffer[1024];
+	// Internal
+	unsigned char 					m_readbuffer[1024];
 
 	boost::asio::deadline_timer		mReconnectTimer;
 
-private:
-	void connect(boost::asio::ip::tcp::endpoint& endpoint);
+	std::shared_ptr<std::thread> 	m_tcpthread;
+	boost::asio::io_service::work 	m_tcpwork; // Create some work to keep IO Service alive
 
-	// Callbacks, executed from the io_service
-	void handle_connect(const boost::system::error_code& error);
-	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
-	void write_end(const boost::system::error_code& error);
-	void do_close();
-	void do_write(const std::string &msg);
-
-	std::shared_ptr<std::thread> m_tcpthread;
-	boost::asio::io_service::work m_tcpwork; // Create some work to keep IO Service alive
+	boost::asio::ip::tcp::socket	mSocket;
+	boost::asio::ip::tcp::endpoint	mEndPoint;
 };

--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -35,6 +35,7 @@ static inline bool startsWith(const std::string &haystack, const std::string &ne
 }
 
 Comm5SMTCP::Comm5SMTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
+	ASyncTCP("Comm5SMTCP"),
 	m_szIPAddress(IPAddress)
 {
 	m_HwdID = ID;
@@ -89,27 +90,18 @@ void Comm5SMTCP::OnDisconnect()
 
 void Comm5SMTCP::Do_Work()
 {
-	bool bFirstTime = true;
-	int count = 0;
+	int sec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
 	while (!m_stoprequested)
 	{
-		m_LastHeartbeat = mytime(NULL);
-		if (bFirstTime)
-		{
-			bFirstTime = false;
-			if (!mIsConnected)
-			{
-				connect(m_szIPAddress, m_usIPPort);
-			}
+		sleep_seconds(1);
+		sec_counter++;
+
+		if (sec_counter % 12 == 0) {
+			m_LastHeartbeat = mytime(NULL);
 		}
-		else
-		{
-			sleep_milliseconds(40);
-			update();
-			if (count++ >= 100) {
-				count = 0;
-				querySensorState();
-			}
+		if (sec_counter % 4 == 0) {
+			querySensorState();
 		}
 	}
 	_log.Log(LOG_STATUS, "Comm5 SM-XXXX: TCP/IP Worker stopped...");

--- a/hardware/DenkoviTCPDevices.h
+++ b/hardware/DenkoviTCPDevices.h
@@ -64,7 +64,6 @@ private:
 	int m_Cmd;
 	bool m_bReadingNow = false;
 	bool m_bUpdateIo = false;
-	bool m_bFirstTime = true;
 	_sDenkoviTCPModbusRequest m_pReq;
 	_sDenkoviTCPModbusResponse m_pResp;
 	std::string m_respBuff;

--- a/hardware/Ec3kMeterTCP.h
+++ b/hardware/Ec3kMeterTCP.h
@@ -34,7 +34,6 @@ class Ec3kMeterTCP : public CDomoticzHardwareBase, ASyncTCP
 public:
 	Ec3kMeterTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort);
 	~Ec3kMeterTCP(void);
-	bool isConnected(){ return mIsConnected; };
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	boost::signals2::signal<void()>	sDisconnected;
 private:
@@ -52,7 +51,6 @@ private:
 	Ec3kLimiter *m_limiter;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	std::shared_ptr<std::thread> m_thread;
 	volatile bool m_stoprequested;

--- a/hardware/FritzboxTCP.h
+++ b/hardware/FritzboxTCP.h
@@ -11,7 +11,6 @@ public:
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	boost::signals2::signal<void()>	sDisconnected;
 private:
-	bool isConnected() { return mIsConnected; };
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, const bool bOn, const double Level, const std::string &defaultname);
@@ -28,7 +27,7 @@ private:
 	int m_retrycntr;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
+	unsigned char m_buffer[1024];
 	int m_bufferpos;
 	std::shared_ptr<std::thread> m_thread;
 	volatile bool m_stoprequested;

--- a/hardware/HEOS.h
+++ b/hardware/HEOS.h
@@ -26,7 +26,6 @@ public:
 	void SendCommand(const std::string&, const int iValue);
 private:
 	void SendCommand(const std::string&);
-	bool isConnected() { return mIsConnected; };
 	_eNotificationTypes	NotificationType(_eMediaStatus nStatus);
 	bool StartHardware() override;
 	bool StopHardware() override;
@@ -61,7 +60,6 @@ private:
 
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	unsigned char m_buffer[1028];
 	int m_bufferpos;
 	std::shared_ptr<std::thread> m_thread;

--- a/hardware/MochadTCP.h
+++ b/hardware/MochadTCP.h
@@ -33,7 +33,6 @@ private:
 
 	std::shared_ptr<std::thread> m_thread;
 	volatile bool m_stoprequested;
-	bool m_bDoRestart;
 	int selected[17][17];
 	int currentHouse;
 	int currentUnit;

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -98,7 +98,7 @@ void MySensorsTCP::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			mytime(&m_LastHeartbeat);
+			m_LastHeartbeat = mytime(NULL);
 		}
 
 		if (isConnected())

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -9,11 +9,11 @@
 #define RETRY_DELAY 30
 
 MySensorsTCP::MySensorsTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
+	ASyncTCP("MySensorsTCP"),
 	m_szIPAddress(IPAddress),
 	m_usIPPort(usIPPort),
 	m_retrycntr(RETRY_DELAY),
-	m_stoprequested(false),
-	m_bDoRestart(false)
+	m_stoprequested(false)
 {
 	m_HwdID = ID;
 }
@@ -29,7 +29,6 @@ bool MySensorsTCP::StartHardware()
 	LoadDevicesFromDatabase();
 
 	m_stoprequested = false;
-	m_bDoRestart = false;
 
 	//force connect the next first time
 	m_retrycntr = RETRY_DELAY;
@@ -57,15 +56,12 @@ bool MySensorsTCP::StopHardware()
 	{
 		//Don't throw from a Stop command
 	}
-	if (isConnected())
+	try {
+		disconnect();
+	}
+	catch (...)
 	{
-		try {
-			disconnect();
-		}
-		catch (...)
-		{
-			//Don't throw from a Stop command
-		}
+		//Don't throw from a Stop command
 	}
 
 	m_bIsStarted = false;
@@ -75,7 +71,6 @@ bool MySensorsTCP::StopHardware()
 void MySensorsTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS, "MySensors: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart = false;
 	m_bIsStarted = true;
 	m_LineReceived.clear();
 
@@ -89,14 +84,14 @@ void MySensorsTCP::OnConnect()
 void MySensorsTCP::OnDisconnect()
 {
 	_log.Log(LOG_STATUS, "MySensors: disconnected");
-	if (!m_stoprequested)
-		m_bDoRestart = true;
 }
 
 void MySensorsTCP::Do_Work()
 {
 	bool bFirstTime = true;
 	int sec_counter = 0;
+	_log.Log(LOG_STATUS, "MySensors: trying to connect to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress, m_usIPPort);
 	while (!m_stoprequested)
 	{
 		sleep_seconds(1);
@@ -106,29 +101,13 @@ void MySensorsTCP::Do_Work()
 			mytime(&m_LastHeartbeat);
 		}
 
-		if (bFirstTime)
+		if (isConnected())
 		{
-			bFirstTime = false;
-			_log.Log(LOG_STATUS, "MySensors: trying to connect to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-			connect(m_szIPAddress, m_usIPPort);
-		}
-		else
-		{
-			time_t atime = time(NULL);
-			if ((m_bDoRestart) && (atime % 30 == 0))
+			if (sec_counter % 10 == 0)
 			{
-				_log.Log(LOG_STATUS, "MySensors: trying to connect to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				connect(m_szIPAddress, m_usIPPort);
-			}
-			update();
-			if (isConnected())
-			{
-				if (sec_counter % 10 == 0)
-				{
-					//Send a Heartbeat message
-					std::string sRequest = "0;0;3;0;18;PING\n";
-					WriteInt(sRequest);
-				}
+				//Send a Heartbeat message
+				std::string sRequest = "0;0;3;0;18;PING\n";
+				WriteInt(sRequest);
 			}
 		}
 	}
@@ -170,10 +149,6 @@ void MySensorsTCP::OnError(const boost::system::error_code& error)
 
 void MySensorsTCP::WriteInt(const std::string &sendStr)
 {
-	if (!mIsConnected)
-	{
-		return;
-	}
 	write((const unsigned char*)sendStr.c_str(), sendStr.size());
 }
 

--- a/hardware/MySensorsTCP.h
+++ b/hardware/MySensorsTCP.h
@@ -8,7 +8,6 @@ class MySensorsTCP : public MySensorsBase, ASyncTCP
 public:
 	MySensorsTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort);
 	~MySensorsTCP(void);
-	bool isConnected() { return mIsConnected; };
 public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;
@@ -19,7 +18,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void WriteInt(const std::string &sendStr) override;
 

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -8,10 +8,10 @@
 #define RETRY_DELAY 30
 
 OTGWTCP::OTGWTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6):
+	ASyncTCP("OTGWTCP"),
 	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_stoprequested=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = RETRY_DELAY;
@@ -25,7 +25,6 @@ OTGWTCP::~OTGWTCP(void)
 bool OTGWTCP::StartHardware()
 {
 	m_stoprequested=false;
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr=RETRY_DELAY;
@@ -51,15 +50,11 @@ bool OTGWTCP::StopHardware()
 	{
 		//Don't throw from a Stop command
 	}
-	if (isConnected())
+	try {
+		disconnect();
+	} catch(...)
 	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
+		//Don't throw from a Stop command
 	}
 
 	m_bIsStarted=false;
@@ -69,7 +64,6 @@ bool OTGWTCP::StopHardware()
 void OTGWTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"OTGW: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 	m_bufferpos=0;
 	sOnConnected(this);
@@ -83,8 +77,8 @@ void OTGWTCP::OnDisconnect()
 
 void OTGWTCP::Do_Work()
 {
-	bool bFirstTime=true;
 	int sec_counter = 25;
+	connect(m_szIPAddress,m_usIPPort);
 	while (!m_stoprequested)
 	{
 		sleep_seconds(1);
@@ -94,36 +88,18 @@ void OTGWTCP::Do_Work()
 			m_LastHeartbeat=mytime(NULL);
 		}
 
-		if (bFirstTime)
+		if (isConnected())
 		{
-			bFirstTime=false;
-			connect(m_szIPAddress,m_usIPPort);
-			if (mIsConnected)
+			if ((sec_counter % 28 == 0) && (m_bRequestVersion))
 			{
+				m_bRequestVersion = false;
+				GetVersion();
+			}
+			else if (sec_counter % 30 == 0)//updates every 30 seconds
+			{
+				SendOutsideTemperature();
+				SendTime();
 				GetGatewayDetails();
-			}
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
-			if (mIsConnected)
-			{
-				if ((sec_counter % 28 == 0) && (m_bRequestVersion))
-				{
-					m_bRequestVersion = false;
-					GetVersion();
-				}
-				else if (sec_counter % 30 == 0)//updates every 30 seconds
-				{
-					bFirstTime=false;
-					SendOutsideTemperature();
-					SendTime();
-					GetGatewayDetails();
-				}
 			}
 		}
 	}
@@ -165,7 +141,7 @@ void OTGWTCP::OnError(const boost::system::error_code& error)
 
 bool OTGWTCP::WriteInt(const unsigned char *pData, const unsigned char Len)
 {
-	if (!mIsConnected)
+	if (!isConnected())
 	{
 		return false;
 	}

--- a/hardware/OTGWTCP.h
+++ b/hardware/OTGWTCP.h
@@ -8,7 +8,6 @@ class OTGWTCP: public OTGWBase, ASyncTCP
 public:
 	OTGWTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6);
 	~OTGWTCP(void);
-	bool isConnected(){ return mIsConnected; };
 public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;
@@ -20,7 +19,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void Do_Work();
 	void OnConnect() override;

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -215,7 +215,7 @@ void OnkyoAVTCP::Do_Work()
 		sec_counter++;
 
 		if (sec_counter  % 12 == 0) {
-			m_LastHeartbeat=mytime(NULL);
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	_log.Log(LOG_STATUS,"OnkyoAVTCP: TCP/IP Worker stopped...");

--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -12,7 +12,6 @@ public:
 	boost::signals2::signal<void()>	sDisconnected;
 	bool SendPacket(const char *pdata);
 private:
-	bool isConnected() { return mIsConnected; };
 	bool SendPacket(const char *pCmd, const char *pArg);
 	bool StartHardware() override;
 	bool StopHardware() override;
@@ -35,7 +34,6 @@ private:
 	int m_PPktLen;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	std::shared_ptr<std::thread> m_thread;
 	volatile bool m_stoprequested;
 };

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -4,13 +4,10 @@
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 
-#define SLEEP_MILLISECONDS 200
-#define RETRY_DELAY_SECONDS 30
-#define HEARTBEAT_SECONDS 12
-
 P1MeterTCP::P1MeterTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const bool disable_crc, const int ratelimit):
-m_szIPAddress(IPAddress),
-m_usIPPort(usIPPort)
+	ASyncTCP("P1MeterTCP"),
+	m_szIPAddress(IPAddress),
+	m_usIPPort(usIPPort)
 {
 	m_HwdID = ID;
 	m_bDisableCRC = disable_crc;
@@ -49,16 +46,12 @@ bool P1MeterTCP::StopHardware()
 	{
 		//Don't throw from a Stop command
 	}
-	if (isConnected())
+	try {
+		disconnect();
+	}
+	catch(...)
 	{
-		try {
-			disconnect();
-			close();
-		}
-		catch(...)
-		{
-			//Don't throw from a Stop command
-		}
+		//Don't throw from a Stop command
 	}
 	m_bIsStarted = false;
 	return true;
@@ -67,35 +60,16 @@ bool P1MeterTCP::StopHardware()
 
 void P1MeterTCP::Do_Work()
 {
-	int heartbeat_counter = 0;
-	int retry_counter = 0;
+	int sec_counter = 0;
+	_log.Log(LOG_STATUS, "P1MeterTCP: attempt connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress, m_usIPPort);
 	while (!m_stoprequested)
 	{
-		if (mIsConnected)
-		{
-			update();
-		}
-		else
-		{
-			if ((retry_counter % (RETRY_DELAY_SECONDS * 1000 / SLEEP_MILLISECONDS)) == 0)
-			{
-				_log.Log(LOG_STATUS, "P1MeterTCP: attempt connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				connect(m_szIPAddress, m_usIPPort);
-				update();
-			}
-			else if ((retry_counter % (RETRY_DELAY_SECONDS * 1000 / SLEEP_MILLISECONDS)) <= (1000 / SLEEP_MILLISECONDS))
-			{
-				// allow for up to 1 second connect time
-				update();
-			}
-			retry_counter++;
-		}
+		sleep_seconds(1);
+		sec_counter++;
 
-		sleep_milliseconds(SLEEP_MILLISECONDS);
-		heartbeat_counter++;
-		if ((heartbeat_counter % (HEARTBEAT_SECONDS * 1000 / SLEEP_MILLISECONDS)) == 0)
-		{
-			m_LastHeartbeat = mytime(NULL);
+		if (sec_counter % 12 == 0) {
+			m_LastHeartbeat=mytime(NULL);
 		}
 	}
 	_log.Log(LOG_STATUS, "P1MeterTCP: TCP/IP Worker stopped...");

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -69,7 +69,7 @@ void P1MeterTCP::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat=mytime(NULL);
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	_log.Log(LOG_STATUS, "P1MeterTCP: TCP/IP Worker stopped...");

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -6,6 +6,7 @@
 #include "../main/localtime_r.h"
 
 CRFLinkTCP::CRFLinkTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort):
+	ASyncTCP("RFLinkTCP"),
 	m_szIPAddress(IPAddress)
 {
 	m_HwdID = ID;
@@ -47,15 +48,11 @@ bool CRFLinkTCP::StopHardware()
 	{
 		//Don't throw from a Stop command
 	}
-	if (isConnected())
+	try {
+		disconnect();
+	} catch(...)
 	{
-		try {
-			disconnect();
-			close();
-		} catch(...)
-		{
-			//Don't throw from a Stop command
-		}
+		//Don't throw from a Stop command
 	}
 
 	m_bIsStarted=false;
@@ -75,8 +72,8 @@ void CRFLinkTCP::OnConnect()
 
 void CRFLinkTCP::OnDisconnect()
 {
+	// Note: No need to set m_bDoRestart = true here, the connection is automatically reinited by ASyncTCP
 	_log.Log(LOG_STATUS,"RFLink: disconnected");
-	m_bDoRestart = true;
 }
 
 void CRFLinkTCP::Do_Work()
@@ -90,12 +87,12 @@ void CRFLinkTCP::Do_Work()
 		sleep_seconds(1);
 		sec_counter++;
 
-		time_t atime = mytime(NULL);
 		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat= atime;
+			m_LastHeartbeat = mytime(NULL);
 		}
-		if ((sec_counter % 20 == 0) && (mIsConnected))
+		if ((sec_counter % 20 == 0) && (isConnected()))
 		{
+			time_t atime = mytime(NULL);
 			//Send ping (keep alive)
 			if (atime - m_LastReceivedTime > 30)
 			{
@@ -103,6 +100,7 @@ void CRFLinkTCP::Do_Work()
 				_log.Log(LOG_ERROR, "RFLink: Nothing received for more than 30 seconds, restarting...");
 				m_retrycntr = 0;
 				m_LastReceivedTime = atime;
+				//TODO: Add method to ASyncTCP to schedule a reconnect
 				m_bDoRestart = true;
 			}
 			else
@@ -160,7 +158,7 @@ void CRFLinkTCP::OnError(const boost::system::error_code& error)
 
 bool CRFLinkTCP::WriteInt(const std::string &sendString)
 {
-	if (!mIsConnected)
+	if (!isConnected())
 	{
 		return false;
 	}

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -83,6 +83,8 @@ void CRFLinkTCP::Do_Work()
 {
 	bool bFirstTime=true;
 	int sec_counter = 0;
+	_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
 	while (!m_stoprequested)
 	{
 		sleep_seconds(1);
@@ -102,52 +104,22 @@ void CRFLinkTCP::Do_Work()
 				m_retrycntr = 0;
 				m_LastReceivedTime = atime;
 				m_bDoRestart = true;
-				try {
-					disconnect();
-					close();
-				}
-				catch (...)
-				{
-					//Don't throw from a Stop command
-				}
 			}
 			else
 				write("10;PING;\n");
 		}
 
-		if (bFirstTime)
+		if ((m_bDoRestart) && (sec_counter % 30 == 0))
 		{
-			bFirstTime=false;
-			if (mIsConnected)
-			{
-				try {
-					disconnect();
-					close();
-				}
-				catch (...)
-				{
-					//Don't throw from a Stop command
-				}
-			}
 			_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				try {
-					disconnect();
-					close();
-				}
-				catch (...)
-				{
-					//Don't throw from a Stop command
-				}
-				connect(m_szIPAddress, m_usIPPort);
+			try {
+				disconnect();
 			}
-			update();
+			catch (...)
+			{
+				//Don't throw from a Stop command
+			}
+			connect(m_szIPAddress, m_usIPPort);
 		}
 	}
 	_log.Log(LOG_STATUS,"RFLink: TCP/IP Worker stopped...");

--- a/hardware/RFLinkTCP.h
+++ b/hardware/RFLinkTCP.h
@@ -8,7 +8,6 @@ class CRFLinkTCP: public CRFLinkBase, ASyncTCP
 public:
 	CRFLinkTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort);
 	~CRFLinkTCP(void);
-	bool isConnected(){ return mIsConnected; };
 public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;

--- a/hardware/RelayNet.h
+++ b/hardware/RelayNet.h
@@ -14,7 +14,6 @@ public:
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	boost::signals2::signal<void()>	sDisconnected;
 private:
-	bool isConnected() { return mIsConnected; };
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void Do_Work();
@@ -46,7 +45,6 @@ private:
 	sockaddr_in 						m_addr;
 	bool								m_poll_inputs;
 	bool								m_poll_relays;
-	bool								m_reconnect;
 	bool								m_bDoRestart;
 	bool								m_setup_devices;
 	int									m_skip_relay_update;

--- a/hardware/S0MeterTCP.h
+++ b/hardware/S0MeterTCP.h
@@ -14,7 +14,6 @@ private:
 	bool StartHardware() override;
 	bool StopHardware() override;
 	bool WriteInt(const std::string &sendString);
-	bool isConnected() { return mIsConnected; };
 	void Do_Work();
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -25,7 +24,6 @@ private:
 	int m_retrycntr;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	std::shared_ptr<std::thread> m_thread;
 	volatile bool m_stoprequested;
 };

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -86,8 +86,7 @@ void CZiBlueTCP::Do_Work()
 		sec_counter++;
 
 		if (sec_counter % 12 == 0) {
-			time_t atime = mytime(NULL);
-			m_LastHeartbeat = atime;
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	_log.Log(LOG_STATUS,"ZiBlue: TCP/IP Worker stopped...");

--- a/hardware/ZiBlueTCP.h
+++ b/hardware/ZiBlueTCP.h
@@ -8,7 +8,6 @@ class CZiBlueTCP: public CZiBlueBase, ASyncTCP
 public:
 	CZiBlueTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort);
 	~CZiBlueTCP(void);
-	bool isConnected(){ return mIsConnected; };
 public:
 	// signals
 	boost::signals2::signal<void()>	sDisconnected;
@@ -21,7 +20,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void Do_Work();
 	void OnConnect() override;


### PR DESCRIPTION
Changes:
- No need to poll
- Thread safe write() since WriteToHardware() is accessed from mainworker as pointed out by @gordonb3
- Fix access modifiers: ASyncTCP does not need any public members or methods, only private and some protected (for use in the derived HW classes)
- Refactor all derived HW classes, including removal of dead / useless code from Do_Work() loop