### PR TITLE
Add scan of /dev/serial/by-id/* and /dev/serial/by-path/* on Linux

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -196,7 +196,7 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 
 #else
 	//scan /dev for /dev/ttyUSB* or /dev/ttyS* or /dev/tty.usbserial* or /dev/ttyAMA* or /dev/ttySAC*
-	//also scan /dev/serial/by-id/* and /dev/serial/by-path/* on Linux
+	//also scan /dev/serial/by-id/* on Linux
 
 	bool bHaveTtyAMAfree=false;
 	std::string sLine = "";
@@ -314,8 +314,8 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 		// Loop while not NULL
 		while ((de = readdir(d)))
 		{
-			// Only consider character devices and symbolic links
-                        if ((de->d_type == DT_CHR) || (de->d_type == DT_LNK))
+			// Only consider symbolic links and limited to 99 chars incl prefix i.e. 81 chars
+                        if ((de->d_type == DT_LNK) && (strlen(de->d_name) <= 81))
                         {
 				std::string fname = de->d_name;
 				ret.push_back("/dev/serial/by-id/" + fname);
@@ -324,22 +324,6 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 		closedir(d);
 	}
 
-	d=opendir("/dev/serial/by-path");
-	if (d != NULL)
-	{
-		struct dirent *de=NULL;
-		// Loop while not NULL
-		while ((de = readdir(d)))
-		{
-			// Only consider character devices and symbolic links
-                        if ((de->d_type == DT_CHR) || (de->d_type == DT_LNK))
-                        {
-				std::string fname = de->d_name;
-				ret.push_back("/dev/serial/by-path/" + fname);
-			}
-		}
-		closedir(d);
-	}
 #endif
 #endif
 	return ret;

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -314,8 +314,8 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 		// Loop while not NULL
 		while ((de = readdir(d)))
 		{
-			// Only consider symbolic links and limited to 99 chars incl prefix i.e. 81 chars
-                        if ((de->d_type == DT_LNK) && (strlen(de->d_name) <= 81))
+			// Only consider symbolic links
+                        if (de->d_type == DT_LNK)
                         {
 				std::string fname = de->d_name;
 				ret.push_back("/dev/serial/by-id/" + fname);

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -196,6 +196,7 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 
 #else
 	//scan /dev for /dev/ttyUSB* or /dev/ttyS* or /dev/tty.usbserial* or /dev/ttyAMA* or /dev/ttySAC*
+	//also scan /dev/serial/by-id/* and /dev/serial/by-path/* on Linux
 
 	bool bHaveTtyAMAfree=false;
 	std::string sLine = "";
@@ -305,6 +306,41 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 		closedir(d);
 	}
 
+#if defined(__linux__) || defined(__linux) || defined(linux)
+	d=opendir("/dev/serial/by-id");
+	if (d != NULL)
+	{
+		struct dirent *de=NULL;
+		// Loop while not NULL
+		while ((de = readdir(d)))
+		{
+			// Only consider character devices and symbolic links
+                        if ((de->d_type == DT_CHR) || (de->d_type == DT_LNK))
+                        {
+				std::string fname = de->d_name;
+				ret.push_back("/dev/serial/by-id/" + fname);
+			}
+		}
+		closedir(d);
+	}
+
+	d=opendir("/dev/serial/by-path");
+	if (d != NULL)
+	{
+		struct dirent *de=NULL;
+		// Loop while not NULL
+		while ((de = readdir(d)))
+		{
+			// Only consider character devices and symbolic links
+                        if ((de->d_type == DT_CHR) || (de->d_type == DT_LNK))
+                        {
+				std::string fname = de->d_name;
+				ret.push_back("/dev/serial/by-path/" + fname);
+			}
+		}
+		closedir(d);
+	}
+#endif
 #endif
 	return ret;
 }

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -34,7 +34,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 131
+#define DB_VERSION 132
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -231,7 +231,7 @@ const char *sqlCreateHardware =
 "[Type] INTEGER NOT NULL, "
 "[Address] VARCHAR(200), "
 "[Port] INTEGER, "
-"[SerialPort] VARCHAR(50) DEFAULT (''), "
+"[SerialPort] VARCHAR(100) DEFAULT (''), "
 "[Username] VARCHAR(100), "
 "[Password] VARCHAR(100), "
 "[Extra] TEXT DEFAULT (''),"
@@ -2566,6 +2566,13 @@ bool CSQLHelper::OpenDatabase()
 		if (dbversion < 131)
 		{
 			query("DROP TABLE IF EXISTS [EventActions]");
+		}
+		if (dbversion < 132)
+		{
+			query("ALTER TABLE Hardware RENAME TO tmp_Hardware;");
+			query(sqlCreateHardware);
+			query("INSERT INTO Hardware(ID, Name, Enabled, Type, Address, Port, SerialPort, Username, Password, Extra, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, DataTimeout) SELECT ID, Name, Enabled, Type, Address, Port, SerialPort, Username, Password, Extra, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, DataTimeout FROM tmp_Hardware;");
+			query("DROP TABLE tmp_Hardware;");
 		}
 	}
 	else if (bNewInstall)

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -34,7 +34,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 132
+#define DB_VERSION 133
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -2567,7 +2567,7 @@ bool CSQLHelper::OpenDatabase()
 		{
 			query("DROP TABLE IF EXISTS [EventActions]");
 		}
-		if (dbversion < 132)
+		if (dbversion < 133)
 		{
 			query("ALTER TABLE Hardware RENAME TO tmp_Hardware;");
 			query(sqlCreateHardware);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -231,7 +231,7 @@ const char *sqlCreateHardware =
 "[Type] INTEGER NOT NULL, "
 "[Address] VARCHAR(200), "
 "[Port] INTEGER, "
-"[SerialPort] VARCHAR(100) DEFAULT (''), "
+"[SerialPort] TEXT DEFAULT (''), "
 "[Username] VARCHAR(100), "
 "[Password] VARCHAR(100), "
 "[Extra] TEXT DEFAULT (''),"

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -1143,7 +1143,7 @@
 			<table class="display" id="hardwareparamsserial" border="0" cellpadding="0" cellspacing="20">
 				<tr>
 					<td align="right" style="width:110px"><label id="lblserialport" for="name"><span data-i18n="Serial Port"></span>:</label></td>
-					<td><select id="comboserialport" style="width:210px" class="combobox ui-corner-all"></select></td>
+					<td><select id="comboserialport" style="width:600px" class="combobox ui-corner-all"></select></td>
 				</tr>
 			</table>
 		</div>


### PR DESCRIPTION
Modern Linux systems allocate /dev/ttyUSB* in an unpredictable order at boot time.
This requires udev rules for consistency at reboot otherwise Domoticz doesn't reliably find USB devices.
This change exposes /dev/serial/by-id/* and /dev/serial/by-path/* when configuring USB devices, which are always predictable.
As a result, the Domoticz user does not have to dive down to the Linux command line to create udev rules, making it a less daunting experience.
See http://www.domoticz.com/forum/viewtopic.php?f=6&t=24619