### PR TITLE
fix(python domoticz): Log should be upper case

### DIFF
--- a/scripts/python/domoticz.py
+++ b/scripts/python/domoticz.py
@@ -39,10 +39,10 @@ import re
 #	pass
 
 def log(*args):
-    domoticz_.log(0, " ".join([str(k) for k in args]))
+    domoticz_.Log(0, " ".join([str(k) for k in args]))
 
 def error(*args):
-    domoticz_.log(1, " ".join([str(k) for k in args]))
+    domoticz_.Log(1, " ".join([str(k) for k in args]))
 
 reloader.auto_reload(__name__)
 


### PR DESCRIPTION
fixes: #2097

I think there's an error in the script causing errors when using `domoticz.log` in python scripts for events. Changing `log` to `Log` seems to solve it.