### PR TITLE
Fix issue #2947: Add call to GetCurrentScenesGroups in SQLHelper  on device state change

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7047,6 +7047,8 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 		//Set new Scene status
 		safe_query("UPDATE Scenes SET nValue=%d WHERE (ID == %" PRIu64 ")",
 			int(newValue), Idx);
+		if (m_sql.m_bEnableEventSystem)  // Only when eventSystem is active
+			m_mainworker.m_eventsystem.GetCurrentScenesGroups(); 
 	}
 }
 


### PR DESCRIPTION
As described in issue #2947 a change in state of an individual device can result in a state change of the groups/scenes where the changed device is part of. This group/scene state-change is performed by SQLHelper but not propagated to the event System.    