### PR TITLE
TTNMQTT: Better GPS/Locations handling, distance calculation (Geofencing) and more

### DIFF
--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -54,37 +54,6 @@ std::string ReadFile(std::string filename)
 }
 #endif
 
-//Haversine formula to calculate distance between two points
-
-#define earthRadiusKm 6371.0
-
-// This function converts decimal degrees to radians
-double deg2rad(double deg)
-{
-	return (deg * 3.14159265358979323846264338327950288 / 180.0);
-}
-
-/**
- * Returns the distance between two points on the Earth.
- * Direct translation from http://en.wikipedia.org/wiki/Haversine_formula
- * @param lat1d Latitude of the first point in degrees
- * @param lon1d Longitude of the first point in degrees
- * @param lat2d Latitude of the second point in degrees
- * @param lon2d Longitude of the second point in degrees
- * @return The distance between the two points in kilometers
- */
-double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
-{
-	double lat1r, lon1r, lat2r, lon2r, u, v;
-	lat1r = deg2rad(lat1d);
-	lon1r = deg2rad(lon1d);
-	lat2r = deg2rad(lat2d);
-	lon2r = deg2rad(lon2d);
-	u = sin((lat2r - lat1r) / 2);
-	v = sin((lon2r - lon1r) / 2);
-	return 2.0 * earthRadiusKm * asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
-}
-
 CBuienRadar::CBuienRadar(const int ID, const int iForecast, const int iThreshold, const std::string& Location)
 {
 	m_HwdID = ID;

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -402,9 +402,9 @@ int CTTNMQTT::CalcDomoticsRssiFromLora(const int gwrssi, const float gwsnr)
 	// snr between -20 and +10 dB
 	// Domoticz expects something between 0 and 11 of what?
 	// But 0 feels weird as how could we measure 'no signal' 
-	if (iCalc >= 0)
+	if (iCalc >= -30 || rint(gwsnr) > 7)
 		iCalc = 9;
-	else if (iCalc > -30)
+	else if (iCalc > -40)
 		iCalc = 8;
 	else if (iCalc > -65)
 		iCalc = 7;
@@ -490,32 +490,163 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 			return;
 		}
 
-		//See if we can find the rssi
-		if (!root["metadata"].empty())
-		{
-			Json::Value MetaData = root["metadata"];
-			if (!MetaData["gateways"].empty())
-			{
-				Json::Value Gateways = MetaData["gateways"];
-				// TO_DO: there could be multiple gateways and we should loop them to find the lowest rssi
-				if (!Gateways[0].empty())
-				{
-					Json::Value Gateway = Gateways[0];
-					int gwrssi = Gateway["rssi"].asInt();
-					float gwsnr = Gateway["snr"].asFloat();
-					rssi = CalcDomoticsRssiFromLora(gwrssi, gwsnr);
-				}
-			}
-		}
-
 		int DeviceID = GetAddDeviceAndSensor(m_HwdID, DeviceName.c_str(), DeviceSerial.c_str());
 		if (DeviceID == 0) // Unable to find the Device and/or Add the new Device
 		{
 			return;
 		}
 
