### PR TITLE
dzVents update to 3.0.9

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -8,9 +8,8 @@ Version 2020.xxxx (xxxx)
 - Implemented: RTL433, switched to Json input
 - Implemented: ZWave, Legend and tooltips in Neighbours overview
 - Implemented: The following sensor types now support RSSI: Distance Sensor, Moisture Sensor, Watt Meter, kWh Meter
-- Updated: dzVents version 3.0.8 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
+- Updated: dzVents version 3.0.9 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
 - Updated: eVehicles, added ODO meter, unlock/open alert, max charge level to Tesla module
-- Updated: OpenZwave, added legend and tooltips in neighbours overview
 - Updated: OpenZWave configuration files
 - Updated: TTNMQTT, improved Improved calculation and storage of signal-levels
 - For a full overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits for details

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -206,16 +206,16 @@ A list of one or more custom event triggers. This eventTrigger can be activate b
 		`domoticz.emitEvent('another event', 'some data')`
 		`domoticz.emitEvent('hugeEvent', { a = 10, b = 20, some = 'text', sub = { x = 10, y = 20 } })`
 
-The customEvent object
-The customeEvent object (second parameter in your execute function) has these attributes:
+##### Attributes
+The customEvent object (second parameter in your execute function) has these attributes:
 
  - **data**: Raw customEevent data.
  - **isJSON**: *Boolean*.<sup>3.0.3</sup> true when the customEvent data is a valid json string. The data is then automatically converted to a Lua table.
  - **isXML**: *Boolean*. <sup>3.0.3</sup> true when the customEvent data is a valid xml string. When true, the data is automatically converted to a Lua table.
- - **json**. *Table*. <sup>3.0.3</sup> When the customEvent data is a valid json string, the response data is automatically converted to a Lua table for quick and easy access.
- - **trigger**, **customEvent**: *String*.<sup>3.0.3</sup> The string that triggered this customEvent instance. This is useful if you have a script that is triggered by multiple different customEvent strings.
- - **xml**. *Table*. <sup>3.0.3</sup> When the response data is a valid xml string, the customeEvent data is automatically converted to a Lua table for quick and easy access.
- 
+ - **json**. *Table*. <sup>3.0.3</sup> When the customEvent data is a valid json string, the response data is automatically converted to a Lua table for quick and easy access. nil otherwise
+ - **trigger**, **customEvent**: *String*.<sup>3.0.3</sup> The string that triggered this customEvent instance. This is useful if you have a script that can be triggered by multiple different customEvent strings.
+ - **xml**. *Table*. <sup>3.0.3</sup> When the response data is a valid xml string, the customEvent data is automatically converted to a Lua table for quick and easy access. nil otherwise
+
 
 #### devices = { ... }
 A list of device-names or indexes. If a device in your system was updated (e.g. switch was triggered or a new temperature was received) and it is listed in this section then the execute function is executed. **Note**: update does not necessarily means the device state or value has changed. Each device can be:
