### PR TITLE
Fixed dzVents combined timer rule where one part of the combination is even or odd week

### DIFF
--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -8,6 +8,8 @@
 - Added tests for twilight and device functions (hotwater) and attributes (evohome- and wind devices)
 - Fixed some date-range rule checking
 - Fixed integration tests by changing API call for creating a domoticz variable (saveuservariable was changed to adduservariable)
+- Fixed combined timer where one part of the combination is even or odd week. 
+- Added tests for combined timer with even/odd week 
 
 [2.4.8]
 - Added telegram as option for domoticz.notify

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -428,10 +428,10 @@ local function Time(sDate, isUTC, _testMS)
 
 		if (string.find(rule, 'every odd week') and not ((self.week % 2) == 0)) then
 			return true
-		end
-
-		if (string.find(rule, 'every even week') and ((self.week % 2) == 0)) then
+		elseif (string.find(rule, 'every even week') and ((self.week % 2) == 0)) then
 			return true
+		elseif string.find(rule, 'every even week') or string.find(rule, 'every odd week') then
+        	return false
 		end
 
 		local weeks = string.match(rule, 'in week% ([0-9%-%,% ]*)')

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1366,12 +1366,12 @@ describe('Time', function()
 				it('should return true when matches odd weeks', function()
 					local t = Time('2017-06-05 02:04:00') -- week 23
 					assert.is_true(t.ruleIsInWeek('every odd week'))
-					assert.is_nil(t.ruleIsInWeek('every even week'))
+					assert.is_false(t.ruleIsInWeek('every even week'))
 				end)
 
 				it('should return true when matches even weeks', function()
 					local t = Time('2017-06-13 02:04:00') -- week 24
-					assert.is_nil(t.ruleIsInWeek('every odd week'))
+					assert.is_false(t.ruleIsInWeek('every odd week'))
 					assert.is_true(t.ruleIsInWeek('every even week'))
 				end)
 
@@ -1470,6 +1470,15 @@ describe('Time', function()
 		end)
 
 		describe('combis', function()
+
+        	it('should return false when not on every second sunday between 1:00 and 1:30', function()
+				local t = Time('2018-12-30 01:04:00') -- on Sunday, odd week at 01:04 
+				assert.is_false(t.matchesRule('between 1:00 and 1:30 on sun every odd week'))
+				assert.is_false(t.matchesRule('between 2:00 and 2:30 on sun every odd week'))
+				assert.is_false(t.matchesRule('between 1:00 and 1:30 on sat every even week'))
+				assert.is_false(t.matchesRule('between 2:00 and 2:30 on sat every even week'))
+				assert.is_true(t.matchesRule('between 1:00 and 1:30 on sun every even week'))
+			end)
 
 			it('should return false when not on the day', function()
 


### PR DESCRIPTION
	modified:   dzVents/documentation/history.md
	modified:   dzVents/runtime/Time.lua
	modified:   dzVents/runtime/tests/testTime.lua