### PR TITLE
update dzVents to 2.5.2 (add base64 decode/ encode, deprecrate some Yeelight specific API calls)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -26,7 +26,7 @@ Version 4.xxxxx (xxx 2019)
 - Fixed: notification, Telegram error when odd number of underscores in text
 - Fixed: API, allow variabletype to be entered as text or integer in adduservariable and updateuservariable (#3320)
 - Updated: OpenZWave version 1.6
-- Updated: dzVents (version 2.5.1 for Lua 5.3) See dzVents/documentation/history.md)
+- Updated: dzVents (version 2.5.2 for Lua 5.3) See dzVents/documentation/history.md)
 
 Version 4.10717 (May 9th 2019)
 - Fixed: dzVents, Allowing no error message for HTTP calls (#3191)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -583,6 +583,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 
     - **dumpTable(table,[levelIndicator])**: *Function*: <sup>2.4.19</sup> print table structure and contents to log
     - **fileExists(path)**: *Function*: <sup>2.4.0</sup> Returns `true` if the file (with full path) exists.
+	- **fromBase64(string)**: *Function*: <sup>2.5.2</sup>) Decode a base64 string
     - **fromJSON(json, fallback <sup>2.4.16</sup>)**: *Function*. Turns a json string to a Lua table. Example: `local t = domoticz.utils.fromJSON('{ "a": 1 }')`. Followed by: `print( t.a )` will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.
 	- **fromXML(xml, fallback )**: *Function*: <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: `local t = domoticz.utils.fromXML('<testtag>What a nice feature!</testtag>') Followed by: `print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.	
     - **groupExists(parm)**: *Function*: <sup>2.4.28</sup> returns name when entered with valid groupID or ID when entered with valid groupName or false when not a groupID or groupName of an existing group
@@ -600,7 +601,9 @@ The domoticz object holds all information about your Domoticz system. It has glo
     - **rightPad(string, length [, character])**: *Function*: <sup>2.4.27</sup> Succeed string with given character(s) (default = space) to given length.
     - **round(number, [decimalPlaces])**: *Function*. Helper function to round numbers. Default decimalPlaces is 0.
     - **sceneExists(parm)**: *Function*: <sup>2.4.28</sup> returns name when entered with valid sceneID or ID when entered with valid sceneName or false when not a sceneID or sceneName of an existing scene
+	- **setLogMarker([marker])**: *Function*: <sup>2.5.2</sup> set logMarker to 'marker'. Defaults to scriptname. Can be used to change logMarker based on flow in script
     - **stringSplit(string, [separator ])**:<sup>2.4.19</sup> *Function*. Helper function to split a line in separate words. Default separator is space. Return is a table with separate words.
+    - **toBase64(string)**: *Function*: <sup>2.5.2</sup>) Encode a string to base64
     - **toCelsius(f, relative)**: *Function*. Converts temperature from Fahrenheit to Celsius along the temperature scale or when relative==true it uses the fact that 1F==0.56C. So `toCelsius(5, true)` returns 5F*(1/1.8) = 2.78C.
     - **toJSON(luaTable)**: *Function*. <sup>2.4.0</sup> Converts a Lua table to a json string.
 	- **toXML(luaTable, [header])**: *Function*. <sup>2.5.1</sup> Converts a Lua table to a xml string.
@@ -787,7 +790,8 @@ Note that if you do not find your specific device type here you can always inspe
  - **updateDistance(distance)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Electric usage
- - **WhActual**: *Number*. Current Watt usage.
+ - **actualWatt**: *Number*. Current Watt usage.
+ - **WhActual**: *Number*. Current Watt usage. (please use actualWatt)
  - **updateEnergy(energy)**: *Function*. In Watt. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Evohome (zones)
@@ -836,12 +840,14 @@ Note that if you do not find your specific device type here you can always inspe
  - **kodiSwitchOff()**: *Function*. Will turn the device off if this is supported in settings on the device.
 
 #### kWh, Electricity (instant and counter)
