### PR TITLE
dzVents bugfix for RGBWW Set Color state and inverted logic in dzVents.cpp

### DIFF
--- a/dzVents/runtime/device-adapters/Adapters.lua
+++ b/dzVents/runtime/device-adapters/Adapters.lua
@@ -170,6 +170,7 @@ local function DeviceAdapters(dummyLogger)
 		['nightmode'] = { b = true, inv = 'Off' },
 		['set to white'] = { b = true, inv = 'Off' },
 		['set kelvin level'] = { b = true, inv = 'Off' },
+		['set color'] = { b = true },
 	}
 
 	return self

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -501,7 +501,7 @@ void CdzVents::SetGlobalVariables(lua_State *lua_state, const bool reasonTime, c
     std::string allowedNetworks;
     rnvalue = 0;
     m_sql.GetPreferencesVar("WebLocalNetworks",rnvalue, allowedNetworks);
-    if (allowedNetworks.find("127.0.0.") == std::string::npos)
+    if (allowedNetworks.find("127.0.0.") != std::string::npos)
     {
         std::string location;
         std::vector<std::string> strarray;


### PR DESCRIPTION
modified:   dzVents/runtime/device-adapters/Adapters.lua
modified:   main/dzVents.cpp