### PR TITLE
Restructure HTTPClient class

### DIFF
--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -25,6 +25,7 @@
 #define LOGONFAILTRESHOLD 3
 #define MINPOLINTERVAL 10
 #define MAXPOLINTERVAL 3600
+#define HTTPTIMEOUT 30
 
 #ifdef _WIN32
 #define gmtime_r(timep, result) gmtime_s(result, timep)
@@ -1907,7 +1908,7 @@ std::string CEvohomeWeb::send_receive_data(std::string url, std::vector<std::str
 	std::vector<unsigned char> vHTTPResponse;
 	std::vector<std::string> vHeaderData;
 
-	bool httpOK = HTTPClient::GETBinary(url, headers, vHTTPResponse, vHeaderData, -1);
+	bool httpOK = HTTPClient::GETBinary(url, headers, vHTTPResponse, vHeaderData, HTTPTIMEOUT);
 
 	return process_response(vHTTPResponse, vHeaderData, httpOK);
 }
@@ -1918,7 +1919,7 @@ std::string CEvohomeWeb::send_receive_data(std::string url, std::string postdata
 	std::vector<unsigned char> vHTTPResponse;
 	std::vector<std::string> vHeaderData;
 
-	bool httpOK = HTTPClient::POSTBinary(url, postdata, headers, vHTTPResponse, vHeaderData);
+	bool httpOK = HTTPClient::POSTBinary(url, postdata, headers, vHTTPResponse, vHeaderData, HTTPTIMEOUT);
 
 	return process_response(vHTTPResponse, vHeaderData, httpOK);
 }
