### PR TITLE
CMakeLists.txt: Add USE_PRECOMPILED_HEADER option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -744,7 +744,10 @@ else()
   target_link_libraries(domoticz -lrt -lresolv ${EXECINFO_LIBRARIES})
 ENDIF()
 
-ADD_PRECOMPILED_HEADER(domoticz "main/stdafx.h")
+option(USE_PRECOMPILED_HEADER "Use precompiled header feature to speed up build time " YES)
+if(USE_PRECOMPILED_HEADER)
+  ADD_PRECOMPILED_HEADER(domoticz "main/stdafx.h")
+ENDIF(USE_PRECOMPILED_HEADER)
 
 IF(CMAKE_COMPILER_IS_GNUCXX)
   option(USE_STATIC_LIBSTDCXX "Build with static libgcc/libstdc++ libraries" YES)


### PR DESCRIPTION
Add USE_PRECOMPILED_HEADER to allow the user to disable precompiled
header feature. Thanks to this, domoticz will be able to be built with
RELRO on buildroot

Fixes:
 - http://autobuild.buildroot.org/results/5c1ca3083ad672401d1e050c6c3a07b8c33b851d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>