### PR TITLE
fixed memory leak in XPath library

### DIFF
--- a/tinyxpath/node_set.cpp
+++ b/tinyxpath/node_set.cpp
@@ -40,6 +40,16 @@ node_set & node_set::operator = (const node_set & ns2)
    u_nb_node = ns2 . u_nb_node;
    if (u_nb_node)
    {
+      if ( vpp_node_set != NULL )
+      {
+          delete[] vpp_node_set;
+      }
+      
+      if ( op_attrib != NULL )
+      {
+          delete[] op_attrib;
+      }
+      
       vpp_node_set = new const void * [u_nb_node];
       memcpy (vpp_node_set, ns2 . vpp_node_set, u_nb_node * sizeof (void *));
       op_attrib = new bool [u_nb_node];


### PR DESCRIPTION
This patch was produced on SourceForge. Was never merged into tinyxpath code.
Seems the maintainer of tinyxpath doesn't maintain that anymore :(  

The XPath library did not take into consideration that a query would be run more
than once.  As a consequence, if it was it was leaking memory in the overridden
assignment operator (=).  I added a check to free the memory to prevent the
memory leak.

This was occurring when I would call the "u_compute_xpath_node_set()" function
in a loop to retrieve the number of nodes in the set.

Credit :  Benjamin Rood <brood@attotech.com>

