### PR TITLE
Small fixes for rgbww related UI

### DIFF
--- a/www/app/ScenesController.js
+++ b/www/app/ScenesController.js
@@ -566,23 +566,22 @@ define(['app'], function (app) {
 			$("#scenecontent #LevelDiv").hide();
 			if (isLED(SubType)) {
 				$("#ScenesLedColor").show();
-			} else {
-				if (bShowLevel == true) {
-					var levelDiv$ = $("#scenecontent #LevelDiv");
-					levelDiv$.find("option").show().end().show();
+			}
+			if (bShowLevel == true && !isLED(SubType)) { // TODO: Show level combo box also for LED
+				var levelDiv$ = $("#scenecontent #LevelDiv");
+				levelDiv$.find("option").show().end().show();
 
-					var dimmerValues = [];
+				var dimmerValues = [];
 
-					$.each(dimmerLevels.split(','), function (i, level) {
-						dimmerValues[i] = level;
-					});
+				$.each(dimmerLevels.split(','), function (i, level) {
+					dimmerValues[i] = level;
+				});
 
-					levelDiv$.find("option").remove();
-					for (var levelCounter = 0; levelCounter < dimmerValues.length; levelCounter++) {
-						var option = $('<option />');
-						option.attr('value', dimmerValues[levelCounter]).text(dimmerValues[levelCounter] + "%");
-						$("#scenecontent #combolevel").append(option);
-					}
+				levelDiv$.find("option").remove();
+				for (var levelCounter = 0; levelCounter < dimmerValues.length; levelCounter++) {
+					var option = $('<option />');
+					option.attr('value', dimmerValues[levelCounter]).text(dimmerValues[levelCounter] + "%");
+					$("#scenecontent #combolevel").append(option);
 				}
 			}
 		}
@@ -695,6 +694,21 @@ define(['app'], function (app) {
 			});
 
 			OnSelChangeDevice();
+
+			var DeviceIdx = $("#scenecontent #combodevice option:selected").val();
+			if (typeof DeviceIdx != 'undefined') {
+				var SubType = "";
+				var DimmerType = "";
+				$.each($.LightsAndSwitches, function (i, item) {
+					if (item.idx == DeviceIdx) {
+						SubType = item.SubType;
+						DimmerType = item.DimmerType;
+					}
+				});
+				var MaxDimLevel = 100; // Always 100 for LED type
+				if (isLED(SubType))
+					ShowRGBWPicker('#scenecontent #ScenesLedColor', DeviceIdx, 0, MaxDimLevel, 50, "", SubType, DimmerType);
+			}
 
 			RefreshDeviceTable(idx);
 			RefreshActivators();

--- a/www/app/timers/DeviceTimersController.js
+++ b/www/app/timers/DeviceTimersController.js
@@ -46,7 +46,7 @@ define(['app', 'timers/factories', 'timers/components'], function (app) {
                     }, setDeviceColor);
                 }
 
-                if (!vm.isLED && vm.isDimmer) {
+                if (vm.isDimmer) {
                     vm.levelOptions = device.getDimmerLevelOptions(1);
                 }
 

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -7590,7 +7590,7 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 	$(selector + ' #popup_picker').wheelColorPicker('setRgb', color_r/255, color_g/255, color_b/255);
 	$(selector + ' #popup_picker').wheelColorPicker('setMaster', LevelInt/MaxDimLevel);
 
-	var rgbhex = $(selector + ' #popup_picker').wheelColorPicker('getValue', 'hex');
+	var rgbhex = $(selector + ' #popup_picker').wheelColorPicker('getValue', 'hex').toUpperCase();
 	$(selector + ' .pickerrgbcolorinput').val(rgbhex);
 
 	// Update color picker controls
@@ -7600,7 +7600,7 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 		clearTimeout($.setColValue);
 
 		var color = $(this).wheelColorPicker('getColor');
-		var rgbhex = $(this).wheelColorPicker('getValue', 'hex');
+		var rgbhex = $(this).wheelColorPicker('getValue', 'hex').toUpperCase();
 		var dimlevel = Math.round((color.m*99)+1); // 1..100
 		var JSONColor = $(selector + ' #popup_picker')[0].getJSONColor();
 		//TODO: Rate limit instead of debounce

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -7486,6 +7486,14 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 			}
 		}
 
+		$(selector + ' .pickerrgbcolorrow').hide();
+		// Show RGB hex input
+		if (LEDType.bHasRGB) {
+			if (mode == "color" || mode == "color_no_master") {
+				$(selector + ' .pickerrgbcolorrow').show();
+			}
+		}
+
 		$(selector + ' #popup_picker').wheelColorPicker('refreshWidget');
 		$(selector + ' #popup_picker').wheelColorPicker('updateSliders');
 		$(selector + ' #popup_picker').wheelColorPicker('redrawSliders');
@@ -7561,9 +7569,6 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 		}
 	}
 
-	// Update color picker controls
-	UpdateColorPicker(colorPickerMode);
-
 	$(selector + ' .pickermodergb').off().click(function(){
 		UpdateColorPicker(DimmerType!="rel"?"color":"color_no_master");
 	});
