### PR TITLE
serial/unix: Replace sys/signal with signal

### DIFF
--- a/hardware/serial/impl/unix.cpp
+++ b/hardware/serial/impl/unix.cpp
@@ -11,7 +11,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <errno.h>
 #include <paths.h>
 #include <sysexits.h>


### PR DESCRIPTION
Fixes warning under musl:

warning redirecting incorrect #include <sys/signal.h> to <signal.h>