### PR TITLE
Added Hue LCS001 to GAMUT_C_BULBS_LIST and extra command to OpenTherm to re-enable PS=0

### DIFF
--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -250,7 +250,7 @@ void OTGWBase::GetGatewayDetails()
 	strcpy(szCmd, "PS=1\r\n");
 	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 
-	/* Wait for 0.75 seconds for the command to complete and switch back to PS=0 to fix use of OtMonitor */
+	/* Wait for 0.75 seconds for the PS=1 command to complete and switch back to PS=0 to fix simultaneous use of OtMonitor besides Domoticz */
 	usleep(750000);
 	strcpy(szCmd, "PS=0\r\n");
 	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
@@ -493,7 +493,7 @@ void OTGWBase::ParseLine()
 				)
 			{
 				//Dont report OT/PS/SC feedback
-				//_log.Log(LOG_STATUS,"OTGW: %s",sLine.c_str());
+				//_log.Log(LOG_STATUS,"OTGW: %s",sLine.c_str()); /* Things get really noisy with PS=0 for now let's quiet it down a little */
 			}
 		}
 	}

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -249,6 +249,11 @@ void OTGWBase::GetGatewayDetails()
 	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 	strcpy(szCmd, "PS=1\r\n");
 	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+
+	/* Wait for 0.75 seconds for the command to complete and switch back to PS=0 to fix use of OtMonitor */
+	usleep(750000);
+	strcpy(szCmd, "PS=0\r\n");
+	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 }
 
 void OTGWBase::SendTime()
@@ -488,7 +493,7 @@ void OTGWBase::ParseLine()
 				)
 			{
 				//Dont report OT/PS/SC feedback
-				_log.Log(LOG_STATUS,"OTGW: %s",sLine.c_str());
+				//_log.Log(LOG_STATUS,"OTGW: %s",sLine.c_str());
 			}
 		}
 	}

--- a/hardware/PhilipsHue/PhilipsHueHelper.cpp
+++ b/hardware/PhilipsHue/PhilipsHueHelper.cpp
@@ -41,7 +41,7 @@ static const point colorPointsGamut_Default[3] = {point(1.0, 0.0),
 
 static const char* GAMUT_A_BULBS_LIST_v[] = {"LLC001", "LLC005", "LLC006", "LLC007", "LLC010", "LLC011", "LLC012", "LLC014", "LLC013", "LST001"};
 static const char* GAMUT_B_BULBS_LIST_v[] = {"LCT001", "LCT002", "LCT003", "LCT004", "LLM001", "LCT005", "LCT006", "LCT007"};
-static const char* GAMUT_C_BULBS_LIST_v[] = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002"};
+static const char* GAMUT_C_BULBS_LIST_v[] = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002", "LCS001"};
 static const char* MULTI_SOURCE_LUMINAIRES_v[] = {"HBL001", "HBL002", "HBL003", "HIL001", "HIL002", "HEL001", "HEL002"};
 static std::vector<std::string> GAMUT_A_BULBS_LIST(GAMUT_A_BULBS_LIST_v, GAMUT_A_BULBS_LIST_v + sizeof(GAMUT_A_BULBS_LIST_v) / sizeof(GAMUT_A_BULBS_LIST_v[0]));
 static std::vector<std::string> GAMUT_B_BULBS_LIST(GAMUT_B_BULBS_LIST_v, GAMUT_B_BULBS_LIST_v + sizeof(GAMUT_B_BULBS_LIST_v) / sizeof(GAMUT_B_BULBS_LIST_v[0]));


### PR DESCRIPTION
I recently got Hue Outdoor Lily Spots and discovered that the bulbs are not known to Domoticz yet. I added LCS001 GAMUT_C_BULBS_LIST.

I use Domoticz and OtMonitor (OpenTherm Monitor) at the same time, Domoticz uses PS=1 to gather information but that causes OtMonitor to stop receiving OT messages. I added a little sleep after sending the PS=1 command followed by sending PS=0. With this Domoticz and OtMonitor can coexist :)
