### PR TITLE
Allow domoticz to build with external cereal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,21 @@ IF (INCLUDE_SPI)
 	ENDIF (HAVE_LINUX_SPI_H)
 ENDIF (INCLUDE_SPI)
 
+option(USE_BUILTIN_CEREAL "Build with built-in cereal" YES)
+include(CheckIncludeFileCXX)
+if(USE_BUILTIN_CEREAL)
+  find_path(cereal_INCLUDE_DIR cereal/cereal.hpp PATHS ${CMAKE_CURRENT_LIST_DIR})
+else(USE_BUILDIN_CEREAL)
+  find_path(cereal_INCLUDE_DIR cereal/cereal.hpp)
+endif(USE_BUILDIN_CEREAL)
+mark_as_advanced(cereal_INCLUDE_DIR)
+include_directories(${cereal_INCLUDE_DIR})
+set(CMAKE_REQUIRED_INCLUDES "${cereal_INCLUDE_DIR}")
+check_include_file_cxx("cereal/cereal.hpp" cereal_FOUND)
+if(NOT cereal_FOUND)
+  MESSAGE(FATAL_ERROR "cereal missing. install e.g. libcereal-dev")
+endif(cereal_FOUND)
+
 #set(CMAKE_EXE_LINKER_FLAGS "-static")
 
 # Macro for setting up precompiled headers. Usage:

--- a/hardware/ColorSwitch.h
+++ b/hardware/ColorSwitch.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cereal/cereal.hpp>
+
 namespace Json
 {
 	class Value;

--- a/hardware/ColorSwitch.h
+++ b/hardware/ColorSwitch.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef WIN32
+#include "../cereal/cereal.hpp"
+#else
 #include <cereal/cereal.hpp>
+#endif
 
 namespace Json
 {

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -4,10 +4,10 @@
 #include "../main/RFXNames.h"
 #include "../main/StoppableTask.h"
 // type support
-#include "../cereal/types/string.hpp"
-#include "../cereal/types/memory.hpp"
+#include <cereal/types/string.hpp>
+#include <cereal/types/memory.hpp>
 // the archiver
-#include "../cereal/archives/portable_binary.hpp"
+#include <cereal/archives/portable_binary.hpp>
 
 enum _eLogLevel : uint32_t;
 enum _eDebugLevel : uint32_t;

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -3,11 +3,19 @@
 #include <boost/signals2.hpp>
 #include "../main/RFXNames.h"
 #include "../main/StoppableTask.h"
+#ifdef WIN32
+// type support
+#include "../cereal/types/string.hpp"
+#include "../cereal/types/memory.hpp"
+// the archiver
+#include "../cereal/archives/portable_binary.hpp"
+#else
 // type support
 #include <cereal/types/string.hpp>
 #include <cereal/types/memory.hpp>
 // the archiver
 #include <cereal/archives/portable_binary.hpp>
+#endif
 
 enum _eLogLevel : uint32_t;
 enum _eDebugLevel : uint32_t;

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../cereal/cereal.hpp"
+#include <cereal/cereal.hpp>
 //#include "../cereal/types/string.hpp"
 //#include "../cereal/types/utility.hpp"
 //#include "../cereal/types/memory.hpp"

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#ifdef WIN32
+#include "../cereal/cereal.hpp"
+#else
 #include <cereal/cereal.hpp>
+#endif
 //#include "../cereal/types/string.hpp"
 //#include "../cereal/types/utility.hpp"
 //#include "../cereal/types/memory.hpp"

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -59,7 +59,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NOMINMAX;ENABLE_PYTHON;_DEBUG;PTW32_STATIC_LIB;WITH_OPENZWAVE;OPENZWAVE_USEDLL;WWW_ENABLE_SSL;HAVE_SNPRINTF;WITH_TLS;_CONSOLE;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <EnablePREfast>false</EnablePREfast>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -59,7 +59,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NOMINMAX;ENABLE_PYTHON;_DEBUG;PTW32_STATIC_LIB;WITH_OPENZWAVE;OPENZWAVE_USEDLL;WWW_ENABLE_SSL;HAVE_SNPRINTF;WITH_TLS;_CONSOLE;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <EnablePREfast>false</EnablePREfast>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -59,7 +59,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;NOMINMAX;ENABLE_PYTHON;_DEBUG;PTW32_STATIC_LIB;WITH_OPENZWAVE;OPENZWAVE_USEDLL;WWW_ENABLE_SSL;HAVE_SNPRINTF;WITH_TLS;_CONSOLE;BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>./Windows Libraries/Boost;../MQTT;..\hardware\openzwave;..\zip;..\zlib;./Windows Libraries/openssl;./Windows Libraries/Curl;./Windows Libraries/pthread;../hardware/plugins/Include;../tinyxpath;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <EnablePREfast>false</EnablePREfast>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/webserver/proxycereal.hpp
+++ b/webserver/proxycereal.hpp
@@ -3,11 +3,11 @@
 #include <string>
 #include <sstream>
 // type support
-#include "../cereal/types/string.hpp"
-#include "../cereal/types/memory.hpp"
+#include <cereal/types/string.hpp>
+#include <cereal/types/memory.hpp>
 // the archiver
-#include "../cereal/archives/portable_binary.hpp"
-#include "../cereal/archives/json.hpp"
+#include <cereal/archives/portable_binary.hpp>
+#include <cereal/archives/json.hpp>
 #include <string>
 
 #define SUBSYSTEM_HTTP 0x01

--- a/webserver/proxycereal.hpp
+++ b/webserver/proxycereal.hpp
@@ -2,12 +2,21 @@
 #ifndef NOCLOUD
 #include <string>
 #include <sstream>
+#ifdef WIN32
+// type support
+#include "../cereal/types/string.hpp"
+#include "../cereal/types/memory.hpp"
+// the archiver
+#include "../cereal/archives/portable_binary.hpp"
+#include "../cereal/archives/json.hpp"
+#else
 // type support
 #include <cereal/types/string.hpp>
 #include <cereal/types/memory.hpp>
 // the archiver
 #include <cereal/archives/portable_binary.hpp>
 #include <cereal/archives/json.hpp>
+#endif
 #include <string>
 
 #define SUBSYSTEM_HTTP 0x01


### PR DESCRIPTION
Hello,
On FreeBSD there is cereal 1.3.0 as ports (on devel/cereal), this patch allow building domoticz with cereal from FreeBSD port.
Per default builtin cereal is used so it should not change anything for other build.
I am open to any suggestions about this kind of patch.

Regards