### PR TITLE
Implementing timeouts in ASyncTCP class.

### DIFF
--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -19,7 +19,7 @@
 
 extern std::string szAppVersion;
 
-#define TIMEOUT 60
+#define PROXY_TIMEOUT 60
 #define PONG "PONG"
 
 namespace http {
@@ -30,6 +30,8 @@ namespace http {
 		CProxyClient::CProxyClient() : ASyncTCP(PROXY_SECURE)
 		{
 			m_pDomServ = NULL;
+			/* use default value for tcp timeouts */
+			SetTimeout(PROXY_TIMEOUT);
 		}
 
 		void CProxyClient::Reset()


### PR DESCRIPTION
After refactoring CProxyClient to use the ASyncTCP class, it lost its timeout capabilities.
This PR re-introduces timeouts for all ASyncTCP clients. By default. it is turned off in order to not break other current ASyncTCP derivates.