### PR TITLE
dzVents update to 2.4.9; bugfixes (wind and youless device-adapter and twilight-handling) add  setHotWater for evohome

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,7 +6,7 @@ Version 4.xxxx (October xxth 2018)
 - Implemented: RFXMeter, Option to specify meter divider
 - Implemented: Starting implementation of Taiwanese language (big thanks to berry lin!)
 - Fixed: Philips Hue, should work correctly now again
-- Updated: Dzvents (version 2.4.8, See dzVents/documentation/history.md )
+- Updated: Dzvents (version 2.4.9, See dzVents/documentation/history.md)
 
 Version 4.9700 (June 23th 2018)
 - Implemented: Blockly, now possible to directly add/update Text devices

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -1969,6 +1969,7 @@ On the other hand, you have to make sure that dzVents can access the json withou
 - Add speedMs and gustMs from wind devices 
 - bugfix for youless device (0 handling)
 - bugfix for time ( twilightstart and twilightend handling)
+- Fixed some date-range rule checking
 
 ##[2.4.8]
 - Added telegram as option for domoticz.notify

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -619,7 +619,7 @@ The domoticz object has these constants available for use in your code e.g. `dom
  - **BASETYPE_DEVICE**, **BASETYPE_SCENE**, **BASETYPE_GROUP**, **BASETYPE_VARIABLE**, **BASETYPE_SECURITY**, **BASETYPE_TIMER**, **BASETYPE_HTTP_RESPONSE**: indicators for the various object types that are passed as the second parameter to the execute function. E.g. you can check if an object is a device object: `if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end`.
  - **BARO_CLOUDY**, **BARO_CLOUDY_RAIN**, **BARO_STABLE**, **BARO_SUNNY**, **BARO_THUNDERSTORM**, **BARO_NOINFO**, **BARO_UNSTABLE**: for updating barometric values.
  - **EVENT_TYPE_DEVICE**, **EVENT_TYPE_VARIABLE**, **EVENT_TYPE_SECURITY**,  **EVENT_TYPE_HTTPRESPONSE**<sup>2.4.0</sup>, **EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
- - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_TEMPORARY_OVERRIDE**, **EVOHOME_MODE_PERMANENT_OVERRIDE**: mode for EvoHome system.
+ - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_TEMPORARY_OVERRIDE**, **EVOHOME_MODE_PERMANENT_OVERRIDE**, **EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
  - **HUM_COMFORTABLE**, **HUM_DRY**, **HUM_NORMAL**, **HUM_WET**: constant for humidity status.
  - **INTEGER**, **FLOAT**, **STRING**, **DATE**, **TIME**: variable types.
  - **LOG_DEBUG**, **LOG_ERROR**, **LOG_INFO**, **LOG_FORCE**: for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
@@ -712,10 +712,18 @@ Note that if you do not find your specific device type here you can always inspe
  - **WhActual**: *Number*. Current Watt usage.
  - **updateEnergy(energy)**: *Function*. In Watt. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
-#### Evohome
+#### Evohome (zones)
  - **setPoint**: *Number*.
- - **updateSetPoint(setPoint, mode, until)**: *Function*. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE or EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **mode**: *string* <sup>2.4.9</sup>.
+ - **untilDate**: *string in ISO 8601 format* or n/a <sup>2.4.9</sup>.
+ - **updateSetPoint(setPoint, mode, until)**: *Function*. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE <sup>2.4.9</sup> or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
+#### Evohome (hotWater) <sup>2.4.9</sup>.
+ - **state**: *string*  ('On' or 'Off')
+ - **mode**: *string* 
+ - **untilDate**: *string in ISO 8601 format* or n/a.
+ - **setHotWater(state, mode, until)**: *Function*. set HotWater Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE You can provide an until date (in ISO 8601 format for domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE e.g.: `os.date("!%Y-%m-%dT%TZ")`). 
+ 
 #### Gas
  - **counter**: *Number*. Value in m<sup>3</sup>
  - **counterToday**: *Number*. Value in m<sup>3</sup>
@@ -922,9 +930,11 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **chill**: *Number*.
  - **direction**: *Number*. Degrees.
  - **directionString**: *String*. Formatted wind direction like N, SE.
- - **gust**: *Number*.
+ - **gust**: *Number*. ( in meters / second, might change in future releases to Meters/Counters settings for Wind Meter ) 
+ - **gustMs**: *Number*. Gust ( in meters / second ) <sup>2.4.9</sup>
  - **temperature**: *Number*
- - **speed**: *Number*.
+ - **speed**: *Number*. Windspeed ( in the unit set in Meters/Counters settings for Wind Meter )
+ - **speedMs**: *Number*. Windspeed ( in meters / second ) <sup>2.4.9</sup>
  - **updateWind(bearing, direction, speed, gust, temperature, chill)**: *Function*. Bearing in degrees, direction in N, S, NNW etc, speed in m/s, gust in m/s, temperature and chill in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Youless meter <sup>2.4.6</sup>
@@ -1952,8 +1962,15 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # Change log
+##[2.4.9]
+- Added evohome hotwater device (state, mode, untilDate and setHotWater function)
+- Added mode and untilDate for evohome zone devices 
+- Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
+- Add speedMs and gustMs from wind devices 
+- bugfix for youless device (0 handling)
+- bugfix for time ( twilightstart and twilightend handling)
 
-[2.4.8]
+##[2.4.8]
 - Added telegram as option for domoticz.notify
 
 ##[2.4.7]

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -610,7 +610,7 @@ The domoticz object has these constants available for use in your code e.g. <cod
 * '''BASETYPE_DEVICE''', '''BASETYPE_SCENE''', '''BASETYPE_GROUP''', '''BASETYPE_VARIABLE''', '''BASETYPE_SECURITY''', '''BASETYPE_TIMER''', '''BASETYPE_HTTP_RESPONSE''': indicators for the various object types that are passed as the second parameter to the execute function. E.g. you can check if an object is a device object: <code>if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end</code>.
 * '''BARO_CLOUDY''', '''BARO_CLOUDY_RAIN''', '''BARO_STABLE''', '''BARO_SUNNY''', '''BARO_THUNDERSTORM''', '''BARO_NOINFO''', '''BARO_UNSTABLE''': for updating barometric values.
 * '''EVENT_TYPE_DEVICE''', '''EVENT_TYPE_VARIABLE''', '''EVENT_TYPE_SECURITY''', '''EVENT_TYPE_HTTPRESPONSE'''<sup>2.4.0</sup>, '''EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
-* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_TEMPORARY_OVERRIDE''', '''EVOHOME_MODE_PERMANENT_OVERRIDE''': mode for EvoHome system.
+* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_TEMPORARY_OVERRIDE''', '''EVOHOME_MODE_PERMANENT_OVERRIDE''', '''EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
 * '''HUM_COMFORTABLE''', '''HUM_DRY''', '''HUM_NORMAL''', '''HUM_WET''': constant for humidity status.
 * '''INTEGER''', '''FLOAT''', '''STRING''', '''DATE''', '''TIME''': variable types.
 * '''LOG_DEBUG''', '''LOG_ERROR''', '''LOG_INFO''', '''LOG_FORCE''': for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
@@ -715,10 +715,19 @@ Note that if you do not find your specific device type here you can always inspe
 * '''WhActual''': ''Number''. Current Watt usage.
 * '''updateEnergy(energy)''': ''Function''. In Watt. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
-==== Evohome ====
+==== Evohome (zones) ====
 
 * '''setPoint''': ''Number''.
-* '''updateSetPoint(setPoint, mode, until)''': ''Function''. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE or EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''mode''': ''string'' <sup>2.4.9</sup>.
+* '''untilDate''': ''string in ISO 8601 format'' or n/a <sup>2.4.9</sup>.
+* '''updateSetPoint(setPoint, mode, until)''': ''Function''. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE <sup>2.4.9</sup> or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+
+==== Evohome (hotWater) <sup>2.4.9</sup>. ====
+
+* '''state''': ''string'' ('On' or 'Off')
+* '''mode''': ''string''
+* '''untilDate''': ''string in ISO 8601 format'' or n/a.
+* '''setHotWater(state, mode, until)''': ''Function''. set HotWater Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE You can provide an until date (in ISO 8601 format for domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>).
 
 ==== Gas ====
 
@@ -960,9 +969,11 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''chill''': ''Number''.
 * '''direction''': ''Number''. Degrees.
 * '''directionString''': ''String''. Formatted wind direction like N, SE.
-* '''gust''': ''Number''.
+* '''gust''': ''Number''. ( in meters / second, might change in future releases to Meters/Counters settings for Wind Meter )
+* '''gustMs''': ''Number''. Gust ( in meters / second ) <sup>2.4.9</sup>
 * '''temperature''': ''Number''
-* '''speed''': ''Number''.
+* '''speed''': ''Number''. Windspeed ( in the unit set in Meters/Counters settings for Wind Meter )
+* '''speedMs''': ''Number''. Windspeed ( in meters / second ) <sup>2.4.9</sup>
 * '''updateWind(bearing, direction, speed, gust, temperature, chill)''': ''Function''. Bearing in degrees, direction in N, S, NNW etc, speed in m/s, gust in m/s, temperature and chill in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Youless meter <sup>2.4.6</sup> ====
@@ -2038,7 +2049,18 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 = Change log =
 
-[2.4.8] - Added telegram as option for domoticz.notify
+== [2.4.9] ==
+
+* Added evohome hotwater device (state, mode, untilDate and setHotWater function)
+* Added mode and untilDate for evohome zone devices
+* Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
+* Add speedMs and gustMs from wind devices
+* bugfix for youless device (0 handling)
+* bugfix for time ( twilightstart and twilightend handling)
+
+== [2.4.8] ==
+
+* Added telegram as option for domoticz.notify
 
 == [2.4.7] ==
 

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -2057,6 +2057,7 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Add speedMs and gustMs from wind devices
 * bugfix for youless device (0 handling)
 * bugfix for time ( twilightstart and twilightend handling)
+* Fixed some date-range rule checking
 
 == [2.4.8] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -6,6 +6,7 @@
 - bugfix for youless device (0 handling)
 - bugfix for time ( twilightstart and twilightend handling)
 - Added tests for twilight and device functions (hotwater) and attributes (evohome- and wind devices)
+- Fixed some date-range rule checking
 
 [2.4.8]
 - Added telegram as option for domoticz.notify

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,12 @@
+[2.4.9]
+- Added evohome hotwater device (state, mode, untilDate and setHotWater function)
+- Added mode and untilDate for evohome zone devices 
+- Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
+- Add speedMs and gustMs from wind devices 
+- bugfix for youless device (0 handling)
+- bugfix for time ( twilightstart and twilightend handling)
+- Added tests for twilight and device functions (hotwater) and attributes (evohome- and wind devices)
+
 [2.4.8]
 - Added telegram as option for domoticz.notify
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,6 @@
+[2.4.9]
+- 
+
 [2.4.8]
 - Added telegram as option for domoticz.notify
 

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -121,6 +121,7 @@ local function Domoticz(settings)
 		['EVOHOME_MODE_AUTO'] = 'Auto',
 		['EVOHOME_MODE_TEMPORARY_OVERRIDE'] = 'TemporaryOverride',
 		['EVOHOME_MODE_PERMANENT_OVERRIDE'] = 'PermanentOverride',
+		['EVOHOME_MODE_FOLLOW_SCHEDULE'] = 'FollowSchedule',
 		['INTEGER'] = 'integer',
 		['FLOAT'] = 'float',
 		['STRING'] = 'string',

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -498,8 +498,6 @@ local function Time(sDate, isUTC, _testMS)
 			return true
 		end
 
-
-
 		-- wildcards
 		for set, day, month in string.gmatch(dates, '(([0-9%*]*)/([0-9%*]*))') do
 			if (day == '*' and month ~= '*') then
@@ -537,12 +535,20 @@ local function Time(sDate, isUTC, _testMS)
 
 				toDay, toMonth = getParts(toSet)
 				fromDay, fromMonth = getParts(fromSet)
-
+				--local _ = require('lodash');
+				--_.print('sm', self.month, 'sd', self.day, 'fm', fromMonth, 'tm', toMonth, 'fd', fromDay, 'td', toDay)
+				--_.print('( self.month > fromMonth and self.month < toMonth )', (self.month > fromMonth and self.month < toMonth))
+				--_.print('( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or', (fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay))
+				--_.print('( self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay ) or', (self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay) )
+				--_.print('( self.month == toMonth and toMonth < fromMonth and  self.day <= toDay )', (self.month == toMonth and toMonth < fromMonth and self.day <= toDay))
+				--_.print('( self.month == toMonth and toMonth > fromMonth and self.day <= toDay )', (self.month == toMonth and toMonth > fromMonth and self.day <= toDay))
 				if (
 					( self.month > fromMonth and self.month < toMonth ) or
 					( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or
-					( self.month == fromMonth and self.day >= fromDay ) or
-					( self.month == toMonth and self.day <= toDay )
+					( self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay ) or
+					( self.month == fromMonth and toMonth > fromMonth and self.day >= fromDay ) or
+					( self.month == toMonth and toMonth < fromMonth and  self.day <= toDay ) or
+					( self.month == toMonth and toMonth > fromMonth and self.day <= toDay )
 				) then
 					return true
 				end
@@ -993,6 +999,7 @@ local function Time(sDate, isUTC, _testMS)
 			-- on any of the specified weeks
 			return false
 		end
+
 		updateTotal(res)
 
 		res = self.ruleIsOnDate(rule)
@@ -1002,6 +1009,8 @@ local function Time(sDate, isUTC, _testMS)
 			return false
 		end
 		updateTotal(res)
+
+
 
 		res = self.ruleIsOnDay(rule) -- range
 		if (res == false) then

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -923,13 +923,13 @@ local function Time(sDate, isUTC, _testMS)
 
 		-- check at civiltwilightstart
 		local twilightstart = string.match(moment, 'civiltwilightstart')
-		if (twilight) then
+		if (twilightstart) then
 			return minutesToTime(getCivilTwilightStart())
 		end
 
 		-- check at civiltwilightend
 		local twilightend = string.match(moment, 'civiltwilightend')
-		if (twilight) then
+		if (twilightend) then
 			return minutesToTime(getCivilTwilightEnd())
 		end
 

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -103,7 +103,7 @@ function self.log(msg, level)
 
 
 	if (level == self.LOG_ERROR) then
-		marker = marker .. 'Error (2.4.8): '
+		marker = marker .. 'Error (2.4.9): '
 	elseif (level == self.LOG_DEBUG) then
 		marker = marker .. 'Debug: '
 	elseif (level == self.LOG_INFO or level == self.LOG_MODULE_EXEC_INFO) then

--- a/dzVents/runtime/device-adapters/evohome_device.lua
+++ b/dzVents/runtime/device-adapters/evohome_device.lua
@@ -16,25 +16,45 @@ return {
 
 		if (not res) then
 			adapterManager.addDummyMethod(device, 'updateSetPoint')
+			adapterManager.addDummyMethod(device, 'setHotWater')
 		end
 
 		return res
 
-	end,
+    end,
 
-	process = function (device, data, domoticz, utils, adapterManager)
+    process = function (device, data, domoticz, utils, adapterManager)
 
-		device.setPoint = tonumber(device.rawData[1] or 0)
+        if (device.deviceSubType == "Hot Water" ) then
 
-		function device.updateSetPoint(setPoint, mode, untilDate)
-			return TimedCommand(domoticz,
-				'SetSetPoint:' ..
-				tostring(device.id),
-			   tostring(setPoint) ..
-			   '#' .. tostring(mode) ..
-			   '#' .. tostring(untilDate) , 'setpoint')
-		end
+            if device.rawData[2] == "On" then device.state = "On" else device.state = "Off" end
+            device.mode = tostring(device.rawData[3] or "n/a")
+            device.untilDate = tostring(device.rawData[4] or "n/a")
 
+            function device.setHotWater(state, mode, untilDate)
+                 if mode == 'TemporaryOverride' and untilDate then
+                    mode = mode .. "&until=" .. untilDate 
+                 end
+                local url = domoticz.settings['Domoticz url'] ..
+                            "/json.htm?type=setused&idx=" .. device.id ..
+                            "&setpoint=&state=" .. state ..
+                            "&mode=" .. mode ..
+                            "&used=true"
+                return domoticz.openURL(url)
+            end
+        else
+
+            device.setPoint = tonumber(device.rawData[1] or 0)
+            device.mode = tostring(device.rawData[3])
+            device.untilDate = tostring(device.rawData[4] or "n/a")
+            
+            function device.updateSetPoint(setPoint, mode, untilDate)
+                return TimedCommand(domoticz,
+                    'SetSetPoint:' .. tostring(device.id),
+                                      tostring(setPoint) .. '#' .. 
+                                      tostring(mode) .. '#' .. 
+                                      tostring(untilDate) , 'setpoint')
+            end
+        end
 	end
-
 }

--- a/dzVents/runtime/device-adapters/wind_device.lua
+++ b/dzVents/runtime/device-adapters/wind_device.lua
@@ -14,9 +14,14 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		-- from data: direction, speed, directionString
+        -- from data:   direction, 
+        --              speed (in the unit set in Meters / Counters Wind Meter unit), 
+        --              directionString
 
-		device.gust = tonumber(device.rawData[4]) / 10
+		device.speedMs = domoticz.utils.round(tonumber(device.rawData[3]) / 10,1)
+		device.gustMs = domoticz.utils.round(tonumber(device.rawData[4]) / 10,1)
+
+        device.gust = tonumber(device.rawData[4]) / 10     -- Until gust is in data ( like speed already is ) we take it from sValues
 		device.temperature = tonumber(device.rawData[5])
 		device.chill = tonumber(device.rawData[6])
 

--- a/dzVents/runtime/device-adapters/wind_device.lua
+++ b/dzVents/runtime/device-adapters/wind_device.lua
@@ -18,8 +18,8 @@ return {
         --              speed (in the unit set in Meters / Counters Wind Meter unit), 
         --              directionString
 
-		device.speedMs = domoticz.utils.round(tonumber(device.rawData[3]) / 10,1)
-		device.gustMs = domoticz.utils.round(tonumber(device.rawData[4]) / 10,1)
+		device.speedMs = adapterManager.round(tonumber(device.rawData[3]) / 10,1)
+		device.gustMs = adapterManager.round(tonumber(device.rawData[4]) / 10,1)
 
         device.gust = tonumber(device.rawData[4]) / 10     -- Until gust is in data ( like speed already is ) we take it from sValues
 		device.temperature = tonumber(device.rawData[5])

--- a/dzVents/runtime/device-adapters/youless_device.lua
+++ b/dzVents/runtime/device-adapters/youless_device.lua
@@ -13,11 +13,11 @@ return {
 	end,
 
 	process = function(device, data, domoticz, utils, adapterManager)
-		-- from data: current, Kwh.
+		-- from data: current, 
 		device.counterDeliveredTotal = tonumber(device.rawData[1])
 		device.powerYield = tonumber(device.rawData[2])
-		device.counterDeliveredToday = tonumber((string.gsub(device.counterToday, "kWh", ""))) * 1000
-
+		device.counterDeliveredToday = (string.match(device.counterToday, "%d+.%d*") or 0) * 1000
+        	
 		function device.updateYouless(total, actual)
 			local value = tostring(total) .. ';' ..
 					tostring(actual)

--- a/dzVents/runtime/dzVents.lua
+++ b/dzVents/runtime/dzVents.lua
@@ -39,7 +39,7 @@ if (tonumber(globalvariables['dzVents_log_level']) == utils.LOG_DEBUG or TESTMOD
 
 	local events, length = helpers.getEventSummary()
 	if (length > 0) then
-		print('Debug: dzVents version: 2.4.8')
+		print('Debug: dzVents version: 2.4.9')
 
 		print('Debug: Event triggers:')
 		for i, event in pairs(events) do

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1178,6 +1178,23 @@ describe('Time', function()
 						assert.is_true(t.ruleMatchesBetweenRange(rule))
 					end)
 
+                    it('between sunset and civiltwilightend',function()
+                    	_G.timeofday = {
+							['CivTwilightStartInMinutes'] = 1070, -- 17:50
+							['CivTwilightEndInMinutes'] = 1090, -- 18:10
+							['SunsetInMinutes'] = 1080,
+                            ['Civildaytime'] = true,
+                            ['Civilnighttime'] = false    -- 18:00
+                                        } 
+						local rule = 'between sunset and civiltwilightend'
+
+						local t = Time('2017-01-01 18:05:00')
+						assert.is_true(t.ruleMatchesBetweenRange(rule))
+
+						local t = Time('2017-01-01 23:12:00')
+						assert.is_false(t.ruleMatchesBetweenRange(rule))
+					end)
+                    
 					it('between sunset and 22:33', function()
 						_G.timeofday = {
 							['SunriseInMinutes'] = 360, -- 06:00

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1085,7 +1085,7 @@ describe('Time', function()
 
 
 				end)
-                
+
                 describe('twilight stuff', function()
 
 					it('between civiltwilightend and civiltwilightstart', function()
@@ -1159,7 +1159,7 @@ describe('Time', function()
 						assert.is_true(t.ruleMatchesBetweenRange(rule))
 					end)
 				end)
-                
+
 				describe('sun stuff', function()
 
 					it('between sunset and sunrise', function()
@@ -1435,7 +1435,7 @@ describe('Time', function()
 					local t = Time('2017-06-20 02:04:00')
 					assert.is_true(t.ruleIsOnDate('on 20/5-22/6'))
 
-					t = Time('2017-05-20 02:04:00')
+					local t = Time('2017-05-20 02:04:00')
 					assert.is_true(t.ruleIsOnDate('on 20/5-22/6'))
 
 					t = Time('2017-05-21 02:04:00')
@@ -1561,6 +1561,11 @@ describe('Time', function()
 
 			end)
 
+			it('on date 20/10-31/10', function()
+				local t = Time('2018-10-19 16:00:00') -- on monday, wk43
+				assert.is_false(t.matchesRule('on 20/10-31/10'))
+			end)
+
 			it('at 08:00-15:00 on 21/4-30/4', function()
 				local t = Time('2017-04-21 08:04:00')
 				assert.is_true(t.matchesRule('at 08:00-15:00 on 21/4-30/4'))
@@ -1611,7 +1616,7 @@ describe('Time', function()
 			it('every 10 minutes between 2 minutes after sunset and 22:33 on 20/11-20/12 in week 49 on mon,fri', function()
 				_G.timeofday = {
 					['SunriseInMinutes'] = 360, -- 06:00
-					['SunsetInMinutes'] = 1080
+					['SunsetInMinutes'] = 1080 -- 18:00
 				}
 
 				local rule = 'every 10 minutes between 2 minutes after sunset and 22:33 on 20/11-20/12 in week 49 on mon,fri'
@@ -1620,9 +1625,9 @@ describe('Time', function()
 				assert.is_false(t.matchesRule(rule))
 
 				t = Time('2017-11-24 18:10:00') -- on fri, week 47
-				assert.is_false(t.matchesRule(rule))
+				assert.is_false(t.matchesRule(rule)) -- should fail because t is in week 47
 
-				t = Time('2017-12-08 18:10:00') -- on fri, week 49
+				local t = Time('2017-12-08 18:10:00') -- on fri, week 49
 				assert.is_true(t.matchesRule(rule))
 
 				t = Time('2017-12-04 18:10:00') -- on mon, week 49

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1085,7 +1085,81 @@ describe('Time', function()
 
 
 				end)
+                
+                describe('twilight stuff', function()
 
+					it('between civiltwilightend and civiltwilightstart', function()
+						_G.timeofday = {
+							['CivTwilightStartInMinutes'] = 360 , -- 06:00
+							['CivTwilightEndInMinutes'] = 1080
+						}
+
+						-- time between 18:00 and 06:00
+						local t = Time('2017-01-01 01:04:00')
+						assert.is_true(t.ruleMatchesBetweenRange('between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 17:00:00')
+						assert.is_false(t.ruleMatchesBetweenRange('between civiltwilightend and civiltwilightstart'))
+					end)
+
+					it('every x minute between civiltwilightend and civiltwilightstart', function()
+						_G.timeofday = {
+							['CivTwilightStartInMinutes'] = 360 , -- 06:00
+							['CivTwilightEndInMinutes'] = 1080
+						}
+
+						-- time between 18:00 and 06:00
+						t = Time('2017-01-01 01:01:00')
+						assert.is_false(t.matchesRule('every 2 minutes between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 01:01:00')
+						assert.is_true(t.matchesRule('every 1 minutes between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 01:02:00')
+						assert.is_true(t.matchesRule('every 2 minutes between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 17:00:00')
+						assert.is_false(t.matchesRule('every 2 minutes between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 17:01:00')
+						assert.is_false(t.matchesRule('every 2 minutes between civiltwilightend and civiltwilightstart'))
+
+						t = Time('2017-01-01 17:01:00')
+						assert.is_false(t.matchesRule('every 1 minutes between civiltwilightend and civiltwilightstart'))
+					end)
+
+					it('between civiltwilightstart and civiltwilightend', function()
+
+						_G.timeofday = {
+							['CivTwilightStartInMinutes'] = 360, -- 06:00
+							['CivTwilightEndInMinutes'] = 1080
+						}
+
+						-- time between 06:00 and 18:00
+						local t = Time('2017-01-01 11:04:00')
+
+						assert.is_true(t.ruleMatchesBetweenRange('between civiltwilightstart and civiltwilightend'))
+					end)
+
+					it('between 10 minutes before civiltwilightstart and 10 minutes after civiltwilightend', function()
+
+						_G.timeofday = {
+							['CivTwilightStartInMinutes'] = 360, -- 06:00
+							['CivTwilightEndInMinutes'] = 1080 -- 18:00
+						}
+
+						local rule = 'between 10 minutes before civiltwilightstart and 10 minutes after civiltwilightend'
+						-- time between 06:00 and 18:00
+						local t = Time('2017-01-01 05:55:00')
+
+						assert.is_true(t.ruleMatchesBetweenRange(rule))
+
+						local t = Time('2017-01-01 18:06:00')
+
+						assert.is_true(t.ruleMatchesBetweenRange(rule))
+					end)
+				end)
+                
 				describe('sun stuff', function()
 
 					it('between sunset and sunrise', function()
@@ -1178,23 +1252,6 @@ describe('Time', function()
 						assert.is_true(t.ruleMatchesBetweenRange(rule))
 					end)
 
-                    it('between sunset and civiltwilightend',function()
-                    	_G.timeofday = {
-							['CivTwilightStartInMinutes'] = 1070, -- 17:50
-							['CivTwilightEndInMinutes'] = 1090, -- 18:10
-							['SunsetInMinutes'] = 1080,
-                            ['Civildaytime'] = true,
-                            ['Civilnighttime'] = false    -- 18:00
-                                        } 
-						local rule = 'between sunset and civiltwilightend'
-
-						local t = Time('2017-01-01 18:05:00')
-						assert.is_true(t.ruleMatchesBetweenRange(rule))
-
-						local t = Time('2017-01-01 23:12:00')
-						assert.is_false(t.ruleMatchesBetweenRange(rule))
-					end)
-                    
 					it('between sunset and 22:33', function()
 						_G.timeofday = {
 							['SunriseInMinutes'] = 360, -- 06:00

--- a/dzVents/runtime/tests/testUtils.lua
+++ b/dzVents/runtime/tests/testUtils.lua
@@ -38,7 +38,7 @@ describe('event helpers', function()
 			end
 
 			utils.log('abc', utils.LOG_ERROR)
-			assert.is_same('Error (2.4.8): abc', printed)
+			assert.is_same('Error (2.4.9): abc', printed)
 		end)
 
 		it('shoud log INFO by default', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -16,7 +16,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("2.4.8")
+	m_version("2.4.9")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION
	modified:   README.md
	modified:   README.wiki
	modified:   ../runtime/Domoticz.lua
	modified:   ../runtime/Time.lua
	modified:   ../runtime/Utils.lua
	modified:   ../runtime/device-adapters/evohome_device.lua
	modified:   ../runtime/device-adapters/wind_device.lua
	modified:   ../runtime/device-adapters/youless_device.lua
	modified:   ../runtime/dzVents.lua
	modified:   ../runtime/tests/testUtils.lua
	modified:   ../../main/dzVents.cpp