### PR TITLE
OpenThermGateway hardware: Fixed Setpoint and OpenThermMonitor compatibility

### DIFF
--- a/dzVents/runtime/device-adapters/opentherm_gateway_device.lua
+++ b/dzVents/runtime/device-adapters/opentherm_gateway_device.lua
@@ -19,7 +19,7 @@ return {
 		function device.updateSetPoint(setPoint)
 			-- send the command using openURL otherwise, due to a bug in Domoticz, you will get a timeout on the script
 			local url = domoticz.settings['Domoticz url'] ..
-					'/json.htm?param=udevice&type=command&idx=' .. device.id .. '&nvalue=0&svalue=' .. setPoint
+					'/json.htm?param=udevice&type=command&idx=' .. device.id .. '&nvalue=' .. toNumber(setPoint) .. '&svalue=' .. setPoint
 			return domoticz.openURL(url)
 		end
 

--- a/hardware/OTGWBase.h
+++ b/hardware/OTGWBase.h
@@ -55,6 +55,7 @@ protected:
 	bool GetOutsideTemperatureFromDomoticz(float &tvalue);
 	bool SwitchLight(const int idx, const std::string &LCmd, const int svalue);
 	void GetGatewayDetails();
+	void SwitchToPS0();
 	void GetVersion();
 	void SendTime();
 	void SendOutsideTemperature();
@@ -64,5 +65,6 @@ protected:
 	bool m_bRequestVersion;
 	int m_OutsideTemperatureIdx;
 	float m_OverrideTemperature;
+	float m_OverrideControlTemperature;
 };
 

--- a/hardware/OTGWTCP.cpp
+++ b/hardware/OTGWTCP.cpp
@@ -64,6 +64,7 @@ void OTGWTCP::Do_Work()
 {
 	int sec_counter = 25;
 	connect(m_szIPAddress,m_usIPPort);
+	int ps;
 	while (!IsStopRequested(1000))
 	{
 		sec_counter++;
@@ -84,6 +85,12 @@ void OTGWTCP::Do_Work()
 				SendOutsideTemperature();
 				SendTime();
 				GetGatewayDetails();
+				ps=1;
+			}
+			else if(ps==1)
+			{
+				ps=0;
+				SwitchToPS0();
 			}
 		}
 	}


### PR DESCRIPTION
The two changes in this fix of the OTGW (OpenTherm Gateway) are:
1 Changed SetPoint from readonly to read/write. 
The setpoint in the OTGW implementation was only able to look at the setpoint set by the thermostat.
With this addition/you can also overwrite the setpoint. Setting a value of zero will cancel the overwrite and the boiler will use the thermostat value again.  
This is very useful in case of controlling the boiler in case of many restarts.

2 Changed PS behaviour PS=1 and PS=0 to be able to use OpenThermMonitor and Domoticz paralel.