### PR TITLE
Bunch of code fixes

### DIFF
--- a/hardware/GpioPin.cpp
+++ b/hardware/GpioPin.cpp
@@ -78,7 +78,7 @@ int CGpioPin::SetReadValueFd(int value)
 	return m_read_value_fd;
 }
 
-bool CGpioPin::SetDBState(int db_state)
+void CGpioPin::SetDBState(int db_state)
 {
 	m_db_state = db_state;
 }

--- a/hardware/GpioPin.h
+++ b/hardware/GpioPin.h
@@ -43,7 +43,7 @@ public:
 	bool GetDBState();
 	int GetActiveLow();
 	int SetReadValueFd(int value);
-	bool SetDBState(int db_state);
+	void SetDBState(int db_state);
 	std::string ToString();
 	bool operator<(const CGpioPin& pin) const { return m_pin_number < pin.m_pin_number; };
 

--- a/hardware/openwebnet/bt_openwebnet.cpp
+++ b/hardware/openwebnet/bt_openwebnet.cpp
@@ -256,14 +256,15 @@ void bt_openwebnet::Set_who_what_where_when()
 		{
 			if (sup[0] != '*')
 				where = FirstToken(sup, "*");
-				// when
-				sup = frame_open.substr(1 + who.length() + 1 + what.length() + 1 + where.length() + 1);
-				if (sup.find("*") == std::string::npos) {
-					when = sup.substr(0, sup.length() - 2);
-				}
-				else
-					if (sup[0] != '*')
-						when = FirstToken(sup, "*");
+
+			// when
+			sup = frame_open.substr(1 + who.length() + 1 + what.length() + 1 + where.length() + 1);
+			if (sup.find("*") == std::string::npos) {
+				when = sup.substr(0, sup.length() - 2);
+			}
+			else
+				if (sup[0] != '*')
+					when = FirstToken(sup, "*");
 		}
 	}
 

--- a/main/SignalHandler.cpp
+++ b/main/SignalHandler.cpp
@@ -38,7 +38,7 @@ extern bool g_bRunAsDaemon;
 extern time_t m_LastHeartbeat;
 
 #if defined(__linux__)
-static bool printRegInfo(siginfo_t * info, ucontext_t * ucontext)
+static void printRegInfo(siginfo_t * info, ucontext_t * ucontext)
 {
 #if defined(REG_RIP) //x86_64
 	_log.Log(LOG_ERROR, "siginfo address=%p, address=%p", info->si_addr, (void*)((ucontext_t *)ucontext)->uc_mcontext.gregs[REG_RIP]);
@@ -53,7 +53,7 @@ static bool printRegInfo(siginfo_t * info, ucontext_t * ucontext)
 #endif
 }
 
-static bool printSingleThreadInfo(FILE* f, const char* pattern, bool& foundThread, bool& gdbSuccess)
+static void printSingleThreadInfo(FILE* f, const char* pattern, bool& foundThread, bool& gdbSuccess)
 {
 	char * line = NULL;
 	size_t len = 0;
@@ -82,7 +82,7 @@ static bool printSingleThreadInfo(FILE* f, const char* pattern, bool& foundThrea
 	}
 }
 
