### PR TITLE
Moved call to std::srand from Helper.cpp to domoticz.cpp

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -916,7 +916,6 @@ void DirectoryListing(std::vector<std::string>& entries, const std::string &dir,
 
 std::string GenerateUserAgent()
 {
-	// srand((unsigned int)time(NULL)); // srand moved to domoticz.cpp so it's only called once This prevents same seed when called again same second 
 	int cversion = rand() % 0xFFFF;
 	int mversion = rand() % 3;
 	int sversion = rand() % 3;
@@ -1273,7 +1272,6 @@ bool IsWSL(void)
 const std::string hexCHARS = "0123456789abcdef";
 std::string GenerateUUID() // DCE/RFC 4122
 {
-	// std::srand((unsigned int)std::time(nullptr)); // srand moved to domoticz.cpp so it's only called once This prevents same seed when called again same second 
 	std::string uuid = std::string(36, ' ');
 
 	uuid[8] = '-';

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -916,7 +916,7 @@ void DirectoryListing(std::vector<std::string>& entries, const std::string &dir,
 
 std::string GenerateUserAgent()
 {
-	srand((unsigned int)time(NULL));
+	// srand((unsigned int)time(NULL)); // srand moved to domoticz.cpp so it's only called once This prevents same seed when called again same second 
 	int cversion = rand() % 0xFFFF;
 	int mversion = rand() % 3;
 	int sversion = rand() % 3;
@@ -1273,7 +1273,7 @@ bool IsWSL(void)
 const std::string hexCHARS = "0123456789abcdef";
 std::string GenerateUUID() // DCE/RFC 4122
 {
-	std::srand((unsigned int)std::time(nullptr));
+	// std::srand((unsigned int)std::time(nullptr)); // srand moved to domoticz.cpp so it's only called once This prevents same seed when called again same second 
 	std::string uuid = std::string(36, ' ');
 
 	uuid[8] = '-';

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -214,7 +214,10 @@ void daemonize(const char *rundir, const char *pidfile)
 		/* Could not fork */
 		exit(EXIT_FAILURE);
 	}
-
+    
+    /* call srand once for the entire app */
+    std::srand((unsigned int)std::time(nullptr));
+    
 	if (pid > 0)
 	{
 		/* Child created ok, so exit parent process */


### PR DESCRIPTION
#3156 
This PR causes the generated userID and AuthToken to be different and unique by calling srand (creating random seed sequence) only once during domoticz start. If srand is called repeatedly in the same second it generates an equal random seed causing duplicate values for AuthToken. These cannot be entered into table usersessions because of the UNIQUE constraint for that field and thus generate sqlite errors    
 	modified:   main/Helper.cpp
	modified:   main/domoticz.cpp