@@ -1930,13 +1931,7 @@ std::string CEvohomeWeb::put_receive_data(std::string url, std::string putdata, 
 	std::vector<unsigned char> vHTTPResponse;
 	std::vector<std::string> vHeaderData;
 
-	bool httpOK = HTTPClient::PUTBinary(url, putdata, headers, vHTTPResponse);
-
-	if (!httpOK && (vHTTPResponse.size() == 0))
-	{
-		// PUTBinary does not return header data
-		return "{\"error\":\"failed sending command to Evohome portal\"}";
-	}
+	bool httpOK = HTTPClient::PUTBinary(url, putdata, headers, vHTTPResponse, vHeaderData, HTTPTIMEOUT);
 
 	return process_response(vHTTPResponse, vHeaderData, httpOK);
 }

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -208,16 +208,16 @@ void CEvohomeWeb::Do_Work()
 	{
 		sec_counter++;
 		m_lastconnect++;
-		if (sec_counter % 10 == 0) {
+		if (sec_counter % 10 == 0)
 			m_LastHeartbeat = mytime(NULL);
+
+		if ((sec_counter % m_refreshrate == 0) && (pollcounter++ > m_logonfailures) && (m_lastconnect >= MINPOLINTERVAL))
+		{
 			if (m_loggedon && (m_LastHeartbeat > m_sessiontimer)) // discard our session with the honeywell server
 			{
 				m_loggedon = false;
 				m_bequiet = true;
 			}
-		}
-		if ((sec_counter % m_refreshrate == 0) && (pollcounter++ > m_logonfailures) && (m_lastconnect>=MINPOLINTERVAL))
-		{
 			GetStatus();
 			pollcounter = LOGONFAILTRESHOLD;
 			m_lastconnect=0;
@@ -839,6 +839,8 @@ std::string CEvohomeWeb::local_to_utc(const std::string &local_time)
 
 bool CEvohomeWeb::login(const std::string &user, const std::string &password)
 {
+	_log.Debug(DEBUG_HARDWARE, "(%s) logon to v2 API", m_Name.c_str());
+
 	std::vector<std::string> LoginHeaders;
 	LoginHeaders.push_back("Authorization: Basic YjAxM2FhMjYtOTcyNC00ZGJkLTg4OTctMDQ4YjlhYWRhMjQ5OnRlc3Q=");
 	LoginHeaders.push_back("Accept: application/json, application/xml, text/json, text/x-json, text/javascript, text/xml");
@@ -919,6 +921,8 @@ bool CEvohomeWeb::renew_login()
 {
 	if (m_v2refresh_token.empty())
 		return false;
+
+	_log.Debug(DEBUG_HARDWARE, "(%s) refresh v2 session token", m_Name.c_str());
 
 	std::vector<std::string> LoginHeaders;
 	LoginHeaders.push_back("Authorization: Basic YjAxM2FhMjYtOTcyNC00ZGJkLTg4OTctMDQ4YjlhYWRhMjQ5OnRlc3Q=");
@@ -1747,6 +1751,8 @@ bool CEvohomeWeb::set_dhw_mode(const std::string &dhwId, const std::string &mode
 
 bool CEvohomeWeb::v1_login(const std::string &user, const std::string &password)
 {
+	_log.Debug(DEBUG_HARDWARE, "(%s) logon to v1 API", m_Name.c_str());
+
 	std::vector<std::string> LoginHeaders;
 	LoginHeaders.push_back("Accept: application/json, application/xml, text/json, text/x-json, text/javascript, text/xml");
 	LoginHeaders.push_back("content-type: application/json");
@@ -1952,8 +1958,8 @@ std::string CEvohomeWeb::process_response(std::vector<unsigned char> vHTTPRespon
 		}
 		else if (vHeaderData[0].size() > 2)
 			sz_retcode = vHeaderData[0];
-		else // sz_retcode is a Curl status code
-			_log.Debug(DEBUG_NORM, "(%s) Attempt to connect to Evohome portal returned Curl status: %s", m_Name.c_str(), sz_retcode.c_str());
+		else // vHeaderData contains a Curl status code
+			_log.Debug(DEBUG_HARDWARE, "(%s) attempt to communicate to Evohome portal returned Curl status: %s", m_Name.c_str(), vHeaderData[0].c_str());
 	}
 
 	if (sz_response.empty())

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -42,7 +42,7 @@ CLogitechMediaServer::CLogitechMediaServer(const int ID) :
 		m_Pwd = result[0][3];
 	}
 
-	SetSettings(10, 3000);
+	SetSettings(10);
 }
 
 CLogitechMediaServer::~CLogitechMediaServer(void)

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -11,7 +11,7 @@
 #include "../notifications/NotificationHelper.h"
 #include "../httpclient/HTTPClient.h"
 
-CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms) :
+CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec) :
 	m_IP(IPAddress),
 	m_User(User),
 	m_Pwd(Pwd),
@@ -21,10 +21,10 @@ CLogitechMediaServer::CLogitechMediaServer(const int ID, const std::string &IPAd
 	m_Port = Port;
 	m_bShowedStartupMessage = false;
 	m_iMissedQueries = 0;
-	SetSettings(PollIntervalsec, PingTimeoutms);
+	SetSettings(PollIntervalsec);
 }
 
-CLogitechMediaServer::CLogitechMediaServer(const int ID) : 
+CLogitechMediaServer::CLogitechMediaServer(const int ID) :
 	m_iThreadsRunning(0)
 {
 	m_HwdID = ID;
@@ -65,7 +65,7 @@ Json::Value CLogitechMediaServer::Query(const std::string &sIP, const int iPort,
 
 	sPostData << sPostdata;
 
-	HTTPClient::SetTimeout(m_iPingTimeoutms / 1000);
+	HTTPClient::SetTimeout(5);
 	bool bRetVal = HTTPClient::POST(sURL.str(), sPostData.str(), ExtraHeaders, sResult);
 
 	if (!bRetVal)
@@ -492,16 +492,13 @@ void CLogitechMediaServer::UpsertPlayer(const std::string &Name, const std::stri
 	ReloadNodes();
 }
 
-void CLogitechMediaServer::SetSettings(const int PollIntervalsec, const int PingTimeoutms)
+void CLogitechMediaServer::SetSettings(const int PollIntervalsec)
 {
 	//Defaults
 	m_iPollInterval = 30;
-	m_iPingTimeoutms = 1000;
 
 	if (PollIntervalsec > 1)
 		m_iPollInterval = PollIntervalsec;
-	if ((PingTimeoutms / 1000 < m_iPollInterval) && (PingTimeoutms != 0))
-		m_iPingTimeoutms = PingTimeoutms;
 }
 
 bool CLogitechMediaServer::WriteToHardware(const char *pdata, const unsigned char length)
@@ -811,11 +808,9 @@ namespace http {
 			}
 			std::string hwid = request::findValue(&req, "idx");
 			std::string mode1 = request::findValue(&req, "mode1");
-			std::string mode2 = request::findValue(&req, "mode2");
 			if (
 				(hwid == "") ||
-				(mode1 == "") ||
-				(mode2 == "")
+				(mode1 == "")
 				)
 				return;
 			int iHardwareID = atoi(hwid.c_str());
@@ -830,10 +825,9 @@ namespace http {
 			root["title"] = "LMSSetMode";
 
 			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
 
-			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')", iMode1, iMode2, hwid.c_str());
-			pHardware->SetSettings(iMode1, iMode2);
+			m_sql.safe_query("UPDATE Hardware SET Mode1=%d WHERE (ID == '%q')", iMode1, hwid.c_str());
+			pHardware->SetSettings(iMode1);
 			pHardware->Restart();
 		}
 

--- a/hardware/LogitechMediaServer.h
+++ b/hardware/LogitechMediaServer.h
@@ -30,7 +30,7 @@ public:
 		int				refID;
 		std::string		Name;
 	};
-	CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec, const int PingTimeoutms);
+	CLogitechMediaServer(const int ID, const std::string &IPAddress, const int Port, const std::string &User, const std::string &Pwd, const int PollIntervalsec);
 	explicit CLogitechMediaServer(const int ID);
 	~CLogitechMediaServer(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
@@ -38,7 +38,7 @@ public:
 	bool UpdateNode(const int ID, const std::string &Name, const std::string &IPAddress, const int Port);
 	void RemoveNode(const int ID);
 	void RemoveAllNodes();
-	void SetSettings(const int PollIntervalsec, const int PingTimeoutms);
+	void SetSettings(const int PollIntervalsec);
 	bool SendCommand(const int ID, const std::string &command, const std::string &param = "");
 	std::vector<LMSPlaylistNode> GetPlaylists();
 	void SendText(const std::string &playerIP, const std::string &subject, const std::string &text, const int duration);
@@ -63,7 +63,6 @@ private:
 
 	int m_iThreadsRunning;
 	int m_iPollInterval;
-	int m_iPingTimeoutms;
 	std::string	m_IP;
 	int	m_Port;
 	std::string m_User;

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -201,10 +201,6 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 			{
 				headers = curl_slist_append(headers, (*itt).c_str());
 			}
-		}
-
-		if (headers != NULL)
-		{
 			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
 
@@ -246,6 +242,214 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 	return false;
 }
 
+
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect)
+{
+	try
+	{
+		if (!CheckIfGlobalInitDone())
+			return false;
+		CURL *curl = curl_easy_init();
+		if (!curl)
+			return false;
+
+		CURLcode res;
+		SetGlobalOptions(curl);
+		if (!bFollowRedirect)
+		{
+			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
+		}
+
+		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_curl_headerdata);
+		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &vHeaderData);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		curl_easy_setopt(curl, CURLOPT_POST, 1);
+
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
+			std::vector<std::string>::const_iterator itt;
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
+			{
+				headers = curl_slist_append(headers, (*itt).c_str());
+			}
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+		}
+
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str());
+		res = curl_easy_perform(curl);
+
+		if (res != CURLE_OK)
+		{
+			// Push response/error code to end of vHeaderData vector
+			std::stringstream ss;
+			if (res == CURLE_HTTP_RETURNED_ERROR)
+			{
+				long responseCode;
+				curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+				ss << responseCode;
+				LogError(responseCode);
+			}
+			else
+				ss << res;
+			vHeaderData.push_back(ss.str());
+		}
+
+		curl_easy_cleanup(curl);
+
+		if (headers != NULL)
+		{
+			curl_slist_free_all(headers); /* free the header list */
+		}
+
+		return (res == CURLE_OK);
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
+std::vector<std::string> &vHeaderData)
+{
+	try
+	{
+		if (!CheckIfGlobalInitDone())
+			return false;
+		CURL *curl = curl_easy_init();
+		if (!curl)
+			return false;
+
+		CURLcode res;
+		SetGlobalOptions(curl);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
+		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
+
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
+			std::vector<std::string>::const_iterator itt;
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
+			{
+				headers = curl_slist_append(headers, (*itt).c_str());
+			}
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+		}
+
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, putdata.c_str());
+		res = curl_easy_perform(curl);
+
+		if (res != CURLE_OK)
+		{
+			// Push response/error code to end of vHeaderData vector
+			std::stringstream ss;
+			if (res == CURLE_HTTP_RETURNED_ERROR)
+			{
+				long responseCode;
+				curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+				ss << responseCode;
+				LogError(responseCode);
+			}
+			else
+				ss << res;
+			vHeaderData.push_back(ss.str());
+		}
+
+		curl_easy_cleanup(curl);
+
+		if (headers != NULL)
+		{
+			curl_slist_free_all(headers); /* free the header list */
+		}
+
+		return (res == CURLE_OK);
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
+std::vector<std::string> &vHeaderData)
+{
+	try
+	{
+		if (!CheckIfGlobalInitDone())
+			return false;
+		CURL *curl = curl_easy_init();
+		if (!curl)
+			return false;
+
+		CURLcode res;
+		SetGlobalOptions(curl);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
+		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
+		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
+
+
+		struct curl_slist *headers = NULL;
+		if (ExtraHeaders.size() > 0)
+		{
+			std::vector<std::string>::const_iterator itt;
+			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
+			{
+				headers = curl_slist_append(headers, (*itt).c_str());
+			}
+			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+		}
+
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, putdata.c_str());
+		res = curl_easy_perform(curl);
+
+		if (res != CURLE_OK)
+		{
+			// Push response/error code to end of vHeaderData vector
+			std::stringstream ss;
+			if (res == CURLE_HTTP_RETURNED_ERROR)
+			{
+				long responseCode;
+				curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
+				ss << responseCode;
+				LogError(responseCode);
+			}
+			else
+				ss << res;
+			vHeaderData.push_back(ss.str());
+		}
+
+		curl_easy_cleanup(curl);
+
+		if (headers != NULL)
+		{
+			curl_slist_free_all(headers); /* free the header list */
+		}
+
+		return (res == CURLE_OK);
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+
+/************************************************************************
+ *									*
+ * binary methods without access to return header data			*
+ *									*
+ ************************************************************************/
+
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
+{
+	std::vector<std::string> vHeaderData;
+	return GETBinary(url, ExtraHeaders, response, vHeaderData, TimeOut);
+}
 
 bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
 {
@@ -310,184 +514,6 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 	return false;
 }
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect)
-{
-	try
-	{
-		if (!CheckIfGlobalInitDone())
-			return false;
-		CURL *curl = curl_easy_init();
-		if (!curl)
-			return false;
-
-		CURLcode res;
-		SetGlobalOptions(curl);
-		if (!bFollowRedirect)
-		{
-			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
-		}
-
-		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_curl_headerdata);
-		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &vHeaderData);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
-		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-		curl_easy_setopt(curl, CURLOPT_POST, 1);
-
-		struct curl_slist *headers = NULL;
-		if (ExtraHeaders.size() > 0)
-		{
-			std::vector<std::string>::const_iterator itt;
-			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
-			{
-				headers = curl_slist_append(headers, (*itt).c_str());
-			}
-		}
-
-		if (headers != NULL)
-		{
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-		}
-
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, postdata.c_str());
-		res = curl_easy_perform(curl);
-
-		// Push status code to end of vHeaderData vector
-		long responseCode;
-		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &responseCode);
-		std::stringstream ss;
-		ss << responseCode;
-		vHeaderData.push_back(ss.str());
-
-		curl_easy_cleanup(curl);
-
-		if (headers != NULL)
-		{
-			curl_slist_free_all(headers); /* free the header list */
-		}
-
-		return (res == CURLE_OK);
-	}
-	catch (...)
-	{
-		return false;
-	}
-}
-
-bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData)
-{
-	try
-	{
-		if (!CheckIfGlobalInitDone())
-			return false;
-		CURL *curl = curl_easy_init();
-		if (!curl)
-			return false;
-
-		CURLcode res;
-		SetGlobalOptions(curl);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
-		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
-		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
-
-
-		struct curl_slist *headers = NULL;
-		if (ExtraHeaders.size() > 0)
-		{
-			std::vector<std::string>::const_iterator itt;
-			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
-			{
-				headers = curl_slist_append(headers, (*itt).c_str());
-			}
-		}
-
-		if (headers != NULL)
-		{
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-		}
-
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, putdata.c_str());
-		res = curl_easy_perform(curl);
-		curl_easy_cleanup(curl);
-
-		if (headers != NULL)
-		{
-			curl_slist_free_all(headers); /* free the header list */
-		}
-
-		return (res == CURLE_OK);
-	}
-	catch (...)
-	{
-		return false;
-	}
-}
-
-bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData)
-{
-	try
-	{
-		if (!CheckIfGlobalInitDone())
-			return false;
-		CURL *curl = curl_easy_init();
-		if (!curl)
-			return false;
-
-		CURLcode res;
-		SetGlobalOptions(curl);
-		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
-		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
-		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-
-
-		struct curl_slist *headers = NULL;
-		if (ExtraHeaders.size() > 0)
-		{
-			std::vector<std::string>::const_iterator itt;
-			for (itt = ExtraHeaders.begin(); itt != ExtraHeaders.end(); ++itt)
-			{
-				headers = curl_slist_append(headers, (*itt).c_str());
-			}
-		}
-
-		if (headers != NULL)
-		{
-			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-		}
-
-		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, putdata.c_str());
-		res = curl_easy_perform(curl);
-		curl_easy_cleanup(curl);
-
-		if (headers != NULL)
-		{
-			curl_slist_free_all(headers); /* free the header list */
-		}
-
-		return (res == CURLE_OK);
-	}
-	catch (...)
-	{
-		return false;
-	}
-}
-
-
-/************************************************************************
- *									*
- * binary methods without access to return header data			*
- *									*
- ************************************************************************/
-
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
-{
-	std::vector<std::string> vHeaderData;
-	return GETBinary(url, ExtraHeaders, response, vHeaderData, TimeOut);
-}
-
 bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect)
 {
 	std::vector<std::string> vHeaderData;
@@ -537,6 +563,30 @@ bool HTTPClient::POST(const std::string &url, const std::string &postdata, const
 	return true;
 }
 
+bool HTTPClient::PUT(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned)
+{
+	response = "";
+	std::vector<unsigned char> vHTTPResponse;
+	if (!PUTBinary(url, putdata, ExtraHeaders, vHTTPResponse, vHeaderData))
+		return false;
+	if (!bIgnoreNoDataReturned && vHTTPResponse.empty())
+		return false;
+	response.insert(response.begin(), vHTTPResponse.begin(), vHTTPResponse.end());
+	return true;
+}
+
+bool HTTPClient::Delete(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned)
+{
+	response = "";
+	std::vector<unsigned char> vHTTPResponse;
+	if (!DeleteBinary(url, putdata, ExtraHeaders, vHTTPResponse, vHeaderData))
+		return false;
+	if (!bIgnoreNoDataReturned && vHTTPResponse.empty())
+		return false;
+	response.insert(response.begin(), vHTTPResponse.begin(), vHTTPResponse.end());
+	return true;
+}
+
 
 /************************************************************************
  *									*
@@ -558,26 +608,14 @@ bool HTTPClient::POST(const std::string &url, const std::string &postdata, const
 
 bool HTTPClient::PUT(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned)
 {
-	response = "";
-	std::vector<unsigned char> vHTTPResponse;
-	if (!PUTBinary(url, putdata, ExtraHeaders, vHTTPResponse))
-		return false;
-	if (!bIgnoreNoDataReturned && vHTTPResponse.empty())
-		return false;
-	response.insert(response.begin(), vHTTPResponse.begin(), vHTTPResponse.end());
-	return true;
+	std::vector<std::string> vHeaderData;
+	return PUT(url, putdata, ExtraHeaders, response, vHeaderData, bIgnoreNoDataReturned);
 }
 
 bool HTTPClient::Delete(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned)
 {
-	response = "";
-	std::vector<unsigned char> vHTTPResponse;
-	if (!DeleteBinary(url, putdata, ExtraHeaders, vHTTPResponse))
-		return false;
-	if (!bIgnoreNoDataReturned && vHTTPResponse.empty())
-		return false;
-	response.insert(response.begin(), vHTTPResponse.begin(), vHTTPResponse.end());
-	return true;
+	std::vector<std::string> vHeaderData;
+	return Delete(url, putdata, ExtraHeaders, response, vHeaderData, bIgnoreNoDataReturned);
 }
 
 
@@ -592,7 +630,6 @@ bool HTTPClient::GET(const std::string &url, std::string &response, const bool b
 	std::vector<std::string> ExtraHeaders;
 	return GET(url, ExtraHeaders, response, bIgnoreNoDataReturned);
 }
-
 
 bool HTTPClient::GETSingleLine(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned)
 {

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -16,8 +16,8 @@ extern std::string szUserDataFolder;
 bool		HTTPClient::m_bCurlGlobalInitialized = false;
 bool		HTTPClient::m_bVerifyHost = false;
 bool		HTTPClient::m_bVerifyPeer = false;
-long		HTTPClient::m_iConnectionTimeout = 10000;
-long		HTTPClient::m_iTimeout = 90000; //max, time that a download has to be finished?
+long		HTTPClient::m_iConnectionTimeout = 10;
+long		HTTPClient::m_iTimeout = 90; //max, time that a download has to be finished?
 std::string	HTTPClient::m_sUserAgent = "domoticz/1.0";
 
 
@@ -103,8 +103,8 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
-	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, m_iConnectionTimeout);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, m_iTimeout);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_bVerifyPeer ? 1L : 0);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_bVerifyHost ? 2L : 0); //allow self signed certificates
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
@@ -148,14 +148,14 @@ void HTTPClient::LogError(const long response_code)
  *									*
  ************************************************************************/
 
-void HTTPClient::SetConnectionTimeout(const float timeout)
+void HTTPClient::SetConnectionTimeout(const long timeout)
 {
-	m_iConnectionTimeout = static_cast<long>(timeout * 1000);
+	m_iConnectionTimeout = timeout;
 }
 
-void HTTPClient::SetTimeout(const float timeout)
+void HTTPClient::SetTimeout(const long timeout)
 {
-	m_iTimeout = static_cast<long>(timeout * 1000);
+	m_iTimeout = timeout;
 }
 
 void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost)
