### PR TITLE
DelayedLink.h: fix build with python 3.8

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -14,6 +14,44 @@
 #include <frameobject.h>
 #include "../../main/Helper.h"
 
+#if PY_VERSION_HEX >= 0x030800f0
+static inline void
+py3__Py_DECREF(const char *filename, int lineno, PyObject *op)
+{
+	(void)filename; /* may be unused, shut up -Wunused-parameter */
+	(void)lineno; /* may be unused, shut up -Wunused-parameter */
+	_Py_DEC_REFTOTAL;
+	if (--op->ob_refcnt != 0)
+	{
+#ifdef Py_REF_DEBUG
+	if (op->ob_refcnt < 0)
+	{
+		_Py_NegativeRefcount(filename, lineno, op);
+	}
+#endif
+	}
+	else
+	{
+		_Py_Dealloc(op);
+	}
+}
+
+#undef Py_DECREF
+#define Py_DECREF(op) py3__Py_DECREF(__FILE__, __LINE__, _PyObject_CAST(op))
+
+static inline void
+py3__Py_XDECREF(PyObject *op)
+{
+	if (op != NULL)
+	{
+		Py_DECREF(op);
+	}
+}
+
+#undef Py_XDECREF
+#define Py_XDECREF(op) py3__Py_XDECREF(_PyObject_CAST(op))
+#endif
+
 namespace Plugins {
 
 #ifdef WIN32


### PR DESCRIPTION
Fix build with python 3.8 by copy/pasting the vim workaround from
https://github.com/vim/vim/commit/13a1f3fb0c9d08bba6109fe2131c9524e6ba7e15

Fix #3703

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>