+ - **actualWatt**: *Number*. Actual usage in Watt.
  - **counterToday**: *Number*.
  - **updateElectricity(power, energy)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **usage**: *Number*.
  - **WhToday**: *Number*. Total Wh usage of the day. Note the unit is Wh and not kWh!
  - **WhTotal**: *Number*. Total Wh usage.
- - **WhActual**: *Number*. Actual reading.
+ - **WhActual**: *Number*. Actual reading in Watt. Please use actualWatt
+ 
 
 #### Leaf wetness
  - **wetness**: *Number*. Wetness value
@@ -895,12 +901,12 @@ See switch below.
  - **updateRain(rate, counter)**: *Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### RGBW(W) / Lighting Limitless/Applamp
- - **decreaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **decreaseBrightness()**: deprecated because only very limited supported and will be removed from API
  - **getColor()**; *Function*. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
- - **increaseBrightness()**: *Function*. <sup>2.4.0</sup> Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **increaseBrightness()**: deprecated because only very limited supported and will be removed from API
  - **setColor(r, g, b, br, cw, ww, m, t)**: *Function*. <sup>2.4.16</sup> Sets the light to requested color.  r, g, b required, others optional. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29). Meaning and limits of parms can be found [here](https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_a_light_to_a_certain_color_or_color_temperature).
  - **setColorBrightness()**: same as setColor
- - **setDiscoMode(modeNum)**: *Function*. <sup>2.4.0</sup> Activate disco mode, `1 =< modeNum <= 9`. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **setDiscoMode(modeNum)**: deprecated because only very limited supported and will be removed from API
 - **setHex(r, g, b)**: *Function*. <sup>2.4.16</sup> Sets the light to requested color.  r, g, b required (decimal Values 0-255). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 - **setHue(hue, brightness, isWhite)**: *Function*. <sup>2.4.16</sup> Sets the light to requested Hue. Hue and brightness required. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **setKelvin(Kelvin)**: *Function*. <sup>2.4.0</sup> Sets Kelvin level of the light (For RGBWW devices only). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
@@ -2077,6 +2083,12 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # History
+
+##[2.5.2]
+- Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+- Add toBase64 and fromBase64 function in utils
+- Add setLogMarker function in utils
+- Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
 
 ##[2.5.1]
 - Added `toXML` and `fromXML` methods to domoticz.utils.

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -573,6 +573,7 @@ else
 end</source></li>
 <li>'''dumpTable(table,[levelIndicator])''': ''Function'': <sup>2.4.19</sup> print table structure and contents to log</li>
 <li>'''fileExists(path)''': ''Function'': <sup>2.4.0</sup> Returns <code>true</code> if the file (with full path) exists.</li>
+<li>'''fromBase64(string)''': ''Function'': <sup>2.5.2</sup>) Decode a base64 string</li>
 <li>'''fromJSON(json, fallback <sup>2.4.16</sup>)''': ''Function''. Turns a json string to a Lua table. Example: <code>local t = domoticz.utils.fromJSON('{ &quot;a&quot;: 1 }')</code>. Followed by: <code>print( t.a )</code> will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.</li>
 <li>'''fromXML(xml, fallback )''': ''Function'': <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: <code>local t = domoticz.utils.fromXML('&lt;testtag&gt;What a nice feature!&lt;/testtag&gt;') Followed by:</code>print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.<br />
 </li>
@@ -589,7 +590,9 @@ Examples:</p>
 <li>'''rightPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Succeed string with given character(s) (default = space) to given length.</li>
 <li>'''round(number, [decimalPlaces])''': ''Function''. Helper function to round numbers. Default decimalPlaces is 0.</li>
 <li>'''sceneExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with valid sceneID or ID when entered with valid sceneName or false when not a sceneID or sceneName of an existing scene</li>
+<li>'''setLogMarker([marker])''': ''Function'': <sup>2.5.2</sup> set logMarker to 'marker'. Defaults to scriptname. Can be used to change logMarker based on flow in script</li>
 <li>'''stringSplit(string, [separator ])''':<sup>2.4.19</sup> ''Function''. Helper function to split a line in separate words. Default separator is space. Return is a table with separate words.</li>