@@ -176,7 +176,7 @@ void HTTPClient::SetUserAgent(const std::string &useragent)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const float TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -189,7 +189,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -241,7 +241,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 }
 
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect, const float TimeOut)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect, const long TimeOut)
 {
 	try
 	{
@@ -254,7 +254,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 		if (!bFollowRedirect)
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 
@@ -310,7 +310,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 }
 
 bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const float TimeOut)
+std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -323,7 +323,7 @@ std::vector<std::string> &vHeaderData, const float TimeOut)
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -376,7 +376,7 @@ std::vector<std::string> &vHeaderData, const float TimeOut)
 }
 
 bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const float TimeOut)
+std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -389,7 +389,7 @@ std::vector<std::string> &vHeaderData, const float TimeOut)
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -448,13 +448,13 @@ std::vector<std::string> &vHeaderData, const float TimeOut)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return GETBinary(url, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
+bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	try
 	{
@@ -467,7 +467,9 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
+		{
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+		}
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -512,19 +514,19 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 	return false;
 }
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect, const float TimeOut)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return POSTBinary(url, postdata, ExtraHeaders, response, vHeaderData, bFollowRedirect, TimeOut);
 }
 
-bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
+bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return PUTBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
+bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return DeleteBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);
@@ -676,4 +678,3 @@ bool HTTPClient::GETBinaryToFile(const std::string &url, const std::string &outp
 		return false;
 	}
 }
