### PR TITLE
Refactor ASyncTCP class to not require polling

### DIFF
--- a/hardware/ASyncTCP.cpp
+++ b/hardware/ASyncTCP.cpp
@@ -33,16 +33,10 @@ ASyncTCP::~ASyncTCP(void)
 
 	// tell the IO service to stop
 	mIos.stop();
-	try {
-		if (m_tcpthread)
-		{
-			m_tcpthread->join();
-			m_tcpthread.reset();
-		}
-	}
-	catch (...)
+	if (m_tcpthread)
 	{
-		//Don't throw from a Stop command
+		m_tcpthread->join();
+		m_tcpthread.reset();
 	}
 }
 

--- a/hardware/ASyncTCP.cpp
+++ b/hardware/ASyncTCP.cpp
@@ -4,6 +4,7 @@
 #include <boost/asio.hpp>
 #include <boost/bind.hpp>
 #include <boost/system/error_code.hpp>     // for error_code
+#include "../main/Helper.h"                // for SetThreadName
 #include "../main/Logger.h"                // for CLogger, _log, _eLogLevel:...
 struct hostent;
 
@@ -11,41 +12,46 @@ struct hostent;
 	#include <unistd.h> //gethostbyname
 #endif
 
-/*
-#ifdef WIN32
-	#include <Mstcpip.h>
-#elif defined(__FreeBSD__)
-	#include <netinet/tcp.h>
-#endif
-*/
-
 #define RECONNECT_TIME 30
 
 ASyncTCP::ASyncTCP()
 	: mIsConnected(false), mIsClosing(false),
 	mSocket(mIos), mReconnectTimer(mIos),
 	mDoReconnect(true), mIsReconnecting(false),
+	m_tcpwork(mIos),
 	mAllowCallbacks(true),
 	m_reconnect_delay(RECONNECT_TIME)
 {
+	// Reset IO Service
+	mIos.reset();
+
+	//Start IO Service worker thread
+	m_tcpthread = std::make_shared<std::thread>(boost::bind(&boost::asio::io_service::run, &mIos));
+	SetThreadName(m_tcpthread->native_handle(), ASYNCTCP_THREAD_NAME);
 }
 
 ASyncTCP::~ASyncTCP(void)
 {
 	disconnect();
+
+	// tell the IO service to stop
+	mIos.stop();
+	try {
+		if (m_tcpthread)
+		{
+			m_tcpthread->join();
+			m_tcpthread.reset();
+		}
+	}
+	catch (...)
+	{
+		//Don't throw from a Stop command
+	}
 }
 
 void ASyncTCP::SetReconnectDelay(int Delay)
 {
 	m_reconnect_delay = Delay;
-}
-
-void ASyncTCP::update()
-{
-	if (mIsClosing)
-		return;
-	// calls the poll() function to process network messages
-	mIos.poll();
 }
 
 void ASyncTCP::connect(const std::string &ip, unsigned short port)
@@ -96,12 +102,6 @@ void ASyncTCP::connect(boost::asio::ip::tcp::endpoint& endpoint)
 
 	mEndPoint = endpoint;
 
-	// restart IO service if it has been stopped
-	if (mIos.stopped()) {
-		_log.Log(LOG_STATUS, "ASyncTCP::connect: reset IO service");
-		mIos.reset();
-	}
-
 	// try to connect, then call handle_connect
 	mSocket.async_connect(endpoint,
         boost::bind(&ASyncTCP::handle_connect, this, boost::asio::placeholders::error));
