### PR TITLE
Make Telegram notification silent when priority is negative

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2476,6 +2476,8 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 			}
 			else if (aParam.size() == 5)
 			{
+				priority = aParam[2];
+				sound = aParam[3];
 				subsystem = aParam[4];
 			}
 			m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, std::string(""), atoi(priority.c_str()), sound, subsystem));

--- a/notifications/NotificationTelegram.cpp
+++ b/notifications/NotificationTelegram.cpp
@@ -46,6 +46,8 @@ bool CNotificationTelegram::SendMessageImplementation(
 	json["chat_id"] = _chatid;
 	json["text"] = CURLEncode::URLDecode(Text);
 	//json["body"] = CURLEncode::URLDecode(Text);
+	if ( Priority < 0 )
+		json["disable_notification"] = 1;
 	sPostData = jsonWriter.write(json);
 
 	//Add the required Content Type


### PR DESCRIPTION
Hello,

I don't know if it's the right method, but after opening a topic in the forum, I was advised to open a pull request. Here is the related topic :
https://www.domoticz.com/forum/viewtopic.php?f=31&t=26083&p=200264&hilit=macjl#p200264

The main point, is to have silent notifications with the Telegram service. It's possible with Telegram API to send messages that don't produce sound or screen notifications when they are received, by adding the 'disable_notification' parameter.

Am I doing right?