### PR TITLE
use HW type to determine correct non-RFX device names

### DIFF
--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -52,7 +52,7 @@ bool CDummy::WriteToHardware(const char *pdata, const unsigned char length)
 	if (pdata[1] == pTypeGeneral)
 	{
 		const _tGeneralDevice *pMeter = reinterpret_cast<const _tGeneralDevice*>(pdata);
-		sdevicetype += "/" + std::string(RFX_Type_SubType_Desc(pMeter->type, pMeter->subtype));
+		sdevicetype += "/" + std::string(RFX_Type_SubType_Desc(pMeter->type, pMeter->subtype, 0));
 	}
 	Log(LOG_STATUS, "Received null operation for %s", sdevicetype.c_str());
 #endif

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -663,7 +663,7 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 	if (!m_IsConnected)
 		return;
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Name, [Type], SubType, nValue, sValue, SwitchType, SignalLevel, BatteryLevel, Options, Description, LastLevel, Color FROM DeviceStatus WHERE (HardwareID==%d) AND (ID==%" PRIu64 ")", HwdID, DeviceRowIdx);
+	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, D.Name, D.Type, SubType, nValue, sValue, SwitchType, SignalLevel, BatteryLevel, Options, Description, LastLevel, Color, H.Type FROM DeviceStatus D, Hardware H WHERE (HardwareID==%d) AND (HardwareID==H.ID) AND (D.ID==%" PRIu64 ")", HwdID, DeviceRowIdx);
 	if (!result.empty())
 	{
 		int iIndex = 0;
@@ -683,6 +683,7 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		std::string description = sd[iIndex++];
 		int LastLevel = atoi(sd[iIndex++].c_str());
 		std::string sColor = sd[iIndex++];
+		int hw_type = atoi(sd[iIndex++].c_str());
 
 		Json::Value root;
 
@@ -692,7 +693,7 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		root["unit"] = dunit;
 		root["name"] = name;
 		root["dtype"] = RFX_Type_Desc((uint8_t)dType,1);
-		root["stype"] = RFX_Type_SubType_Desc((uint8_t)dType, (uint8_t)dSubType);
+		root["stype"] = RFX_Type_SubType_Desc((uint8_t)dType, (uint8_t)dSubType, hw_type);
 
 		if (IsLightOrSwitch(dType, dSubType) == true) {
 			root["switchType"] = Switch_Type_Desc(switchType);

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -541,7 +541,19 @@ const char* RFX_Type_Desc(const unsigned char i, const unsigned char snum)
 	return findTableIDSingle2(Table, i);
 }
 
-const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char sType)
+// TODO: check for any non-RFX hardware, not just BleBox
+// (invert the logic - return true only if HTYPE_RFX*, etc.)
+static bool Is_Rfx_HardwareType(int hw_type) {
+  switch (hw_type) {
+  case HTYPE_BleBox:
+    return false;
+
+  default:
+    return true;
+  }
+}
+
+const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char sType, int hw_type)
 {
 	static const STR_TABLE_ID1_ID2	Table[] =
 	{
@@ -955,7 +967,22 @@ const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 	{ pTypeGeneralSwitch, sSwitchTypeV2Phoenix, "V2Phoenix" },
 	{ 0,0,NULL }
 	};
-	return findTableID1ID2(Table, dType, sType);
+
+  if (!Is_Rfx_HardwareType(hw_type)) {
+    static const STR_TABLE_SINGLE GenericTypesTable[] = {
+        {pTypeTEMP, "Generic temperature sensor"},
+        {pTypeAirQuality, "Generic air quality sensor"},
+    };
+
+    auto t = GenericTypesTable;
+    while (t->str1) {
+      if (t->id == dType)
+        return t->str1;
+      t++;
+    }
+  }
+
+  return findTableID1ID2(Table, dType, sType);
 }
 
 const char* Media_Player_States(const _eMediaStatus Status)

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -255,7 +255,7 @@ enum _eNotificationTypes
 };
 
 const char *RFX_Type_Desc(const unsigned char i, const unsigned char snum);
