### PR TITLE
Fix some Tinyxpath issues.

### DIFF
--- a/tinyxpath/byte_stream.h
+++ b/tinyxpath/byte_stream.h
@@ -50,7 +50,7 @@ public :
    /// constructor
    byte_stream (const char * cp_in)
    {
-      u_length = strlen (cp_in) + 1;
+      u_length = unsigned (strlen (cp_in)) + 1;
       bp_in = new _byte_ [u_length] ;
       memcpy (bp_in, cp_in, u_length);
       bp_current = bp_in;

--- a/tinyxpath/lex_token.h
+++ b/tinyxpath/lex_token.h
@@ -115,7 +115,7 @@ public :
 
       l_enum = lex_in;
       delete [] cp_value;
-      u_length = strlen (cp_repre);
+      u_length = unsigned(strlen (cp_repre));
       cp_value = new char [u_length + 1];
       strcpy (cp_value, cp_repre);
    }

--- a/tinyxpath/node_set.cpp
+++ b/tinyxpath/node_set.cpp
@@ -40,6 +40,16 @@ node_set & node_set::operator = (const node_set & ns2)
    u_nb_node = ns2 . u_nb_node;
    if (u_nb_node)
    {
+      if ( vpp_node_set != NULL)
+      {
+	 delete[] vpp_node_set;
+      }
+
+      if (op_attrib != NULL)
+      {
+	 delete[] op_attrib;
+      }
+	   
       vpp_node_set = new const void * [u_nb_node];
       memcpy (vpp_node_set, ns2 . vpp_node_set, u_nb_node * sizeof (void *));
       op_attrib = new bool [u_nb_node];

--- a/tinyxpath/node_set.h
+++ b/tinyxpath/node_set.h
@@ -27,7 +27,16 @@ distribution.
 
 #include "tinyxml.h"
 #include "tinyxpath_conf.h"
-
+ 
+inline double atof_locale_c (const TIXML_STRING & S_value)
+{
+    double result = 0.0;
+    std::istringstream istr (S_value);
+    istr.imbue (std::locale::classic ());
+    istr >> result;
+    return result;
+}
+ 
 namespace TinyXPath
 {
 
@@ -157,7 +166,7 @@ public :
    /// Get the real value of a node
    double d_get_value (unsigned u_which)
    {
-      return atof (S_get_value (u_which) . c_str ());
+      return atof_locale_c (S_get_value (u_which));
    }
 
    void v_copy_node_children (const TiXmlNode * XNp_root);

--- a/tinyxpath/xpath_expression.cpp
+++ b/tinyxpath/xpath_expression.cpp
@@ -57,7 +57,7 @@ double expression_result::d_get_double ()
       case e_bool :
          return o_content ? 1.0 : 0.0;
       default :
-         return atof (S_get_string () . c_str ());
+         return atof_locale_c (S_get_string ());
 	}
 }
 

--- a/tinyxpath/xpath_processor.cpp
+++ b/tinyxpath/xpath_processor.cpp
@@ -758,7 +758,7 @@ void xpath_processor::v_execute_one (
                if (! o_skip_only)
                {
                   if (strchr (S_literal . c_str (), '.'))
-                     v_push_double (atof (S_literal . c_str ()));
+                     v_push_double (atof_locale_c (S_literal));
                   else
                      v_push_int (atoi (S_literal . c_str ()), "primary number");
                }


### PR DESCRIPTION
This PR will add some unmerged patch from source forge (tinyxpath seems more or less orphaned project... unfortunatly)

- Fix for local-dependant floating point parsing
- Fix some memory leak (seems not really a big issue, well I hope someone can have a look if the patch proposed on SF is not too brain damaged)
- Fix some compilator warning about unsigned stuff.

Kind regards