### PR TITLE
correct query range for meter reports

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6044,7 +6044,7 @@ void CSQLHelper::AddCalendarTemperature()
 		std::vector<std::string> sddev = itt;
 		uint64_t ID = std::strtoull(sddev[0].c_str(), nullptr, 10);
 
-		result = safe_query("SELECT MIN(Temperature), MAX(Temperature), AVG(Temperature), MIN(Chill), MAX(Chill), AVG(Humidity), AVG(Barometer), MIN(DewPoint), MIN(SetPoint), MAX(SetPoint), AVG(SetPoint) FROM Temperature WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT MIN(Temperature), MAX(Temperature), AVG(Temperature), MIN(Chill), MAX(Chill), AVG(Humidity), AVG(Barometer), MIN(DewPoint), MIN(SetPoint), MAX(SetPoint), AVG(SetPoint) FROM Temperature WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6123,7 +6123,7 @@ void CSQLHelper::AddCalendarUpdateRain()
 
 		if (subType == sTypeRAINWU || subType == sTypeRAINByRate)
 		{
-			result = safe_query("SELECT Total, Total, Rate FROM Rain WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q') ORDER BY ROWID DESC LIMIT 1",
+			result = safe_query("SELECT Total, Total, Rate FROM Rain WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00') ORDER BY ROWID DESC LIMIT 1",
 				ID,
 				szDateStart,
 				szDateEnd
@@ -6131,7 +6131,7 @@ void CSQLHelper::AddCalendarUpdateRain()
 		}
 		else
 		{
-			result = safe_query("SELECT MIN(Total), MAX(Total), MAX(Rate) FROM Rain WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+			result = safe_query("SELECT MIN(Total), MAX(Total), MAX(Rate) FROM Rain WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 				ID,
 				szDateStart,
 				szDateEnd
@@ -6249,7 +6249,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 		}
 
 
-		result = safe_query("SELECT MIN(Value), MAX(Value), AVG(Value) FROM Meter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT MIN(Value), MAX(Value), AVG(Value) FROM Meter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6429,7 +6429,7 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 		//_eMeterType metertype=(_eMeterType)switchtype;
 
 		result = safe_query(
-			"SELECT MIN(Value1), MAX(Value1), MIN(Value2), MAX(Value2), MIN(Value3), MAX(Value3), MIN(Value4), MAX(Value4), MIN(Value5), MAX(Value5), MIN(Value6), MAX(Value6) FROM MultiMeter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+			"SELECT MIN(Value1), MAX(Value1), MIN(Value2), MAX(Value2), MIN(Value3), MAX(Value3), MIN(Value4), MAX(Value4), MIN(Value5), MAX(Value5), MIN(Value6), MAX(Value6) FROM MultiMeter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6537,7 +6537,7 @@ void CSQLHelper::AddCalendarUpdateWind()
 		std::vector<std::string> sddev = itt;
 		uint64_t ID = std::strtoull(sddev[0].c_str(), nullptr, 10);
 
-		result = safe_query("SELECT AVG(Direction), MIN(Speed), MAX(Speed), MIN(Gust), MAX(Gust) FROM Wind WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT AVG(Direction), MIN(Speed), MAX(Speed), MIN(Gust), MAX(Gust) FROM Wind WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6595,7 +6595,7 @@ void CSQLHelper::AddCalendarUpdateUV()
 		std::vector<std::string> sddev = itt;
 		uint64_t ID = std::strtoull(sddev[0].c_str(), nullptr, 10);
 
-		result = safe_query("SELECT MAX(Level) FROM UV WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT MAX(Level) FROM UV WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6645,7 +6645,7 @@ void CSQLHelper::AddCalendarUpdatePercentage()
 		std::vector<std::string> sddev = itt;
 		uint64_t ID = std::strtoull(sddev[0].c_str(), nullptr, 10);
 
-		result = safe_query("SELECT MIN(Percentage), MAX(Percentage), AVG(Percentage) FROM Percentage WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT MIN(Percentage), MAX(Percentage), AVG(Percentage) FROM Percentage WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd
@@ -6699,7 +6699,7 @@ void CSQLHelper::AddCalendarUpdateFan()
 		std::vector<std::string> sddev = itt;
 		uint64_t ID = std::strtoull(sddev[0].c_str(), nullptr, 10);
 
-		result = safe_query("SELECT MIN(Speed), MAX(Speed), AVG(Speed) FROM Fan WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<'%q')",
+		result = safe_query("SELECT MIN(Speed), MAX(Speed), AVG(Speed) FROM Fan WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
 			szDateStart,
 			szDateEnd

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -16553,25 +16553,34 @@ namespace http {
 
 							root["result"][ii]["d"] = szDateEnd;
 
-							std::string szValue;
-
-							sprintf(szTmp, "%llu", total_real_usage_1);
-							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", (float)(total_real_usage_1 / divider));
 							root["result"][ii]["v"] = szTmp;
-							sprintf(szTmp, "%llu", total_real_usage_2);
-							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", (float)(total_real_usage_2 / divider));
 							root["result"][ii]["v2"] = szTmp;
 
-							sprintf(szTmp, "%llu", total_real_deliv_1);
-							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", (float)(total_real_deliv_1 / divider));
 							root["result"][ii]["r1"] = szTmp;
-							sprintf(szTmp, "%llu", total_real_deliv_2);
-							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", (float)(total_real_deliv_2 / divider));
 							root["result"][ii]["r2"] = szTmp;
+
+							sprintf(szTmp, "%.3f", (float)(total_min_usage_1 / divider));
+							root["result"][ii]["c1"] = szTmp;
+							sprintf(szTmp, "%.3f", (float)(total_min_usage_2 / divider));
+							root["result"][ii]["c3"] = szTmp;
+
+							if (total_max_deliv_2 != 0)
+							{
+								sprintf(szTmp, "%.3f", (float)(total_min_deliv_1 / divider));
+								root["result"][ii]["c2"] = szTmp;
+								sprintf(szTmp, "%.3f", (float)(total_min_deliv_2 / divider));
+								root["result"][ii]["c4"] = szTmp;
+							}
+							else
+							{
+								strcpy(szTmp, "0");
+								root["result"][ii]["c2"] = szTmp;
+								root["result"][ii]["c4"] = szTmp;
+							}
 
 							ii++;
 						}


### PR DESCRIPTION
As discussed in issue #3896 the daily totals in meter reports do not include the last 5 minutes of the day due to the fact that the following midnight belongs to the next day. This patch extends the range for the various updates to `(multi)meter_calendar` to include the midnight value.

Additionally I reviewed the code for creating the line for `today` in the P1 report and added the missing `MIN(counter)` values to it. 