### PR TITLE
add missing includes

### DIFF
--- a/main/Logger.h
+++ b/main/Logger.h
@@ -4,6 +4,9 @@
 #include <list>
 #include <string>
 #include <fstream>
+#include <mutex>
+#include <map>
+#include <sstream>
 
 enum _eLogLevel : uint32_t
 {

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <string>
+#include <map>
+#include <vector>
 
 #define sTypeTH_LC_TC 0xA0   //La Cross Temp_Hum combined
 #define sTypeTEMP_SYSTEM 0xA0  //Internal sensor

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <string>
+#include <iomanip>
+#include <map>
+#include <thread>
+#include <vector>
+
 #include "RFXNames.h"
 #include "../hardware/hardwaretypes.h"
 #include "Helper.h"


### PR DESCRIPTION
Extracted from closed PR:
https://github.com/domoticz/domoticz/pull/3876

- allows the given files to be complied in different contexts
- required by new blebox integration (mitigates precompiled header issues)
- reduces dependency on obsolete Microsoft/stdafx precompiled header setup
