### PR TITLE
Prevent touch scroll while using jQuery wheel color picker

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2032,3 +2032,8 @@ table.display thead th.sorting_disabled div.DataTables_sort_wrapper {
 .battery.empty {background-color: #ED3745;}
 .battery.empty:before, .battery.empty:after {border-color: #ED3745;}
 .battery.half {background-color: #F9D023;}
+
+/* Prevent touch scroll while using jQuery Wheel color picker */
+.jQWCP-wWidget {
+	touch-action: none;
+}


### PR DESCRIPTION
When using touch and slide on jQuery wheel color picker elements the page will scroll as well.
The is fixed here using the same method as in the component used for level slider:
https://github.com/jquery/jquery-ui/blob/master/themes/base/slider.css#L22
