### PR TITLE
Small cleanup of AsyncSerial class

### DIFF
--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -72,19 +72,9 @@ public:
     boost::function<void (const char*, size_t)> callback;
 };
 
-AsyncSerial::AsyncSerial(): pimpl(new AsyncSerialImpl)
+AsyncSerial::AsyncSerial(const std::string thread_name): pimpl(new AsyncSerialImpl)
 {
 
-}
-
-AsyncSerial::AsyncSerial(const std::string& devname, unsigned int baud_rate,
-        boost::asio::serial_port_base::parity opt_parity,
-        boost::asio::serial_port_base::character_size opt_csize,
-        boost::asio::serial_port_base::flow_control opt_flow,
-        boost::asio::serial_port_base::stop_bits opt_stop)
-        : pimpl(new AsyncSerialImpl)
-{
-    open(devname,baud_rate,opt_parity,opt_csize,opt_flow,opt_stop);
 }
 
 AsyncSerial::~AsyncSerial()
@@ -104,10 +94,13 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
     pimpl->port.open(devname);
 	try {
 		pimpl->port.set_option(boost::asio::serial_port_base::baud_rate(baud_rate));
-		pimpl->port.set_option(opt_parity);
-		pimpl->port.set_option(opt_csize);
-		pimpl->port.set_option(opt_flow);
-		pimpl->port.set_option(opt_stop);
+		if (set_options)
+		{
+			pimpl->port.set_option(opt_parity);
+			pimpl->port.set_option(opt_csize);
+			pimpl->port.set_option(opt_flow);
+			pimpl->port.set_option(opt_stop);
+		}
 	}
 	catch (...)
 	{

--- a/hardware/ASyncSerial.h
+++ b/hardware/ASyncSerial.h
@@ -22,37 +22,20 @@ class AsyncSerialImpl;
 class AsyncSerial
 	: private domoticz::noncopyable
 {
-public:
-    AsyncSerial();
+protected:
+    AsyncSerial() = delete;
 
     /**
-     * Constructor. Creates and opens a serial device.
-     * \param devname serial device name, example "/dev/ttyS0" or "COM1"
-     * \param baud_rate serial baud rate
-     * \param opt_parity serial parity, default none
-     * \param opt_csize serial character size, default 8bit
-     * \param opt_flow serial flow control, default none
-     * \param opt_stop serial stop bits, default 1
-     * \throws boost::system::system_error if cannot open the
-     * serial device
+     * Constructor. Creates and a serial device.
+     * \param thread_name name of the io thread (for debugging)
      */
-    AsyncSerial(const std::string& devname, unsigned int baud_rate,
-        boost::asio::serial_port_base::parity opt_parity=
-            boost::asio::serial_port_base::parity(
-                boost::asio::serial_port_base::parity::none),
-        boost::asio::serial_port_base::character_size opt_csize=
-            boost::asio::serial_port_base::character_size(8),
-        boost::asio::serial_port_base::flow_control opt_flow=
-            boost::asio::serial_port_base::flow_control(
-                boost::asio::serial_port_base::flow_control::none),
-        boost::asio::serial_port_base::stop_bits opt_stop=
-            boost::asio::serial_port_base::stop_bits(
-                boost::asio::serial_port_base::stop_bits::one));
+    AsyncSerial(const std::string& thread_name);
 
     /**
     * Opens a serial device.
     * \param devname serial device name, example "/dev/ttyS0" or "COM1"
     * \param baud_rate serial baud rate
+    * \param set_options set serial port options, default true
     * \param opt_parity serial parity, default none
     * \param opt_csize serial character size, default 8bit
     * \param opt_flow serial flow control, default none
@@ -60,7 +43,7 @@ public:
     * \throws boost::system::system_error if cannot open the
     * serial device
     */
-    void open(const std::string& devname, unsigned int baud_rate,
+    void open(const std::string& devname, unsigned int baud_rate, bool set_options = true,
         boost::asio::serial_port_base::parity opt_parity=
             boost::asio::serial_port_base::parity(
                 boost::asio::serial_port_base::parity::none),
@@ -72,18 +55,6 @@ public:
         boost::asio::serial_port_base::stop_bits opt_stop=
             boost::asio::serial_port_base::stop_bits(
                 boost::asio::serial_port_base::stop_bits::one));
-	void openOnlyBaud(const std::string& devname, unsigned int baud_rate,
-		boost::asio::serial_port_base::parity opt_parity=
-		boost::asio::serial_port_base::parity(
-		boost::asio::serial_port_base::parity::none),
-		boost::asio::serial_port_base::character_size opt_csize=
-		boost::asio::serial_port_base::character_size(8),
-		boost::asio::serial_port_base::flow_control opt_flow=
-		boost::asio::serial_port_base::flow_control(
-		boost::asio::serial_port_base::flow_control::none),
-		boost::asio::serial_port_base::stop_bits opt_stop=
-		boost::asio::serial_port_base::stop_bits(
-		boost::asio::serial_port_base::stop_bits::one));
 
     /**
      * \return true if serial device is open
@@ -192,7 +163,6 @@ protected:
      * Once this method has been called, you have to open the port and register the read callback again.
      */
     void terminate(bool silent = true);
-
 };
 
 

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -12,6 +12,7 @@
 */
 
 Comm5Serial::Comm5Serial(const int ID, const std::string& devname, unsigned int baudRate /*= 115200*/) :
+	AsyncSerial("Comm5Serial"),
 	m_szSerialPort(devname),
 	m_baudRate(baudRate)
 {
@@ -70,10 +71,7 @@ bool Comm5Serial::StartHardware()
 	{
 		open(
 			m_szSerialPort,
-			m_baudRate,
-			boost::asio::serial_port_base::parity(
-			boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_baudRate
 			);
 	}
 	catch (boost::exception & e)

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -18,6 +18,7 @@
 //Class CurrentCostMeterSerial
 //
 CurrentCostMeterSerial::CurrentCostMeterSerial(const int ID, const std::string& devname, unsigned int baudRate):
+	AsyncSerial("CurrentCostMeterSerial"),
 	m_stoprequested(false),
 	m_szSerialPort(devname),
 	m_baudRate(baudRate)
@@ -42,10 +43,7 @@ bool CurrentCostMeterSerial::StartHardware()
 		_log.Log(LOG_STATUS,"CurrentCost Smart Meter: Using serial port: %s", m_szSerialPort.c_str());
 		open(
 			m_szSerialPort,
-			m_baudRate,
-			boost::asio::serial_port_base::parity(
-			boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_baudRate
 			);
 	}
 	catch (boost::exception & e)

--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -25,6 +25,7 @@
 #define round(a) ( int ) ( a + .5 )
 
 CDavisLoggerSerial::CDavisLoggerSerial(const int ID, const std::string& devname, unsigned int baud_rate) :
+	AsyncSerial("DavisLoggerSerial"),
 	m_szSerialPort(devname)
 {
 	m_HwdID = ID;

--- a/hardware/DenkoviUSBDevices.cpp
+++ b/hardware/DenkoviUSBDevices.cpp
@@ -20,6 +20,7 @@ enum _edaeUsbState
 #define DAE_IO_TYPE_RELAY		2
 
 CDenkoviUSBDevices::CDenkoviUSBDevices(const int ID, const std::string& comPort, const int model) :
+	AsyncSerial("DenkoviUSB"),
 	m_szSerialPort(comPort)
 {
 	m_HwdID = ID;
@@ -47,7 +48,7 @@ bool CDenkoviUSBDevices::StartHardware()
 {
 	m_stoprequested = false;
 	m_thread = std::make_shared<std::thread>(&CDenkoviUSBDevices::Do_Work, this);
-	//m_thread = boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&CDenkoviUSBDevices::Do_Work, this)));
+	SetThreadName(m_thread->native_handle(), "DenkoviUSB");
 
 	if (m_iModel == DDEV_USB_16R)
 		m_baudRate = 9600;
@@ -57,13 +58,7 @@ bool CDenkoviUSBDevices::StartHardware()
 	{
 		open(
 			m_szSerialPort,
-			m_baudRate,
-			boost::asio::serial_port_base::parity(
-				boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8),
-			boost::asio::serial_port_base::flow_control(
-			boost::asio::serial_port_base::flow_control::none),
-			boost::asio::serial_port_base::stop_bits(boost::asio::serial_port_base::stop_bits::one)
+			m_baudRate
 		);
 	}
 	catch (boost::exception & e)

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -624,7 +624,8 @@ typedef struct enocean_data_structure_MDA {
 							* @}
 							*/
 
-CEnOceanESP2::CEnOceanESP2(const int ID, const std::string& devname, const int type)
+CEnOceanESP2::CEnOceanESP2(const int ID, const std::string& devname, const int type) :
+	AsyncSerial("EnOceanESP2")
 {
 	m_HwdID = ID;
 	m_szSerialPort = devname;

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -401,7 +401,8 @@ bool CEnOceanESP3::sendFrameQueue(unsigned char frametype, unsigned char *databu
 	return true;
 }
 
-CEnOceanESP3::CEnOceanESP3(const int ID, const std::string& devname, const int type)
+CEnOceanESP3::CEnOceanESP3(const int ID, const std::string& devname, const int type) :
+	AsyncSerial("EnOceanESP3")
 {
 	m_HwdID=ID;
 	m_szSerialPort=devname;

--- a/hardware/EvohomeSerial.cpp
+++ b/hardware/EvohomeSerial.cpp
@@ -8,7 +8,8 @@
 #include <boost/exception/diagnostic_information.hpp>
 
 CEvohomeSerial::CEvohomeSerial(const int ID, const std::string &szSerialPort, const int baudrate, const std::string &UserContID) :
-CEvohomeRadio(ID, UserContID)
+	AsyncSerial("EvohomeSerial"),
+	CEvohomeRadio(ID, UserContID)
 {
     if(baudrate!=0)
 	{

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -18,7 +18,8 @@
 
 #define RETRY_DELAY 30
 
-KMTronic433::KMTronic433(const int ID, const std::string& devname)
+KMTronic433::KMTronic433(const int ID, const std::string& devname) :
+	AsyncSerial("KMTronic433")
 {
 	m_HwdID = ID;
 	m_szSerialPort = devname;
@@ -107,18 +108,15 @@ bool KMTronic433::OpenSerialDevice()
 	{
 		_log.Log(LOG_STATUS, "KMTronic: Using serial port: %s", m_szSerialPort.c_str());
 #ifndef WIN32
-		openOnlyBaud(
+		open(
 			m_szSerialPort,
 			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			false // Do not set options (parity, character width, flow control, stop bits)
 			);
 #else
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 			);
 #endif
 	}

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -18,7 +18,8 @@
 
 #define RETRY_DELAY 30
 
-KMTronicSerial::KMTronicSerial(const int ID, const std::string& devname)
+KMTronicSerial::KMTronicSerial(const int ID, const std::string& devname) :
+	AsyncSerial("KMTronicSerial")
 {
 	m_HwdID=ID;
 	m_szSerialPort=devname;
@@ -103,18 +104,15 @@ bool KMTronicSerial::OpenSerialDevice()
 	{
 		_log.Log(LOG_STATUS, "KMTronic: Using serial port: %s", m_szSerialPort.c_str());
 #ifndef WIN32
-		openOnlyBaud(
+		open(
 			m_szSerialPort,
 			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			false // Do not set options (parity, character width, flow control, stop bits)
 			);
 #else
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 			);
 #endif
 	}

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -27,6 +27,7 @@
 //Class Meteostick
 //
 Meteostick::Meteostick(const int ID, const std::string& devname, const unsigned int baud_rate):
+	AsyncSerial("Meteostick"),
 	m_szSerialPort(devname)
 {
 	m_HwdID=ID;
@@ -87,9 +88,7 @@ bool Meteostick::OpenSerialDevice()
 		_log.Log(LOG_STATUS, "Meteostick: Using serial port: %s", m_szSerialPort.c_str());
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 			);
 	}
 	catch (boost::exception & e)

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -19,6 +19,7 @@
 #define RETRY_DELAY 30
 
 MySensorsSerial::MySensorsSerial(const int ID, const std::string& devname, const int Mode1) :
+	AsyncSerial("MySensorsSerial"),
 	m_retrycntr(RETRY_DELAY),
 	m_stoprequested(false)
 {
@@ -113,18 +114,15 @@ bool MySensorsSerial::OpenSerialDevice()
 	{
 		_log.Log(LOG_STATUS, "MySensors: Using serial port: %s", m_szSerialPort.c_str());
 #ifndef WIN32
-		openOnlyBaud(
+		open(
 			m_szSerialPort,
 			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			false // Do not set options (parity, character width, flow control, stop bits)
 		);
 #else
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 		);
 #endif
 	}

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -20,7 +20,8 @@
 //
 //Class OTGWSerial
 //
-OTGWSerial::OTGWSerial(const int ID, const std::string& devname, const unsigned int baud_rate, const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6)
+OTGWSerial::OTGWSerial(const int ID, const std::string& devname, const unsigned int baud_rate, const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6) :
+	AsyncSerial("OTGWSerial")
 {
 	m_HwdID=ID;
 	m_szSerialPort=devname;
@@ -86,9 +87,7 @@ bool OTGWSerial::OpenSerialDevice()
 		_log.Log(LOG_STATUS,"OTGW: Using serial port: %s", m_szSerialPort.c_str());
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 			);
 	}
 	catch (boost::exception & e)

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -25,7 +25,8 @@ License: Public domain
 #include <string>
 
 
-COpenWebNetUSB::COpenWebNetUSB(const int ID, const std::string& devname, unsigned int baud_rate)
+COpenWebNetUSB::COpenWebNetUSB(const int ID, const std::string& devname, unsigned int baud_rate) :
+	AsyncSerial("OpenWebNetUSB")
 {
 	m_HwdID = ID;
 	m_stoprequested = false;
@@ -302,18 +303,15 @@ bool COpenWebNetUSB::sendCommand(bt_openwebnet& command, std::vector<bt_openwebn
 	{
 		_log.Log(LOG_STATUS, "COpenWebNetUSB: Using serial port: %s", m_szSerialPort.c_str());
 #ifndef WIN32
-		openOnlyBaud(
+		open(
 			m_szSerialPort,
 			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			false // Do not set options (parity, character width, flow control, stop bits)
 			);
 #else
 		open(
 			m_szSerialPort,
-			m_iBaudRate,
-			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-			boost::asio::serial_port_base::character_size(8)
+			m_iBaudRate
 			);
 #endif
 	}

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -22,25 +22,14 @@
 //Class P1MeterSerial
 //
 P1MeterSerial::P1MeterSerial(const int ID, const std::string& devname, const unsigned int baud_rate, const bool disable_crc, const int ratelimit):
-m_szSerialPort(devname)
+	AsyncSerial("P1MeterSerial"),
+	m_szSerialPort(devname)
 {
 	m_HwdID=ID;
 	m_iBaudRate=baud_rate;
 	m_stoprequested = false;
 	m_bDisableCRC = disable_crc;
 	m_ratelimit = ratelimit;
-}
-
-P1MeterSerial::P1MeterSerial(const std::string& devname,
-        unsigned int baud_rate,
-        boost::asio::serial_port_base::parity opt_parity,
-        boost::asio::serial_port_base::character_size opt_csize,
-        boost::asio::serial_port_base::flow_control opt_flow,
-        boost::asio::serial_port_base::stop_bits opt_stop)
-        :AsyncSerial(devname,baud_rate,opt_parity,opt_csize,opt_flow,opt_stop),
-		m_iBaudRate(baud_rate)
-{
-	m_stoprequested = false;
 }
 
 P1MeterSerial::~P1MeterSerial()
@@ -74,6 +63,7 @@ bool P1MeterSerial::StartHardware()
 			open(
 				m_szSerialPort,
 				m_iBaudRate,
+				true,
 				boost::asio::serial_port_base::parity(
 				boost::asio::serial_port_base::parity::even),
 				boost::asio::serial_port_base::character_size(7)
@@ -84,10 +74,7 @@ bool P1MeterSerial::StartHardware()
 			//DSMRv4
 			open(
 				m_szSerialPort,
-				m_iBaudRate,
-				boost::asio::serial_port_base::parity(
-				boost::asio::serial_port_base::parity::none),
-				boost::asio::serial_port_base::character_size(8)
+				m_iBaudRate
 				);
 			if (m_bDisableCRC) {
 				_log.Log(LOG_STATUS,"P1 Smart Meter: CRC validation disabled through hardware control");

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -12,8 +12,12 @@
 //Rainforest RAVEn USB ZigBee Smart Meter Adapter
 //https://rainforestautomation.com/rfa-z106-raven/
 
-RAVEn::RAVEn(const int ID, const std::string& devname)
-: device_(devname), m_wptr(m_buffer), m_currUsage(0), m_totalUsage(0)
+RAVEn::RAVEn(const int ID, const std::string& devname) :
+	AsyncSerial("RAVEn"),
+	device_(devname),
+	m_wptr(m_buffer),
+	m_currUsage(0),
+	m_totalUsage(0)
 {
     m_HwdID = ID;
 }

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -6,7 +6,8 @@
 #include <boost/exception/diagnostic_information.hpp>
 
 CRFLinkSerial::CRFLinkSerial(const int ID, const std::string& devname) :
-m_szSerialPort(devname)
+	AsyncSerial("RFLinkSerial"),
+	m_szSerialPort(devname)
 {
 	m_HwdID = ID;
 	m_stoprequested = false;

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -60,6 +60,7 @@ const unsigned char PKT_VERIFY_OK[5] = { 0x08, 0x01, 0x00, 0x00, 0x00 };
 //Class RFXComSerial
 //
 RFXComSerial::RFXComSerial(const int ID, const std::string& devname, unsigned int baud_rate) :
+	AsyncSerial("RFXComSerial"),
 	m_szSerialPort(devname)
 {
 	m_HwdID = ID;

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -104,7 +104,8 @@ RegoRegisters g_allRegisters[] = {
 //Class Rego6XXSerial
 //
 CRego6XXSerial::CRego6XXSerial(const int ID, const std::string& devname, const int type) :
-m_szSerialPort(devname)
+	AsyncSerial("Rego6XXSerial"),
+	m_szSerialPort(devname)
 {
 	m_HwdID=ID;
     m_regoType = type;

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -117,11 +117,11 @@
 //===========================================================================
 
 RelayNet::RelayNet(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &username, const std::string &password, const bool pollInputs, const bool pollRelays, const int pollInterval, const int inputCount, const int relayCount) :
-m_szIPAddress(IPAddress),
-m_username(CURLEncode::URLEncode(username)),
-m_password(CURLEncode::URLEncode(password)),
-m_stoprequested(false),
-m_reconnect(false)
+	m_szIPAddress(IPAddress),
+	m_username(CURLEncode::URLEncode(username)),
+	m_password(CURLEncode::URLEncode(password)),
+	m_stoprequested(false),
+	m_reconnect(false)
 {
 	m_stoprequested = false;
 	m_setup_devices = true;

--- a/hardware/S0MeterSerial.cpp
+++ b/hardware/S0MeterSerial.cpp
@@ -26,7 +26,8 @@
 	};
 #endif
 
-S0MeterSerial::S0MeterSerial(const int ID, const std::string& devname, const unsigned int baud_rate)
+S0MeterSerial::S0MeterSerial(const int ID, const std::string& devname, const unsigned int baud_rate) :
+	AsyncSerial("S0MeterSerial")
 {
 	m_HwdID=ID;
 	m_szSerialPort=devname;
@@ -47,9 +48,10 @@ bool S0MeterSerial::StartHardware()
 	{
 		_log.Log(LOG_STATUS,"S0 Meter: Using serial port: %s", m_szSerialPort.c_str());
 #ifndef WIN32
-		openOnlyBaud(
+		open(
 			m_szSerialPort,
 			m_iBaudRate,
+			false, // Do not set options (parity, character width, flow control, stop bits)
 			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::even),
 			boost::asio::serial_port_base::character_size(7)
 			);
@@ -57,6 +59,7 @@ bool S0MeterSerial::StartHardware()
 		open(
 			m_szSerialPort,
 			m_iBaudRate,
+			true,
 			boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::even),
 			boost::asio::serial_port_base::character_size(7)
 			);

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -36,7 +36,8 @@ History :
 #include <iostream>
 #include <string>
 
-CTeleinfoSerial::CTeleinfoSerial(const int ID, const std::string& devname, const int datatimeout, unsigned int baud_rate, const bool disable_crc, const int ratelimit)
+CTeleinfoSerial::CTeleinfoSerial(const int ID, const std::string& devname, const int datatimeout, unsigned int baud_rate, const bool disable_crc, const int ratelimit) :
+	AsyncSerial("TeleinfoSerial")
 {
 	m_HwdID = ID;
 	m_szSerialPort = devname;
@@ -83,7 +84,7 @@ bool CTeleinfoSerial::StartHardware()
 	try
 	{
 		_log.Log(LOG_STATUS, "(%s) Teleinfo device uses serial port: %s at %i bauds", m_Name.c_str(), m_szSerialPort.c_str(), m_iBaudRate);
-		open(m_szSerialPort, m_iBaudRate, m_iOptParity, m_iOptCsize);
+		open(m_szSerialPort, true, m_iBaudRate, m_iOptParity, m_iOptCsize);
 	}
 	catch (boost::exception & e)
 	{
@@ -91,7 +92,7 @@ bool CTeleinfoSerial::StartHardware()
 		_log.Log(LOG_STATUS, "Teleinfo: Serial port open failed, let's retry with CharSize:8 ...");
 
 		try {
-			open(m_szSerialPort, m_iBaudRate, m_iOptParity, boost::asio::serial_port_base::character_size(8));
+			open(m_szSerialPort, true, m_iBaudRate, m_iOptParity, boost::asio::serial_port_base::character_size(8));
 			_log.Log(LOG_STATUS, "Teleinfo: Serial port open successfully with CharSize:8 ...");
 		}
 		catch (...) {

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -70,7 +70,8 @@ History :
 #define FreeCan			0x02
 
 USBtin::USBtin(const int ID, const std::string& devname,unsigned int BusCanType,unsigned int DebugMode) :
-m_szSerialPort(devname)
+	AsyncSerial("USBtin"),
+	m_szSerialPort(devname)
 {
 	m_HwdID = ID;
 	m_stoprequested=false;

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -9,7 +9,8 @@
 #define ZiBlue_RETRY_DELAY 30
 
 CZiBlueSerial::CZiBlueSerial(const int ID, const std::string& devname) :
-m_szSerialPort(devname)
+	AsyncSerial("ZiBlueSerial"),
+	m_szSerialPort(devname)
 {
 	m_HwdID=ID;
 	m_stoprequested=false;

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -908,7 +908,7 @@ namespace Plugins {
 		}
 	}
 
-	CPluginTransportSerial::CPluginTransportSerial(int HwdID, PyObject* pConnection, const std::string & Port, int Baud) : CPluginTransport(HwdID, pConnection), m_Baud(Baud)
+	CPluginTransportSerial::CPluginTransportSerial(int HwdID, PyObject* pConnection, const std::string & Port, int Baud) : AsyncSerial("PluginSerial"), CPluginTransport(HwdID, pConnection), m_Baud(Baud)
 	{
 		m_Port = Port;
 	}
@@ -924,11 +924,7 @@ namespace Plugins {
 			if (!isOpen())
 			{
 				m_bConnected = false;
-				open(m_Port, m_Baud,
-					boost::asio::serial_port_base::parity(boost::asio::serial_port_base::parity::none),
-					boost::asio::serial_port_base::character_size(8),
-					boost::asio::serial_port_base::flow_control(boost::asio::serial_port_base::flow_control::none),
-					boost::asio::serial_port_base::stop_bits(boost::asio::serial_port_base::stop_bits::one));
+				open(m_Port, m_Baud);
 
 				m_tLastSeen = time(0);
 				m_bConnected = isOpen();


### PR DESCRIPTION
Make AsyncSerial members restricted instead of public
Merge AsyncSerial::openOnlyBaud with AsyncSerial::open.
Name threads.
Remove dead code.