### PR TITLE
TTNMQTT: Possibility to use TTN custom decoder for decoding (incl. batterylevel)

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -528,7 +528,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 
 				UTCttntime = MetaData["time"].asString().c_str();
 				sscanf(UTCttntime, "%d-%d-%dT%d:%d:%fZ", &y, &M, &d, &h, &m, &s);
-				constructTime(msgtime, t, y, M, d, h, m, s);
+				constructTime(msgtime, t, y, M, d, h, m, (int)floor(s));
 			}
 			if (!(MetaData["latitude"].empty() || MetaData["longitude"].empty()))
 			{

--- a/hardware/TTNMQTT.h
+++ b/hardware/TTNMQTT.h
@@ -48,8 +48,10 @@ private:
 
 	bool ConnectInt();
 	bool ConnectIntEx();
-	Json::Value GetSensorWithChannel(const Json::Value &root, const int sChannel);
-	void FlagSensorWithChannelUsed(Json::Value &root, const std::string &stype, const int sChannel);
+	Json::Value GetSensorWithChannel(const Json::Value &root, const uint8_t sChannel);
+	void FlagSensorWithChannelUsed(Json::Value &root, const std::string &stype, const uint8_t sChannel);
+	bool ConvertField2Payload(const std::string sType, const std::string sValue, const uint8_t channel, const uint8_t index, Json::Value &payload);
+	bool ConvertFields2Payload(const Json::Value &fields, Json::Value &payload);
 	int CalcDomoticsRssiFromLora(const int gwrssi, const float gwsnr);
 	int GetAddDeviceAndSensor(const int m_HwdId, const std::string &DeviceName, const std::string &MacAddress);
 };


### PR DESCRIPTION
This PR add the possibility of processing custom payload fields to the TTNMQTT module.

Within the The Things Network not only CayenneLPP payloads can be used, but there is also an option to use a custom 'external' decoder (custom Javascript decoder running on the TTN backend manageable through the TTN Console) to decode received payloads on the backend BEFORE they are send to MQTT subscribers.

These custom decoded fields become part of the MQTT payload (payload_fields) so can be used.

As the TTNMQTT module is one of those MQTT subscribers, if the structure of the decoded data is not too complex and similar to the defined CayenneLPP fields, the module tries to map the 'payload_fields' and processes them.

This means, within a customer decoder the fields with measurement should be called similar to the CayenneLPP field types:
- temp (or temperature)
- hum (or humidity)
- baro
- gps
- digital_input
- digital_output
- analog_input
- analog_output
- presence
- luminocity

and a special one called 'batterylevel' (percentage 0-100) which is processed as the 'battery level' of the device.

For GPS, the measurement value should be a single string like  '[lat];[lon];[alt]' where lat/lon in digital degrees and alt in meters.

So using the 'custom encoder' option of TTN and this processing, it becomes possible to process data from LoRa devices that do not send there data in CayenneLPP format.

(I will document this more properly on the Domoticz Wiki when part of the Beta and more testing has been done).