### PR TITLE
dzVents 3.0.5; fix settings.url and add dumpSelection

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,6 @@
 Version 2020.xxxx (xxxx)
 - Implemented: Allow complete IPv6 address in local network setting
-- Updated: dzVents version 3.0.4 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
+- Updated: dzVents version 3.0.5 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
 - Updated: TTNMQTT, improved Improved calculation and storage of signal-levels
 - Updated: eVehicles, add ODO meter, unlock/open alert, max charge level to Tesla module
 - For a full overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits for details

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -2445,6 +2445,7 @@ On the other hand, you have to make sure that dzVents can access the json withou
 
 ## [3.0.5]
 - Add dumpSelection() method 
+- Fixed settings.url
 
 ## [3.0.4]
 - Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -585,10 +585,10 @@ There are several options for time triggers. It is important to know that Domoti
 			'at civiltwilightstart',	-- uses civil twilight start/end info from Domoticz
 			'at civiltwilightend',
 			'at sunset on sat,sun',
-			'xx minutes before civiltwilightstart',
-			'xx minutes after civiltwilightstart',
-			'xx minutes before civiltwilightend',
-			'xx minutes after civiltwilightend',
+			'xx minutes before civiltwilightstart',		--
+			'xx minutes after civiltwilightstart',		-- Please note that these relative times
+			'xx minutes before civiltwilightend',		-- cannot cross dates
+			'xx minutes after civiltwilightend',		--
 			'xx minutes before sunset',
 			'xx minutes after sunset',
 			'xx minutes before sunrise',
@@ -875,6 +875,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **deviceSubType**: *String*. See Domoticz devices table in Domoticz GUI.
  - **deviceType**: *String*. See Domoticz devices table in Domoticz GUI.
  - **dump()**: *Function*. Dump all attributes to the Domoticz log. This ignores the log level setting.
+ - **dumpSelection([{'attributes'} 'functions' 'tables'])**: *Function*. <sup>3.0.5</sup>  Dump attributes, function-names or table-names to the Domoticz log. This ignores the log level setting.
  - **hardwareName**: *String*. See Domoticz devices table in Domoticz GUI.
  - **hardwareId**: *Number*. See Domoticz devices table in Domoticz GUI.
  - **hardwareType**: *String*. See Domoticz devices table in Domoticz GUI.
@@ -2297,7 +2298,7 @@ Also, make sure that your device names are unique! dzVents will throw a warning 
 If your script is still not triggered, you can try to create a classic Lua event script and see if that does work.
 
 ### Debugging your script
-A simple way to inspect a device in your script is to dump it to the log: `myDevice.dump()`. This will dump all the attributes (and more) of the device so you can inspect what its state is.
+A simple way to inspect a device in your script is to dump it to the log: `myDevice.dump()`. This will dump everything known to dzVents of the device so you can inspect what its state is. If you only need to see a subset you can use dumpSelection('attributes'), dumpSelection('functions') or dumpSelection('tables')
 Use print statements or domoticz.log() statements in your script at cricital locations to see if the Lua interpreter reaches that line.
 Don't try to print a device object though; use the `myDevice.dump()` method for that. It wil log all attributes of the device in the Domoticz log.
 
@@ -2441,6 +2442,9 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and you're good to go.
 
 # History
+
+## [3.0.5]
+- Add dumpSelection() method 
 
 ## [3.0.4]
 - Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -2386,6 +2386,10 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 = History =
 
+== [3.0.5] ==
+
+* Add dumpSelection()
+
 == [3.0.4] ==
 
 * Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -557,10 +557,10 @@ There are several options for time triggers. It is important to know that Domoti
             'at civiltwilightstart',    -- uses civil twilight start/end info from Domoticz
             'at civiltwilightend',
             'at sunset on sat,sun',
-            'xx minutes before civiltwilightstart',
-            'xx minutes after civiltwilightstart',
-            'xx minutes before civiltwilightend',
-            'xx minutes after civiltwilightend',
+            'xx minutes before civiltwilightstart',     --
+            'xx minutes after civiltwilightstart',      -- Please note that these relative times
+            'xx minutes before civiltwilightend',       -- cannot cross dates
+            'xx minutes after civiltwilightend',        --
             'xx minutes before sunset',
             'xx minutes after sunset',
             'xx minutes before sunrise',