@@ -111,16 +111,11 @@ void ASyncTCP::disconnect(const bool silent)
 {
 	try
 	{
-		if (isConnected())
-		{
-			// tell socket to close the connection
-			close();
+		// tell socket to close the connection
+		close();
 
-			// tell the IO service to stop
-			mIos.stop();
-			mIsConnected = false;
-			mIsClosing = false;
-		}
+		mIsConnected = false;
+		mIsClosing = false;
 	}
 	catch (...)
 	{
@@ -156,70 +151,27 @@ void ASyncTCP::close()
 	mIos.post(boost::bind(&ASyncTCP::do_close, this));
 }
 
-/*
-bool ASyncTCP::set_tcp_keepalive()
+void ASyncTCP::read()
 {
-	int keep_alive_timeout = 10;
+	if (!mIsConnected) return;
+	if (mIsClosing) return;
 
-#ifdef __OSX__
-	int native_fd = socket->native();
-	int timeout = *keep_alive_timeout;
-	int intvl = 1;
-	int on = 1;
-
-	// Set the timeout before the first keep alive message
-	int ret_sokeepalive = setsockopt(native_fd, SOL_SOCKET, SO_KEEPALIVE, (void*)&on, sizeof(int));
-	int ret_tcpkeepalive = setsockopt(native_fd, IPPROTO_TCP, TCP_KEEPALIVE, (void*)&timeout, sizeof(int));
-	int ret_tcpkeepintvl = setsockopt(native_fd, IPPROTO_TCP, TCP_CONNECTIONTIMEOUT, (void*)&intvl, sizeof(int));
-
-	if (ret_sokeepalive || ret_tcpkeepalive || ret_tcpkeepintvl)
-	{
-		string message("Failed to enable keep alive on TCP client socket!");
-		Logger::error(message, port, host);
-		return false;
-	}
-#elif defined(WIN32)
-	// Partially supported on windows
-	struct tcp_keepalive keepalive_options;
-	keepalive_options.onoff = 1;
-	keepalive_options.keepalivetime = keep_alive_timeout * 1000;
-	keepalive_options.keepaliveinterval = 2000;
-
-	BOOL keepalive_val = true;
-	SOCKET native = mSocket.native();
-	DWORD bytes_returned;
-
-	int ret_keepalive = setsockopt(native, SOL_SOCKET, SO_KEEPALIVE, (const char *)&keepalive_val, sizeof(keepalive_val));
-	int ret_iotcl = WSAIoctl(native, SIO_KEEPALIVE_VALS, (LPVOID)& keepalive_options, (DWORD) sizeof(keepalive_options), NULL, 0,
-		(LPDWORD)& bytes_returned, NULL, NULL);
-
-	if (ret_keepalive || ret_iotcl)
-	{
-		_log.Log(LOG_ERROR, "Failed to set keep alive timeout on TCP client socket!");
-		return false;
-	}
-#else
-	// For *n*x systems
-	int native_fd = mSocket.native();
-	int timeout = keep_alive_timeout;
-	int intvl = 1;
-	int probes = 10;
-	int on = 1;
-
-	int ret_keepalive = setsockopt(native_fd, SOL_SOCKET, SO_KEEPALIVE, (void*)&on, sizeof(int));
-	int ret_keepidle = setsockopt(native_fd, SOL_TCP, TCP_KEEPIDLE, (void*)&timeout, sizeof(int));
-	int ret_keepintvl = setsockopt(native_fd, SOL_TCP, TCP_KEEPINTVL, (void*)&intvl, sizeof(int));
-	int ret_keepinit = setsockopt(native_fd, SOL_TCP, TCP_KEEPCNT, (void*)&probes, sizeof(int));
-
-	if (ret_keepalive || ret_keepidle || ret_keepintvl || ret_keepinit)
-	{
-		_log.Log(LOG_ERROR, "Failed to set keep alive timeout on TCP client socket!");
-		return false;
-	}
-#endif
-	return true;
+	mSocket.async_read_some(boost::asio::buffer(m_rx_buffer, sizeof(m_rx_buffer)),
+		boost::bind(&ASyncTCP::handle_read,
+			this,
+			boost::asio::placeholders::error,
+			boost::asio::placeholders::bytes_transferred));
 }
-*/
+
+void ASyncTCP::write(const uint8_t *pData, size_t length)
+{
+	write(std::string((const char*)pData, length));
+}
+
+void ASyncTCP::write(const std::string &msg)
+{
+	mIos.post(boost::bind(&ASyncTCP::do_write, this, msg));
+}
 
 // callbacks
 
@@ -263,18 +215,6 @@ void ASyncTCP::handle_connect(const boost::system::error_code& error)
 			StartReconnect();
 		}
 	}
-}
-
-void ASyncTCP::read()
-{
-	if (!mIsConnected) return;
-	if (mIsClosing) return;
-
-	mSocket.async_read_some(boost::asio::buffer(m_rx_buffer, sizeof(m_rx_buffer)),
-		boost::bind(&ASyncTCP::handle_read,
-			this,
-			boost::asio::placeholders::error,
-			boost::asio::placeholders::bytes_transferred));
 }
 
 void ASyncTCP::handle_read(const boost::system::error_code& error, size_t bytes_transferred)
@@ -339,23 +279,6 @@ void ASyncTCP::write_end(const boost::system::error_code& error)
 	}
 }
 
