### PR TITLE
Remove worker from classes derived from ASyncTCP

### DIFF
--- a/hardware/ASyncTCP.h
+++ b/hardware/ASyncTCP.h
@@ -15,14 +15,14 @@ namespace boost { namespace system { class error_code; } }
 class ASyncTCP
 {
 protected:
-	ASyncTCP();
+	ASyncTCP(/*const std::string foo*/);
 	virtual ~ASyncTCP(void);
 	// Async connect and start async read from the socket, data is delivered in OnData()
 	// No action if mIsConnected = true. If the connection is lost, it will automatically be setup again
 	void connect(const std::string &hostname, unsigned short port);
 
-	// Schedule reconnect (TODO: Implement)
-	void schedule_reconnect(const int Delay = 30);
+	// Schedule reconnect
+	void schedule_reconnect();
 
 	bool isConnected() { return mIsConnected; };
 
@@ -49,7 +49,8 @@ protected:
 	virtual void OnError(const boost::system::error_code& error) = 0;
 
 protected:
-	boost::asio::io_service			mIos; // protected to allow derived classes to attach timers etc.
+	boost::asio::io_service			mIos;        // protected to allow derived classes to attach timers etc.
+	std::shared_ptr<std::thread> 	m_tcpthread; // protected to allow derived classes to set thread name etc.
 
 private:
 	// Internal helper functions
@@ -80,7 +81,6 @@ private:
 	int								m_reconnect_delay;
 	boost::asio::deadline_timer		mReconnectTimer;
 
-	std::shared_ptr<std::thread> 	m_tcpthread;
 	boost::asio::io_service::work 	m_tcpwork; // Create some work to keep IO Service alive
 
 	boost::asio::ip::tcp::socket	mSocket;

--- a/hardware/Comm5SMTCP.h
+++ b/hardware/Comm5SMTCP.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
+#include <boost/asio/steady_timer.hpp>
 
 class Comm5SMTCP : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -21,7 +22,7 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void ParseData(const unsigned char *data, const size_t len);
 	void querySensorState();
 private:
@@ -30,6 +31,7 @@ private:
 	std::string buffer;
 	bool initSensorData;
 	bool m_bReceiverStarted;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_sec_counter;
 };
 

--- a/hardware/Comm5TCP.h
+++ b/hardware/Comm5TCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
+#include <boost/asio/steady_timer.hpp>
 
 class Comm5TCP : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -21,7 +22,7 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void ParseData(const unsigned char *data, const size_t len);
 
 	void queryRelayState();
@@ -41,6 +42,7 @@ private:
 
 	bool m_bReceiverStarted;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_sec_counter;
 };
 

--- a/hardware/DenkoviTCPDevices.h
+++ b/hardware/DenkoviTCPDevices.h
@@ -3,6 +3,7 @@
 #include "DomoticzHardware.h"
 #include "ASyncTCP.h"
 #include <iosfwd>
+#include <boost/asio/steady_timer.hpp>
 
 enum _eDenkoviTCPDevice
 {
@@ -47,7 +48,7 @@ private:
 	void Init();
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void GetMeterDetails();
 	void readCallBack(const char * data, size_t len);
 	void ConvertResponse(const std::string pData, const size_t length);
@@ -59,7 +60,8 @@ private:
 	int m_pollInterval;
 	int m_slaveId;
 	int m_iModel;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_halfsec_counter;
 	int m_Cmd;
 	bool m_bReadingNow = false;
 	bool m_bUpdateIo = false;

--- a/hardware/Ec3kMeterTCP.h
+++ b/hardware/Ec3kMeterTCP.h
@@ -2,7 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
-
+#include <boost/asio/steady_timer.hpp>
 
 #define MAX_EC3K_METERS 64
 #define EC3K_UPDATE_INTERVAL 60
@@ -39,7 +39,7 @@ public:
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void ParseData(const unsigned char *pData, int Len);
 
 	void OnConnect() override;
@@ -53,6 +53,6 @@ private:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 

--- a/hardware/FritzboxTCP.h
+++ b/hardware/FritzboxTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
+#include <boost/asio/steady_timer.hpp>
 
 class FritzboxTCP : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -15,7 +16,7 @@ private:
 	bool StopHardware() override;
 	void UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, const bool bOn, const double Level, const std::string &defaultname);
 	void WriteInt(const std::string &sendStr);
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void ParseData(const unsigned char *pData, int Len);
 	void ParseLine();
 
