### PR TITLE
Minor ui fixes for evohome

### DIFF
--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -371,6 +371,7 @@ define(['app'], function (app) {
 								}
 								else if (item.SubType == "Evohome") {
 									img = EvohomeImg(item);
+									bigtext = GetLightStatusText(item);
 								}
 								else if (item.SwitchType == "X10 Siren") {
 									if (
@@ -915,7 +916,7 @@ define(['app'], function (app) {
 								'\t      <td id="name">' + item.Name + '</td>\n' +
 								'\t      <td id="bigtext">';
 							var bigtext = TranslateStatusShort(item.Status);
-							if (item.SwitchType === "Selector") {
+							if (item.SwitchType === "Selector" || item.SubType == "Evohome") {
 								bigtext = GetLightStatusText(item);
 							}
 							if (item.UsedByCamera == true) {

--- a/www/styles/elemental/custom.css
+++ b/www/styles/elemental/custom.css
@@ -132,6 +132,10 @@ li {
 	line-height: 4px;
 }
 
+.ui-popup li {
+	line-height: 20px;
+}
+
 .navbar .nav .dropdown-toggle .caret {
 	margin-top: 0px;
 }


### PR DESCRIPTION
The menu height for the evohome popup menu is squashed in the elemental theme. This is because the elemental custom css overrides the normal li line-height. The popup looks bad and is difficult to use on a touch device therefore add a specific ui-popup lil override in the elemental custom css that restores the  default line height for the evohome popup menu.

The human readable mode text for the evohome controller device is no longer being displayed. The original behaviour has been restored with a minor update to LightsController.js