-static bool printSingleCallStack(FILE* f, const char* pattern, bool& foundThread, bool& gdbSuccess)
+static void printSingleCallStack(FILE* f, const char* pattern, bool& foundThread, bool& gdbSuccess)
 {
 	char * line = NULL;
 	size_t len = 0;

--- a/main/SunRiseSet.cpp
+++ b/main/SunRiseSet.cpp
@@ -154,7 +154,7 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 
 	rise = UtcToLocal(rise, timezone);
 	set = UtcToLocal(set, timezone);
-	result.SunAtSouthMin = static_cast<int>(modf((rise+set)/2.0, &_tmpH)*60+0,5);
+	result.SunAtSouthMin = static_cast<int>(modf((rise+set)/2.0, &_tmpH)*60+0.5);
 	result.SunAtSouthHour = static_cast<int>(_tmpH);
 
 	switch(rs) {

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -11140,7 +11140,7 @@ bool MainWorker::GetSensorData(const uint64_t idx, int &nValue, std::string &sVa
 
 			unsigned long long total_min = std::strtoull(sd2[0].c_str(), nullptr, 10);
 			unsigned long long total_max = std::strtoull(sd2[1].c_str(), nullptr, 10);
-			unsigned long long total_real = total_real = total_max - total_min;
+			unsigned long long total_real = total_max - total_min;
 			sprintf(szTmp, "%llu", total_real);
 
 			float musage = 0;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -10965,7 +10965,7 @@ void MainWorker::decode_Weather(const int HwdID, const _eHardwareTypes HwdType, 
 		}
 		pRFXDevice->SendWind(windID, BatteryLevel, intDirection, (float)intSpeed, (float)intGust, temp, chill, true, bHaveChill, procResult.DeviceName, SignalLevel);
 
-		if (subType = sTypeWEATHER2)
+		if (subType == sTypeWEATHER2)
 		{
 			int Humidity = (int)pResponse->WEATHER.humidity;
 			unsigned char HumidityStatus = pResponse->WEATHER.humidity_status;
@@ -10976,7 +10976,7 @@ void MainWorker::decode_Weather(const int HwdID, const _eHardwareTypes HwdType, 
 		}
 
 		//Rain
-		if ((subType = sTypeWEATHER1) || (subType = sTypeWEATHER2))
+		if ((subType == sTypeWEATHER1) || (subType == sTypeWEATHER2))
 		{
 			float TotalRain = 0;
 
@@ -10992,14 +10992,14 @@ void MainWorker::decode_Weather(const int HwdID, const _eHardwareTypes HwdType, 
 		}
 
 		//UV
-		if (subType = sTypeWEATHER2)
+		if (subType == sTypeWEATHER2)
 		{
 			float UV = (float)pResponse->WEATHER.uv;
 			pRFXDevice->SendUVSensor(windID, 1, BatteryLevel, UV, procResult.DeviceName, SignalLevel);
 		}
 
 		//Solar
-		if (subType = sTypeWEATHER2)
+		if (subType == sTypeWEATHER2)
 		{
 			float radiation = (float)((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow);
 			pRFXDevice->SendSolarRadiationSensor(windID, BatteryLevel, radiation, procResult.DeviceName);

--- a/push/WebsocketPush.cpp
+++ b/push/WebsocketPush.cpp
@@ -41,7 +41,7 @@ void CWebSocketPush::Stop()
 
 void CWebSocketPush::ListenTo(const unsigned long long DeviceRowIdx)
 {
-	std::unique_lock<std::mutex>(listenMutex);
+	std::unique_lock<std::mutex> lock(listenMutex);
 	bool bExists = std::find(listenIdxs.begin(), listenIdxs.end(), DeviceRowIdx) != listenIdxs.end();
 	if (!bExists) {
 		listenIdxs.push_back(DeviceRowIdx);
@@ -50,13 +50,13 @@ void CWebSocketPush::ListenTo(const unsigned long long DeviceRowIdx)
 
 void CWebSocketPush::UnlistenTo(const unsigned long long DeviceRowIdx)
 {
-	std::unique_lock<std::mutex>(listenMutex);
+	std::unique_lock<std::mutex> lock(listenMutex);
 	listenIdxs.erase(std::remove(listenIdxs.begin(), listenIdxs.end(), DeviceRowIdx), listenIdxs.end());
 }
 
 void CWebSocketPush::ClearListenTable()
 {
-	std::unique_lock<std::mutex>(listenMutex);
+	std::unique_lock<std::mutex> lock(listenMutex);
 	listenIdxs.clear();
 }
 
@@ -96,7 +96,7 @@ void CWebSocketPush::onDeviceTableChanged()
 
 bool CWebSocketPush::WeListenTo(const unsigned long long DeviceRowIdx)
 {
-	std::unique_lock<std::mutex>(listenMutex);
+	std::unique_lock<std::mutex> lock(listenMutex);
 	return std::find(listenIdxs.begin(), listenIdxs.end(), DeviceRowIdx) != listenIdxs.end();
 }
 

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -245,7 +245,7 @@ void connection::MyWrite(const std::string &buf)
 	case connection_http:
 	case connection_websocket:
 		// we dont send data anymore in websocket closing state
-		std::unique_lock<std::mutex>(writeMutex);
+		std::unique_lock<std::mutex> lock(writeMutex);
 		if (write_in_progress) {
 			// write in progress, add to queue
 			writeQ.push(buf);
@@ -382,7 +382,7 @@ void connection::handle_read(const boost::system::error_code& error, std::size_t
 
 void connection::handle_write(const boost::system::error_code& error, size_t bytes_transferred)
 {
-	std::unique_lock<std::mutex>(writeMutex);
+	std::unique_lock<std::mutex> lock(writeMutex);
 	write_buffer.clear();
 	write_in_progress = false;
 	if (!error) {

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -221,7 +221,7 @@ namespace http {
 
 		void CProxyClient::MyWrite(pdu_type type, CValueLengthPart &parameters)
 		{
-			std::unique_lock<std::mutex>(writeMutex);
+			std::unique_lock<std::mutex> lock(writeMutex);
 			if (connection_status != status_connected) {
 				return;
 			}


### PR DESCRIPTION
Fixes a bunch of code that's obviously incorrect. These were found by enabling -Wall and looking at the compiler output (see #2546). It'd by nice if more warnings were fixed so they can be enabled by default to avoid introducing detectable bugs.

In commit 28c9207 I had to choose between changing the indentation or introducing braces, I chose to change the indentation because that preserves the current meaning of the code, and seems to be how the code was introduced in 1d1d5404b (function Assegna_chi_cosa_dove_quando).

Sorry about basing commits on the development branch instead of master. I didn't look at the contributing guidelines before writing these fixes, and rebasing them causes a bunch of conflicts.