### PR TITLE
www: move Update button next to Add (HW setup)

### DIFF
--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -453,7 +453,6 @@
 	<table id="updelclr" border="0" cellpadding="0" cellspacing="0" width="100%">
 		<tr>
 			<td>
-				<a class="btnstyle3-dis" id="hardwareupdate" data-i18n="Update">Update</a>&nbsp;&nbsp;&nbsp;
 				<a class="btnstyle3-dis" id="hardwaredelete" data-i18n="Delete">Delete</a>
 			</td>
 		</tr>
@@ -1322,6 +1321,7 @@
 			<tr>
 				<td align="right" style="width:110px"></td>
 				<td><a class="btnstyle3" onclick="AddHardware();" data-i18n="Add">Add</a></td>
+				<td><a class="btnstyle3-dis" id="hardwareupdate" data-i18n="Update">Update</a></td>
 			</tr>
 		</table>
 	</div>

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -3093,7 +3093,7 @@ define(['app'], function (app) {
 		RefreshHardwareTable = function () {
 			$('#modal').show();
 
-			$('#updelclr #hardwareupdate').attr("class", "btnstyle3-dis");
+			$("#hardwarecontent #hardwareupdate").attr("class", "btnstyle3-dis");
 			$('#updelclr #hardwaredelete').attr("class", "btnstyle3-dis");
 
 			var oTable = $('#hardwaretable').dataTable();
@@ -3345,24 +3345,24 @@ define(['app'], function (app) {
 			$("#hardwaretable tbody").on('click', 'tr', function () {
 				if ($(this).hasClass('row_selected')) {
 					$(this).removeClass('row_selected');
-					$('#updelclr #hardwareupdate').attr("class", "btnstyle3-dis");
+					$("#hardwarecontent #hardwareupdate").attr("class", "btnstyle3-dis");
 					$('#updelclr #hardwaredelete').attr("class", "btnstyle3-dis");
 				}
 				else {
 					var oTable = $('#hardwaretable').dataTable();
 					oTable.$('tr.row_selected').removeClass('row_selected');
 					$(this).addClass('row_selected');
-					$('#updelclr #hardwareupdate').attr("class", "btnstyle3");
+					$("#hardwarecontent #hardwareupdate").attr("class", "btnstyle3");
 					$('#updelclr #hardwaredelete').attr("class", "btnstyle3");
 					var anSelected = fnGetSelected(oTable);
 					if (anSelected.length !== 0) {
 						var data = oTable.fnGetData(anSelected[0]);
 						var idx = data["DT_RowId"];
 						if (data["Type"] != "PLUGIN") { // Plugins can have non-numeric Mode data
-							$("#updelclr #hardwareupdate").attr("href", "javascript:UpdateHardware(" + idx + "," + data["Mode1"] + "," + data["Mode2"] + "," + data["Mode3"] + "," + data["Mode4"] + "," + data["Mode5"] + "," + data["Mode6"] + ")");
+							$("#hardwarecontent #hardwareupdate").attr("href", "javascript:UpdateHardware(" + idx + "," + data["Mode1"] + "," + data["Mode2"] + "," + data["Mode3"] + "," + data["Mode4"] + "," + data["Mode5"] + "," + data["Mode6"] + ")");
 						}
 						else {
-							$("#updelclr #hardwareupdate").attr("href", "javascript:UpdateHardware(" + idx + ",'" + data["Mode1"] + "','" + data["Mode2"] + "','" + data["Mode3"] + "','" + data["Mode4"] + "','" + data["Mode5"] + "','" + data["Mode6"] + "')");
+							$("#hardwarecontent #hardwareupdate").attr("href", "javascript:UpdateHardware(" + idx + ",'" + data["Mode1"] + "','" + data["Mode2"] + "','" + data["Mode3"] + "','" + data["Mode4"] + "','" + data["Mode5"] + "','" + data["Mode6"] + "')");
 						}
 						$("#updelclr #hardwaredelete").attr("href", "javascript:DeleteHardware(" + idx + ")");
 						$("#hardwarecontent #hardwareparamstable #hardwarename").val(data["Name"]);


### PR DESCRIPTION
Extracted from closed PR:
#3876

In the web hardware setup, the location of the "Update" button is non intuitive.

This moves it next to the "Add" button under the input fields.

(So the user can select a hardware device from the table, change it's options using inputs, and click "Update" when done).

Ideally, the "Add" / "Update" form should pop up as a modal dialog, but that's not worth the time until web assets are built through a pipeline.