### PR TITLE
Add Support for Fibaro FGRM-222 Roller Shutter

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -1176,3 +1176,8 @@ bool ZWaveBase::WriteToHardware(const char* pdata, const unsigned char length)
 	return true;
 }
 
+bool ZWaveBase::IsFibaroFgrm222(const _tZWaveDevice &pDevice)
+{
+	return (
+		(pDevice.Manufacturer_id == 0x010F) && ((pDevice.Product_type == 0x0301) || (pDevice.Product_type == 0x0302)));
+}

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -157,6 +157,8 @@ private:
 	virtual bool IsNodeIncluded() = 0;
 	virtual bool IsNodeExcluded() = 0;
 
+	bool IsFibaroFgrm222(const _tZWaveDevice &pDevice);
+
 	bool m_bControllerCommandInProgress;
 	bool m_bControllerCommandCanceled;
 	time_t m_ControllerCommandStartTime;


### PR DESCRIPTION
Should fix #3221

On an existing database, the first (and only) switch device changes to ON/OFF because the FGRM-222 exposes this first. This supports full open-close in all Roller Shutter Modes.

Three new devices are created, IDs end in 10, 11 and 12
10 Level -> Used to set position in Gate, Blind and Venetian Blind mode marked "with positioning" (see parameter 10 "Roller Shutter operating modes")
11 Venetian Blind slat position -> Similar to 10 Level
12 Venetian blind tilt position -> as the name says

For Tilt reporting, set Parameter 3 "Reports type" to 1 - Blind position reports sent to the main controller using Fibar
Command Class.

I checked my FGRM-222 and can control my FGRM in both Blinds and Venetian Blinds mode.

However, I had to check with ZNiffer: the device has its own mind about what to report back, sometimes it reports on ID ...10, sometimes ...11 or both. In Blinds mode, Tilt also changes reported position. This behaviour might be specific to my hardware revision and firmware.

The code is relatively simple but one warning, although I tested this, this line is semantically different and might have an impact.

Old:
if (GetValueByCommandClassIndex(pDevice->nodeID, instanceID, COMMAND_CLASS_SWITCH_MULTILEVEL, ValueID_Index_SwitchMultiLevel::Level, vID) == true)

New:
if (GetValueByCommandClassIndex(pDevice->nodeID, pDevice->orgInstanceID, pDevice->commandClassID, pDevice->orgIndexID, vID) == true)

The change is needed because the FGRM Multilevel Venetian Blind switch devices use CC "proprietary" and orgInstanceID encodes the real instance for OZW (while IndexID is 10, 11 or 12).