### PR TITLE
travis: update cmake to 3.16.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ matrix:
           - libdigest-sha-perl
           - python3-dev
     script:
-      - curl -sSL https://github.com/Kitware/CMake/releases/download/v3.14.3/cmake-3.14.3-Linux-x86_64.tar.gz -o cmake.tar.gz;
+      - curl -sSL https://github.com/Kitware/CMake/releases/download/v3.16.3/cmake-3.16.3-Linux-x86_64.tar.gz -o cmake.tar.gz;
       - sudo tar xf cmake.tar.gz --strip 1 -C /usr/local;
       - export PATH=/usr/local/bin:$PATH;
       - wget https://dl.bintray.com/boostorg/release/1.72.0/source/boost_1_72_0.tar.gz >> /dev/null 2>&1


### PR DESCRIPTION
Extracted from closed PR: #3876

Updates CMake to 3.16, which enables useful feature like built-in precompiled header support, more and better default modules, and lots of bug fixes.

Distros often contain very old versions of CMake, so it usually has to be downloaded and installed anyway - and so, it makes no sense to support older versions of CMake.