+		//See what info we can use from the provided metadata and gateway(s) data
+		const std::string format = "%Y-%m-%dT%H:%M:%S";
+		time_t msgtime = 0;
+		double ssrlat = 0;
+		double ssrlon = 0;
+		float ssralt = 0;
+		double devlat = 0;
+		double devlon = 0;
+		float devalt = 0;
+		double gwlat = 0;
+		double gwlon = 0;
+		float gwalt = 0;
+		int gwrssi = -999;
+		float gwsnr = -999;
+
+		// Let's look at the metadata that TTN also sends when receiving a LoRa message
+		if (!root["metadata"].empty())
+		{
+			Json::Value MetaData = root["metadata"];
+			if (!MetaData["time"].empty())
+			{
+				// Retrieve the moment the TTN backend receives the (first part of) this packet
+				// So we have a more accurate time when the measurement happened, compared to
+				// the moment we see the message here in Domoticz
+				// TTN time is in ISO8601 format and UTC
+				std::tm t = {};
+				int y,M,d,h,m;
+				float s;
+				const char* UTCttntime;
+
+				UTCttntime = MetaData["time"].asString().c_str();
+				sscanf(UTCttntime, "%d-%d-%dT%d:%d:%fZ", &y, &M, &d, &h, &m, &s);
+				t.tm_year = y - 1900; // Year since 1900
+				t.tm_mon = M - 1;     // 0-11
+				t.tm_mday = d;        // 1-31
+				t.tm_hour = h;        // 0-23
+				t.tm_min = m;         // 0-59
+				t.tm_sec = (int)s;    // 0-61 (0-60 in C++11)
+				msgtime = timegm(&t);
+			}
+			if (!(MetaData["latitude"].empty() || MetaData["longitude"].empty()))
+			{
+				// For this device, Location coordinates are set in the metadata.
+				// Makes sense for non moving sensors without own GPS
+				devlat = MetaData["latitude"].asDouble();
+				devlon = MetaData["longitude"].asDouble();
+				if (!MetaData["altitude"].empty())
+				{
+					devalt = MetaData["altitude"].asFloat();
+				}
+			}
+			// Let's see if there is metadata from 1 or more gateways that have received this message
+			if (!MetaData["gateways"].empty())
+			{
+				Json::Value Gateways = MetaData["gateways"];
+				// Loop over all gateways and try to find the one with the best signal
+				// and see if the GW has a Geo Location that we could use
+				uint8_t iGW = 0;
+				do
+				{
+					if (!Gateways[iGW].empty())
+					{
+						Json::Value Gateway = Gateways[iGW];
+
+						int lrssi = Gateway["rssi"].asInt();
+						float lsnr = Gateway["snr"].asFloat();
+						bool bBetter = false;
+						bool bGwGeo = (!(Gateway["latitude"].empty() || Gateway["longitude"].empty()));
+						bool bPrevGwGeo = (!(gwlat == 0 || gwlon == 0));
+
+						// Is this gateway closer to the sensor than the previous one (or is this the first/only one)
+						if (lsnr > 0 && floor(lsnr) >= floor(gwsnr))
+						{
+							if (floor(lsnr) == floor(gwsnr))
+							{
+								if(!bGwGeo && bPrevGwGeo)
+								{
+									if (floor((lrssi/10)) > floor((gwrssi/10)))
+									{
+										bBetter = true;
+									}
+								}
+								else if (bGwGeo && !bPrevGwGeo)
+								{
+									bBetter = true;
+								}
+								else
+								{
+									// Current and previous both either do or do not have Geo data
+									if (lrssi > gwrssi)
+									{
+										bBetter = true;
+									}
+								}
+							}
+							else
+							{
+								// Postitive SNR is better by a full point at least
+								bBetter = true;
+							}
+						}
+						else if (lsnr <= 0 && lrssi > gwrssi)
+						{
+							if(!bGwGeo && bPrevGwGeo)
+							{
+								// The previous found closest GW has Geo info and this one doesn't
+								// If the signals are very simular, we prefer the one with Geo
+								if (floor((lrssi/10)) > floor((gwrssi/10)))
+								{
+									bBetter = true;
+								}
+							}
+							else
+							{
+								bBetter = true;
+							}
+						}
+
+						if (bBetter)
+						{
+							// Ok, this gateway seems to be closer
+							// Let's see if it has Geo Location data
+							if (bGwGeo)
+							{
+								gwlat = Gateway["latitude"].asDouble();
+								gwlon = Gateway["longitude"].asDouble();
+								if (!Gateway["altitude"].empty())
+								{
+									gwalt = Gateway["altitude"].asDouble();
+								}
+							}
+							else if (bPrevGwGeo)
+							{
+ 								// No Geo data for this gateway, but we have a previous gateway further away. See clear the gwloc data
+								gwlat = 0;
+								gwlon = 0;
+								gwalt = 0;
+							}
+							gwsnr = lsnr;
+							gwrssi = lrssi;
+						}
+					}
+					iGW++;
+				}
+				while (!Gateways[iGW].empty());
+				rssi = CalcDomoticsRssiFromLora(gwrssi, gwsnr);
+			}
+		}
+
 		// Walk over the payload to find all used channels. Each channel represents a single sensor.
-		int chanSensors [65] = {};	// CayenneLPP Data Channel ranges from 0 to 64
+		uint8_t chanSensors [65] = {};	// CayenneLPP Data Channel ranges from 0 to 64
 		for (auto itt = payload.begin(); itt != payload.end(); ++itt)
 		{
 			uint8_t channel = (uint8_t)(*itt)["channel"].asInt();
@@ -526,12 +657,14 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 		}
 
 		// Now walk over each channel/sensor to find the different measurement types and values