@@ -29,7 +30,7 @@ private:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 	int m_bufferpos;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 	unsigned char m_buffer[1024];
 };
 

--- a/hardware/HEOS.h
+++ b/hardware/HEOS.h
@@ -3,6 +3,7 @@
 #include "DomoticzHardware.h"
 #include "ASyncTCP.h"
 #include <string>
+#include <boost/asio/steady_timer.hpp>
 
 class CHEOS : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -30,7 +31,7 @@ private:
 	bool StartHardware() override;
 	bool StopHardware() override;
 	bool WriteInt(const std::string &sendStr);
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -63,5 +64,7 @@ private:
 	unsigned short m_usIPPort;
 	unsigned char m_buffer[1028];
 	int m_bufferpos;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_sec_counter;
+	bool m_bCheckedForPlayers;
 };

--- a/hardware/MochadTCP.h
+++ b/hardware/MochadTCP.h
@@ -3,6 +3,7 @@
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
 #include "../main/RFXtrx.h"
+#include <boost/asio/steady_timer.hpp>
 
 class MochadTCP: public CDomoticzHardwareBase,  ASyncTCP
 {
@@ -13,7 +14,7 @@ public:
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -30,7 +31,7 @@ private:
 	RBUF m_mochadsec;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 	int selected[17][17];
 	int currentHouse;
 	int currentUnit;
@@ -39,6 +40,5 @@ private:
 	unsigned char m_mochadbuffer[1028];
 	char s_buffer[1028];
 	int m_bufferpos;
-
 };
 

--- a/hardware/MySensorsTCP.h
+++ b/hardware/MySensorsTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "MySensorsBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class MySensorsTCP : public MySensorsBase, ASyncTCP
 {
@@ -21,7 +22,7 @@ protected:
 
 	void WriteInt(const std::string &sendStr) override;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -29,6 +30,6 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 

--- a/hardware/OTGWTCP.h
+++ b/hardware/OTGWTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "OTGWBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class OTGWTCP: public OTGWBase, ASyncTCP
 {
@@ -20,7 +21,7 @@ protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -28,6 +29,7 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_sec_counter;
 };
 

--- a/hardware/OnkyoAVTCP.h
+++ b/hardware/OnkyoAVTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
+#include <boost/asio/steady_timer.hpp>
 
 class OnkyoAVTCP : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -21,7 +22,7 @@ private:
 	bool ReceiveXML(const char *pData, int Len);
 	void EnsureSwitchDevice(int Unit, const char *options = NULL);
 	std::string BuildSelectorOptions(const std::string & names, const std::string & ids);
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -36,5 +37,5 @@ private:
 	int m_PPktLen;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };

