### PR TITLE
Providing WWWFolder instead of WebRoot

### DIFF
--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1134,7 +1134,7 @@ Error:
 					ADD_STRING_TO_DICT(pParamsDict, "HomeFolder", m_HomeFolder);
 					ADD_STRING_TO_DICT(pParamsDict, "StartupFolder", szStartupFolder);
 					ADD_STRING_TO_DICT(pParamsDict, "UserDataFolder", szUserDataFolder);
-					ADD_STRING_TO_DICT(pParamsDict, "WebRoot", szWebRoot);
+					ADD_STRING_TO_DICT(pParamsDict, "WWWFolder", szWWWFolder);
 					ADD_STRING_TO_DICT(pParamsDict, "Database", dbasefile);
 					ADD_STRING_TO_DICT(pParamsDict, "Version", m_Version);
 					ADD_STRING_TO_DICT(pParamsDict, "Author", m_Author);


### PR DESCRIPTION
We should have access to szWWWFolder instead of szWebRoot which is pointing the Web folder for url ( Web root path (for instance mydomoticz, Domoticz url will become https://127.0.0.1:8080/mydomoticz/ )