### PR TITLE
main/unzip_iterator.h: include zlib.h

### DIFF
--- a/main/unzip_iterator.h
+++ b/main/unzip_iterator.h
@@ -39,6 +39,7 @@
 #include <iterator>
 #include <string>
 #include <unzip.h>
+#include <zlib.h>
 #include "unzip_stream.h"
 
 namespace clx {


### PR DESCRIPTION
Include zlib.h to be able to build domoticz with minizip 2.9.0
(https://github.com/nmoinvaz/minizip) indeed minizip does not define
uLong (see https://github.com/nmoinvaz/minizip/issues/405)

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>