-const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char sType);
+const char *RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char sType, int hw_type);
 unsigned char Get_Humidity_Level(const unsigned char hlevel);
 const char *RFX_Humidity_Status_Desc(const unsigned char status);
 const char *Switch_Type_Desc(const _eSwitchType sType);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -8694,3 +8694,13 @@ float CSQLHelper::GetCounterDivider(const int metertype, const int dType, const 
 	}
 	return divider;
 }
+
+// NOTE: used only for obtaining devices names, so returning 0 is ok
+int CSQLHelper::GetHardwareType(int hw_id) const {
+	try {
+		const char *query = "SELECT Type FROM Hardware WHERE ID==%d";
+		return std::stoi(m_sql.safe_query(query, hw_id).at(0).at(0));
+	} catch (std::out_of_range &) { return 0; } catch (std::invalid_argument &) {
+		return 0;
+	}
+}

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -429,6 +429,7 @@ public:
 	bool SetDeviceOptions(const uint64_t idx, const std::map<std::string, std::string> & options);
 
 	float GetCounterDivider(const int metertype, const int dType, const float DefaultValue);
+	int GetHardwareType(int hw_id) const;
 public:
 	std::string m_LastSwitchID;	//for learning command
 	uint64_t m_LastSwitchRowID;

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -788,8 +788,11 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 	for (iterator = m_mainworker.m_eventsystem.m_devicestates.begin(); iterator != m_mainworker.m_eventsystem.m_devicestates.end(); ++iterator)
 	{
 		CEventSystem::_tDeviceStatus sitem = iterator->second;
+
+		int hw_type = m_sql.GetHardwareType(sitem.hardwareID);
+
 		const char *dev_type = RFX_Type_Desc(sitem.devType, 1);
-		const char *sub_type = RFX_Type_SubType_Desc(sitem.devType, sitem.subType);
+		const char *sub_type = RFX_Type_SubType_Desc(sitem.devType, sitem.subType, hw_type);
 
 		bool triggerDevice = false;
 		std::vector<CEventSystem::_tEventQueue>::const_iterator itt;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -2480,7 +2480,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 		if (pRXCommand[1] == pTypeGeneral)
 		{
 			const _tGeneralDevice* pMeter = reinterpret_cast<const _tGeneralDevice*>(pRXCommand);
-			sdevicetype += "/" + std::string(RFX_Type_SubType_Desc(pMeter->type, pMeter->subtype));
+			sdevicetype += "/" + std::string(RFX_Type_SubType_Desc(pMeter->type, pMeter->subtype, pHardware->HwdType));
 		}
 		std::stringstream sTmp;
 		sTmp << "(" << pHardware->m_Name << ") " << sdevicetype << " (" << DeviceName << ")";

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -463,10 +463,10 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 	}
 
 	if (nexpected > 0) {
-		_log.Log(LOG_STATUS, "Warning: Expecting svalue with at least %d elements separated by semicolon, %d elements received (\"%s\"), notification not sent (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s)", nexpected, nsize, sValue.c_str(), HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+		_log.Log(LOG_STATUS, "Warning: Expecting svalue with at least %d elements separated by semicolon, %d elements received (\"%s\"), notification not sent (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s)", nexpected, nsize, sValue.c_str(), HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType, pHardware->HwdType));
 	}
 	else {
-		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s), please report on GitHub!", HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType));
+		_log.Log(LOG_STATUS, "Warning: Notification NOT handled (Hardware: %d - %s, ID: %s, Unit: %d, Type: %02X - %s, SubType: %d - %s), please report on GitHub!", HardwareID, hName.c_str(), ID.c_str(), unit, cType, RFX_Type_Desc(cType, 1), cSubType, RFX_Type_SubType_Desc(cType, cSubType, pHardware->HwdType));
 	}
 
 	return false;

