### PR TITLE
Added LCS001 (Outdoor Lily Spots) to GAMUT_C_BULBS_LIST

### DIFF
--- a/hardware/PhilipsHue/PhilipsHueHelper.cpp
+++ b/hardware/PhilipsHue/PhilipsHueHelper.cpp
@@ -41,7 +41,7 @@ static const point colorPointsGamut_Default[3] = {point(1.0, 0.0),
 
 static const char* GAMUT_A_BULBS_LIST_v[] = {"LLC001", "LLC005", "LLC006", "LLC007", "LLC010", "LLC011", "LLC012", "LLC014", "LLC013", "LST001"};
 static const char* GAMUT_B_BULBS_LIST_v[] = {"LCT001", "LCT002", "LCT003", "LCT004", "LLM001", "LCT005", "LCT006", "LCT007"};
-static const char* GAMUT_C_BULBS_LIST_v[] = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002"};
+static const char* GAMUT_C_BULBS_LIST_v[] = {"LCT010", "LCT011", "LCT012", "LCT014", "LCT015", "LCT016", "LLC020", "LST002", "LCS001"};
 static const char* MULTI_SOURCE_LUMINAIRES_v[] = {"HBL001", "HBL002", "HBL003", "HIL001", "HIL002", "HEL001", "HEL002"};
 static std::vector<std::string> GAMUT_A_BULBS_LIST(GAMUT_A_BULBS_LIST_v, GAMUT_A_BULBS_LIST_v + sizeof(GAMUT_A_BULBS_LIST_v) / sizeof(GAMUT_A_BULBS_LIST_v[0]));
 static std::vector<std::string> GAMUT_B_BULBS_LIST(GAMUT_B_BULBS_LIST_v, GAMUT_B_BULBS_LIST_v + sizeof(GAMUT_B_BULBS_LIST_v) / sizeof(GAMUT_B_BULBS_LIST_v[0]));


### PR DESCRIPTION
Recently I've bought the Lily Spots starter set but they're not known in PhilipsHueHelper.cpp

This pull request adds LCS001 to GAMUT_C_BULBS_LIST

"colorgamuttype":"C","colorgamut":[[0.6915,0.3083],[0.1700,0.7000],[0.1532,0.0475]]

PS Sorry for the messy pull requests, this is the last time :)

`{"state":{"on":true,"bri":38,"hue":5819,"sat":254,"effect":"none","xy":[0.5730,0.3973],"ct":500,"alert":"select","colormode":"xy","mode":"homeautomation","reachable":true},"swupdate":{"state":"noupdates","lastinstall":"2019-04-23T22:17:31"},"type":"Extended color light","name":"Hue outdoor spot 2","modelid":"LCS001","manufacturername":"Philips","productname":"Hue outdoor spot","capabilities":{"certified":true,"control":{"mindimlevel":500,"maxlumen":650,"colorgamuttype":"C","colorgamut":[[0.6915,0.3083],[0.1700,0.7000],[0.1532,0.0475]],"ct":{"min":153,"max":500}},"streaming":{"renderer":true,"proxy":true}},"config":{"archetype":"groundspot","function":"decorative","direction":"upwards","startup":{"mode":"safety","configured":true}},"uniqueid":"xxxxxx","swversion":"1.46.13_r26312","swconfigid":"xxxxxx","productid":"ENA-LCS001-1-LilySpikev1"}`