-		int channel = 0;
+		uint8_t channel = 0;
+		uint8_t iGps = 0;
+		uint8_t iGpsChannel = 0;
 		do {
 			if(chanSensors[channel] > 0)
 			{
 				//_log.Log(LOG_STATUS, "TTN_MQTT: Processing %i Sensorvalues for channel %i!", chanSensors[channel],channel);
-				bool bTemp = false, bHumidity = false, bBaro = false, bGps = false, bDin = false, bDout = false, bAin = false, bAout = false, bPresense = false, bLuminosity = false;
+				bool bTemp = false, bHumidity = false, bBaro = false, bDin = false, bDout = false, bAin = false, bAout = false, bPresense = false, bLuminosity = false;
 				float temp = 0, hum = 0, baro = 0, lat = 0, lon = 0, alt = 0, ain = 0, aout = 0, presence = 0, luminocity = 0;
 				int din = 0, dout = 0;
 				uint8_t nforecast = wsbaroforecast_some_clouds;
@@ -558,12 +691,19 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 							bBaro = true;
 						}
 						else if (type == "gps") {
-							std::stringstream sstr;
-							sstr << vSensor["lat"].asFloat() << "," << vSensor["lon"].asFloat() << "," << vSensor["alt"].asFloat();
+							ssrlat = vSensor["lat"].asDouble();
+							ssrlon = vSensor["lon"].asDouble();
+							ssralt = vSensor["alt"].asFloat();
+							//SendGpsLocation(DeviceID, channel, BatteryLevel, rssi, DeviceName, ssrlat, ssrlon, ssralt);
 
-							SendPercentageSensor(DeviceID, channel, BatteryLevel, vSensor["alt"].asFloat(), DeviceName + " Altitude");
-							UpdateUserVariable(DeviceName, sstr.str());
-							bGps = true;
+							std::stringstream sstr;
+							sstr << ssrlat << ";" << ssrlon << ";" << ssralt;
+							SendCustomSensor(DeviceID, channel, BatteryLevel, ssralt, DeviceName + " Geo", "meters", rssi);
+							UpdateUserVariable(DeviceName + " Geo", sstr.str());
+
+							iGps++;
+							iGpsChannel = channel;
+
 						}
 						else if (type == "digital_input") {
 							SendGeneralSwitch(DeviceID, channel, BatteryLevel, vSensor["value"].asInt(), 0, DeviceName, rssi);
@@ -657,6 +797,88 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 			channel++;
 		}
 		while (channel < 65);
+
+		// Now we have processed all readings for all channels
+		// If we have not seen any GPS data on any channel in this payload
+		// and the metadata contains Location coordinates, let's process these 
+		if(iGps == 0 && !(devlat == 0 || devlon == 0))
+		{
+			std::stringstream sstr;
+			sstr << devlat << ";" << devlon << ";" << devalt;
+
+			SendCustomSensor(DeviceID, channel, BatteryLevel, devalt, DeviceName + " Geo", "meters", rssi);
+			UpdateUserVariable(DeviceName + " Geo", sstr.str());
+
+			// Set the Meta location as sensor location for further processing
+			ssrlat = devlat;
+			ssrlon = devlon;
+			ssralt = devalt;
+
+			iGpsChannel = channel;
+		}
+
+		// If we have a Geo Location of the sensor (either own or meta), calculate distance from 'home'
+		if(iGps == 1 || !(devlat == 0 || devlon == 0))
+		{
+			double fDomLat;
+			double fDomLon;
+			int nValue;
+			std::string sValue;
+			std::string Latitude;
+			std::string Longitude;
+
+			// Let's get the 'home' Location of this Domoticz instance from the Preferences
+			if (m_sql.GetPreferencesVar("Location", nValue, sValue))
+			{
+				std::vector<std::string> strarray;
+				StringSplit(sValue, ";", strarray);
+
+				if (strarray.size() == 2)
+				{
+					Latitude = strarray[0];
+					Longitude = strarray[1];
+
+					if (!((Latitude == "1") && (Longitude == "1")))
+					{
+						fDomLat = std::stod(Latitude);
+						fDomLon = std::stod(Longitude);
+
+						uint64_t nSsrDistance = (rint(1000 * distanceEarth(fDomLat, fDomLon, ssrlat, ssrlon)));
+						SendCustomSensor(DeviceID, (iGpsChannel + 64), BatteryLevel, nSsrDistance, DeviceName + " Home Distance", "meters", rssi);
+						//_log.Log(LOG_STATUS, "TTN_MQTT: Distance between Sensordevice and Domoticz Home is %i meters!", nSsrDistance);
+					}
+					else
+					{
+						_log.Log(LOG_ERROR, "TTN_MQTT: Invalid Location found in Settings! (Check your Latitude/Longitude!)");
+					}
+				}
+				else
+				{
+					_log.Log(LOG_ERROR, "TTN_MQTT: Invalid Location found in Settings! (Check your Latitude/Longitude!)");
+				}
+			}
+			else
+			{
+				_log.Log(LOG_ERROR, "TTN_MQTT: Invalid Location found in Settings! (Check your Latitude/Longitude!)");
+			}
+		}
+
+		// Did we find any Geo Location data from the Gateway with the best reception
+		if (!(gwlat == 0 && gwlon == 0))
+		{
+			//_log.Log(LOG_STATUS, "TTN_MQTT: Found Geo Location data for the Gateway with the best reception at lat: %f, lon: %f, alt: %f", gwlat, gwlon, gwalt);
+			// We have Geo Location data of the sensor AND of the gateway, so we can calculate the distance
+			if (iGps > 1)
+			{
+				_log.Log(LOG_STATUS, "TTN_MQTT: More than 1 GPS measurements found! Unable to determine which one to pick for distance calculations!"); 
+			}
+			else if (!(ssrlat == 0 && ssrlon == 0))
+			{
+				uint64_t nGwDistance = (rint(1000 * distanceEarth(gwlat, gwlon, ssrlat, ssrlon)));
+				SendCustomSensor(DeviceID, (channel + 128), BatteryLevel, nGwDistance, DeviceName + " Gateway Distance", "meters", rssi);
+			//	_log.Log(LOG_STATUS, "TTN_MQTT: Distance between Sensordevice and gateway is %i meters!", nGwDistance);
+			}
+		}
 	}
 	catch (...)
 	{

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -539,6 +539,36 @@ float pressureSeaLevelFromAltitude(float altitude, float atmospheric, float temp
 		(temp + 0.0065F * altitude + 273.15F)), -5.257F);
 }
 