--- a/hardware/P1MeterTCP.h
+++ b/hardware/P1MeterTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "P1MeterBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class P1MeterTCP : public P1MeterBase, ASyncTCP
 {
@@ -22,7 +23,7 @@ protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -30,6 +31,6 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -196,7 +196,6 @@ CRFLinkBase::CRFLinkBase()
 	m_bRFDebug = false;
 	memset(&m_rfbuffer,0,sizeof(m_rfbuffer));
 	m_rfbufferpos = 0;
-	m_retrycntr = RFLINK_RETRY_DELAY;
 	/*
 	ParseLine("20;4F;LIVCOL;ID=1a2b3c4;SWITCH=00;RGBW=ec5a;CMD=ON;");
 	ParseLine("20;08;NewKaku;ID=31c42a;SWITCH=2;CMD=OFF;");

--- a/hardware/RFLinkBase.h
+++ b/hardware/RFLinkBase.h
@@ -25,7 +25,6 @@ protected:
 protected:
 	unsigned char m_rfbuffer[RFLINK_READ_BUFFER_SIZE];
 	int m_rfbufferpos;
-	int m_retrycntr;
 	time_t m_LastReceivedTime;
 };
 

--- a/hardware/RFLinkSerial.h
+++ b/hardware/RFLinkSerial.h
@@ -7,7 +7,7 @@ class CRFLinkSerial: public AsyncSerial, public CRFLinkBase
 {
 public:
 	CRFLinkSerial(const int ID, const std::string& devname);
-    ~CRFLinkSerial();
+	~CRFLinkSerial();
 private:
 	void Init();
 	bool StartHardware() override;
@@ -17,6 +17,7 @@ private:
 	bool WriteInt(const std::string &sendString) override;
 	std::shared_ptr<std::thread> m_thread;
 	std::string m_szSerialPort;
-    void readCallback(const char *data, size_t len);
+	void readCallback(const char *data, size_t len);
+	int m_retrycntr;
 };
 

--- a/hardware/RFLinkTCP.h
+++ b/hardware/RFLinkTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "RFLinkBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class CRFLinkTCP: public CRFLinkBase, ASyncTCP
 {
@@ -18,16 +19,15 @@ private:
 protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	bool m_bDoRestart;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
 	void OnData(const unsigned char *pData, size_t length) override;
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
-
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
+	int m_sec_counter;
 };
 

--- a/hardware/RFXBase.h
+++ b/hardware/RFXBase.h
@@ -7,12 +7,9 @@
 
 class CRFXBase: public CDomoticzHardwareBase
 {
-friend class RFXComSerial;
-friend class RFXComTCP;
-friend class MainWorker;
 public:
 	CRFXBase();
-    ~CRFXBase();
+	~CRFXBase();
 	std::string m_Version;
 	int m_NoiseLevel;
 	bool SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned char Mode2, const unsigned char Mode3, const unsigned char Mode4, const unsigned char Mode5, const unsigned char Mode6);
@@ -22,10 +19,9 @@ protected:
 	std::mutex readQueueMutex;
 	unsigned char m_rxbuffer[RX_BUFFER_SIZE] = { 0 };
 	unsigned char m_rxbufferpos = { 0 };
+	bool m_bReceiverStarted;
 private:
 	static bool CheckValidRFXData(const uint8_t *pData);
 	void SendCommand(const unsigned char Cmd);
-	std::shared_ptr<std::thread> m_thread;
-	bool m_bReceiverStarted;
 };
 

--- a/hardware/RFXComSerial.h
+++ b/hardware/RFXComSerial.h
@@ -40,7 +40,8 @@ private:
 	unsigned char m_rx_input_buffer[512];
 	int m_rx_tot_bytes;
 	int m_retrycntr;
-    void readCallback(const char *data, size_t len);
+	void readCallback(const char *data, size_t len);
+	std::shared_ptr<std::thread> m_thread;
 };
 
 #endif //BUFFEREDASYNCSERIAL_H

--- a/hardware/RFXComTCP.cpp
+++ b/hardware/RFXComTCP.cpp
@@ -6,11 +6,13 @@
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
+#include <boost/asio/placeholders.hpp>
 
 #define RETRY_DELAY 30
 
 RFXComTCP::RFXComTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort) :
-	m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress),
+	m_heartbeat_timer(mIos)
 {
 	m_HwdID=ID;
 	m_usIPPort=usIPPort;
@@ -31,20 +33,22 @@ bool RFXComTCP::StartHardware()
 	m_bIsStarted=true;
 	m_rxbufferpos=0;
 
-	//Start worker thread
-	m_thread = std::make_shared<std::thread>(&RFXComTCP::Do_Work, this);
-	SetThreadName(m_thread->native_handle(), "RFXComTCP");
-	return (m_thread != nullptr);
+	//Connect
+	connect(m_szIPAddress,m_usIPPort);
+	SetThreadName(m_tcpthread->native_handle(), "RFXComTCP");
+
+	//Start heartbeat timer
+	Do_Work(boost::system::error_code());
+
+	return (m_tcpthread != nullptr);
 }
 
 bool RFXComTCP::StopHardware()
 {
-	if (m_thread)
-	{
-		RequestStop();
-		m_thread->join();
-		m_thread.reset();
-	}
+	RequestStop();
+	terminate();
+	_log.Log(LOG_STATUS,"RFXCOM: TCP/IP Worker stopped...");
+
 	m_bIsStarted = false;
 	return true;
 }
@@ -62,21 +66,16 @@ void RFXComTCP::OnDisconnect()
 	_log.Log(LOG_STATUS, "RFXCOM: disconnected");
 }
 
-void RFXComTCP::Do_Work()
+void RFXComTCP::Do_Work(const boost::system::error_code& error)
 {
-	int sec_counter = 0;
-	connect(m_szIPAddress, m_usIPPort);
-	while (!IsStopRequested(1000))
+	if (!IsStopRequested(0) && !error)
 	{
-		sec_counter++;
+		m_LastHeartbeat = mytime(NULL);
 
-		if (sec_counter  % 12 == 0) {
-			m_LastHeartbeat = mytime(NULL);
-		}
+		// Schedule next heartbeat
+		m_heartbeat_timer.expires_from_now(std::chrono::seconds(12));
+		m_heartbeat_timer.async_wait(boost::bind(&RFXComTCP::Do_Work, this, boost::asio::placeholders::error));
 	}
-	terminate();
-
-	_log.Log(LOG_STATUS,"RFXCOM: TCP/IP Worker stopped...");
 }
 
 void RFXComTCP::OnData(const unsigned char *pData, size_t length)

--- a/hardware/RFXComTCP.h
+++ b/hardware/RFXComTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "RFXBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class RFXComTCP : public CRFXBase, ASyncTCP
 {
@@ -12,7 +13,7 @@ public:
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -22,5 +23,6 @@ private:
 private:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 

--- a/hardware/RelayNet.h
+++ b/hardware/RelayNet.h
@@ -3,6 +3,7 @@
 #include "ASyncTCP.h"
 #include "DomoticzHardware.h"
 #include "../main/RFXtrx.h"
+#include <boost/asio/steady_timer.hpp>
 
 class RelayNet : public CDomoticzHardwareBase, ASyncTCP
 {
@@ -16,7 +17,7 @@ public:
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 	void Init();
 	void SetupDevices();
 	void TcpGetSetRelay(int RelayNumber, bool Set, bool State);
@@ -50,7 +51,8 @@ private:
 	int									m_input_count;
 	int									m_relay_count;
 	int									m_retrycntr;
-	std::shared_ptr<std::thread> 	m_thread;
+	boost::asio::steady_timer 			m_heartbeat_timer;
+	int 								m_sec_counter;
 	tRBUF 								m_Packet;
 };
 

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -4,11 +4,13 @@
 #include "../main/Helper.h"
 #include <iostream>
 #include "../main/localtime_r.h"
+#include <boost/asio/placeholders.hpp>
 
 #define S0METER_RETRY_DELAY 30
 
 S0MeterTCP::S0MeterTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort):
-	m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress),
+	m_heartbeat_timer(mIos)
 {
 	m_HwdID=ID;
 	m_usIPPort=usIPPort;
@@ -31,20 +33,23 @@ bool S0MeterTCP::StartHardware()
 	m_bufferpos = 0;
 	ReloadLastTotals();
 
-	//Start worker thread
-	m_thread = std::make_shared<std::thread>(&S0MeterTCP::Do_Work, this);
-	SetThreadName(m_thread->native_handle(), "S0MeterTCP");
-	return (m_thread != nullptr);
+	//Connect
+	_log.Log(LOG_ERROR, "S0 Meter: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
+	SetThreadName(m_tcpthread->native_handle(), "S0MeterTCP");
+
+	//Start heartbeat timer
+	Do_Work(boost::system::error_code());
+
+	return (m_tcpthread != nullptr);
 }
 
 bool S0MeterTCP::StopHardware()
 {
-	if (m_thread)
-	{
-		RequestStop();
-		m_thread->join();
-		m_thread.reset();
-	}
+	RequestStop();
+	terminate();
+	_log.Log(LOG_STATUS,"S0 Meter: TCP/IP Worker stopped...");
+
 	m_bIsStarted=false;
 	return true;
 }
@@ -62,22 +67,17 @@ void S0MeterTCP::OnDisconnect()
 	_log.Log(LOG_STATUS,"S0 Meter: disconnected");
 }
 
-void S0MeterTCP::Do_Work()
+void S0MeterTCP::Do_Work(const boost::system::error_code& error)
 {
-	int sec_counter = 0;
-	_log.Log(LOG_ERROR, "S0 Meter: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	connect(m_szIPAddress,m_usIPPort);
-	while (!IsStopRequested(1000))
+	if (!IsStopRequested(0) && !error)
 	{
-		sec_counter++;
+		m_LastHeartbeat = mytime(NULL);
 
-		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat = mytime(NULL);
-		}
+		// Schedule next heartbeat
+		m_heartbeat_timer.expires_from_now(std::chrono::seconds(12));
+		m_heartbeat_timer.async_wait(boost::bind(&S0MeterTCP::Do_Work, this, boost::asio::placeholders::error));
 	}
-	terminate();
 
-	_log.Log(LOG_STATUS,"S0 Meter: TCP/IP Worker stopped...");
 }
 
 bool S0MeterTCP::WriteToHardware(const char *pdata, const unsigned char length)

--- a/hardware/S0MeterTCP.h
+++ b/hardware/S0MeterTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "S0MeterBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class S0MeterTCP: public S0MeterBase, ASyncTCP
 {
@@ -14,7 +15,7 @@ private:
 	bool StartHardware() override;
 	bool StopHardware() override;
 	bool WriteInt(const std::string &sendString);
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -25,6 +26,6 @@ private:
 	int m_retrycntr;
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -4,11 +4,13 @@
 #include "../main/Helper.h"
 #include <iostream>
 #include "../main/localtime_r.h"
+#include <boost/asio/placeholders.hpp>
 
 #define ZiBlue_RETRY_DELAY 30
 
 CZiBlueTCP::CZiBlueTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort):
-	m_szIPAddress(IPAddress)
+	m_szIPAddress(IPAddress),
+	m_heartbeat_timer(mIos)
 {
 	m_HwdID=ID;
 	m_usIPPort=usIPPort;
@@ -27,20 +29,23 @@ bool CZiBlueTCP::StartHardware()
 	m_retrycntr=ZiBlue_RETRY_DELAY;
 	m_bIsStarted=true;
 
-	//Start worker thread
-	m_thread = std::make_shared<std::thread>(&CZiBlueTCP::Do_Work, this);
-	SetThreadName(m_thread->native_handle(), "ZiBlueTCP");
-	return (m_thread != nullptr);
+	//Connect
+	_log.Log(LOG_STATUS, "ZiBlue: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress,m_usIPPort);
+	SetThreadName(m_tcpthread->native_handle(), "ZiBlueTCP");
+
+	//Start heartbeat timer
+	Do_Work(boost::system::error_code());
+
+	return (m_tcpthread != nullptr);
 }
 
 bool CZiBlueTCP::StopHardware()
 {
-	if (m_thread)
-	{
-		RequestStop();
-		m_thread->join();
-		m_thread.reset();
-	}
+	RequestStop();
+	terminate();
+	_log.Log(LOG_STATUS,"ZiBlue: TCP/IP Worker stopped...");
+
 	m_bIsStarted=false;
 	return true;
 }
@@ -60,22 +65,17 @@ void CZiBlueTCP::OnDisconnect()
 	_log.Log(LOG_STATUS,"ZiBlue: disconnected");
 }
 
-void CZiBlueTCP::Do_Work()
+void CZiBlueTCP::Do_Work(const boost::system::error_code& error)
 {
-	int sec_counter = 0;
-	_log.Log(LOG_STATUS, "ZiBlue: trying to connect to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
-	connect(m_szIPAddress,m_usIPPort);
-	while (!IsStopRequested(1000))
+	if (!IsStopRequested(0) && !error)
 	{
-		sec_counter++;
+		m_LastHeartbeat = mytime(NULL);
 
-		if (sec_counter % 12 == 0) {
-			m_LastHeartbeat = mytime(NULL);
-		}
+		// Schedule next heartbeat
+		m_heartbeat_timer.expires_from_now(std::chrono::seconds(12));
+		m_heartbeat_timer.async_wait(boost::bind(&CZiBlueTCP::Do_Work, this, boost::asio::placeholders::error));
 	}
-	terminate();
 
-	_log.Log(LOG_STATUS,"ZiBlue: TCP/IP Worker stopped...");
 }
 
 void CZiBlueTCP::OnData(const unsigned char *pData, size_t length)

--- a/hardware/ZiBlueTCP.h
+++ b/hardware/ZiBlueTCP.h
@@ -2,6 +2,7 @@
 
 #include "ASyncTCP.h"
 #include "ZiBlueBase.h"
+#include <boost/asio/steady_timer.hpp>
 
 class CZiBlueTCP: public CZiBlueBase, ASyncTCP
 {
@@ -21,7 +22,7 @@ protected:
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
 
-	void Do_Work();
+	void Do_Work(const boost::system::error_code& error);
 
 	void OnConnect() override;
 	void OnDisconnect() override;
@@ -29,6 +30,6 @@ protected:
 	void OnError(const std::exception e) override;
 	void OnError(const boost::system::error_code& error) override;
 
-	std::shared_ptr<std::thread> m_thread;
+	boost::asio::steady_timer m_heartbeat_timer;
 };
 


### PR DESCRIPTION
- Replace derived class' worker thread with periodic timers
- Expose ASyncTCP's thread to allow derived class to set thread name
- Start ASyncTCP's thread on connect() and stop it on terminate()