### PR TITLE
Fix sign extension and overflow problems with fault log date handling

### DIFF
--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -1720,14 +1720,14 @@ bool CEvohomeRadio::DecodeDeviceInfo(CEvohomeMsg& msg)
 	char sFaultType[15], sFaultCode[20], sDevType[15], sFaultDateTime[21];
 
 	msg.Get(nFaultType, 1).Get(nFaultCode, 4);
-	nFaultDateTime = static_cast<long long>(msg.payload[10]) << 32 | static_cast<long>(msg.payload[11]) << 24 | msg.payload[12] << 16 | msg.payload[13] << 8 | msg.payload[14];
+	nFaultDateTime = static_cast<long long>(msg.payload[10]) << 32 | static_cast<long long>(msg.payload[11]) << 24 | msg.payload[12] << 16 | msg.payload[13] << 8 | msg.payload[14];
 
-	nFaultYear = static_cast<uint8_t>((nFaultDateTime & 0b1111111UL << 24) >> 24);
-	nFaultMonth = static_cast<uint8_t>((nFaultDateTime & 0b1111ULL << 36) >> 36);
-	nFaultDay = static_cast<uint8_t>((nFaultDateTime & 0b11111UL << 31) >> 31);
-	nFaultHour = static_cast<uint8_t>((nFaultDateTime & 0b11111UL << 19) >> 19);
-	nFaultMinute = static_cast<uint8_t>((nFaultDateTime & 0b111111UL << 13) >> 13);
-	nFaultSecond = static_cast<uint8_t>((nFaultDateTime & 0b111111UL << 7) >> 7);
+	nFaultYear = static_cast<uint8_t>((nFaultDateTime >> 24) & 127);
+	nFaultMonth = static_cast<uint8_t>((nFaultDateTime >> 36) & 15);
+	nFaultDay = static_cast<uint8_t>((nFaultDateTime >> 31) & 31);
+	nFaultHour = static_cast<uint8_t>((nFaultDateTime >> 19) & 31);
+	nFaultMinute = static_cast<uint8_t>((nFaultDateTime >> 13) & 63);
+	nFaultSecond = static_cast<uint8_t>((nFaultDateTime >> 7) & 63);
 	sprintf(sFaultDateTime, "20%02d-%02d-%02d %02d:%02d:%02d", nFaultYear, nFaultMonth, nFaultDay, nFaultHour, nFaultMinute, nFaultSecond);
 
 	// Code to plain speak as used on the Controller Fault Logbook


### PR DESCRIPTION
If we cast payload[11]<<24 to a signed long, then when it gets implicitly
cast to uint64_t as it's masked in with the others, it gets sign-extended
and overwrites payload[10] with all ones. This causes the month to appear
as 15 whenever the day number is odd. Fix it by casting to (long long)
instead. Although switching everything to unsigned times would probably
have worked too.

Also, when calculating the day we find that (0b11111UL << 31) is
truncated to 32 bits, giving 0x80000000 not 0xf80000000. Thus the
top bits of the day are lost. Fix all the mask-and-shift to shift
*first* then mask, which is simpler and doesn't suffer the same
problem.