-

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -16,8 +16,8 @@ extern std::string szUserDataFolder;
 bool		HTTPClient::m_bCurlGlobalInitialized = false;
 bool		HTTPClient::m_bVerifyHost = false;
 bool		HTTPClient::m_bVerifyPeer = false;
-long		HTTPClient::m_iConnectionTimeout = 10;
-long		HTTPClient::m_iTimeout = 90; //max, time that a download has to be finished?
+long		HTTPClient::m_iConnectionTimeout = 10000;
+long		HTTPClient::m_iTimeout = 90000; //max, time that a download has to be finished?
 std::string	HTTPClient::m_sUserAgent = "domoticz/1.0";
 
 
@@ -103,8 +103,8 @@ void HTTPClient::SetGlobalOptions(void *curlobj)
 	curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
 	curl_easy_setopt(curl, CURLOPT_UNRESTRICTED_AUTH, 1L);
 	curl_easy_setopt(curl, CURLOPT_USERAGENT, m_sUserAgent.c_str());
-	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, m_iConnectionTimeout);
-	curl_easy_setopt(curl, CURLOPT_TIMEOUT, m_iTimeout);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, m_iConnectionTimeout);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, m_iTimeout);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, m_bVerifyPeer ? 1L : 0);
 	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, m_bVerifyHost ? 2L : 0); //allow self signed certificates
 	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
