### PR TITLE
Allow changing icon for Lighting 6 types

### DIFF
--- a/www/app/devices/deviceFactory.js
+++ b/www/app/devices/deviceFactory.js
@@ -5,7 +5,7 @@ define(function () {
 
         function DeviceIcon(device) {
             this.isConfigurable = function() {
-                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Color Switch'].includes(device.Type) &&
+                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch'].includes(device.Type) &&
                     [0, 2, 7, 9, 10, 11, 17, 18, 19, 20].includes(device.SwitchTypeVal);
             };
 


### PR DESCRIPTION

Tested and working according to the reply in forum topic ["Can not change icons for switch Lightning 6"](https://www.domoticz.com/forum/viewtopic.php?f=28&t=32213
)