### PR TITLE
Avoid out-of-array pointer dereferencing in mkdir_deep()

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -490,7 +490,7 @@ int mkdir_deep(const char *szDirName, int secattr)
 	{
 		if (('\\' == *p) || ('/' == *p))
 		{
-			if (':' != *(p-1))
+			if ((p > szDirName) && (':' != *(p-1)))
 			{
 				ret = createdir(DirName, secattr);
 			}


### PR DESCRIPTION
The check for the presence of a colon in front of a slash or backslash in the directory name string supplied to ```mkdir_deep()```, obviously there to protect against attempting to create a directory named ```C:``` or similar, will cause ```mkdir_deep()``` to access the address immediately preceding the supplied string, if that string starts with a slash or backslash.

This small change adds a check to prevent such a dereference, and the segmentation violation it will cause with some of the more aggressively protective malloc implementations available.