### PR TITLE
Fixes issue #2842

### DIFF
--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -135,7 +135,6 @@ std::string CCameraHandler::GetCameraURL(cameraDevice *pCamera)
 		s_str << szURLPreFix << "://" << CURLEncode::URLEncode(pCamera->Username) << ":" << CURLEncode::URLEncode(pCamera->Password) << "@" << pCamera->Address << ":" << pCamera->Port;
 	else
 		s_str << szURLPreFix << "://" << pCamera->Address << ":" << pCamera->Port;
-
 	return s_str.str();
 }
 

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -132,9 +132,14 @@ std::string CCameraHandler::GetCameraURL(cameraDevice *pCamera)
 	std::string szURLPreFix = (pCamera->Protocol == CPROTOCOL_HTTP) ? "http" : "https";
 
 	if ((!bHaveUPinURL) && ((pCamera->Username != "") || (pCamera->Password != "")))
-		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
+// v_ok
+//		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
+		s_str << szURLPreFix << "://" << CURLEncode::URLEncode(pCamera->Username) << ":" << CURLEncode::URLEncode(pCamera->Password) << "@" << pCamera->Address << ":" << pCamera->Port;
+//v_2		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
+//v_3		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
 	else
 		s_str << szURLPreFix << "://" << pCamera->Address << ":" << pCamera->Port;
+
 	return s_str.str();
 }
 

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -132,11 +132,7 @@ std::string CCameraHandler::GetCameraURL(cameraDevice *pCamera)
 	std::string szURLPreFix = (pCamera->Protocol == CPROTOCOL_HTTP) ? "http" : "https";
 
 	if ((!bHaveUPinURL) && ((pCamera->Username != "") || (pCamera->Password != "")))
-// v_ok
-//		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
 		s_str << szURLPreFix << "://" << CURLEncode::URLEncode(pCamera->Username) << ":" << CURLEncode::URLEncode(pCamera->Password) << "@" << pCamera->Address << ":" << pCamera->Port;
-//v_2		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
-//v_3		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
 	else
 		s_str << szURLPreFix << "://" << pCamera->Address << ":" << pCamera->Port;
 

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -132,7 +132,7 @@ std::string CCameraHandler::GetCameraURL(cameraDevice *pCamera)
 	std::string szURLPreFix = (pCamera->Protocol == CPROTOCOL_HTTP) ? "http" : "https";
 
 	if ((!bHaveUPinURL) && ((pCamera->Username != "") || (pCamera->Password != "")))
-		s_str << szURLPreFix << "://" << pCamera->Username << ":" << pCamera->Password << "@" << pCamera->Address << ":" << pCamera->Port;
+		s_str << szURLPreFix << "://" << CURLEncode::URLEncode((pCamera->Username).c_str()).c_str() << ":" << CURLEncode::URLEncode((pCamera->Password).c_str()).c_str() << "@" << pCamera->Address << ":" << pCamera->Port;
 	else
 		s_str << szURLPreFix << "://" << pCamera->Address << ":" << pCamera->Port;
 	return s_str.str();


### PR DESCRIPTION
This pull request fixes issue #2842 - Username and password used in URL for downloading images from cameras should be url encoded.