### PR TITLE
SolarEdge frequency reading displayed as percentage, instead of Hz #3554

### DIFF
--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -390,7 +390,7 @@ void SolarEdgeAPI::GetInverterDetails(const _tInverterSettings *pInverterSetting
 		{
 			float acFrequency = reading["L1Data"]["acFrequency"].asFloat();
 			sprintf(szTmp, "Hz %s", pInverterSettings->name.c_str());
-			SendPercentageSensor(1 + iInverterNumber, SE_FREQ, 255, acFrequency, szTmp);
+			SendCustomSensor(1 + iInverterNumber, SE_FREQ, 255, acFrequency, szTmp, "Hz");
 		}
 	}
 }


### PR DESCRIPTION
As reported in issue #3554: store Hz value from SolarEdge inverter as custom value. Update existing values by changing the corresponding DeviceStatus entry or entries.