### PR TITLE
Allow changing icon for Home confort types

### DIFF
--- a/www/app/devices/deviceFactory.js
+++ b/www/app/devices/deviceFactory.js
@@ -5,7 +5,7 @@ define(function () {
 
         function DeviceIcon(device) {
             this.isConfigurable = function() {
-                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch'].includes(device.Type) &&
+                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort'].includes(device.Type) &&
                     [0, 2, 7, 9, 10, 11, 17, 18, 19, 20].includes(device.SwitchTypeVal);
             };
 


### PR DESCRIPTION
        
Tested and working according to the reply in forum topic "Can not change icons for switch Lightning 6"

Typo in "Home confort" does exists throughout domoticz source files

Don't know if I can corrected that without causing issues for existing users

```
www/app/LightsController.js:139:                        //Home confort
www/app/LightsController.js:1660:                               //Home Confort
www/app/LightsController.js:1796:                               //Home Confort
www/app/LightsController.js:2024:                               //Home Confort
www/app/devices/deviceFactory.js:8:                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort'].includes(device.Type) &&
www/app/hardware/Hardware.html:138:                                     <td><input type="checkbox" id="HC" name="HC">&nbsp;<label for="HC">Home Confort</label></td>
www/views/lights.html:102:                                      <option value="302">Home Confort TEL-010</option>
main/WebServer.cpp:4648:                                                //Home Confort
main/WebServer.cpp:5277:                                                //Home Confort
main/mainworker.cpp:2794:                                       WriteMessage("Home Confort      enabled");
main/mainworker.cpp:2796:                                       WriteMessage("Home Confort      disabled");
main/RFXtrx.h:150:      Home Confort added
main/RFXtrx.h:914://types for Home Confort
main/RFXNames.cpp:481:  { pTypeHomeConfort, "Home Confort" , "lightbulb" },
dzVents/runtime/device-adapters/switch_device.lua:28:                   device.deviceType == 'Home Confort' or -- typo should be there
```