+//Haversine formula to calculate distance between two points
+
+#define earthRadiusKm 6371.0
+
+// This function converts decimal degrees to radians
+double deg2rad(double deg)
+{
+	return (deg * 3.14159265358979323846264338327950288 / 180.0);
+}
+
+/**
+ * Returns the distance between two points on the Earth.
+ * Direct translation from http://en.wikipedia.org/wiki/Haversine_formula
+ * @param lat1d Latitude of the first point in degrees
+ * @param lon1d Longitude of the first point in degrees
+ * @param lat2d Latitude of the second point in degrees
+ * @param lon2d Longitude of the second point in degrees
+ * @return The distance between the two points in kilometers
+ */
+double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
+{
+	double lat1r, lon1r, lat2r, lon2r, u, v;
+	lat1r = deg2rad(lat1d);
+	lon1r = deg2rad(lon1d);
+	lat2r = deg2rad(lat2d);
+	lon2r = deg2rad(lon2d);
+	u = sin((lat2r - lat1r) / 2);
+	v = sin((lon2r - lon1r) / 2);
+	return 2.0 * earthRadiusKm * asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
+}
 
 std::string &stdstring_ltrim(std::string &s)
 {

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -41,6 +41,8 @@ double CalculateAltitudeFromPressure(double pressure);
 float pressureSeaLevelFromAltitude(float altitude, float atmospheric, float temp);
 float pressureToAltitude(float seaLevel, float atmospheric, float temp);
 
+double deg2rad(double deg);
+double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d);
 std::string &stdstring_ltrim(std::string &s);
 std::string &stdstring_rtrim(std::string &s);
 std::string &stdstring_trim(std::string &s);


### PR DESCRIPTION
This PR is an alternative for PR [#4123 ](https://github.com/domoticz/domoticz/pull/4123).

It processes GPS data from a CayenneLPP payload now as a custom sensor showing the Altitude AND puts the Lat;Lon;Alt data into a User Variable.

The TTN MetaData coming with each LoRa message is now also fully processed. This means when the Geo Location of a (usually static) sensor is set in the settings of a LoRa device through the TTN Console, this data becomes part of the MetaData and will be used as if the sensor has send GPS data.

Also when the Location of Domoticz is set in the generic settings, the distance between the Geo Location of the sensor and the 'home' location of the Domoticz instance is calculated (in meters) and stored into a separate device.

Using the standard notification functionality, this distance device can be used as a 'Geofence' to trigger an action if a sensor comes within reach or gets outside of reach. 

The distance calculations are done using the (now generic) DistanceEarth function originally found in the BuienRadar module.

Now also the MetaData of all LoRa gateways that have seen the sensor is being processed (instead of only the first one) and based on the 'best' reception of the signal, the one 'closest' to the sensor is selected. If the gateway has Geo Location data than this location is also stored as a separate sensor and the distance between the sensor and this nearest gateway gets calculated and stored as well.
  
Finally, the RSSI calculation has been improved a little. 