### PR TITLE
Correcting the handling of the free_fall state of the agara cube

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -1177,7 +1177,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 							level = 20;
 							on = true;
 						}
-						else if ((status == "long_click_press") || (status == "move") || (aqara_wireless3 == "both_click") || (status == "free_fall")) {
+						else if ((status == "long_click_press") || (status == "move") || (aqara_wireless3 == "both_click") ) {
 							level = 30;
 							on = true;
 						}


### PR DESCRIPTION
	modified:   hardware/XiaomiGateway.cpp

as reported on the [forum](https://www.domoticz.com/forum/viewtopic.php?f=6&t=29886l)