### PR TITLE
Get rid of annoying "Async Secure Read Exception: 1, stream truncated"

### DIFF
--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -481,6 +481,7 @@ namespace Plugins {
 			else
 			{
 				if ((e.value() != boost::asio::error::eof) &&
+					(e.value() != 1) &&	// Stream truncated, this exception occurs when third party closes the connection
 					(e.value() != 121) &&	// Semaphore timeout expiry or end of file aka 'lost contact'
 					(e.value() != 125) &&	// Operation canceled
 					(e != boost::asio::error::operation_aborted) &&


### PR DESCRIPTION
It happens with plugins that use https connection, when the third party closes the connection (meaning most of the time)