### PR TITLE
Added code to Enphase API to read (net) consumption counters from pro…

### DIFF
--- a/hardware/EnphaseAPI.h
+++ b/hardware/EnphaseAPI.h
@@ -17,10 +17,18 @@ private:
 	void getProduction();
 	void getProductionDetail();
 
+	void getConsumption();
+	void getConsumptionDetail();
+
+	void getNetConsumption();
+	void getNetConsumptionDetail();
+
 	int getSunRiseSunSetMinutes(const bool bGetSunRise);
 private:
 	std::string m_szIPAddress;
 	P1Power m_p1power;
+	P1Power m_c1power;
+	P1Power m_c2power;
 	std::shared_ptr<std::thread> m_thread;
 };
 


### PR DESCRIPTION
…duction.json. The consumption counters are read all day in stead of only between sunrise and sunset (as is done for production readings).

As I only have a Metered version of the Envoy, I haven't been able to test against non-Metered Envoy, but I reckon it shouldn't cause any problems.