### PR TITLE
Add Philips Hue dimmers / switches as GeneralSwitch

### DIFF
--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -108,8 +108,8 @@ bool CPhilipsHue::StopHardware()
 		m_thread->join();
 		m_thread.reset();
 	}
-    m_bIsStarted=false;
-    return true;
+	m_bIsStarted=false;
+	return true;
 }
 
 
@@ -144,7 +144,6 @@ bool CPhilipsHue::WriteToHardware(const char *pdata, const unsigned char length)
 	const tRBUF *pSen = reinterpret_cast<const tRBUF*>(pdata);
 
 	unsigned char packettype = pSen->ICMND.packettype;
-	//unsigned char subtype = pSen->ICMND.subtype;
 
 	int svalue = 0;
 	int svalue2 = 0;
@@ -152,29 +151,31 @@ bool CPhilipsHue::WriteToHardware(const char *pdata, const unsigned char length)
 	std::string LCmd = "";
 	int nodeID = 0;
 
-	if (packettype == pTypeLighting2)
+	if (packettype == pTypeGeneralSwitch)
 	{
+		const _tGeneralSwitch *pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pSen);
 		//light command
-		nodeID = (pSen->LIGHTING2.id3 << 8) + pSen->LIGHTING2.id4;
-		if ((pSen->LIGHTING2.cmnd == light2_sOff) || (pSen->LIGHTING2.cmnd == light2_sGroupOff))
+		nodeID = static_cast<int>(pSwitch->id);
+		if ((pSwitch->cmnd == gswitch_sOff) || (pSwitch->cmnd == gswitch_sGroupOff))
 		{
 			LCmd = "Off";
 			svalue = 0;
 		}
-		else if ((pSen->LIGHTING2.cmnd == light2_sOn) || (pSen->LIGHTING2.cmnd == light2_sGroupOn))
+		else if ((pSwitch->cmnd == gswitch_sOn) || (pSwitch->cmnd == gswitch_sGroupOn))
 		{
 			LCmd = "On";
 			svalue = 254;
 		}
-		else
+		else if (pSwitch->cmnd == gswitch_sSetLevel)
 		{
+			// From Philips Hue API documentation:
+			// Brightness is a scale from 1 (the minimum the light is capable of) to 254 (the maximum). Note: a brightness of 1 is not off.
 			LCmd = "Set Level";
-			float fvalue = (254.0f / 15.0f)*float(pSen->LIGHTING2.level);
+			float fvalue = (254.0f / 100.0f)*float(pSwitch->level);
 			if (fvalue > 254.0f)
 				fvalue = 254.0f;
 			svalue = round(fvalue);
 		}
-		//_log.Log(LOG_STATUS, "HueBridge state change: svalue = %d, psen-level = %d", svalue, pSen->LIGHTING2.level);
 		SwitchLight(nodeID, LCmd, svalue);
 	}
 	else if (packettype == pTypeColorSwitch)
@@ -614,32 +615,17 @@ void CPhilipsHue::InsertUpdateSwitch(const int NodeID, const _eHueLightType LTyp
 	}
 	else
 	{
-		//Send as Lighting 2
+		//Send as GeneralSwitch
 		char szID[10];
-		sprintf(szID, "%07X", (unsigned int)NodeID);
+		sprintf(szID, "%08X", (unsigned int)NodeID);
 		unsigned char unitcode = 1;
-		int cmd = (tstate.on ? light2_sOn : light2_sOff);
-		int level = 0;
-
-		if (LType == HLTYPE_NORMAL)
-			tstate.on ? level = 15 : level = 0;
-		else
-		{
-			float flevel = (15.0f / 100.0f)*float(tstate.level);
-			level = round(flevel);
-			if (level > 15)
-				level = 15;
-			if (level == 0)
-				level += 1; //If brightnesslevel < 6, level = 0 even if light is on
-		}
-		char szLevel[20];
-		sprintf(szLevel, "%d", level);
+		int cmd = (tstate.on ? gswitch_sOn : gswitch_sOff);
 
 		//Check if we already exist
 		std::vector<std::vector<std::string> > result;
-		result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d) AND (SubType==%d) AND (DeviceID=='%q')",
+		result = m_sql.safe_query("SELECT nValue, LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d) AND (SubType==%d) AND (DeviceID=='%q')",
 			m_HwdID, int(unitcode), pTypeLighting2, sTypeAC, szID);
-		//_log.Log(LOG_STATUS, "HueBridge state change: Bri = %d, Level = %d", BrightnessLevel, level);
+		//_log.Log(LOG_STATUS, "HueBridge state change for DeviceID '%s': Level = %d", szID, tstate.level);
 
 		if (result.empty() && !AddMissingDevice)
 			return;
@@ -651,25 +637,17 @@ void CPhilipsHue::InsertUpdateSwitch(const int NodeID, const _eHueLightType LTyp
 			int nvalue = atoi(result[0][0].c_str());
 		}
 
-		if (tstate.on && (level != 15))
-			cmd = light2_sSetLevel;
+		if (tstate.on && (tstate.level != 100))
+			cmd = gswitch_sSetLevel;
 
