### PR TITLE
Fixing lua table uservariables_lastupdate returning nothing

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3049,7 +3049,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	uservariablesMutexLock.unlock();
 
 	boost::shared_lock<boost::shared_mutex> scenesgroupsMutexLock(m_scenesgroupsMutex);
-	luaTable = new CLuaTable(lua_state, "uservariables_lastupdate", (int)m_scenesgroups.size(), 0);
+	luaTable = new CLuaTable(lua_state, "otherdevices_scenesgroups", (int)m_scenesgroups.size(), 0);
 	std::map<uint64_t, _tScenesGroups>::const_iterator it_scgr;
 	for (it_scgr = m_scenesgroups.begin(); it_scgr != m_scenesgroups.end(); ++it_scgr) {
 		_tScenesGroups sgitem = it_scgr->second;


### PR DESCRIPTION
solve issue #3919, lua table uservariables_lastupdate was created twice, second one should be renamed to otherdevices_scenesgroups.