### PR TITLE
ZWave hardware setup, missing '$interval' inject

### DIFF
--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -8,7 +8,7 @@ define(['app'], function (app) {
         controller: ZWaveHardwareController
     });
 
-    function ZWaveHardwareController ($scope) {
+    function ZWaveHardwareController ($scope, $interval) {
         var $ctrl = this;
 
         $ctrl.$onInit = function() {


### PR DESCRIPTION
without we can add new devices