@@ -148,14 +148,14 @@ void HTTPClient::LogError(const long response_code)
  *									*
  ************************************************************************/
 
-void HTTPClient::SetConnectionTimeout(const long timeout)
+void HTTPClient::SetConnectionTimeout(const float timeout)
 {
-	m_iConnectionTimeout = timeout;
+	m_iConnectionTimeout = static_cast<long>(timeout * 1000);
 }
 
-void HTTPClient::SetTimeout(const long timeout)
+void HTTPClient::SetTimeout(const float timeout)
 {
-	m_iTimeout = timeout;
+	m_iTimeout = static_cast<long>(timeout * 1000);
 }
 
 void HTTPClient::SetSecurityOptions(const bool verifypeer, const bool verifyhost)
@@ -176,7 +176,7 @@ void HTTPClient::SetUserAgent(const std::string &useragent)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const float TimeOut)
 {
 	try
 	{
@@ -189,7 +189,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -241,7 +241,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 }
 
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect, const long TimeOut)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect, const float TimeOut)
 {
 	try
 	{
@@ -254,7 +254,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
 		if (!bFollowRedirect)
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
 
@@ -310,7 +310,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 }
 
 bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const long TimeOut)
+std::vector<std::string> &vHeaderData, const float TimeOut)
 {
 	try
 	{
@@ -323,7 +323,7 @@ std::vector<std::string> &vHeaderData, const long TimeOut)
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -376,7 +376,7 @@ std::vector<std::string> &vHeaderData, const long TimeOut)
 }
 
 bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const long TimeOut)
