### PR TITLE
add resilience to RGBWW API calls and add actualWatt attribute (= WhActual)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -26,7 +26,7 @@ Version 4.xxxxx (xxx 2019)
 - Fixed: notification, Telegram error when odd number of underscores in text
 - Fixed: API, allow variabletype to be entered as text or integer in adduservariable and updateuservariable (#3320)
 - Updated: OpenZWave version 1.6
-- Updated: dzVents (version 2.5.1 for Lua 5.3) See dzVents/documentation/history.md)
+- Updated: dzVents (version 2.5.2 for Lua 5.3) See dzVents/documentation/history.md)
 
 Version 4.10717 (May 9th 2019)
 - Fixed: dzVents, Allowing no error message for HTTP calls (#3191)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -787,7 +787,8 @@ Note that if you do not find your specific device type here you can always inspe
  - **updateDistance(distance)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Electric usage
- - **WhActual**: *Number*. Current Watt usage.
+ - **actualWatt**: *Number*. Current Watt usage.
+ - **WhActual**: *Number*. Current Watt usage. (please use actualWatt)
  - **updateEnergy(energy)**: *Function*. In Watt. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Evohome (zones)
@@ -836,12 +837,14 @@ Note that if you do not find your specific device type here you can always inspe
  - **kodiSwitchOff()**: *Function*. Will turn the device off if this is supported in settings on the device.
 
 #### kWh, Electricity (instant and counter)
+ - **actualWatt**: *Number*. Actual usage in Watt.
  - **counterToday**: *Number*.
  - **updateElectricity(power, energy)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **usage**: *Number*.
  - **WhToday**: *Number*. Total Wh usage of the day. Note the unit is Wh and not kWh!
  - **WhTotal**: *Number*. Total Wh usage.
- - **WhActual**: *Number*. Actual reading.
+ - **WhActual**: *Number*. Actual reading in Watt. Please use actualWatt
+ 
 
 #### Leaf wetness
  - **wetness**: *Number*. Wetness value
@@ -895,6 +898,7 @@ See switch below.
  - **updateRain(rate, counter)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### RGBW(W) / Lighting Limitless/Applamp
+**Note**: not all methods are available for all hardwareTypes !
  - **decreaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **getColor()**; *Function*. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
  - **increaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
@@ -2077,6 +2081,10 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # History
+
+##[2.5.2]
+- Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+- Add resilience to increaseBrightness() and decreaseBrightness() methods (only avaiable for Yeelight)
 
 ##[2.5.1]
 - Added `toXML` and `fromXML` methods to domoticz.utils.

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -1,4 +1,4 @@
-'''Note''': This document is maintained on [https://github.com/domoticz/domoticz/blob/development/dzVents/documentation/README.md github], and the wiki version is automatically generated. Edits should be performed on github, or they may be suggested on the wiki article's [https://www.domoticz.com/wiki/Talk:DzVents:_next_generation_LUA_scripting Discussion page].
+'''Note''': This document is maintained on [https://github.com/domoticz/domoticz/blob/development/dzVents/documentation/README.md github], and the wiki version is automatically generated. Edits should be performed on github, or they may be suggested on the wiki article’s [https://www.domoticz.com/wiki/Talk:DzVents:_next_generation_LUA_scripting Discussion page].
 
 '''Breaking change warning!!''': For people using with dzVents prior to version 2.4: Please read the [[#Change_log|change log]] below as there is an easy-to-fix breaking change regarding the second parameter passed to the execute function (it is no longer <code>nil</code> for timer/security triggers).
 
@@ -8,9 +8,9 @@ Documentation for dzVents 2.2.0 (Domoticz v3.8153) can be found [https://github.
 
 = About dzVents 2.4.x (Domoticz v3.8837+) =
 
-dzVents /diː ziː vɛnts/, short for Domoticz Easy Events, brings Lua scripting in Domoticz to a whole new level. Writing scripts for Domoticz has never been so easy. Not only can you define triggers more easily, and have full control over timer-based scripts with extensive scheduling support, dzVents presents you with an easy to use API to all necessary information in Domoticz. No longer do you have to combine all kinds of information given to you by Domoticz in many different data tables. You don't have to construct complex commandArrays anymore. dzVents encapsulates all the Domoticz peculiarities regarding controlling and querying your devices. And on top of that, script performance has increased a lot if you have many scripts because Domoticz will fetch all device information only once for all your device scripts and timer scripts. And ... '''it is 100% Lua'''! So if you already have a bunch of event scripts for Domoticz, upgrading should be fairly easy.
+dzVents /diː ziː vɛnts/, short for Domoticz Easy Events, brings Lua scripting in Domoticz to a whole new level. Writing scripts for Domoticz has never been so easy. Not only can you define triggers more easily, and have full control over timer-based scripts with extensive scheduling support, dzVents presents you with an easy to use API to all necessary information in Domoticz. No longer do you have to combine all kinds of information given to you by Domoticz in many different data tables. You don’t have to construct complex commandArrays anymore. dzVents encapsulates all the Domoticz peculiarities regarding controlling and querying your devices. And on top of that, script performance has increased a lot if you have many scripts because Domoticz will fetch all device information only once for all your device scripts and timer scripts. And … '''it is 100% Lua'''! So if you already have a bunch of event scripts for Domoticz, upgrading should be fairly easy.
 
-Let's start with an example. Say you have a switch that when activated, it should activate another switch but only if the room temperature is above a certain level. And when done, it should send a notification. This is how it looks in dzVents:
+Let’s start with an example. Say you have a switch that when activated, it should activate another switch but only if the room temperature is above a certain level. And when done, it should send a notification. This is how it looks in dzVents:
 
 <pre>return {
    on = {
@@ -66,7 +66,7 @@ Just to give you an idea! Everything in your Domoticz system is now logically av
 
 = Using dzVents with Domoticz =
 
-In Domoticz go to '''Setup &gt; Settings &gt; Other''' and in the section EventSystem make sure the check-box 'dzVents disabled' is not checked. Also make sure that in the Security section in the settings '''(Setup &gt; Settings &gt; System &gt; Local Networks (no username/password)''' you allow 127.0.0.1 to not need a password. dzVents uses that port to send certain commands to Domoticz. Finally make sure you have set your current location in '''Setup &gt; Settings &gt; System &gt; Location''', otherwise there is no way to determine nighttime/daytime state.
+In Domoticz go to '''Setup &gt; Settings &gt; Other''' and in the section EventSystem make sure the check-box ‘dzVents disabled’ is not checked. Also make sure that in the Security section in the settings '''(Setup &gt; Settings &gt; System &gt; Local Networks (no username/password)''' you allow 127.0.0.1 to not need a password. dzVents uses that port to send certain commands to Domoticz. Finally make sure you have set your current location in '''Setup &gt; Settings &gt; System &gt; Location''', otherwise there is no way to determine nighttime/daytime state.
 
 There are two ways of creating dzVents event scripts in Domoticz:
 
@@ -75,34 +75,34 @@ There are two ways of creating dzVents event scripts in Domoticz:
 
 '''Note: scripts that you write on the file-system and inside Domoticz using the internal web-editor all share the same name-space. That means that if you have two scripts with the same name, only the one of the file-system will be used. The log will tell you when this happens.'''
 
-'''Note: Scripts created in the internal editor are stored in the domoticz database and are all written to <code>/path/to/domoticz/scripts/dzVents/generated_scripts</code> on every domoticz restart and every &quot;EventSystem: reset all events...&quot;. Scripts in <code>/path/to/domoticz/scripts/dzVents/scripts</code> are not stored in the database and should be backed-up separately. '''
+'''Note: Scripts created in the internal editor are stored in the domoticz database and are all written to <code>/path/to/domoticz/scripts/dzVents/generated_scripts</code> on every domoticz restart and every “EventSystem: reset all events…”. Scripts in <code>/path/to/domoticz/scripts/dzVents/scripts</code> are not stored in the database and should be backed-up separately. '''
 
 == Quickstart ==
 
 If you made sure that dzVents system is active, we can do a quick test if everything works:
 
-<ul>
-<li>Pick a switch in your Domoticz system. Write down the exact name of the switch. If you don't have a switch then you can create a Dummy switch and use that one.</li>
-<li>Create a new file in the <code>/path/to/domoticz/scripts/dzVents/scripts/</code> folder (or using the web-editor in Domoticz, switch to dzVents mode first.). Call the file <code>test.lua</code>. ''Note: when you create a script in the web-editor you do '''not''' add the .lua extension!'' Also, valid script names follow the same rules as [https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words filesystem names].</li>
-<li><p>Open <code>test.lua</code> in an editor and fill it with this code and change <code>&lt;exact name of the switch&gt;</code> with the .. you guessed it... exact name of the switch device:</p>
-<pre> return {
-   on = {
-      devices = {
-         '&lt;exact name of the switch&gt;'
-      }
-   },
-   execute = function(domoticz, switch)
-      if (switch.state == 'On') then
-         domoticz.log('Hey! I am on!')
-      else
-         domoticz.log('Hey! I am off!')
-      end
-   end
-}</pre></li>
-<li>Save the script</li>
-<li>Open the Domoticz log in the browser</li>
-<li>In Domoticz GUI (perhaps in another browser tab) press the switch.</li>
-<li><p>You can watch the log in Domoticz and it should show you that indeed it triggered your script and you should see the log messages.</p></li></ul>
+* Pick a switch in your Domoticz system. Write down the exact name of the switch. If you don’t have a switch then you can create a Dummy switch and use that one.
+* Create a new file in the <code>/path/to/domoticz/scripts/dzVents/scripts/</code> folder (or using the web-editor in Domoticz, switch to dzVents mode first.). Call the file <code>test.lua</code>. ''Note: when you create a script in the web-editor you do '''not''' add the .lua extension!'' Also, valid script names follow the same rules as [https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words filesystem names].
+* Open <code>test.lua</code> in an editor and fill it with this code and change <code>&lt;exact name of the switch&gt;</code> with the .. you guessed it… exact name of the switch device:
+
+<pre>     return {
+       on = {
+          devices = {
+             '&lt;exact name of the switch&gt;'
+          }
+       },
+       execute = function(domoticz, switch)
+          if (switch.state == 'On') then
+             domoticz.log('Hey! I am on!')
+          else
+             domoticz.log('Hey! I am off!')
+          end
+       end
+    }</pre>
+* Save the script
+* Open the Domoticz log in the browser
+* In Domoticz GUI (perhaps in another browser tab) press the switch.
+* You can watch the log in Domoticz and it should show you that indeed it triggered your script and you should see the log messages.
 
 See the examples folder <code>/path/to/domoticz/scripts/dzVents/examples</code> for more examples. This folder includes templates you can use to get started as well. And, if you use the GUI web editor to write your script, you will find boilerplate examples in the drop-down below the script type setting.
 
@@ -147,43 +147,43 @@ Each dzVents event script has this structure:
 }</pre>
 === active = true/false (optional) ===
 
-If <code>active = false</code>, then the script is not activated: ''dzVents will ignore the script completely''. If you don't have <code>active</code> specified, <code>true</code> is assumed (default value). If you write scripts with Domoticz' internal script editor then you don't need this part as the editor has its own way of enabling and disabling scripts.
+If <code>active = false</code>, then the script is not activated: ''dzVents will ignore the script completely''. If you don’t have <code>active</code> specified, <code>true</code> is assumed (default value). If you write scripts with Domoticz’ internal script editor then you don’t need this part as the editor has its own way of enabling and disabling scripts.
 
 So, <code>active</code> can either be:
 
 * '''true''': (default) the script file will be processed.
 * '''false''': the script file is ignored.
-* '''function(domoticz) ... end''': A function returning <code>true</code> or <code>false</code>. The function will receive the domoticz object with all the information about your domoticz instance: <code>active = function(domoticz) .... end</code>. For example you could check for a Domoticz variable or switch and prevent the script from being executed. '''However, be aware that for ''every script'' in your scripts folder, this active function will be called, every cycle!! Therefore, it is better to put all your logic in the execute function instead of in the active function.'''
+* '''function(domoticz) … end''': A function returning <code>true</code> or <code>false</code>. The function will receive the domoticz object with all the information about your domoticz instance: <code>active = function(domoticz) .... end</code>. For example you could check for a Domoticz variable or switch and prevent the script from being executed. '''However, be aware that for ''every script'' in your scripts folder, this active function will be called, every cycle!! Therefore, it is better to put all your logic in the execute function instead of in the active function.'''
 
-=== on = { ... } ===
+=== on = { … } ===
 
 The <code>on</code> section tells dzVents ''when'' the execute function has to be executed. It holds all the events/'''triggers''' that are monitored by dzVents. If any of the events or triggers match with the current event coming from Domoticz, then the <code>execute</code> part of the script is executed by dzVents. The <code>on</code> section has many kinds of subsections that ''can all be used simultaneously'' :
 
-==== devices = { ... } ====
+==== devices = { … } ====
 
-A list of device-names or indexes. If a device in your system was changed (e.g. switch was triggered or a new temperature was received) and it is listed in this section then the execute function is executed. Each device can be:
+A list of device-names or indexes. If a device in your system was changed (e.g. switch was triggered or a new temperature was received) and it is listed in this section then the execute function is executed. Each device can be:
 
 * The name of your device between string quotes. '''You can use the asterisk (*) wild-card here e.g. <code>PIR_*</code> or <code>*_PIR</code>'''. E.g.: <code>devices = { 'myDevice', 'anotherDevice', 123, 'pir*' }</code>
 * The index (idx) of your device (as the name may change, the index will usually stay the same, the index can be found in the devices section in Domoticz). '''Note that idx is a number;'''
 * The name or idx of your device followed by a time constraint, such as: <code>['myDevice']  = { 'at 15:*', 'at 22:* on sat, sun' }</code> The script will be executed if <code>myDevice</code> was changed, '''and''' it is either between 15:00 and 16:00 or between 22:00 and 23:00 in the weekend. See [[#timer_trigger_rules|time trigger rules]].
 
-==== scenes = { ... } ====
+==== scenes = { … } ====
 
 A list of one or more scene-names or indexes. The same rules as devices apply. So if your scene is listed in this table then the executed function will be triggered, e.g.: <code>on = { scenes = { 'myScene', 'anotherScene' } },</code>.
 
-==== groups = { ...} ====
+==== groups = { …} ====
 
 A list of one or more group-names or indexes. The same rules as devices apply.
 
-==== timer = { ... } ====
+==== timer = { … } ====
 
-A list of one ore more time 'rules' like <code>every minute</code> or <code>at 17:*</code>. See [[#timer_trigger_rules|''timer'' trigger rules]]. If any or the rules matches with the current time/date then your execute function is called. E.g.: <code>on = { timer = { 'between 30 minutes before sunset and 30 minutes after sunrise' } }</code>.
+A list of one ore more time ‘rules’ like <code>every minute</code> or <code>at 17:*</code>. See [[#timer_trigger_rules|''timer'' trigger rules]]. If any or the rules matches with the current time/date then your execute function is called. E.g.: <code>on = { timer = { 'between 30 minutes before sunset and 30 minutes after sunrise' } }</code>.
 
-==== variables = { ... } ====
+==== variables = { … } ====
 
 A list of one or more user variable-names as defined in Domoticz ( ''Setup &gt; More options &gt; User variables''). If any of the variables listed here changes, the script is executed. '''Note''': Script will only execute when this variable is updated directly by dzVents or by a JSON. If updated with a standard Lua script (using commandArray) or in combination with a time option like afterXXX no event will be triggered.
 
-==== security = { ... } ====
+==== security = { … } ====
 
 A list of one or more of these security states:
 
@@ -193,17 +193,15 @@ A list of one or more of these security states:
 
 If the security state in Domoticz changes and it matches with any of the states listed here, the script will be executed. See <code>/path/to/domoticz/scripts/dzVents/examples/templates/security.lua</code> for an example see [[#Security_Panel|Security Panel]] for information about how to create a security panel device.
 
-==== httpResponses = { ...} <sup>2.4.0</sup> ====
+==== httpResponses = { …} <sup>2.4.0</sup> ====
 
 A list of one or more http callback triggers. Use this in conjunction with <code>domoticz.openURL()</code> where you will provide Domoticz with the callback trigger. See [[Asynchronous_HTTP_requests|Asynchronous HTTP requests]] for more information.
 
-=== execute = function('''domoticz, item, triggerInfo''') ... end ===
+=== execute = function('''domoticz, item, triggerInfo''') … end ===
 
 When all the above conditions are met (active == true and the on section has at least one matching rule), then this <code>execute</code> function is called. This is the heart of your script. The function has three parameters:
 
-==== 1. ('''domoticz''', item, triggerInfo) ====
-
-The [[#Domoticz_object_API_.28Application_Programming_Interface.29|domoticz object]]. This object gives you access to almost everything in your Domoticz system, including all methods to manipulate them—like modifying switches or sending notifications. More about the [[#Domoticz_object_API_.28Application_Programming_Interface.29|domoticz object]] below.
+####1. ('''domoticz''', item, triggerInfo) The [[#Domoticz_object_API_.28Application_Programming_Interface.29|domoticz object]]. This object gives you access to almost everything in your Domoticz system, including all methods to manipulate them—like modifying switches or sending notifications. More about the [[#Domoticz_object_API_.28Application_Programming_Interface.29|domoticz object]] below.
 
 ==== 2. (domoticz, '''item''', triggerInfo) ====
 
@@ -255,11 +253,11 @@ The names of the execute parameters are actually something you can change to you
       dz.log(mySwitch.state, dz.LOG_INFO)
    end
 }</pre>
-=== data = { ... } (optional) ===
+=== data = { … } (optional) ===
 
 The optional data section allows you to define local variables that will hold their values ''between'' script runs. These variables can get a value in your execute function and the next time the script is executed these variables will have their previous state restored. For more information see the section [[#Persistent_data|Persistent data]].
 
-=== logging = { ... } (optional) ===
+=== logging = { … } (optional) ===
 
 The optional logging section allows you to override the global logging setting of dzVents as set in ''Setup &gt; Settings &gt; Other &gt; EventSystem &gt; dzVents Log Level''. This can be handy when you only want this script to have extensive debug logging while the rest of your script executes silently. You have these options:
 
@@ -276,7 +274,7 @@ Example:
 
 === Device changes ===
 
-Suppose you have two devices—a smoke detector 'myDetector' and a room temperature sensor 'roomTemp', and you want to send a notification when either the detector detects smoke or the temperature is too high:
+Suppose you have two devices—a smoke detector ‘myDetector’ and a room temperature sensor ‘roomTemp’, and you want to send a notification when either the detector detects smoke or the temperature is too high:
 
 <pre>return {
    on = {
@@ -294,7 +292,7 @@ Suppose you have two devices—a smoke detector 'myDetector' and a room temperat
 }</pre>
 === Scene / group changes ===
 
-Suppose you have a scene 'myScene' and a group 'myGroup', and you want to turn on the group as soon as myScene is activated:
+Suppose you have a scene ‘myScene’ and a group ‘myGroup’, and you want to turn on the group as soon as myScene is activated:
 
 <pre>return {
    on = {
@@ -338,7 +336,7 @@ Suppose you want to check the soil humidity every 30 minutes during the day and 
 }</pre>
 === Variable changes ===
 
-Suppose you have a script that updates a variable 'myAmountOfMoney', and if that variable reaches a certain level you want to be notified:
+Suppose you have a script that updates a variable ‘myAmountOfMoney’, and if that variable reaches a certain level you want to be notified:
 
 <pre>return {
    on = {
@@ -391,7 +389,7 @@ See [[Asynchronous_HTTP_requests|Asynchronous HTTP requests]] for more informati
 
 === Combined rules ===
 
-Let's say you have a script that checks the status of a lamp and is triggered by motion detector:
+Let’s say you have a script that checks the status of a lamp and is triggered by motion detector:
 
 <pre>return {
    on = {
@@ -481,7 +479,7 @@ There are several options for time triggers. It is important to know that Domoti
    }</pre>
 The timer events are triggered every minute. If such a trigger occurs, dzVents will scan all timer-based events and will evaluate the timer rules. So, if you have a rule <code>on mon</code> then the script will be executed ''every minute'' but only on Monday.
 
-Be mindful of the logic if using multiple types of timer triggers. It may not make sense to combine a trigger for a specific or instantaneous time with a trigger for a span or sequence of times (like 'at sunset' with 'every 6 minutes') in the same construct. Similarly, <code>'between aa and bb'</code> only makes sense with instantaneous times for <code>aa</code> and <code>bb</code>.
+Be mindful of the logic if using multiple types of timer triggers. It may not make sense to combine a trigger for a specific or instantaneous time with a trigger for a span or sequence of times (like ‘at sunset’ with ‘every 6 minutes’) in the same construct. Similarly, <code>'between aa and bb'</code> only makes sense with instantaneous times for <code>aa</code> and <code>bb</code>.
 
 '''One important note: if Domoticz, for whatever reason, skips a timer event then you may miss the trigger! Therefore, you should build in some fail-safe checks or some redundancy if you have critical time-based stuff to control. There is nothing dzVents can do about it'''
 
@@ -493,7 +491,7 @@ The domoticz object passed as the first parameter to the <code>execute</code> fu
 
 <code>domoticz.time.isDayTime</code> or <code>domoticz.devices('My sensor').temperature</code> or <code>domoticz.devices('My sensor').lastUpdate.minutesAgo</code>.
 
-The domoticz object consists of a logically arranges structure. It harbors all methods to manipulate Domoticz. dzVents will take care to notify Domoticz with all your intended changes and actions. Earlier you had to fill a commandArray with obscure commands. That's no longer the case.
+The domoticz object consists of a logically arranges structure. It harbors all methods to manipulate Domoticz. dzVents will take care to notify Domoticz with all your intended changes and actions. Earlier you had to fill a commandArray with obscure commands. That’s no longer the case.
 
 Some more examples: <code>domoticz.devices(123).switchOn().forMin(5).afterSec(10)</code> or <code>domoticz.devices('My dummy sensor').updateBarometer(1034, domoticz.BARO_THUNDERSTORM)</code>.
 
@@ -505,100 +503,103 @@ The domoticz object holds all information about your Domoticz system. It has glo
 
 === Domoticz attributes and methods ===
 
-<ul>
-<li>'''devices(idx/name)''': ''Function''. A function returning a device by idx or name: <code>domoticz.devices(123)</code> or <code>domoticz.devices('My switch')</code>. For the device API see [[#Device_object_API|Device object API]]. To iterate over all devices do: <code>domoticz.devices().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.devices()) do .. end</code>.</li>
-<li>'''dump()''': ''Function''. <sup>2.4.16</sup> Dump all domoticz.settings attributes to the Domoticz log. This ignores the log level setting.</li>
-<li>'''email(subject, message, mailTo)''': ''Function''. Send email.</li>
-<li>'''groups(idx/name)''': ''Function'': A function returning a group by name or idx. Each group has the same interface as a device. To iterate over all groups do: <code>domoticz.groups().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.groups()) do .. end</code>. Read more about [[#Group|Groups]].</li>
-<li>'''helpers''': ''Table''. Collection of shared helper functions available to all your dzVents scripts. See [[#Shared_helper_functions|Shared helper functions]].</li>
-<li>'''log(message, [level])''': ''Function''. Creates a logging entry in the Domoticz log but respects the log level settings. You can provide the loglevel: <code>domoticz.LOG_INFO</code>, <code>domoticz.LOG_DEBUG</code>, <code>domoticz.LOG_ERROR</code> or <code>domoticz.LOG_FORCE</code>. In Domoticz settings you can set the log level for dzVents.</li>
-<li>'''notify(subject, message, priority, sound, extra, subsystem)''': ''Function''. Send a notification (like Prowl). Priority can be like <code>domoticz.PRIORITY_LOW, PRIORITY_MODERATE, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_EMERGENCY</code>. For sound see the SOUND constants below. <code>subsystem</code> can be a table containing one or more notification subsystems. See <code>domoticz.NSS_xxx</code> types.</li>
-<li>'''openURL(url/options)''': ''Function''. Have Domoticz 'call' a URL. If you just pass a url then Domoticz will execute the url after your script has finished but you will not get notified. If you pass a table with options then you have to possibility to receive the results of the request in a dzVents script. Read more about [[#Asynchronous_HTTP_requests|asynchronous http requests]]<sup>2.4.0</sup> with dzVents. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].</li>
-<li>'''scenes(idx/name)''': ''Function'': A function returning a scene by name or id. Each scene has the same interface as a device. See [[#Device_object_API|Device object API]]. To iterate over all scenes do: <code>domoticz.scenes().forEach(..)</code>. See [[#looping-through-the-collections-iterators|Looping through the collections: iterators]]. (#Looping_through_the_collections:_iterators). Note that you cannot do <code>for i, j in pairs(domoticz.scenes()) do .. end</code>. Read more about [[#Scene|Scenes]].</li>
-<li>'''security''': Holds the state of the security system e.g. <code>Armed Home</code> or <code>Armed Away</code>.</li>
-<li>'''sendCommand(command, value)''': Generic (low-level)command method (adds it to the commandArray) to the list of commands that are being sent back to domoticz. ''There is likely no need to use this directly. Use any of the device methods instead (see below).''</li>
-<li>'''settings''':
-<ul>
-<li>'''domoticzVersion''':<sup>2.4.15</sup> domoticz version string.</li>
-<li>'''dzVentsVersion''':<sup>2.4.15</sup> dzVents version string.</li>
-<li>'''location'''
-<ul>
-<li>'''latitude''':<sup>2.4.14</sup> domoticz settings locations latitude.</li>
-<li>'''longitude''':<sup>2.4.14</sup> domoticz settings locations longitude.</li>
-<li>'''name''':<sup>2.4.14</sup> domoticz settings location Name.</li></ul>
-</li>
-<li>'''serverPort''': webserver listening port.</li>
-<li>'''url''': internal url to access the API service.</li>
-<li>'''webRoot''': <code>webroot</code> value as specified when starting the Domoticz service.</li></ul>
-</li>
-<li>'''sms(message)''': ''Function''. Sends an sms if it is configured in Domoticz.</li>
-<li>'''snapshot(cameraID or camera Name<sup>2.4.15</sup>,subject)''':<sup>2.4.11</sup> ''Function''. Sends email with a camera snapshot if email is configured and set for attachments in Domoticz.</li>
-<li>'''startTime''': ''[[#Time_object|Time Object]]''. Returns the startup time of the Domoticz service.</li>
-<li>'''systemUptime''': ''Number''. Number of seconds the system is up.</li>
-<li>'''time''': ''[[#Time_object|Time Object]]'': Current system time. Additional to Time object attributes:
-<ul>
-<li>'''isDayTime''': ''Boolean''</li>
-<li>'''isNightTime''': ''Boolean''</li>
-<li>'''isCivilDayTime''': ''Boolean''. <sup>2.4.7</sup></li>
-<li>'''isCivilNightTime''': ''Boolean''. <sup>2.4.7</sup></li>
-<li>'''isToday''': ''Boolean''. Indicates if the device was updated today</li>
-<li>'''sunriseInMinutes''': ''Number''. Number of minutes since midnight when the sun will rise.</li>
-<li>'''sunsetInMinutes''': ''Number''. Number of minutes since midnight when the sun will set.</li>
-<li>'''civTwilightStartInMinutes''': ''Number''. <sup>2.4.7</sup> Number of minutes since midnight when the civil twilight will start.</li>
-<li>'''civTwilightEndInMinutes''': ''Number''. <sup>2.4.7</sup> Number of minutes since midnight when the civil twilight will end.</li></ul>
-</li>
-<li>'''triggerIFTTT(makerName [,sValue1, sValue2, sValue3])''': ''Function''. <sup>2.4.18</sup> Have Domoticz 'call' an IFTTT maker event. makerName is required, 0-3 sValue's are optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].</li>
-<li><p>'''utils''': <sup>2.4.0</sup>. A subset of handy utilities: Note that these functions must be preceded by domoticz.utils. If you use more then a few declare something like local _u = domoticz.utils at the beginning of your script and use _u.functionName in the remainder. Example:</p>
-<source lang="lua">    _u = domoticz.utils
-    print(_u.rightPad('test',10) .. '|||') -- =>  test      |||</source>
-<ul>
-<li><p>_''':lodash:''' This is an entire collection with very handy Lua functions. Read more about [[#lodash_for_Lua|lodash]]. E.g.:</p>
-<source lang="lua">domoticz.utils._.size({'abc', 'def'}))` Returns 2.</source></li>
-<li>'''cameraExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid cameraID or ID when entered with valid cameraName or false when not a cameraID or cameraName of an existing camera</li>
-<li><p>'''deviceExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid deviceID or ID when entered with valid deviceName or false when not a deviceID or deviceName of an existing device.<br />
-example:</p>
-<source lang="lua">local dz = domoticz
-local _u = dz.utils
-if _u.deviceExists('myDevice') then 
-   dz.devices('myDevice').switchOn()
-else
-   dz.log('Device myDevice does not exist!', dz.LOG_ERROR)
-end
+* '''devices(idx/name)''': ''Function''. A function returning a device by idx or name: <code>domoticz.devices(123)</code> or <code>domoticz.devices('My switch')</code>. For the device API see [[#Device_object_API|Device object API]]. To iterate over all devices do: <code>domoticz.devices().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.devices()) do .. end</code>.
+* '''dump()''': ''Function''. <sup>2.4.16</sup> Dump all domoticz.settings attributes to the Domoticz log. This ignores the log level setting.
+* '''email(subject, message, mailTo)''': ''Function''. Send email.
+* '''groups(idx/name)''': ''Function'': A function returning a group by name or idx. Each group has the same interface as a device. To iterate over all groups do: <code>domoticz.groups().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.groups()) do .. end</code>. Read more about [[#Group|Groups]].
+* '''helpers''': ''Table''. Collection of shared helper functions available to all your dzVents scripts. See [[#Shared_helper_functions|Shared helper functions]].
+* '''log(message, [level])''': ''Function''. Creates a logging entry in the Domoticz log but respects the log level settings. You can provide the loglevel: <code>domoticz.LOG_INFO</code>, <code>domoticz.LOG_DEBUG</code>, <code>domoticz.LOG_ERROR</code> or <code>domoticz.LOG_FORCE</code>. In Domoticz settings you can set the log level for dzVents.
+* '''notify(subject, message, priority, sound, extra, subsystem)''': ''Function''. Send a notification (like Prowl). Priority can be like <code>domoticz.PRIORITY_LOW, PRIORITY_MODERATE, PRIORITY_NORMAL, PRIORITY_HIGH, PRIORITY_EMERGENCY</code>. For sound see the SOUND constants below. <code>subsystem</code> can be a table containing one or more notification subsystems. See <code>domoticz.NSS_xxx</code> types.
+* '''openURL(url/options)''': ''Function''. Have Domoticz ‘call’ a URL. If you just pass a url then Domoticz will execute the url after your script has finished but you will not get notified. If you pass a table with options then you have to possibility to receive the results of the request in a dzVents script. Read more about [[#Asynchronous_HTTP_requests|asynchronous http requests]]<sup>2.4.0</sup> with dzVents. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''scenes(idx/name)''': ''Function'': A function returning a scene by name or id. Each scene has the same interface as a device. See [[#Device_object_API|Device object API]]. To iterate over all scenes do: <code>domoticz.scenes().forEach(..)</code>. See [[#looping-through-the-collections-iterators|Looping through the collections: iterators]]. (#Looping_through_the_collections:_iterators). Note that you cannot do <code>for i, j in pairs(domoticz.scenes()) do .. end</code>. Read more about [[#Scene|Scenes]].
+* '''security''': Holds the state of the security system e.g. <code>Armed Home</code> or <code>Armed Away</code>.
+* '''sendCommand(command, value)''': Generic (low-level)command method (adds it to the commandArray) to the list of commands that are being sent back to domoticz. ''There is likely no need to use this directly. Use any of the device methods instead (see below).''
+* '''settings''':
+** '''domoticzVersion''':<sup>2.4.15</sup> domoticz version string.
+** '''dzVentsVersion''':<sup>2.4.15</sup> dzVents version string.
+** '''location'''
+*** '''latitude''':<sup>2.4.14</sup> domoticz settings locations latitude.
+*** '''longitude''':<sup>2.4.14</sup> domoticz settings locations longitude.
+*** '''name''':<sup>2.4.14</sup> domoticz settings location Name.
+** '''serverPort''': webserver listening port.
+** '''url''': internal url to access the API service.
+** '''webRoot''': <code>webroot</code> value as specified when starting the Domoticz service.
+* '''sms(message)''': ''Function''. Sends an sms if it is configured in Domoticz.
+* '''snapshot(cameraID or camera Name<sup>2.4.15</sup>,subject)''':<sup>2.4.11</sup> ''Function''. Sends email with a camera snapshot if email is configured and set for attachments in Domoticz.
+* '''startTime''': ''[[#Time_object|Time Object]]''. Returns the startup time of the Domoticz service.
+* '''systemUptime''': ''Number''. Number of seconds the system is up.
+* '''time''': ''[[#Time_object|Time Object]]'': Current system time. Additional to Time object attributes:
+** '''isDayTime''': ''Boolean''
+** '''isNightTime''': ''Boolean''
+** '''isCivilDayTime''': ''Boolean''. <sup>2.4.7</sup>
+** '''isCivilNightTime''': ''Boolean''. <sup>2.4.7</sup>
+** '''isToday''': ''Boolean''. Indicates if the device was updated today
+** '''sunriseInMinutes''': ''Number''. Number of minutes since midnight when the sun will rise.
+** '''sunsetInMinutes''': ''Number''. Number of minutes since midnight when the sun will set.
+** '''civTwilightStartInMinutes''': ''Number''. <sup>2.4.7</sup> Number of minutes since midnight when the civil twilight will start.
+** '''civTwilightEndInMinutes''': ''Number''. <sup>2.4.7</sup> Number of minutes since midnight when the civil twilight will end.
+* '''triggerIFTTT(makerName [,sValue1, sValue2, sValue3])''': ''Function''. <sup>2.4.18</sup> Have Domoticz ‘call’ an IFTTT maker event. makerName is required, 0-3 sValue’s are optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''utils''': <sup>2.4.0</sup>. A subset of handy utilities: Note that these functions must be preceded by domoticz.utils. If you use more then a few declare something like local _u = domoticz.utils at the beginning of your script and use _u.functionName in the remainder. Example:
 
-local myName = _u.deviceExists(123)
-if myName then
-   dz.log('Device 123 is ' .. myName, dz.LOG_INFO)
-else
-   dz.log('Device 123 does not exist', dz.LOG_ERROR)
-end</source></li>
-<li>'''dumpTable(table,[levelIndicator])''': ''Function'': <sup>2.4.19</sup> print table structure and contents to log</li>
-<li>'''fileExists(path)''': ''Function'': <sup>2.4.0</sup> Returns <code>true</code> if the file (with full path) exists.</li>
-<li>'''fromJSON(json, fallback <sup>2.4.16</sup>)''': ''Function''. Turns a json string to a Lua table. Example: <code>local t = domoticz.utils.fromJSON('{ &quot;a&quot;: 1 }')</code>. Followed by: <code>print( t.a )</code> will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.</li>
-<li>'''fromXML(xml, fallback )''': ''Function'': <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: <code>local t = domoticz.utils.fromXML('&lt;testtag&gt;What a nice feature!&lt;/testtag&gt;') Followed by:</code>print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.<br />
-</li>
-<li>'''groupExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid groupID or ID when entered with valid groupName or false when not a groupID or groupName of an existing group</li>
-<li>'''inTable(table, searchString)''': ''Function'': <sup>2.4.21</sup> Returns <code>&quot;key&quot;</code> if table has searchString as a key, <code>&quot;value&quot;</code> if table has searchString as value and <code>false</code> otherwise.</li>
-<li>'''leftPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Precede string with given character(s) (default = space) to given length.</li>
-<li>'''centerPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Center string by preceding and succeeding with given character(s) (default = space) to given length.</li>
-<li><p>'''numDecimals(number [, integer [, decimals ]])''': ''Function'': <sup>2.4.27</sup> Format number to float representation<br />
-Examples:</p>
-<source lang="lua">    domoticz.utils.numDecimals(12.23, 4, 4) -- => 12.2300,
-    domoticz.utils.numDecimals (12.23,1,1) -- => 12.2,
-    domoticz.utils.leadingZeros(domoticz.utils.numDecimals (12.23,4,4),9) -- => 0012.2300</source></li>
-<li>'''osExecute(cmd)''': ''Function'': Execute an os command.</li>
-<li>'''rightPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Succeed string with given character(s) (default = space) to given length.</li>
-<li>'''round(number, [decimalPlaces])''': ''Function''. Helper function to round numbers. Default decimalPlaces is 0.</li>
-<li>'''sceneExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid sceneID or ID when entered with valid sceneName or false when not a sceneID or sceneName of an existing scene</li>
-<li>'''stringSplit(string, [separator ])''':<sup>2.4.19</sup> ''Function''. Helper function to split a line in separate words. Default separator is space. Return is a table with separate words.</li>
-<li>'''toCelsius(f, relative)''': ''Function''. Converts temperature from Fahrenheit to Celsius along the temperature scale or when relative==true it uses the fact that 1F==0.56C. So <code>toCelsius(5, true)</code> returns 5F*(1/1.8) = 2.78C.</li>
-<li>'''toJSON(luaTable)''': ''Function''. <sup>2.4.0</sup> Converts a Lua table to a json string.</li>
-<li>'''toXML(luaTable, [header])''': ''Function''. <sup>2.5.1</sup> Converts a Lua table to a xml string.</li>
-<li>'''urlDecode(s)''': <sup>2.4.13</sup> ''Function''. Simple deCoder to convert a string with escaped chars (%20, %3A and the likes) to human readable format</li>
-<li>'''urlEncode(s, [strSub])''': ''Function''. Simple url encoder for string so you can use them in <code>openURL()</code>. <code>strSub</code> is optional and defaults to + but you can also pass %20 if you like/need.</li>
-<li>'''variableExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid variableID or ID when entered with valid variableName or false when not a variableID or variableName of an existing variable</li>
-<li><p>'''leadingZeros(number, length)''': ''Function'': <sup>2.4.27</sup> Precede number with given zeros to given length.</p></li></ul>
-</li>
-<li><p>'''variables(idx/name)''': ''Function''. A function returning a variable by it's name or idx. See [Variable object API] (#Variable_object_API_.28user_variables.29) for the attributes. To iterate over all variables do: <code>domoticz.variables().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. '''Note that you cannot do <code>for i, j in pairs(domoticz.variables()) do .. end</code>'''.</p></li></ul>
+<source lang="lua">        _u = domoticz.utils
+        print(_u.rightPad('test',10) .. '|||') -- =>  test      |||</source>
+<pre>-   \_**:lodash:** This is an entire collection with very handy
+    Lua functions. Read more about
+    [lodash](#lodash_for_Lua &quot;wikilink&quot;). E.g.:
+    ``` {.lua}
+    domoticz.utils._.size({'abc', 'def'}))` Returns 2.
+    ```
+
+- **cameraExists(parm)**: *Function*: &lt;sup&gt;2.4.28&lt;/sup&gt; returns name when entered with valid cameraID or ID when entered with valid cameraName or false when not a cameraID or cameraName of an existing camera
+-   **deviceExists(parm)**: *Function*: ^2.4.28^ returns name when
+    entered with valid deviceID or ID when entered with valid
+    deviceName or false when not a deviceID or deviceName of an
+    existing device.  
+    example:
+
+    ``` {.lua}
+    local dz = domoticz
+    local _u = dz.utils
+    if _u.deviceExists('myDevice') then 
+       dz.devices('myDevice').switchOn()
+    else
+       dz.log('Device myDevice does not exist!', dz.LOG_ERROR)
+    end
+
+    local myName = _u.deviceExists(123)
+    if myName then
+       dz.log('Device 123 is ' .. myName, dz.LOG_INFO)
+    else
+       dz.log('Device 123 does not exist', dz.LOG_ERROR)
+    end
+    ```
+
+- **dumpTable(table,[levelIndicator])**: *Function*: &lt;sup&gt;2.4.19&lt;/sup&gt; print table structure and contents to log
+- **fileExists(path)**: *Function*: &lt;sup&gt;2.4.0&lt;/sup&gt; Returns `true` if the file (with full path) exists.
+- **fromJSON(json, fallback &lt;sup&gt;2.4.16&lt;/sup&gt;)**: *Function*. Turns a json string to a Lua table. Example: `local t = domoticz.utils.fromJSON('{ &quot;a&quot;: 1 }')`. Followed by: `print( t.a )` will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.
+- **fromXML(xml, fallback )**: *Function*: &lt;sup&gt;2.5.1&lt;/sup&gt;. Turns a xml string to a Lua table. Example: `local t = domoticz.utils.fromXML('&lt;testtag&gt;What a nice feature!&lt;/testtag&gt;') Followed by: `print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.   
+- **groupExists(parm)**: *Function*: &lt;sup&gt;2.4.28&lt;/sup&gt; returns name when entered with valid groupID or ID when entered with valid groupName or false when not a groupID or groupName of an existing group
+- **inTable(table, searchString)**: *Function*: &lt;sup&gt;2.4.21&lt;/sup&gt; Returns `&quot;key&quot;` if table has searchString as a key, `&quot;value&quot;` if table has searchString as value and `false` otherwise.
+- **leftPad(string, length [, character])**: *Function*: &lt;sup&gt;2.4.27&lt;/sup&gt; Precede string with given character(s) (default = space) to given length.
+- **centerPad(string, length [, character])**: *Function*: &lt;sup&gt;2.4.27&lt;/sup&gt; Center string by preceding and succeeding with given character(s) (default = space) to given length.
+- **numDecimals(number [, integer [, decimals ]])**: *Function*: &lt;sup&gt;2.4.27&lt;/sup&gt; Format number to float representation  
+  Examples:</pre>
+<source lang="lua">            domoticz.utils.numDecimals(12.23, 4, 4) -- => 12.2300,
+            domoticz.utils.numDecimals (12.23,1,1) -- => 12.2,
+            domoticz.utils.leadingZeros(domoticz.utils.numDecimals (12.23,4,4),9) -- => 0012.2300</source>
+<pre>- **osExecute(cmd)**: *Function*:  Execute an os command.
+- **rightPad(string, length [, character])**: *Function*: &lt;sup&gt;2.4.27&lt;/sup&gt; Succeed string with given character(s) (default = space) to given length.
+- **round(number, [decimalPlaces])**: *Function*. Helper function to round numbers. Default decimalPlaces is 0.
+- **sceneExists(parm)**: *Function*: &lt;sup&gt;2.4.28&lt;/sup&gt; returns name when entered with valid sceneID or ID when entered with valid sceneName or false when not a sceneID or sceneName of an existing scene
+- **stringSplit(string, [separator ])**:&lt;sup&gt;2.4.19&lt;/sup&gt; *Function*. Helper function to split a line in separate words. Default separator is space. Return is a table with separate words.
+- **toCelsius(f, relative)**: *Function*. Converts temperature from Fahrenheit to Celsius along the temperature scale or when relative==true it uses the fact that 1F==0.56C. So `toCelsius(5, true)` returns 5F*(1/1.8) = 2.78C.
+- **toJSON(luaTable)**: *Function*. &lt;sup&gt;2.4.0&lt;/sup&gt; Converts a Lua table to a json string.
+- **toXML(luaTable, [header])**: *Function*. &lt;sup&gt;2.5.1&lt;/sup&gt; Converts a Lua table to a xml string.
+- **urlDecode(s)**: &lt;sup&gt;2.4.13&lt;/sup&gt; *Function*. Simple deCoder to convert a string with escaped chars (%20, %3A and the likes) to human readable format
+- **urlEncode(s, [strSub])**: *Function*. Simple url encoder for string so you can use them in `openURL()`. `strSub` is optional and defaults to + but you can also pass %20 if you like/need.
+- **variableExists(parm)**: *Function*: &lt;sup&gt;2.4.28&lt;/sup&gt; returns name when entered with valid variableID or ID when entered with valid variableName or false when not a variableID or variableName of an existing variable
+- **leadingZeros(number, length)**: *Function*: &lt;sup&gt;2.4.27&lt;/sup&gt; Precede number with given zeros to given length.</pre>
+* '''variables(idx/name)''': ''Function''. A function returning a variable by it’s name or idx. See [Variable object API] (#Variable_object_API_.28user_variables.29) for the attributes. To iterate over all variables do: <code>domoticz.variables().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. '''Note that you cannot do <code>for i, j in pairs(domoticz.variables()) do .. end</code>'''.
 
 === Looping through the collections: iterators ===
 
@@ -609,7 +610,7 @@ The domoticz object has these collections (tables): devices, scenes, groups, var
 # '''filter(function / table)''': returns items in the collection for which the function returns true. You can also provide a table with names and/or ids.
 # '''reduce(function, initial)''': Loop over all items in the collection and do some calculation with it. You call it with the function and the initial value. Each iteration the function is called with the accumulator and the item in the collection. The function does something with the accumulator and returns a new value for it.
 
-==== Examples: ====
+####Examples:
 
 find():
 
@@ -681,20 +682,20 @@ The domoticz object has these constants available for use in your code e.g. <cod
 
 == Device object API ==
 
-If you have a dzVents script that is triggered by switching a device in Domoticz then the second parameter passed to the execute function will be a ''device'' object. Also, each device in Domoticz can be found in the <code>domoticz.devices()</code> collection (see above). The device object has a set of fixed attributes like ''name'' and ''idx''. Many devices, however, have different attributes and methods depending on their (hardware)type, subtype and other device specific identifiers. It is possible that you will get an error if you call a method on a device that doesn't support it, so please check the device properties for your specific hardware to see which are supported (can also be done in your script code!).
+If you have a dzVents script that is triggered by switching a device in Domoticz then the second parameter passed to the execute function will be a ''device'' object. Also, each device in Domoticz can be found in the <code>domoticz.devices()</code> collection (see above). The device object has a set of fixed attributes like ''name'' and ''idx''. Many devices, however, have different attributes and methods depending on their (hardware)type, subtype and other device specific identifiers. It is possible that you will get an error if you call a method on a device that doesn’t support it, so please check the device properties for your specific hardware to see which are supported (can also be done in your script code!).
 
-dzVents recognizes most of the different device types in Domoticz and creates the proper attributes and methods. It is possible that your device type has attributes that are not recognized; if that's the case, please create a ticket in the Domoticz [https://github.com/domoticz/domoticz/issues issue tracker on GitHub], and an adapter for that device will be added.
+dzVents recognizes most of the different device types in Domoticz and creates the proper attributes and methods. It is possible that your device type has attributes that are not recognized; if that’s the case, please create a ticket in the Domoticz [https://github.com/domoticz/domoticz/issues issue tracker on GitHub], and an adapter for that device will be added.
 
 If for some reason you miss a specific attribute or data for a device, then likely the <code>rawData</code> attribute will have that information.
 
 === Device attributes and methods for all devices ===
 
-* '''active''': ''Boolean''. Is true for some common states like 'On' or 'Open' or 'Motion'. Same as bState.
+* '''active''': ''Boolean''. Is true for some common states like ‘On’ or ‘Open’ or ‘Motion’. Same as bState.
 * '''batteryLevel''': ''Number'' If applicable for that device then it will be from 0-100.
-* '''bState''': ''Boolean''. Is true for some common states like 'On' or 'Open' or 'Motion'. Better to use active.
+* '''bState''': ''Boolean''. Is true for some common states like ‘On’ or ‘Open’ or ‘Motion’. Better to use active.
 * '''changed''': ''Boolean''. True if the device was changed
 * '''description''': ''String''. Description of the device.
-* '''deviceId''': ''String''. Another identifier of devices in Domoticz. dzVents uses the id(x) attribute. See device list in Domoticz' settings table.
+* '''deviceId''': ''String''. Another identifier of devices in Domoticz. dzVents uses the id(x) attribute. See device list in Domoticz’ settings table.
 * '''deviceSubType''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''deviceType''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''dump()''': ''Function''. Dump all attributes to the Domoticz log. This ignores the log level setting.
@@ -703,7 +704,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''hardwareType''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''hardwareTypeValue''': ''Number''. See Domoticz devices table in Domoticz GUI.
 * '''icon''': ''String''. Name of the icon in Domoticz GUI.
-* '''id''': ''Number''. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It's not truly an index but is unique enough for dzVents to be treated as an id.
+* '''id''': ''Number''. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It’s not truly an index but is unique enough for dzVents to be treated as an id.
 * '''idx''': ''Number''. Same as id: index of the device
 * '''lastUpdate''': ''[[#Time_object|Time Object]]'': Time when the device was updated.
 * '''name''': ''String''. Name of the device.
@@ -713,17 +714,17 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''protectionOn()''': ''Function''. <sup>2.4.27</sup> switch protection to on. Supports some [command options] !! **Note: domoticz protects against GUI and API access only. switchOn / switchOff type Blockly / Lua / dzVents commands are not influenced (because they are executed as admin user)
 * '''rawData''': ''Table'': All values are ''String'' types and hold the raw data received from Domoticz.
 * '''rename(newName)''': ''Function''. <sup>2.4.24</sup> Change current devicename to new devicename Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setDescription(description)''': ''Function''. <sup>2.4.16</sup> Generic method to update the description for all devices, groups and scenes. E.g.: device.setDescription(device.description .. '/nChanged by '.. item.trigger .. 'at ' .. domoticz.time.raw). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''setDescription(description)''': ''Function''. <sup>2.4.16</sup> Generic method to update the description for all devices, groups and scenes. E.g.: device.setDescription(device.description .. ‘/nChanged by’.. item.trigger .. ‘at’ .. domoticz.time.raw). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''setIcon(iconNumber)''': ''Function''. <sup>2.4.17</sup> method to update the icon for devices. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setState(newState)''': ''Function''. Generic update method for switch-like devices. E.g.: device.setState('On'). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setValues(nValue,[ sValue1, sValue2, ...])''': ''Function''. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValue. Uses domoticz JSON API to force subsequent events like pushing to influxdb. nValue required but when set to nil it will use current nValue. sValue parms are optional and can be many.
-* '''state''': ''String''. For switches, holds the state like 'On' or 'Off'. For dimmers that are on, it is also 'On' but there is a level attribute holding the dimming level. '''For selector switches''' (Dummy switch) the state holds the ''name'' of the currently selected level. The corresponding numeric level of this state can be found in the '''rawData''' attribute: <code>device.rawData[1]</code>.
+* '''setState(newState)''': ''Function''. Generic update method for switch-like devices. E.g.: device.setState(‘On’). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''setValues(nValue,[ sValue1, sValue2, …])''': ''Function''. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValue. Uses domoticz JSON API to force subsequent events like pushing to influxdb. nValue required but when set to nil it will use current nValue. sValue parms are optional and can be many.
+* '''state''': ''String''. For switches, holds the state like ‘On’ or ‘Off’. For dimmers that are on, it is also ‘On’ but there is a level attribute holding the dimming level. '''For selector switches''' (Dummy switch) the state holds the ''name'' of the currently selected level. The corresponding numeric level of this state can be found in the '''rawData''' attribute: <code>device.rawData[1]</code>.
 * '''signalLevel''': ''Number'' If applicable for that device then it will be from 0-100.
-* '''switchType''': ''String''. See Domoticz devices table in Domoticz GUI(Switches tab). E.g. 'On/Off', 'Door Contact', 'Motion Sensor' or 'Blinds'
+* '''switchType''': ''String''. See Domoticz devices table in Domoticz GUI(Switches tab). E.g. ‘On/Off’, ‘Door Contact’, ‘Motion Sensor’ or ‘Blinds’
 * '''sValue''': ''String''. <sup>2.4.21</sup> Returns the sValue (string Value) of a device.
 * '''switchTypeValue''': ''Number''. See Domoticz devices table in Domoticz GUI.
-* '''timedOut''': ''Boolean''. Is true when the device couldn't be reached.
-* '''unit''': ''Number''. Device unit. See device list in Domoticz' settings for the unit.
+* '''timedOut''': ''Boolean''. Is true when the device couldn’t be reached.
+* '''unit''': ''Number''. Device unit. See device list in Domoticz’ settings for the unit.
 * '''update(&lt; params &gt;)''': ''Function''. Generic update method. Accepts any number of parameters that will be sent back to Domoticz. There is no need to pass the device.id here. It will be passed for you. Example to update a temperature: <code>device.update(0,12)</code>. This will eventually result in a commandArray entry <code>['UpdateDevice']='&lt;idx&gt;|0|12'</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 === Device attributes and methods for specific devices ===
@@ -762,7 +763,7 @@ Note that if you do not find your specific device type here you can always inspe
 ==== Counter, managed Counter <sup>2.4.12</sup>,counter incremental ====
 
 * '''counter''': ''Number''
-* '''counterToday''': ''Number''. Today's counter value.
+* '''counterToday''': ''Number''. Today’s counter value.
 * '''updateCounter(value)''': ''Function''. '''This will overwrite; and not increment !'''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''incrementCounter(value)''': <sup>2.4.23</sup>''Function''. (counter incremental) Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''valueQuantity''': ''String''. For counters.
@@ -781,7 +782,8 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Electric usage ====
 
-* '''WhActual''': ''Number''. Current Watt usage.
+* '''actualWatt''': ''Number''. Current Watt usage.
+* '''WhActual''': ''Number''. Current Watt usage. (please use actualWatt)
 * '''updateEnergy(energy)''': ''Function''. In Watt. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Evohome (zones) ====
@@ -797,7 +799,7 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Evohome (hotWater) <sup>2.4.9</sup>. ====
 
-* '''state''': ''string'' ('On' or 'Off')
+* '''state''': ''string'' (‘On’ or ‘Off’)
 * '''mode''': ''string''
 * '''untilDate''': ''string in ISO 8601 format'' or n/a.
 * '''setHotWater(state, mode, until)''': ''Function''. set HotWater Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE You can provide an until date (in ISO 8601 format for domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>).
@@ -810,7 +812,7 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Group ====
 
-* '''devices()''': ''Function''. Returns the collection of associated devices. Supports the same iterators as for <code>domoticz.devices()</code>: <code>forEach()</code>, <code>filter()</code>, <code>find()</code>, <code>reduce()</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that the function doesn't allow you to get a device by its name or id. Use <code>domoticz.devices()</code> for that.
+* '''devices()''': ''Function''. Returns the collection of associated devices. Supports the same iterators as for <code>domoticz.devices()</code>: <code>forEach()</code>, <code>filter()</code>, <code>find()</code>, <code>reduce()</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that the function doesn’t allow you to get a device by its name or id. Use <code>domoticz.devices()</code> for that.
 * '''protectionOff()''': ''Function''. <sup>2.4.27</sup> switch protection to off. Supports some [command options]
 * '''protectionOn()''': ''Function''. <sup>2.4.27</sup> switch protection to on. Supports some [command options]
 * '''rename(newName)''': ''Function''. <sup>2.4.24</sup> Change current group-name to new group-name Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
@@ -830,7 +832,7 @@ Note that if you do not find your specific device type here you can always inspe
 * '''kodiExecuteAddOn(addonId)''': ''Function''. Will send an Execute Addon command sending no parameters. Addon IDs are embedded in the addon configuration and are not to be confused with the Addon Name. For example: http://forums.homeseer.com/showthread.php?p=1213403.
 * '''kodiPause()''': ''Function''. Will send a Pause command, only effective if the device is streaming.
 * '''kodiPlay()''': ''Function''. Will send a Play command, only effective if the device was streaming and has been paused.
-* '''kodiPlayFavorites([position])''': ''Function''. Will play an item from the Kodi's Favorites list optionally starting at ''position''. Favorite positions start from 0 which is the default.
+* '''kodiPlayFavorites([position])''': ''Function''. Will play an item from the Kodi’s Favorites list optionally starting at ''position''. Favorite positions start from 0 which is the default.
 * '''kodiPlayPlaylist(name, [position])''': ''Function''. Will play a music or video Smart Playlist with ''name'' optionally starting at ''position''. Playlist positions start from 0 which is the default.
 * '''kodiSetVolume(level)''': ''Function''. Set the volume for a Kodi device, 0 &lt;= level &lt;= 100.
 * '''kodiStop()''': ''Function''. Will send a Stop command, only effective if the device is streaming.
@@ -838,12 +840,13 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== kWh, Electricity (instant and counter) ====
 
+* '''actualWatt''': ''Number''. Actual usage in Watt.
 * '''counterToday''': ''Number''.
 * '''updateElectricity(power, energy)''': ''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''usage''': ''Number''.
 * '''WhToday''': ''Number''. Total Wh usage of the day. Note the unit is Wh and not kWh!
 * '''WhTotal''': ''Number''. Total Wh usage.
-* '''WhActual''': ''Number''. Actual reading.
+* '''WhActual''': ''Number''. Actual reading in Watt. Please use actualWatt
 
 ==== Leaf wetness ====
 
@@ -908,18 +911,7 @@ See switch below.
 
 ==== RGBW(W) / Lighting Limitless/Applamp ====
 
-* '''decreaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''getColor()'''; ''Function''. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
-* '''increaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setColor(r, g, b, br, cw, ww, m, t)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required, others optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. Meaning and limits of parms can be found [https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_a_light_to_a_certain_color_or_color_temperature here].
-* '''setColorBrightness()''': same as setColor
-* '''setDiscoMode(modeNum)''': ''Function''. <sup>2.4.0</sup> Activate disco mode, <code>1 =&lt; modeNum &lt;= 9</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setHex(r, g, b)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required (decimal Values 0-255). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setHue(hue, brightness, isWhite)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested Hue. Hue and brightness required. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setKelvin(Kelvin)''': ''Function''. <sup>2.4.0</sup> Sets Kelvin level of the light (For RGBWW devices only). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setNightMode()''': ''Function''. <sup>2.4.0</sup> Sets the lamp to night mode. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setRGB(red, green, blue)''': ''Function''. <sup>2.4.0</sup> Set the lamps RGB color. Values are from 0-255. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setWhiteMode()''': ''Function''. <sup>2.4.0</sup> Sets the lamp to white mode. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+'''Note''': not all methods are available for all hardwareTypes ! - '''decreaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''getColor()'''; ''Function''. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set. - '''increaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setColor(r, g, b, br, cw, ww, m, t)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required, others optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. Meaning and limits of parms can be found [https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_a_light_to_a_certain_color_or_color_temperature here]. - '''setColorBrightness()''': same as setColor - '''setDiscoMode(modeNum)''': ''Function''. <sup>2.4.0</sup> Activate disco mode, <code>1 =&lt; modeNum &lt;= 9</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setHex(r, g, b)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required (decimal Values 0-255). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setHue(hue, brightness, isWhite)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested Hue. Hue and brightness required. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setKelvin(Kelvin)''': ''Function''. <sup>2.4.0</sup> Sets Kelvin level of the light (For RGBWW devices only). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setNightMode()''': ''Function''. <sup>2.4.0</sup> Sets the lamp to night mode. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setRGB(red, green, blue)''': ''Function''. <sup>2.4.0</sup> Set the lamps RGB color. Values are from 0-255. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. - '''setWhiteMode()''': ''Function''. <sup>2.4.0</sup> Sets the lamp to white mode. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Scale weight ====
 
@@ -928,7 +920,7 @@ See switch below.
 
 ==== Scene ====
 
-* '''devices()''': ''Function''. Returns the collection of associated devices. Supports the same iterators as for <code>domoticz.devices()</code>: <code>forEach()</code>, <code>filter()</code>, <code>find()</code>, <code>reduce()</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that the function doesn't allow you to get a device by its name or id. Use <code>domoticz.devices()</code> for that.
+* '''devices()''': ''Function''. Returns the collection of associated devices. Supports the same iterators as for <code>domoticz.devices()</code>: <code>forEach()</code>, <code>filter()</code>, <code>find()</code>, <code>reduce()</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that the function doesn’t allow you to get a device by its name or id. Use <code>domoticz.devices()</code> for that.
 * '''protectionOff()''': ''Function''. <sup>2.4.27</sup> switch protection to off. Supports some [command options]
 * '''protectionOn()''': ''Function''. <sup>2.4.27</sup> switch protection to on. Supports some [command options]
 * '''rename(newName)''': ''Function''. <sup>2.4.24</sup> Change current scene-name to new scene-name Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
@@ -941,7 +933,7 @@ Create a security device:
 
 # Set a security panel password in Domoticz settings.
 # Activate the security panel ('''Setup &gt; More Options &gt; Security Panel''' and set it to '''Disarm''' (using your password)).
-# Go to the device list in ('''Setup &gt; Devices''') where it should show the security panel device under 'Not used'.
+# Go to the device list in ('''Setup &gt; Devices''') where it should show the security panel device under ‘Not used’.
 # Add the device and give it a name.
 
 Methods/attributes:
@@ -977,8 +969,8 @@ There are many switch-like devices. Not all methods are applicable for all switc
 
 * '''close()''': ''Function''. Set device to Close if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''dimTo(percentage)''': ''Function''. Switch a dimming device on and/or dim to the specified level. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''lastLevel''': Number. The level of a dimmer just before it was switched off. '''Note: lastLevel only shows you the previous level if you have a trigger for the device itself. So for instance you have a on-trigger for 'myDimmer' and the dimmer is set from 20% to 30%, in your script <code>myDimmer.level == 30</code> and <code>myDimmer.lastLevel == 20</code>. '''
-* '''level''': ''Number''. For dimmers and other 'Set Level..%' devices this holds the level like selector switches.
+* '''lastLevel''': Number. The level of a dimmer just before it was switched off. '''Note: lastLevel only shows you the previous level if you have a trigger for the device itself. So for instance you have a on-trigger for ‘myDimmer’ and the dimmer is set from 20% to 30%, in your script <code>myDimmer.level == 30</code> and <code>myDimmer.lastLevel == 20</code>. '''
+* '''level''': ''Number''. For dimmers and other ‘Set Level..%’ devices this holds the level like selector switches.
 * '''levelActions''': ''String''. |-separated list of url actions for selector switches.
 * '''levelName''': ''String''. Current level name for selector switches.
 * '''levelNames''': ''Table''. Table holding the level names for selector switch devices.
@@ -986,11 +978,11 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''open()''': ''Function''. Set device to Open if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''quietOn()''': ''Function''. <sup>2.4.20</sup> Set deviceStatus to on without physically switching it. Subsequent Events are triggered. Supports some [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''quietOff()''': ''Function''. <sup>2.4.20</sup> set deviceStatus to off without physically switching it. Subsequent Events are triggered. Supports some [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''setLevel(percentage)''': ''Function''. <sup>2.4.29</sup> Set device to a given level if it supports it (e.g. blinds percentage). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''stop()''': ''Function''. Set device to Stop if it supports it (e.g. blinds). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''setLevel(percentage)''': ''Function''. <sup>2.4.29</sup> Set device to a given level if it supports it (e.g. blinds percentage). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''stop()''': ''Function''. Set device to Stop if it supports it (e.g. blinds). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOff()''': ''Function''. Switch device off it is supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOn()''': ''Function''. Switch device on if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* '''switchSelector(&lt;[level]|[levelname] <sup>2.4.22</sup> &gt;)''': ''Function''. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Levelname is only supported when level 0 (&quot;Off&quot;) is not removed Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''switchSelector(&lt;[level]|[levelname] <sup>2.4.22</sup> &gt;)''': ''Function''. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Levelname is only supported when level 0 (“Off”) is not removed Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''toggleSwitch()''': ''Function''. Toggles the state of the switch (if it is togglable) like On/Off, Open/Close etc.
 
 ==== Temperature sensor ====
@@ -1100,31 +1092,23 @@ device.switchOff().withinMin(10).forMin(2)
 device.close().forMin(15)
 device.open().afterSec(20)
 device.open().afterMin(2)</pre>
--- switch on but do not trigger follow up events device.switchOn().silent()
+– switch on but do not trigger follow up events device.switchOn().silent()
 
--- flash a light for 3 times device.switchOn().forSec(2).repeatAfterSec(1, 3)
+– flash a light for 3 times device.switchOn().forSec(2).repeatAfterSec(1, 3)
 
--- switch the device on but only if the current state isn't already on: device.switchOn().checkFirst() -- this is a short for: if (device.state == 'Off') then devices.switchOn() end
+– switch the device on but only if the current state isn’t already on: device.switchOn().checkFirst() – this is a short for: if (device.state == ‘Off’) then devices.switchOn() end
 
-==== Options ====
-
-* '''afterHour(hours), afterMin(minutes), afterSec(seconds)''': ''Function''. Activates the command after a certain number of hours, minutes or seconds.
-* '''cancelQueuedCommands()''': ''Function''. <sup>2.4.0</sup> Cancels queued commands. E.g. you switch on a device after 10 minutes: <code>myDevice.switchOn().afterMin(10)</code>. Within those 10 minutes you can cancel that command by calling: <code>myDevice.cancelQueuedCommands()</code>.
-* '''checkFirst()''': ''Function''. Checks if the '''current''' state of the device is different than the desired new state. If the target state is the same, no command is sent. If you do <code>mySwitch.switchOn().checkFirst()</code>, then no switch command is sent if the switch is already on. This command only works with switch-like devices. It is not available for toggle and dim commands, either.
-* '''forHour(hours), forMin(minutes), forSec(seconds)''': ''Function''. Activates the command for the duration of hours, minutes or seconds. See table below for applicability and the warning on unexpected behavior of these functions.
-* '''withinHour(hours), withinMin(minutes), withinSec(seconds)''': ''Function''. Activates the command within a certain period (specified in hours, minutes or seconds) ''randomly''. See table below for applicability.
-* '''silent()''': ''Function''. No follow-up events will be triggered: <code>mySwitch.switchOff().silent()</code>.
-* '''repeatAfterHour(hours, [number]), repeatAfterMin(minutes, [number]), repeatAfterSec(seconds, [number])''': ''Function''. Repeats the sequence ''number'' times after the specified duration (specified in hours, minutes, or seconds). If no ''number'' is provided, 1 is used. '''Note that <code>afterXXX()</code> and <code>withinXXX()</code> are only applied at the beginning of the sequence and not between the repeats!'''
+####Options - '''afterHour(hours), afterMin(minutes), afterSec(seconds)''': ''Function''. Activates the command after a certain number of hours, minutes or seconds. - '''cancelQueuedCommands()''': ''Function''. <sup>2.4.0</sup> Cancels queued commands. E.g. you switch on a device after 10 minutes: <code>myDevice.switchOn().afterMin(10)</code>. Within those 10 minutes you can cancel that command by calling: <code>myDevice.cancelQueuedCommands()</code>. - '''checkFirst()''': ''Function''. Checks if the '''current''' state of the device is different than the desired new state. If the target state is the same, no command is sent. If you do <code>mySwitch.switchOn().checkFirst()</code>, then no switch command is sent if the switch is already on. This command only works with switch-like devices. It is not available for toggle and dim commands, either. - '''forHour(hours), forMin(minutes), forSec(seconds)''': ''Function''. Activates the command for the duration of hours, minutes or seconds. See table below for applicability and the warning on unexpected behavior of these functions. - '''withinHour(hours), withinMin(minutes), withinSec(seconds)''': ''Function''. Activates the command within a certain period (specified in hours, minutes or seconds) ''randomly''. See table below for applicability. - '''silent()''': ''Function''. No follow-up events will be triggered: <code>mySwitch.switchOff().silent()</code>. - '''repeatAfterHour(hours, [number]), repeatAfterMin(minutes, [number]), repeatAfterSec(seconds, [number])''': ''Function''. Repeats the sequence ''number'' times after the specified duration (specified in hours, minutes, or seconds). If no ''number'' is provided, 1 is used. '''Note that <code>afterXXX()</code> and <code>withinXXX()</code> are only applied at the beginning of the sequence and not between the repeats!'''
 
 Note that the actual switching or changing of the device is done by Domoticz and not by dzVents. dzVents only tells Domoticz what to do; if the options are not carried out as expected, this is likely a Domoticz or hardware issue.
 
-'''Important note when using forXXX()''': Let's say you have a light that is triggered by a motion detector. Currently the light is <code>Off</code> and you do this: <code>light.switchOn().forMin(5)</code>. What happens inside Domoticz is this: at t<sub>0</sub> Domoticz issues the <code>switchOn()</code> command and schedules a command to restore the '''current''' state at t<sub>5</sub> which is <code>Off</code>. So at t<sub>5</sub> it will switch the light off.
+'''Important note when using forXXX()''': Let’s say you have a light that is triggered by a motion detector. Currently the light is <code>Off</code> and you do this: <code>light.switchOn().forMin(5)</code>. What happens inside Domoticz is this: at t<sub>0</sub> Domoticz issues the <code>switchOn()</code> command and schedules a command to restore the '''current''' state at t<sub>5</sub> which is <code>Off</code>. So at t<sub>5</sub> it will switch the light off.
 
 If, however, ''before the scheduled <code>switchOff()</code> happens at t<sub>5</sub>'', new motion is detected and you send this command again at t<sub>2</sub> then something unpredictable may seem to happen: ''the light is never turned off!'' This is what happens:
 
-At t<sub>2</sub> Domoticz receives the <code>switchOn().forMin(5)</code> command again. It sees a scheduled command at t<sub>5</sub> and deletes that command (it is within the new interval). Then Domoticz performs the (unnecessary, it's already on) <code>switchOn()</code> command. Then it checks the current state of the light which is <code>On</code>!! and schedules a command to return to that state at t<sub>2+5</sub>=t<sub>7</sub>. So, at t<sub>7</sub> the light is switched on again. And there you have it: the light is not switched off and never will be because future commands will always be checked against the current on-state.
+At t<sub>2</sub> Domoticz receives the <code>switchOn().forMin(5)</code> command again. It sees a scheduled command at t<sub>5</sub> and deletes that command (it is within the new interval). Then Domoticz performs the (unnecessary, it’s already on) <code>switchOn()</code> command. Then it checks the current state of the light which is <code>On</code>!! and schedules a command to return to that state at t<sub>2+5</sub>=t<sub>7</sub>. So, at t<sub>7</sub> the light is switched on again. And there you have it: the light is not switched off and never will be because future commands will always be checked against the current on-state.
 
-That's just how it works and you will have to deal with it in your script. So, instead of simply re-issuing <code>switchOn().forMin(5)</code> you have to check the switch's state first:
+That’s just how it works and you will have to deal with it in your script. So, instead of simply re-issuing <code>switchOn().forMin(5)</code> you have to check the switch’s state first:
 
 <pre>if (light.active) then
    light.switchOff().afterMin(5)
@@ -1135,9 +1119,7 @@ or issue these two commands ''both'' as they are mutually exclusive:
 
 <pre>light.switchOff().checkFirst().afterMin(5)
 light.switchOn().checkFirst().forMin(5)</pre>
-==== Availability ====
-
-Some options are not available to all commands. All the options are available to device switch-like commands like <code>myDevice.switchOff()</code>, <code>myGroup.switchOn()</code> or <code>myBlinds.open()</code>. For updating (usually Dummy ) devices like a text device <code>myTextDevice.updateText('zork')</code> you can only use <code>silent()</code>. For thermostat setpoint devices and snapshot command silent() is not available. See table below
+####Availability Some options are not available to all commands. All the options are available to device switch-like commands like <code>myDevice.switchOff()</code>, <code>myGroup.switchOn()</code> or <code>myBlinds.open()</code>. For updating (usually Dummy ) devices like a text device <code>myTextDevice.updateText('zork')</code> you can only use <code>silent()</code>. For thermostat setpoint devices and snapshot command silent() is not available. See table below
 
 {|
 !width="20%"| option
@@ -1209,7 +1191,7 @@ Some options are not available to all commands. All the options are available to
 
 ==== Follow-up event triggers ====
 
-Normally if you issue a command, Domoticz will immediately trigger follow-up events, and dzVents will automatically trigger defined event scripts. If you trigger a scene, all devices in that scene will issue a change event. If you have event triggers for these devices, they will be executed by dzVents. If you don't want this to happen, add <code>.silent()</code> to your commands (exception is updateSetPoint).
+Normally if you issue a command, Domoticz will immediately trigger follow-up events, and dzVents will automatically trigger defined event scripts. If you trigger a scene, all devices in that scene will issue a change event. If you have event triggers for these devices, they will be executed by dzVents. If you don’t want this to happen, add <code>.silent()</code> to your commands (exception is updateSetPoint).
 
 === Create your own device adapter ===
 
@@ -1245,7 +1227,7 @@ You can also create your own:
 
 <pre>    local Time = require('Time')
     local t = Time('2016-12-12 07:35:00') -- must be this format!!</pre>
-If you don't pass a time string:
+If you don’t pass a time string:
 
 <pre>    local Time = require('Time')
     local currentTime = Time()</pre>
@@ -1303,7 +1285,7 @@ local utcTime = Time('2017-12-31 22:19:15', true)</pre>
 * '''msAgo''': ''Number''. Number of milliseconds since the last update.
 * '''raw''': ''String''. Generated by Domoticz
 * '''rawDate''': ''String''. Returns the date part of the raw data.
-* '''rawDateTime''': ''String''. <sup>2.4.25</sup> Combined date / time formatted as domoticz does in API / JSON returns (rawDate .. ' '.. rawTime )
+* '''rawDateTime''': ''String''. <sup>2.4.25</sup> Combined date / time formatted as domoticz does in API / JSON returns (rawDate .. ’ ’.. rawTime )
 * '''rawTime''': ''String''. Returns the time part of the raw data.
 * '''seconds''': ''Number''
 * '''secondsSinceMidnight''': ''Number''
@@ -1332,7 +1314,7 @@ local utcTime = Time('2017-12-31 22:19:15', true)</pre>
 
 == Shared helper functions ==
 
-It is not unlikely that at some point you want to share Lua code among your scripts. Normally in Lua you would have to create a module and require that module in all you scripts. But dzVents makes that easier for you: Inside your scripts folder or in Domoticz' GUI web editor, create a <code>global_data.lua</code> script (same as for global persistent data) and feed it with this code:
+It is not unlikely that at some point you want to share Lua code among your scripts. Normally in Lua you would have to create a module and require that module in all you scripts. But dzVents makes that easier for you: Inside your scripts folder or in Domoticz’ GUI web editor, create a <code>global_data.lua</code> script (same as for global persistent data) and feed it with this code:
 
 <pre>return {
    helpers = {
@@ -1373,17 +1355,17 @@ And pass it along:
       local results = domoticz.helpers.myHandyFunction(domoticz, 'bla', 'boo')
    end
 }</pre>
-'''Note''': there can be only '''one''' <code>global_data.lua</code> on your system. Either in <code>/path/to/domoticz/scripts/dzVents/script</code> or in Domoticz' internal GUI web editor.
+'''Note''': there can be only '''one''' <code>global_data.lua</code> on your system. Either in <code>/path/to/domoticz/scripts/dzVents/script</code> or in Domoticz’ internal GUI web editor.
 
 == Requiring your own modules ==
 
-If you don't want to use the helpers support, but you want to require your own modules, place them either in <code>/path/to/domoticz/scripts/dzVents/modules</code> or <code>/path/to/domoticz/scripts/dzVents/scripts/modules</code> as these folders are already added to the Lua package path. You can just require those modules: <code>local myModule = require('myModule')</code>
+If you don’t want to use the helpers support, but you want to require your own modules, place them either in <code>/path/to/domoticz/scripts/dzVents/modules</code> or <code>/path/to/domoticz/scripts/dzVents/scripts/modules</code> as these folders are already added to the Lua package path. You can just require those modules: <code>local myModule = require('myModule')</code>
 
 = Persistent data =
 
-In many situations you need to store a device state or other information in your scripts for later use. Like knowing what the state was of a device the previous time the script was executed or what the temperature in a room was 10 minutes ago. Without dzVents, you had to resort to user variables. These are global variables that you create in the Domoticz GUI and that you can access in your scripts like: domoticz.variables('previousTemperature').
+In many situations you need to store a device state or other information in your scripts for later use. Like knowing what the state was of a device the previous time the script was executed or what the temperature in a room was 10 minutes ago. Without dzVents, you had to resort to user variables. These are global variables that you create in the Domoticz GUI and that you can access in your scripts like: domoticz.variables(‘previousTemperature’).
 
-Now, for some this is rather inconvenient and they want to control this state information in the event scripts themselves or want to use all of Lua's variable types. dzVents has a solution for that: '''persistent script data'''. This can either be on the script level or on a global level.
+Now, for some this is rather inconvenient and they want to control this state information in the event scripts themselves or want to use all of Lua’s variable types. dzVents has a solution for that: '''persistent script data'''. This can either be on the script level or on a global level.
 
 == Script level persistent variables ==
 
@@ -1420,7 +1402,7 @@ You do not have to provide an initial value though. In that case the initial val
           print(tostring(domoticz.data.x)) -- prints nil
        end
     }</pre>
-You can define as many variables as you like and put whatever value in there that you like. It doesn't have to be just a number. Just don't put something in there with functions (well, they are filtered out actually).
+You can define as many variables as you like and put whatever value in there that you like. It doesn’t have to be just a number. Just don’t put something in there with functions (well, they are filtered out actually).
 
 === Size matters and watch your speed!! ===
 
@@ -1468,7 +1450,7 @@ Just define the variables that you need and access them in your scripts:
           end
         end
     }</pre>
-'''Note''': there can be only one <code>global_data.lua</code> on your system. Either in <code>/path/to/domoticz/scripts/dzVents/script</code> or in Domoticz' internal GUI web editor.
+'''Note''': there can be only one <code>global_data.lua</code> on your system. Either in <code>/path/to/domoticz/scripts/dzVents/script</code> or in Domoticz’ internal GUI web editor.
 
 You can use <code>domoticz.globalData.initialize('&lt;varname&gt;')</code> just as like <code>domoticz.data.initialize('&lt;varname&gt;')</code>.
 
@@ -1497,7 +1479,7 @@ In some situations, storing a previous value for a sensor is not enough, and you
           local average = sum / count
         end
     }</pre>
-The problem with this is that you have to do a lot of bookkeeping to make sure that there isn't too much data to store (see [[#How_does_the_storage_stuff_work.3F|below for how it works]]) . Fortunately, dzVents has done this for you:
+The problem with this is that you have to do a lot of bookkeeping to make sure that there isn’t too much data to store (see [[#How_does_the_storage_stuff_work.3F|below for how it works]]) . Fortunately, dzVents has done this for you:
 
 <pre>    return {
         active = true,
@@ -1526,14 +1508,14 @@ Define a script variable or global variable in the data section and set <code>hi
 
 * '''maxItems''': ''Number''. Controls how many items are stored in the variable. maxItems has precedence over maxHours and maxMinutes.
 * '''maxHours''': ''Number''. Data older than <code>maxHours</code> from now will be discarded. E.g., if set to 2, then data older than 2 hours will be removed at the beginning of the script.
-* '''maxMinutes''': ''Number''. Same as maxHours but, you guessed it: for minutes this time.. All these options can be combined. '''Reminder: don't store too much data. Only put in what you really need!'''
+* '''maxMinutes''': ''Number''. Same as maxHours but, you guessed it: for minutes this time.. All these options can be combined. '''Reminder: don’t store too much data. Only put in what you really need!'''
 
 === Adding data ===
 
 Add new values to a historical variable:
 
 <pre>domoticz.data.myVar.add(value)</pre>
-As soon as this new value is put on top of the list, the older values shift one place down the line. If <code>maxItems</code> is reached, then the oldest value will be discarded. ''All methods, like calculating averages or sums, will immediately use this new value!'' If you don't want this to happen, set the new value at the end of your script or after you have done your analysis.
+As soon as this new value is put on top of the list, the older values shift one place down the line. If <code>maxItems</code> is reached, then the oldest value will be discarded. ''All methods, like calculating averages or sums, will immediately use this new value!'' If you don’t want this to happen, set the new value at the end of your script or after you have done your analysis.
 
 Any kind of data may be stored in the historical variable: numbers, strings, but also more complex data like tables. However, in order to use the [[#Statistical_functions|statistical methods]], numeric values are required.
 
@@ -1545,7 +1527,7 @@ Values in a historical variable are indexed, where index 1 is the newest value, 
 print(item.data)</pre>
 However, all data in the storage are time-stamped:
 
-local item = domoticz.data.myVar.getLatest() print(item.time.secondsAgo) -- access the time stamp print(item.data) -- access the data
+local item = domoticz.data.myVar.getLatest() print(item.time.secondsAgo) – access the time stamp print(item.data) – access the data
 
 The time attribute by itself is a table with many properties that help you inspect the data points more easily. See [[#Time_object|Time Object]] for all attributes and methods.
 
@@ -1555,11 +1537,11 @@ All data in the set can be addressed using an index. The item with index = 1 is 
 
 ==== Time specification (''timeAgo'') ====
 
-Every data point in the set has a timestamp and the set is ordered so that the youngest item is the first and the oldest item the last. Many functions require a moment in the past to be specified by passing a string in the format '''<code>hh:mm:ss</code>''', where ''hh'' is the number of hours ago, ''mm'' the number of minutes and ''ss'' the number of seconds. The times are added together, so you don't have to consider 60 minute boundaries, etc. A time specification of <code>12:88:03</code> is valid, and points to the data point at or around <code>12*3600 + 88*60 + 3 = 48.483 seconds</code> in the past.
+Every data point in the set has a timestamp and the set is ordered so that the youngest item is the first and the oldest item the last. Many functions require a moment in the past to be specified by passing a string in the format '''<code>hh:mm:ss</code>''', where ''hh'' is the number of hours ago, ''mm'' the number of minutes and ''ss'' the number of seconds. The times are added together, so you don’t have to consider 60 minute boundaries, etc. A time specification of <code>12:88:03</code> is valid, and points to the data point at or around <code>12*3600 + 88*60 + 3 = 48.483 seconds</code> in the past.
 
 Example:
 
--- get average for the past 30 minutes: local avg = myVar.avgSince('00:30:00')
+– get average for the past 30 minutes: local avg = myVar.avgSince(‘00:30:00’)
 
 ==== Getting data points ====
 
@@ -1570,7 +1552,7 @@ Example:
 * '''size''': Return the number of data points in the set.
 * '''subset( [fromIdx], [toIdx] )''': Returns a subset of the stored data. Default value, if omitted, of <code>fromIdx</code> is 1. Omitting <code>toIdx</code> takes all items until the end of the set (oldest). E.g., <code>myVar.subset()</code> returns all data. The result set supports [[#Looping_through_the_data:_iterators|iterators]] <code>forEach</code>, <code>filter</code>, <code>find</code> and <code>reduce</code>.
 * '''subsetSince( [[#Time_specification_.28timeAgo.29|timeAgo]] )''': Returns a subset of the stored data since the relative time specified by timeAgo. So calling <code>myVar.subsetSince('00:60:00')</code> returns all items that have been added to the list in the past 60 minutes. The result set supports [[#Looping_through_the_data:_iterators|iterators]] <code>forEach</code>, <code>filter</code>, <code>find</code> and <code>reduce</code>.
-* '''reset( )''': Removes all the items from the set. It could be a good practice to do this often when you know you don't need older data. For instance, when you turn on a heater and you just want to monitor rising temperatures starting from this moment when the heater is activated. If you don't need data points from before, then you may call reset.
+* '''reset( )''': Removes all the items from the set. It could be a good practice to do this often when you know you don’t need older data. For instance, when you turn on a heater and you just want to monitor rising temperatures starting from this moment when the heater is activated. If you don’t need data points from before, then you may call reset.
 
 ==== Looping through the data: iterators ====
 
@@ -1581,7 +1563,10 @@ Similar to the iterators as described [[#Looping_through_the_collections:_iterat
 <li>'''filter(function)''': Create a filtered set of items. The function receives the item and returns true if the item is in the result set. E.g. get a set with item values larger than 20: <code>subset = myVar.filter( function (item) return (item.data &gt; 20) end )</code>.</li>
 <li>'''find(function)''': Search for a specific item in the set: E.g. find the first item with a value higher than 20: <code>local item = myVar.find( function (item) return (item.data &gt; 20) end )</code>.</li>
 <li><p>'''reduce(function, initial)''': Loop over all items in the set and do some calculation with it. You call reduce with the function and the initial value. Each iteration the function is called with the accumulator. The function does something with the accumulator and returns a new value for it. Once you get the hang of it, it is very powerful. Best to give an example. To sum all values:</p>
-<p>local sum = myVar.reduce(function(acc, item) local value = item.data return acc + value end, 0)</p></li></ul>
+<pre>local sum = myVar.reduce(function(acc, item)
+  local value = item.data
+  return acc + value</pre>
+<p>end, 0)</p></li></ul>
 
 Suppose you want to get data points older than 45 minutes and count the values that are higher than 20 (of course there are more ways to do this):
 
@@ -1591,7 +1576,7 @@ local olderItems = myVar.filter(function (item) return (item.time.minutesAgo &gt
 
 local count = olderItems.reduce(function(acc, item) if (item.data &gt; 20) then acc = acc + 1 end return acc end, 0)
 
-print('Found ' .. tostring(count) .. ' items')
+print(‘Found’ .. tostring(count) .. ’ items’)
 
 ==== Statistical functions ====
 
@@ -1599,10 +1584,10 @@ Statistical functions require ''numerical'' data in the set. If the set is just 
 
 <pre>myVar.add(myDevice.temperature) -- adds a number to the set
 myVar.avg() -- returns the average</pre>
-If, however, you add more complex data or you want to do a computation first, then you have to ''tell dzVents how to get a numeric value from these data''. So let's say you do this to add data to the set:
+If, however, you add more complex data or you want to do a computation first, then you have to ''tell dzVents how to get a numeric value from these data''. So let’s say you do this to add data to the set:
 
 <pre>myVar.add( { 'person' = 'John', waterUsage = u })</pre>
-Where <code>u</code> is a variable that got its value earlier. If you want to calculate the average water usage, then dzVents will not be able to do this because it doesn't know the value is actually in the <code>waterUsage</code> attribute! You will get <code>nil</code>.
+Where <code>u</code> is a variable that got its value earlier. If you want to calculate the average water usage, then dzVents will not be able to do this because it doesn’t know the value is actually in the <code>waterUsage</code> attribute! You will get <code>nil</code>.
 
 To make this work you have to provide a '''getValue function''' in the data section when you define the historical variable:
 
@@ -1622,7 +1607,7 @@ To make this work you have to provide a '''getValue function''' in the data sect
 }</pre>
 This function tells dzVents how to get the numeric value for a data item. '''Note: the <code>getValue</code> function has to return a number!'''.
 
-Of course, if you don't intend to use any of these statistical functions you can put whatever you want in the set.
+Of course, if you don’t intend to use any of these statistical functions you can put whatever you want in the set.
 
 <ul>
 <li>'''avg( [fromIdx], [toIdx], [default] )''': Calculates the average of all item values within the range <code>fromIdx</code> to <code>toIdx</code>. If no data are in the set, the value <code>default</code> will be returned instead of <code>0</code>.</li>
@@ -1638,7 +1623,7 @@ Of course, if you don't intend to use any of these statistical functions you can
 <li>'''deltaSince([[#Time_specification_.28timeAgo.29|timeAgo]], [smoothRange], [default] )''': Same as '''delta''' but within the <code>timeAgo</code> interval. The function also returns the fromItem and the toItem that is used to calculate the delta with: <code>local delta, from, to = deltaSince('00:00:10', 3)</code>.</li>
 <li>'''deltaSinceOrOldest([[#Time_specification_.28timeAgo.29|timeAgo]], [smoothRangeFrom], [smoothRangeTo], [default] )''': <sup>2.4.0</sup> Same as '''deltaSince''' but it will take the oldest value in the set if ''timeAgo'' is older than the age of the entire set. The function also returns the fromItem and the toItem that is used to calculate the delta with: <code>local delta, from, to = deltaSinceOrOldest('00:00:10', 3, 3)</code>.</li>
 <li><p>'''localMin( [smoothRange], default )''': Returns the first minimum value (and the item holding the minimal value) in the past. [[#Data_smoothing|Supports data smoothing]] when providing a <code>smoothRange</code> value. For example, given this range of values in the data set (from new to old): <code>10 8 7 5 3 4 5 6</code>, it will return <code>3</code> because older values ''and'' newer values are higher: a local minimum. Use this if you want to know at what time a temperature started to rise after it had been dropping. E.g.:</p>
-local value, item = myVar.localMin() print(' minimum was : ' .. value .. ': ' .. item.time.secondsAgo .. ' seconds ago' )</li>
+local value, item = myVar.localMin() print(’ minimum was : ’ .. value .. ‘:’ .. item.time.secondsAgo .. ’ seconds ago’ )</li>
 <li>'''localMax([smoothRange], default)''': Same as '''localMin''' but for the maximum value. [[#Data_smoothing|Supports data smoothing]] when providing a <code>smoothRange</code> value.</li>
 <li><p>'''smoothItem(itemIdx, [smoothRange])''': Returns a the value of <code>itemIdx</code> in the set but smoothed by averaging with its neighbors. The number of neighbors is set by <code>smoothRange</code>. See [[#Data_smoothing|Data smoothing]].</p></li></ul>
 
@@ -1778,16 +1763,16 @@ scripts/
         yourscript1.lua
         yourscript2.lua
         global_data.lua</pre>
-If you dare to, you can watch inside these files. Every time some data are changed, dzVents will stream the changes back into the data files. '''Again, make sure you don't put too much stuff in your persisted data as it may slow things down too much.'''
+If you dare to, you can watch inside these files. Every time some data are changed, dzVents will stream the changes back into the data files. '''Again, make sure you don’t put too much stuff in your persisted data as it may slow things down too much.'''
 
 = Asynchronous HTTP requests =
 
-As of 2.4.0 dzVents allows you to make asynchronous HTTP request and handle the results. Asynchronous means that you don't block the system while waiting for the response. Earlier you had to use os functions like <code>curl</code> or <code>wget</code> and some magic to make sure that you didn't block the system for too long after which Domoticz will terminate the script with a message that it took more than 10 seconds.
+As of 2.4.0 dzVents allows you to make asynchronous HTTP request and handle the results. Asynchronous means that you don’t block the system while waiting for the response. Earlier you had to use os functions like <code>curl</code> or <code>wget</code> and some magic to make sure that you didn’t block the system for too long after which Domoticz will terminate the script with a message that it took more than 10 seconds.
 
 dzVents to the rescue. With dzVents there are two ways to make an http call and it is determined by how you use the <code>domoticz.openURL()</code> command. The simplest form simply calls <code>openURL</code> on the domoticz object with only the url as the parameter (a string value):
 
 <pre>domoticz.openURL('http://domain/path/to/something?withparameters=1')</pre>
-After your script is finished, Domoticz will make the request that's where it ends. No callback. Nothing.
+After your script is finished, Domoticz will make the request that’s where it ends. No callback. Nothing.
 
 The second way is different. Instead of passing a url you pass in a table with all the parameters to make the request '''and''' your provide a ''callback trigger'' which is just a string or a name:
 
@@ -1844,7 +1829,7 @@ Of course you can combine the script that issues the request and handles the res
 }</pre>
 == API ==
 
-=== Making the request: ===
+###Making the request:
 
 '''domoticz.openURL(options)''': ''options'' <sup>2.4.0</sup> is a Lua table:
 
@@ -1882,7 +1867,7 @@ Whenever you do an http request it is not just some data that is sent. Along wit
 
 dzVents allow you to set custom request headers that will accompany the data in the request. Sometimes it is necessary to set these headers like for instance when a API or webservice require a security token or key or when the service needs to know what the format of the response data is. Check the documentation of the web service.
 
-So, let's say you need to call a web service that requires an api key in the headers and the documentation states it needs to be passed in an x-access-token header. Your openURL command then may look like this:
+So, let’s say you need to call a web service that requires an api key in the headers and the documentation states it needs to be passed in an x-access-token header. Your openURL command then may look like this:
 
 <pre>domoticz.openURL({
     url = 'https://somedomain.com/service/getInfo',
@@ -1894,7 +1879,7 @@ Check google for more information about request headers. All you need to know he
 
 ==== response headers ====
 
-As said earlier, the response also contains a bunch of headers. You can inspect those headers with dzVents but ususally you don't have to. For starters, dzVents already checks the <code>Content-Type</code> header which usually states what kind of data format the response is. If it is <code>application/json</code> then it automatically converts the json data to a Lua table. Also, it checks the <code>Status</code> header to see if the request was successful. If so, then it sets the <code>ok</code> attribute on the response object. So normally you don't have to inspect the headers. However, sometimes the web service puts a session token in the response header that you have to use in follow-up requests.
+As said earlier, the response also contains a bunch of headers. You can inspect those headers with dzVents but ususally you don’t have to. For starters, dzVents already checks the <code>Content-Type</code> header which usually states what kind of data format the response is. If it is <code>application/json</code> then it automatically converts the json data to a Lua table. Also, it checks the <code>Status</code> header to see if the request was successful. If so, then it sets the <code>ok</code> attribute on the response object. So normally you don’t have to inspect the headers. However, sometimes the web service puts a session token in the response header that you have to use in follow-up requests.
 
 So here an example where we have to log in before we can fetch data. It uses two requests: the first performs the log-in and the second grabs the session token from the login response data and uses that token in the second request to get the data we need. In this example we do this every hour.
 
@@ -1936,7 +1921,7 @@ That would look like this:
         end
     end
 }</pre>
-Some remarks about the response header <code>Content-Type</code>. If a service is a good web-citizen then it tells you what the format of the data is in this header. So, if the data is a json object then the header should be <code>application/json</code>. Unfortunately, there are lot of lazy programmers out there who don't set this header properly. If that is the case, dzVents cannot detect the format and will not turn it into a Lua table for you automatically. So, if you know it is json but the header is not properly set, then you can easily convert it into a Lua table in your code:
+Some remarks about the response header <code>Content-Type</code>. If a service is a good web-citizen then it tells you what the format of the data is in this header. So, if the data is a json object then the header should be <code>application/json</code>. Unfortunately, there are lot of lazy programmers out there who don’t set this header properly. If that is the case, dzVents cannot detect the format and will not turn it into a Lua table for you automatically. So, if you know it is json but the header is not properly set, then you can easily convert it into a Lua table in your code:
 
 <pre>return {
     on = {
@@ -1962,7 +1947,7 @@ Some remarks about the response header <code>Content-Type</code>. If a service i
 }</pre>
 === Fetching data from Domoticz itself ===
 
-Most of the things you need to do in your dzVents script is already exposed somewhere in the dzVents object hierarchy. Sometimes however you need some data that is not available in dzVents. Just to give an example, let's assume you have some zwave hardware and you want to know the <code>last seen</code> information of zwave devices or the status. This information is available in the node overview on the hardware page in Domoticz GUI. So, here is an example of how you can get that information into dzVents:
+Most of the things you need to do in your dzVents script is already exposed somewhere in the dzVents object hierarchy. Sometimes however you need some data that is not available in dzVents. Just to give an example, let’s assume you have some zwave hardware and you want to know the <code>last seen</code> information of zwave devices or the status. This information is available in the node overview on the hardware page in Domoticz GUI. So, here is an example of how you can get that information into dzVents:
 
 <pre>return {
     on = {
@@ -2005,7 +1990,7 @@ Most of the things you need to do in your dzVents script is already exposed some
 
 Settings for dzVents are found in the Domoticz GUI: '''Setup &gt; Settings &gt; Other &gt; EventSystem''':
 
-* '''dzVents disabled''': Tick this if you don't want any dzVents script to be executed.
+* '''dzVents disabled''': Tick this if you don’t want any dzVents script to be executed.
 * '''Log level''': (Note that you can override this setting in the logging section of your script)
 ** ''Errors'',
 ** ''Errors + minimal execution info'': Errors and some minimal information about which script is being executed and why,
@@ -2023,35 +2008,35 @@ Check the settings (see above) and make sure the checkbox '''dzVents disabled'''
 
 === Is your script enabled? ===
 
-Make sure the active section in your script is set to <code>true</code>: <code>active = true</code>. And, on top of that, if you are using the internal web editor to write your script, make sure that your script is active there and you have clicked Save! &quot;Event active&quot; is a separate checkbox that must be ticked for every active script. When not active, the script name will be red in the list on the right.
+Make sure the active section in your script is set to <code>true</code>: <code>active = true</code>. And, on top of that, if you are using the internal web editor to write your script, make sure that your script is active there and you have clicked Save! “Event active” is a separate checkbox that must be ticked for every active script. When not active, the script name will be red in the list on the right.
 
 === Turn on debug logging ===
 
-Activate debug logging in the settings (see above). This will produce a lot of extra messages in the Domoticz log (don't forget to turn it off when you are done troubleshooting!). It is best to monitor the log through the command line, as the log in the browser sometimes tends to not always show all log messages. See the Domoticz manual for how to do that.
+Activate debug logging in the settings (see above). This will produce a lot of extra messages in the Domoticz log (don’t forget to turn it off when you are done troubleshooting!). It is best to monitor the log through the command line, as the log in the browser sometimes tends to not always show all log messages. See the Domoticz manual for how to do that.
 
-When debug logging is enabled, every time dzVents kicks into action (Domoticz throws an event) it will log it, and it will create a file <code>/path/to/domoticz/scripts/dzVents/domoticzData.lua</code> with a dump of the data sent to dzVents. These data lie at the core of the dzVents object model. You can open this file in an editor to see if your device/variable/scene/group is in there. Note that the data in the file are not exactly the same as what you will get when you interact with dzVents, but it is a good start. If your device is not in the data file, then you will not have access to it in dzVents and dzVents will not be able to match triggers with that device. Something's wrong if you expect your device to be in there but it is not (is the device active/used?).
+When debug logging is enabled, every time dzVents kicks into action (Domoticz throws an event) it will log it, and it will create a file <code>/path/to/domoticz/scripts/dzVents/domoticzData.lua</code> with a dump of the data sent to dzVents. These data lie at the core of the dzVents object model. You can open this file in an editor to see if your device/variable/scene/group is in there. Note that the data in the file are not exactly the same as what you will get when you interact with dzVents, but it is a good start. If your device is not in the data file, then you will not have access to it in dzVents and dzVents will not be able to match triggers with that device. Something’s wrong if you expect your device to be in there but it is not (is the device active/used?).
 
 Every time Domoticz starts dzVents and debug logging is enabled you should see these lines:
 
 <pre>dzVents version: x.y.z
 Event trigger type: xxxx</pre>
-Where xxxx can be time, device, uservariable, security or scenegroup. That should give you a clue what kind of event is active. If you don't see this information then dzVents is not active (or debug logging is not active).
+Where xxxx can be time, device, uservariable, security or scenegroup. That should give you a clue what kind of event is active. If you don’t see this information then dzVents is not active (or debug logging is not active).
 
 === Script is still not executed ===
 
-If for some reason your script is not executed while all of the above is done, it is possible that your triggers are not correct. Either the time rule is not matching with the current time (try to set the rule to <code>every minute</code> or something simple), or the device name is not correct (check casing), or you use an id that doesn't exist. Note that in the <code>on</code> section, you cannot use the dzVents domoticz object!
+If for some reason your script is not executed while all of the above is done, it is possible that your triggers are not correct. Either the time rule is not matching with the current time (try to set the rule to <code>every minute</code> or something simple), or the device name is not correct (check casing), or you use an id that doesn’t exist. Note that in the <code>on</code> section, you cannot use the dzVents domoticz object!
 
-Make sure that if you use an id in the <code>on</code> section that this id is correct. Go to the device list in Domoticz and find the device and make sure the device is in the 'used' list!. Unused devices will not create an event. Find the idx for the device and use that as the id.
+Make sure that if you use an id in the <code>on</code> section that this id is correct. Go to the device list in Domoticz and find the device and make sure the device is in the ‘used’ list!. Unused devices will not create an event. Find the idx for the device and use that as the id.
 
-Also, make sure that your device names are unique! dzVents will throw a warning in the log if multiple device names match. It's best practice to have unique names for your devices. Use some clever naming like prefixing like 'Temperature: living room' or 'Lights: living room'. That also makes using wild cards on your <code>on</code> section easier.
+Also, make sure that your device names are unique! dzVents will throw a warning in the log if multiple device names match. It’s best practice to have unique names for your devices. Use some clever naming like prefixing like ‘Temperature: living room’ or ‘Lights: living room’. That also makes using wild cards on your <code>on</code> section easier.
 
 If your script is still not triggered, you can try to create a classic Lua event script and see if that does work.
 
 === Debugging your script ===
 
-A simple way to inspect a device in your script is to dump it to the log: <code>myDevice.dump()</code>. This will dump all the attributes (and more) of the device so you can inspect what its state is. Use print statements or domoticz.log() statements in your script at cricital locations to see if the Lua interpreter reaches that line. Don't try to print a device object though; use the <code>myDevice.dump()</code> method for that. It wil log all attributes of the device in the Domoticz log.
+A simple way to inspect a device in your script is to dump it to the log: <code>myDevice.dump()</code>. This will dump all the attributes (and more) of the device so you can inspect what its state is. Use print statements or domoticz.log() statements in your script at cricital locations to see if the Lua interpreter reaches that line. Don’t try to print a device object though; use the <code>myDevice.dump()</code> method for that. It wil log all attributes of the device in the Domoticz log.
 
-If you place a print statement all the way at the top of your script file it will be printed every time dzVents loads your script (that is done at the beginning of each event cycle). Sometimes that is handy to see if your script gets loaded in the first place. If you don't see your print statement in the log, then likely dzVents didn't load it and it will not work.
+If you place a print statement all the way at the top of your script file it will be printed every time dzVents loads your script (that is done at the beginning of each event cycle). Sometimes that is handy to see if your script gets loaded in the first place. If you don’t see your print statement in the log, then likely dzVents didn’t load it and it will not work.
 
 === Get help ===
 
@@ -2071,7 +2056,7 @@ Check out the great documentation [http://axmat.github.io/lodash.lua/ here].
 
 As you can read in the change log below there are a couple of changes in 2.0 that will break older scripts.
 
-== The 'on={..}' section. ==
+== The ‘on={..}’ section. ==
 
 The on-section needs the items to be grouped based on their type. Prior to 2.0 you had
 
@@ -2175,184 +2160,79 @@ In 1.x.x you had a changedAttributes collection on a device. That is no longer t
 
 == Using rawData ==
 
-Prior to 2.x you likely used the rawData attribute to get to certain device values. With 2.x this is likely not needed anymore. Check the various device types above and check if there isn't a named attribute for you device type. dzVents 2.x uses so called device adapters which should take care of interpreting raw values and put them in named attributes for you. If you miss your device you can file a ticket or create an adapter yourself. See [[File:#Create_your_own_device_adapter|Create your own device adapter]].
+Prior to 2.x you likely used the rawData attribute to get to certain device values. With 2.x this is likely not needed anymore. Check the various device types above and check if there isn’t a named attribute for you device type. dzVents 2.x uses so called device adapters which should take care of interpreting raw values and put them in named attributes for you. If you miss your device you can file a ticket or create an adapter yourself. See [[File:#Create_your_own_device_adapter|Create your own device adapter]].
 
 == What happened to fetch http data? ==
 
-In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you're good to go.
+In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you’re good to go.
 
 = History =
 
-== [2.5.1] ==
+##[2.5.2] - Add actualWatt to replace WhActual (left in WhActual for compatibility reasons) - Add resilience to increaseBrightness() and decreaseBrightness() methods (only avaiable for Yeelight)
 
-* Added <code>toXML</code> and <code>fromXML</code> methods to domoticz.utils.
-* Add attributes isXML, xmlVersion, xmlEncoding
+##[2.5.1] - Added <code>toXML</code> and <code>fromXML</code> methods to domoticz.utils. - Add attributes isXML, xmlVersion, xmlEncoding
 
-== [2.5.0] ==
+##[2.5.0] - Prepared for Lua 5.3
 
-* Prepared for Lua 5.3
+##[2.4.29] - Add error message including affected module when module got corrupted on disk. - Add setLevel method for switchTypes. - Increased resilience against badly formatted type Time user-variables. - Use native domoticz command for increaseCounter method. - Set inverse of “set color” to Off to enable use of toggleSwitch for RGB type of devices.
 
-== [2.4.29] ==
+##[2.4.28] - Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils - increased httpResponse resilience against different use of Upper-, Lowercase in headers[‘content-type’] to ensure JSON conversion to Lua table
 
-* Add error message including affected module when module got corrupted on disk.
-* Add setLevel method for switchTypes.
-* Increased resilience against badly formatted type Time user-variables.
-* Use native domoticz command for increaseCounter method.
-* Set inverse of &quot;set color&quot; to Off to enable use of toggleSwitch for RGB type of devices.
+##[2.4.27] - Add attribute protected for devices / scenes and groups - Add methods protectionOn and protectionOff for devices / scenes and groups - Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
 
-== [2.4.28] ==
+##[2.4.26] - Add Smoke Detector device (activate and reset functions )
 
-* Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils
-* increased httpResponse resilience against different use of Upper-, Lowercase in headers['content-type'] to ensure JSON conversion to Lua table
+##[2.4.25] - Add rawDateTime - fix for combined device / civil[day|night]time trigger rule - fix for checkFirst on stopped status
 
-== [2.4.27] ==
+##[2.4.24] - Add method rename for devices, user-variables , scenes and groups
 
-* Add attribute protected for devices / scenes and groups
-* Add methods protectionOn and protectionOff for devices / scenes and groups
-* Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
+##[2.4.23] - Add method setMode for evohome device - Add method incrementCounter for incremental counter - Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm) - fix wildcard device
 
-== [2.4.26] ==
+##[2.4.22] - selector.switchSelector method accepts levelNames - increased selector.switchSelector resilience - fix wildcard timerule
 
-* Add Smoke Detector device (activate and reset functions )
+##[2.4.21] - fixed wrong direction for open() and close() for some types of blinds - Add inTable function to domoticz.utils - Add sValue attribute to devices
 
-== [2.4.25] ==
+##[2.4.20] - Add quietOn() and quietOff() method to switchType devices
 
-* Add rawDateTime
-* fix for combined device / civil[day|night]time trigger rule
-* fix for checkFirst on stopped status
+##[2.4.19] - Add stringSplit function to domoticz.utils. - Add statusText and protocol to HTTPResponse
 
-== [2.4.24] ==
+##[2.4.18] - Add triggerIFTTT() to domoticz
 
-* Add method rename for devices, user-variables , scenes and groups
+##[2.4.17] - Add dumpTable() to domoticz.utils - Add setValues for devices - Add setIcon for devices
 
-== [2.4.23] ==
+##[2.4.16] - Add method dump() to domoticz (dumps settings) - Add setHue, setColor, setHex, getColor for RGBW(W) devices - Add setDescription for devices, groups and scenes - Add volumeUp / volumeDown for Logitech Media Server (LMS) - Changed domoticz.utils.fromJSON (add optional fallback param)
 
-* Add method setMode for evohome device
-* Add method incrementCounter for incremental counter
-* Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
-* fix wildcard device
+##[2.4.15] - Add option to use camera name in snapshot command - Add domoticz.settings.domoticzVersion - Add domoticz.settings.dzVentsVersion
 
-== [2.4.22] ==
+##[2.4.14] - Added domoticz.settings.location.longitude and domoticz.settings.location.latitude - Added check for- and message when call to openURL cannot open local (127.0.0.1) - '''BREAKING CHANGE''' :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name) - prevent call to updateCounter with table
 
-* selector.switchSelector method accepts levelNames
-* increased selector.switchSelector resilience
-* fix wildcard timerule
+##[2.4.13] - Added domoticz.settings.location (domoticz settings location Name) - Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
 
-== [2.4.21] ==
+##[2.4.12] - Added managed Counter (to counter)
 
-* fixed wrong direction for open() and close() for some types of blinds
-* Add inTable function to domoticz.utils
-* Add sValue attribute to devices
+##[2.4.11] - Added snapshot command to send Email with camera snapshot ( afterXXX() and withinXXX() options available)
 
-== [2.4.20] ==
+##[2.4.10] - Added option to use afterXXX() and withinXXX() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup> - Changed function updateMode to display mode as string in domoticz log
 
-* Add quietOn() and quietOff() method to switchType devices
+##[2.4.9] - Added evohome hotwater device (state, mode, untilDate and setHotWater function) - Added mode and untilDate for evohome zone devices - Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices - Add speedMs and gustMs from wind devices - bugfix for youless device (0 handling) - bugfix for time ( twilightstart and twilightend handling) - Fixed some date-range rule checking
 
-== [2.4.19] ==
+##[2.4.8] - Added telegram as option for domoticz.notify
 
-* Add stringSplit function to domoticz.utils.
-* Add statusText and protocol to HTTPResponse
+##[2.4.7] - Added support for civil twilight in rules
 
-== [2.4.18] ==
+##[2.4.6] - Added Youless device - Added more to the documentation section for http requests - Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
 
-* Add triggerIFTTT() to domoticz
+##[2.4.5] - Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&amp;t=23109).
 
-== [2.4.17] ==
+##[2.4.4] - Fixed rawTime and rawData so it shows leading zeros when values are below 10. - Fixed one wildcard issue. Should now work as expected. - Fixed a problem in Domoticz where you couldn’t change the state of some door contact-like switches using the API or dzVents. That seems to work now.
 
-* Add dumpTable() to domoticz.utils
-* Add setValues for devices
-* Add setIcon for devices
+##[2.4.3] - Fixed trigger wildcards. Now you can do <code>*aa*bb*cc</code> or <code>a*</code> which will require the target to start with an <code>a</code> - Added more EvoHome device types to the EvoHome device adapter.
 
-== [2.4.16] ==
+##[2.4.2] - Fixed RGBW device adapter - Fixed EvoHome device adapter - Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&amp;t=21620&amp;p=170469#p170469)
 
-* Add method dump() to domoticz (dumps settings)
-* Add setHue, setColor, setHex, getColor for RGBW(W) devices
-* Add setDescription for devices, groups and scenes
-* Add volumeUp / volumeDown for Logitech Media Server (LMS)
-* Changed domoticz.utils.fromJSON (add optional fallback param)
+##[2.4.1] - Fixed week number problems on Windows - Fixed ‘on date’ rules to support dd/mm format (e.g. 01/02)
 
-== [2.4.15] ==
-
-* Add option to use camera name in snapshot command
-* Add domoticz.settings.domoticzVersion
-* Add domoticz.settings.dzVentsVersion
-
-== [2.4.14] ==
-
-* Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
-* Added check for- and message when call to openURL cannot open local (127.0.0.1)
-* '''BREAKING CHANGE''' :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
-* prevent call to updateCounter with table
-
-== [2.4.13] ==
-
-* Added domoticz.settings.location (domoticz settings location Name)
-* Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
-
-== [2.4.12] ==
-
-* Added managed Counter (to counter)
-
-== [2.4.11] ==
-
-* Added snapshot command to send Email with camera snapshot ( afterXXX() and withinXXX() options available)
-
-== [2.4.10] ==
-
-* Added option to use afterXXX() and withinXXX() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup>
-* Changed function updateMode to display mode as string in domoticz log
-
-== [2.4.9] ==
-
-* Added evohome hotwater device (state, mode, untilDate and setHotWater function)
-* Added mode and untilDate for evohome zone devices
-* Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
-* Add speedMs and gustMs from wind devices
-* bugfix for youless device (0 handling)
-* bugfix for time ( twilightstart and twilightend handling)
-* Fixed some date-range rule checking
-
-== [2.4.8] ==
-
-* Added telegram as option for domoticz.notify
-
-== [2.4.7] ==
-
-* Added support for civil twilight in rules
-
-== [2.4.6] ==
-
-* Added Youless device
-* Added more to the documentation section for http requests
-* Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
-
-== [2.4.5] ==
-
-* Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&amp;t=23109).
-
-== [2.4.4] ==
-
-* Fixed rawTime and rawData so it shows leading zeros when values are below 10.
-* Fixed one wildcard issue. Should now work as expected.
-* Fixed a problem in Domoticz where you couldn't change the state of some door contact-like switches using the API or dzVents. That seems to work now.
-
-== [2.4.3] ==
-
-* Fixed trigger wildcards. Now you can do <code>*aa*bb*cc</code> or <code>a*</code> which will require the target to start with an <code>a</code>
-* Added more EvoHome device types to the EvoHome device adapter.
-
-== [2.4.2] ==
-
-* Fixed RGBW device adapter
-* Fixed EvoHome device adapter
-* Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&amp;t=21620&amp;p=170469#p170469)
-
-== [2.4.1] ==
-
-* Fixed week number problems on Windows
-* Fixed 'on date' rules to support dd/mm format (e.g. 01/02)
-
-== [2.4.0] ==
+##[2.4.0]
 
 * '''BREAKING CHANGE''': The second parameter passed to the execute function is no longer <code>nil</code> when the script was triggered by a timer or a security event. Please check your scripts. The second parameter has checks to determine the type. E.g. <code>execute = function(domoticz, item) .. end</code>. You can inspect <code>item</code> using: <code>item.isDevice</code>, <code>item.isTimer</code>, <code>item.isVariable</code>, <code>item.isScene</code>, <code>item.isGroup</code>, <code>item.isSecurity</code>, <code>item.isHTTPResponse</code>. Please read the documentation about the execute function.
 * Added <code>.cancelQueuedCommands()</code> to devices, groups, scenes and variables. Calling this method will cancel any scheduled future commands issued using for instance <code>.afterMin(10)</code> or <code>.repeatAfterMin(1, 4)</code>
@@ -2371,19 +2251,19 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Added support for Lighting Limitless/Applamp RGBW devices. You can now set Kelvin and RGB values, NightMode, WhiteMode and increase and decrease the brightness and discoMode. See the documentation.
 * Added device adapter for Onkyo receiver hardware.
 * Added <code>scriptName</code> to the triggerInfo object passed as the third parameter to the execute function. This holds the name of the script being executed.
-* Fixed bug in Domoticz where using forXXX() with selector switches didn't always work.
+* Fixed bug in Domoticz where using forXXX() with selector switches didn’t always work.
 * Fixed bug in Domoticz where improper states were passed to the event scripts. This may happen on slower machines where several devices may have been updated before the event-system had a change to operate on them. In that case the event scripts received the current final state instead of the state at the moment of the actual event.
 * Added support for webroot. dzVents will now use the proper API url when domoticz is started with the -webroot switch.
 * Added support for event-bursts. If (on slower machines) events get queued up in Domoticz, they will be sent to dzVents in one-package. This makes event processing significantly faster.
 * Added <code>domoticz.data.initialize(varName)</code>. This will re-initialize non-historical variables to the initial value as defined in the data section.
 * You now no longer have to provide an initial value for a persistent variable when you declare it. So you can do <code>data = { 'a', 'b', 'c'}</code> instead of <code>data = {a={initial = nil}, b={initial=nil}, c={initial=nil} }</code>. You have to quote the names though.
-* A filter can now accept a table with names/id's instead of only functions. You can now do <code>domoticz.devices().filter({ 'mySwitch', 'myPIR', 34, 35, 'livingLights'})</code> which will give you a collection of devices with these names and ids.
+* A filter can now accept a table with names/id’s instead of only functions. You can now do <code>domoticz.devices().filter({ 'mySwitch', 'myPIR', 34, 35, 'livingLights'})</code> which will give you a collection of devices with these names and ids.
 * Added and documented <code>domoticz.settings.url</code>, <code>domoticz.settings.webRoot</code> and <code>domoticz.settings.serverPort</code>.
 * Removed fixed limit on historical variables if there is a limit specified.
 
-== [2.3.0] ==
+##[2.3.0]
 
-* Added <code>active</code> attribute to devices (more logical naming than the attribute 'bState'). <code>myDevice.active</code> is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like <code>if mySwitch.active then .. end</code>
+* Added <code>active</code> attribute to devices (more logical naming than the attribute ‘bState’). <code>myDevice.active</code> is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like <code>if mySwitch.active then .. end</code>
 * Added <code>domoticz.urlEncode</code> method on the <code>domoticz</code> object so you can prepare a string before using it with <code>openURL()</code>.
 * Updating devices, user variables, scenes and groups now always trigger the event system for follow-up events.
 * Added support for groups and scenes change-event scripts. Use <code>on = { scenes = { 'myScene1', 'myScene2' }, groups = {'myGroup1'} }</code>
@@ -2398,44 +2278,44 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Added <code>compare(time)</code> method to <code>Time</code> object to calculate the difference between them. Returns a table. See documentation.
 * Added <code>domoticz.round()</code> method to <code>domoticz</code> object.
 * Added <code>text</code> property to alert sensor.
-* <code>active</code> section is now optional in your dzVents script. If you don't specify an <code>active = true/false</code> then true is assumed (script is active). Handy for when you use Domoticz' GUI script editor as it has its own way of activating and deactivating scripts.
+* <code>active</code> section is now optional in your dzVents script. If you don’t specify an <code>active = true/false</code> then true is assumed (script is active). Handy for when you use Domoticz’ GUI script editor as it has its own way of activating and deactivating scripts.
 * Added <code>humidityStatusValue</code> for humidity devices. This value matches with the values used for setting the humidity status.
 * <code>Time</code> object will initialize to current time if nothing is passed: <code>local current = Time()</code>.
 * Added the lua lodash library (http://axmat.github.io/lodash.lua, MIT license).
 * Fixed documentation about levelNames for selector switches and added the missing levelName.
 * Moved dzVents runtime code away from the <code>/path/to/domoticz/scripts/dzVents</code> folder as this scripts folder contains user stuff.
 * Added more trigger examples in the documentation.
-* You can now put your own non-dzVents modules in your scripts folder or write them with the Domoticz GUI editor. dzVents is no longer bothered by it. You can require your modules in Lua's standard way.
+* You can now put your own non-dzVents modules in your scripts folder or write them with the Domoticz GUI editor. dzVents is no longer bothered by it. You can require your modules in Lua’s standard way.
 * Added <code>/path/to/domoticz/scripts/dzVents/scripts/modules</code> and <code>/path/to/domoticz/scripts/dzVents/modules</code> to the Lua package path for custom modules. You can now place your modules in there and require them from anywhere in your scripts.
 * Added dzVents-specific boilerplate/templates for internal web editor.
 * Fixed the confusing setting for enabling/disabling dzVents event system in Domoticz settings.
-* Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn't executed.
+* Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn’t executed.
 
-== [2.2.0] ==
+##[2.2.0]
 
 * Fixed typo in the doc WActual &gt; WhActual.
 * Updated switch adapter to match more switch-like devices.
 * Added Z-Wave Thermostat mode device adapter.
 * Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
-* Added secondsSinceMidnight to time attributes (e.g. lastUpdate.secondsSinceMidnight)
+* Added secondsSinceMidnight to time attributes (e.g. lastUpdate.secondsSinceMidnight)
 * Added 4 new time-rules: xx minutes before/after sunset/sunrise.
 * Added example script to fake user presence.
 * Fixed support for uservariables with spaces in their names.
-* Show a warning when an item's name isn't unique in the collection.
+* Show a warning when an item’s name isn’t unique in the collection.
 * Added timing options for security methods armAway, armHome and disarm like device.armAway().afterSec(10).
-* Added idx, deviceId and unit to device objects. Don't confuse deviceId with device.id(x) which is actually the index of the device.
+* Added idx, deviceId and unit to device objects. Don’t confuse deviceId with device.id(x) which is actually the index of the device.
 * Added instructions on how to create a security panel device in Domoticz. This device now has a state that has the same value as domoticz.security.
 * Fixed bug in check battery levels example.
 * Fixed some irregularities with dimmer levels.
 
-== [2.1.1] ==
+##[2.1.1]
 
 * Fixed typo in the doc WActual &gt; WhActual.
 * Updated switch adapter to match more switch-like devices.
 * Added Z-Wave Thermostat mode device adapter.
 * Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
 
-== [2.1.0] ==
+##[2.1.0]
 
 * Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
 * Added support for Ampère 1 and 3-phase devices
@@ -2447,17 +2327,17 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Added support for waterflow devices
 * Added missing color attribute to alert sensor devices
 * Added updateEnergy() to electric usage devices
-* Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
+* Fixed casing for WhTotal, WhActual methods on kWh devices (Watt’s in a name?)
 * Added toCelsius() helper method to domoticz object as the various update temperature methods all need Celsius.
 * Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
 * Added integration tests for full round-trip Domoticz &gt; dzVents &gt; Domoticz &gt; dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
-* Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
-* Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
+* Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won’t get uservariable event scripts triggered in dzVents.
+* Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it’s own heartbeat.
 * avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
 * Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
 * Use different api command for setting setPoints in the Thermostat setpoint device adapter.
 
-== [2.0.0] Domoticz integration ==
+##[2.0.0] Domoticz integration
 
 * Almost a complete rewrite.
 * '''BREAKING CHANGE''': Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing <code>domoticz.devices['myDevice']</code> you now have to call a function: <code>domoticz.devices('myDevice')</code>. This applies also for the other collections: <code>domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()</code>. If you want to loop over these collection '''you can no longer use the standard Lua for..pairs or for..ipairs construct'''. You have to use the iterators like forEach, filter and reduce: <code>domoticz.devices().forEach(function() .. end)</code> (see [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. '''So please change your existing dzVents scripts!'''
@@ -2476,30 +2356,30 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Settings are now moved to the Domoticz GUI ('''Setup &gt; Settings &gt; Other''') and no longer in a settings file.
 * You can now override the log settings per script. So you can turn-off logging globally (see log level in the settings) and still have debug-level logging for that one script you are working on. You can even add a prefix string to the log messages for easy filtering in the Domoticz log. See the documentation about the <code>logging = { .. }</code> section.
 * No more need to do http-calls to get extended data from Domoticz. All relevant internal Domoticz state-data is now available inside your dzVents scripts. Thanks Scotty!!
-* Support for many many more device types and their specific methods. See the documentation for the list of attributes and events that are available. Note that device-type specific attributes are only available for those type of devices. You will receive an error in the log if you try to access an attribute that doesn't exist for that particular device. Hopefully you don't have to use the rawData table anymore. If you still do please file a report or create a device adapter yourself.
+* Support for many many more device types and their specific methods. See the documentation for the list of attributes and events that are available. Note that device-type specific attributes are only available for those type of devices. You will receive an error in the log if you try to access an attribute that doesn’t exist for that particular device. Hopefully you don’t have to use the rawData table anymore. If you still do please file a report or create a device adapter yourself.
 * You can now write dzVents scripts using the internal editor in Domoticz. These scripts will be automatically exported to the filesystem (one-way only) so dzVents can execute them (generated_scripts folder). Thanks again Scotty!
 * Support for variable change events (<code>on = { variables = { 'varA', 'varB'} }</code>)
 * Support for security change events (<code>on = { security = { domoticz.SECURITY_ARMEDAWAY } }</code>)
 * The triggerInfo passed to the execute function now includes information about which security state triggered the script if it was a security event.
 * Extended the timer-rule with time range e.g. <code>at 16:45-21:00</code> and <code>at nighttime</code> and <code>at daytime</code> and you can provide a custom function. See documentation for examples. The timer rules can be combined as well.
 * Timer rules for <code>every xx minutes</code> or <code>every xx hours</code> are now limited to intervals that will reach *:00 minutes or hours. So for minutes you can only do these intervals: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20 and 30. Likewise for hours.
-* The Time object (e.g. domoticz.time) now has a method <code>matchesRule(rule)</code>. <code>rule</code> is a string same as you use for timer options: <code>if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end</code>. The rule matches if the current system time matches with the rule.
+* The Time object (e.g. domoticz.time) now has a method <code>matchesRule(rule)</code>. <code>rule</code> is a string same as you use for timer options: <code>if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end</code>. The rule matches if the current system time matches with the rule.
 * A device trigger can have a time-rule constraint: <code>on = { devices = { ['myDevice'] = 'at nighttime' } }</code>. This only triggers the script when myDevice was changed '''and''' the time is after sunset and before sunrise.
 * Add support for subsystem selection for domoticz.notify function.
-* Fixed a bug where a new persistent variable wasn't picked up when that variable was added to an already existing data section.
+* Fixed a bug where a new persistent variable wasn’t picked up when that variable was added to an already existing data section.
 
-== [1.1.2] ==
+##[1.1.2]
 
 * More robust way of updating devices.lua
 * Added device level information for non-dimmer-like devices
 
-== [1.1.1] ==
+##[1.1.1]
 
-* Added support for a devices table in the 'on' section.
+* Added support for a devices table in the ‘on’ section.
 * Added extra log level for only showing information about the execution of a script module.
 * Added example script for System-alive checker notifications (preventing false negatives).
 
-== [1.1] ==
+##[1.1]
 
 * Added example script for controlling the temperature in a room with hysteresis control.
 * Fixed updateLux (thanks to neutrino)
@@ -2507,34 +2387,34 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Fixed updateCounter
 * Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
 
-== [1.0.2] ==
+##[1.0.2]
 
 * Added device description attribute.
 * Added support for setting the setpoint for opentherm gateway.
 * Added timedOut boolean attribute to devices. Requires http data fetching to be enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
 * Properly detects usage devices and their Wattage.
 
-== [1.0.1] ==
+##[1.0.1]
 
 * Added updateCustomSensor(value) method.
 * Fixed reset() for historical data.
 
-== [1.0][1.0-beta2] ==
+##[1.0][1.0-beta2]
 
 * Deprecated setNew(). Use add() instead. You can now add multiple values at once in a script by calling multiple add()s in succession.
 * Fixed printing device logs when a value was boolean or nil
 * Fixed WActual/total/today for energy devices.
 * Added updateSetPoint method on devices for dummy thermostat devices and EvoHome setpoint devices
 * Added couple of helper properties on Time object. See README.
-* Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don't overwrite your settings when you copy over a new version of dzVents to your system.
+* Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don’t overwrite your settings when you copy over a new version of dzVents to your system.
 
-== [1.0-beta1] ==
+##[1.0-beta1]
 
 * Added data persistence for scripts between script runs (see readme for more info)
 * Added a time-line based data type for you scripts with historical information and many statistical functions for retreiving information like average, minumum, maximum, delta, data smoothing (averaging values over neighbours) etc. See readme for more information.
 * Added SMS method to the domoticz object.
 * Added toggleSwitch() method to devices that support it.
-* Added more switch states that control device.bState (e.g. on == true, open == true 'all on' == true)
+* Added more switch states that control device.bState (e.g. on == true, open == true ‘all on’ == true)
 * Added secondsAgo to the lastUpdate attribute
 * Added tests (test code coverage is above 96%!)
 * Refactored code significantly.
@@ -2546,33 +2426,33 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Added scenes and groups collections to the domoticz object
 * Added Quick Reference Guide.
 
-== [0.9.13] ==
+##[0.9.13]
 
 * Fixed some timer functions
 
-== [0.9.12] ==
+##[0.9.12]
 
 * Fixed a bug with log level printing. Now errors are printed.
 * Added setPoint, heatingMode, lux, WhTotal, WhToday, WActual attributes to devices that support it. No need to access rawData for these anymore.
 
-== [0.9.11] ==
+##[0.9.11]
 
 * Added log method to domoticz object. Using this to log message in the Domoticz log will respect the log level setting in the settings file. [dannybloe]
 * Updated readme. Better overview, more attributes described.
 * Added iterator functions (forEach and filter) to domoticz.devices, domoticz.changedDevices and domoticz.variables to iterate or filter more easily over these collections.
 * Added a couple of example scripts.
 
-== [0.9.10] ==
+##[0.9.10]
 
 * A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
 * Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
 * Added support for sounds in domoticz.notify(). [WebStarVenlo]
 
-== [0.9.9] ==
+##[0.9.9]
 
-* Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy...
+* Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy…
 
-== [0.9.8] ==
+##[0.9.8]
 
 * Fixed a bug where a device can have underscores in its name.
 * Added dimTo(percentage) method to control dimmers.
@@ -2582,7 +2462,7 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 * Added http request data from Domoticz to devices. Now you can check the battery level and switch type and more. Make sure to edit dzVents_settings.lua file first and check the readme for install instructions!!!
 * Added log level setting in dzVents_settings.lua
 
-= [0.9.7] =
+#[0.9.7]
 
 * Added domoticz object resource structure. Updated readme accordingly. No more (or hardly any) need for juggling with all the Domoticz Lua tables and commandArrays.
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,7 @@
+[2.5.2]
+- Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+- Add resilience to increaseBrightness() and decreaseBrightness() methods (only avaiable for Yeelight)
+
 [2.5.1]
 - Added `toXML` and `fromXML` methods to domoticz.utils.
 - Add attributes isXML, xmlVersion, xmlEncoding

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -8,7 +8,7 @@ local self = {
 	LOG_MODULE_EXEC_INFO = 2,
 	LOG_INFO = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '2.5.1', -- domoticz >= V4/11494 (Lua 5.3)
+	DZVERSION = '2.5.2', 
 }
 
 function math.pow(x, y)

--- a/dzVents/runtime/device-adapters/electric_usage_device.lua
+++ b/dzVents/runtime/device-adapters/electric_usage_device.lua
@@ -11,7 +11,8 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device['WhActual'] = tonumber(device.rawData[1] or 0)
+		device['WhActual'] = tonumber(device.rawData[1] or 0) -- left in for compatibility reasons
+		device['actualWatt'] = tonumber(device.rawData[1] or 0)
 
 		function device.updateEnergy(energy)
 			return device.update(0, energy)

--- a/dzVents/runtime/device-adapters/kwh_device.lua
+++ b/dzVents/runtime/device-adapters/kwh_device.lua
@@ -28,7 +28,8 @@ return {
 		device['whTotal'] = nil
 		device['WhTotal'] = data.data.whTotal
 		device['whActual'] = nil
-		device['WhActual'] = data.data.whActual
+		device['WhActual'] = data.data.whActual -- left in for compatibility reasons
+		device['actualWatt'] = data.data.whActual or 0
 
 		device['counterToday'] = info['value']
 

--- a/dzVents/runtime/device-adapters/p1_smartmeter_device.lua
+++ b/dzVents/runtime/device-adapters/p1_smartmeter_device.lua
@@ -14,7 +14,8 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device['WhActual'] = tonumber(device.rawData[5]) or 0
+		device['WhActual'] = tonumber(device.rawData[5]) or 0 -- left in for compatibility reasons
+		device['actualWatt'] = tonumber(device.rawData[5]) or 0 
 
 		device['usage1'] = tonumber(device.rawData[1])
 		device['usage2'] = tonumber(device.rawData[2])

--- a/dzVents/runtime/device-adapters/rgbw_device.lua
+++ b/dzVents/runtime/device-adapters/rgbw_device.lua
@@ -27,6 +27,12 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
+		local function methodNotAvailableMessage(device, methodName)
+			domoticz.log('Method ' .. methodName .. ' is not available for device ' .. ' "' .. device.name .. '"' , utils.LOG_ERROR)
+			domoticz.log('(id=' .. device.id .. ', type=' .. device.deviceType .. ', subtype=' .. device.deviceSubType .. ', hardwareType=' .. device.hardwareType .. ')', utils.LOG_ERROR)
+			domoticz.log('If you believe this is not correct, please report on the forum.', utils.LOG_ERROR)
+		end
+
 		if (device.deviceSubType == 'RGBWW') or (device.deviceSubType == 'WW')  then
 			function device.setKelvin(kelvin)
 				local url
@@ -44,17 +50,25 @@ return {
 		end
 
 		function device.increaseBrightness()
-			local url
-			url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=brightnessup&type=command&idx=' .. device.id
-			return domoticz.openURL(url)
+			if device.hardwareType and device.hardwareType == 'YeeLight LED' then 
+				local url
+				url = domoticz.settings['Domoticz url'] ..
+						'/json.htm?param=brightnessup&type=command&idx=' .. device.id
+				return domoticz.openURL(url)
+			else
+				methodNotAvailableMessage(device, 'increaseBrightness')
+			end
 		end
 
 		function device.decreaseBrightness()
-			local url
-			url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=brightnessdown&type=command&idx=' .. device.id
-			return domoticz.openURL(url)
+			if device.hardwareType and device.hardwareType == 'YeeLight LED' then 
+				local url
+				url = domoticz.settings['Domoticz url'] ..
+						'/json.htm?param=brightnessdown&type=command&idx=' .. device.id
+				return domoticz.openURL(url)
+			else
+				methodNotAvailableMessage(device, 'decreaseBrightness')
+			end
 		end
 
 		function device.setNightMode()

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -41,12 +41,13 @@ else
 	echo dzVents will be tested against domoticz version $NewVersion.
 fi
  
- currenttime=$(date +%H:%M)
+currenttime=$(date +%H:%M)
 if [[ "$currenttime" > "00:00" ]] && [[ "$currenttime" < "00:31" ]]; then 
 	echo Script cannot be execute dbetween 00:00 and 00:30. Time checks will fail
 	exit 1
 fi	
 
+dzVersion=$(grep DZVERSION dzVents/runtime/Utils.lua | head -1 | grep -oP "'.*'"  | sed s/\'//g)
 
 function leadingZero
 	{
@@ -131,7 +132,7 @@ function fillTimes
 
 function fillNumberOfTests
 	{
-		Device_ExpectedTests=113
+		Device_ExpectedTests=115
 		Domoticz_ExpectedTests=70
 		EventHelpers_ExpectedTests=32
 		EventHelpersStorage_ExpectedTests=50
@@ -204,14 +205,13 @@ cp $basedir/domoticz.db $basedir/domoticz.db_$$
 rm -f $basedir/domoticz.db
 
 cd $basedir
-./domoticz > domoticz.log$$ &
+./domoticz  -www 8080 -sslwww 444 > domoticz.log$$ &
 checkStarted "domoticz" 20
 
 clear
-echo "========================= $NewVersion ================+========================== Tests ============================+"
-printf "|%6s %21s %83s " " time |" " test-script"  " | expected | tests | result | successful | failed |  seconds  |"
-echo
-echo "===================================================+=============================================================+"
+echo "========= domoticz $NewVersion, dzVents V$dzVersion =======+========================== Tests ==============================+"
+echo "  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |"
+echo "===================================================+===============================================================+"
 
 fillTimes
 fillNumberOfTests
@@ -252,6 +252,6 @@ else
 fi
 
 echo Total tests: $totalTest
-echo Finished without erors after $(showTime)
+echo $(date)';' dzVents version $dzVersion tested without erors after $(showTime)
 stopBackgroundProcesses 0
 cleanup

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -356,6 +356,7 @@ describe('device', function()
 			})
 
 			assert.is_same(12345, device.WhActual)
+			assert.is_same(12345, device.actualWatt)
 			device.updateEnergy(1000)
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="1000", _trigger=true} } }, commandArray)
 		end)
@@ -409,6 +410,7 @@ describe('device', function()
 			assert.is_same(5.789, device.counterDeliveredToday)
 			assert.is_same(5.6780, device.counterToday)
 			assert.is_same(12345, device.WhActual)
+			assert.is_same(12345, device.actualWatt)
 
 			device.updateP1(1, 2, 3, 4, 5, 6)
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="1;2;3;4;5;6", _trigger=true} } }, commandArray)
@@ -1639,6 +1641,26 @@ describe('device', function()
 			it('should handle increaseBrightness method correctly', function()
 				commandArray = {}
 				device.increaseBrightness()
+				assert.are_not.same({ 'http://127.0.0.1:8080/json.htm?param=brightnessup&type=command&idx=1' }, commandArray)
+			end)
+
+			it('should handle decreaseBrightness method correctly', function()
+				commandArray = {}
+				device.decreaseBrightness()
+				assert.are_not.same({ 'http://127.0.0.1:8080/json.htm?param=brightnessdown&type=command&idx=1' }, commandArray)
+			end)
+
+			local device = getDevice(domoticz, {
+					['name'] = 'myRGBW',
+					['state'] = 'Set Kelvin Level',
+					['subType'] = 'RGBWW',
+					['type'] = 'Color Switch',
+                    ['hardwareType'] = 'YeeLight LED',
+				})
+
+			it('should handle increaseBrightness method correctly', function()
+				commandArray = {}
+				device.increaseBrightness()
 				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessup&type=command&idx=1' }, commandArray)
 			end)
 
@@ -1647,8 +1669,8 @@ describe('device', function()
 				device.decreaseBrightness()
 				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessdown&type=command&idx=1' }, commandArray)
 			end)
-
-			it('should handle dsetNightMode method correctly', function()
+			
+            it('should handle dsetNightMode method correctly', function()
 				commandArray = {}
 				device.setNightMode()
 				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=nightlight&type=command&idx=1' }, commandArray)

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -16,7 +16,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("2.5.1")
+	m_version("2.5.2")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION
```
========= domoticz V4.11535, dzVents V2.5.2 =======+========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        115      OK            115         0      0.5664
00:00:03  Domoticz                                      1         70      OK             70         0      0.5090
00:00:03  EventHelpers                                  1         32      OK             32         0      0.4816
00:00:04  EventHelpersStorage                           1         50      OK             50         0      0.4560
00:00:05  HTTPResponse                                  1          6      OK              6         0      0.0248
00:00:05  ScriptdzVentsDispatching                      1          2      OK              2         0      0.1105
00:00:05  TimedCommand                                  1         42      OK             42         0      0.1725
00:00:05  Time                                          3        326      OK            326         0      1.2167
00:00:07  Utils                                         1         19      OK             19         0      0.0616
00:00:07  Variable                                      1         15      OK             15         0      0.0552
00:00:07  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.1251
00:00:10  DelayedVariableScene                          8          2      OK              2         0      7.1260
00:00:17  EventState                                   19          2      OK              2         0     18.1409
00:00:36  Integration                                  33        217      OK            217         0     31.6969
00:01:07  SelectorSwitch                               10          2      OK              2         0      9.4225

Total tests: 902
Tue 26 Nov 2019 10:48:55 PM CET; dzVents version 2.5.2 tested without erors after 00:01:17
```

	modified:   History.txt
	modified:   dzVents/documentation/README.md
	modified:   dzVents/documentation/README.wiki
	modified:   dzVents/documentation/history.md
	modified:   dzVents/runtime/Utils.lua
	modified:   dzVents/runtime/device-adapters/electric_usage_device.lua
	modified:   dzVents/runtime/device-adapters/kwh_device.lua
	modified:   dzVents/runtime/device-adapters/p1_smartmeter_device.lua
	modified:   dzVents/runtime/device-adapters/rgbw_device.lua
	modified:   dzVents/runtime/misc/testdzVents.sh
	modified:   dzVents/runtime/tests/testDevice.lua
	modified:   main/dzVents.cpp