@@ -291,7 +291,7 @@ When all the above conditions are met (active == true and the on section has at 
 
 Since you can define multiple on-triggers in your script, it is not always clear what the type is of this second parameter. In your code you need to know this in order to properly respond to the different events. To help you inspect the object you can use these attributes like `if (item.isDevice) then ... end`:
 
- - **isCustomEvent**: <sup>3.0.0</sup>. returns `true` if the item is a customEvent.
+ - **isCustomEvent**: <sup>3.0.0</sup>. returns `true` if the item is a customEvent object.
  - **isDevice**: . returns `true` if the item is a Device object.
  - **isGroup**: . returns `true` if the item is a Group object.
  - **isHTTPResponse**: .  returns `true` if the item is an HTTPResponse object.
@@ -657,8 +657,8 @@ The domoticz object holds all information about your Domoticz system. It has glo
  - **devices(idx/name)**: *Function*. A function returning a device by idx or name: `domoticz.devices(123)` or `domoticz.devices('My switch')`. For the device API see [Device object API](#Device_object_API). To iterate over all devices do: `domoticz.devices().forEach(..)`. See [Looping through the collections: iterators](#Looping_through_the_collections:_iterators). Note that you cannot do `for i, j in pairs(domoticz.devices()) do .. end`.
  - **dump([osfile]<sup>3.0.0</sup>)**: *Function*. <sup>2.4.16</sup> Dump all domoticz.settings attributes to the Domoticz log. This ignores the log level setting.
  - **email(subject, message, mailTo)**: *Function*. Send email.
- - **emitEvent(name,[extra data ])**:*Function*. <sup>3.0.0</sup> Have Domoticz 'call' a customEvent. If you just pass a name then Domoticz will execute the script(s) that subscribed to the named customEvent after your script has finished. You can optionally pass extra information as a string or table. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- - **groups(idx/name)**: *Function*: A function returning a group by name or idx. Each group has the same interface as a device. To iterate over all groups do: `domoticz.groups().forEach(..)`. See [Looping through the collections: iterators](#Looping_through_the_collections:_iterators). Note that you cannot do `for i, j in pairs(domoticz.groups()) do .. end`. Read more about [Groups](#Group).
+ - **emitEvent(name,[extra data ])**:*Function*. <sup>3.0.0</sup> Have Domoticz 'call' a customEvent. If you just pass a name then Domoticz will execute the script(s) that subscribed to the named customEvent after your script has finished. You can optionally pass extra information as a string or table. A table will be automatically converted into a json string and converted back to a table in the subscribed script(s). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+  - **groups(idx/name)**: *Function*: A function returning a group by name or idx. Each group has the same interface as a device. To iterate over all groups do: `domoticz.groups().forEach(..)`. See [Looping through the collections: iterators](#Looping_through_the_collections:_iterators). Note that you cannot do `for i, j in pairs(domoticz.groups()) do .. end`. Read more about [Groups](#Group).
  - **hardwareInfo(idx/name)**: <sup>3.0.6</sup> *Function*: A function returning hardwareInfo of a hardware module by name or idx. The return of the function is a table with attributes name, type, typeValue, deviceNames (table with names of all active devices defined on this hardware) and deviceIds (table with idx of all active devices defined on this hardware)
  - **hardware(idx/name)**:  <sup>3.0.7</sup> *Function*: A function returning a hardware module by name or idx. Each hardware has an interface comparable to group. To iterate over all hardware do: `domoticz.hardware().forEach(..)`. See [Looping through the collections: iterators](#Looping_through_the_collections:_iterators). Note that you cannot do `for i, j in pairs(domoticz.hardware()) do .. end`. Read more about [Hardware](#Hardware).
  - **helpers**: *Table*. Collection of shared helper functions available to all your dzVents scripts. See [Shared helper functions](#Shared_helper_functions).
@@ -1144,7 +1144,6 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **stop()**: *Function*. Set device to Stop if it supports it (e.g. blinds). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **switchOff()**: *Function*. Switch device off it is supports it. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **switchOn()**: *Function*. Switch device on if it supports it. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- * '''switchSelector(&lt;[level]|[levelname] &gt;) '''  : 
  - **switchSelector(<[level]|[levelname] >)** <sup>levelname >= 2.4.22</sup> : *Function*. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Levelname is only supported when level 0 ("Off") is not removed Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **toggleSwitch()**: *Function*. Toggles the state of the switch (if it is togglable) like On/Off, Open/Close etc.
 
@@ -1504,7 +1503,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
  - **hoursAgo**: *Number*. Number of hours since the last update.
  - **isToday**: *Boolean*. Indicates if the device was updated today
  - **isUTC**: *Boolean*.
- - **makeTime(timeString,[isUTC])**: *time object*. <sup>2.5.4</sup> time object based on parameter format must 'yyyy-mm-dd hh:mm:ss'. isUTC defaults to false
+ - **makeTime(string | table,[isUTC])**: *domoticz time object*. <sup>2.5.4</sup> returns domoticz time object based on first parameter (time as table or string) string format must be 'yyyy-mm-dd hh:mm:ss'. isUTC defaults to false.
  - **matchesRule(rule) **: *Function*. Returns true if the rule matches with the time. See [time trigger rules](#timer_trigger_rules) for rule examples.
  - **millisecondsAgo**: *Number*. Number of milliseconds since the last update.
  - **minutes**: *Number*
@@ -1524,6 +1523,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
  - **sunsetInMinutes**: *Number*. Minutes from midnight until sunset.
  - **sunriseInMinutes**: *Number*. Minutes from midnight until sunrise.
  - **time**: *String*. <sup>2.5.6</sup> Returns the time part of the raw data as HH:MM
+ - **toUTC(string | table,[offset])**: *domoticz time object*. <sup>3.0.9</sup> returns domoticz time object based on first parameter (time as table or string) string format must be 'yyyy-mm-dd hh:mm:ss'. offset defaults to 0.
  - **utcSystemTime**: *Table*. UTC system time (only when in UTC mode):
 	- **day**: *Number*
 	- **hour**: *Number*
@@ -1542,7 +1542,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
  - **wday**: *Number* day of the week. Sunday = 1, Saturday = 7
  - **week**: *Number* week of the year
 
-**Note: it is currently not possible to change the domoticz.time object instance.** ( but you can create a new one )
+**Note: it is currently not possible to change the domoticz.time object instance.** ( but you can create a new one with- or without an offset)
 
 ## Shared helper functions
 It is not unlikely that at some point you want to share Lua code among your scripts. Normally in Lua you would have to create a module and require that module in all you scripts. But dzVents makes that easier for you:
@@ -2453,6 +2453,11 @@ In 2.x it is no longer needed to make timed json calls to Domoticz to get extra 
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and/or `::1` and you're good to go.
 
 # History
+
+## [3.0.9]
+- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
+- Add function toUTC to time object.
+- Allow table as parm to function makeTime
 
 ## [3.0.8]
 - Allow IPv6 ::1 as localhost in domoticz settings 

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -189,14 +189,16 @@ A list of one or more custom event triggers. This eventTrigger can be activate b
     `domoticz.emitEvent('myEvent') -- no data`
     `domoticz.emitEvent('another event', 'some data')`
     `domoticz.emitEvent('hugeEvent', { a = 10, b = 20, some = 'text', sub = { x = 10, y = 20 } })`</pre>
-The customEvent object The customeEvent object (second parameter in your execute function) has these attributes:
+===== Attributes =====
+
+The customEvent object (second parameter in your execute function) has these attributes:
 
 * '''data''': Raw customEevent data.
 * '''isJSON''': ''Boolean''.<sup>3.0.3</sup> true when the customEvent data is a valid json string. The data is then automatically converted to a Lua table.
 * '''isXML''': ''Boolean''. <sup>3.0.3</sup> true when the customEvent data is a valid xml string. When true, the data is automatically converted to a Lua table.
-* '''json'''. ''Table''. <sup>3.0.3</sup> When the customEvent data is a valid json string, the response data is automatically converted to a Lua table for quick and easy access.
-* '''trigger''', '''customEvent''': ''String''.<sup>3.0.3</sup> The string that triggered this customEvent instance. This is useful if you have a script that is triggered by multiple different customEvent strings.
-* '''xml'''. ''Table''. <sup>3.0.3</sup> When the response data is a valid xml string, the customeEvent data is automatically converted to a Lua table for quick and easy access.
+* '''json'''. ''Table''. <sup>3.0.3</sup> When the customEvent data is a valid json string, the response data is automatically converted to a Lua table for quick and easy access. nil otherwise
+* '''trigger''', '''customEvent''': ''String''.<sup>3.0.3</sup> The string that triggered this customEvent instance. This is useful if you have a script that can be triggered by multiple different customEvent strings.
+* '''xml'''. ''Table''. <sup>3.0.3</sup> When the response data is a valid xml string, the customEvent data is automatically converted to a Lua table for quick and easy access. nil otherwise
 
 ==== devices = { … } ====
 
@@ -274,7 +276,7 @@ Depending on what actually triggered the script, <code>item</code> is either a:
 
 Since you can define multiple on-triggers in your script, it is not always clear what the type is of this second parameter. In your code you need to know this in order to properly respond to the different events. To help you inspect the object you can use these attributes like <code>if (item.isDevice) then ... end</code>:
 
-* '''isCustomEvent''': <sup>3.0.0</sup>. returns <code>true</code> if the item is a customEvent.
+* '''isCustomEvent''': <sup>3.0.0</sup>. returns <code>true</code> if the item is a customEvent object.
 * '''isDevice''': . returns <code>true</code> if the item is a Device object.
 * '''isGroup''': . returns <code>true</code> if the item is a Group object.
 * '''isHTTPResponse''': . returns <code>true</code> if the item is an HTTPResponse object.
@@ -628,7 +630,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 <li>'''devices(idx/name)''': ''Function''. A function returning a device by idx or name: <code>domoticz.devices(123)</code> or <code>domoticz.devices('My switch')</code>. For the device API see [[#Device_object_API|Device object API]]. To iterate over all devices do: <code>domoticz.devices().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.devices()) do .. end</code>.</li>
 <li>'''dump([osfile]<sup>3.0.0</sup>)''': ''Function''. <sup>2.4.16</sup> Dump all domoticz.settings attributes to the Domoticz log. This ignores the log level setting.</li>
 <li>'''email(subject, message, mailTo)''': ''Function''. Send email.</li>
-<li>'''emitEvent(name,[extra data ])''':''Function''. <sup>3.0.0</sup> Have Domoticz ‘call’ a customEvent. If you just pass a name then Domoticz will execute the script(s) that subscribed to the named customEvent after your script has finished. You can optionally pass extra information as a string or table. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].</li>
+<li>'''emitEvent(name,[extra data ])''':''Function''. <sup>3.0.0</sup> Have Domoticz ‘call’ a customEvent. If you just pass a name then Domoticz will execute the script(s) that subscribed to the named customEvent after your script has finished. You can optionally pass extra information as a string or table. A table will be automatically converted into a json string and converted back to a table in the subscribed script(s). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].</li>
 <li>'''groups(idx/name)''': ''Function'': A function returning a group by name or idx. Each group has the same interface as a device. To iterate over all groups do: <code>domoticz.groups().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.groups()) do .. end</code>. Read more about [[#Group|Groups]].</li>
 <li>'''hardwareInfo(idx/name)''': <sup>3.0.6</sup> ''Function'': A function returning hardwareInfo of a hardware module by name or idx. The return of the function is a table with attributes name, type, typeValue, deviceNames (table with names of all active devices defined on this hardware) and deviceIds (table with idx of all active devices defined on this hardware)</li>
 <li>'''hardware(idx/name)''': <sup>3.0.7</sup> ''Function'': A function returning a hardware module by name or idx. Each hardware has an interface comparable to group. To iterate over all hardware do: <code>domoticz.hardware().forEach(..)</code>. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]. Note that you cannot do <code>for i, j in pairs(domoticz.hardware()) do .. end</code>. Read more about [[#Hardware|Hardware]].</li>
@@ -1130,7 +1132,6 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''stop()''': ''Function''. Set device to Stop if it supports it (e.g. blinds). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOff()''': ''Function''. Switch device off it is supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''switchOn()''': ''Function''. Switch device on if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
-* ’‘’switchSelector(&lt;[level]|[levelname] &gt;)’’’ :
 * '''switchSelector(&lt;[level]|[levelname] &gt;)''' <sup>levelname &gt;= 2.4.22</sup> : ''Function''. Switches a selector switch to a specific level ( levelname or level(numeric) required ) levelname must be exact, for level the closest fit will be picked. See the edit page in Domoticz for such a switch to get a list of the values). Levelname is only supported when level 0 (“Off”) is not removed Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''toggleSwitch()''': ''Function''. Toggles the state of the switch (if it is togglable) like On/Off, Open/Close etc.
 
@@ -1491,7 +1492,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
 * '''hoursAgo''': ''Number''. Number of hours since the last update.
 * '''isToday''': ''Boolean''. Indicates if the device was updated today
 * '''isUTC''': ''Boolean''.
-* '''makeTime(timeString,[isUTC])''': ''time object''. <sup>2.5.4</sup> time object based on parameter format must ‘yyyy-mm-dd hh:mm:ss’. isUTC defaults to false
+* '''makeTime(string | table,[isUTC])''': ''domoticz time object''. <sup>2.5.4</sup> returns domoticz time object based on first parameter (time as table or string) string format must be ‘yyyy-mm-dd hh:mm:ss’. isUTC defaults to false.
 * '''matchesRule(rule) ''': ''Function''. Returns true if the rule matches with the time. See [[#timer_trigger_rules|time trigger rules]] for rule examples.
 * '''millisecondsAgo''': ''Number''. Number of milliseconds since the last update.
 * '''minutes''': ''Number''
@@ -1511,6 +1512,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
 * '''sunsetInMinutes''': ''Number''. Minutes from midnight until sunset.
 * '''sunriseInMinutes''': ''Number''. Minutes from midnight until sunrise.
 * '''time''': ''String''. <sup>2.5.6</sup> Returns the time part of the raw data as HH:MM
+* '''toUTC(string | table,[offset])''': ''domoticz time object''. <sup>3.0.9</sup> returns domoticz time object based on first parameter (time as table or string) string format must be ‘yyyy-mm-dd hh:mm:ss’. offset defaults to 0.
 * '''utcSystemTime''': ''Table''. UTC system time (only when in UTC mode):
 ** '''day''': ''Number''
 ** '''hour''': ''Number''
@@ -1529,7 +1531,7 @@ local someTime = domoticz.time.makeTime() -- someTime = new domoticz time object
 * '''wday''': ''Number'' day of the week. Sunday = 1, Saturday = 7
 * '''week''': ''Number'' week of the year
 
-'''Note: it is currently not possible to change the domoticz.time object instance.''' ( but you can create a new one )
+'''Note: it is currently not possible to change the domoticz.time object instance.''' ( but you can create a new one with- or without an offset)
 
 == Shared helper functions ==
 
@@ -2398,6 +2400,12 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and/or <code>::1</code> and you’re good to go.
 
 = History =
+
+== [3.0.9] ==
+
+* Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time.
+* Add function toUTC to time object.
+* Allow table as parm to function makeTime
 
 == [3.0.8] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,8 @@
+[3.0.9]
+- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
+- Add function toUTC to time object.
+- Allow table as parm to function makeTime
+
 [3.0.8]
 - Allow IPv6 ::1 as localhost in domoticz settings 
 - Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)

--- a/dzVents/runtime/Camera.lua
+++ b/dzVents/runtime/Camera.lua
@@ -8,8 +8,8 @@ local function Camera(domoticz, data, dummyLogger)
 	local state
 	local adapterManager = Adapters(dummyLogger)
 
-	function self.dump()
-		domoticz.logCamera(self)
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'Camera')
 	end
 
 	self['name'] = data.name

--- a/dzVents/runtime/CustomEvent.lua
+++ b/dzVents/runtime/CustomEvent.lua
@@ -17,8 +17,12 @@ local function CustomEvent(domoticz, eventData)
 	self.isJSON = false
 	self.data = eventData.data.data
 
-	if self.data and utils.isJSON(self.data) then 
-		local json = utils.fromJSON(self.data:gsub("'",'"')) 
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'customEvent')
+	end
+
+	if self.data and utils.isJSON(self.data) then
+		local json = utils.fromJSON(self.data:gsub("'",'"'))
 		if json and type(json) == 'table' then
 			self.isJSON = true
 			self.json = json

--- a/dzVents/runtime/Device.lua
+++ b/dzVents/runtime/Device.lua
@@ -22,7 +22,7 @@ local function Device(domoticz, data, dummyLogger)
 	end
 
 	function self.dump( filename )
-		domoticz.logDevice(self, filename)
+		domoticz.logObject(self, filename, 'device')
 	end
 
 	function self.dumpSelection( selection )

--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -314,16 +314,8 @@ local function Domoticz(settings)
 		self.utils.dumpTable(settings, '> ', file)
 	end
 
-	function self.logDevice(device, file)
-		self.utils.dumpTable(device, '> ', file)
-	end
-
-	function self.logCamera(camera, file)
-		self.utils.dumpTable(camera, '> ', file)
-	end
-
-	function self.logHardware(hardware, file)
-		self.utils.dumpTable(hardware, '> ', file)
+	function self.logObject(object, file, objectType )
+		self.utils.dumpTable(object, objectType .. '> ', file)
 	end
 
 	self.__cameras = {}

--- a/dzVents/runtime/HTTPResponse.lua
+++ b/dzVents/runtime/HTTPResponse.lua
@@ -27,6 +27,10 @@ local function HTTPResponce(domoticz, responseData, testResponse)
 		end
 	end
 
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'HTTPResponse')
+	end
+
 	self.isXML = false
 	self.isJSON = false
 

--- a/dzVents/runtime/Security.lua
+++ b/dzVents/runtime/Security.lua
@@ -1,13 +1,17 @@
 local evenItemIdentifier = require('eventItemIdentifier')
 local function Security(domoticz, rule)
 
-    local self = {
-        state = domoticz.security
-    }
+	local self = {
+		state = domoticz.security
+	}
 
 	evenItemIdentifier.setType(self, 'isSecurity', domoticz.BASETYPE_SECURITY, rule)
 
-    return self
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'security')
+	end
+
+	return self
 
 end
 

--- a/dzVents/runtime/SystemEvent.lua
+++ b/dzVents/runtime/SystemEvent.lua
@@ -23,6 +23,10 @@ local function SystemEvent(domoticz, eventData)
 	self.duration = eventData.data and eventData.data.duration or nil
 	self.location = eventData.data and eventData.data.location or nil
 
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'systemEvent')
+	end
+
 	evenItemIdentifier.setType(
 		self,
 		'isSystemEvent',

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -307,11 +307,11 @@ local function Time(sDate, isUTC, _testMS)
 	end
 
 	function self.addSeconds(seconds, factor)
-		if type(seconds) ~= 'number' then 
+		if type(seconds) ~= 'number' then
 			self.utils.log(tostring(seconds) .. ' is not a valid parameter to this function. Please change to use a number value!', utils.LOG_ERROR)
 		else
 			factor = factor or 1
-			return Time( os.date("%Y-%m-%d %X", self.dDate +  factor * math.floor(seconds) )) 
+			return Time( os.date("%Y-%m-%d %X", self.dDate +  factor * math.floor(seconds) ))
 		end
 	end
 
@@ -327,8 +327,15 @@ local function Time(sDate, isUTC, _testMS)
 		return self.addSeconds(minutes, 60)
 	end
 
-	function self.makeTime(sDate, isUTC)
+	function self.makeTime(oDate, isUTC)
+		local sDate = ( type(oDate) == 'table' and os.date("%Y-%m-%d %H:%M:%S", os.time(oDate)) ) or oDate
 		return Time(sDate, isUTC)
+	end
+
+	function self.toUTC(oDate, offset)
+		local sDate = ( type(oDate) == 'table' and os.date("%Y-%m-%d %H:%M:%S", os.time(oDate)) ) or oDate
+		local offset = offset or 0
+		return Time(sDate).addSeconds(-1 * getTimezone() + offset).raw
 	end
 
 	-- return ISO format
@@ -403,7 +410,7 @@ local function Time(sDate, isUTC, _testMS)
 
 	-- returns true if the current time is within a time range: startH:startM and stopH:stopM
 	local function timeIsInRange(startH, startM, stopH, stopM)
-	
+
 		local function getMinutes(hours, minutes)
 			return (hours * 60) + minutes
 		end
@@ -411,10 +418,10 @@ local function Time(sDate, isUTC, _testMS)
 		local currentMinutes = getMinutes(self.hour, self.min)
 		local startMinutes = getMinutes(startH, startM)
 		local stopMinutes = getMinutes(stopH, stopM)
-	
+
 		if stopMinutes < startMinutes then -- add 24 hours (1440 minutes ) if endTime < startTime
 			if currentMinutes < stopMinutes then currentMinutes = currentMinutes + 1440 end
-			stopMinutes = stopMinutes + 1440 
+			stopMinutes = stopMinutes + 1440
 		end
 
 		return ( currentMinutes >= startMinutes and currentMinutes <= stopMinutes )
@@ -863,7 +870,7 @@ local function Time(sDate, isUTC, _testMS)
 
 	-- returns true if self.time is in time range: at hh:mm-hh:mm
 	function self.ruleMatchesTimeRange(rule)
-		local fromH, fromM, toH, toM =  string.match(rule, 'at% ([0-9%*]+):([0-9%*]+)-([0-9%*]+):([0-9%*]+)') 
+		local fromH, fromM, toH, toM =  string.match(rule, 'at% ([0-9%*]+):([0-9%*]+)-([0-9%*]+):([0-9%*]+)')
 
 		if (fromH ~= nil) then
 			-- all will be nil if fromH is nil

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -7,7 +7,7 @@ local self = {
 	LOG_MODULE_EXEC_INFO = 2,
 	LOG_INFO = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '3.0.8',
+	DZVERSION = '3.0.9',
 }
 
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)
@@ -470,7 +470,7 @@ function self.dumpSelection(object, selection)
 				self.print('> ' .. attr .. ': ' .. tostring(value))
 			end
 		end
-		if object.baseType ~= 'hardware' then 
+		if object.baseType ~= 'hardware' then
 			self.print('')
 			self.print('> lastUpdate: ' .. (object.lastUpdate.raw or '') )
 		end

--- a/dzVents/runtime/Variable.lua
+++ b/dzVents/runtime/Variable.lua
@@ -21,6 +21,10 @@ local function Variable(domoticz, data)
 		self['nValue'] = data.data.value
 	end
 
+	function self.dump( filename )
+		domoticz.logObject(self, filename, 'variable')
+	end
+
 	function self.dumpSelection( selection )
 		domoticz.utils.dumpSelection(self, ( selection or 'attributes' ))
 	end

--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -103,7 +103,6 @@ return {
 			device['batteryLevel'] = bat
 			device['signalLevel'] = sig
 			device['deviceSubType'] = data.subType
-
 			device['lastUpdate'] = Time(data.lastUpdate)
 			device['rawData'] = data.rawData
 			device['nValue'] = data.data._nValue
@@ -122,6 +121,8 @@ return {
 			device['description'] = data.description
 			device['protected'] = data.protected
 			device['lastUpdate'] = Time(data.lastUpdate)
+			device['thisUpdate'] = Time(data.thisUpdate)
+			device.thisUpdate.raw = device.thisUpdate.rawDateTime
 			device['rawData'] = { [1] = data.data._state }
 			device['changed'] = data.changed
 			device['cancelQueuedCommands'] = function()
@@ -134,7 +135,6 @@ return {
 		end
 
 		setStateAttribute(data.data._state, device, _states)
-
 
 		function device.setDescription(description)
 			local url = domoticz.settings['Domoticz url'] ..

--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -121,8 +121,6 @@ return {
 			device['description'] = data.description
 			device['protected'] = data.protected
 			device['lastUpdate'] = Time(data.lastUpdate)
-			device['thisUpdate'] = Time(data.thisUpdate)
-			device.thisUpdate.raw = device.thisUpdate.rawDateTime
 			device['rawData'] = { [1] = data.data._state }
 			device['changed'] = data.changed
 			device['cancelQueuedCommands'] = function()

--- a/dzVents/runtime/integration-tests/domoticzTestTools.lua
+++ b/dzVents/runtime/integration-tests/domoticzTestTools.lua
@@ -136,8 +136,7 @@ local function DomoticzTestTools(port, debug, webroot)
 		local url = "type=addscene&name=" .. name .. "&scenetype=0"
 
 		local ok, json, result, respcode, respheaders, respstatus = self.doAPICall(url)
-		local idx = json.idx
-		return ok, idx, json, result, respcode, respheaders, respstatus
+		return ok, json, result, respcode, respheaders, respstatus
 	end
 
 	function self.createGroup(name)
@@ -378,9 +377,10 @@ local function DomoticzTestTools(port, debug, webroot)
 	end
 
 	function self.addSceneDevice(sceneIdx, devIdx)
-		-- http://localhost:8080/json.htm?type=command&param=addscenedevice&idx=2&isscene=false&devidx=1&command=On&level=100&hue=0&ondelay=&offdelay=
-		local url = "param=addscenedevice&type=command&idx=" .. tostring(sceneIdx) .. "&isscene=false&devidx=" .. tostring(devIdx) .. "&command=On&level=100&hue=0&ondelay=&offdelay="
-		local ok, json, result, respcode, respheaders, respstatus = self.doAPICall(url)
+		-- http://nuc:8080/json.htm?type=command&param=addscenedevice&idx=1&isscene=false&devidx=6&command=On&level=100&color=&ondelay=0&offdelay=0
+		local url = "param=addscenedevice&type=command&idx=" .. tostring(sceneIdx) .. "&isscene=false&devidx=" .. tostring(devIdx) .. "&command=On&level=100&color=&ondelay=0&offdelay=0"
+		print (url)
+        local ok, json, result, respcode, respheaders, respstatus = self.doAPICall(url)
 		return ok
 	end
 

--- a/dzVents/runtime/integration-tests/scriptTestCustomAndSystemEventsScript.lua
+++ b/dzVents/runtime/integration-tests/scriptTestCustomAndSystemEventsScript.lua
@@ -1,20 +1,22 @@
-return 
+return
 {
-	on = 
+	on =
 	{
 		system = { 'manualBackupFinished', 'st*' },
 		customEvents = { [ 'myEvents*' ] = { 'at 04:00-03:45'} },
 	},
 
-	execute = function(domoticz, item, info)
+	execute = function(domoticz, item)
 
 		dz = domoticz
 
-		local filename = 'eventsIntegrationtests.triggers' 
+		local filename = 'eventsIntegrationtests.triggers'
 
-		if item.trigger == 'start' then 
+		if item.trigger == 'start' then
 			os.execute('rm -f ' .. _G.dataFolderPath .. '/../dumps/' .. filename)
 		end
+
+		item.dump()
 
 		dz.utils.dumpTable({ item },nil ,filename)
 	end

--- a/dzVents/runtime/integration-tests/scriptTestEventState.lua
+++ b/dzVents/runtime/integration-tests/scriptTestEventState.lua
@@ -31,7 +31,7 @@ return {
 	},
 	execute = function(dz, item)
 
-		local function sleep (a) 
+		local function sleep (a)
 			local function osExecute(cmd)
 				local fileHandle = assert(io.popen(cmd, 'r'))
 				local commandOutput = assert(fileHandle:read('*a'))
@@ -52,7 +52,7 @@ return {
 			end
 
 			local rc = osExecute("sleep " .. a)
-			if rc ~= 0 then 
+			if rc ~= 0 then
 				dz.log("We seem to be on Windows; trying os.execute now", dz.LOG_FORCE )
 				os.execute("timeout " .. a)
 				dz.log("That took you some time !", dz.LOG_FORCE )
@@ -116,11 +116,11 @@ return {
 			local ok = true
 
 			if (dz.data.switchStates ~= 'OnOffOnOff') then
-				print('Error: ' .. dz.data.switchStates)
+				print('switchStates Error: ' .. dz.data.switchStates)
 				ok = false
 			end
-			if (dz.data.sceneStates ~= 'OnOffOnOff') then
-				print('Error: ' .. dz.data.sceneStates)
+			if (dz.data.sceneStates ~= 'OnOn') then -- Scenes can no longer be switched Off
+				print('sceneStates Error: ' .. dz.data.sceneStates)
 				ok = false
 			end
 			if (dz.data.varStates ~= '10203040') then

--- a/dzVents/runtime/integration-tests/stage1.lua
+++ b/dzVents/runtime/integration-tests/stage1.lua
@@ -740,7 +740,7 @@ local testSelectorSwitch = function(name)
 		["timedOut"] = false;
 	})
 
-	res = res and ( dz.logDevice(dev) == nil )
+	res = res and ( dz.logObject(dev, nil, 'device' ) == nil )
 	res = res and expectEql('Off', dev.levelNames[1])
 	res = res and expectEql('Level1', dev.levelNames[2])
 	res = res and expectEql('Level2', dev.levelNames[3])

--- a/dzVents/runtime/integration-tests/testEventState.lua
+++ b/dzVents/runtime/integration-tests/testEventState.lua
@@ -5,8 +5,6 @@ package.path = package.path ..
 local TestTools = require('domoticzTestTools')('8080', true)
 local socket = require("socket")
 
-local _ = require 'lodash'
-
 local fsScripts = {'scriptTestEventState.lua'}
 
 describe('Test event state', function ()
@@ -26,10 +24,8 @@ describe('Test event state', function ()
 		TestTools.createVariable('varInt', 0, 0)
 		ok, scSwitchIdx = TestTools.createVirtualDevice(dummyIdx, 'sceneSilentSwitch1', 6)
 		TestTools.createVirtualDevice(dummyIdx, 'vdTempHumBaro', 84)
-
 		TestTools.createScene('scScene')
-		TestTools.addSceneDevice(sceneIdx, scSwitchIdx)
-
+        TestTools.addSceneDevice(1, scSwitchIdx)
 		TestTools.installFSScripts(fsScripts)
 
 

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -40,9 +40,9 @@ if [[ $? -ne 0 ]];then
 else
 	echo dzVents will be tested against domoticz version $NewVersion.
 fi
- 
+
 currenttime=$(date +%H:%M)
-if [[ "$currenttime" > "00:00" ]] && [[ "$currenttime" < "00:31" ]]; then 
+if [[ "$currenttime" > "00:00" ]] && [[ "$currenttime" < "00:31" ]]; then
 	echo Script cannot be execute dbetween 00:00 and 00:30. Time checks will fail
 	exit 1
 fi
@@ -142,7 +142,7 @@ function fillNumberOfTests
 		Lodash_ExpectedTests=100
 		ScriptdzVentsDispatching_ExpectedTests=2
 		TimedCommand_ExpectedTests=46
-		Time_ExpectedTests=340
+		Time_ExpectedTests=342
 		Utils_ExpectedTests=27
 		Variable_ExpectedTests=15
 		ContactDoorLockInvertedSwitch_ExpectedTests=2
@@ -167,16 +167,16 @@ function testDir
 			Tests=$(( $(($testFile$underScoreTests)) / 1 ))
 			if test $i == 'testSystemAndCustomEvents.lua' ; then
 				tput sc # save cursor
-				stopBackgroundProcesses 
+				stopBackgroundProcesses
 				sleep 6
 				tput rc;tput el # rc
 			fi
 			echo -n $(showTime) " "
-			printf "%-42s %4d "  $testFile $Expected 
+			printf "%-42s %4d "  $testFile $Expected
 			printf "%10d" $Tests
 			# busted $i  2>&1 >/dev/null
 			busted $i  > $outfile
-			
+
 			if [[ $? -ne 0 ]];then
 				printf "%-10s" "===>> NOT OK"
 				echo
@@ -250,7 +250,7 @@ if [[ $? -eq 0 ]];then
 			#echo Errors are to be expected
 			echo -n
 		else
-			grep -i Error  domoticz.log$$ | grep -v CheckAuthToken
+			grep -i Error  domoticz.log$$ | grep -v CheckAuthToken | grep -v LOG_ERROR
 			stopBackgroundProcesses 1
 		fi
 	else

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -190,9 +190,9 @@ describe('Time', function()
 		end)
 
 		it('should have addDays', function()
-            if localNow.day ~= 1 then 
-                assert.is_same(localNow.day - 1 , t.addDays(-1).day )
-            end
+			if localNow.day ~= 1 then
+				assert.is_same(localNow.day - 1 , t.addDays(-1).day )
+			end
 		end)
 
 		it('should return nil when called with a non number',function()
@@ -203,12 +203,45 @@ describe('Time', function()
 	end)
 
 	describe('makeTime functions', function()
-		local t = Time( os.time()).makeTime('2017-06-05 02:04:00')
-		assert.is_same(23, t.week)
-		t = Time('2017-01-01 02:04:00')
-		assert.is_same(52, t.week)
-		t = Time('2016-01-01 02:04:00')
-		assert.is_same(53, t.week)
+
+		it('should have makeTime ' , function()
+
+			local timeFromString = Time( os.time()).makeTime('2017-06-05 02:04:00')
+			assert.is_same(23, timeFromString.week)
+			assert.is_same(2, timeFromString.hour)
+
+			local timeFromString = Time( os.time()).makeTime('2017-06-05 02:04:00', true)
+			assert.is_same(4, timeFromString.hour)
+
+			local timeFromTable = Time( os.time()).makeTime(timeFromString)
+			assert.is_same(23, timeFromTable.week)
+			assert.is_same(4, timeFromTable.hour)
+
+			local timeFromTable = Time( os.time()).makeTime(timeFromString, true)
+			assert.is_same(6, timeFromTable.hour)
+		end)
+	end)
+
+
+	describe('toUTC functions', function()
+
+		it('should have toUTC ' , function()
+
+			local timeFromString = Time( os.time()).makeTime('2017-06-05 02:04:00')
+			assert.is_same(23, timeFromString.week)
+
+			timeFromString = Time('2017-01-01 02:04:00')
+			assert.is_same(52, timeFromString.week)
+			timeFromString = Time('2016-01-01 02:04:00')
+			assert.is_same(53, timeFromString.week)
+			local timeFromTable = Time( os.time()).makeTime(timeFromString)
+			assert.is_same(53, timeFromTable.week)
+			assert.is_same(2, timeFromTable.hour)
+			local timeFromTable = Time( os.time()).makeTime(timeFromString, true)
+			assert.is_same(4, timeFromTable.hour)
+
+		end)
+
 	end)
 
 	describe('non UTC', function()
@@ -486,7 +519,7 @@ describe('Time', function()
 
 				it('should return proper result', function()
 					local t = Time('2020-01-22 19:33:21')
-							local atRules = 
+							local atRules =
 							{
 								{rule = 'at 20:45-21:00', expected = false },
 								{rule = 'at 23:00-01:30', expected = false },
@@ -1388,10 +1421,10 @@ describe('Time', function()
 
 						assert.is_true(t.ruleMatchesBetweenRange(rule))
 					end)
-	
+
 					it('between two times', function()
 						local t = Time('2020-01-22 19:33:21')
-							local betweenRules = 
+							local betweenRules =
 							{
 								{rule = 'between 20:45 and 21:00',		expected = false },
 								{rule = 'between 23:00 and 01:30',		expected = false },
@@ -1424,9 +1457,9 @@ describe('Time', function()
 								{rule = 'between 22:00 and 22:15',		expected = false },
 								{rule = 'between 22:15 and 22:30',		expected = false },
 								{rule = 'between 22:30 and 23:00',		expected = false },
-								{rule = 'between 00:00 and 23:23',		expected = true }, 
+								{rule = 'between 00:00 and 23:23',		expected = true },
 							}
-		
+
 						for index, ruleRow in ipairs(betweenRules) do
 							if ruleRow.expected == false then
 								assert.is_false(t.matchesRule(ruleRow.rule))
@@ -1623,7 +1656,7 @@ describe('Time', function()
 					local t = Time('2017-06-05 02:04:00')
 					assert.is_false(t.ruleIsOnDate('on 6/5'))
 					assert.is_false(t.ruleIsOnDate('on 1/01-2/2,31/12,6/5,1/1'))
- 
+
 					t = Time('2018-12-3 02:04:00')
 					assert.is_true(t.ruleIsOnDate('on 03/12'))
 					assert.is_true(t.ruleIsOnDate('on 3/12'))
@@ -1805,7 +1838,7 @@ describe('Time', function()
 							assert.is_true(t.matchesRule('at 00:30-23:55 on 01/' .. fromMonth .. '-31/' .. toMonth))
 						else
 							assert.is_false(t.matchesRule('at 00:30-23:55 on 01/' .. fromMonth .. '-31/' .. toMonth))
-						end			
+						end
 					end)
 				end
 			end
@@ -1819,7 +1852,7 @@ describe('Time', function()
 							assert.is_true(t.matchesRule('at 00:30-23:55 on */' .. fromMonth .. '-*/' .. toMonth))
 						else
 							assert.is_false(t.matchesRule('at 00:30-23:55 on */' .. fromMonth .. '-*/' .. toMonth))
-						end			
+						end
 					end)
 				end
 			end

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -25,7 +25,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-		m_version("3.0.8")
+		m_version("3.0.9")
 {
 	m_bdzVentsExist = false;
 }
@@ -660,7 +660,7 @@ void CdzVents::IterateTable(lua_State *lua_state, const int tIndex, std::vector<
 		else if (std::string(luaL_typename(lua_state, -1)) == "number")
 		{
 			item.type = TYPE_FLOAT;
-			item.fValue = (float)lua_tonumber(lua_state, -1);
+			item.fValue = lua_tonumber(lua_state, -1);
 			item.name = std::string(lua_tostring(lua_state, -2));
 		}
 		else if (std::string(luaL_typename(lua_state, -1)) == "boolean")


### PR DESCRIPTION

```
========= domoticz V2020.2 (12119), dzVents V3.0.9 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        115      OK            115         0      0.2816
00:00:02  Domoticz                                      1         74      OK             74         0      0.2769
00:00:02  EventHelpers                                  1         32      OK             32         0      0.2376
00:00:03  EventHelpersStorage                           1         50      OK             50         0      0.2440
00:00:03  HTTPResponse                                  1          6      OK              6         0      0.0149
00:00:03  Lodash                                        1        100      OK            100         0      0.1652
00:00:03  ScriptdzVentsDispatching                      1          2      OK              2         0      0.0640
00:00:03  TimedCommand                                  1         46      OK             46         0      0.1049
00:00:03  Time                                          3        342      OK            342         0      0.6609
00:00:04  Utils                                         1         27      OK             27         0      0.0486
00:00:04  Variable                                      1         15      OK             15         0      0.0337
00:00:04  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.0622
00:00:08  DelayedVariableScene                          8          2      OK              2         0      7.0708
00:00:15  EventState                                   19          2      OK              2         0     18.0776
00:00:33  Integration                                  34        222      OK            222         0     28.6033
00:01:02  SelectorSwitch                               10          2      OK              2         0      9.2059
00:01:17  SystemAndCustomEvents                         1          7      OK              7         0      0.0345


Total tests: 1046
Wed 03 Jun 2020 08:35:11 PM CEST; dzVents version 3.0.9 tested without erors after 00:01:17

```
[3.0.9]
- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
- Add function toUTC to time object.
- Allow table as parm to function makeTime
- Fix eventState tests