### PR TITLE
csocket: Replace sys/poll with poll

### DIFF
--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -16,7 +16,7 @@
 #include <sys/errno.h>
 #include <unistd.h>
 #include <fcntl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #endif
 
 #ifndef WIN32


### PR DESCRIPTION
Fixes warning when compiling under musl:

warning redirecting incorrect #include <sys/poll.h> to <poll.h>