### PR TITLE
fixed working of httpclient redirect

### DIFF
--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -87,6 +87,7 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+	curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
 	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
 	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);


### PR DESCRIPTION
After compilation of the domoticz, the redirection of URL by the HTTPClient didn't work anymore.
It seems:
"Starting in 7.58.0, libcurl will specifically prevent "Authorization:" headers from being sent to other hosts than the first used one, unless specifically permitted with the CURLOPT_UNRESTRICTED_AUTH option."
see https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html
 
I added parameter to make libcurl continue to send authentication (user+password) credentials when following locations, even when hostname changed.