### PR TITLE
Opens domoticz window instead of stack overflow on desktop notification

### DIFF
--- a/www/app/app.notifications.js
+++ b/www/app/app.notifications.js
@@ -39,9 +39,10 @@ define(['angular'], function () {
                         //icon: 'http://cdn.sstatic.net/stackexchange/img/logos/so/so-icon.png',
                         body: body,
                     });
+                    var href = $window.location.href;
 
                     notification.onclick = function () {
-                        window.open("http://stackoverflow.com/a/13328397/1269037");
+                        window.open(href);
                     };
                 }
             },


### PR DESCRIPTION
I fixed the behaviour that every time I click on a desktop notification it goes to the stackoverflow post where this code came from. It will now open the domoticz window instead.