### PR TITLE
fix compiler error in SQLHelper due to missing newline at end of file

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -8550,3 +8550,4 @@ float CSQLHelper::GetCounterDivider(const int metertype, const int dType, const 
 	}
 	return divider;
 }
+


### PR DESCRIPTION
See C++03 Standard [2.1.1.2]

Note:
According to the specifications for C++11 this should no longer apply
because the compiler is supposed to handle the file as if it has the
newline appended to it. Although GNU 7.3 compiler (and possibly others)
state that it does add the additional newline, this still causes the
make command to terminate during the first run and you have to run it
a second time to complete the job.