@@ -7585,10 +7590,17 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 	$(selector + ' #popup_picker').wheelColorPicker('setRgb', color_r/255, color_g/255, color_b/255);
 	$(selector + ' #popup_picker').wheelColorPicker('setMaster', LevelInt/MaxDimLevel);
 
+	var rgbhex = $(selector + ' #popup_picker').wheelColorPicker('getValue', 'hex');
+	$(selector + ' .pickerrgbcolorinput').val(rgbhex);
+
+	// Update color picker controls
+	UpdateColorPicker(colorPickerMode);
+
 	$(selector + ' #popup_picker').off('slidermove sliderup').on('slidermove sliderup', function() {
 		clearTimeout($.setColValue);
 
 		var color = $(this).wheelColorPicker('getColor');
+		var rgbhex = $(this).wheelColorPicker('getValue', 'hex');
 		var dimlevel = Math.round((color.m*99)+1); // 1..100
 		var JSONColor = $(selector + ' #popup_picker')[0].getJSONColor();
 		//TODO: Rate limit instead of debounce
@@ -7596,6 +7608,10 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 			var fn = callback || SetColValue;
 			fn(devIdx, JSONColor, dimlevel);
 		}, 400);
+		$(selector + ' .pickerrgbcolorinput').val(rgbhex);
+	});
+	$(selector + ' .pickerrgbcolorinput').off('input').on('input', function() {
+		$(selector + ' #popup_picker').wheelColorPicker('setValue', this.value)
 	});
 }
 

--- a/www/views/device_light_edit.html
+++ b/www/views/device_light_edit.html
@@ -403,6 +403,11 @@
                                    data-wcp-sliders="wvkl"/>
                         </td>
                     </tr>
+                    <tr class="pickerrgbcolorrow">
+                        <td align="left" style="width:200px;padding-left:0px">
+                            {{:: 'RGB Color:' | translate }} <input type="text" class="pickerrgbcolorinput">
+                        </td>
+                    </tr>
                 </table>
             </td>
             <td align="left" style="vertical-align: top;">

--- a/www/views/scenes.html
+++ b/www/views/scenes.html
@@ -167,17 +167,16 @@
 								<a><img src="images/Customww48_Sel.png" class="lcursor pickermodecustomww selected" height="48" width="48"></a>
 							</td>
 						</tr>
-						<!--<tr id="LedColor2">
-							<td>-->
-								<!--<table class="display" id="ledtable2" border="0" cellpadding="0" cellspacing="0">-->
-								<tr>
-									<td align="left" style="width:200px;padding-left:0px">
-										<input type="text" id="popup_picker"  data-wheelcolorpicker="" data-wcp-layout="block" data-wcp-sliders="wvkl"/>
-									</td>
-								</tr>
-								<!--</table>-->
-							<!--</td>
-						</tr>-->
+						<tr>
+							<td align="left" style="width:200px;padding-left:0px">
+								<input type="text" id="popup_picker"  data-wheelcolorpicker="" data-wcp-layout="block" data-wcp-sliders="wvkl"/>
+							</td>
+						</tr>
+						<tr class="pickerrgbcolorrow">
+							<td align="left" style="width:200px;padding-left:0px">
+								{{:: 'RGB Color:' | translate }} <input type="text" class="pickerrgbcolorinput">
+							</td>
+						</tr>
 					</table>
 				</td>
 			</tr>

--- a/www/views/timers.html
+++ b/www/views/timers.html
@@ -177,7 +177,7 @@
                 </select>
             </td>
         </tr>
-        <tr id="TimersLedColor" ng-show="::vm.isColorSettingsAvailable" class="ng-hide">
+        <tr id="TimersLedColor" ng-show="::vm.isColorSettingsAvailable" class="ng-show">
             <td align="right">
                 <label>{{:: 'Color' | translate }}:</label>
             </td>
@@ -207,18 +207,17 @@
                                     height="48" width="48"></a>
                         </td>
                     </tr>
-                    <!--<tr id="LedColor2">
-                        <td>-->
-                    <!--<table class="display" id="ledtable3" border="0" cellpadding="0" cellspacing="0">-->
                     <tr>
                         <td align="left" style="width:200px;padding-left:0px">
                             <input type="text" id="popup_picker" data-wheelcolorpicker="" data-wcp-layout="block"
                                    data-wcp-sliders="wvkl"/>
                         </td>
                     </tr>
-                    <!--</table>-->
-                    <!--</td>
-                </tr>-->
+                    <tr class="pickerrgbcolorrow">
+                        <td align="left" style="width:200px;padding-left:0px">
+                            {{:: 'RGB Color:' | translate }} <input type="text" class="pickerrgbcolorinput">
+                        </td>
+                    </tr>
                 </table>
             </td>
         </tr>


### PR DESCRIPTION
Fix several small issues:

- Show hex rgb input in light edit, timer editor and scene editor for RGB lights, when color mode is RGB, as requested in #2368:
![image](https://user-images.githubusercontent.com/14281572/47609285-e550bf00-da3b-11e8-9497-640a56396ce9.png)

- Show dim level combo box in timer editor for RGB lights, as requested in #2307:
![image](https://user-images.githubusercontent.com/14281572/47609288-01546080-da3c-11e8-8715-dfe6450a4918.png)

- Fix scene editor bug when default device was RGB type

- Fix timer editor bug causing incorrect default level to be shown for RGB lights