### PR TITLE
Make Anne Thermostaat work with both old and new XML file format

### DIFF
--- a/hardware/AnnaThermostat.h
+++ b/hardware/AnnaThermostat.h
@@ -2,6 +2,11 @@
 
 #include "DomoticzHardware.h"
 
+// setup for different formats XML from the ANNA/Smile
+
+#define ANNA_VERSION_UNKNOWN 0
+#define ANNA_VERSION_LF 1
+
 class CAnnaThermostat : public CDomoticzHardwareBase
 {
 public:
@@ -10,21 +15,23 @@ public:
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	void SetSetpoint(const int idx, const float temp);
 	void SetProgramState(const int newState);
+	static int m_AnnaVersion;
 private:
 	void Init();
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void Do_Work();
 	void GetMeterDetails();
-
+    void AnnaVersionCheck();
 	void SendSetPointSensor(const unsigned char Idx, const float Temp, const std::string &defaultname);
 	bool SetAway(const bool bIsAway);
 private:
-	std::string m_IPAddress;
+   	std::string m_IPAddress;
 	unsigned short m_IPPort;
 	std::string m_UserName;
 	std::string m_Password;
 	std::string m_ThermostatID;
 	std::shared_ptr<std::thread> m_thread;
 };
-
+ 
+	


### PR DESCRIPTION
Patch will make allow the plugin  to read both version of XML input/output created by the two version of the ANNA (smile gateway) that seem to exist
When Domoticz starts or when new hardware is added the plugin will attempt to read the info of the gateway, based on the result it  will set a static flag that will be used to  handle the input out put for the two version

Tested against firmware 3.1.4  from Domoticz running on mac and on raspberry pi 3
No test has been done against older firmware as no device was available, however on forum volunteers are willing to test is as soon as it s merged in the beta build

