### PR TITLE
Add YRD220 with id=aa00

### DIFF
--- a/Config/manufacturer_specific.xml
+++ b/Config/manufacturer_specific.xml
@@ -202,6 +202,7 @@
 	</Manufacturer>
 	<Manufacturer id="0129" name="Assa Abloy">
 		<Product type="0001" id="0000" name="Yale Touchscreen Lever (YRL220)" config="assa_abloy/TouchLever.xml"/>
+		<Product type="0002" id="aa00" name="Yale Touchscreen Deadbolt (YRD220)" config="assa_abloy/TouchDeadbolt.xml" />
 		<Product type="0002" id="0000" name="Yale Touchscreen Deadbolt (YRD220)" config="assa_abloy/TouchDeadbolt.xml" />
 		<Product type="0002" id="0209" name="Yale Key Free Touchscreen Deadbolt (YRD240)" config="assa_abloy/TouchDeadbolt.xml"/>
 		<Product type="8002" id="0600" name="Yale Key Free Touchscreen Deadbolt (YRD446)" config="assa_abloy/TouchDeadbolt.xml"/>


### PR DESCRIPTION
It seems that Assa Abloy (Yale) has YRD220's with an ID of aa00, in addition to 0000.  I have added this change to my own xml file and it works with my YRD220.