### PR TITLE
Strip innosetup version from path 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,9 +30,12 @@ platform: x86
 #- .\vcpkg integrate install
 #- cd %APPVEYOR_BUILD_FOLDER%
 
+environment:
+  INNOSETUP_VERSION: "6.0.4"
+  
 before_build:
 - ps: >-
-    nuget install Tools.InnoSetup
+    nuget install Tools.InnoSetup -Version $env:INNOSETUP_VERSION
 
 - cmd: >-    
     cd msbuild
@@ -52,7 +55,7 @@ after_build:
 - cd %APPVEYOR_BUILD_FOLDER%
 - cp appversion.h version_windows_x86.h
 - cp History.txt history_windows_x86.txt
-- Tools.InnoSetup.6.0.3\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
+- Tools.InnoSetup%INNOSETUP_VERSION%\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
 - msbuild msbuild\package.proj
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,12 +30,9 @@ platform: x86
 #- .\vcpkg integrate install
 #- cd %APPVEYOR_BUILD_FOLDER%
 
-environment:
-  INNOSETUP_VERSION: "6.0.4"
-  
 before_build:
 - ps: >-
-    nuget install Tools.InnoSetup -Version $env:INNOSETUP_VERSION
+    nuget install Tools.InnoSetup
 
 - cmd: >-    
     cd msbuild
@@ -55,7 +52,8 @@ after_build:
 - cd %APPVEYOR_BUILD_FOLDER%
 - cp appversion.h version_windows_x86.h
 - cp History.txt history_windows_x86.txt
-- Tools.InnoSetup.%INNOSETUP_VERSION%\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
+- move Tools.InnoSetup.* Tools.InnoSetup
+- Tools.InnoSetup\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
 - msbuild msbuild\package.proj
 
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ after_build:
 - cd %APPVEYOR_BUILD_FOLDER%
 - cp appversion.h version_windows_x86.h
 - cp History.txt history_windows_x86.txt
-- Tools.InnoSetup%INNOSETUP_VERSION%\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
+- Tools.InnoSetup.%INNOSETUP_VERSION%\tools\ISCC msbuild\WindowsInstaller\DomoticzSetup.iss
 - msbuild msbuild\package.proj
 
 artifacts:


### PR DESCRIPTION
This will prevent ci from breaking on every innosetup new version.
Another option would be to move the directory to strip the version.
I think it depends if you want to keep control over innosetup version or not.