### PR TITLE
Devices page improvements

### DIFF
--- a/www/app/devices/Devices.css
+++ b/www/app/devices/Devices.css
@@ -3,9 +3,7 @@
     flex-direction: column;
 }
 
-.page-devices-wrapper > .usage-filter {
-    display: flex;
-    justify-content: space-between;
+.page-devices-wrapper > .top-panel {
     margin-bottom: 8px;
 }
 

--- a/www/app/devices/Devices.html
+++ b/www/app/devices/Devices.html
@@ -2,11 +2,15 @@
     <page-loading-indicator ng-hide="::$ctrl.devices" />
 
     <div class="page-devices-wrapper" ng-if="::$ctrl.devices">
-        <device-filter-by-usage
-                class="usage-filter"
-                ng-model="$ctrl.filter"
-                ng-change="$ctrl.applyFilter()"
-        />
+        <section class="top-panel">
+            <device-filter-by-usage
+                    class="btn-group"
+                    ng-model="$ctrl.filter"
+                    ng-change="$ctrl.applyFilter()"
+            />
+
+            <button class="btn btn-default pull-right" ng-click="$ctrl.refreshDevices()">{{:: 'Refresh' | translate}}</button>
+        </section>
 
         <section class="page-devices">
             <devices-filters

--- a/www/app/devices/Devices.js
+++ b/www/app/devices/Devices.js
@@ -532,7 +532,6 @@ define(['app'], function (app) {
             domoticzApi.sendRequest({
                 type: 'devices',
                 displayhidden: 1,
-                displaydisabled: 1,
                 filter: 'all',
                 used: 'all'
             })

--- a/www/app/devices/Devices.js
+++ b/www/app/devices/Devices.js
@@ -100,7 +100,7 @@ define(['app'], function (app) {
                             orderable: false,
                             render: actionsRenderer
                         },
-                        { title: $.t('Last Seen'), width: '150px', data: 'LastUpdate', type: 'date' },
+                        { title: $.t('Last Seen'), width: '150px', data: 'LastUpdate', type: 'date-us' },
                     ]
                 }));
 


### PR DESCRIPTION
#3084 Devices: Ability to manually refresh device list
#3093 Devices: Hide disabled devices if such option is enabled in settings
#3103 Devices: Fix sorting by Date in Safari

Added refresh button at the top of the table
![image](https://user-images.githubusercontent.com/2734836/54070480-2f0ea900-4269-11e9-8370-3f83cf7d66f0.png)
