### PR TITLE
Update to dzVents 2.4.23

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -12,7 +12,7 @@ Version 4.xxxxx (xxx 2019)
 - Fixed: YouLess, possible buffer overflow (#3261)
 - Fixed: notification, Telegram error when odd number of underscores in text
 - Updated: OpenZWave version 1.6
-- Updated: dzVents (version 2.4.22, See dzVents/documentation/history.md)
+- Updated: dzVents (version 2.4.23, See dzVents/documentation/history.md)
 
 Version 4.10717 (May 9th 2019)
 - Fixed: dzVents, Allowing no error message for HTTP calls (#3191)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -632,10 +632,11 @@ The domoticz object has these constants available for use in your code e.g. `dom
  - **BARO_CLOUDY**, **BARO_CLOUDY_RAIN**, **BARO_STABLE**, **BARO_SUNNY**, **BARO_THUNDERSTORM**, **BARO_NOINFO**, **BARO_UNSTABLE**: for updating barometric values.
  - **EVENT_TYPE_DEVICE**, **EVENT_TYPE_VARIABLE**, **EVENT_TYPE_SECURITY**,  **EVENT_TYPE_HTTPRESPONSE**<sup>2.4.0</sup>, **EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
  - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_TEMPORARY_OVERRIDE**, **EVOHOME_MODE_PERMANENT_OVERRIDE**, **EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
+ - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_AUTOWITHRESET**, **EVOHOME_MODE_AUTOWITHECO**, **EVOHOME_MODE_AWAY**, **EVOHOME_MODE_DAYOFF**, **EVOHOME_MODE_CUSTOM**, **EVOHOME_MODE_HEATINGOFF** <sup>2.4.23</sup>: mode for EvoHome controller
  - **HUM_COMFORTABLE**, **HUM_DRY**, **HUM_NORMAL**, **HUM_WET**: constant for humidity status.
  - **INTEGER**, **FLOAT**, **STRING**, **DATE**, **TIME**: variable types.
  - **LOG_DEBUG**, **LOG_ERROR**, **LOG_INFO**, **LOG_FORCE**: for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
- - **NSS_GOOGLE_CLOUD_MESSAGING**, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>: for notification subsystem
+ - **NSS_FIREBASE**, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>: for notification subsystem
  - **PRIORITY_LOW**, **PRIORITY_MODERATE**, **PRIORITY_NORMAL**, **PRIORITY_HIGH**, **PRIORITY_EMERGENCY**: for notification priority.
  - **SECURITY_ARMEDAWAY**, **SECURITY_ARMEDHOME**, **SECURITY_DISARMED**: for security state.
  - **SOUND_ALIEN** , **SOUND_BIKE**, **SOUND_BUGLE**, **SOUND_CASH_REGISTER**, **SOUND_CLASSICAL**, **SOUND_CLIMB** , **SOUND_COSMIC**, **SOUND_DEFAULT** , **SOUND_ECHO**, **SOUND_FALLING**  , **SOUND_GAMELAN**, **SOUND_INCOMING**, **SOUND_INTERMISSION**, **SOUND_MAGIC** , **SOUND_MECHANICAL**, **SOUND_NONE**, **SOUND_PERSISTENT**, **SOUND_PIANOBAR** , **SOUND_SIREN** , **SOUND_SPACEALARM**, **SOUND_TUGBOAT**  , **SOUND_UPDOWN**: for notification sounds.
@@ -710,7 +711,8 @@ Note that if you do not find your specific device type here you can always inspe
 #### Counter, managed Counter <sup>2.4.12</sup>,counter incremental
  - **counter**: *Number*
  - **counterToday**: *Number*. Today's counter value.
- - **updateCounter(value)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateCounter(value)**: *Function*. **This will overwrite; and not increment !**. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **incrementCounter(value)**: <sup>2.4.23</sup>*Function*. (counter incremental) Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **valueQuantity**: *String*. For counters.
  - **valueUnits**: *String*.
 
@@ -732,6 +734,9 @@ Note that if you do not find your specific device type here you can always inspe
  - **mode**: *string* <sup>2.4.9</sup>.
  - **untilDate**: *string in ISO 8601 format* or n/a <sup>2.4.9</sup>.
  - **updateSetPoint(setPoint, mode, until)**: *Function*. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE <sup>2.4.9</sup> or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+
+#### Evohome (controller) <sup>2.4.23</sup>
+ - **setMode(mode, dparm, action, ooc )**: *Function*. set mode for controller. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_AUTOWITHRESET, domoticz.EVOHOME_MODE_AUTOWITHECO, domoticz.EVOHOME_MODE_AWAY, domoticz.EVOHOME_MODE_DAYOFF, domoticz.EVOHOME_MODE_CUSTOM or domoticz.EVOHOME_MODE_HEATINGOFF. dParm <optional> can be a future time string (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`), a future time object, a future time as number of seconds since epoch or a number representing a positive offset in minutes (max 1 year). action <optional> (1 = run on action script, 0 = disable), ooc <optional> (1 = only trigger the event & log on change, 0 = always trigger & log)
 
 #### Evohome (hotWater) <sup>2.4.9</sup>.
  - **state**: *string*  ('On' or 'Off')
@@ -829,7 +834,7 @@ See switch below.
  - **decreaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **getColor()**; *Function*. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
  - **increaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- - **setColor(r, g, b, br, cw, ww, m, t)**: *Function*. <sup>2.4.16</sup> Sets the light to requested color.  r, g, b required, others optional. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **setColor(r, g, b, br, cw, ww, m, t)**: *Function*. <sup>2.4.16</sup> Sets the light to requested color.  r, g, b required, others optional. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29). Meaning and limits of parms can be found [here](https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_an_RGB_CW_WW_or_CW_WW_light_to_a_certain_color_temperature). 
  - **setColorBrightness()**: same as setColor
  - **setDiscoMode(modeNum)**: *Function*. <sup>2.4.0</sup> Activate disco mode, `1 =< modeNum <= 9`. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 - **setHex(r, g, b)**: *Function*. <sup>2.4.16</sup> Sets the light to requested color.  r, g, b required (decimal Values 0-255). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
@@ -1994,6 +1999,12 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # Change log
+##[2.4.23]
+- Add method setMode for evohome device
+- Add method incrementCounter for incremental counter
+- Removed Google Cloud Messaging as notification option because Google deprecated this service
+- Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
+
 ##[2.4.22]
 - selector.switchSelector method accepts levelNames
 - increased selector.switchSelector resilience
@@ -2307,7 +2318,7 @@ On the other hand, you have to make sure that dzVents can access the json withou
 
  - A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
  - Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
- - Added support for sounds in domiticz.notify(). [WebStarVenlo]
+ - Added support for sounds in domoticz.notify(). [WebStarVenlo]
 
 ##[0.9.9]
 

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -636,7 +636,7 @@ The domoticz object has these constants available for use in your code e.g. `dom
  - **HUM_COMFORTABLE**, **HUM_DRY**, **HUM_NORMAL**, **HUM_WET**: constant for humidity status.
  - **INTEGER**, **FLOAT**, **STRING**, **DATE**, **TIME**: variable types.
  - **LOG_DEBUG**, **LOG_ERROR**, **LOG_INFO**, **LOG_FORCE**: for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
- - **NSS_FIREBASE**, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>: for notification subsystem
+ - **NSS_GOOGLE_CLOUD_MESSAGING**, **NSS_FIREBASE**, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>: for notification subsystem
  - **PRIORITY_LOW**, **PRIORITY_MODERATE**, **PRIORITY_NORMAL**, **PRIORITY_HIGH**, **PRIORITY_EMERGENCY**: for notification priority.
  - **SECURITY_ARMEDAWAY**, **SECURITY_ARMEDHOME**, **SECURITY_DISARMED**: for security state.
  - **SOUND_ALIEN** , **SOUND_BIKE**, **SOUND_BUGLE**, **SOUND_CASH_REGISTER**, **SOUND_CLASSICAL**, **SOUND_CLIMB** , **SOUND_COSMIC**, **SOUND_DEFAULT** , **SOUND_ECHO**, **SOUND_FALLING**  , **SOUND_GAMELAN**, **SOUND_INCOMING**, **SOUND_INTERMISSION**, **SOUND_MAGIC** , **SOUND_MECHANICAL**, **SOUND_NONE**, **SOUND_PERSISTENT**, **SOUND_PIANOBAR** , **SOUND_SIREN** , **SOUND_SPACEALARM**, **SOUND_TUGBOAT**  , **SOUND_UPDOWN**: for notification sounds.
@@ -2002,7 +2002,6 @@ On the other hand, you have to make sure that dzVents can access the json withou
 ##[2.4.23]
 - Add method setMode for evohome device
 - Add method incrementCounter for incremental counter
-- Removed Google Cloud Messaging as notification option because Google deprecated this service
 - Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
 
 ##[2.4.22]

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -628,7 +628,7 @@ The domoticz object has these constants available for use in your code e.g. <cod
 * '''HUM_COMFORTABLE''', '''HUM_DRY''', '''HUM_NORMAL''', '''HUM_WET''': constant for humidity status.
 * '''INTEGER''', '''FLOAT''', '''STRING''', '''DATE''', '''TIME''': variable types.
 * '''LOG_DEBUG''', '''LOG_ERROR''', '''LOG_INFO''', '''LOG_FORCE''': for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
-* '''NSS_FIREBASE''', '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM''' <sup>2.4.8</sup>: for notification subsystem
+* '''NSS_GOOGLE_CLOUD_MESSAGING''', '''NSS_FIREBASE''', '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM''' <sup>2.4.8</sup>: for notification subsystem
 * '''PRIORITY_LOW''', '''PRIORITY_MODERATE''', '''PRIORITY_NORMAL''', '''PRIORITY_HIGH''', '''PRIORITY_EMERGENCY''': for notification priority.
 * '''SECURITY_ARMEDAWAY''', '''SECURITY_ARMEDHOME''', '''SECURITY_DISARMED''': for security state.
 * '''SOUND_ALIEN''' , '''SOUND_BIKE''', '''SOUND_BUGLE''', '''SOUND_CASH_REGISTER''', '''SOUND_CLASSICAL''', '''SOUND_CLIMB''' , '''SOUND_COSMIC''', '''SOUND_DEFAULT''' , '''SOUND_ECHO''', '''SOUND_FALLING''' , '''SOUND_GAMELAN''', '''SOUND_INCOMING''', '''SOUND_INTERMISSION''', '''SOUND_MAGIC''' , '''SOUND_MECHANICAL''', '''SOUND_NONE''', '''SOUND_PERSISTENT''', '''SOUND_PIANOBAR''' , '''SOUND_SIREN''' , '''SOUND_SPACEALARM''', '''SOUND_TUGBOAT''' , '''SOUND_UPDOWN''': for notification sounds.
@@ -2119,7 +2119,6 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 * Add method setMode for evohome device
 * Add method incrementCounter for incremental counter
-* Removed Google Cloud Messaging as notification option because Google deprecated this service
 * Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
 
 == [2.4.22] ==

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -624,10 +624,11 @@ The domoticz object has these constants available for use in your code e.g. <cod
 * '''BARO_CLOUDY''', '''BARO_CLOUDY_RAIN''', '''BARO_STABLE''', '''BARO_SUNNY''', '''BARO_THUNDERSTORM''', '''BARO_NOINFO''', '''BARO_UNSTABLE''': for updating barometric values.
 * '''EVENT_TYPE_DEVICE''', '''EVENT_TYPE_VARIABLE''', '''EVENT_TYPE_SECURITY''', '''EVENT_TYPE_HTTPRESPONSE'''<sup>2.4.0</sup>, '''EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
 * '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_TEMPORARY_OVERRIDE''', '''EVOHOME_MODE_PERMANENT_OVERRIDE''', '''EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
+* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_AUTOWITHRESET''', '''EVOHOME_MODE_AUTOWITHECO''', '''EVOHOME_MODE_AWAY''', '''EVOHOME_MODE_DAYOFF''', '''EVOHOME_MODE_CUSTOM''', '''EVOHOME_MODE_HEATINGOFF''' <sup>2.4.23</sup>: mode for EvoHome controller
 * '''HUM_COMFORTABLE''', '''HUM_DRY''', '''HUM_NORMAL''', '''HUM_WET''': constant for humidity status.
 * '''INTEGER''', '''FLOAT''', '''STRING''', '''DATE''', '''TIME''': variable types.
 * '''LOG_DEBUG''', '''LOG_ERROR''', '''LOG_INFO''', '''LOG_FORCE''': for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
-* '''NSS_GOOGLE_CLOUD_MESSAGING''', '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM''' <sup>2.4.8</sup>: for notification subsystem
+* '''NSS_FIREBASE''', '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM''' <sup>2.4.8</sup>: for notification subsystem
 * '''PRIORITY_LOW''', '''PRIORITY_MODERATE''', '''PRIORITY_NORMAL''', '''PRIORITY_HIGH''', '''PRIORITY_EMERGENCY''': for notification priority.
 * '''SECURITY_ARMEDAWAY''', '''SECURITY_ARMEDHOME''', '''SECURITY_DISARMED''': for security state.
 * '''SOUND_ALIEN''' , '''SOUND_BIKE''', '''SOUND_BUGLE''', '''SOUND_CASH_REGISTER''', '''SOUND_CLASSICAL''', '''SOUND_CLIMB''' , '''SOUND_COSMIC''', '''SOUND_DEFAULT''' , '''SOUND_ECHO''', '''SOUND_FALLING''' , '''SOUND_GAMELAN''', '''SOUND_INCOMING''', '''SOUND_INTERMISSION''', '''SOUND_MAGIC''' , '''SOUND_MECHANICAL''', '''SOUND_NONE''', '''SOUND_PERSISTENT''', '''SOUND_PIANOBAR''' , '''SOUND_SIREN''' , '''SOUND_SPACEALARM''', '''SOUND_TUGBOAT''' , '''SOUND_UPDOWN''': for notification sounds.
@@ -711,7 +712,8 @@ Note that if you do not find your specific device type here you can always inspe
 
 * '''counter''': ''Number''
 * '''counterToday''': ''Number''. Today's counter value.
-* '''updateCounter(value)''': ''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateCounter(value)''': ''Function''. '''This will overwrite; and not increment !'''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''incrementCounter(value)''': <sup>2.4.23</sup>''Function''. (counter incremental) Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''valueQuantity''': ''String''. For counters.
 * '''valueUnits''': ''String''.
 
@@ -737,6 +739,10 @@ Note that if you do not find your specific device type here you can always inspe
 * '''mode''': ''string'' <sup>2.4.9</sup>.
 * '''untilDate''': ''string in ISO 8601 format'' or n/a <sup>2.4.9</sup>.
 * '''updateSetPoint(setPoint, mode, until)''': ''Function''. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE <sup>2.4.9</sup> or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+
+==== Evohome (controller) <sup>2.4.23</sup> ====
+
+* '''setMode(mode, dparm, action, ooc )''': ''Function''. set mode for controller. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_AUTOWITHRESET, domoticz.EVOHOME_MODE_AUTOWITHECO, domoticz.EVOHOME_MODE_AWAY, domoticz.EVOHOME_MODE_DAYOFF, domoticz.EVOHOME_MODE_CUSTOM or domoticz.EVOHOME_MODE_HEATINGOFF. dParm <optional> can be a future time string (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>), a future time object, a future time as number of seconds since epoch or a number representing a positive offset in minutes (max 1 year). action <optional> (1 = run on action script, 0 = disable), ooc <optional> (1 = only trigger the event &amp; log on change, 0 = always trigger &amp; log)
 
 ==== Evohome (hotWater) <sup>2.4.9</sup>. ====
 
@@ -851,7 +857,7 @@ See switch below.
 * '''decreaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''getColor()'''; ''Function''. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
 * '''increaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setColor(r, g, b, br, cw, ww, m, t)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required, others optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''setColor(r, g, b, br, cw, ww, m, t)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required, others optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. Meaning and limits of parms can be found [https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_an_RGB_CW_WW_or_CW_WW_light_to_a_certain_color_temperature here].
 * '''setColorBrightness()''': same as setColor
 * '''setDiscoMode(modeNum)''': ''Function''. <sup>2.4.0</sup> Activate disco mode, <code>1 =&lt; modeNum &lt;= 9</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''setHex(r, g, b)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required (decimal Values 0-255). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
@@ -2109,6 +2115,13 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 = Change log =
 
+== [2.4.23] ==
+
+* Add method setMode for evohome device
+* Add method incrementCounter for incremental counter
+* Removed Google Cloud Messaging as notification option because Google deprecated this service
+* Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
+
 == [2.4.22] ==
 
 * selector.switchSelector method accepts levelNames
@@ -2443,7 +2456,7 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 * A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
 * Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
-* Added support for sounds in domiticz.notify(). [WebStarVenlo]
+* Added support for sounds in domoticz.notify(). [WebStarVenlo]
 
 == [0.9.9] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,9 @@
+[2.4.23]
+- Add method setMode for evohome device
+- Add method incrementCounter for incremental counter
+- Removed Google Cloud Messaging as notification option because Google deprecated this service
+- Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
+
 [2.4.22]
 - selector.switchSelector method accepts levelNames
 - increased selector.switchSelector resilience

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,7 +1,6 @@
 [2.4.23]
 - Add method setMode for evohome device
 - Add method incrementCounter for incremental counter
-- Removed Google Cloud Messaging as notification option because Google deprecated this service
 - Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
 
 [2.4.22]

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -124,11 +124,18 @@ local function Domoticz(settings)
 		['EVOHOME_MODE_TEMPORARY_OVERRIDE'] = 'TemporaryOverride',
 		['EVOHOME_MODE_PERMANENT_OVERRIDE'] = 'PermanentOverride',
 		['EVOHOME_MODE_FOLLOW_SCHEDULE'] = 'FollowSchedule',
+		['EVOHOME_MODE_AUTOWITHRESET'] = 'AutoWithReset',
+		['EVOHOME_MODE_AUTOWITHECO'] = 'AutoWithEco',
+		['EVOHOME_MODE_AWAY'] = 'Away',
+		['EVOHOME_MODE_DAYOFF'] = 'DayOff',
+		['EVOHOME_MODE_CUSTOM'] = 'Custom',
+		['EVOHOME_MODE_HEATINGOFF'] = 'HeatingOff',
 		['INTEGER'] = 'integer',
 		['FLOAT'] = 'float',
 		['STRING'] = 'string',
 		['DATE'] = 'date',
 		['TIME'] = 'time',
+		['NSS_FIREBASE'] = 'fcm',
 		['NSS_GOOGLE_CLOUD_MESSAGING'] = 'gcm',
 		['NSS_HTTP'] = 'http',
 		['NSS_KODI'] = 'kodi',
@@ -236,6 +243,11 @@ local function Domoticz(settings)
 				_subSystem = ''
 			end
 		end
+
+		if _subSystem:find('gcm') then
+			utils.log('Notification subsystem Google Cloud Messaging (gcm) has been deprecated by Google. Please consider switching to Firebase', utils.LOG_ERROR)
+		end
+
 		local data = subject
 				.. '#' .. message
 				.. '#' .. tostring(priority)

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -135,7 +135,7 @@ local function Domoticz(settings)
 		['STRING'] = 'string',
 		['DATE'] = 'date',
 		['TIME'] = 'time',
-		['NSS_FIREBASE'] = 'fcm',
+		['NSS_FIREBASE'] = 'gcm',  -- For the moment the change to fcm is only done in the url 
 		['NSS_GOOGLE_CLOUD_MESSAGING'] = 'gcm',
 		['NSS_HTTP'] = 'http',
 		['NSS_KODI'] = 'kodi',
@@ -244,10 +244,12 @@ local function Domoticz(settings)
 			end
 		end
 
-		if _subSystem:find('gcm') then
+		--[[
+        if _subSystem:find('gcm') then
 			utils.log('Notification subsystem Google Cloud Messaging (gcm) has been deprecated by Google. Please consider switching to Firebase', utils.LOG_ERROR)
 		end
-
+        ]] --
+        
 		local data = subject
 				.. '#' .. message
 				.. '#' .. tostring(priority)

--- a/dzVents/runtime/EventHelpers.lua
+++ b/dzVents/runtime/EventHelpers.lua
@@ -277,7 +277,7 @@ local function EventHelpers(domoticz, mainMethod)
 
 				return res
 			else
-				utils.log('An error occured when calling event handler ' .. eventHandler.name, utils.LOG_ERROR)
+				utils.log('An error occurred when calling event handler ' .. eventHandler.name, utils.LOG_ERROR)
 				utils.log(res, utils.LOG_ERROR) -- error info
 			end
 		else

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -7,7 +7,7 @@ local self = {
 	LOG_MODULE_EXEC_INFO = 2,
 	LOG_INFO = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '2.4.22',
+	DZVERSION = '2.4.23',
 }
 
 function self.fileExists(name)
@@ -30,6 +30,7 @@ function self.stringSplit(text, sep)
 end
 
 function self.inTable(searchTable, element)
+	if type(searchTable) ~= 'table' then return false end
 	local res = res
 	for k, v in pairs(searchTable) do
 		if type(v) == 'table' then res = self.inTable(v, element) end

--- a/dzVents/runtime/device-adapters/counter_device.lua
+++ b/dzVents/runtime/device-adapters/counter_device.lua
@@ -5,12 +5,13 @@ return {
 	name = 'Counter device adapter',
 
 	matches = function (device, adapterManager)
-		local res = (       device.deviceSubType == 'RFXMeter counter' 
-                        or  device.deviceSubType == 'Counter Incremental'
-                        or  device.deviceSubType == 'Managed Counter')
+		local res = ( device.deviceSubType == 'RFXMeter counter' 
+						or  device.deviceSubType == 'Counter Incremental'
+						or  device.deviceSubType == 'Managed Counter')
 
 		if (not res) then
 			adapterManager.addDummyMethod(device, 'updateCounter')
+			adapterManager.addDummyMethod(device, 'incrementCounter')
 		end
 
 		return res
@@ -27,20 +28,31 @@ return {
 		valueFormatted = device.counter or ''
 		info = adapterManager.parseFormatted(valueFormatted, domoticz['radixSeparator'])
 		device['counter'] = info['value']
-        
-        if device.deviceSubType == 'Managed Counter' and ( device.valueUnits == nil or device.valueUnits == "" ) then
-            device.valueUnits = string.match(device._data.data.counter, "%a+%d*") or ''  
-        end
-        
-		function device.updateCounter(value)
-			if type(value) == "table" then
-                domoticz.log('no updateCounter with value of type table allowed !! ', utils.LOG_ERROR)
-                return nil
-            else
-                return device.update(0, value)
-            end
+
+		if device.deviceSubType == 'Managed Counter' and ( device.valueUnits == nil or device.valueUnits == "" ) then
+			device.valueUnits = string.match(device._data.data.counter, "%a+%d*") or ''  
 		end
 
-	end
+		function device.updateCounter(value)
+			if type(value) == "table" then
+				utils.log('no updateCounter with value of type table allowed !! ', utils.LOG_ERROR)
+				return nil
+			else
+				return device.update(0, value)
+			end
+		end
 
+		function device.incrementCounter(value)
+			if type(value) ~= 'number' then
+				utils.log('incrementCounter only accept numbers; your value is a ' .. type(value) .. ' !! ', utils.LOG_ERROR)
+				return nil
+			elseif device.deviceSubType ~= 'Counter Incremental' then 
+				utils.log('method incrementCounter not valid for ' .. device.deviceSubType .. ' !! ', utils.LOG_ERROR)
+				return nil
+			else
+				local url = domoticz.settings['Domoticz url'] .. '/json.htm?type=command&param=udevice&idx=' .. device.id .. '&svalue=' .. value 
+				domoticz.openURL(url)
+			end	
+		end	
+	end
 }

--- a/dzVents/runtime/device-adapters/evohome_device.lua
+++ b/dzVents/runtime/device-adapters/evohome_device.lua
@@ -17,6 +17,7 @@ return {
 		if (not res) then
 			adapterManager.addDummyMethod(device, 'updateSetPoint')
 			adapterManager.addDummyMethod(device, 'setHotWater')
+			adapterManager.addDummyMethod(device, 'setMode')
 		end
 
 		return res
@@ -43,7 +44,7 @@ return {
 				return domoticz.openURL(url)
 			end
 		else
-
+			device.state = device.rawData[2]
 			device.setPoint = tonumber(device.rawData[1] or 0)
 			device.mode = tostring(device.rawData[3])
 			device.untilDate = tostring(device.rawData[4] or "n/a")
@@ -54,6 +55,64 @@ return {
 					tostring(setPoint) .. '#' ..
 					tostring(mode) .. '#' ..
 					tostring(untilDate) , 'setpoint')
+			end
+			function device.setMode(mode, dParm, action, ooc)
+
+				local function checkTimeAndReturnISO(tm)
+					local now = domoticz.time
+					local iso8601Pattern = "(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)Z"
+					local iso8601Format = "%Y-%m-%dT%TZ"
+
+					local function inFuture(tmISO)
+						local function makeFutureISOTime(str, hours)
+							local xyear, xmonth, xday, xhour, xminute, xseconds = str:match(iso8601Pattern)
+							local seconds = os.time({year = xyear, month = xmonth, day = xday, hour = xhour, min = xminute, sec = xseconds})
+							local offset = (seconds + ( hours or 0 ) *  3600)
+							return os.date(iso8601Format,offset),  offset
+						end
+
+						local _, epoch = makeFutureISOTime(tmISO)
+						return epoch >= now.dDate and tmISO
+					end
+
+					if type(tm) == 'string' and tm:find(iso8601Pattern) then return inFuture(tm) end                -- Something like '2016-04-29T06:32:58Z'
+					if type(tm) == 'table' and tm.getISO then return inFuture(tm.getISO()) end                      -- a dzVents time object
+					if type(tm) == 'table' and tm.day then return inFuture(os.date(iso8601Format,os.time(tm))) end  -- a standard time object
+					if type(tm) == 'number' and tm > now.dDate then return inFuture(os.date(iso8601Format,tm)) end  -- seconds since epoch
+					if type(tm) == 'number' and tm > 0 and tm < ( 365 * 24 * 60 ) then return inFuture(os.date(iso8601Format,now.dDate + ( tm * 60 ))) end  -- seconds since epoch + tm
+
+					domoticz.log('dParm ' .. tostring(dParm) .. ' cannot be processed. (it will be ignored)',utils.LOG_ERROR)
+					return false -- not a time as we know it
+				end
+
+				local function isValid(mode)
+					for _, value in pairs(domoticz) do
+						local res =  type(value) == 'string' and value == mode
+						if res then return res end
+					end
+					return mode == 'Busted' or false 
+				end
+
+				local function binary(num, default)
+					if num == 0 or num == 1 then return num else return default end
+				end
+
+				if isValid( tostring(mode) ) then -- is it in the list of valid modes ?
+					local dParm = dParm and checkTimeAndReturnISO(dParm) -- if there is a dParm then check if valid and make a valid ISO date
+					dParm = ( dParm and '&until=' .. dParm ) or '' 
+					local action = ( action and '&action=' .. binary(action, 1) ) or '&action=1' 
+					local ooc = ( ooc and '&ooc=' .. binary(ooc, 0) ) or '&ooc=0'
+					
+					local url = domoticz.settings['Domoticz url'] ..
+								'/json.htm?type=command&param=switchmodal&idx=' .. device.id ..
+								"&status=" .. mode ..
+								dParm .. 
+								action ..
+								ooc
+					return domoticz.openURL(url)
+				else
+					utils.log('Unknown status for setMode requested: ' .. tostring(mode),utils.LOG_ERROR)
+				end
 			end
 		end
 	end

--- a/dzVents/runtime/device-adapters/switch_device.lua
+++ b/dzVents/runtime/device-adapters/switch_device.lua
@@ -131,6 +131,8 @@ return {
 
 			if not level and sLevel then
 				utils.log('levelname ' .. sLevel .. ' does not exist', domoticz.LOG_ERROR )
+			elseif device.switchType ~= "Selector" then 
+				utils.log('method switchSelector not available for type ' .. device.switchType, domoticz.LOG_ERROR )
 			else
 				return TimedCommand(domoticz, device.name, 'Set Level ' .. guardLevel(level), 'device' )
 			end

--- a/dzVents/runtime/integration-tests/scriptTestUpdatedDocumentation.lua
+++ b/dzVents/runtime/integration-tests/scriptTestUpdatedDocumentation.lua
@@ -1,0 +1,50 @@
+return {
+	on = {
+		devices = {'vdDocumentationSwitch'},
+	},
+	
+	execute = function(dz, item)
+		local documents = {'history.md', 'README.md', 'README.wiki' }
+		local documentPath = globalvariables.runtime_path:gsub('runtime','documentation')
+		local docVar = dz.variables('varUpdateDocument')
+		local updateDocfails = 0
+		
+		local function osExecute(cmd)
+			local fileHandle = assert(io.popen(cmd, 'r'))
+			local commandOutput = assert(fileHandle:read('*a'))
+			local returnTable = {fileHandle:close()}
+			
+			local log = dz.LOG_DEBUG
+			local msg = "0 (OK)"
+			if returnTable[3] ~= 0 then
+				log = dz.LOG_ERROR
+				if commandOutput == nil or commandOutput == '' then
+					commandOutput = '- failed -'
+				end
+				msg = returnTable[3] .. " ( " .. commandOutput .." )"
+			end
+			dz.log("Command: " .. cmd .. ", returnCode: " .. msg, log )
+			return returnTable[3] -- rc[3] is returnCode
+		end
+	
+		local function grep (file, str, isLinux )
+			return ( isLinux and  osExecute("grep " .. str .." " .. file ) ) or ( os.execute("findstr " .. str .. " " .. file ) )
+		end
+		
+		docVar.set(99) -- if something unexpected happens we will notice it because of this setting
+		for _,document in ipairs(documents) do	
+			if not dz.utils.fileExists(documentPath .. document) then
+				print ('shit ' .. documentPath .. document .." does not exist")
+			else
+				print (documentPath .. document .." found")
+				local rc = grep( documentPath .. document, globalvariables.dzVents_version, osExecute("sleep 0" ) ) 
+				if rc ~= 0  then
+					dz.log("Problems !! ( Returncode: " .. rc .. ") ", dz.LOG_ERROR )
+					updateDocfails = updateDocfails + 1
+				end
+			end
+		end
+		docVar.set(updateDocfails) 
+		
+	end
+}

--- a/dzVents/runtime/integration-tests/stage1.lua
+++ b/dzVents/runtime/integration-tests/stage1.lua
@@ -83,7 +83,6 @@ local testQuietOnSwitch = function(name)
 	local dev = dz.devices(name)
 	local res = true
 	res = res and checkAttributes(dev, {
-		["id"] = 49,
 		["name"] = name,
 		["maxDimLevel"] = 100,
 		["baseType"] = dz.BASETYPE_DEVICE,
@@ -107,7 +106,6 @@ local testQuietOffSwitch = function(name)
 	local dev = dz.devices(name)
 	local res = true
 	res = res and checkAttributes(dev, {
-		["id"] = 50,
 		["name"] = name,
 		["maxDimLevel"] = 100,
 		["baseType"] = dz.BASETYPE_DEVICE,
@@ -291,6 +289,7 @@ end
 local testCounterIncremental = function(name)
 	local dev = dz.devices(name)
 	local res = true
+	local res2 = true
 	res = res and checkAttributes(dev, {
 		["id"] = 8,
 		["name"] = name,
@@ -310,8 +309,12 @@ local testCounterIncremental = function(name)
 		["timedOut"] = false;
 	})
 	dev.updateCounter(1234)
-	tstMsg('Test counter incremental device', res)
-	return res
+	tstMsg('Test method updateCounter for counter incremental device', res)
+
+	dev.incrementCounter(10)
+	tstMsg('Test method incrementCounter for counter incremental device', res2)
+
+	return res and res2
 end
 
 local testCustomSensor = function(name)
@@ -1374,6 +1377,14 @@ local testHTTPSwitch = function(name)
 	return res
 end
 
+local testDocumentationSwitch = function(name)
+	local res = true
+	local dev = dz.devices(name)
+	dev.switchOn()
+	tstMsg('Start test documentation switch device', res)
+	return res
+end
+
 local testDescriptionSwitchDevice = function(name)
 	local res = true
 	local dev = dz.devices(name)
@@ -1482,6 +1493,7 @@ return {
 		res = res and testLocation();
 		res = res and testVersion();
 		res = res and testHTTPSwitch('vdHTTPSwitch');
+		res = res and testDocumentationSwitch('vdDocumentationSwitch');
 		res = res and testDescriptionSwitchGroup('gpDescriptionGroup');
 		res = res and testDescriptionSwitchDevice('vdDescriptionSwitch');
 		res = res and testDescriptionSwitchScene('scDescriptionScene');

--- a/dzVents/runtime/integration-tests/stage2.lua
+++ b/dzVents/runtime/integration-tests/stage2.lua
@@ -115,7 +115,7 @@ local testCounterIncremental = function(name)
 	local dev = dz.devices(name)
 	local res = true
 	res = res and checkAttributes(dev, {
-		["counter"] = 1.234;
+		["counter"] = 1.244;
 		["counterToday"] = 0;
 	})
 	handleResult('Test counter incremental device', res)
@@ -698,9 +698,17 @@ end
 
 local testVarCancelled = function(name)
 	local res = true
-	local var = dz.variables('varCancelled')
+	local var = dz.variables(name)
 	res = res and expectEql(0, var.value)
-	handleResult('Test cancelled variable', res)
+	handleResult('Test ' .. name .. ' variable', res)
+	return res
+end
+
+local testVarDocumentation = function(name)
+	local res = true
+	local var = dz.variables(name)
+	res = res and expectEql(0, var.value)
+	handleResult('Test ' .. name .. ' variable', res)
 	return res
 end
 
@@ -891,6 +899,7 @@ return {
 		res = res and testLastUpdates(stage2Trigger)
 		res = res and testRepeatSwitch('vdRepeatSwitch')
 		res = res and testVarCancelled('varCancelled')
+		res = res and testVarDocumentation('varUpdateDocument')
 		res = res and testCancelledScene('scCancelledScene')
 		res = res and testHTTPSwitch('vdHTTPSwitch');
 		res = res and testDescription('vdDescriptionSwitch', descriptionString, "device")

--- a/dzVents/runtime/integration-tests/testIntegration.lua
+++ b/dzVents/runtime/integration-tests/testIntegration.lua
@@ -75,6 +75,7 @@ local VIRTUAL_DEVICES = {
 	TEMPERATURE = {80, 'vdTemperature'},
 	TEXT = {5, 'vdText'},
 	THERMOSTAT_SETPOINT = {8, 'vdThermostatSetpoint'},
+    UPDATEDOCUMENT_SWITCH = { 6, 'vdDocumentationSwitch' },
 	USAGE_ELECTRIC = {248, 'vdUsageElectric'},
 	UV = {87, 'vdUV'},
 	VISIBILITY = {12, 'vdVisibility'},
@@ -85,8 +86,8 @@ local VIRTUAL_DEVICES = {
 	-- increment SECPANEL_INDEX_CHECK when adding a new one !!!!!!!!!!
 }
 
-local SECPANEL_INDEX_CHECK = 59
-local SECPANEL_INDEX = TestTools.tableEntries(VIRTUAL_DEVICES) + 10 -- 10 is number of groups / scenes + managed counter + dimmer switch+ ?
+local SECPANEL_INDEX_CHECK = 60
+local SECPANEL_INDEX = TestTools.tableEntries(VIRTUAL_DEVICES) + 10 -- 10 is number of groups / scenes + managed counter + dimmer switch + ?
 
 local VAR_TYPES = {
 	INT = {0, 'varInteger', 42},
@@ -95,7 +96,8 @@ local VAR_TYPES = {
 	DATE = {3, 'varDate', '31/12/2017'},
 	TIME = {4, 'varTime', '23:59'},
 	SILENT = { 0, 'varSilent', 1 },
-	CANCELLED = { 0, 'varCancelled', 0}
+	CANCELLED = { 0, 'varCancelled', 0},
+	UPDATEDOCUMENT = { 0, 'varUpdateDocument', 88},
 }
 
 local getResultsFromfile = function(file)
@@ -135,6 +137,7 @@ describe('Integration test',
 		TestTools.removeFSScript('vdCancelledRepeatSwitch.lua')
 		TestTools.removeFSScript('vdRepeatSwitch.lua')
 		TestTools.removeFSScript('vdSwitchDimmer.lua')
+		TestTools.removeFSScript('scriptTestUpdatedDocumentation.lua')
 		TestTools.removeGUIScript('stage1.lua')
 	end)
 
@@ -420,6 +423,11 @@ describe('Integration test',
 			local ok, idx = TestTools.createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.HTTP_SWITCH[2], VIRTUAL_DEVICES.HTTP_SWITCH[1])
 			assert.is_true(ok)
 		end)
+        
+        it('should create an Update Documentationswitch to trigger test UpdatedDocumentation script', function()
+			local ok, idx = TestTools.createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.UPDATEDOCUMENT_SWITCH[2], VIRTUAL_DEVICES.UPDATEDOCUMENT_SWITCH[1])
+			assert.is_true(ok)
+		end)
 
 		it('should create a DESCRIPTION switch to trigger description script', function()
 			local ok, idx = TestTools.createVirtualDevice(dummyIdx, VIRTUAL_DEVICES.DESCRIPTION_SWITCH[2], VIRTUAL_DEVICES.DESCRIPTION_SWITCH[1])
@@ -600,6 +608,11 @@ describe('Integration test',
 			local ok, idx = TestTools.createVariable(VAR_TYPES.CANCELLED[2], VAR_TYPES.CANCELLED[1], VAR_TYPES.CANCELLED[3])
 			assert.is_true(ok)
 		end)
+        
+        it('should create an integer variable to hold status of updateDocumentation check', function()
+			local ok, idx = TestTools.createVariable(VAR_TYPES.UPDATEDOCUMENT[2], VAR_TYPES.UPDATEDOCUMENT[1], VAR_TYPES.UPDATEDOCUMENT[3])
+			assert.is_true(ok)
+		end)
 	end)
 
 	describe('Preparing security panel', function ()
@@ -682,6 +695,10 @@ describe('Integration test',
 
 		it('Should move a httpResponse event script in place', function()
 			TestTools.createFSScript('httpResponseScript.lua')
+		end)
+        
+        it('Should move a updateDocumentation event script in place', function()
+			TestTools.createFSScript('scriptTestUpdatedDocumentation.lua')
 		end)
 
 		it('Should create the stage1 trigger switch', function()

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -549,6 +549,7 @@ describe('device', function()
 					"disarm",
 					"getColor",
 					'increaseBrightness',
+					'incrementCounter',
 					"kodiExecuteAddOn",
 					"kodiPause",
 					"kodiPlay",
@@ -572,6 +573,7 @@ describe('device', function()
 					"setHotWater",
 					"setHue",
 					"setKelvin",
+					"setMode",
 					'setNightMode',
 					'setRGB',
 					"setVolume",
@@ -653,13 +655,13 @@ describe('device', function()
 								[3] = "TemporaryOverride";
 								[4] = "2016-04-29T06:32:58Z" }
 								})
-			
+
 			local res;
 
 			domoticz.openURL = function(url)
 				res = url;
 			end
-			
+
 			assert.is_same('On', device.state)
 			assert.is_same('TemporaryOverride', device.mode)
 			assert.is_same('2016-04-29T06:32:58Z', device.untilDate)
@@ -667,6 +669,33 @@ describe('device', function()
 			device.setHotWater('Off', 'Permanent')
 
 			assert.is_same('http://127.0.0.1:8080/json.htm?type=setused&idx=1&setpoint=&state=Off&mode=Permanent&used=true', res)
+		end)
+
+		it('should detect an evohome Heating device', function()
+
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'Heating',
+				['subType'] = 'Evohome',
+				['hardwareTypeValue'] = 39,
+				['rawData'] = { [2] = "On";
+								[3] = "TemporaryOverride";
+								[4] = "2016-04-29T06:32:58Z" }
+				})
+
+			local res;
+
+			domoticz.openURL = function(url)
+				res = url;
+			end
+
+			assert.is_same('On', device.state)
+			assert.is_same('TemporaryOverride', device.mode)
+			assert.is_same('2016-04-29T06:32:58Z', device.untilDate)
+
+			device.setMode('Busted')
+
+			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=switchmodal&idx=1&status=Busted&action=1&ooc=0', res)
 		end)
 
 		it('should detect an opentherm gateway device', function()
@@ -856,8 +885,16 @@ describe('device', function()
 			assert.is_same(123.44, device.counterToday)
 			assert.is_same(6.7894, device.counter)
 
+			domoticz.openURL = function(url)
+				res = url;
+			end
+
 			device.updateCounter(555)
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="555", _trigger=true} } }, commandArray)
+		  
+			local domoticz = require('Domoticz')
+			device.incrementCounter(10)
+			assert.is_same('http://127.0.0.1:8080/json.htm?type=command&param=udevice&idx=1&svalue=10', res)
 		end)
 
 		it('should detect a pressure device', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -16,7 +16,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("2.4.22")
+	m_version("2.4.23")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION
Update to dzVents 2.4.23
- Add setMode for evoHome controller
- Add incrementCounter for counter incremental
- Prepared for fcm (Firebase Cloud Messaging)
- Fixed small typo's 
- Prevent use of method switchSelector for devices other then selectors.

	modified:   History.txt
	modified:   dzVents/documentation/README.md
	modified:   dzVents/documentation/README.wiki
	modified:   dzVents/documentation/history.md
	modified:   dzVents/runtime/Domoticz.lua
	modified:   dzVents/runtime/EventHelpers.lua
	modified:   dzVents/runtime/Utils.lua
	modified:   dzVents/runtime/device-adapters/counter_device.lua
	modified:   dzVents/runtime/device-adapters/evohome_device.lua
	modified:   dzVents/runtime/device-adapters/switch_device.lua
	new file:   dzVents/runtime/integration-tests/scriptTestUpdatedDocumentation.lua
	modified:   dzVents/runtime/integration-tests/stage1.lua
	modified:   dzVents/runtime/integration-tests/stage2.lua
	modified:   dzVents/runtime/integration-tests/testIntegration.lua
	modified:   dzVents/runtime/tests/testDevice.lua
	modified:   main/dzVents.cpp