### PR TITLE
Tesla: Introduced optional keep-asleep mode

### DIFF
--- a/hardware/eVehicles/TeslaApi.cpp
+++ b/hardware/eVehicles/TeslaApi.cpp
@@ -68,6 +68,11 @@ bool CTeslaApi::RefreshLogin()
 	return false;
 }
 
+int CTeslaApi::GetSleepInterval()
+{
+	return 20;
+}
+
 bool CTeslaApi::GetAllData(tAllCarData& data)
 {
 	Json::Value reply;
@@ -122,6 +127,9 @@ void CTeslaApi::GetChargeData(Json::Value& jsondata, CVehicleApi::tChargeData& d
 	data.status_string = jsondata["charging_state"].asString();
 	data.is_connected = (data.status_string != "Disconnected");
 	data.is_charging = (data.status_string == "Charging") || (data.status_string == "Starting");
+
+	if(data.status_string == "Disconnected")
+		data.status_string = "Charge Cable Disconnected";
 }
 
 bool CTeslaApi::GetClimateData(tClimateData& data)

--- a/hardware/eVehicles/TeslaApi.h
+++ b/hardware/eVehicles/TeslaApi.h
@@ -11,6 +11,7 @@ public:
 
 	bool Login() override;
 	bool RefreshLogin() override;
+	int GetSleepInterval() override;
 	bool SendCommand(eCommandType command) override;
 	bool GetAllData(tAllCarData& data) override;
 	bool GetLocationData(tLocationData& data) override;

--- a/hardware/eVehicles/VehicleApi.h
+++ b/hardware/eVehicles/VehicleApi.h
@@ -49,6 +49,8 @@ public:
 	virtual bool GetLocationData(tLocationData& data) = 0;
 	virtual bool GetChargeData(tChargeData& data) = 0;
 	virtual bool GetClimateData(tClimateData& data) = 0;
+	
+	virtual int GetSleepInterval() = 0;
 
 	std::string m_carname;
 };

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -976,7 +976,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CTado(ID, Username, Password);
 		break;
 	case HTYPE_Tesla:
-		pHardware = new CeVehicle(ID, CeVehicle::Tesla, Username, Password, Mode1, Mode2, Extra);
+		pHardware = new CeVehicle(ID, CeVehicle::Tesla, Username, Password, Mode1, Mode2, Mode3, Extra);
 		break;
 	case HTYPE_Honeywell:
 		pHardware = new CHoneywell(ID, Username, Password, Extra);

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1033,17 +1033,37 @@
 			</tr>
 			<tr>
 				<td align="right" style="width:110px"><label><span data-i18n="Default interval"></span>:</label></td>
-				<td><input type="text" id="defaultinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="10"/>&nbsp;(<span data-i18n="Minutes"></span>)</td>
+				<td><input type="text" id="defaultinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="10" />&nbsp;(<span data-i18n="Minutes"></span>)</td>
 			</tr>
 			<tr>
 				<td align="right" style="width:110px"><label for="awayinterval"><span data-i18n="Active interval"></span>:</label></td>
-				<td><input type="text" id="activeinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="1"/>&nbsp;(<span data-i18n="Minutes"></span>).</td>
+				<td><input type="text" id="activeinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="1" />&nbsp;(<span data-i18n="Minutes"></span>).</td>
 			</tr>
 			<tr>
 				<td></td>
-				<td>Two interval types need to be specified:<ul>
-						<li>Default interval is used when the car is not at home, or home but not charging or using climate controls</li>
+				<td>
+					Two interval types need to be specified:<ul>
+						<li>Default interval is used when the car is not at home, or home but not charging or using climate controls<br />
+							Note that a too low interval (less than 20 minutes) will prevent the car to sleep.</li>
 						<li>Active interval is used when the car is home, and charging or using climate controls</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label id="lblallowwakeup" for="name"><span data-i18n="Allow wake up"></span>:</label></td>
+				<td>
+					<select id="comboallowwakeup" style="width:60px" class="combobox ui-corner-all">
+						<option value="0">False</option>
+						<option value="1">True</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td></td>
+				<td>
+					If not allowed, the car will not be woken up when polled for status information to avoid battery drain. Exceptions:<ul>
+						<li>Commands sent to the car will always wake up the car</li>
+						<li>While the car is connected to a charger (home or not home), the car will always be woken up</li>
 					</ul>
 				</td>
 			</tr>

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -934,8 +934,9 @@ define(['app'], function (app) {
 				}
 				var defaultinterval = parseInt($("#hardwarecontent #divtesla #defaultinterval").val());
 				if (defaultinterval < 1) {
-					defaultinterval = 10;
+					defaultinterval = 20;
 				}
+				var allowwakeup = $("#hardwarecontent #divtesla #comboallowwakeup").val();
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&username=" + encodeURIComponent(username) +
@@ -946,7 +947,8 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&extra=" + vinnr +
 					"&Mode1=" + defaultinterval +
-					"&Mode2=" + activeinterval,
+					"&Mode2=" + activeinterval + 
+					"&Mode3=" + allowwakeup,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -2155,8 +2157,9 @@ define(['app'], function (app) {
 				}
 				var defaultinterval = parseInt($("#hardwarecontent #divtesla #defaultinterval").val());
 				if (defaultinterval < 1) {
-					defaultinterval = 1;
+					defaultinterval = 20;
 				}
+				var allowwakeup = $("#hardwarecontent #divtesla #comboallowwakeup").val();
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&username=" + encodeURIComponent(username) +
@@ -2166,7 +2169,8 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&extra=" + vinnr +
 					"&Mode1=" + defaultinterval +
-					"&Mode2=" + activeinterval,
+					"&Mode2=" + activeinterval +
+					"&Mode3=" + allowwakeup,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -3680,6 +3684,7 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamstesla #vinnr").val(data["Extra"]);
 							$("#hardwarecontent #hardwareparamstesla #defaultinterval").val(data["Mode1"]);
 							$("#hardwarecontent #hardwareparamstesla #activeinterval").val(data["Mode2"]);
+							$("#hardwarecontent #hardwareparamstesla #comboallowwakeup").val(data["Mode3"]);
 						}
 						else if (data["Type"].indexOf("Satel Integra") >= 0) {
 							$("#hardwarecontent #hardwareparamspollinterval #pollinterval").val(data["Mode1"]);


### PR DESCRIPTION
This will prevent the car to be woken up by domoticz.

This prevents battery drain. In this mode, car updates are only retrieved at the configured
interval when the car is awake. In case the car wakes up by itself for any reason, an update is
also retrieved. User commands sent to the car (e.g. start charge) will always wake up the car.

Also reconfigured the state device, it now provides only a new value when it's different from the
previous value.