### PR TITLE
Fixed: Evohome SYNC bug

### DIFF
--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -1627,11 +1627,11 @@ bool CEvohomeRadio::DecodeSync(CEvohomeMsg &msg) //0x1F09
 	{
 		if (msg.payloadsize == 1)
 		{
-			Log(true, LOG_STATUS, "evohome: %s: Type 0x%02x", msg.payload[0]);
+			Log(true, LOG_STATUS, "evohome: %s: Type 0x%02x", tag, msg.payload[0]);
 		}
 		else
 		{
-			Log(true, LOG_STATUS, "evohome: %s: Type 0x%02x (%d)", msg.payload[0], msg.payload[1] << 8 | msg.payload[2]);
+			Log(true, LOG_STATUS, "evohome: %s: Type 0x%02x (%d)", tag, msg.payload[0], msg.payload[1] << 8 | msg.payload[2]);
 		}
 		return true;
 	}


### PR DESCRIPTION
This fixes a bug which was introduced in the recent update to EvohomeRadio to add the SYNC command which causes Domoticz to crash. 

See discussion of bug here:

https://www.domoticz.com/forum/viewtopic.php?f=6&t=27484

Thanks,

Dan