### PR TITLE
Revert "Updating CMake configuration file to use version 3.14 as minimum"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-#set to minimum version that supports clean build
-cmake_minimum_required(VERSION 3.14.0)
+#set to minimum version that supports clean build on cygwin
+cmake_minimum_required(VERSION 2.8.4)
 
 project(domoticz)
 


### PR DESCRIPTION
This partially reverts commit 4e4ee999c4b323514c0ba81ab1ff3afb10d2f1cd to avoid bumping cmake requirement version from 2.8.4 to 3.14. Indeed, it seems that domoticz builds fine with older cmake such as 3.8.2.