### PR TITLE
[EnphaseAPI] Bugfix on PR #3378: check if consumption data is present

### DIFF
--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -236,7 +236,11 @@ void EnphaseAPI::getConsumptionDetail()
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
 		return;
 	}
-	if ((root["consumption"].empty() == true) || (root["consumption"][0].empty() == true))
+	if (root["consumption"].empty() == true)
+	{
+		return;
+	}
+	if (root["consumption"][0].empty() == true)
 	{
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
 		return;
@@ -290,7 +294,11 @@ void EnphaseAPI::getNetConsumptionDetail()
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received!");
 		return;
 	}
-	if ((root["consumption"].empty() == true) || (root["consumption"][0].empty() == true))
+	if (root["consumption"].empty() == true)
+	{
+		return;
+	}
+	if (root["consumption"][0].empty() == true)
 	{
 		_log.Log(LOG_ERROR, "EnphaseAPI: Invalid data received");
 		return;


### PR DESCRIPTION
In case root["consumption"] is empty return and not write error entry to logs.

Addition to PR #3378.