### PR TITLE
Alpine/MUSL: Replace u_short by uint16_t

### DIFF
--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -126,7 +126,7 @@ int csocket::connect( const char* remoteHost, const unsigned int remotePort )
 #endif
 
 	// connect to remote socket
-	m_remoteSocketAddr.sin_port = htons((u_short)m_remotePort);
+	m_remoteSocketAddr.sin_port = htons((uint16_t)m_remotePort);
 #ifdef WIN32
 	unsigned long nonblock = 1;
 	ioctlsocket(m_socket, FIONBIO, &nonblock);

--- a/hardware/eHouse/EhouseTcpClient.cpp
+++ b/hardware/eHouse/EhouseTcpClient.cpp
@@ -254,7 +254,7 @@ void eHouseTCP::EhouseSubmitData(int SocketIndex)
 	}
 	server.sin_addr.s_addr = m_SrvAddrU | (m_SrvAddrM << 8) | (ClientCon->AddrH << 16) | (ClientCon->AddrL << 24);
 	server.sin_family = AF_INET;                    //tcp v4
-	server.sin_port = htons((u_short)m_EHOUSE_TCP_PORT);       //assign eHouse Port
+	server.sin_port = htons((uint16_t)m_EHOUSE_TCP_PORT);       //assign eHouse Port
 	if (m_DEBUG_TCPCLIENT) _log.Log(LOG_STATUS, "[TCP Cli %d] Connecting to: %s", SocketIndex, line);
 	if (connect(ClientCon->Socket, (struct sockaddr *) &server, sizeof(server)) < 0)
 	{

--- a/hardware/eHouseTCP.cpp
+++ b/hardware/eHouseTCP.cpp
@@ -602,7 +602,7 @@ int eHouseTCP::ConnectTCP(unsigned int IP)
 		saddr.sin_addr.s_addr = IP;
 	else
 		saddr.sin_addr.s_addr = m_addr.sin_addr.s_addr;
-	saddr.sin_port = htons((u_short)m_EHOUSE_TCP_PORT);
+	saddr.sin_port = htons((uint16_t)m_EHOUSE_TCP_PORT);
 	memset(&server, 0, sizeof(server));               //clear server structure
 	memset(&challange, 0, sizeof(challange));         //clear buffer
 	char line[20];
@@ -617,7 +617,7 @@ int eHouseTCP::ConnectTCP(unsigned int IP)
 	}
 	server.sin_addr.s_addr = m_addr.sin_addr.s_addr;
 	server.sin_family = AF_INET;                    //tcp v4
-	server.sin_port = htons((u_short)m_EHOUSE_TCP_PORT);       //assign eHouse Port
+	server.sin_port = htons((uint16_t)m_EHOUSE_TCP_PORT);       //assign eHouse Port
 	_log.Log(LOG_STATUS, "[TCP Cli Status] Trying Connecting to: %s", line);
 	if (connect(TCPSocket, (struct sockaddr *)&server, sizeof(server)) < 0)
 	{


### PR DESCRIPTION
u_short doesn't exist under Alpine/MUSL, changed to uint16_t as discussed into #2583