+std::vector<std::string> &vHeaderData, const float TimeOut)
 {
 	try
 	{
@@ -389,7 +389,7 @@ std::vector<std::string> &vHeaderData, const long TimeOut)
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
 
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -448,13 +448,13 @@ std::vector<std::string> &vHeaderData, const long TimeOut)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return GETBinary(url, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
+bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
 {
 	try
 	{
@@ -467,9 +467,7 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-		{
-			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
-		}
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(TimeOut * 1000));
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -479,12 +477,9 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 			{
 				headers = curl_slist_append(headers, (*itt).c_str());
 			}
-		}
-
-		if (headers != NULL)
-		{
 			curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 		}
+
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data_single_line);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
@@ -517,19 +512,19 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 	return false;
 }
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect, const long TimeOut)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect, const float TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return POSTBinary(url, postdata, ExtraHeaders, response, vHeaderData, bFollowRedirect, TimeOut);
 }
 
-bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
+bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return PUTBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
+bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return DeleteBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -176,7 +176,7 @@ void HTTPClient::SetUserAgent(const std::string &useragent)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const int TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -189,9 +189,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 		CURLcode res;
 		SetGlobalOptions(curl);
 		if (TimeOut != -1)
-		{
 			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
-		}
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -243,7 +241,7 @@ bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string
 }
 
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect, const long TimeOut)
 {
 	try
 	{
@@ -255,10 +253,10 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 
 		CURLcode res;
 		SetGlobalOptions(curl);
+		if (TimeOut != -1)
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
 		if (!bFollowRedirect)
-		{
 			curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 0L);
-		}
 
 		curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, write_curl_headerdata);
 		curl_easy_setopt(curl, CURLOPT_HEADERDATA, &vHeaderData);
@@ -312,7 +310,7 @@ bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata,
 }
 
 bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData)
+std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -324,6 +322,9 @@ std::vector<std::string> &vHeaderData)
 
 		CURLcode res;
 		SetGlobalOptions(curl);
+		if (TimeOut != -1)
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
@@ -375,7 +376,7 @@ std::vector<std::string> &vHeaderData)
 }
 
 bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData)
+std::vector<std::string> &vHeaderData, const long TimeOut)
 {
 	try
 	{
@@ -387,11 +388,13 @@ std::vector<std::string> &vHeaderData)
 
 		CURLcode res;
 		SetGlobalOptions(curl);
+		if (TimeOut != -1)
+			curl_easy_setopt(curl, CURLOPT_TIMEOUT, TimeOut);
+
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&response);
 		curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
 		//curl_easy_setopt(curl, CURLOPT_PUT, 1);
 		curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "DELETE");
-
 
 		struct curl_slist *headers = NULL;
 		if (ExtraHeaders.size() > 0)
@@ -445,13 +448,13 @@ std::vector<std::string> &vHeaderData)
  *									*
  ************************************************************************/
 
-bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
+bool HTTPClient::GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
 	return GETBinary(url, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut)
+bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	try
 	{
@@ -514,22 +517,22 @@ bool HTTPClient::GETBinarySingleLine(const std::string &url, const std::vector<s
 	return false;
 }
 
-bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect)
+bool HTTPClient::POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
-	return POSTBinary(url, postdata, ExtraHeaders, response, vHeaderData, bFollowRedirect);
+	return POSTBinary(url, postdata, ExtraHeaders, response, vHeaderData, bFollowRedirect, TimeOut);
 }
 
-bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response)
+bool HTTPClient::PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
-	return PUTBinary(url, putdata, ExtraHeaders, response, vHeaderData);
+	return PUTBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
-bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response)
+bool HTTPClient::DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut)
 {
 	std::vector<std::string> vHeaderData;
-	return DeleteBinary(url, putdata, ExtraHeaders, response, vHeaderData);
+	return DeleteBinary(url, putdata, ExtraHeaders, response, vHeaderData, TimeOut);
 }
 
 

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -31,8 +31,8 @@ public:
 	 *									*
 	 ************************************************************************/
 	
