### PR TITLE
Fix Detection of Python 3.x libraries on FreeBSD (Delayed Link).

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -160,6 +160,12 @@ namespace Plugins {
 				if (!shared_lib_) FindLibrary("python3.6", true);
 				if (!shared_lib_) FindLibrary("python3.5", true);
 				if (!shared_lib_) FindLibrary("python3.4", true);
+#ifdef __FreeBSD__
+				if (!shared_lib_) FindLibrary("python3.7m", true);
+				if (!shared_lib_) FindLibrary("python3.6m", true);
+				if (!shared_lib_) FindLibrary("python3.5m", true);
+				if (!shared_lib_) FindLibrary("python3.4m", true);
+#endif /* FreeBSD */
 #endif
 				if (shared_lib_)
 				{


### PR DESCRIPTION
On FreeBSD the shared lib used for Python has the suffix "m" (don't ask me why)..
This trivial patch fix the delayed linker to find the right lib on FreeBSD.

Regards