### PR TITLE
Adds Philips Hue 'Geofence' sensor support (untested)

### DIFF
--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -25,6 +25,7 @@
 #define SensorTypeZLLPresence "ZLLPresence"
 #define SensorTypeZLLTemperature "ZLLTemperature"
 #define SensorTypeZLLLightLevel "ZLLLightLevel"
+#define SensorTypeGeofence "Geofence"
 
 //#define DEBUG_PhilipsHue
 
@@ -1070,6 +1071,14 @@ bool CPhilipsHue::GetSensors(const Json::Value &root)
 			{
 			}
 			else if (current_sensor.m_type == SensorTypeZLLPresence)
+			{
+				if ((previous_sensor.m_state.m_presence != current_sensor.m_state.m_presence)
+					|| (bNewSensor))
+				{
+					InsertUpdateSwitch(sID, STYPE_Motion, current_sensor.m_state.m_presence, device_name, current_sensor.m_config.m_battery);
+				}
+			}
+            else if (current_sensor.m_type == SensorTypeGeofence)
 			{
 				if ((previous_sensor.m_state.m_presence != current_sensor.m_state.m_presence)
 					|| (bNewSensor))


### PR DESCRIPTION
I don't have a working cpp build environment, but I have added some lines of code to add Philips Hue Geofence support. It seems very trivial, so I think it should work, but maybe someone else has the opportunity to test it?

A Geofence sensor is returned from the Hue API as such:

```json
{"state":{"presence":false,"lastupdated":"none"},"config":{"on":true,"reachable":true},"name":"iPhone van Jesse","type":"Geofence","modelid":"HA_GEOFENCE","manufacturername":"Philips","swversion":"1.0","uniqueid":"L_02_yHUyS","recycle":false}
```

Which, as you can see, is very much like a motion sensor. For example:

```json
{"state":{"presence":false,"lastupdated":"2019-08-07T07:11:32"},"swupdate":{"state":"noupdates","lastinstall":"2019-04-02T12:09:49"},"config":{"on":true,"battery":97,"reachable":true,"alert":"lselect","ledindication":false,"usertest":false,"sensitivity":2,"sensitivitymax":2,"pending":[]},"name":"Entree Sensor","type":"ZLLPresence","modelid":"SML001","manufacturername":"Philips","productname":"Hue motion sensor","swversion":"6.1.1.27575","uniqueid":"00:17:88:01:02:03:4c:ac-02-0406","capabilities":{"certified":true,"primary":true}}
```

I am adding the Geofence as a STYPE motion sensor. This seemed the most logical, since it's about presence, just like a motion sensor.

Of course, comments and suggestions are welcome, but like I said, I can't build and run the code myself, so I am kind of restricted in my options.