### PR TITLE
Arilux driver brightness level support and code cleanup

### DIFF
--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -26,9 +26,10 @@ Based on christianTF boblightwifi plugin for Arilux and Belville Flux Led python
 Arilux::Arilux(const int ID)
 {
 	m_HwdID = ID;
-	m_bDoRestart = false;
-	m_isWhite = true;
-
+  m_color.r = 0xff;
+  m_color.g = 0xff;
+  m_color.b = 0xff;
+  m_color.ww = 0xff;
 }
 
 Arilux::~Arilux(void)
@@ -38,8 +39,6 @@ Arilux::~Arilux(void)
 bool Arilux::StartHardware()
 {
 	RequestStart();
-
-	m_bDoRestart = false;
 
 	//force connect the next first time
 	m_bIsStarted = true;
@@ -81,71 +80,35 @@ void Arilux::Do_Work()
 }
 
 
-void Arilux::InsertUpdateSwitch(const std::string &/*nodeID*/, const std::string &lightName, const int &YeeType, const std::string &Location, const bool bIsOn, const std::string &ariluxBright, const std::string &/*ariluxHue*/)
+void Arilux::InsertUpdateSwitch(const std::string lightName, const int subType, const std::string location)
 {
-	std::vector<std::string> ipaddress;
-	StringSplit(Location, ".", ipaddress);
-	if (ipaddress.size() != 4)
-	{
-		Log(LOG_ERROR, "Invalid location received! (No IP Address)");
+	uint32_t sID;
+	try {
+		sID = boost::asio::ip::address_v4::from_string(location).to_ulong();
+	} catch (const std::exception &e) {
+		Log(LOG_ERROR, "Bad IP address: %s (%s)", location.c_str(), e.what());
 		return;
 	}
-	uint32_t sID = (uint32_t)(atoi(ipaddress[0].c_str()) << 24) | (uint32_t)(atoi(ipaddress[1].c_str()) << 16) | (atoi(ipaddress[2].c_str()) << 8) | atoi(ipaddress[3].c_str());
 	char szDeviceID[20];
-	if (sID == 1)
-		sprintf(szDeviceID, "%d", 1);
-	else
-		sprintf(szDeviceID, "%08X", (unsigned int)sID);
+	sprintf(szDeviceID, "%08X", sID);
 
-	bool tIsOn = !(bIsOn);
-	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT nValue, LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (SubType==%d)", m_HwdID, szDeviceID, pTypeColorSwitch, YeeType);
+	std::vector<std::vector<std::string>> result;
+	result = m_sql.safe_query("SELECT nValue, LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (SubType==%d)", m_HwdID, szDeviceID, pTypeColorSwitch, subType);
 	if (result.empty())
 	{
-		Log(LOG_STATUS, "New controller added (%s/%s)", Location.c_str(), lightName.c_str());
-		int value = atoi(ariluxBright.c_str());
-		int cmd = Color_LedOn;
-		//int level = 100;
-		if (!bIsOn) {
-			cmd = Color_LedOff;
-			//level = 0;
-		}
+		Log(LOG_STATUS, "New controller added (%s/%s)", location.c_str(), lightName.c_str());
 		_tColorSwitch ycmd;
-		ycmd.subtype = (uint8_t)YeeType;
+		ycmd.subtype = (uint8_t)subType;
 		ycmd.id = sID;
 		ycmd.dunit = 0;
-		ycmd.value = value;
-		ycmd.command = (uint8_t)cmd;
+		ycmd.value = 0;
+		ycmd.command = Color_LedOff;
 		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&ycmd, NULL, -1);
-		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', SwitchType=%d, LastLevel=%d WHERE(HardwareID == %d) AND (DeviceID == '%q')", lightName.c_str(), (STYPE_Dimmer), value, m_HwdID, szDeviceID);
-	}
-	else {
-
-		int nvalue = atoi(result[0][0].c_str());
-		tIsOn = (nvalue != 0);
-		int lastLevel = atoi(result[0][1].c_str());
-		int value = atoi(ariluxBright.c_str());
-		if ((bIsOn != tIsOn) || (value != lastLevel))
-		{
-			int cmd = Color_LedOn;
-			if (!bIsOn) {
-				cmd = Color_LedOff;
-			}
-			if (value != lastLevel) {
-				cmd = Color_SetBrightnessLevel;
-			}
-			_tColorSwitch ycmd;
-			ycmd.subtype = (uint8_t)YeeType;
-			ycmd.id = sID;
-			ycmd.dunit = 0;
-			ycmd.value = value;
-			ycmd.command = (uint8_t)cmd;
-			m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&ycmd, NULL, -1);
-		}
+		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', switchType=%d WHERE(HardwareID == %d) AND (DeviceID == '%q')", lightName.c_str(), STYPE_Dimmer, m_HwdID, szDeviceID);
 	}
 }
 
