### PR TITLE
Add a quirk for the Popp Stop water cut-off valve

### DIFF
--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -1238,6 +1238,14 @@ bool COpenZWave::SwitchLight(const int nodeID, const int instanceID, const int c
 				bHandleAsBinary = true;
 			}
 		}
+		if (pDevice->Manufacturer_id == 0x0154)
+		{
+			if ((pDevice->Product_id == 0x0003) && (pDevice->Product_type == 0x0005))
+			{
+				//Special case for the Popp 009501 Flow Stop
+				bHandleAsBinary = true;
+			}
+		}
 	}
 
 	OpenZWave::ValueID vID(0, 0, OpenZWave::ValueID::ValueGenre_Basic, 0, 0, 0, OpenZWave::ValueID::ValueType_Bool);

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -1238,7 +1238,7 @@ bool COpenZWave::SwitchLight(const int nodeID, const int instanceID, const int c
 				bHandleAsBinary = true;
 			}
 		}
-		if (pDevice->Manufacturer_id == 0x0154)
+		else if (pDevice->Manufacturer_id == 0x0154)
 		{
 			if ((pDevice->Product_id == 0x0003) && (pDevice->Product_type == 0x0005))
 			{


### PR DESCRIPTION
I recently supplied a configuration file for the Popp Stop water cut-off valve to OpenZwave, and the Domoticz project has imported this (Config/popp/009501.xml). The Popp unit claims to have a multilevel setting, which is untrue (I've even opened it up to verify that the hardware can't support one; it has no position sensing, just microswitches at the end stops). My XML code, as submitted to OpenZwave, includes the rejection of this part of the configuration (using \<CommandClass id="38" action="remove" />), but while this keeps the offending bits out of the generated configuration, Domoticz still tries to send multilevel switch commands to the device.

This change adds a quirk for the device, patterned on existing ones for other devices.