### PR TITLE
csocket: remove sys/errno.h

### DIFF
--- a/hardware/csocket.cpp
+++ b/hardware/csocket.cpp
@@ -13,7 +13,6 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <errno.h>
-#include <sys/errno.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <poll.h>


### PR DESCRIPTION
The proper include is errno.h. Fixes musl warning:

#warning redirecting incorrect #include <sys/errno.h> to <errno.h>