--- a/push/GooglePubSubPush.cpp
+++ b/push/GooglePubSubPush.cpp
@@ -115,8 +115,8 @@ void CGooglePubSubPush::DoGooglePubSubPush()
 #endif
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query(
-		"SELECT A.DeviceID, A.DelimitedValue, B.ID, B.Type, B.SubType, B.nValue, B.sValue, A.TargetType, A.TargetVariable, A.TargetDeviceID, A.TargetProperty, A.IncludeUnit, B.SwitchType, strftime('%%s', B.LastUpdate), B.Name FROM GooglePubSubLink as A, DeviceStatus as B "
-		"WHERE (A.DeviceID == '%" PRIu64 "' AND A.Enabled = '1' AND A.DeviceID==B.ID)",
+		"SELECT A.DeviceID, A.DelimitedValue, B.ID, B.Type, B.SubType, B.nValue, B.sValue, A.TargetType, A.TargetVariable, A.TargetDeviceID, A.TargetProperty, A.IncludeUnit, B.SwitchType, strftime('%%s', B.LastUpdate), B.Name, H.Type FROM GooglePubSubLink as A, DeviceStatus as B, Hardware as H "
+		"WHERE (A.DeviceID == '%" PRIu64 "' AND A.Enabled = '1' AND A.DeviceID==B.ID AND B.HardwareID == H.ID)",
 		m_DeviceRowIdx);
 	if (!result.empty())
 	{
@@ -167,6 +167,8 @@ void CGooglePubSubPush::DoGooglePubSubPush()
 			char szLocalTimeUtcMs[21];
 			sprintf(szLocalTimeUtcMs, "%llu", localTimeUtc * 1000);
 
+			int hw_type = atoi(sd[22].c_str());
+
 			std::string llastUpdate = get_lastUpdate(localTimeUtc);
 
 			// Replace keywords
@@ -189,7 +191,7 @@ void CGooglePubSubPush::DoGooglePubSubPush()
 
 			std::string lunit = getUnit(delpos, metertype);
 			std::string lType = RFX_Type_Desc(dType, 1);
-			std::string lSubType = RFX_Type_SubType_Desc(dType, dSubType);
+			std::string lSubType = RFX_Type_SubType_Desc(dType, dSubType, hw_type);
 
 			char hostname[256];
 			gethostname(hostname, sizeof(hostname));

--- a/push/HttpPush.cpp
+++ b/push/HttpPush.cpp
@@ -71,8 +71,8 @@ void CHttpPush::DoHttpPush()
 	}
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query(
-		"SELECT A.DeviceID, A.DelimitedValue, B.ID, B.Type, B.SubType, B.nValue, B.sValue, A.TargetType, A.TargetVariable, A.TargetDeviceID, A.TargetProperty, A.IncludeUnit, B.SwitchType, strftime('%%s', B.LastUpdate), B.Name FROM HttpLink as A, DeviceStatus as B "
-		"WHERE (A.DeviceID == '%" PRIu64 "' AND A.Enabled = '1' AND A.DeviceID==B.ID)",
+		"SELECT A.DeviceID, A.DelimitedValue, B.ID, B.Type, B.SubType, B.nValue, B.sValue, A.TargetType, A.TargetVariable, A.TargetDeviceID, A.TargetProperty, A.IncludeUnit, B.SwitchType, strftime('%%s', B.LastUpdate), B.Name, H.Type FROM HttpLink as A, DeviceStatus as B , Hardware as H "
+		"WHERE (A.DeviceID == '%" PRIu64 "' AND A.Enabled = '1' AND A.DeviceID==B.ID AND B.HardwareID == H.ID)",
 		m_DeviceRowIdx);
 	if (!result.empty())
 	{
@@ -105,6 +105,7 @@ void CHttpPush::DoHttpPush()
 			std::string ltargetVariable = sd[8].c_str();
 			std::string ltargetDeviceId = sd[9].c_str();
 			std::string lname = sd[14].c_str();
+			int hw_type = atoi(sd[15].c_str());
 			sendValue = sValue;
 
 			unsigned long tzoffset = get_tzoffset();
@@ -148,7 +149,7 @@ void CHttpPush::DoHttpPush()
 
 			std::string lunit = getUnit(delpos, metertype);
 			std::string lType = RFX_Type_Desc(dType, 1);
-			std::string lSubType = RFX_Type_SubType_Desc(dType, dSubType);
+			std::string lSubType = RFX_Type_SubType_Desc(dType, dSubType, hw_type);
 
 			char hostname[256];
 			gethostname(hostname, sizeof(hostname));


### PR DESCRIPTION
Extracted from closed PR:
#3876

Allows showing generic names (like "generic temperature") for non-RFX devices, instead of confusing RFX default devices like "Lacross TX" or "Voltcraft".

This allows supporting new products based on existing RFX types, but without their confusing names.

"0" means the previous functionality is used.