-bool Arilux::SendTCPCommand(char ip[50],std::vector<unsigned char> &command)
+bool Arilux::SendTCPCommand(uint32_t ip,std::vector<unsigned char> &command)
 {
 	Log(LOG_STATUS, "Sending data to device");
 
@@ -156,16 +119,11 @@ bool Arilux::SendTCPCommand(char ip[50],std::vector<unsigned char> &command)
 
 	boost::asio::io_service io_service;
 	boost::asio::ip::tcp::socket sendSocket(io_service);
-	boost::asio::ip::tcp::resolver resolver(io_service);
-	boost::asio::ip::tcp::resolver::query query(boost::asio::ip::tcp::v4(), ip, "5577");
-	boost::asio::ip::tcp::resolver::iterator iterator = resolver.resolve(query);
-
-
-
-
+	boost::asio::ip::address_v4 address(ip);
+	boost::asio::ip::tcp::endpoint endpoint(address, 5577);
 	try
 	{
-		boost::asio::connect(sendSocket, iterator);
+		sendSocket.connect(endpoint);
 	}
 	catch (const std::exception &e)
 	{
@@ -180,10 +138,6 @@ bool Arilux::SendTCPCommand(char ip[50],std::vector<unsigned char> &command)
 	//Log(LOG_STATUS, "Command sent");
 	sleep_milliseconds(50);
 
-	/*sendSocket.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
-	sendSocket.close();
-	io_service.stop();*/
-
 	return true;
 
 }
@@ -193,31 +147,6 @@ bool Arilux::WriteToHardware(const char *pdata, const unsigned char /*length*/)
 {
 	Debug(DEBUG_HARDWARE, "WriteToHardware...............................");
 	const _tColorSwitch *pLed = reinterpret_cast<const _tColorSwitch*>(pdata);
-	//uint8_t command = pLed->command;
-	std::vector<std::vector<std::string> > result;
-
-	unsigned long lID;
-	char ipAddress[50];
-	bool sendOnFirst = false;
-
-	if (pLed->id == 1)
-		sprintf(ipAddress, "%d", 1);
-	else
-		sprintf(ipAddress, "%08X", (unsigned int)pLed->id);
-	std::string ID = ipAddress;
-
-	std::stringstream s_strid;
-	s_strid << std::hex << ID;
-	s_strid >> lID;
-
-	unsigned char ID1 = (unsigned char)((lID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((lID & 0x00FF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((lID & 0x0000FF00) >> 8);
-	unsigned char ID4 = (unsigned char)((lID & 0x000000FF));
-
-	//IP Address
-	sprintf(ipAddress, "%d.%d.%d.%d", ID1, ID2, ID3, ID4);
-
 
 	//Code for On/Off and RGB command
 	unsigned char Arilux_On_Command_Tab[] = { 0x71, 0x23, 0x0f };
@@ -229,127 +158,54 @@ bool Arilux::WriteToHardware(const char *pdata, const unsigned char /*length*/)
 	std::vector<unsigned char> Arilux_Off_Command(Arilux_Off_Command_Tab, Arilux_Off_Command_Tab + sizeof(Arilux_Off_Command_Tab) / sizeof(unsigned char));
 	std::vector<unsigned char> Arilux_RGBCommand_Command(Arilux_RGBCommand_Command_Tab, Arilux_RGBCommand_Command_Tab + sizeof(Arilux_RGBCommand_Command_Tab) / sizeof(unsigned char));
 
-
-
-
-
-	std::vector<unsigned char> commandToSend;
-
 	switch (pLed->command)
 	{
 	case Color_LedOn:
-		commandToSend = Arilux_On_Command;
-
-		break;
+		return SendTCPCommand(pLed->id, Arilux_On_Command);
 	case Color_LedOff:
-		commandToSend = Arilux_Off_Command;
-		break;
-
+		return SendTCPCommand(pLed->id, Arilux_Off_Command);
 	case Color_SetColorToWhite:
-		sendOnFirst = true;
-		m_isWhite = true;
-		Arilux_RGBCommand_Command[1] = 0xff;
-		Arilux_RGBCommand_Command[2] = 0xff;
-		Arilux_RGBCommand_Command[3] = 0xff;
-		Arilux_RGBCommand_Command[4] = 0xff;
-		commandToSend = Arilux_RGBCommand_Command;
-		break;
+		Arilux_RGBCommand_Command[1] = m_color.r = 0xff;
+		Arilux_RGBCommand_Command[2] = m_color.g = 0xff;
+		Arilux_RGBCommand_Command[3] = m_color.b = 0xff;
+		Arilux_RGBCommand_Command[4] = m_color.ww = 0xff;
+		return SendTCPCommand(pLed->id, Arilux_RGBCommand_Command);
 	case Color_SetColor:
 		if (pLed->color.mode == ColorModeWhite)
 		{
-			m_isWhite = true;
+			m_color.r = 0xff;
+			m_color.g = 0xff;
+			m_color.b = 0xff;
+      m_color.ww = 0xff;
 		}
 		else if (pLed->color.mode == ColorModeRGB)
 		{
-			m_isWhite = false;
 			m_color.r = pLed->color.r;
 			m_color.g = pLed->color.g;
 			m_color.b = pLed->color.b;
+      m_color.ww = 0;
+		}
+		else if (pLed->color.mode == ColorModeCustom)
+		{
+			m_color.r = pLed->color.r;
+			m_color.g = pLed->color.g;
+			m_color.b = pLed->color.b;
+      m_color.ww = pLed->color.ww;
 		}
 		else {
 			Log(LOG_ERROR, "SetRGBColour - Color mode %d is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum", pLed->color.mode);
+      return false;
 		}
 		// No break, fall through to send combined color + brightness command
-	case Color_SetBrightnessLevel: {
-
-		int red, green, blue;
-		int BrightnessBase = (int)pLed->value;
-		int dMax_Send = (int)(round((255.0f / 100.0f)*float(BrightnessBase)));
-		red = m_color.r;
-		green = m_color.g;
-		blue = m_color.b;
-
-		if (m_isWhite) // TODO: Use m_color.mode instead
-		{
-			Arilux_RGBCommand_Command[1] = (unsigned char)0xff;
-			Arilux_RGBCommand_Command[2] = (unsigned char)0xff;
-			Arilux_RGBCommand_Command[3] = (unsigned char)0xff;
-			Arilux_RGBCommand_Command[4] = (unsigned char)dMax_Send;
-
-			commandToSend = Arilux_RGBCommand_Command;
-		}
-		else
-		{
-			//Log(LOG_NORM, "Red: %03d, Green:%03d, Blue:%03d, Brightness:%03d", red, green, blue, dMax_Send);
-
-			Arilux_RGBCommand_Command[1] = (unsigned char)red;
-			Arilux_RGBCommand_Command[2] = (unsigned char)green;
-			Arilux_RGBCommand_Command[3] = (unsigned char)blue;
-			Arilux_RGBCommand_Command[4] = (unsigned char)dMax_Send;
-
-			commandToSend = Arilux_RGBCommand_Command;
-		}
+	case Color_SetBrightnessLevel:
+		Arilux_RGBCommand_Command[1] = m_color.r * pLed->value / 100;
+		Arilux_RGBCommand_Command[2] = m_color.g * pLed->value / 100;
+		Arilux_RGBCommand_Command[3] = m_color.b * pLed->value / 100;
+		Arilux_RGBCommand_Command[4] = m_color.ww * pLed->value / 100;
+		return SendTCPCommand(pLed->id, Arilux_RGBCommand_Command);
 	}
-	break;
-	case Color_SetBrightUp:
-		Log(LOG_STATUS, "SetBrightUp - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_SetBrightDown:
-		Log(LOG_STATUS, "SetBrightDown - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_WarmWhiteIncrease:
-		Log(LOG_STATUS, "WarmWhiteIncrease - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_CoolWhiteIncrease:
-		Log(LOG_STATUS, "CoolWhiteIncrease - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_NightMode:
-		Log(LOG_STATUS, "NightMode - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_FullBrightness:
-		Log(LOG_STATUS, "FullBrightness - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_DiscoMode:
-		Log(LOG_STATUS, "DiscoMode - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	case Color_DiscoSpeedFasterLong:
-		Log(LOG_STATUS, "DiscoSpeedFasterLong - This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
-		break;
-	default:
-
-		break;
-	}
-
-
-	if (commandToSend.empty())return false; //No command to send
-
-
-
-
-
-
-
-	bool returnValue = false;
-
-
-	if (sendOnFirst)
-	{
-		returnValue= SendTCPCommand(ipAddress,Arilux_On_Command);
-	}
-
-	returnValue= SendTCPCommand(ipAddress,commandToSend);
-
-	return returnValue;
+	Log(LOG_STATUS, "This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");
+	return false;
 }
 
 //Webserver helpers
@@ -375,7 +231,7 @@ namespace http {
 			int HwdID = atoi(idx.c_str());
 
 			Arilux Arilux(HwdID);
-			Arilux.InsertUpdateSwitch("123", sname, (stype == "0") ? sTypeColor_RGB : sTypeColor_RGB_W, sipaddress, false, "0", "0");
+			Arilux.InsertUpdateSwitch(sname, (stype == "0") ? sTypeColor_RGB : sTypeColor_RGB_W_Z, sipaddress);
 		}
 	}
 }

--- a/hardware/Arilux.h
+++ b/hardware/Arilux.h
@@ -9,16 +9,13 @@ public:
 	explicit Arilux(const int ID);
 	~Arilux(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
-	boost::signals2::signal<void()> sDisconnected;
-	void InsertUpdateSwitch(const std::string &nodeID, const std::string &SketchName, const int &YeeType, const std::string &Location, const bool bIsOn, const std::string &ariluxBright, const std::string &ariluxHue);
+	void InsertUpdateSwitch(const std::string name, const int switchType, const std::string location);
 private:
-	bool SendTCPCommand(char ip[50],std::vector<unsigned char> &command);
+	bool SendTCPCommand(uint32_t ip,std::vector<unsigned char> &command);
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void Do_Work();
 private:
 	_tColor m_color;
-	bool m_isWhite;
-	bool m_bDoRestart;
 	std::shared_ptr<std::thread> m_thread;
 };


### PR DESCRIPTION
This PR changes the following in the arilux hardware driver:
* RGBW controllers changed from `sTypeColor_RGB_W` to `sTypeColor_RGB_W_Z` so all 4 channels can be used independently
* `value` is no longer ignored in `Color_SetColor` RGB mode (this prevented dimming in most situations)
* removed some dead code
* simplified IP address manipulation
