### PR TITLE
Increase camera fetch timeout to 10s

### DIFF
--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -263,7 +263,7 @@ bool CCameraHandler::TakeSnapshot(const uint64_t CamID, std::vector<unsigned cha
 		return TakeUVCSnapshot(pCamera->Username, camimage);
 
 	std::vector<std::string> ExtraHeaders;
-	return HTTPClient::GETBinary(szURL, ExtraHeaders, camimage, 5);
+	return HTTPClient::GETBinary(szURL, ExtraHeaders, camimage, 10);
 }
 
 std::string WrapBase64(const std::string &szSource, const size_t lsize = 72)


### PR DESCRIPTION
I use a CGI script to fetch a snapshot from an RTSP stream:

```
 #!/bin/sh
 cat <<EOF
 Content-Type: image/jpeg

 EOF
 ffmpeg -skip_frame nokey -i rtsp://${CAMERA}:554/ch01.264 \
      -qscale:v 4 -frames:v 1 -f image2pipe -
```
It takes a little over 5 seconds, every time. I had to bump the
timeout up to 10s. This could be configurable, maybe, and perhaps
we should even teach Domoticz to spawn ffmpeg for itself for an
RTSP camera URI. But a ten-second timeout, and doing the image
processing on a more powerful box, works well in the short term.