### PR TITLE
DomoticzTCP fix no timeout and hanging on shutdown

### DIFF
--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -28,7 +28,7 @@ public:
 
 	int m_HwdID = { 0 }; //must be uniquely assigned
 	bool m_bSkipReceiveCheck = { false };
-	unsigned long m_DataTimeout = { 0 };
+	int m_DataTimeout = { 0 };
 	std::string m_Name;
 	_eHardwareTypes HwdType;
 	unsigned char m_SeqNr = { 0 };

--- a/hardware/DomoticzTCP.h
+++ b/hardware/DomoticzTCP.h
@@ -6,6 +6,7 @@
 #include "ws2tcpip.h"
 #endif
 
+class csocket;
 class DomoticzTCP : public CRFXBase
 {
 public:
@@ -25,11 +26,8 @@ public:
 #endif
 private:
 	void write(const char *data, size_t size);
-	bool isConnectedTCP();
-	void disconnectTCP();
 	bool StartHardware() override;
 	bool StopHardware() override;
-	void writeTCP(const char *data, size_t size);
 	void Do_Work();
 	bool ConnectInternal();
 #ifndef NOCLOUD
@@ -47,10 +45,8 @@ private:
 	std::string m_password;
 	int m_retrycntr;
 	std::shared_ptr<std::thread> m_thread;
-	sockaddr_in6 m_addr;
-	struct addrinfo *info;
-	int m_socket;
-	unsigned char mBuffer[512];
+	csocket *m_connection;
+
 #ifndef NOCLOUD
 	std::string token;
 	bool b_ProxyConnected;

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -16,6 +16,7 @@ CDummy::CDummy(const int ID)
 {
 	m_HwdID=ID;
 	m_bSkipReceiveCheck = true;
+	m_DataTimeout = -1;
 }
 
 CDummy::~CDummy(void)

--- a/hardware/EvohomeScript.cpp
+++ b/hardware/EvohomeScript.cpp
@@ -10,11 +10,11 @@
  *
  *  Copyright 2014 - fullTalgoRythm https://github.com/fullTalgoRythm/Domoticz-evohome
  *
- *  Licensed under GNU General Public License 3.0 or later. 
+ *  Licensed under GNU General Public License 3.0 or later.
  *  Some rights reserved. See COPYING, AUTHORS.
  *
  * @license GPL-3.0+ <http://spdx.org/licenses/GPL-3.0+>
- * 
+ *
  * based in part on https://github.com/mouse256/evomon
  * and details available at http://www.domoticaforum.eu/viewtopic.php?f=7&t=5806&start=90#p72564
  */
@@ -37,6 +37,7 @@ CEvohomeScript::CEvohomeScript(const int ID)
 {
 	m_HwdID=ID;
 	m_bSkipReceiveCheck = true;
+	m_DataTimeout = -1;
 }
 
 
@@ -115,7 +116,7 @@ void CEvohomeScript::RunScript(const char *pdata, const unsigned char /*length*/
 		std::stringstream s_strid;
 		s_strid << std::hex << sd[1];
 		s_strid >> ID;
-		
+
 		std::string OnAction(sd[6]);
 		if (OnAction.find("script://")!=std::string::npos)
 		{
@@ -154,7 +155,7 @@ void CEvohomeScript::RunScript(const char *pdata, const unsigned char /*length*/
 				scriptparams=scriptname.substr(pindex+1);
 				scriptname=scriptname.substr(0,pindex);
 			}
-			
+
 			if (file_exist(scriptname.c_str()))
 			{
 				m_sql.AddTaskItem(_tTaskItem::ExecuteScript(0.2f,scriptname,scriptparams));

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -46,6 +46,7 @@ CEvohomeWeb::CEvohomeWeb(const int ID, const std::string &Username, const std::s
 {
 	m_HwdID = ID;
 	m_bSkipReceiveCheck = true;
+	m_DataTimeout = -1;
 
 	m_locationId = (installation >> 12) & 15;
 	m_gatewayId = (installation >> 8) & 15;

--- a/hardware/Limitless.cpp
+++ b/hardware/Limitless.cpp
@@ -164,6 +164,7 @@ m_szIPAddress(IPAddress)
 	m_usIPPort=usIPPort;
 	m_RemoteSocket=INVALID_SOCKET;
 	m_bSkipReceiveCheck = true;
+	m_DataTimeout = -1;
 	m_BridgeType = (_eLimitlessBridgeType)BridgeType;
 	m_LEDType=LedType;
 	m_bIsStarted=false;

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -151,6 +151,7 @@ CPinger::CPinger(const int ID, const int PollIntervalsec, const int PingTimeoutm
 {
 	m_HwdID = ID;
 	m_bSkipReceiveCheck = true;
+	m_DataTimeout = -1;
 	SetSettings(PollIntervalsec, PingTimeoutms);
 }
 

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -16,10 +16,10 @@ CTellstick::CTellstick(const TelldusFunctions& functions, const int ID, int repe
       m_sensorEventId(-1),
       m_numRepeats(repeats),
       m_repeatInterval(repeatInterval)
-
 {
     m_HwdID = ID;
     m_bSkipReceiveCheck = true;
+    m_DataTimeout = -1;
 }
 
 void CTellstick::SetSettings(int repeats, int repeatInterval)

--- a/hardware/WOL.cpp
+++ b/hardware/WOL.cpp
@@ -20,6 +20,7 @@ CWOL::CWOL(const int ID, const std::string &BroadcastAddress, const unsigned sho
 	m_HwdID = ID;
 	m_bSkipReceiveCheck = true;
 	m_wol_port = Port;//9;
+	m_DataTimeout = -1;
 }
 
 CWOL::~CWOL(void)

--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -86,7 +86,6 @@ int csocket::resolveHost(const std::string& szRemoteHostName, struct sockaddr_in
 	return FAILURE;
 }
 
-
 int csocket::connect( const char* remoteHost, const unsigned int remotePort )
 {
 	m_strRemoteHost = remoteHost;
@@ -335,3 +334,15 @@ csocket::SocketState csocket::getState( void ) const
 {
 	return m_socketState;
 }
+
+int csocket::setSockOpt(int level, int option_name, const void *option_value, socklen_t option_len)
+{
+	if (setsockopt(m_socket, level, option_name, option_value, option_len) < 0)
+#ifndef WIN32
+		return errno;
+#else
+		return WSAGetLastError();
+#endif
+	return 0;
+}
+

--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -335,7 +335,11 @@ csocket::SocketState csocket::getState( void ) const
 	return m_socketState;
 }
 
+#ifndef WIN32
 int csocket::setSockOpt(int level, int option_name, const void *option_value, socklen_t option_len)
+#else
+int csocket::setSockOpt(int level, int option_name, char *option_value, int option_len)
+#endif
 {
 	if (setsockopt(m_socket, level, option_name, option_value, option_len) < 0)
 #ifndef WIN32

--- a/hardware/csocket.h
+++ b/hardware/csocket.h
@@ -38,6 +38,7 @@ public:
     virtual int     write( const char* pDataBuffer, unsigned int numBytesToWrite );
     SocketState     getState( void ) const;
     void            close();
+    int             setSockOpt(int level, int option_name, const void *option_value, socklen_t option_len);
 private:
 
 

--- a/hardware/csocket.h
+++ b/hardware/csocket.h
@@ -38,7 +38,11 @@ public:
     virtual int     write( const char* pDataBuffer, unsigned int numBytesToWrite );
     SocketState     getState( void ) const;
     void            close();
-    int             setSockOpt(int level, int option_name, const void *option_value, socklen_t option_len);
+#ifndef WIN32
+	int             setSockOpt(int level, int option_name, const void *option_value, socklen_t option_len);
+#else
+	int             setSockOpt(int level, int option_name, char *option_value, int option_len);
+#endif
 private:
 
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12868,7 +12868,7 @@ void MainWorker::HeartbeatCheck()
 		if (!pHardware->m_bSkipReceiveCheck)
 		{
 			//Skip Dummy Hardware
-			bool bDoCheck = (pHardware->HwdType != HTYPE_Dummy) && (pHardware->HwdType != HTYPE_Domoticz) && (pHardware->HwdType != HTYPE_EVOHOME_SCRIPT);
+			bool bDoCheck = (pHardware->HwdType != HTYPE_Dummy) && (pHardware->HwdType != HTYPE_EVOHOME_SCRIPT);
 			if (bDoCheck)
 			{
 				//Check Thread Timeout
@@ -12895,7 +12895,7 @@ void MainWorker::HeartbeatCheck()
 			{
 				std::vector<std::vector<std::string> > result;
 				result = m_sql.safe_query("SELECT Name FROM Hardware WHERE (ID='%d')", pHardware->m_HwdID);
-				if (result.size() == 1)
+				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1077,7 +1077,8 @@ bool MainWorker::AddHardwareFromParams(
 	{
 		pHardware->HwdType = Type;
 		pHardware->m_Name = Name;
-		pHardware->m_DataTimeout = DataTimeout;
+		if (pHardware->m_DataTimeout != -1)
+			pHardware->m_DataTimeout = DataTimeout;
 		AddDomoticzHardware(pHardware);
 
 		if (bDoStart)
@@ -12861,10 +12862,9 @@ void MainWorker::HeartbeatCheck()
 	}
 
 	//Check hardware heartbeats
-	std::vector<CDomoticzHardwareBase*>::const_iterator itt;
-	for (itt = m_hardwaredevices.begin(); itt != m_hardwaredevices.end(); ++itt)
+	for (auto const & itt : m_hardwaredevices)
 	{
-		CDomoticzHardwareBase *pHardware = (CDomoticzHardwareBase *)(*itt);
+		CDomoticzHardwareBase *pHardware = (CDomoticzHardwareBase *)(itt);
 		if (!pHardware->m_bSkipReceiveCheck)
 		{
 			//Skip Dummy Hardware
@@ -12885,59 +12885,57 @@ void MainWorker::HeartbeatCheck()
 					}
 				}
 			}
+		}
 
-			if (pHardware->m_DataTimeout > 0)
+		if (pHardware->m_DataTimeout > 0)
+		{
+			//Check Receive Timeout
+			double diff = difftime(now, pHardware->m_LastHeartbeatReceive);
+			if (diff > pHardware->m_DataTimeout)
 			{
-				//Check Receive Timeout
-				double diff = difftime(now, pHardware->m_LastHeartbeatReceive);
-				if (diff > pHardware->m_DataTimeout)
+				std::vector<std::vector<std::string> > result;
+				result = m_sql.safe_query("SELECT Name FROM Hardware WHERE (ID='%d')", pHardware->m_HwdID);
+				if (result.size() == 1)
 				{
-					std::vector<std::vector<std::string> > result;
-					result = m_sql.safe_query("SELECT Name FROM Hardware WHERE (ID='%d')", pHardware->m_HwdID);
-					if (result.size() == 1)
-					{
-						std::vector<std::string> sd = result[0];
+					std::vector<std::string> sd = result[0];
 
-						std::string sDataTimeout = "";
-						int totNum = 0;
-						if (pHardware->m_DataTimeout < 60) {
-							totNum = pHardware->m_DataTimeout;
-							sDataTimeout = "Seconds";
-						}
-						else if (pHardware->m_DataTimeout < 3600) {
-							totNum = pHardware->m_DataTimeout / 60;
-							if (totNum == 1) {
-								sDataTimeout = "Minute";
-							}
-							else {
-								sDataTimeout = "Minutes";
-							}
-						}
-						else if (pHardware->m_DataTimeout < 86400) {
-							totNum = pHardware->m_DataTimeout / 3600;
-							if (totNum == 1) {
-								sDataTimeout = "Hour";
-							}
-							else {
-								sDataTimeout = "Hours";
-							}
+					std::string sDataTimeout = "";
+					int totNum = 0;
+					if (pHardware->m_DataTimeout < 60) {
+						totNum = pHardware->m_DataTimeout;
+						sDataTimeout = "Seconds";
+					}
+					else if (pHardware->m_DataTimeout < 3600) {
+						totNum = pHardware->m_DataTimeout / 60;
+						if (totNum == 1) {
+							sDataTimeout = "Minute";
 						}
 						else {
-							totNum = pHardware->m_DataTimeout / 60;
-							if (totNum == 1) {
-								sDataTimeout = "Day";
-							}
-							else {
-								sDataTimeout = "Days";
-							}
+							sDataTimeout = "Minutes";
 						}
-
-						_log.Log(LOG_ERROR, "%s hardware (%d) nothing received for more than %d %s!....", sd[0].c_str(), pHardware->m_HwdID, totNum, sDataTimeout.c_str());
-						m_devicestorestart.push_back(pHardware->m_HwdID);
 					}
+					else if (pHardware->m_DataTimeout < 86400) {
+						totNum = pHardware->m_DataTimeout / 3600;
+						if (totNum == 1) {
+							sDataTimeout = "Hour";
+						}
+						else {
+							sDataTimeout = "Hours";
+						}
+					}
+					else {
+						totNum = pHardware->m_DataTimeout / 60;
+						if (totNum == 1) {
+							sDataTimeout = "Day";
+						}
+						else {
+							sDataTimeout = "Days";
+						}
+					}
+					_log.Log(LOG_ERROR, "%s hardware (%d) nothing received for more than %d %s!....", sd[0].c_str(), pHardware->m_HwdID, totNum, sDataTimeout.c_str());
+					m_devicestorestart.push_back(pHardware->m_HwdID);
 				}
 			}
-
 		}
 	}
 }


### PR DESCRIPTION
I've had a few times the remote connection dropped without notice, keeping the socket alive forever (well at least for about a day..). Using keepalive is a good method to prevent this, set to 600 sec instead of default 7200 sec to speed things up (except for win32, only default possible).

Data timeout set on hardware was ignored when m_bSkipReceiveCheck is set, which is used / should only be used for ignoring heartbeats. I've moved that out of it's scope, changed m_DataTimeout to int so we can check for -1 to ignore certain hardware. I've changed those that were already affected by the bSkipReceiveCheck, the authors can decide themselves if DataTimeout should be ignored or not (just m_DataTimeout = -1 to get default value of 0).

Moved disconnectTCP() to StopHardware(), so the thread continues on stopping (shutdown on socket effectively interrupts the blocking read). This fixes hanging for minutes on shutdown.