@@ -823,6 +823,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''deviceSubType''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''deviceType''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''dump()''': ''Function''. Dump all attributes to the Domoticz log. This ignores the log level setting.
+* '''dumpSelection([{‘attributes’} ‘functions’ ‘tables’])''': ''Function''. <sup>3.0.5</sup> Dump attributes, function-names or table-names to the Domoticz log. This ignores the log level setting.
 * '''hardwareName''': ''String''. See Domoticz devices table in Domoticz GUI.
 * '''hardwareId''': ''Number''. See Domoticz devices table in Domoticz GUI.
 * '''hardwareType''': ''String''. See Domoticz devices table in Domoticz GUI.
@@ -2251,7 +2252,7 @@ If your script is still not triggered, you can try to create a classic Lua event
 
 === Debugging your script ===
 
-A simple way to inspect a device in your script is to dump it to the log: <code>myDevice.dump()</code>. This will dump all the attributes (and more) of the device so you can inspect what its state is. Use print statements or domoticz.log() statements in your script at cricital locations to see if the Lua interpreter reaches that line. Don’t try to print a device object though; use the <code>myDevice.dump()</code> method for that. It wil log all attributes of the device in the Domoticz log.
+A simple way to inspect a device in your script is to dump it to the log: <code>myDevice.dump()</code>. This will dump everything known to dzVents of the device so you can inspect what its state is. If you only need to see a subset you can use dumpSelection(‘attributes’), dumpSelection(‘functions’) or dumpSelection(‘tables’) Use print statements or domoticz.log() statements in your script at cricital locations to see if the Lua interpreter reaches that line. Don’t try to print a device object though; use the <code>myDevice.dump()</code> method for that. It wil log all attributes of the device in the Domoticz log.
 
 If you place a print statement all the way at the top of your script file it will be printed every time dzVents loads your script (that is done at the beginning of each event cycle). Sometimes that is handy to see if your script gets loaded in the first place. If you don’t see your print statement in the log, then likely dzVents didn’t load it and it will not work.
 
@@ -2388,7 +2389,8 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 
 == [3.0.5] ==
 
-* Add dumpSelection()
+* Add dumpSelection() method
+* Fixed settings.url
 
 == [3.0.4] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,5 +1,6 @@
 [3.0.5]
-- add dumpSeletion()
+- add dumpSelection()
+- fixed settings.url
 
 [3.0.4]
 - Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,6 @@
+[3.0.5]
+- add dumpSeletion()
+
 [3.0.4]
 - Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 
 - add isJSON, isXML functions to Utils 

--- a/dzVents/runtime/Device.lua
+++ b/dzVents/runtime/Device.lua
@@ -25,6 +25,10 @@ local function Device(domoticz, data, dummyLogger)
 		domoticz.logDevice(self, filename)
 	end
 
+	function self.dumpSelection( selection )
+		utils.dumpSelection(self, ( selection or 'attributes' ))
+	end
+
 	self['name'] = data.name
 	self['id'] = data.id -- actually, this is the idx
 	self['idx'] = self.id -- for completeness

--- a/dzVents/runtime/EventHelpers.lua
+++ b/dzVents/runtime/EventHelpers.lua
@@ -40,7 +40,7 @@ local function EventHelpers(domoticz, mainMethod)
 	local settings = {
 		['Log level'] = tonumber(globalvariables['dzVents_log_level']) or 1,
 		['Domoticz url'] = _url,
-		url = url,
+		url = _url,
 		webRoot = tostring(webRoot),
 		serverPort = globalvariables['domoticz_listening_port'] or '8080',
 		dzVentsVersion = globalvariables.dzVents_version,

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -1,6 +1,15 @@
 local jsonParser = require('JSON')
 local _ = require('lodash')
 
+local self = {
+	LOG_ERROR = 1,
+	LOG_FORCE = 0.5,
+	LOG_MODULE_EXEC_INFO = 2,
+	LOG_INFO = 3,
+	LOG_DEBUG = 4,
+	DZVERSION = '3.0.5',
+}
+
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)
 	if type(value_of_unsupported_type) == 'function' then
 		return '"Function"'
@@ -8,15 +17,6 @@ function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)
 		return nil
 	end
 end
-
-local self = {
-	LOG_ERROR = 1,
-	LOG_FORCE = 0.5,
-	LOG_MODULE_EXEC_INFO = 2,
-	LOG_INFO = 3,
-	LOG_DEBUG = 4,
-	DZVERSION = '3.0.4',
-}
 
 function math.pow(x, y)
 	self.log('Function math.pow(x, y) has been deprecated in Lua 5.3. Please consider changing code to x^y', self.LOG_FORCE)
@@ -185,6 +185,7 @@ function self.urlDecode(str, strSub)
 end
 
 function self.isJSON(str, content)
+
 	local str = str or ''
 	local content = content or ''
 	local jsonPattern = '^%s*%[*{.+}%]*%s*$'
@@ -261,6 +262,7 @@ function self.toBase64(s) -- from http://lua-users.org/wiki/BaseSixtyFour
 end
 
 function self.isXML(str, content)
+
 	local str = str or ''
 	local content = content or ''
 	local xmlPattern = '^%s*%<.+%>%s*$'
@@ -305,6 +307,7 @@ function self.fromXML(xml, fallback)
 end
 
 function self.toXML(luaTable, header)
+
 	if header == nil then header = 'LuaTable' end
 
 	local toXML = function(luaTable, header)
@@ -389,7 +392,7 @@ function self.rgbToHSB(r, g, b)
 		if (r == max) then
 			hsb.h = (g - b) / delta
 		elseif (g == max) then
-			 hsb.h = 2 + (b - r) / delta
+			hsb.h = 2 + (b - r) / delta
 		else
 			hsb.h = 4 + (r - g) / delta
 		end
@@ -450,6 +453,38 @@ function self.dumpTable(t, level, filename)
 			end
 		else
 			self.print(level .. attr .. '()', filename)
+		end
+	end
+end
+
+function self.dumpSelection(object, selection)
+	self.print ('dump ' .. selection .. ' of ' .. object.baseType .. ' ' .. object.name)
+	if selection == 'attributes' then
+		for attr, value in pairs(object) do
+			if type(value) ~= 'function' and type(value) ~= 'table' then
+				self.print('> ' .. attr .. ': ' .. tostring(value))
+			end
+		end
+		self.print('')
+		self.print('> lastUpdate: ' .. (object.lastUpdate.raw or '') )
+		if object.baseType ~= 'variable' then
+			self.print('> adapters: ' .. table.concat(object._adapters or {},', ') )
+		end
+		if object.baseType == 'device' then
+			self.print('> levelNames: ' .. table.concat(object.levelNames or {},', ') )
+			self.print('> rawData: ' .. table.concat(object.rawData or {},', ') )
+		end
+	elseif selection == 'tables' then
+		for attr, value in pairs(object) do
+			if type(value) == 'table' then
+				self.print('> ' .. attr .. ': ' )
+			end
+		end
+	elseif selection == 'functions' then
+		for attr, value in pairs(object) do
+			if type(value) == 'function' then
+				self.print('> ' .. attr .. '()')
+			end
 		end
 	end
 end

--- a/dzVents/runtime/Variable.lua
+++ b/dzVents/runtime/Variable.lua
@@ -21,6 +21,10 @@ local function Variable(domoticz, data)
 		self['nValue'] = data.data.value
 	end
 
+	function self.dumpSelection( selection )
+		domoticz.utils.dumpSelection(self, ( selection or 'attributes' ))
+	end
+
 	if (data.variableType == 'date') then
 		local d, mon, y = string.match(data.data.value, "(%d+)[%p](%d+)[%p](%d+)")
 		local date = y .. '-' .. mon .. '-' .. d .. ' 00:00:00'

--- a/dzVents/runtime/integration-tests/stage2.lua
+++ b/dzVents/runtime/integration-tests/stage2.lua
@@ -733,12 +733,54 @@ local testSetIconSwitch = function(name)
 	return res
 end
 
-local testDeviceDump = function(name)
+local testDeviceDumps = function(name)
 	local utils = require('Utils')
-	local dev = dz.devices(name)
+	local dv = dz.devices(name)
 	local res = true
-	res = res and ( utils.dumpTable(dev, '> ') == nil)
-	handleResult('Test device dump', res)
+	res = res and ( dv.dump() == nil )
+	res = res and ( dv.dumpSelection() == nil ) 
+	res = res and ( dv.dumpSelection('attributes') == nil ) 
+	res = res and ( dv.dumpSelection('functions') == nil ) 
+	res = res and ( dv.dumpSelection('tables') == nil ) 
+	handleResult('Test device dumps', res)
+	return res
+end
+
+local testGroupDumps = function(name)
+	local utils = require('Utils')
+	local gp = dz.groups(name )
+	local res = true
+	res = res and ( gp.dump() == nil )
+	res = res and ( gp.dumpSelection() == nil ) 
+	res = res and ( gp.dumpSelection('attributes') == nil ) 
+	res = res and ( gp.dumpSelection('functions') == nil ) 
+	res = res and ( gp.dumpSelection('tables') == nil ) 
+	handleResult('Test group dumps', res)
+	return res
+end
+
+local testSceneDumps = function(name)
+	local utils = require('Utils')
+	local sc = dz.scenes(name)
+	local res = true
+	res = res and ( sc.dump() == nil )
+	res = res and ( sc.dumpSelection() == nil ) 
+	res = res and ( sc.dumpSelection('attributes') == nil ) 
+	res = res and ( sc.dumpSelection('functions') == nil ) 
+	res = res and ( sc.dumpSelection('tables') == nil ) 
+	handleResult('Test scene dumps', res)
+	return res
+end
+
+local testVariableDumps = function(name)
+	local utils = require('Utils')
+	local var = dz.variables(name)
+	local res = true
+	res = res and ( var.dumpSelection() == nil ) 
+	res = res and ( var.dumpSelection('attributes') == nil ) 
+	res = res and ( var.dumpSelection('functions') == nil ) 
+	res = res and ( var.dumpSelection('tables') == nil ) 
+	handleResult('Test Variable dumps', res)
 	return res
 end
 
@@ -959,7 +1001,10 @@ return {
 		res = res and testDescription('vdDescriptionSwitch', descriptionString, "device")
 		res = res and testDescription('sceneDescriptionSwitch1', descriptionString, "scene")
 		res = res and testDescription('groupDescriptionSwitch1', descriptionString, "group")
-		res = res and testDeviceDump(vdSwitchDimmer)
+		res = res and testDeviceDumps('vdSwitchDimmer')
+		res = res and testGroupDumps('gpGroup')
+		res = res and testSceneDumps('scScene')
+		res = res and testVariableDumps('varString' )
 		res = res and testCameraDump()
 		res = res and testSettingsDump()
 		res = res and testIFTTT('myEvent')

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -127,7 +127,7 @@ function fillTimes
 		ContactDoorLockInvertedSwitch_ExpectedSeconds=30
 		DelayedVariableScene_ExpectedSeconds=80
 		EventState_ExpectedSeconds=190
-		Integration_ExpectedSeconds=330
+		Integration_ExpectedSeconds=340
 		SelectorSwitch_ExpectedSeconds=100
 		SystemAndCustomEvents_ExpectedSeconds=10
 	}
@@ -148,7 +148,7 @@ function fillNumberOfTests
 		ContactDoorLockInvertedSwitch_ExpectedTests=2
 		DelayedVariableScene_ExpectedTests=2
 		EventState_ExpectedTests=2
-		Integration_ExpectedTests=217
+		Integration_ExpectedTests=220
 		SelectorSwitch_ExpectedTests=2
 		SystemAndCustomEvents_ExpectedTests=7
 	}

--- a/dzVents/runtime/tests/testEventHelpers.lua
+++ b/dzVents/runtime/tests/testEventHelpers.lua
@@ -433,6 +433,7 @@ describe('event helpers', function()
 
 		it('should have proper settings', function()
 			assert.are.same('http://127.0.0.1:8181', helpers.settings['Domoticz url'])
+			assert.are.same('http://127.0.0.1:8181', helpers.settings.url)
 		end)
 
 		it('should have proper location settings', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -24,7 +24,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("3.0.4")
+        m_version("3.0.5")
 {
 	m_bdzVentsExist = false;
 }


### PR DESCRIPTION
```
========= domoticz V2020.2 (12017), dzVents V3.0.5 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        113      OK            113         0      0.2777
00:00:02  Domoticz                                      1         74      OK             74         0      0.2864
00:00:03  EventHelpers                                  1         32      OK             32         0      0.2468
00:00:03  EventHelpersStorage                           1         50      OK             50         0      0.2360
00:00:03  HTTPResponse                                  1          6      OK              6         0      0.0148
00:00:04  Lodash                                        1        100      OK            100         0      0.1484
00:00:04  ScriptdzVentsDispatching                      1          2      OK              2         0      0.0642
00:00:04  TimedCommand                                  1         46      OK             46         0      0.0995
00:00:04  Time                                          3        340      OK            340         0      0.6601
00:00:05  Utils                                         1         27      OK             27         0      0.0462
00:00:05  Variable                                      1         15      OK             15         0      0.0311
00:00:05  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.0610
00:00:08  DelayedVariableScene                          8          2      OK              2         0      7.0727
00:00:15  EventState                                   19          2      OK              2         0     18.0782
00:00:33  Integration                                  34        220      OK            220         0     28.5812
00:01:02  SelectorSwitch                               10          2      OK              2         0      9.2029
00:01:17  SystemAndCustomEvents                         1          7      OK              7         0      0.0343


Total tests: 1040
Fri 08 May 2020 01:21:11 PM CEST; dzVents version 3.0.5 tested without errors after 00:01:17

```
dumpSelection() dumps a subset of a device, group, scene or variable.

Possible parms: 'attributes' = default, 'functions' or 'table'
Added to help debugging for users looking at GUI for log output.
dump() produces more lines then can be viewed and most of the time
showing the attributes is enough.

settings.url was nil because of a typo in one of the earlier updates