-	static void SetConnectionTimeout(const long timeout);
-	static void SetTimeout(const long timeout);
+	static void SetConnectionTimeout(const float timeout);
+	static void SetTimeout(const float timeout);
 	static void SetUserAgent(const std::string &useragent);
 	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost);
 
@@ -85,11 +85,11 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
-	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true, const long TimeOut = -1);
-	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
-	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
+	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true, const float TimeOut = -1);
+	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
+	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
 
 
 	/************************************************************************
@@ -98,12 +98,12 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true, const long TimeOut = -1);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const float TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true, const float TimeOut = -1);
 	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const long TimeOut = -1);
+std::vector<std::string> &vHeaderData, const float TimeOut = -1);
 	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const long TimeOut = -1);
+std::vector<std::string> &vHeaderData, const float TimeOut = -1);
 
 
 

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -73,6 +73,8 @@ public:
 
 	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned = false);
 	static bool POST(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect=true, const bool bIgnoreNoDataReturned = false);
+	static bool PUT(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned = false);
+	static bool Delete(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned = false);
 
 
 	/************************************************************************

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -85,11 +85,11 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
-	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true);
-	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
-	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true, const long TimeOut = -1);
+	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
 
 
 	/************************************************************************
@@ -98,12 +98,12 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const int TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true, const long TimeOut = -1);
 	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData);
+std::vector<std::string> &vHeaderData, const long TimeOut = -1);
 	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData);
+std::vector<std::string> &vHeaderData, const long TimeOut = -1);
 
 
 

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -2,51 +2,115 @@
 
 class HTTPClient
 {
+	// give MainWorker acces to the protected Cleanup() function
+	friend class MainWorker;
+
+
 public:
 	enum _eHTTPmethod
 	{
 		HTTP_METHOD_GET,
 		HTTP_METHOD_POST
 	};
-	//GET functions
-	static bool GET(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
-	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
-	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned = false);
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const int TimeOut = -1);
 
-	static bool GETBinaryToFile(const std::string &url, const std::string &outputfile);
 
-	static bool GETSingleLine(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
-	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
-
-	//POST functions, postdata looks like: "name=john&age=123&country=this"
-	static bool POST(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bFollowRedirect=true, const bool bIgnoreNoDataReturned = false);
-	static bool POST(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect=true, const bool bIgnoreNoDataReturned = false);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true);
-
-	//PUT functions, postdata looks like: "name=john&age=123&country=this"
-	static bool PUT(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
-	static bool PUTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
-
-	//DELETE functions, postdata looks like: "name=john&age=123&country=this"
-	static bool Delete(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
-	static bool DeleteBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
-
+protected:
 	//Cleanup function, should be called before application closed
 	static void Cleanup();
 
-	//Configuration functions
+
+public:
+	/************************************************************************
+	 *									*
+	 * Configuration functions						*
+	 *									*
+	 * CAUTION!								*
+	 * Because these settings are global they may affect other classes	*
+	 * that use HTTPClient. Please add a debug line to your class if you	*
+	 * access any of these functions.					*
+	 *									*
+	 ************************************************************************/
+	
 	static void SetConnectionTimeout(const long timeout);
 	static void SetTimeout(const long timeout);
 	static void SetUserAgent(const std::string &useragent);
 	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost);
+
+
+	/************************************************************************
+	 *									*
+	 * simple access methods						*
+	 *   - use for unprotected sites					*
+	 *									*
+	 ************************************************************************/
+
+	static bool GET(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
+	static bool GETSingleLine(const std::string &url, std::string &response, const bool bIgnoreNoDataReturned = false);
+	static bool GETBinaryToFile(const std::string &url, const std::string &outputfile);
+
+
+	/************************************************************************
+	 *									*
+	 * methods with optional headers					*
+	 *   - use for sites that require additional header data		*
+	 *     e.g. authorization token, charset definition, etc.		*
+	 *									*
+	 ************************************************************************/
+
+	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
+	static bool POST(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bFollowRedirect=true, const bool bIgnoreNoDataReturned = false);
+	static bool PUT(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
+	static bool Delete(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::string &response, const bool bIgnoreNoDataReturned = false);
+
+
+	/************************************************************************
+	 *									*
+	 * methods with access to the return headers				*
+	 *   - use if you require access to the HTTP return codes for		*
+	 *     handling specific errors						*
+	 *									*
+	 ************************************************************************/
+
+	static bool GET(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bIgnoreNoDataReturned = false);
+	static bool POST(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::string &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect=true, const bool bIgnoreNoDataReturned = false);
+
+
+	/************************************************************************
+	 *									*
+	 * binary methods without access to return header data			*
+	 *   - use if you require access to the return content even if there	*
+	 *     was an error							*
+	 *									*
+	 ************************************************************************/
+
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
+	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const int TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true);
+	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
+	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response);
+
+
+	/************************************************************************
+	 *									*
+	 * binary methods with access to return header data			*
+	 *									*
+	 ************************************************************************/
+
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const int TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true);
+	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
+std::vector<std::string> &vHeaderData);
+	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
+std::vector<std::string> &vHeaderData);
+
+
+
 private:
 	static void SetGlobalOptions(void *curlobj);
 	static bool CheckIfGlobalInitDone();
 	static void LogError(const long response_code);
