### PR TITLE
dzVents: Add openURL PUT and DELETE support

### DIFF
--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -2082,10 +2082,10 @@ return {
  **domoticz.openURL(options)**: *options*	is a Lua table:
 
  - **url**: *String*.
- - **method**: *String*. Optional. Either `'GET'` (default) or `'POST'`.
+ - **method**: *String*. Optional. Either `'GET'` (default), `'POST'`, `'PUT'` or `'DELETE'`.
  - **callback**: *String*. Optional. A custom string that will be used by dzVents to find a the callback handler script.
  - **headers**: *Table*. Optional. A Lua table with additions http request-headers.
- - **postData**: Optional. When doing a `POST` this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header `application/json` is set. So no need to do that manually.
+ - **postData**: Optional. When doing a `POST`, `PUT` or `DELETE` this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header `application/json` is set. So no need to do that manually.
 
 Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
@@ -2426,6 +2426,8 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # History
+## [3.0.2]
+- Add `PUT` and `DELETE` support to `openURL`
 
 ## [3.0.1] 
 - Add option `at()` to the various commands/methods

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -2037,10 +2037,10 @@ Of course you can combine the script that issues the request and handles the res
 '''domoticz.openURL(options)''': ''options'' is a Lua table:
 
 * '''url''': ''String''.
-* '''method''': ''String''. Optional. Either <code>'GET'</code> (default) or <code>'POST'</code>.
+* '''method''': ''String''. Optional. Either <code>'GET'</code> (default), <code>'POST'</code>, <code>'PUT'</code> pr <code>'DELETE'</code>.
 * '''callback''': ''String''. Optional. A custom string that will be used by dzVents to find a the callback handler script.
 * '''headers''': ''Table''. Optional. A Lua table with additions http request-headers.
-* '''postData''': Optional. When doing a <code>POST</code> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header <code>application/json</code> is set. So no need to do that manually.
+* '''postData''': Optional. When doing a <code>POST</code>, <code>PUT</code> or <code>DELETE</code> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header <code>application/json</code> is set. So no need to do that manually.
 
 Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
@@ -2371,6 +2371,10 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and you’re good to go.
 
 = History =
+
+== [3.0.2] ==
+
+* Add <code>PUT</code> and <code>DELETE</code> support to <code>openURL</code>
 
 == [3.0.1] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,6 @@
+[3.0.2]
+- Add `PUT` and `DELETE` support to `openURL`
+
 [3.0.1] 
 - Add option 'at' to the various commands/methods
  

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -188,7 +188,7 @@ local function Domoticz(settings)
 			local postData
 
 			-- process body data
-			if (method == 'POST') then
+			if (method ~= 'GET') then
 				postData = ''
 				if (options.postData ~= nil) then
 					if (type(options.postData) == 'table') then

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -366,12 +366,26 @@ bool CdzVents::OpenURL(lua_State *lua_state, const std::vector<_tLuaTableValues>
 	}
 
 	HTTPClient::_eHTTPmethod eMethod = HTTPClient::HTTP_METHOD_GET; // defaults to GET
-	if (!method.empty() && method == "POST")
-		eMethod = HTTPClient::HTTP_METHOD_POST;
-
-	if (!postData.empty() && eMethod != HTTPClient::HTTP_METHOD_POST)
+	if (!method.empty())
 	{
-		_log.Log(LOG_ERROR, "dzVents: You can only use postdata with method POST..");
+		if (method == "GET")
+			eMethod = HTTPClient::HTTP_METHOD_GET;
+		else if (method == "POST")
+			eMethod = HTTPClient::HTTP_METHOD_POST;
+		else if (method == "PUT")
+			eMethod = HTTPClient::HTTP_METHOD_PUT;
+		else if (method == "DELETE")
+			eMethod = HTTPClient::HTTP_METHOD_DELETE;
+		else
+		{
+			_log.Log(LOG_ERROR, "dzVents: Invalid HTTP method '%s'", method.c_str());
+			return false;
+		}
+	}
+
+	if (!postData.empty() && eMethod == HTTPClient::HTTP_METHOD_GET)
+	{
+		_log.Log(LOG_ERROR, "dzVents: You cannot use postdata with method GET.");
 		return false;
 	}
 


### PR DESCRIPTION
Oops, missed the 2020.1 release with the second part of this. This is what allows me to control my cat flap...

```
local apibase='https://app.api.surehub.io/api/'

local tags = {
	['Truckle'] = 102331;
	['Frank'] = 102333;
	['Daisy'] = 102427;
};
local tag_cats = {
	[102331] = 'Truckle';
	[102333] = 'Frank';
	[102427] = 'Daisy';
};

local profiles = {
	['Kept out'] = 5;
	['Allowed out'] = 2;
	['Kept in'] = 3;
};

local profile_levels = {
	[5] = 'Kept out';
	[2] = 'Allowed out';
	[3] = 'Kept in';
};

local level_numbers = {
      ['Kept out'] = 0;
      ['Allowed out'] = 10;
      ['Kept in'] = 20;
};

local function refresh(domoticz)
	local options = {
	  	url = apibase .. 'device/422826/tag',
		method = 'GET',
		headers = {
		    ['Authorization'] = 'Bearer ' .. domoticz.data.token
		},
		callback = 'Poll'
	    }
	domoticz.openURL(options)
end

local function update(domoticz, pet, profile)
	local tag = tags[pet]
	local options = {
	    	url = apibase .. 'device/422826/tag/' .. tag,
		method = 'PUT',
		postData = '{"profile":' .. profile .. '}',
		headers = {
		    ['Content-Type'] = 'application/json',
		    ['Authorization'] = 'Bearer ' .. domoticz.data.token
		},
		callback = pet
	    }
	domoticz.openURL(options)
end

local function setlocal(domoticz, cat, profile)
	local level = profile_levels[profile]
	if (cat ~= nil and level ~= nil) then
		local catdev = domoticz.devices(cat)
		if (catdev ~= nil and catdev.state ~= level) then
		   	domoticz.log("Set " .. cat .. " to " .. level_numbers[level], domoticz.LOG_INFO)
			domoticz.data.netstatus[cat] = level
			catdev.switchSelector(level_numbers[level])
		end
	end
end

return {
        on = {
                devices = {
                        'Truckle',
                        'Frank',
                        'Daisy'
                },
		httpResponses = {
			'Truckle',
			'Frank',
			'Daisy',
			'Poll'
		},
		timer = {'every minute'}
        },
	data = {
		'token',
		'etags',
		'set',
		'netstatus'
	},
        execute = function(domoticz, device)
		if (domoticz.data.etags == nil) then
		   domoticz.data.etags = {}
		end
		if (domoticz.data.set == nil) then
		   domoticz.data.set = {}
		end
		if (domoticz.data.netstatus == nil) then
		   domoticz.data.netstatus = {}
		end
		if (domoticz.data.token == nil) then
                        -- FIXME: Do login properly; do these tokens expire?
			domoticz.data.token = 'eyJ....O5k'
		end

		if (device.isTimer) then
			domoticz.log('Cat flap poll', domoticz.LOG_INFO)
			refresh(domoticz)
			return
		elseif (device.isHTTPResponse) then
	    		domoticz.log(device.callback .. ' Response code ' .. device.statusCode .. ' data: ' .. device.data, domoticz.LOG_INFO)
			if (device.callback == 'Poll') then
				for i,rec in pairs(device.json.data) do
					local cat = tag_cats[rec.id]
					if (cat ~= nil and domoticz.data.set[cat] == nil) then
						print('ID ' .. rec.id .. ' Cat ' .. cat .. ' profile ' .. rec.profile)
						setlocal(domoticz, cat, rec.profile)
					end
				end
				return
			elseif (tags[device.callback] ~= nil) then
			       domoticz.data.set[device.callback] = nil
			       setlocal(domoticz, device.callback, device.json.data.profile)
			end
--			for h in pairs(device.headers) do
--				 domoticz.log(h .. ': ' .. device.headers[h], domoticz.LOG_INFO)
--			end
			return
		end

		if (domoticz.data.netstatus[device.name] == device.state) then
			domoticz.log('Cat ' .. device.name .. ' incoming change to ' .. device.state , domoticz.LOG_INFO)
		else
			domoticz.log('Cat ' .. device.name .. ' was changed locally to ' .. device.state , domoticz.LOG_INFO)

			local profile = profiles[device.state]

			domoticz.data.set[device.name] = profile
			update(domoticz, device.name, profile)
		end
		domoticz.data.netstatus[device.name] = nil
        end
}

```