### PR TITLE
Adding support for reading consumption and net consumption counters from Enphase Envoy Metered

### DIFF
--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -236,7 +236,7 @@ void EnphaseAPI::getConsumptionDetail()
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
 		return;
 	}
-	if ((root["consumption"].empty() == true) || (root["consumption"][0].emtpy() == true))
+	if ((root["consumption"].empty() == true) || (root["consumption"][0].empty() == true))
 	{
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
 		return;
@@ -290,7 +290,7 @@ void EnphaseAPI::getNetConsumptionDetail()
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
 		return;
 	}
-	if ((root["consumption"].empty() == true) || (root["consumption"][0].emtpy() == true))
+	if ((root["consumption"].empty() == true) || (root["consumption"][0].empty() == true))
 	{
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
 		return;

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -42,6 +42,8 @@ EnphaseAPI::EnphaseAPI(const int ID, const std::string &IPAddress, const unsigne
 	m_szIPAddress(IPAddress)
 {
 	m_p1power.ID = 1;
+	m_c1power.ID = 2;
+	m_c2power.ID = 3;
 
 	m_HwdID = ID;
 }
@@ -90,6 +92,8 @@ void EnphaseAPI::Do_Work()
 		if (sec_counter % Enphase_request_INTERVAL == 0)
 		{
 			getProduction();
+			getConsumption();
+			getNetConsumption();
 		}
 	}
 	_log.Log(LOG_STATUS, "EnphaseAPI Worker stopped...");
@@ -195,4 +199,112 @@ void EnphaseAPI::getProductionDetail()
 	m_p1power.powerusage2 = 0;
 	m_p1power.usagecurrent = musage;
 	sDecodeRXMessage(this, (const unsigned char *)&m_p1power, "Enphase Production kWh Total", 255);
+}
+
+void EnphaseAPI::getConsumption()
+{
+	getConsumptionDetail();
+}
+
+void EnphaseAPI::getConsumptionDetail()
+{
+	std::string sResult;
+
+#ifdef DEBUG_EnphaseAPI
+	sResult = ReadFile("C:\\TEMP\\EnphaseAPI_get_production.txt");
+#else
+	std::stringstream sURL;
+	sURL << "http://" << m_szIPAddress << "/production.json";
+
+	bool bret;
+	std::string szURL = sURL.str();
+	bret = HTTPClient::GET(szURL, sResult);
+	if (!bret)
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Error getting http data!");
+		return;
+	}
+
+#endif
+
+	Json::Value root;
+	Json::Reader jReader;
+
+	bool ret = jReader.parse(sResult, root);
+	if ((!ret) || (!root.isObject()))
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
+		return;
+	}
+	if ((root["consumption"].empty() == true) || (root["consumption"][0].emtpy() == true))
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
+		return;
+	}
+
+	Json::Value reading = root["consumption"][0];
+
+	int musage = reading["wNow"].asInt();
+	int mtotal = reading["whLifetime"].asInt();
+
+	SendKwhMeter(m_HwdID, 2, 255, musage, mtotal / 1000.0, "Enphase kWh Consumption");
+
+	m_c1power.powerusage1 = mtotal;
+	m_c1power.powerusage2 = 0;
+	m_c1power.usagecurrent = musage;
+	sDecodeRXMessage(this, (const unsigned char *)&m_c1power, "Enphase Consumption kWh Total", 255);
+}
+
+void EnphaseAPI::getNetConsumption()
+{
+	getNetConsumptionDetail();
+}
+
+void EnphaseAPI::getNetConsumptionDetail()
+{
+	std::string sResult;
+
+#ifdef DEBUG_EnphaseAPI
+	sResult = ReadFile("C:\\TEMP\\EnphaseAPI_get_production.txt");
+#else
+	std::stringstream sURL;
+	sURL << "http://" << m_szIPAddress << "/production.json";
+
+	bool bret;
+	std::string szURL = sURL.str();
+	bret = HTTPClient::GET(szURL, sResult);
+	if (!bret)
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Error getting http data!");
+		return;
+	}
+
+#endif
+
+	Json::Value root;
+	Json::Reader jReader;
+
+	bool ret = jReader.parse(sResult, root);
+	if ((!ret) || (!root.isObject()))
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
+		return;
+	}
+	if ((root["consumption"].empty() == true) || (root["consumption"][0].emtpy() == true))
+	{
+		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
+		return;
+	}
+
+	Json::Value reading = root["consumption"][0];
+
+	int musage = reading["wNow"].asInt();
+	int mtotal = reading["whLifetime"].asInt();
+
+	SendKwhMeter(m_HwdID, 3, 255, musage, mtotal / 1000.0, "Enphase kWh Net Consumption");
+
+	m_c2power.powerusage1 = mtotal;
+	m_c2power.powerusage2 = 0;
+	m_c2power.usagecurrent = musage;
+	sDecodeRXMessage(this, (const unsigned char *)&m_c2power, "Enphase Net Consumption kWh Total", 255);
 }

--- a/hardware/EnphaseAPI.h
+++ b/hardware/EnphaseAPI.h
@@ -17,10 +17,18 @@ private:
 	void getProduction();
 	void getProductionDetail();
 
+	void getConsumption();
+	void getConsumptionDetail();
+
+	void getNetConsumption();
+	void getNetConsumptionDetail();
+
 	int getSunRiseSunSetMinutes(const bool bGetSunRise);
 private:
 	std::string m_szIPAddress;
 	P1Power m_p1power;
+	P1Power m_c1power;
+	P1Power m_c2power;
 	std::shared_ptr<std::thread> m_thread;
 };
 


### PR DESCRIPTION
Added code to Enphase API to read (net) consumption counters from production.json. The consumption counters are read all day in stead of only between sunrise and sunset (as is done for production readings).