### PR TITLE
CMakeLists.txt: fix build with python and cmake <= 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ ENDIF(USE_BUILTIN_SQLITE)
 
 option(USE_PYTHON "Use Python for Plugins and Event-Scripts" YES)
 IF(USE_PYTHON)
+  find_package(PythonInterp 3.4)
   find_package(PythonLibs 3.4)
   IF(PYTHONLIBS_FOUND)
     MESSAGE(STATUS "Python3 includes found at: ${PYTHON_INCLUDE_PATH}")


### PR DESCRIPTION
domoticz will fail to build with python and older cmake
Indeed, find_package(PythonLibs 3.4) will not recognize python 3.7 until
cmake 3.7 and the following commit:
https://github.com/Kitware/CMake/commit/c31573b9641e0f1bc7a34149506db51f3494323b

To fix this, add a call to find_package(PythonInterp 3.4). Indeed, if
FindPythonInterp has already found the major and minor version, that
version will be inserted between the user supplied versions and the
stock version list since cmake in version 3.1 and
https://github.com/Kitware/CMake/commit/3816cd2dc7a7cc220e4f1b1e87fee986545b9cb3

Fixes:
 - http://autobuild.buildroot.org/results/8e82501a7b49da628ec026132ffca44c0c813040

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>