### PR TITLE
Document the app root command line parameter in usage

### DIFF
--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -63,10 +63,12 @@ const char *szHelp =
 "\t-wwwroot file_path (for example D:\\www)\n"
 "\t-dbase file_path (for example D:\\domoticz.db)\n"
 "\t-userdata file_path (for example D:\\domoticzdata)\n"
+"\t-approot file_path (for example D:\\domoticzdata)\n"
 #else
 "\t-wwwroot file_path (for example /opt/domoticz/www)\n"
 "\t-dbase file_path (for example /opt/domoticz/domoticz.db)\n"
 "\t-userdata file_path (for example /opt/domoticz)\n"
+"\t-approot file_path (for example /opt/domoticz)\n"
 #endif
 "\t-webroot additional web root, useful with proxy servers (for example domoticz)\n"
 "\t-startupdelay seconds (default=0)\n"

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -63,7 +63,7 @@ const char *szHelp =
 "\t-wwwroot file_path (for example D:\\www)\n"
 "\t-dbase file_path (for example D:\\domoticz.db)\n"
 "\t-userdata file_path (for example D:\\domoticzdata)\n"
-"\t-approot file_path (for example D:\\domoticzdata)\n"
+"\t-approot file_path (for example D:\\domoticz)\n"
 #else
 "\t-wwwroot file_path (for example /opt/domoticz/www)\n"
 "\t-dbase file_path (for example /opt/domoticz/domoticz.db)\n"


### PR DESCRIPTION
Update the usage string for the main Domoticz binary to include the `-approot` parameter.