### PR TITLE
Add Logging to SendSwitchIfNotExists if devices with same DeviceID

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -234,7 +234,28 @@ void ZWaveBase::SendSwitchIfNotExists(const _tZWaveDevice* pDevice)
 		result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d) AND (SubType==%d) AND (DeviceID=='%q')",
 			m_HwdID, int(unitcode), pTypeGeneralSwitch, sSwitchGeneralSwitch, szID);
 		if (!result.empty())
+		{
+			std::string first_non_matched_string_id;
+			std::map<std::string, _tZWaveDevice>::iterator itt;
+			for (itt = m_devices.begin(); itt != m_devices.end(); ++itt)
+			{
+				if (
+					(itt->second.nodeID == pDevice->nodeID) &&
+					(itt->second.instanceID == pDevice->instanceID) &&
+					(itt->second.string_id != pDevice->string_id))
+				{
+					first_non_matched_string_id = itt->second.string_id;
+				}
+			}
+			if (!first_non_matched_string_id.empty())
+
+				_log.Log(
+					LOG_ERROR,
+					"SendSwitchIfNotExists: Not adding '%s' because database already has DeviceID '%s'. That ID matches '%s'",
+					pDevice->string_id.c_str(), szID, first_non_matched_string_id.c_str());
+
 			return; //Already in the system
+		}
 
 		//Send as pTypeGeneralSwitch/sSwitchGeneralSwitch
 


### PR DESCRIPTION
Example device is FGRM-222 having both "binary" and "multilevel" switch, log example:

Error: SendSwitchIfNotExists: Not adding '4.instance.1.index.0.commandClasses.38' because database already has DeviceID '00000401'. That ID matches '4.instance.1.index.0.commandClasses.37'

Helps diagnosing https://github.com/domoticz/domoticz/issues/3221