### PR TITLE
Fix Telegram notification error when odd number of underscores in text

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -7,6 +7,7 @@ Version 4.xxxxx (xxx 2019)
 - Fixed: GUI, Switch Log, date parsing in device log (#3206)
 - Fixed: GUI, Weight Log now displays correct Unit (#3211)
 - Fixed: GUI, OpenZWave Abort Include/Exclude button
+- Fixed: notification, Telegram error when odd number of underscores in text
 - Updated: OpenZWave version 1.6
 - Updated: dzVents (version 2.4.21, See dzVents/documentation/history.md)
 

--- a/notifications/NotificationTelegram.cpp
+++ b/notifications/NotificationTelegram.cpp
@@ -1,5 +1,6 @@
 #include "stdafx.h"
 #include "NotificationTelegram.h"
+#include "../main/Helper.h"
 #include "../httpclient/HTTPClient.h"
 #include "../main/Logger.h"
 #include "../json/json.h"
@@ -42,11 +43,15 @@ bool CNotificationTelegram::SendMessageImplementation(
 	sBuildUrl << "https://api.telegram.org/bot" << _apikey << "/sendMessage";
 	sUrl = sBuildUrl.str();
 
+	//prepare Text
+	std::string sPreparedText(Text);
+	stdreplace(sPreparedText,"_","\\_");
+	
 	//Build the message in JSON
 	json["chat_id"] = _chatid;
-	json["text"] = CURLEncode::URLDecode(Text);
+	json["text"] = CURLEncode::URLDecode(sPreparedText);
 	json["parse_mode"] = "Markdown";
-	//json["body"] = CURLEncode::URLDecode(Text);
+
 	if ( Priority < 0 )
 		json["disable_notification"] = 1;
 	sPostData = jsonWriter.write(json);


### PR DESCRIPTION
	modified:   History.txt
	modified:   notifications/NotificationTelegram.cpp

also references [this issue ](https://github.com/eternnoir/pyTelegramBotAPI/issues/114)