### PR TITLE
Fix BleBox search issues with duplicate devices

### DIFF
--- a/hardware/BleBox.cpp
+++ b/hardware/BleBox.cpp
@@ -1251,32 +1251,19 @@ void BleBox::UpdateFirmware()
 	}
 }
 
-void BleBox::SearchNodes(const std::string & ipmask)
+void BleBox::SearchNodes(const std::string & pattern)
 {
-	std::vector<std::string> strarray;
-	StringSplit(ipmask, ".", strarray); // ipmask - expected "x.y.z.*"
-	if (strarray.size() != 4)
+	std::vector<std::string> hosts;
+	if(!PrepareHostList(pattern, hosts))
+	{
+		Log(LOG_ERROR, "Invalid or unsupported IP pattern : %s (expected e.g. 192.168.1.*)", pattern.c_str());
 		return;
-	if (strarray[3] != "*")
-		return;
-	if (!isInt(strarray[0]) || !isInt(strarray[1]) || !isInt(strarray[2]))
-		return;
+	}
 
 	std::vector<std::thread> searchingThreads;
-
-	std::stringstream sstr;
-	sstr << strarray[0] << "." << strarray[1] << "." << strarray[2] << ".";
-	const std::string ipStart = sstr.str();
-
-	for (unsigned int i = 1; i < 255; ++i)
-	{
-		std::string IPAddress = ipStart + std::to_string(i);
-
-		if (m_devices.find(IPAddress) == m_devices.end())
-		{
-			searchingThreads.emplace_back(&BleBox::AddNode, this, "unknown", std::ref(IPAddress), false);
-		}
-	}
+	for(auto&& host : hosts)
+		if (m_devices.find(host) == m_devices.end())
+			searchingThreads.emplace_back(&BleBox::AddNode, this, "unknown", std::ref(host), false);
 
 	for (auto&& thread : searchingThreads)
 	{
@@ -1284,4 +1271,31 @@ void BleBox::SearchNodes(const std::string & ipmask)
 	}
 
 	ReloadNodes();
+}
+
+bool BleBox::PrepareHostList(const std::string& pattern, std::vector<std::string>& hosts)
+{
+	std::vector<std::string> strarray;
+	StringSplit(pattern, ".", strarray);
+
+	if (strarray.size() != 4)
+		return false;
+
+	if (strarray[3] != "*")
+		return false;
+
+	if (!isInt(strarray[0]) || !isInt(strarray[1]) || !isInt(strarray[2]))
+		return false;
+
+	std::stringstream sstr;
+	sstr << strarray[0] << "." << strarray[1] << "." << strarray[2] << ".";
+	const std::string ipStart = sstr.str();
+
+	for (unsigned int i = 1; i < 255; ++i)
+	{
+		std::string host = ipStart + std::to_string(i);
+		hosts.push_back(host);
+	}
+
+	return !hosts.empty();
 }

--- a/hardware/BleBox.h
+++ b/hardware/BleBox.h
@@ -28,7 +28,7 @@ public:
 	bool DoesNodeExists(const Json::Value &root, const std::string &node);
 	bool DoesNodeExists(const Json::Value &root, const std::string &node, const std::string &value);
 	std::string GetUptime(const std::string &IPAddress);
-	void SearchNodes(const std::string &ipmask);
+	void SearchNodes(const std::string &pattern);
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
@@ -57,4 +57,6 @@ private:
 	_tColor m_RGBWColorState;
 	bool m_RGBWisWhiteState;
 	int m_RGBWbrightnessState;
+
+	bool PrepareHostList(const std::string& pattern, std::vector<std::string>& hosts);
 };


### PR DESCRIPTION
Cause:

During a search, temporary/stack-based `IPAddress` (std::string) objects were passed to long running threads, which means the `addNode()` threads were likely using already destroyed `IPAddress` objects.

During the `for` loop, those destroyed stack objects were replaced with  IPAddress objects from next iterations, which either caused the detection to fail (connecting to a different ip) or create duplicate devices (connecting to an address already added by another thread, or adding a record with an ip from another loop iteration).

Other changes:

- log an error if the pattern is invalid or unsupported
- minor renames ("pattern") and more helpful comments
- skip search if pattern results in no hosts (future-proof)