### PR TITLE
Added parameter to the Wunderground API call that enables decimal num…

### DIFF
--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -220,7 +220,7 @@ void CWunderground::GetMeterDetails()
 #else
 	std::stringstream sURL;
 	std::string szLoc = CURLEncode::URLEncode(m_Location);
-	sURL << "https://api.weather.com/v2/pws/observations/current?stationId=" << szLoc << "&format=json&units=m&apiKey=" << m_APIKey;
+	sURL << "https://api.weather.com/v2/pws/observations/current?stationId=" << szLoc << "&format=json&units=m&numericPrecision=decimal&apiKey=" << m_APIKey;
 	bool bret;
 	std::string szURL=sURL.str();
 	bret=HTTPClient::GET(szURL,sResult);


### PR DESCRIPTION
…eric precision for temperature and wind speed.

This parameter was a much asked one and added a few days ago.
Described in API documentation: https://docs.google.com/document/d/1KGb8bTVYRsNgljnNH67AMhckY8AQT2FVwZ9urj8SWBs/edit