### PR TITLE
Prevent use of wrong commands in switchcmd parm of switchscene JSON

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -2470,7 +2470,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 	if ((BatteryLevel != -1) && (procResult.bProcessBatteryValue))
 	{
 		m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d WHERE (ID==%" PRIu64 ")", BatteryLevel, DeviceRowIdx);
-		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily...
+		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily... 
 	}
 
 	if ((defaultName != NULL) && ((DeviceName == "Unknown") || (DeviceName.empty())))

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -333,12 +333,6 @@ void MainWorker::StopDomoticzHardware()
 	}
 }
 
-bool MainWorker::Inarray(const std::string &value, const std::vector<std::string> strarray)
-{
-	return std::find(strarray.begin(), strarray.end(), value) != strarray.end();
-}
-
-
 void MainWorker::GetAvailableWebThemes()
 {
 	std::string ThemeFolder = szWWWFolder + "/styles/";
@@ -13023,8 +13017,8 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 
 		if (scenetype == SGTYPE_GROUP)
 		{
-			std::vector<std::string> validGroupSwitchcmd {"On", "Off", "Toggle", "Group On" , "Chime", "All On"};
-			if (!MainWorker::Inarray(switchcmd, validGroupSwitchcmd))
+			std::vector<std::string> validCmdArray {"On", "Off", "Toggle", "Group On" , "Chime", "All On"};
+			if (std::find(validCmdArray.begin(), validCmdArray.end(), switchcmd) == validCmdArray.end())
 				return false;
 			//when asking for Toggle, just switch to the opposite value
 			if (switchcmd == "Toggle") {
@@ -13034,9 +13028,8 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 		}
 		else
 		{
-			std::vector<std::string> validSceneSwitchcmd {"On"};
-			if (!MainWorker::Inarray(switchcmd, validSceneSwitchcmd))
-				return false;
+			if (switchcmd != "On")
+				return false; //A Scene can only be turned On
 		}
 		m_sql.HandleOnOffAction((nValue == 1), onaction, offaction);
 	}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -333,6 +333,12 @@ void MainWorker::StopDomoticzHardware()
 	}
 }
 
+bool MainWorker::Inarray(const std::string &value, const std::vector<std::string> strarray)
+{
+	return std::find(strarray.begin(), strarray.end(), value) != strarray.end();
+}
+
+
 void MainWorker::GetAvailableWebThemes()
 {
 	std::string ThemeFolder = szWWWFolder + "/styles/";
@@ -2470,7 +2476,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 	if ((BatteryLevel != -1) && (procResult.bProcessBatteryValue))
 	{
 		m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d WHERE (ID==%" PRIu64 ")", BatteryLevel, DeviceRowIdx);
-		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily... 
+		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily...
 	}
 
 	if ((defaultName != NULL) && ((DeviceName == "Unknown") || (DeviceName.empty())))
@@ -13017,11 +13023,20 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 
 		if (scenetype == SGTYPE_GROUP)
 		{
+			std::vector<std::string> validGroupSwitchcmd {"On", "Off", "Toggle", "Group On" , "Chime", "All On"};
+			if (!MainWorker::Inarray(switchcmd, validGroupSwitchcmd))
+				return false;
 			//when asking for Toggle, just switch to the opposite value
 			if (switchcmd == "Toggle") {
 				nValue = (atoi(status.c_str()) == 0 ? 1 : 0);
 				switchcmd = (nValue == 1 ? "On" : "Off");
 			}
+		}
+		else
+		{
+			std::vector<std::string> validSceneSwitchcmd {"On"};
+			if (!MainWorker::Inarray(switchcmd, validSceneSwitchcmd))
+				return false;
 		}
 		m_sql.HandleOnOffAction((nValue == 1), onaction, offaction);
 	}

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -129,8 +129,7 @@ public:
 	bool m_bHaveDownloadedDomoticzUpdateSuccessFull;
 	std::string m_UpdateStatusMessage;
 
-		bool Inarray(const std::string &value, const std::vector<std::string> strarray);
-		void GetAvailableWebThemes();
+	void GetAvailableWebThemes();
 
 	tcp::server::CTCPServer m_sharedserver;
 	std::string m_LastSunriseSet;

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -129,7 +129,8 @@ public:
 	bool m_bHaveDownloadedDomoticzUpdateSuccessFull;
 	std::string m_UpdateStatusMessage;
 
-	void GetAvailableWebThemes();
+		bool Inarray(const std::string &value, const std::vector<std::string> strarray);
+		void GetAvailableWebThemes();
 
 	tcp::server::CTCPServer m_sharedserver;
 	std::string m_LastSunriseSet;


### PR DESCRIPTION
Code logic caused wrong spelled commands to be interpreted as Off
So if a user misspelled On like on it would cause unexpected behavior.

It could well be that the way I tried to fix this is not conform the standard domoticz way of handling it.
In that case please advise how to tackle this.