### PR TITLE
Find python3.x lib on MacOS

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -300,6 +300,25 @@ namespace Plugins {
 						library = "/usr/local/lib/lib" + sLibrary + "m.so";
 						shared_lib_ = dlopen(library.c_str(), RTLD_LAZY | RTLD_GLOBAL);
 					}
+					// MacOS
+					// look for .dylib in /usr/local/lib
+					if (!shared_lib_)
+					{
+						library = "/usr/local/lib/lib" + sLibrary + ".dylib";
+						shared_lib_ = dlopen(library.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+					}
+					// look for .dylib in /Library/Frameworks/Python.framework/Versions/*/lib
+					if (!shared_lib_)
+					{
+						library = "/Library/Frameworks/Python.framework/Versions/"+sLibrary.substr(sLibrary.size() - 3)+"/lib/lib" + sLibrary + ".dylib";
+						shared_lib_ = dlopen(library.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+					}
+					// Finally look for .dylib installed by Homebrew
+					if (!shared_lib_)
+					{
+						library = "/usr/local/Frameworks/Python.framework/Versions/"+sLibrary.substr(sLibrary.size() - 3)+"/lib/lib" + sLibrary + ".dylib";
+						shared_lib_ = dlopen(library.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+					}
 				}
 				else
 				{


### PR DESCRIPTION
Improved search for libpython3.x.dylib on MacOS. 

When trying to dynamically load the python library, domoticz will now find libpython3.x.dylib installed either using the official download from www.python.org or python3 installed by using homebrew. 