### PR TITLE
fix for ignored afterXXX function in updateSetPoint thermostat_setpoint

### DIFF
--- a/dzVents/runtime/device-adapters/thermostat_setpoint_device.lua
+++ b/dzVents/runtime/device-adapters/thermostat_setpoint_device.lua
@@ -1,5 +1,3 @@
-local TimedCommand = require('TimedCommand')
-
 return {
 
 	baseType = 'device',
@@ -19,7 +17,7 @@ return {
 		device.setPoint = tonumber(device.rawData[1] or 0)
 
 		function device.updateSetPoint(setPoint)
-			return TimedCommand(domoticz, 'SetSetPoint:' .. tostring(device.id), tostring(setPoint) , 'setpoint')
+			return device.update(0, setPoint)
 		end
 
 	end

--- a/dzVents/runtime/integration-tests/stage1.lua
+++ b/dzVents/runtime/integration-tests/stage1.lua
@@ -866,7 +866,11 @@ local testThermostatSetpoint = function(name)
 		["timedOut"] = false;
 	})
 
-	dev.updateSetPoint(22).afterSec(1)  --  20190112 Add afterSec
+	
+	
+    dev.updateSetPoint(11) 
+    dev.updateSetPoint(22).afterSec(2)    --  20190112 Add afterSec
+	dev.updateSetPoint(33).afterSec(200)  --  20190116 To test that afterSec is actually waiting and not ignored
 	tstMsg('Test thermostat device', res)
 	return res
 end

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -422,8 +422,8 @@ describe('device', function()
 			assert.is_same(12.5, device.setPoint)
 
 			device.updateSetPoint(14)
-			assert.is_same({ { ['SetSetPoint:1'] = '14'} }, commandArray)
-
+            assert.is_same( { { ["UpdateDevice"] = { idx=1, nValue=0, sValue="14", _trigger=true } } }, commandArray)
+      
 		end)
 
 		it('should detect a text device', function()


### PR DESCRIPTION
adapter
	modified:   dzVents/runtime/device-adapters/thermostat_setpoint_device.lua
	modified:   dzVents/runtime/integration-tests/stage1.lua
	modified:   dzVents/runtime/tests/testDevice.lua