-void ASyncTCP::write(const uint8_t *pData, size_t length)
-{
-	if(!mIsConnected) return;
-
-	if (!mIsClosing)
-	{
-		boost::asio::async_write(mSocket,
-			boost::asio::buffer(pData,length),
-			boost::bind(&ASyncTCP::write_end, this, boost::asio::placeholders::error));
-	}
-}
-
-void ASyncTCP::write(const std::string &msg)
-{
-	write((const uint8_t*)msg.c_str(), msg.size());
-}
-
 void ASyncTCP::do_close()
 {
 	if(mIsClosing) return;
@@ -383,6 +306,18 @@ void ASyncTCP::do_reconnect(const boost::system::error_code& /*error*/)
 	mSocket.async_connect(mEndPoint,
         boost::bind(&ASyncTCP::handle_connect, this, boost::asio::placeholders::error));
 	mIsReconnecting = false;
+}
+
+void ASyncTCP::do_write(const std::string &msg)
+{
+	if(!mIsConnected) return;
+
+	if (!mIsClosing)
+	{
+		boost::asio::async_write(mSocket,
+			boost::asio::buffer(msg.c_str(), msg.size()),
+			boost::bind(&ASyncTCP::write_end, this, boost::asio::placeholders::error));
+	}
 }
 
 void ASyncTCP::OnErrorInt(const boost::system::error_code& error)

--- a/hardware/ASyncTCP.h
+++ b/hardware/ASyncTCP.h
@@ -8,61 +8,81 @@
 #include <boost/smart_ptr/shared_ptr.hpp>  // for shared_ptr
 #include <exception>                       // for exception
 
+#define ASYNCTCP_THREAD_NAME "ASyncTCP"
+
 namespace boost { namespace system { class error_code; } }
 
 class ASyncTCP
 {
-public:
+protected:
 	ASyncTCP();
 	virtual ~ASyncTCP(void);
+	// Async connect and start async read from the socket, data is delivered in OnData()
+	// No action if mIsConnected = true. If the connection is lost, it will automatically be setup again
+	void connect(const std::string &hostname, unsigned short port);
 
-	void connect(const std::string &ip, unsigned short port);
-	void connect(boost::asio::ip::tcp::endpoint& endpoint);
+	// Schedule reconnect (TODO: Implement)
+	void schedule_reconnect(const int Delay = 30);
+
 	bool isConnected() { return mIsConnected; };
+
+	// Async disconnect from the socket, no action if mIsConnected = false
 	void disconnect(const bool silent = true);
+
+	// Disable callback, async disconnect from the socket
 	void terminate(const bool silent = true);
 
+	// Async write to the socket, no action if mIsConnected = false
 	void write(const std::string &msg);
+
+	// Async write to the socket, no action if mIsConnected = false
 	void write(const uint8_t *pData, size_t length);
 
-	void update();
+	// Set reconnect delay in seconds, set to 0 to disable reconnect
+	void SetReconnectDelay(const int Delay = 30);
 
-	void SetReconnectDelay(int Delay = 30); //0 disabled retry
-protected:
+	// Callback interface to implement in derived classes
 	virtual void OnConnect() = 0;
 	virtual void OnDisconnect() = 0;
 	virtual void OnData(const unsigned char *pData, size_t length) = 0;
 	virtual void OnError(const std::exception e) = 0;
 	virtual void OnError(const boost::system::error_code& error) = 0;
+
+protected:
+	boost::asio::io_service			mIos; // protected to allow derived classes to attach timers etc.
+
 private:
-	void read();
+	// Internal helper functions
+	void connect(boost::asio::ip::tcp::endpoint& endpoint);
 	void close();
+	void read();
+	void OnErrorInt(const boost::system::error_code& error);
+	void StartReconnect();
 
-	//bool set_tcp_keepalive();
-
-	// callbacks
+	// Callbacks for the io_service, executed from the io_service worker thread context
 	void handle_connect(const boost::system::error_code& error);
 	void handle_read(const boost::system::error_code& error, size_t bytes_transferred);
 	void write_end(const boost::system::error_code& error);
 	void do_close();
-
 	void do_reconnect(const boost::system::error_code& error);
-	void OnErrorInt(const boost::system::error_code& error);
-	void StartReconnect();
-	int m_reconnect_delay;
+	void do_write(const std::string &msg);
+
+	// State variables
 	bool							mIsConnected;
 	bool							mIsClosing;
 	bool							mDoReconnect;
 	bool							mIsReconnecting;
 	bool							mAllowCallbacks;
 
-	boost::asio::ip::tcp::endpoint	mEndPoint;
+	// Internal
+	unsigned char 					m_rx_buffer[1024];
 
-	boost::asio::io_service			mIos;
-	boost::asio::ip::tcp::socket	mSocket;
-
-	unsigned char m_rx_buffer[1024];
-
+	int								m_reconnect_delay;
 	boost::asio::deadline_timer		mReconnectTimer;
 
+	std::shared_ptr<std::thread> 	m_tcpthread;
+	boost::asio::io_service::work 	m_tcpwork; // Create some work to keep IO Service alive
+
+	boost::asio::ip::tcp::socket	mSocket;
+	boost::asio::ip::tcp::endpoint	mEndPoint;
 };

