### PR TITLE
separate monthly usage and return totals

### DIFF
--- a/www/app/report/EnergyMultiCounterReport.html
+++ b/www/app/report/EnergyMultiCounterReport.html
@@ -24,13 +24,17 @@
     <div>{{:: 'Total Usage' | translate }}:
         {{:: 'T1' | translate }}: {{:: $ctrl.data.usage1.usage.toFixed(3) }} {{:: $ctrl.unit}},
         {{:: 'T2' | translate }}: {{:: $ctrl.data.usage2.usage.toFixed(3) }} {{:: $ctrl.unit}},
-        {{:: 'Total' | translate }}: {{:: $ctrl.data.usage.toFixed(3) }} {{:: $ctrl.unit}}
+        {{:: 'Total' | translate }}: {{:: ($ctrl.data.usage1.usage + $ctrl.data.usage2.usage).toFixed(3) }} {{:: $ctrl.unit}}
     </div>
 
     <div ng-if="::$ctrl.hasReturn">{{:: 'Total Return' | translate }}:
         {{:: 'R1' | translate }}: {{:: $ctrl.data.return1.usage.toFixed(3) }} {{:: $ctrl.unit}},
         {{:: 'R2' | translate }}: {{:: $ctrl.data.return2.usage.toFixed(3) }} {{:: $ctrl.unit}},
-        {{:: 'Total' | translate }}: {{:: $ctrl.data.usage.toFixed(3) }} {{:: $ctrl.unit}}
+        {{:: 'Total' | translate }}: {{:: ($ctrl.data.return1.usage + $ctrl.data.return2.usage).toFixed(3) }} {{:: $ctrl.unit}}
+    </div>
+
+    <div ng-if="::$ctrl.hasReturn">
+	    {{:: 'Total' | translate }}: {{$ctrl.data.usage.toFixed(3) }} {{:: $ctrl.unit}}
     </div>
 
     <div>{{:: 'Monthly Cost' | translate }}: {{:: $ctrl.data.cost.toFixed(2) }}</div>


### PR DESCRIPTION
In the monthly report for energy, if you can return energy, the totals shown next to the usage (T1 + T2) and the return (R1 + R2) are both the same: the grand total ( (T1 + T2) - (R1 + R2) ) - not very useful IMO:

![before](https://user-images.githubusercontent.com/998449/66953512-f9cc0400-f05e-11e9-9ee6-2c0a94b54d65.png)

This patch makes it so that the T1 and T2 are totalled, and R1 and R2 too. Then, the grand total (which was previously shown after both) is displayed separately:

![after](https://user-images.githubusercontent.com/998449/66953533-ffc1e500-f05e-11e9-8477-d50f6054d74e.png)