+<li>'''toBase64(string)''': ''Function'': <sup>2.5.2</sup>) Encode a string to base64</li>
 <li>'''toCelsius(f, relative)''': ''Function''. Converts temperature from Fahrenheit to Celsius along the temperature scale or when relative==true it uses the fact that 1F==0.56C. So <code>toCelsius(5, true)</code> returns 5F*(1/1.8) = 2.78C.</li>
 <li>'''toJSON(luaTable)''': ''Function''. <sup>2.4.0</sup> Converts a Lua table to a json string.</li>
 <li>'''toXML(luaTable, [header])''': ''Function''. <sup>2.5.1</sup> Converts a Lua table to a xml string.</li>
@@ -781,7 +784,8 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== Electric usage ====
 
-* '''WhActual''': ''Number''. Current Watt usage.
+* '''actualWatt''': ''Number''. Current Watt usage.
+* '''WhActual''': ''Number''. Current Watt usage. (please use actualWatt)
 * '''updateEnergy(energy)''': ''Function''. In Watt. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Evohome (zones) ====
@@ -838,12 +842,13 @@ Note that if you do not find your specific device type here you can always inspe
 
 ==== kWh, Electricity (instant and counter) ====
 
+* '''actualWatt''': ''Number''. Actual usage in Watt.
 * '''counterToday''': ''Number''.
 * '''updateElectricity(power, energy)''': ''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''usage''': ''Number''.
 * '''WhToday''': ''Number''. Total Wh usage of the day. Note the unit is Wh and not kWh!
 * '''WhTotal''': ''Number''. Total Wh usage.
-* '''WhActual''': ''Number''. Actual reading.
+* '''WhActual''': ''Number''. Actual reading in Watt. Please use actualWatt
 
 ==== Leaf wetness ====
 
@@ -908,12 +913,12 @@ See switch below.
 
 ==== RGBW(W) / Lighting Limitless/Applamp ====
 
-* '''decreaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''decreaseBrightness()''': deprecated because only very limited supported and will be removed from API
 * '''getColor()'''; ''Function''. <sup>2.4.17</sup> Returns table with color attributes or nil when color field of device is not set.
-* '''increaseBrightness()''': ''Function''. <sup>2.4.0</sup> Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''increaseBrightness()''': deprecated because only very limited supported and will be removed from API
 * '''setColor(r, g, b, br, cw, ww, m, t)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required, others optional. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. Meaning and limits of parms can be found [https://www.domoticz.com/wiki/Domoticz_API/JSON_URL's#Set_a_light_to_a_certain_color_or_color_temperature here].
 * '''setColorBrightness()''': same as setColor
-* '''setDiscoMode(modeNum)''': ''Function''. <sup>2.4.0</sup> Activate disco mode, <code>1 =&lt; modeNum &lt;= 9</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''setDiscoMode(modeNum)''': deprecated because only very limited supported and will be removed from API
 * '''setHex(r, g, b)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested color. r, g, b required (decimal Values 0-255). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''setHue(hue, brightness, isWhite)''': ''Function''. <sup>2.4.16</sup> Sets the light to requested Hue. Hue and brightness required. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''setKelvin(Kelvin)''': ''Function''. <sup>2.4.0</sup> Sets Kelvin level of the light (For RGBWW devices only). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
@@ -2182,6 +2187,13 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you're good to go.
 
 = History =
+
+== [2.5.2] ==
+
+* Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+* Add toBase64 and fromBase64 function in utils
+* Add setLogMarker function in utils
+* Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
 
 == [2.5.1] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,9 @@
+[2.5.2]
+- Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+- Add toBase64 and fromBase64 function in utils
+- Add setLogMarker function in utils
+- Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and when used leave the device stateless)
+
 [2.5.1]
 - Added `toXML` and `fromXML` methods to domoticz.utils.
 - Add attributes isXML, xmlVersion, xmlEncoding

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -149,6 +149,10 @@ local function Domoticz(settings)
 		utils = {
 			_ = _,
 
+			setLogMarker = function(logMarker)
+				return utils.setLogMarker(logMarker)
+			end,
+
 			toCelsius = function(f, relative)
 				return utils.toCelsius(f, relative)
 			end,
@@ -187,6 +191,14 @@ local function Domoticz(settings)
 
 			toXML = function( luaTable, header)
 				return utils.toXML(luaTable, header)
+			end,
+
+			toBase64 = function (s)
+				return utils.toBase64(s)
+			end,
+
+			fromBase64 = function (s)
+				return utils.fromBase64(s)
 			end,
 
 			rgbToHSB = function(r, g, b)

--- a/dzVents/runtime/device-adapters/electric_usage_device.lua
+++ b/dzVents/runtime/device-adapters/electric_usage_device.lua
@@ -11,7 +11,8 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device['WhActual'] = tonumber(device.rawData[1] or 0)
+		device['WhActual'] = tonumber(device.rawData[1] or 0) -- left in for compatibility reasons
+		device['actualWatt'] = tonumber(device.rawData[1] or 0)
 
 		function device.updateEnergy(energy)
 			return device.update(0, energy)

--- a/dzVents/runtime/device-adapters/kwh_device.lua
+++ b/dzVents/runtime/device-adapters/kwh_device.lua
@@ -28,7 +28,8 @@ return {
 		device['whTotal'] = nil
 		device['WhTotal'] = data.data.whTotal
 		device['whActual'] = nil
-		device['WhActual'] = data.data.whActual
+		device['WhActual'] = data.data.whActual -- left in for compatibility reasons
+		device['actualWatt'] = data.data.whActual or 0
 
 		device['counterToday'] = info['value']
 

--- a/dzVents/runtime/device-adapters/p1_smartmeter_device.lua
+++ b/dzVents/runtime/device-adapters/p1_smartmeter_device.lua
@@ -14,7 +14,8 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
-		device['WhActual'] = tonumber(device.rawData[5]) or 0
+		device['WhActual'] = tonumber(device.rawData[5]) or 0 -- left in for compatibility reasons
+		device['actualWatt'] = tonumber(device.rawData[5]) or 0 
 
 		device['usage1'] = tonumber(device.rawData[1])
 		device['usage2'] = tonumber(device.rawData[2])

--- a/dzVents/runtime/device-adapters/rgbw_device.lua
+++ b/dzVents/runtime/device-adapters/rgbw_device.lua
@@ -27,6 +27,12 @@ return {
 
 	process = function (device, data, domoticz, utils, adapterManager)
 
+		local function methodNotAvailableMessage(device, methodName)
+			domoticz.log('Method ' .. methodName .. ' is not available for device ' .. ' "' .. device.name .. '"' , utils.LOG_ERROR)
+			domoticz.log('(id=' .. device.id .. ', type=' .. device.deviceType .. ', subtype=' .. device.deviceSubType .. ', hardwareType=' .. device.hardwareType .. ')', utils.LOG_ERROR)
+			domoticz.log('If you believe this is not correct, please report on the forum.', utils.LOG_ERROR)
+		end
+
 		if (device.deviceSubType == 'RGBWW') or (device.deviceSubType == 'WW')  then
 			function device.setKelvin(kelvin)
 				local url
@@ -44,17 +50,27 @@ return {
 		end
 
 		function device.increaseBrightness()
-			local url
-			url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=brightnessup&type=command&idx=' .. device.id
-			return domoticz.openURL(url)
+			-- API will be removed; kept here until then to get user reports (if any)
+			if false and device.hardwareType and device.hardwareType == 'YeeLight LED' then 
+				local url
+				url = domoticz.settings['Domoticz url'] ..
+						'/json.htm?param=brightnessup&type=command&idx=' .. device.id
+				return domoticz.openURL(url)
+			else
+				methodNotAvailableMessage(device, 'increaseBrightness')
+			end
 		end
 
 		function device.decreaseBrightness()
-			local url
-			url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=brightnessdown&type=command&idx=' .. device.id
-			return domoticz.openURL(url)
+            -- API will be removed; kept here until then to get user reports (if any)
+			if false and device.hardwareType and device.hardwareType == 'YeeLight LED' then 
+				local url
+				url = domoticz.settings['Domoticz url'] ..
+						'/json.htm?param=brightnessdown&type=command&idx=' .. device.id
+				return domoticz.openURL(url)
+			else
+				methodNotAvailableMessage(device, 'decreaseBrightness')
+			end
 		end
 
 		function device.setNightMode()
@@ -65,13 +81,17 @@ return {
 		end
 
 		function device.setDiscoMode(modeNum)
-			if (type(modeNum) ~= 'number' or modeNum < 1 or modeNum > 9) then
-				domoticz.log('Mode number needs to be a number from 1-9', utils.LOG_ERROR)
+			if false then  -- API will be removed; kept here until then to get user reports (if any)
+                if (type(modeNum) ~= 'number' or modeNum < 1 or modeNum > 9) then
+                    domoticz.log('Mode number needs to be a number from 1-9', utils.LOG_ERROR)
+                end
+                local url
+                url = domoticz.settings['Domoticz url'] ..
+                        '/json.htm?param=discomodenum' .. tonumber(modeNum) .. '&type=command&idx=' .. device.id
+                return domoticz.openURL(url)
+            else
+				methodNotAvailableMessage(device, 'setDiscoMode')
 			end
-			local url
-			url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=discomodenum' .. tonumber(modeNum) .. '&type=command&idx=' .. device.id
-			return domoticz.openURL(url)
 		end
 
 		local function inRange(value, low, high)

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -41,12 +41,13 @@ else
 	echo dzVents will be tested against domoticz version $NewVersion.
 fi
  
- currenttime=$(date +%H:%M)
+currenttime=$(date +%H:%M)
 if [[ "$currenttime" > "00:00" ]] && [[ "$currenttime" < "00:31" ]]; then 
 	echo Script cannot be execute dbetween 00:00 and 00:30. Time checks will fail
 	exit 1
 fi	
 
+dzVersion=$(grep DZVERSION dzVents/runtime/Utils.lua | head -1 | grep -oP "'.*'"  | sed s/\'//g)
 
 function leadingZero
 	{
@@ -139,7 +140,7 @@ function fillNumberOfTests
 		ScriptdzVentsDispatching_ExpectedTests=2
 		TimedCommand_ExpectedTests=42
 		Time_ExpectedTests=326
-		Utils_ExpectedTests=19
+		Utils_ExpectedTests=24
 		Variable_ExpectedTests=15
 		ContactDoorLockInvertedSwitch_ExpectedTests=2
 		DelayedVariableScene_ExpectedTests=2
@@ -204,14 +205,13 @@ cp $basedir/domoticz.db $basedir/domoticz.db_$$
 rm -f $basedir/domoticz.db
 
 cd $basedir
-./domoticz > domoticz.log$$ &
+./domoticz  -www 8080 -sslwww 444 > domoticz.log$$ &
 checkStarted "domoticz" 20
 
 clear
-echo "========================= $NewVersion ================+========================== Tests ============================+"
-printf "|%6s %21s %83s " " time |" " test-script"  " | expected | tests | result | successful | failed |  seconds  |"
-echo
-echo "===================================================+=============================================================+"
+echo "========= domoticz $NewVersion, dzVents V$dzVersion =======+========================== Tests ==============================+"
+echo "  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |"
+echo "===================================================+===============================================================+"
 
 fillTimes
 fillNumberOfTests
@@ -252,6 +252,6 @@ else
 fi
 
 echo Total tests: $totalTest
-echo Finished without erors after $(showTime)
+echo $(date)';' dzVents version $dzVersion tested without erors after $(showTime)
 stopBackgroundProcesses 0
 cleanup

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -356,6 +356,7 @@ describe('device', function()
 			})
 
 			assert.is_same(12345, device.WhActual)
+			assert.is_same(12345, device.actualWatt)
 			device.updateEnergy(1000)
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="1000", _trigger=true} } }, commandArray)
 		end)
@@ -409,6 +410,7 @@ describe('device', function()
 			assert.is_same(5.789, device.counterDeliveredToday)
 			assert.is_same(5.6780, device.counterToday)
 			assert.is_same(12345, device.WhActual)
+			assert.is_same(12345, device.actualWatt)
 
 			device.updateP1(1, 2, 3, 4, 5, 6)
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="1;2;3;4;5;6", _trigger=true} } }, commandArray)
@@ -1636,19 +1638,37 @@ describe('device', function()
 				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=whitelight&type=command&idx=1' }, commandArray)
 			end)
 
+			local device = getDevice(domoticz, {
+					['name'] = 'myRGBW',
+					['state'] = 'Set Kelvin Level',
+					['subType'] = 'RGBWW',
+					['type'] = 'Color Switch',
+                    ['hardwareType'] = 'YeeLight LED',
+				})
+
 			it('should handle increaseBrightness method correctly', function()
-				commandArray = {}
+                commandArray = {}
+				domoticz.log = function(message)
+					msg = message
+				end
+
 				device.increaseBrightness()
-				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessup&type=command&idx=1' }, commandArray)
+				assert.is_not_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessup&type=command&idx=1' }, commandArray)
+                assert.is_same('If you believe this is not correct, please report on the forum.', msg)
 			end)
 
 			it('should handle decreaseBrightness method correctly', function()
-				commandArray = {}
-				device.decreaseBrightness()
-				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessdown&type=command&idx=1' }, commandArray)
+                commandArray = {}
+				domoticz.log = function(message)
+					msg = message
+				end
+				
+                device.decreaseBrightness()
+				assert.is_not_same({ 'http://127.0.0.1:8080/json.htm?param=brightnessdown&type=command&idx=1' }, commandArray)
+                assert.is_same('If you believe this is not correct, please report on the forum.', msg)
 			end)
-
-			it('should handle dsetNightMode method correctly', function()
+			
+            it('should handle setNightMode method correctly', function()
 				commandArray = {}
 				device.setNightMode()
 				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=nightlight&type=command&idx=1' }, commandArray)
@@ -1686,8 +1706,14 @@ describe('device', function()
 
 			it('should handle setDiscomode method correctly',function()
 				commandArray = {}
-				device.setDiscoMode(8)
-				assert.is_same({ 'http://127.0.0.1:8080/json.htm?param=discomodenum8&type=command&idx=1' }, commandArray)
+				
+                domoticz.log = function(message)
+					msg = message
+				end
+				
+                device.setDiscoMode(8)
+				assert.is_not_same({ 'http://127.0.0.1:8080/json.htm?param=discomodenum8&type=command&idx=1' }, commandArray)
+                assert.is_same('If you believe this is not correct, please report on the forum.', msg)
 			end)
 
 			it('should handle setHue method correctly',function()

--- a/dzVents/runtime/tests/testUtils.lua
+++ b/dzVents/runtime/tests/testUtils.lua
@@ -40,7 +40,7 @@ describe('event helpers', function()
 			assert.is_same('Error: (' .. utils.DZVERSION .. ') abc', printed)
 		end)
 
-		it('shoud log INFO by default', function()
+		it('should log INFO by default', function()
 			local printed
 
 			utils.print = function(msg)
@@ -54,7 +54,28 @@ describe('event helpers', function()
 			assert.is_same('Info: something', printed)
 		end)
 
-		it('shoud not log above level', function()
+		it('should log print with requested marker', function()
+			local printed
+
+			utils.print = function(msg)
+				printed = msg
+			end
+
+			_G.logLevel = utils.LOG_INFO
+			utils.log('something')
+			assert.is_same('Info: something', printed)
+
+			_G.moduleLabel = 'testUtils'
+			utils.setLogMarker()
+			utils.log('something')
+			assert.is_same('Info: testUtils: something', printed)
+
+			utils.setLogMarker('Busted')
+			utils.log('something')
+			assert.is_same('Info: Busted: something', printed)
+		end)
+
+		it('should not log above level', function()
 			local printed
 			utils.print = function(msg)
 				printed = msg
@@ -84,21 +105,21 @@ describe('event helpers', function()
 		assert.is_same(utils.rightPad('string',7,'@'),'string@')
 		assert.is_same(utils.rightPad('string',2),'string')
 	end)
-   
+
 	it('should left pad a string', function()
 		assert.is_same(utils.leftPad('string',7),' string')
 		assert.is_same(utils.leftPad('string',7,'@'),'@string')
 		assert.is_same(utils.leftPad('string',2),'string')
 	end)
-   
-   
+
+
 	it('should center and pad a string', function()
 		assert.is_same(utils.centerPad('string',8),' string ')
 		assert.is_same(utils.centerPad('string',8,'@'),'@string@')
 		assert.is_same(utils.centerPad('string',2),'string')
 	end)
-   
-	   
+
+
 	it('should pad a number with leading zeros', function()
 		assert.is_same(utils.leadingZeros(99,3),'099')
 		assert.is_same(utils.leadingZeros(999,2),'999')
@@ -144,7 +165,7 @@ describe('event helpers', function()
 		local t = utils.fromXML(xml, fallback)
 		assert.is_same('What a nice feature!', t.testXML)
 
-        local xml = nil
+		local xml = nil
 		local fallback  = { a=1 }
 		local t = utils.fromXML(xml, fallback)
 		assert.is_same(1, t['a'])
@@ -166,6 +187,49 @@ describe('event helpers', function()
 		local t = { a= 1 }
 		local res = utils.toXML(t, 'busted')
 		assert.is_same('<busted>\n<a>1</a>\n</busted>\n', res)
+	end)
+
+	it('should convert a string or number to base64Code', function()
+		local res = utils.toBase64('Busted in base64')
+		assert.is_same('QnVzdGVkIGluIGJhc2U2NA==', res)
+
+		local res = utils.toBase64(123.45)
+		assert.is_same('MTIzLjQ1', res)
+
+		local res = utils.toBase64(1234567890)
+		assert.is_same('MTIzNDU2Nzg5MA==', res)
+
+	end)
+
+	it('should send errormessage when sending table to toBase64', function()
+
+		utils.log = function(msg)
+			printed = msg
+		end
+
+		local t = { a= 1 }
+
+		local res = utils.toBase64(t)
+		assert.is_same('toBase64: parm should be a number or a string; you supplied a table', printed)
+
+	end)
+
+	it('should decode a base64 encoded string', function()
+		local res = utils.fromBase64('QnVzdGVkIGluIGJhc2U2NA==')
+		assert.is_same('Busted in base64', res)
+	end)
+
+	it('should send errormessage when sending table to fromBase64', function()
+
+		utils.log = function(msg)
+			printed = msg
+		end
+
+		local t = { a= 1 }
+
+		local res = utils.fromBase64(t)
+		assert.is_same('fromBase64: parm should be a string; you supplied a table', printed)
+
 	end)
 
 	it('should dump a table to log', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -16,7 +16,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("2.5.1")
+	m_version("2.5.2")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION

Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
Add toBase64 and fromBase64 function in utils
Add setLogMarker function in utils
Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and when used leave the device stateless)

```
========= domoticz V4.11539, dzVents V2.5.2 =======+========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        113      OK            113         0      1.1140
00:00:04  Domoticz                                      1         70      OK             70         0      0.9637
00:00:05  EventHelpers                                  1         32      OK             32         0      0.8113
00:00:06  EventHelpersStorage                           1         50      OK             50         0      0.8123
00:00:07  HTTPResponse                                  1          6      OK              6         0      0.0493
00:00:07  ScriptdzVentsDispatching                      1          2      OK              2         0      0.1891
00:00:08  TimedCommand                                  1         42      OK             42         0      0.3093
00:00:08  Time                                          3        326      OK            326         0      2.2479
00:00:10  Utils                                         1         24      OK             24         0      0.1313
00:00:11  Variable                                      1         15      OK             15         0      0.0949
00:00:11  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.2156
00:00:14  DelayedVariableScene                          8          2      OK              2         0      7.2046
00:00:22  EventState                                   19          2      OK              2         0     18.2432
00:00:40  Integration                                  33        217      OK            217         0     32.5639
00:01:13  SelectorSwitch                               10          2      OK              2         0      9.6634


Total tests: 905
Sat Nov 30 15:53:50 CET 2019; dzVents version 2.5.2 tested without erors after 00:01:23
```	

