### PR TITLE
Fix build if PYTHON is disabled

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -125,7 +125,9 @@
 #include "../hardware/ZiBlueTCP.h"
 #include "../hardware/Yeelight.h"
 #include "../hardware/XiaomiGateway.h"
+#ifdef ENABLE_PYTHON
 #include "../hardware/plugins/Plugins.h"
+#endif
 #include "../hardware/Arilux.h"
 #include "../hardware/OpenWebNetUSB.h"
 #include "../hardware/InComfort.h"


### PR DESCRIPTION
Without this patch build fails with:

```
FAILED: CMakeFiles/domoticz.dir/main/mainworker.cpp.o
/usr/bin/c++  -DHAVE_EXECINFO_H -DWITH_LIBUSB -DWITH_TLS -DWWW_ENABLE_SSL -I/usr/local/include/lua53 -I/wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main -I/usr/local/include/minizip -isystem /usr/local/include -O2 -pipe -fstack-protector-strong -fno-strict-aliasing -O2 -pipe -fstack-protector-strong -fno-strict-aliasing   -pthread -std=gnu++11 -MD -MT CMakeFiles/domoticz.dir/main/mainworker.cpp.o -MF CMakeFiles/domoticz.dir/main/mainworker.cpp.o.d -o CMakeFiles/domoticz.dir/main/mainworker.cpp.o -c /wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main/mainworker.cpp
In file included from /wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main/mainworker.cpp:128:
In file included from /wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main/../hardware/plugins/Plugins.h:6:
In file included from /wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main/../hardware/plugins/PythonObjects.h:4:
/wrkdirs/usr/ports/www/domoticz/work/domoticz-2020.2/main/../hardware/plugins/DelayedLink.h:12:10: fatal error: 'Python.h' file not found
#include <Python.h>
         ^~~~~~~~~~
1 error generated.
```