### PR TITLE
Allow compiling with external JSonCPP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,28 @@ ELSE(USE_BUILTIN_SQLITE)
   ENDIF(SQLite_FOUND)
 ENDIF(USE_BUILTIN_SQLITE)
 
+option(USE_BUILTIN_JSONCPP "Use builtin JSonCPP" YES)
+IF(USE_BUILTIN_JSONCPP)
+  MESSAGE(STATUS "Using builtin JSonCPP")
+  set (domoticz_jsoncpp_SRCS
+       json/json_reader.cpp
+       json/json_value.cpp
+       json/json_writer.cpp
+  )
+ELSE(USE_BUILTIN_JSCONCPP)
+  MESSAGE(STATUS "Using external JSonCPP")
+  find_package(PkgConfig)
+  pkg_check_modules(JSONCPP jsoncpp)
+  IF(JSONCPP_FOUND)
+    INCLUDE_DIRECTORIES(${JSONCPP_INCLUDE_DIRS})
+    add_definitions(-DWITH_EXTERNAL_JSONCPP)
+    link_directories(${JSONCPP_LIBRARY_DIRS})
+    MESSAGE(STATUS "JSonCPP found at ${JSONCPP_INCLUDE_DIRS} and ${JSONCPP_LIBRARY_DIRS}")
+  ELSE(JSCONCPP_FOUND)
+    MESSAGE(FATAL_ERROR "JSonCPP not found but USE_BUILTIN_JSONCPP=NO")
+  ENDIF(JSONCPP_FOUND)
+ENDIF(USE_BUILTIN_JSONCPP)
+
 option(USE_PYTHON "Use Python for Plugins and Event-Scripts" YES)
 IF(USE_PYTHON)
   find_package(PythonInterp 3.4)
@@ -532,9 +554,6 @@ webserver/request_parser.cpp
 webserver/server.cpp
 webserver/Websockets.cpp
 webserver/WebsocketHandler.cpp
-json/json_reader.cpp
-json/json_value.cpp
-json/json_writer.cpp
 tinyxpath/action_store.cpp
 tinyxpath/htmlutil.cpp
 tinyxpath/lex_util.cpp
@@ -552,7 +571,7 @@ tinyxpath/xpath_stack.cpp
 tinyxpath/xpath_static.cpp
 tinyxpath/xpath_syntax.cpp
 )
-add_executable(domoticz ${domoticz_SRCS})
+add_executable(domoticz ${domoticz_SRCS} ${domoticz_jsoncpp_SRCS})
 
 # explicitly say that the executable depends on the revisiontag
 add_dependencies(domoticz revisiontag)
@@ -742,7 +761,7 @@ else()
   message(STATUS "Not found telldus-core (telldus-core.h), not adding tellstick support")
 endif (TELLDUSCORE_INCLUDE)
 
-target_link_libraries(domoticz ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${MINIZIP_LIBRARIES} ${CURL_LIBRARIES} pthread ${MQTT_LIBRARIES} ${LUA_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES})
+target_link_libraries(domoticz ${Boost_LIBRARIES} ${ZLIB_LIBRARIES} ${MINIZIP_LIBRARIES} ${CURL_LIBRARIES} pthread ${MQTT_LIBRARIES} ${LUA_LIBRARIES} ${SQLite_LIBRARIES} ${CMAKE_DL_LIBS} ${TELLDUS_LIBRARIES} ${JSONCPP_LIBRARIES})
 
 IF(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   target_link_libraries(domoticz -lresolv)

--- a/main/json_helper.h
+++ b/main/json_helper.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef WITH_EXTERNAL_JSONCPP
+#include <json/json.h>
+#else
 #include "../json/json.h"
+#endif
 
 bool ParseJSon(const std::string& inStr, Json::Value& json_output, std::string* errstr = nullptr);
 bool ParseJSonStrict(const std::string& inStr, Json::Value& json_output, std::string* errstr = nullptr);


### PR DESCRIPTION
This small patch permit to compile if the user / maintainer need / want Domoticz with an external JSonCPP library. 
Avoiding to have code that is not shared by the project.
This patch works on my FreeBSD port for days, without any pain.
Please consider adding this into Domoticz since it does not change the original way it is compiled (like for example zlib / minizip dependency).
Regards,