### PR TITLE
inclreased Nest_Poll_Interval due to Nest rate limits

### DIFF
--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -97,7 +97,7 @@ bool CNest::StopHardware()
     return true;
 }
 
-#define NEST_POLL_INTERVAL 30
+#define NEST_POLL_INTERVAL 60
 
 void CNest::Do_Work()
 {

--- a/hardware/NestOAuthAPI.cpp
+++ b/hardware/NestOAuthAPI.cpp
@@ -74,7 +74,7 @@ bool CNestOAuthAPI::StopHardware()
     return true;
 }
 
-#define NEST_POLL_INTERVAL 30
+#define NEST_POLL_INTERVAL 60
 
 void CNestOAuthAPI::Do_Work()
 {


### PR DESCRIPTION
For the connection to the Nest Service, there is a rate limit, see 
[Nest](https://developers.nest.com/guides/api/data-rate-limits)

 To avoid errors, we recommend you limit requests to one call per minute, maximum.

kind regards,

Joris Weijters