--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -87,26 +87,17 @@ void Comm5SMTCP::OnDisconnect()
 
 void Comm5SMTCP::Do_Work()
 {
-	bool bFirstTime = true;
-	int count = 0;
-	while (!IsStopRequested(40))
+	int sec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
+	while (!IsStopRequested(1000))
 	{
-		m_LastHeartbeat = mytime(NULL);
-		if (bFirstTime)
-		{
-			bFirstTime = false;
-			if (!isConnected())
-			{
-				connect(m_szIPAddress, m_usIPPort);
-			}
+		sec_counter++;
+
+		if (sec_counter % 12 == 0) {
+			m_LastHeartbeat = mytime(NULL);
 		}
-		else
-		{
-			update();
-			if (count++ >= 100) {
-				count = 0;
-				querySensorState();
-			}
+		if (sec_counter % 4 == 0) {
+			querySensorState();
 		}
 	}
 	terminate();

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -94,26 +94,17 @@ void Comm5TCP::OnDisconnect()
 
 void Comm5TCP::Do_Work()
 {
-	bool bFirstTime = true;
-	int count = 0;
-	while (!IsStopRequested(40))
+	int sec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
+	while (!IsStopRequested(1000))
 	{
-		m_LastHeartbeat = mytime(NULL);
-		if (bFirstTime)
-		{
-			bFirstTime = false;
-			if (!isConnected())
-			{
-				connect(m_szIPAddress, m_usIPPort);
-			}
+		sec_counter++;
+
+		if (sec_counter % 12 == 0) {
+			m_LastHeartbeat = mytime(NULL);
 		}
-		else
-		{
-			update();
-			if (count++ >= 100) {
-				count = 0;
-				querySensorState();
-			}
+		if (sec_counter % 4 == 0) {
+			querySensorState();
 		}
 	}
 	terminate();

--- a/hardware/DenkoviTCPDevices.cpp
+++ b/hardware/DenkoviTCPDevices.cpp
@@ -230,30 +230,19 @@ bool CDenkoviTCPDevices::StopHardware()
 
 void CDenkoviTCPDevices::Do_Work()
 {
-	int poll_interval = m_pollInterval / 100;
-	int poll_counter = poll_interval - 2;
-
-	int msec_counter = 0;
-
-	while (!IsStopRequested(100))
+	int poll_interval = m_pollInterval / 500;
+	int halfsec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
+	while (!IsStopRequested(500))
 	{
-		m_LastHeartbeat = mytime(NULL);
-		if (m_bFirstTime)
-		{
-			m_bFirstTime = false;
-			if (!isConnected())
-			{
-				connect(m_szIPAddress, m_usIPPort);
-			}
+		halfsec_counter++;
+
+		if (halfsec_counter % 24 == 0) {
+			m_LastHeartbeat = mytime(NULL);
 		}
-		else
-		{
-			update();
-			if (msec_counter++ >= poll_interval) {
-				msec_counter = 0;
-				if (m_bReadingNow == false && m_bUpdateIo == false)
-					GetMeterDetails();
-			}
+		if (halfsec_counter % poll_interval == 0) {
+			if (m_bReadingNow == false && m_bUpdateIo == false)
+				GetMeterDetails();
 		}
 	}
 	terminate();

--- a/hardware/DenkoviTCPDevices.h
+++ b/hardware/DenkoviTCPDevices.h
@@ -63,7 +63,6 @@ private:
 	int m_Cmd;
 	bool m_bReadingNow = false;
 	bool m_bUpdateIo = false;
-	bool m_bFirstTime = true;
 	_sDenkoviTCPModbusRequest m_pReq;
 	_sDenkoviTCPModbusResponse m_pResp;
 	std::string m_respBuff;

--- a/hardware/Ec3kMeterTCP.cpp
+++ b/hardware/Ec3kMeterTCP.cpp
@@ -44,10 +44,9 @@
 #define RESET_COUNT "reset_counter"
 
 Ec3kMeterTCP::Ec3kMeterTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
-m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = RETRY_DELAY;
 	m_limiter = new(Ec3kLimiter);
@@ -59,7 +58,6 @@ Ec3kMeterTCP::~Ec3kMeterTCP(void)
 
 bool Ec3kMeterTCP::StartHardware()
 {
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr=RETRY_DELAY;
@@ -92,7 +90,6 @@ bool Ec3kMeterTCP::StopHardware()
 void Ec3kMeterTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"Ec3kMeter: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 
 	sOnConnected(this);
@@ -107,26 +104,13 @@ void Ec3kMeterTCP::Do_Work()
 {
 	bool bFirstTime=true;
 	int sec_counter = 0;
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
 		if (sec_counter  % 12 == 0) {
-			m_LastHeartbeat=mytime(NULL);
-		}
-
-		if (bFirstTime)
-		{
-			bFirstTime=false;
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	terminate();

--- a/hardware/Ec3kMeterTCP.h
+++ b/hardware/Ec3kMeterTCP.h
@@ -52,7 +52,6 @@ private:
 	Ec3kLimiter *m_limiter;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	std::shared_ptr<std::thread> m_thread;
 };

--- a/hardware/EvohomeTCP.cpp
+++ b/hardware/EvohomeTCP.cpp
@@ -7,7 +7,10 @@
 #include "../main/localtime_r.h"
 
 CEvohomeTCP::CEvohomeTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, const std::string &UserContID) :
-CEvohomeRadio(ID, UserContID), m_szIPAddress(IPAddress), m_usIPPort(usIPPort)
+
+	CEvohomeRadio(ID, UserContID),
+	m_szIPAddress(IPAddress),
+	m_usIPPort(usIPPort)
 {
 }
 
@@ -56,43 +59,20 @@ void CEvohomeTCP::Do_Work()
     nStartup = 0;
     nStarts = 0;
 
-	bool bFirstTime = true;
 	int sec_counter = 0;
 
+	_log.Log(LOG_STATUS, "evohome TCP/IP: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
-		time_t atime = mytime(NULL);
 		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat= atime;
+			m_LastHeartbeat= mytime(NULL);
 		}
 
-		if (bFirstTime)
-		{
-			bFirstTime=false;
-
-			if (isConnected())
-			{
-				disconnect();
-			}
-			_log.Log(LOG_STATUS, "evohome TCP/IP: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				_log.Log(LOG_STATUS, "evohome TCP/IP: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				disconnect();
-				connect(m_szIPAddress, m_usIPPort);
-			}
-            update();
-            Idle_Work();
-		}
+		Idle_Work();
 	}
-	terminate();
-
 	_log.Log(LOG_STATUS,"evohome TCP/IP: TCP/IP Worker stopped...");
 }
 

--- a/hardware/FritzboxTCP.cpp
+++ b/hardware/FritzboxTCP.cpp
@@ -36,10 +36,9 @@ datum;DISCONNECT;ConnectionID;dauerInSekunden;
 */
 
 FritzboxTCP::FritzboxTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
-m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = RETRY_DELAY;
 	m_bufferpos = 0;
@@ -51,7 +50,6 @@ FritzboxTCP::~FritzboxTCP(void)
 
 bool FritzboxTCP::StartHardware()
 {
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr=RETRY_DELAY;
@@ -78,7 +76,6 @@ bool FritzboxTCP::StopHardware()
 void FritzboxTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"Fritzbox: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 	m_bufferpos=0;
 
@@ -92,28 +89,14 @@ void FritzboxTCP::OnDisconnect()
 
 void FritzboxTCP::Do_Work()
 {
-	bool bFirstTime=true;
 	int sec_counter = 0;
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
 		if (sec_counter  % 12 == 0) {
-			m_LastHeartbeat=mytime(NULL);
-		}
-
-		if (bFirstTime)
-		{
-			bFirstTime=false;
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	terminate();

--- a/hardware/FritzboxTCP.h
+++ b/hardware/FritzboxTCP.h
@@ -28,7 +28,6 @@ private:
 	int m_retrycntr;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	int m_bufferpos;
 	std::shared_ptr<std::thread> m_thread;
 	unsigned char m_buffer[1024];

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -22,7 +22,6 @@ CHEOS::CHEOS(const int ID, const std::string &IPAddress, const unsigned short us
 	m_Pwd(Pwd)
 {
 	m_HwdID = ID;
-	m_bDoRestart = false;
 	m_usIPPort = usIPPort;
 	m_retrycntr = RETRY_DELAY;
 	SetSettings(PollIntervalsec, PingTimeoutms);
@@ -505,11 +504,10 @@ void CHEOS::Do_Work()
 
 	ReloadNodes();
 
-	bool bFirstTime = true;
 	bool bCheckedForPlayers = false;
 	int sec_counter = 25;
 	m_lastUpdate = 25;
-
+	connect(m_IP, m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
@@ -519,36 +517,22 @@ void CHEOS::Do_Work()
 			m_LastHeartbeat = mytime(NULL);
 		}
 
-		if (bFirstTime)
+		if (isConnected())
 		{
-			bFirstTime = false;
-			connect(m_IP, m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
+			if (!bCheckedForPlayers)
 			{
-				connect(m_IP, m_usIPPort);
+				// Update all players and groups
+				SendCommand("getPlayers");
+				bCheckedForPlayers = true;
+				// Enable event changes
+				SendCommand("registerForEvents");
 			}
-			update();
-			if (isConnected())
+			if (sec_counter % 30 == 0 && m_lastUpdate >= 30)//updates every 30 seconds
 			{
-				if (!bCheckedForPlayers)
+				std::vector<HEOSNode>::const_iterator itt;
+				for (itt = m_nodes.begin(); itt != m_nodes.end(); ++itt)
 				{
-					// Update all players and groups
-					SendCommand("getPlayers");
-					bCheckedForPlayers = true;
-					// Enable event changes
-					SendCommand("registerForEvents");
-				}
-				if (sec_counter % 30 == 0 && m_lastUpdate >= 30)//updates every 30 seconds
-				{
-					bFirstTime = false;
-					std::vector<HEOSNode>::const_iterator itt;
-					for (itt = m_nodes.begin(); itt != m_nodes.end(); ++itt)
-					{
-						SendCommand("getPlayState", itt->DevID);
-					}
+					SendCommand("getPlayState", itt->DevID);
 				}
 			}
 		}
@@ -574,8 +558,6 @@ _eNotificationTypes	CHEOS::NotificationType(_eMediaStatus nStatus)
 
 bool CHEOS::StartHardware()
 {
-	m_bDoRestart = false;
-
 	//force connect the next first time
 	m_retrycntr = RETRY_DELAY;
 	m_bIsStarted = true;
@@ -601,7 +583,6 @@ bool CHEOS::StopHardware()
 void CHEOS::OnConnect()
 {
 	_log.Log(LOG_STATUS, "HEOS by DENON: Connected to: %s:%d", m_IP.c_str(), m_usIPPort);
-	m_bDoRestart = false;
 	m_bIsStarted = true;
 	m_bufferpos = 0;
 	sOnConnected(this);

--- a/hardware/HEOS.h
+++ b/hardware/HEOS.h
@@ -61,7 +61,6 @@ private:
 
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	unsigned char m_buffer[1028];
 	int m_bufferpos;
 	std::shared_ptr<std::thread> m_thread;

--- a/hardware/MochadTCP.h
+++ b/hardware/MochadTCP.h
@@ -31,7 +31,6 @@ private:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 	std::shared_ptr<std::thread> m_thread;
-	bool m_bDoRestart;
 	int selected[17][17];
 	int currentHouse;
 	int currentUnit;

--- a/hardware/MySensorsTCP.h
+++ b/hardware/MySensorsTCP.h
@@ -18,7 +18,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void WriteInt(const std::string &sendStr) override;
 

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -11,7 +11,6 @@ OTGWTCP::OTGWTCP(const int ID, const std::string &IPAddress, const unsigned shor
 	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = RETRY_DELAY;
 	SetModes(Mode1,Mode2,Mode3,Mode4,Mode5,Mode6);
@@ -23,7 +22,6 @@ OTGWTCP::~OTGWTCP(void)
 
 bool OTGWTCP::StartHardware()
 {
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr=RETRY_DELAY;
@@ -50,7 +48,6 @@ bool OTGWTCP::StopHardware()
 void OTGWTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"OTGW: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 	m_bufferpos=0;
 	sOnConnected(this);
@@ -64,8 +61,8 @@ void OTGWTCP::OnDisconnect()
 
 void OTGWTCP::Do_Work()
 {
-	bool bFirstTime=true;
 	int sec_counter = 25;
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
@@ -74,36 +71,18 @@ void OTGWTCP::Do_Work()
 			m_LastHeartbeat=mytime(NULL);
 		}
 
-		if (bFirstTime)
+		if (isConnected())
 		{
-			bFirstTime=false;
-			connect(m_szIPAddress,m_usIPPort);
-			if (isConnected())
+			if ((sec_counter % 28 == 0) && (m_bRequestVersion))
 			{
+				m_bRequestVersion = false;
+				GetVersion();
+			}
+			else if (sec_counter % 30 == 0)//updates every 30 seconds
+			{
+				SendOutsideTemperature();
+				SendTime();
 				GetGatewayDetails();
-			}
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
-			if (isConnected())
-			{
-				if ((sec_counter % 28 == 0) && (m_bRequestVersion))
-				{
-					m_bRequestVersion = false;
-					GetVersion();
-				}
-				else if (sec_counter % 30 == 0)//updates every 30 seconds
-				{
-					bFirstTime=false;
-					SendOutsideTemperature();
-					SendTime();
-					GetGatewayDetails();
-				}
 			}
 		}
 	}

--- a/hardware/OTGWTCP.h
+++ b/hardware/OTGWTCP.h
@@ -19,7 +19,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void Do_Work();
 

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -130,10 +130,9 @@ static struct {
 
 
 OnkyoAVTCP::OnkyoAVTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
-m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = RETRY_DELAY;
 	m_pPartialPkt = NULL;
@@ -153,7 +152,6 @@ OnkyoAVTCP::~OnkyoAVTCP(void)
 
 bool OnkyoAVTCP::StartHardware()
 {
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr=RETRY_DELAY;
@@ -180,7 +178,6 @@ bool OnkyoAVTCP::StopHardware()
 void OnkyoAVTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"OnkyoAVTCP: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 
 	SendPacket("NRIQSTN");
@@ -194,28 +191,14 @@ void OnkyoAVTCP::OnDisconnect()
 
 void OnkyoAVTCP::Do_Work()
 {
-	bool bFirstTime=true;
 	int sec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
 		if (sec_counter  % 12 == 0) {
-			m_LastHeartbeat=mytime(NULL);
-		}
-
-		if (bFirstTime)
-		{
-			bFirstTime=false;
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	terminate();

--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -36,6 +36,5 @@ private:
 	int m_PPktLen;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	std::shared_ptr<std::thread> m_thread;
 };

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -56,24 +56,27 @@ void CRFLinkTCP::OnConnect()
 
 void CRFLinkTCP::OnDisconnect()
 {
+	// Note: No need to set m_bDoRestart = true here, the connection is automatically reinited by ASyncTCP
 	_log.Log(LOG_STATUS,"RFLink: disconnected");
-	m_bDoRestart = true;
 }
 
 void CRFLinkTCP::Do_Work()
 {
 	bool bFirstTime=true;
 	int sec_counter = 0;
+	_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
 		time_t atime = mytime(NULL);
 		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat= atime;
+			m_LastHeartbeat = mytime(NULL);
 		}
 		if ((sec_counter % 20 == 0) && (isConnected()))
 		{
+			time_t atime = mytime(NULL);
 			//Send ping (keep alive)
 			if (atime - m_LastReceivedTime > 30)
 			{
@@ -81,32 +84,18 @@ void CRFLinkTCP::Do_Work()
 				_log.Log(LOG_ERROR, "RFLink: Nothing received for more than 30 seconds, restarting...");
 				m_retrycntr = 0;
 				m_LastReceivedTime = atime;
+				//TODO: Add method to ASyncTCP to schedule a reconnect
 				m_bDoRestart = true;
-				disconnect();
 			}
 			else
 				write("10;PING;\n");
 		}
 
-		if (bFirstTime)
+		if ((m_bDoRestart) && (sec_counter % 30 == 0))
 		{
-			bFirstTime=false;
-			if (isConnected())
-			{
-				disconnect();
-			}
 			_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				_log.Log(LOG_STATUS, "RFLink: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				disconnect();
-				connect(m_szIPAddress, m_usIPPort);
-			}
-			update();
+			disconnect();
+			connect(m_szIPAddress, m_usIPPort);
 		}
 	}
 	terminate();

--- a/hardware/RFXComTCP.cpp
+++ b/hardware/RFXComTCP.cpp
@@ -10,7 +10,7 @@
 #define RETRY_DELAY 30
 
 RFXComTCP::RFXComTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
-m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
 	m_usIPPort=usIPPort;
@@ -62,22 +62,14 @@ void RFXComTCP::OnDisconnect()
 
 void RFXComTCP::Do_Work()
 {
-	bool bFirstTime = true;
-	while (!IsStopRequested(40))
+	int sec_counter = 0;
+	connect(m_szIPAddress, m_usIPPort);
+	while (!IsStopRequested(1000))
 	{
-		m_LastHeartbeat = mytime(NULL);
-		if (bFirstTime)
-		{
-			bFirstTime = false;
-			if (!isConnected())
-			{
-				m_rxbufferpos = 0;
-				connect(m_szIPAddress, m_usIPPort);
-			}
-		}
-		else
-		{
-			update();
+		sec_counter++;
+
+		if (sec_counter  % 12 == 0) {
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	terminate();

--- a/hardware/RelayNet.h
+++ b/hardware/RelayNet.h
@@ -44,8 +44,6 @@ private:
 	sockaddr_in 						m_addr;
 	bool								m_poll_inputs;
 	bool								m_poll_relays;
-	bool								m_reconnect;
-	bool								m_bDoRestart;
 	bool								m_setup_devices;
 	int									m_skip_relay_update;
 	int									m_poll_interval;

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -11,7 +11,6 @@ S0MeterTCP::S0MeterTCP(const int ID, const std::string &IPAddress, const unsigne
 	m_szIPAddress(IPAddress)
 {
 	m_HwdID=ID;
-	m_bDoRestart=false;
 	m_usIPPort=usIPPort;
 	m_retrycntr = S0METER_RETRY_DELAY;
 	InitBase();
@@ -23,7 +22,6 @@ S0MeterTCP::~S0MeterTCP(void)
 
 bool S0MeterTCP::StartHardware()
 {
-	m_bDoRestart=false;
 
 	//force connect the next first time
 	m_retrycntr= S0METER_RETRY_DELAY;
@@ -53,7 +51,6 @@ bool S0MeterTCP::StopHardware()
 void S0MeterTCP::OnConnect()
 {
 	_log.Log(LOG_STATUS,"S0 Meter: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	m_bDoRestart=false;
 	m_bIsStarted=true;
 	m_bufferpos = 0;
 	sOnConnected(this);
@@ -62,40 +59,19 @@ void S0MeterTCP::OnConnect()
 void S0MeterTCP::OnDisconnect()
 {
 	_log.Log(LOG_STATUS,"S0 Meter: disconnected");
-	m_bDoRestart = true;
 }
 
 void S0MeterTCP::Do_Work()
 {
-	bool bFirstTime=true;
 	int sec_counter = 0;
+	_log.Log(LOG_ERROR, "S0 Meter: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
 
-		time_t atime = mytime(NULL);
 		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat= atime;
-		}
-
-		if (bFirstTime)
-		{
-			bFirstTime=false;
-			if (isConnected())
-			{
-				disconnect();
-			}
-			_log.Log(LOG_ERROR, "S0 Meter: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-			connect(m_szIPAddress,m_usIPPort);
-		}
-		else
-		{
-			if ((m_bDoRestart) && (sec_counter % 30 == 0))
-			{
-				_log.Log(LOG_ERROR, "S0 Meter: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-				connect(m_szIPAddress,m_usIPPort);
-			}
-			update();
+			m_LastHeartbeat = mytime(NULL);
 		}
 	}
 	terminate();

--- a/hardware/S0MeterTCP.h
+++ b/hardware/S0MeterTCP.h
@@ -25,7 +25,6 @@ private:
 	int m_retrycntr;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 	std::shared_ptr<std::thread> m_thread;
 };
 

--- a/hardware/ZiBlueTCP.h
+++ b/hardware/ZiBlueTCP.h
@@ -20,7 +20,6 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
 	void Do_Work();
 


### PR DESCRIPTION
This PR replaces #2697 

Changes:
- No need to poll
- Thread safe write() since WriteToHardware() is accessed from mainworker (as pointed out by @gordonb3)
- Fix access modifiers: ASyncTCP does not need any public members or methods, only private and some protected (for use in the derived HW classes)
- Add documentation in ASyncTCP.h
- Simplify DoWork() of all derived classes since there is no longer any polling needed

