### PR TITLE
Fix Compilations error on FreeBSD

### DIFF
--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -908,7 +908,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 				if (!HTTPClient::POST(sUrl, sPostData, _vExtraHeaders, sResponse, _vResponseHeaders, true, bIgnoreEmptyResponse))
 				{
 					for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) _ssResponseHeaderString << _vResponseHeaders[i];
-					_log.Log(LOG_ERROR, "Tado: Failed to perform POST request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
+					_log.Log(LOG_ERROR, "Tado: Failed to perform POST request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.c_str());
 					return false;
 				}
 				break;
@@ -917,7 +917,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 				if (!HTTPClient::GET(sUrl, _vExtraHeaders, sResponse, _vResponseHeaders, bIgnoreEmptyResponse))
 				{
 					for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) _ssResponseHeaderString << _vResponseHeaders[i];
-					_log.Log(LOG_ERROR, "Tado: Failed to perform GET request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
+					_log.Log(LOG_ERROR, "Tado: Failed to perform GET request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.c_str());
 					return false;
 				}
 				break;


### PR DESCRIPTION
This fix this compilation errors on FreeBSD :
```
/home/kiwi/domoticz.dev/hardware/Tado.cpp:911:123: error: cannot pass
      non-trivial object of type 'std::__1::basic_stringstream<char,
      std::__1::char_traits<char>, std::__1::allocator<char> >::string_type'
      (aka 'basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >') to variadic method; expected type from
      format string was 'char *' [-Wnon-pod-varargs]
  ...Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
                       ~~                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kiwi/domoticz.dev/hardware/Tado.cpp:911:123: note: did you mean to call
      the c_str() method?
  ...headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
                                      ^
                                                                   .c_str()
/home/kiwi/domoticz.dev/hardware/Tado.cpp:920:122: error: cannot pass
      non-trivial object of type 'std::__1::basic_stringstream<char,
      std::__1::char_traits<char>, std::__1::allocator<char> >::string_type'
      (aka 'basic_string<char, std::__1::char_traits<char>,
      std::__1::allocator<char> >') to variadic method; expected type from
      format string was 'char *' [-Wnon-pod-varargs]
  ...Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
                       ~~                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kiwi/domoticz.dev/hardware/Tado.cpp:920:122: note: did you mean to call
      the c_str() method?
  ...headers: %s", sResponse.c_str(), _ssResponseHeaderString.str());
                                      ^
                                                                   .c_str()
2 errors generated.
```