### PR TITLE
Alpine/MUSL: Fix timeval by better importing sys/time.h

### DIFF
--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -26,7 +26,6 @@
 	#include <fstream>
 	#include <string>
 	#include <limits>
-	#include <sys/time.h>
 	#include <unistd.h>
 
 	struct _tDUsageStruct

--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -13,7 +13,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
-#include <sys/time.h>
 #include <sys/errno.h>
 #include <unistd.h>
 #include <fcntl.h>

--- a/hardware/serial/impl/unix.cpp
+++ b/hardware/serial/impl/unix.cpp
@@ -24,7 +24,6 @@
 #endif
 
 #include <sys/select.h>
-#include <sys/time.h>
 #include <time.h>
 #ifdef __MACH__
 #include <AvailabilityMacros.h>

--- a/httpclient/sock_port.h
+++ b/httpclient/sock_port.h
@@ -37,7 +37,6 @@
  #include <sys/types.h>
  #include <sys/socket.h>
  #include <netdb.h>
- #include <sys/time.h>
  #include <sys/poll.h>
 
  #if !defined( NEED_IOCTLSOCKET )

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -33,7 +33,6 @@
 
 // Includes for SystemUptime()
 #if defined(__linux__) || defined(__linux) || defined(linux)
-#include <sys/time.h>
 #include <sys/sysinfo.h>
 #elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
 #include <time.h>

--- a/main/stdafx.h
+++ b/main/stdafx.h
@@ -16,6 +16,7 @@ typedef unsigned char       BYTE;
 //#include <stdlib.h>
 #include <string>
 	#include <sys/socket.h> // Needed for the socket functions
+	#include <sys/time.h>
 	#include <netdb.h>
 	#include <arpa/inet.h>
 	typedef int SOCKET;


### PR DESCRIPTION
Musl on Alpine doesn't auto include ```sys/time.h```, including it as discussed in #2583 