### PR TITLE
update to dzVents 2.4.22; selector switchselector to accept levelnames / fix for wildcarded time rule

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -9,7 +9,7 @@ Version 4.xxxxx (xxx 2019)
 - Fixed: GUI, OpenZWave Abort Include/Exclude button
 - Fixed: notification, Telegram error when odd number of underscores in text
 - Updated: OpenZWave version 1.6
-- Updated: dzVents (version 2.4.21, See dzVents/documentation/history.md)
+- Updated: dzVents (version 2.4.22, See dzVents/documentation/history.md)
 
 Version 4.10717 (May 9th 2019)
 - Fixed: dzVents, Allowing no error message for HTTP calls (#3191)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -892,7 +892,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **stop()**: *Function*. Set device to Stop if it supports it (e.g. blinds). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **switchOff()**: *Function*. Switch device off it is supports it. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **switchOn()**: *Function*. Switch device on if it supports it. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- - **switchSelector(level)**: *Function*. Switches a selector switch to a specific level (numeric value, see the edit page in Domoticz for such a switch to get a list of the values). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **switchSelector(<[level]|[levelname]>)**: *Function*. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **toggleSwitch()**: *Function*. Toggles the state of the switch (if it is togglable) like On/Off, Open/Close etc.
 
 #### Temperature sensor
@@ -1994,6 +1994,11 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # Change log
+##[2.4.22]
+- selector.switchSelector method accepts levelNames
+- increased selector.switchSelector resilience
+- fix wildcard timerule 
+
 ##[2.4.21]
 - fixed wrong direction for open() and close() for some types of blinds
 - Add inTable function to domoticz.utils

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -921,7 +921,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''stop()''': ''Function''. Set device to Stop if it supports it (e.g. blinds). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOff()''': ''Function''. Switch device off it is supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOn()''': ''Function''. Switch device on if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''switchSelector(level)''': ''Function''. Switches a selector switch to a specific level (numeric value, see the edit page in Domoticz for such a switch to get a list of the values). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''switchSelector(&lt;[level]|[levelname]&gt;)''': ''Function''. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''toggleSwitch()''': ''Function''. Toggles the state of the switch (if it is togglable) like On/Off, Open/Close etc.
 
 ==== Temperature sensor ====
@@ -2108,6 +2108,12 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you're good to go.
 
 = Change log =
+
+== [2.4.22] ==
+
+* selector.switchSelector method accepts levelNames
+* increased selector.switchSelector resilience
+* fix wildcard timerule
 
 == [2.4.21] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,8 @@
+[2.4.22]
+- selector.switchSelector method accepts levelNames
+- increased selector.switchSelector resilience
+- fix wildcard timerule 
+
 [2.4.21]
 - fixed wrong direction for open() and close() for some types of blinds
 - Add inTable function to domoticz.utils

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -153,10 +153,7 @@ local function Domoticz(settings)
 			_ = _,
 
 			toCelsius = function(f, relative)
-				if (relative) then
-					return f*(1/1.8)
-				end
-				return ((f-32) / 1.8)
+				return utils.toCelsius(f, relative)
 			end,
 
 			urlEncode = function(s, strSub)
@@ -167,15 +164,8 @@ local function Domoticz(settings)
 				return utils.urlDecode(s)
 			end,
 
-			round = function(x, n)
-				n = math.pow(10, n or 0)
-				x = x * n
-				if x >= 0 then
-					x = math.floor(x + 0.5)
-				else
-					x = math.ceil(x - 0.5)
-				end
-				return x / n
+			round = function(x,n)
+				return utils.round(x,n)
 			end,
 
 			osExecute = function(cmd)
@@ -388,7 +378,7 @@ local function Domoticz(settings)
 	function self.round(x, n)
 		utils.log('domoticz.round deprecated. Please use domoticz.utils.round.', utils.LOG_INFO)
 		return self.utils.round(x, n)
-	end
+	 end
 
 	function self.dump()
 		self.utils.dumpTable(settings, '> ')

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -431,7 +431,7 @@ local function Time(sDate, isUTC, _testMS)
 		elseif (string.find(rule, 'every even week') and ((self.week % 2) == 0)) then
 			return true
 		elseif string.find(rule, 'every even week') or string.find(rule, 'every odd week') then
-        	return false
+			return false
 		end
 
 		local weeks = string.match(rule, 'in week% ([0-9%-%,% ]*)')
@@ -441,7 +441,6 @@ local function Time(sDate, isUTC, _testMS)
 		end
 
 		-- from here on, if there is a match we return true otherwise false
-
 		-- remove spaces and add a comma
 		weeks = string.gsub(weeks, ' ', '') .. ',' --remove spaces and add a , so each number is terminated with a , so we can do simple search for the number
 
@@ -500,11 +499,13 @@ local function Time(sDate, isUTC, _testMS)
 
 		-- wildcards
 		for set, day, month in string.gmatch(dates, '(([0-9%*]*)/([0-9%*]*))') do
+ 
 			if (day == '*' and month ~= '*') then
 				if (self.month == tonumber(month)) then
 					return true
 				end
 			end
+			
 			if (day ~= '*' and month == '*') then
 				if (self.day == tonumber(day)) then
 					return true
@@ -512,36 +513,33 @@ local function Time(sDate, isUTC, _testMS)
 			end
 		end
 
+		
 		local getParts = function(set)
 			local day, month = string.match(set, '([0-9]+)/([0-9]+)')
 			return tonumber(day), tonumber(month)
 		end
 
 		--now get the ranges
-		for fromSet, toSet in string.gmatch(dates, '([0-9%/]*)-([0-9%/]*)') do
+		for fromSet, toSet in string.gmatch(dates, '([0-9%/*]*)-([0-9%/*]*)') do
+			local ttoSet = string.gsub(toSet,'%*','31') -- catch wildcarded not current months
+			local ffromSet = string.gsub(fromSet,'%*','01') -- catch wildcarded not current months
+
 			local fromDay, toDay, fromMonth, toMonth
 
-			if (isEmpty(fromSet) and not isEmpty(toSet)) then
-				toDay, toMonth = getParts(toSet)
+			if (isEmpty(ffromSet) and not isEmpty(ttoSet)) then
+				toDay, toMonth = getParts(ttoSet)
 				if ((self.month < toMonth) or (self.month == toMonth and self.day <= toDay)) then
 					return true
 				end
-			elseif (not isEmpty(fromSet) and isEmpty(toSet)) then
-				fromDay, fromMonth = getParts(fromSet)
+			elseif (not isEmpty(ffromSet) and isEmpty(ttoSet)) then
+				fromDay, fromMonth = getParts(ffromSet)
 				if ((self.month > fromMonth) or (self.month == fromMonth and self.day >= fromDay)) then
 					return true
 				end
 			else
 
-				toDay, toMonth = getParts(toSet)
-				fromDay, fromMonth = getParts(fromSet)
-				--local _ = require('lodash');
-				--_.print('sm', self.month, 'sd', self.day, 'fm', fromMonth, 'tm', toMonth, 'fd', fromDay, 'td', toDay)
-				--_.print('( self.month > fromMonth and self.month < toMonth )', (self.month > fromMonth and self.month < toMonth))
-				--_.print('( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or', (fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay))
-				--_.print('( self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay ) or', (self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay) )
-				--_.print('( self.month == toMonth and toMonth < fromMonth and  self.day <= toDay )', (self.month == toMonth and toMonth < fromMonth and self.day <= toDay))
-				--_.print('( self.month == toMonth and toMonth > fromMonth and self.day <= toDay )', (self.month == toMonth and toMonth > fromMonth and self.day <= toDay))
+				toDay, toMonth = getParts(ttoSet)
+				fromDay, fromMonth = getParts(ffromSet)
 				if (
 					( self.month > fromMonth and self.month < toMonth ) or
 					( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -431,7 +431,7 @@ local function Time(sDate, isUTC, _testMS)
 		elseif (string.find(rule, 'every even week') and ((self.week % 2) == 0)) then
 			return true
 		elseif string.find(rule, 'every even week') or string.find(rule, 'every odd week') then
-			return false
+        	return false
 		end
 
 		local weeks = string.match(rule, 'in week% ([0-9%-%,% ]*)')
@@ -441,6 +441,7 @@ local function Time(sDate, isUTC, _testMS)
 		end
 
 		-- from here on, if there is a match we return true otherwise false
+
 		-- remove spaces and add a comma
 		weeks = string.gsub(weeks, ' ', '') .. ',' --remove spaces and add a , so each number is terminated with a , so we can do simple search for the number
 
@@ -499,13 +500,11 @@ local function Time(sDate, isUTC, _testMS)
 
 		-- wildcards
 		for set, day, month in string.gmatch(dates, '(([0-9%*]*)/([0-9%*]*))') do
- 
 			if (day == '*' and month ~= '*') then
 				if (self.month == tonumber(month)) then
 					return true
 				end
 			end
-			
 			if (day ~= '*' and month == '*') then
 				if (self.day == tonumber(day)) then
 					return true
@@ -513,33 +512,36 @@ local function Time(sDate, isUTC, _testMS)
 			end
 		end
 
-		
 		local getParts = function(set)
-			local day, month = string.match(set, '([0-9]+)/([0-9]+)')
-			return tonumber(day), tonumber(month)
+			local day, month = string.match(set, '([0-9%*]+)/([0-9%*]+)')
+			return day and tonumber( day ), month and tonumber( month )
 		end
 
 		--now get the ranges
-		for fromSet, toSet in string.gmatch(dates, '([0-9%/*]*)-([0-9%/*]*)') do
-			local ttoSet = string.gsub(toSet,'%*','31') -- catch wildcarded not current months
-			local ffromSet = string.gsub(fromSet,'%*','01') -- catch wildcarded not current months
-
+		for fromSet, toSet in string.gmatch(dates, '([0-9%/%*]*)-([0-9%/%*]*)') do
 			local fromDay, toDay, fromMonth, toMonth
 
-			if (isEmpty(ffromSet) and not isEmpty(ttoSet)) then
-				toDay, toMonth = getParts(ttoSet)
+			if (isEmpty(fromSet) and not isEmpty(toSet)) then
+				toDay, toMonth = getParts(toSet)
 				if ((self.month < toMonth) or (self.month == toMonth and self.day <= toDay)) then
 					return true
 				end
-			elseif (not isEmpty(ffromSet) and isEmpty(ttoSet)) then
-				fromDay, fromMonth = getParts(ffromSet)
+			elseif (not isEmpty(fromSet) and isEmpty(toSet)) then
+				fromDay, fromMonth = getParts(fromSet)
 				if ((self.month > fromMonth) or (self.month == fromMonth and self.day >= fromDay)) then
 					return true
 				end
 			else
 
-				toDay, toMonth = getParts(ttoSet)
-				fromDay, fromMonth = getParts(ffromSet)
+				toDay, toMonth = getParts(toSet)
+				fromDay, fromMonth = getParts(fromSet)
+				--local _ = require('lodash');
+				--_.print('sm', self.month, 'sd', self.day, 'fm', fromMonth, 'tm', toMonth, 'fd', fromDay, 'td', toDay)
+				--_.print('( self.month > fromMonth and self.month < toMonth )', (self.month > fromMonth and self.month < toMonth))
+				--_.print('( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or', (fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay))
+				--_.print('( self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay ) or', (self.month == fromMonth and toMonth < fromMonth and self.day >= fromDay) )
+				--_.print('( self.month == toMonth and toMonth < fromMonth and  self.day <= toDay )', (self.month == toMonth and toMonth < fromMonth and self.day <= toDay))
+				--_.print('( self.month == toMonth and toMonth > fromMonth and self.day <= toDay )', (self.month == toMonth and toMonth > fromMonth and self.day <= toDay))
 				if (
 					( self.month > fromMonth and self.month < toMonth ) or
 					( fromMonth == toMonth and self.month == fromMonth and self.day >= fromDay and self.day <= toDay ) or

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -7,7 +7,7 @@ local self = {
 	LOG_MODULE_EXEC_INFO = 2,
 	LOG_INFO = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '2.4.21',
+	DZVERSION = '2.4.22',
 }
 
 function self.fileExists(name)
@@ -37,6 +37,24 @@ function self.inTable(searchTable, element)
 		if res then return res end
 	end
 	return false
+end
+
+function self.round(x, n)
+	n = math.pow(10, n or 0)
+	x = x * n
+	if x >= 0 then
+		x = math.floor(x + 0.5)
+	else
+		x = math.ceil(x - 0.5)
+	end
+	return x / n
+end
+
+function self.toCelsius(f, relative)
+	if (relative) then
+		return f*(1/1.8)
+	end
+	return ((f-32) / 1.8)
 end
 
 function self.osExecute(cmd)

--- a/dzVents/runtime/device-adapters/Adapters.lua
+++ b/dzVents/runtime/device-adapters/Adapters.lua
@@ -134,15 +134,6 @@ local function DeviceAdapters(dummyLogger)
 		end
 	end
 
-	function self.round(num, numDecimalPlaces)
-		if (num == nil) then
-			--print(debug.traceback())
-			num = 0
-		end
-		local mult = 10 ^ (numDecimalPlaces or 0)
-		return math.floor(num * mult + 0.5) / mult
-	end
-
 	self.states = {
 		on = { b = true, inv = 'Off' },
 		open = { b = true, inv = 'Off' },

--- a/dzVents/runtime/device-adapters/switch_device.lua
+++ b/dzVents/runtime/device-adapters/switch_device.lua
@@ -112,7 +112,29 @@ return {
 		end
 
 		function device.switchSelector(level)
-			return TimedCommand(domoticz, device.name, 'Set Level ' .. tostring(level), 'device')
+
+			local function guardLevel(val)
+				local maxLevel = #device.levelNames * 10 - 10
+				val = ( val % 10 ~= 0 ) and ( utils.round(val / 10) * 10 ) or val
+				return tostring(( math.min(math.max(val,0),maxLevel) ))
+			end
+
+			local sLevel
+			if type(level) == 'string' then
+				sLevel = level
+				local levels = {}
+				for i=1, #device.levelNames do
+					levels[device.levelNames[(i)]] = i * 10 - 10
+				end 
+				level = levels[level]
+			end
+
+			if not level and sLevel then
+				utils.log('levelname ' .. sLevel .. ' does not exist', domoticz.LOG_ERROR )
+			else
+				return TimedCommand(domoticz, device.name, 'Set Level ' .. guardLevel(level), 'device' )
+			end
+
 		end
 
 		if (device.switchType == 'Selector') then
@@ -122,5 +144,4 @@ return {
 		end
 
 	end
-
 }

--- a/dzVents/runtime/device-adapters/visibility_device.lua
+++ b/dzVents/runtime/device-adapters/visibility_device.lua
@@ -14,7 +14,7 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device.visbility = adapterManager.round(data.data.visibility, 1)
+		device.visbility = utils.round(data.data.visibility, 1)
 
 		device['updateVisibility'] = function (visibility)
 			return device.update(0, visibility)

--- a/dzVents/runtime/device-adapters/wind_device.lua
+++ b/dzVents/runtime/device-adapters/wind_device.lua
@@ -14,14 +14,10 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-        -- from data:   direction,
-        --              speed (in the unit set in Meters / Counters Wind Meter unit),
-        --              directionString
+		device.speedMs = utils.round(tonumber(device.rawData[3]) / 10, 1)
+		device.gustMs = utils.round(tonumber(device.rawData[4]) / 10, 1)
 
-		device.speedMs = adapterManager.round(tonumber(device.rawData[3]) / 10,1)
-		device.gustMs = adapterManager.round(tonumber(device.rawData[4]) / 10,1)
-
-        device.gust = tonumber(device.rawData[4]) / 10     -- Until gust is in data ( like speed already is ) we take it from sValues
+		device.gust = tonumber(device.rawData[4]) / 10     -- Until gust is in data ( like speed already is ) we take it from sValues
 		device.temperature = tonumber(device.rawData[5])
 		device.chill = tonumber(device.rawData[6])
 

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -1106,7 +1106,7 @@ describe('device', function()
 				switch.open()
 				assert.is_same({ { ["s1"] = "On" } }, commandArray)
 			end)
-            
+
 			it('should open Blinds', function()
 				switch.switchType = "Blinds"
 				switch.open()
@@ -1134,9 +1134,44 @@ describe('device', function()
 				assert.is_same({ { ["s1"] = "Set Level 50" } }, commandArray)
 			end)
 
-			it('should switch a selector', function()
-				switch.switchSelector(15)
-				assert.is_same({ {["s1"]="Set Level 15"}}, commandArray)
+			it('should switch a selector with numeric level', function()
+				local switch = getDevice(domoticz, {
+					['type'] = 'Light/Switch',
+					['name'] = 's1',
+					['additionalRootData'] = { ['switchType'] = 'Selector'},
+					['additionalDataData'] = 
+					{ levelNames = "Off|bb|cc|dd|ee|ff|gg|hh|ii|jj|kk|ll|mm|nn|oo|pp|qq|rr|ss|tt" },
+				})
+
+				commandArray = {} ;switch.switchSelector(0)
+					assert.is_same({ {["s1"]="Set Level 0"}}, commandArray)
+				commandArray = {} ;switch.switchSelector(20)
+					assert.is_same({ {["s1"]="Set Level 20"}}, commandArray)
+				commandArray = {} ;switch.switchSelector(112)
+					assert.is_same({ {["s1"]="Set Level 110"}}, commandArray)
+				commandArray = {} ;switch.switchSelector(500)
+					assert.is_same({ {["s1"]="Set Level 190"}}, commandArray)
+				commandArray = {} ;switch.switchSelector(-10.5)
+					assert.is_same({ {["s1"]="Set Level 0"}}, commandArray)
+				
+			end)
+
+			it('should switch a selector with levelname', function()
+				local switch = getDevice(domoticz, {
+					['type'] = 'Light/Switch',
+					['name'] = 's1',
+					['additionalRootData'] = { ['switchType'] = 'Selector'},
+					['additionalDataData'] = 
+					{ levelNames = "Off|bb|cc|dd|ee|ff|gg|hh|ii|jj|kk|ll|mm|nn|oo|pp|qq|rr|ss|tt" },
+				})
+				commandArray = {} ;switch.switchSelector('bb')
+					assert.is_same({ {["s1"]="Set Level 10"}}, commandArray)
+				commandArray = {} ;switch.switchSelector('bb')
+					assert.is_same({ {["s1"]="Set Level 10"}}, commandArray)
+				commandArray = {} ;switch.switchSelector('Off')
+					assert.is_same({ {["s1"]="Set Level 0"}}, commandArray)
+				commandArray = {} ;switch.switchSelector('zzz')
+					assert.is_same( {}, commandArray)
 			end)
 
 			it('should detect a selector', function()
@@ -1277,24 +1312,17 @@ describe('device', function()
 		describe('Quiet device ( quietOn and quietOff', function()
 	
 			local commandArray = {}
-			local utils = require('Utils')
-			domoticz.utils  = utils
-
 			domoticz.openURL = function(url)
 				return table.insert(commandArray, url)
 			end
-				
-			domoticz.log	= function()
-				return
-			end
-
-				local device = getDevice(domoticz, {
-					['name'] = 'quietDevice',
-					['state'] = 'On',
-						  ['type'] = 'Light/Switch',
-					['subType'] = 'RGBWW',
-					['type'] = 'Color Switch'
-				})
+			
+			local device = getDevice(domoticz, {
+				['name'] = 'quietDevice',
+				['state'] = 'On',
+					  ['type'] = 'Light/Switch',
+				['subType'] = 'RGBWW',
+				['type'] = 'Color Switch'
+			})
 
 			it('should handle the quietOn method correctly )', function()
 				commandArray = {}
@@ -1312,7 +1340,7 @@ describe('device', function()
 		describe('RGBW device #RGB', function()
 
 			local commandArray = {}
-			local utils = require('Utils')
+			-- local utils = require('Utils')
 			domoticz.utils  = utils
 
 			domoticz.openURL = function(url)

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1086,7 +1086,7 @@ describe('Time', function()
 
 				end)
 
-                describe('twilight stuff', function()
+				describe('twilight stuff', function()
 
 					it('between civiltwilightend and civiltwilightstart', function()
 						_G.timeofday = {
@@ -1471,7 +1471,7 @@ describe('Time', function()
 
 		describe('combis', function()
 
-        	it('should return false when not on every second sunday between 1:00 and 1:30', function()
+			it('should return false when not on every second sunday between 1:00 and 1:30', function()
 				local t = Time('2018-12-30 01:04:00') -- on Sunday, odd week at 01:04 
 				assert.is_false(t.matchesRule('between 1:00 and 1:30 on sun every odd week'))
 				assert.is_false(t.matchesRule('between 2:00 and 2:30 on sun every odd week'))
@@ -1583,7 +1583,35 @@ describe('Time', function()
 				assert.is_false(t.matchesRule('at 08:00-15:00 on 21/4-30/4'))
 
 			end)
+			
+			for fromMonth=1,12 do
+				for toMonth=math.min(fromMonth+1,12),12 do
+					it('at 08:00-23:00 on 01/' .. fromMonth .. '-30/' .. toMonth, function()
+						local t = Time()
+						if t.dDate > Time(t.year .. '-' .. fromMonth ..'-01 00:00:01').dDate and
+						   t.dDate < Time(t.year .. '-' .. toMonth ..'-30 23:59:59').dDate then
+							assert.is_true(t.matchesRule('at 00:30-23:30 on 01/' .. fromMonth .. '-30/' .. toMonth)) 
+						else
+							assert.is_false(t.matchesRule('at 00:30-23:30 on 01/' .. fromMonth .. '-30/' .. toMonth)) 
+						end						
+					end)
+				end
+			end
 
+			for fromMonth=1,12 do
+				for toMonth=math.min(fromMonth+1,12),12 do
+					it('at 08:00-23:00 on */' .. fromMonth .. '-*/' .. toMonth, function()
+						local t = Time()
+						if  t.dDate > Time(t.year .. '-' .. fromMonth ..'-01 00:00:01').dDate and
+							t.dDate < Time(t.year .. '-' .. toMonth ..'-30 23:59:59').dDate then
+							assert.is_true(t.matchesRule('at 00:30-23:30 on */' .. fromMonth .. '-*/' .. toMonth)) 
+						else
+							assert.is_false(t.matchesRule('at 00:30-23:30 on */' .. fromMonth .. '-*/' .. toMonth)) 
+						end						
+					end)
+				end
+			end
+			
 			it('every 3 minutes on -15/4,15/10-', function()
 				local t = Time('2017-04-18 11:24:00')
 				assert.is_false(t.matchesRule('every 3 minutes on -15/4,15/10-'))

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -16,7 +16,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("2.4.21")
+	m_version("2.4.22")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION
fix for wildcard timeRule
	modified:   History.txt
	modified:   dzVents/documentation/README.md
	modified:   dzVents/documentation/README.wiki
	modified:   dzVents/documentation/history.md
	modified:   dzVents/runtime/Domoticz.lua
	modified:   dzVents/runtime/Time.lua
	modified:   dzVents/runtime/Utils.lua
	modified:   dzVents/runtime/device-adapters/Adapters.lua
	modified:   dzVents/runtime/device-adapters/switch_device.lua
	modified:   dzVents/runtime/device-adapters/visibility_device.lua
	modified:   dzVents/runtime/device-adapters/wind_device.lua
	modified:   dzVents/runtime/tests/testDevice.lua
	modified:   dzVents/runtime/tests/testTime.lua
	modified:   main/dzVents.cpp