### PR TITLE
Add parsing of current readings to P1MeterBase code

### DIFF
--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -33,7 +33,7 @@ enum _eP1MatchType {
 #define P1VOLTL3	"1-0:72.7.0"	// voltage L3 (DSMRv5)
 #define P1AMPEREL1	"1-0:31.7.0"	// amperage L1 (DSMRv5)
 #define P1AMPEREL2	"1-0:51.7.0"	// amperage L2 (DSMRv5)
-#define P1AMPEREL3	"1-0:71.7.0"	// amerage L3 (DSMRv5)
+#define P1AMPEREL3	"1-0:71.7.0"	// amperage L3 (DSMRv5)
 #define P1GTS		"0-n:24.3.0"	// DSMR2 timestamp gas usage sample
 #define P1GUDSMR2	"("		// DSMR2 gas usage sample
 #define P1GUDSMR4	"0-n:24.2.1"	// DSMR4 gas usage sample

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -31,6 +31,9 @@ enum _eP1MatchType {
 #define P1VOLTL1	"1-0:32.7.0"	// voltage L1 (DSMRv5)
 #define P1VOLTL2	"1-0:52.7.0"	// voltage L2 (DSMRv5)
 #define P1VOLTL3	"1-0:72.7.0"	// voltage L3 (DSMRv5)
+#define P1AMPEREL1	"1-0:31.7.0"	// amperage L1 (DSMRv5)
+#define P1AMPEREL2	"1-0:51.7.0"	// amperage L2 (DSMRv5)
+#define P1AMPEREL3	"1-0:71.7.0"	// amerage L3 (DSMRv5)
 #define P1GTS		"0-n:24.3.0"	// DSMR2 timestamp gas usage sample
 #define P1GUDSMR2	"("		// DSMR2 gas usage sample
 #define P1GUDSMR4	"0-n:24.2.1"	// DSMR4 gas usage sample
@@ -50,6 +53,9 @@ enum _eP1Type {
 	P1TYPE_VOLTAGEL1,
 	P1TYPE_VOLTAGEL2,
 	P1TYPE_VOLTAGEL3,
+	P1TYPE_AMPERAGEL1,
+	P1TYPE_AMPERAGEL2,
+	P1TYPE_AMPERAGEL3,
 	P1TYPE_MBUSDEVICETYPE,
 	P1TYPE_GASUSAGEDSMR4,
 	P1TYPE_GASTIMESTAMP,
@@ -78,6 +84,9 @@ P1Match matchlist[] = {
 	{STD,		P1TYPE_VOLTAGEL1,		P1VOLTL1,	"voltagel1",		11,  5},
 	{STD,		P1TYPE_VOLTAGEL2,		P1VOLTL2,	"voltagel2",		11,  5},
 	{STD,		P1TYPE_VOLTAGEL3,		P1VOLTL3,	"voltagel3",		11,  5},
+	{STD,		P1TYPE_AMPERAGEL1,		P1AMPEREL1,	"amperagel1",		11,  3},
+	{STD,		P1TYPE_AMPERAGEL2,		P1AMPEREL2,	"amperagel2",		11,  3},
+	{STD,		P1TYPE_AMPERAGEL3,		P1AMPEREL3,	"amperagel3",		11,  3},
 	{DEVTYPE,	P1TYPE_MBUSDEVICETYPE,		P1MBTYPE,	"mbusdevicetype",	11,  3},
 	{GAS,		P1TYPE_GASUSAGEDSMR4,		P1GUDSMR4,	"gasusage",	 	26,  8},
 	{LINE17,	P1TYPE_GASTIMESTAMP,		P1GTS,		"gastimestamp",		11, 12},
@@ -113,6 +122,10 @@ void P1MeterBase::Init()
 	m_voltagel1 = 0;
 	m_voltagel2 = 0;
 	m_voltagel3 = 0;
+
+	m_amperagel1=0;
+	m_amperagel2=0;
+	m_amperagel3=0;
 
 	memset(&m_buffer, 0, sizeof(m_buffer));
 	memset(&l_buffer, 0, sizeof(l_buffer));
@@ -241,6 +254,9 @@ bool P1MeterBase::MatchLine()
 					if (m_voltagel3)
 						SendVoltageSensor(0, 3, 255, m_voltagel3, "Voltage L3");
 				}
+				if (m_amperagel1 || m_amperagel2 || m_amperagel3 ) {
+					SendCurrentSensor(0, 255, m_amperagel1, m_amperagel2, m_amperagel3, "Amperage" );
+				}
 				if ((m_gas.gasusage > 0) && ((m_gas.gasusage != m_lastgasusage) || (difftime(atime, m_lastSharedSendGas) >= 300)))
 				{
 					//only update gas when there is a new value, or 5 minutes are passed
@@ -329,6 +345,7 @@ bool P1MeterBase::MatchLine()
 
 			unsigned long temp_usage = 0;
 			float temp_volt = 0;
+			float temp_ampere = 0;
 			char *validate = value + ePos;
 
 			switch (t->type)
@@ -400,6 +417,20 @@ bool P1MeterBase::MatchLine()
 				if (temp_volt < 300)
 					m_voltagel3 = temp_volt; //Voltage L3;
 				break;
+			case P1TYPE_AMPERAGEL1:
+				temp_ampere = strtof(value,&validate);
+				if (temp_ampere < 100)
+					m_amperagel1 = temp_ampere; //Amperage L1;
+				break;
+			case P1TYPE_AMPERAGEL2:
+				temp_ampere = strtof(value,&validate);
+				if (temp_ampere < 100)
+					m_amperagel2 = temp_ampere; //Amperage L2;
+				break;
+			case P1TYPE_AMPERAGEL3:
+				temp_ampere = strtof(value,&validate);
+				if (temp_ampere < 100)
+					m_amperagel3 = temp_ampere; //Amperage L3;
 			case P1TYPE_GASTIMESTAMP:
 				m_gastimestamp = std::string(value);
 				break;

--- a/hardware/P1MeterBase.h
+++ b/hardware/P1MeterBase.h
@@ -38,6 +38,10 @@ private:
 	float m_voltagel2;
 	float m_voltagel3;
 
+	float m_amperagel1;
+	float m_amperagel2;
+	float m_amperagel3;
+
 	unsigned char m_gasmbuschannel;
 	std::string m_gasprefix;
 	std::string m_gastimestamp;


### PR DESCRIPTION
The DSMR telegram contains current values for all phases L1, L2, L3. The current P1MeterBase code does not parse those values.

This PR adds code to read those values and output them to a current sensor.