### PR TITLE
Fix issue #2927: Remove hardcoded legacy rtl_433 command line arguments

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -395,7 +395,7 @@ void CRtl433::Do_Work()
 		std::string headerLine = "";
 		m_sLastLine = "";
 
-		std::string szFlags = "-F csv -q -I 2 " + m_cmdline; // -f 433.92e6 -f 868.24e6 -H 60 -d 0
+		std::string szFlags = "-F csv " + m_cmdline; // -f 433.92e6 -f 868.24e6 -H 60 -d 0
 #ifdef WIN32
 		std::string szCommand = "C:\\rtl_433.exe " + szFlags;
 		m_hPipe = _popen(szCommand.c_str(), "r");


### PR DESCRIPTION
Hardcoded arguments break RTL-SDR integration for newer versions of rtl_433 software after 18.05

It should be possible to specify extra arguments in additional command-line arguments for RTL-SDR version, depending on rtl_433 version in use, so supporting old and new versions of rtl_433 software.