-		tRBUF lcmd;
-		memset(&lcmd, 0, sizeof(RBUF));
-		lcmd.LIGHTING2.packetlength = sizeof(lcmd.LIGHTING2) - 1;
-		lcmd.LIGHTING2.packettype = pTypeLighting2;
-		lcmd.LIGHTING2.subtype = sTypeAC;
-		lcmd.LIGHTING2.seqnbr = 1;
-		lcmd.LIGHTING2.id1 = 0;
-		lcmd.LIGHTING2.id2 = 0;
-		lcmd.LIGHTING2.id3 = NodeID >> 8;
-		lcmd.LIGHTING2.id4 = NodeID;
-		lcmd.LIGHTING2.unitcode = unitcode;
-		lcmd.LIGHTING2.cmnd = cmd;
-		lcmd.LIGHTING2.level = level;
-		lcmd.LIGHTING2.filler = 0;
-		lcmd.LIGHTING2.rssi = 12;
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd.LIGHTING2, Name.c_str(), 255);
+		_tGeneralSwitch lcmd;
+		lcmd.subtype = sSwitchGeneralSwitch;
+		lcmd.id = NodeID;
+		lcmd.unitcode = unitcode;
+		lcmd.cmnd = cmd;
+		lcmd.level = tstate.level;
+		lcmd.seqnbr = 1;
+		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd, Name.c_str(), 255);
 
 		if (result.empty())
 		{
@@ -773,25 +751,38 @@ void CPhilipsHue::LightStateFromJSON(const Json::Value &lightstate, _tHueLightSt
 			//Lamp with brightness control
 			hasBri = true;
 			int tbri = lightstate["bri"].asInt();
-			tlight.level = int((100.0f / 254.0f)*float(tbri));
+			// Clamp to conform to HUE API
+			tbri = std::max(1, tbri);
+			tbri = std::min(254, tbri);
+			tlight.level = int(ceil((100.0f / 254.0f)*float(tbri)));
 		}
 		if (!lightstate["sat"].empty())
 		{
 			//Lamp with color control
 			hasHueSat = true;
 			tlight.sat = lightstate["sat"].asInt();
+			// Clamp to conform to HUE API
+			tlight.sat = std::max(0, tlight.sat);
+			tlight.sat = std::min(254, tlight.sat);
 		}
 		if (!lightstate["hue"].empty())
 		{
 			//Lamp with color control
 			hasHueSat = true;
 			tlight.hue = lightstate["hue"].asInt();
+			// Clamp to conform to HUE API
+			tlight.hue = std::max(0, tlight.hue);
+			tlight.hue = std::min(65535, tlight.hue);
 		}
 		if (!lightstate["ct"].empty())
 		{
 			//Lamp with color temperature control
 			hasTemp = true;
-			tlight.ct = int((float(lightstate["ct"].asInt())-153.0)/(500.0-153.0));
+			int ct = lightstate["ct"].asInt();
+			// Clamp to conform to HUE API
+			ct = std::max(153, ct);
+			ct = std::min(500, ct);
+			tlight.ct = int((float(ct)-153.0)/(500.0-153.0));
 		}
 		if (!lightstate["xy"].empty())
 		{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -34,7 +34,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 131
+#define DB_VERSION 132
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -2568,6 +2568,41 @@ bool CSQLHelper::OpenDatabase()
 		if (dbversion < 131)
 		{
 			query("DROP TABLE IF EXISTS [EventActions]");
+		}
+		if (dbversion < 132)
+		{
+			//Patch for PhilipsHue pTypeLighting2/sTypeAC to pTypeGeneralSwitch/sSwitchGeneralSwitch
+			std::stringstream szQuery;
+			std::vector<std::vector<std::string> > result, result2;
+			std::vector<std::string> sd;
+			szQuery.clear();
+			szQuery.str("");
+			szQuery << "SELECT ID FROM Hardware WHERE([Type]==" << HTYPE_Philips_Hue << ")";
+			result = query(szQuery.str());
+			if (!result.empty())
+			{
+				for (const auto & itt : result)
+				{
+					sd = itt;
+					szQuery.clear();
+					szQuery.str("");
+					szQuery << "SELECT ID, DeviceID FROM DeviceStatus WHERE ([Type]=" << pTypeLighting2 << ") AND (SubType=" << sTypeAC << ") AND (HardwareID=" << sd[0] << ")";
+					result2 = query(szQuery.str());
+					if (!result2.empty())
+					{
+						for (const auto & itt2 : result2)
+						{
+							sd = itt2;
+							std::string ndeviceid = "0" + sd[1];
+
+							szQuery.clear();
+							szQuery.str("");
+							szQuery << "UPDATE DeviceStatus SET DeviceID='" << ndeviceid << "', [Type]=" << pTypeGeneralSwitch << ", SubType=" << sSwitchGeneralSwitch << " WHERE (ID=" << sd[0] << ")";
+							query(szQuery.str());
+						}
+					}
+				}
+			}
 		}
 	}
 	else if (bNewInstall)


### PR DESCRIPTION
- Add Philips Hue basic dimmers and switches as GeneralSwitch to improve dimmer resolution from 15 steps to 100 steps
- Migrate existing Philips Hue HW added as lighting2 to generalswitch
- Clamp HUE API values to conform to API spec

Closes #2659