### PR TITLE
Buienradar stability fix

### DIFF
--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -500,7 +500,7 @@ void CBuienRadar::GetMeterDetails()
 
 void CBuienRadar::GetRainPrediction()
 {
-	if (m_szMyLatitude.empty() or m_szMyLongitude.empty() or std::stoi(m_szMyLatitude)<1 or std::stoi(m_szMyLongitude)<1)
+	if (m_szMyLatitude.empty() || m_szMyLongitude.empty() ||  std::stoi(m_szMyLatitude)<1 || std::stoi(m_szMyLongitude)<1)
 		return;
 
 	std::string sResult;

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -70,6 +70,7 @@ CBuienRadar::CBuienRadar(const int ID, const int iForecast, const int iThreshold
 			{
 				try {
 					m_iStationID = std::stoi(strarray[0]);
+					m_stationidprovided=true;
 				}
 				catch (const std::exception& e) {
 					Log(LOG_ERROR, "Bad Station ID provided: %s (%s), please recheck hardware setup.", strarray[0].c_str(), e.what());
@@ -370,6 +371,26 @@ void CBuienRadar::GetMeterDetails()
 
 	//iconurl : "https://www.buienradar.nl/resources/images/icons/weather/30x30/a.png"
 	//graphUrl : "https://www.buienradar.nl/nederland/weerbericht/weergrafieken/a"
+
+	// Update Location details if a configured station is used
+	if (m_stationidprovided)
+	{
+		if (!root["lon"].empty())
+		{
+			if (root["lon"].asFloat()>0)
+			{
+				m_szMyLongitude = std::to_string(root["lon"].asDouble());
+			}
+		}
+
+		if (!root["lat"].empty())
+		{
+			if (root["lat"].asFloat()>0)
+			{
+				m_szMyLatitude = std::to_string(root["lat"].asDouble());
+			}
+		}
+	}
 
 	float temp = -999.9f;
 	int humidity = 0;

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -479,7 +479,7 @@ void CBuienRadar::GetMeterDetails()
 
 void CBuienRadar::GetRainPrediction()
 {
-	if (m_szMyLatitude.empty())
+	if (m_szMyLatitude.empty() or m_szMyLongitude.empty() or std::stoi(m_szMyLatitude)<1 or std::stoi(m_szMyLongitude)<1)
 		return;
 
 	std::string sResult;

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -524,6 +524,13 @@ void CBuienRadar::GetRainPrediction()
 		Log(LOG_ERROR, "Problem Connecting to Buienradar! (Check your Internet Connection!)");
 		return;
 	}
+	if (sResult.size()==0)
+	{
+		// Log(LOG_ERROR, "Problem getting Rainprediction: no prediction available at Buienradar");
+		// no data to process, so don't update the sensros
+		return;
+	}
+
 #ifdef DEBUG_BUIENRADARW
 	SaveString2Disk(sResult, "E:\\br_rain.txt");
 #endif

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -350,7 +350,7 @@ void CBuienRadar::GetMeterDetails()
 		return;
 	}
 
-	if (root["timestamp"].empty() == true || root["stationid"].empty() == true)
+	if (root["timestamp"].empty() == true || (root["stationid"].empty() == true && root["stationId"].empty() == true))
 	{
 		Log(LOG_ERROR, "Invalid data received (timestamp or staionid missing) or no data returned!");
 		return;

--- a/hardware/Buienradar.h
+++ b/hardware/Buienradar.h
@@ -26,6 +26,7 @@ private:
 	int m_iForecast = 15;
 	int m_iThreshold = 25;
 	int m_iStationID = 0;
+	bool m_stationidprovided = false;
 	bool m_itIsRaining = false;
 	int m_rainShowerLeadTime = 0;
 };


### PR DESCRIPTION
handles several situations in buienradar json, which occur every now and then(e.g. look at [this thread](https://www.domoticz.com/forum/viewtopic.php?f=12&t=32999&hilit=buienradar), i've seen this behaviour several times now) so buienradar gives less errors and updates the sensors more often:
- handle situation when lat/lon are reported as 0 by buienradar  (and recover from that if that was the case during initialisation of the hardware)
- handle situation when there is no rain prediction on serverside
- handle the stationid if it is reported as stationId (difference = capital I) 

"unfortunately"  buienradar is now stable, so i could not test all extra code. I have had this code running for this afternoon and do see a  lot less errors on buienradar. But a code review would be nice before merging.