### PR TITLE
Put correct node name in button titles in association group view

### DIFF
--- a/www/zwavetopology.html
+++ b/www/zwavetopology.html
@@ -171,7 +171,7 @@
 													var removeNodeId = this * 1;
 													var removeNode = nodes[Math.round(removeNodeId)];
 													button.click({node: node, group: group, removeNode: removeNode, removeNodeId: this}, removeNodeFromGroup);
-													button.attr('title', getNodeName(node) + ' on ' + getGroupName(group));
+													button.attr('title', getNodeName(removeNode) + ' on ' + getGroupName(group));
 													button.appendTo(td);
 												}
 											});


### PR DESCRIPTION
In the association group view (reached by selecing "Groups & Networks" from the "Node Management" menu over the Z-Wave node list), active association group connections are represented by little buttons with the node number of the referenced node on them. If you hover the mouse pointer over one of these, you're shown an explanatory text of the form ```<node name> on <group name>``` -- but the node name shown is that of the referencing node, *not* the one the button represents a reference to.

This simple patch corrects this.