-	//our static variables
+
+private:
 	static bool m_bCurlGlobalInitialized;
 	static bool m_bVerifyHost;
 	static bool m_bVerifyPeer;

--- a/httpclient/HTTPClient.h
+++ b/httpclient/HTTPClient.h
@@ -31,8 +31,8 @@ public:
 	 *									*
 	 ************************************************************************/
 	
-	static void SetConnectionTimeout(const float timeout);
-	static void SetTimeout(const float timeout);
+	static void SetConnectionTimeout(const long timeout);
+	static void SetTimeout(const long timeout);
 	static void SetUserAgent(const std::string &useragent);
 	static void SetSecurityOptions(const bool verifypeer, const bool verifyhost);
 
@@ -85,11 +85,11 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
-	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true, const float TimeOut = -1);
-	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
-	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const float TimeOut = -1);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool GETBinarySingleLine(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const bool bFollowRedirect = true, const long TimeOut = -1);
+	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
+	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, const long TimeOut = -1);
 
 
 	/************************************************************************
@@ -98,12 +98,12 @@ public:
 	 *									*
 	 ************************************************************************/
 
-	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const float TimeOut = -1);
-	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true, const float TimeOut = -1);
+	static bool GETBinary(const std::string &url, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const long TimeOut = -1);
+	static bool POSTBinary(const std::string &url, const std::string &postdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response, std::vector<std::string> &vHeaderData, const bool bFollowRedirect = true, const long TimeOut = -1);
 	static bool PUTBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const float TimeOut = -1);
+std::vector<std::string> &vHeaderData, const long TimeOut = -1);
 	static bool DeleteBinary(const std::string &url, const std::string &putdata, const std::vector<std::string> &ExtraHeaders, std::vector<unsigned char> &response,
-std::vector<std::string> &vHeaderData, const float TimeOut = -1);
+std::vector<std::string> &vHeaderData, const long TimeOut = -1);
 
 
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -850,7 +850,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_LogitechMediaServer:
 		//Logitech Media Server
-		pHardware = new CLogitechMediaServer(ID, Address, Port, Username, Password, Mode1, Mode2);
+		pHardware = new CLogitechMediaServer(ID, Address, Port, Username, Password, Mode1);
 		break;
 	case HTYPE_Sterbox:
 		//LAN

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1206,6 +1206,8 @@ bool MainWorker::Stop()
 
 		//    m_cameras.StopCameraGrabber();
 
+		HTTPClient::Cleanup();
+
 		RequestStop();
 		m_thread->join();
 		m_thread.reset();

--- a/www/app/HardwareController.js
+++ b/www/app/HardwareController.js
@@ -3664,14 +3664,10 @@ define(['app'], function (app) {
 			var Mode1 = parseInt($("#hardwarecontent #lmssettingstable #pollinterval").val());
 			if (Mode1 < 1)
 				Mode1 = 30;
-			var Mode2 = parseInt($("#hardwarecontent #lmssettingstable #pingtimeout").val());
-			if (Mode2 < 500)
-				Mode2 = 500;
 			$.ajax({
 				url: "json.htm?type=command&param=lmssetmode" +
 				"&idx=" + $.devIdx +
-				"&mode1=" + Mode1 +
-				"&mode2=" + Mode2,
+				"&mode1=" + Mode1,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -3693,7 +3689,6 @@ define(['app'], function (app) {
 			$('#hardwarecontent').i18n();
 
 			$("#hardwarecontent #lmssettingstable #pollinterval").val(Mode1);
-			$("#hardwarecontent #lmssettingstable #pingtimeout").val(Mode2);
 
 			var oTable = $('#lmsnodestable').dataTable({
 				"sDom": '<"H"lfrC>t<"F"ip>',

--- a/www/views/hardware.html
+++ b/www/views/hardware.html
@@ -712,10 +712,6 @@
             <td><input type="text" id="pollinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" />&nbsp;(<span data-i18n="Seconds">Seconds</span>)</td>
         </tr>
         <tr>
-            <td align="right" style="width:110px"><label for="pingtimeout"><span data-i18n="Ping Timeout"></span>:</label></td>
-            <td><input type="text" id="pingtimeout" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" />&nbsp;(<span data-i18n="Milliseconds"></span>)</td>
-        </tr>
-        <tr>
             <td></td>
             <td><a class="btn btn-danger sub-tabs-apply" onclick="SetLMSSettings();" data-i18n="Apply Settings">Apply Settings</a></td>
         </tr>


### PR DESCRIPTION
A user pointed me to an issue with HTTPClient class allowing other classes to set timeout values as a global parameter. This causes classes that need to access resources on the internet to fail if another class sets the timeout values expecting to talk to a local(net) resource.

While investigating I found that the various web access methods did not all offer the same functionality, with only one of the GET functions allowing an override of the global timeout value. I have regrouped the functions according to their input parameter complexity and extended functionality where needed. This includes allowing timeout override for all web access methods and allow access to either the HTTP or Curl return code which was previously only offered by the GET and POST methods.

This PR includes an update to EvohomeWeb class making use of these extended functions, because this was the reason for wanting to redo the HTTPClient class.