### PR TITLE
Add "Has Node Failed" and "Replace Failed Node" to ZWave GUI

### DIFF
--- a/hardware/OpenZWave.h
+++ b/hardware/OpenZWave.h
@@ -114,6 +114,7 @@ public:
 	bool CancelControllerCommand(const bool bForce = false);
 	bool IncludeDevice(const bool bSecure);
 	bool ExcludeDevice(const uint8_t nodeID);
+	bool IsNodeReplaced();
 	bool IsNodeIncluded();
 	bool IsNodeExcluded();
 	bool SoftResetDevice();

--- a/hardware/OpenZWave.h
+++ b/hardware/OpenZWave.h
@@ -114,6 +114,7 @@ public:
 	bool CancelControllerCommand(const bool bForce = false);
 	bool IncludeDevice(const bool bSecure);
 	bool ExcludeDevice(const uint8_t nodeID);
+	bool IsHasNodeFailedDone();
 	bool IsNodeReplaced();
 	bool IsNodeIncluded();
 	bool IsNodeExcluded();

--- a/hardware/OpenZWave.h
+++ b/hardware/OpenZWave.h
@@ -104,6 +104,8 @@ public:
 	//Controller Commands
 	bool RequestNodeConfig(const unsigned int homeID, const uint8_t nodeID);
 	bool RequestNodeInfo(const unsigned int homeID, const uint8_t nodeID);
+	bool ReplaceFailedNode(const unsigned int homeID, const uint8_t nodeID);
+	bool HasNodeFailed(const unsigned int homeID, const uint8_t nodeID);
 	bool RemoveFailedDevice(const uint8_t nodeID);
 	bool HasNodeFailed(const uint8_t nodeID);
 	bool ReceiveConfigurationFromOtherController();

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -29,6 +29,11 @@ ZWaveBase::ZWaveBase() :
 {
 	m_bNodeReplaced=true;
 	m_NodeToBeReplaced=0;
+
+	m_bHasNodeFailedDone=false;
+	m_sHasNodeFailedResult="";
+	m_HasNodeFailedIdx=-1;
+
 	m_LastIncludedNode = 0;
 	m_bControllerCommandInProgress = false;
 	m_bControllerCommandCanceled = false;

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -27,7 +27,8 @@ ZWaveBase::ZWaveBase() :
 	m_updateTime(0),
 	m_ControllerCommandStartTime(0)
 {
-	m_bNodeReplaced=false;
+	m_bNodeReplaced=true;
+	m_NodeToBeReplaced=0;
 	m_LastIncludedNode = 0;
 	m_bControllerCommandInProgress = false;
 	m_bControllerCommandCanceled = false;

--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -27,6 +27,7 @@ ZWaveBase::ZWaveBase() :
 	m_updateTime(0),
 	m_ControllerCommandStartTime(0)
 {
+	m_bNodeReplaced=false;
 	m_LastIncludedNode = 0;
 	m_bControllerCommandInProgress = false;
 	m_bControllerCommandCanceled = false;

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -125,6 +125,7 @@ public:
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 public:
 	bool m_bNodeReplaced;
+	uint8_t m_NodeToBeReplaced;
 	int m_LastIncludedNode;
 	std::string m_LastIncludedNodeType;
 	bool m_bHaveLastIncludedNodeInfo;

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -126,6 +126,11 @@ public:
 public:
 	bool m_bNodeReplaced;
 	uint8_t m_NodeToBeReplaced;
+
+	bool m_bHasNodeFailedDone;
+	std::string m_sHasNodeFailedResult;
+	uint8_t m_HasNodeFailedIdx;
+	
 	int m_LastIncludedNode;
 	std::string m_LastIncludedNodeType;
 	bool m_bHaveLastIncludedNodeInfo;

--- a/hardware/ZWaveBase.h
+++ b/hardware/ZWaveBase.h
@@ -124,6 +124,7 @@ public:
 	bool StopHardware() override;
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 public:
+	bool m_bNodeReplaced;
 	int m_LastIncludedNode;
 	std::string m_LastIncludedNodeType;
 	bool m_bHaveLastIncludedNodeInfo;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -634,6 +634,7 @@ namespace http {
 			RegisterCommandCode("zwaveisnodeincluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeIncluded, this, _1, _2, _3));
 			RegisterCommandCode("zwaveisnodeexcluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeExcluded, this, _1, _2, _3));
 			RegisterCommandCode("zwaveisnodereplaced", boost::bind(&CWebServer::Cmd_ZWaveIsNodeReplaced, this, _1, _2, _3));
+			RegisterCommandCode("zwaveishasnodefaileddone", boost::bind(&CWebServer::Cmd_ZWaveIsHasNodeFailedDone, this, _1, _2, _3));
 
 			RegisterCommandCode("zwavesoftreset", boost::bind(&CWebServer::Cmd_ZWaveSoftReset, this, _1, _2, _3));
 			RegisterCommandCode("zwavehardreset", boost::bind(&CWebServer::Cmd_ZWaveHardReset, this, _1, _2, _3));

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -633,6 +633,7 @@ namespace http {
 
 			RegisterCommandCode("zwaveisnodeincluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeIncluded, this, _1, _2, _3));
 			RegisterCommandCode("zwaveisnodeexcluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeExcluded, this, _1, _2, _3));
+			RegisterCommandCode("zwaveisnodereplaced", boost::bind(&CWebServer::Cmd_ZWaveIsNodeReplaced, this, _1, _2, _3));
 
 			RegisterCommandCode("zwavesoftreset", boost::bind(&CWebServer::Cmd_ZWaveSoftReset, this, _1, _2, _3));
 			RegisterCommandCode("zwavehardreset", boost::bind(&CWebServer::Cmd_ZWaveHardReset, this, _1, _2, _3));

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -644,6 +644,8 @@ namespace http {
 			RegisterCommandCode("zwavegroupinfo", boost::bind(&CWebServer::Cmd_ZWaveGroupInfo, this, _1, _2, _3));
 			RegisterCommandCode("zwavecancel", boost::bind(&CWebServer::Cmd_ZWaveCancel, this, _1, _2, _3));
 			RegisterCommandCode("applyzwavenodeconfig", boost::bind(&CWebServer::Cmd_ApplyZWaveNodeConfig, this, _1, _2, _3));
+			RegisterCommandCode("zwavehasnodefailed", boost::bind(&CWebServer::Cmd_ZWaveHasNodeFailed, this, _1, _2, _3));
+			RegisterCommandCode("zwavereplacefailednode", boost::bind(&CWebServer::Cmd_ZWaveReplaceFailedNode, this, _1, _2, _3));
 			RegisterCommandCode("requestzwavenodeconfig", boost::bind(&CWebServer::Cmd_ZWaveRequestNodeConfig, this, _1, _2, _3));
 			RegisterCommandCode("requestzwavenodeinfo", boost::bind(&CWebServer::Cmd_ZWaveRequestNodeInfo, this, _1, _2, _3));
 			RegisterCommandCode("zwavestatecheck", boost::bind(&CWebServer::Cmd_ZWaveStateCheck, this, _1, _2, _3));

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -339,6 +339,7 @@ private:
 	void Cmd_ZWaveDeleteNode(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveInclude(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveExclude(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveIsNodeReplaced(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -352,6 +352,8 @@ private:
 	void Cmd_ZWaveCancel(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ApplyZWaveNodeConfig(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveStateCheck(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveHasNodeFailed(WebEmSession& session, const request& req, Json::Value& root);
+	void Cmd_ZWaveReplaceFailedNode(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_ZWaveRequestNodeConfig(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_ZWaveRequestNodeInfo(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_ZWaveReceiveConfigurationFromOtherController(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -342,6 +342,7 @@ private:
 	void Cmd_ZWaveIsNodeReplaced(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveIsNodeIncluded(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveIsNodeExcluded(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_ZWaveIsHasNodeFailedDone(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveSoftReset(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveHardReset(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_ZWaveNetworkHeal(WebEmSession & session, const request& req, Json::Value &root);

--- a/www/app/hardware/setup/ZWave.html
+++ b/www/app/hardware/setup/ZWave.html
@@ -15,7 +15,7 @@
 					<div class="control-group">
 						<center>
 							<div id="rzwd_waiting" style="display:none;">
-								<span>Press the include button on your new device...</span><br>
+								<span data-i18n="Press the include button on your new device..."></span><br>
 								<br>
 								<div class="sk-fading-circle" style="width: 48px; height: 48px;">
 									<div class="sk-circle1 sk-circle"></div>

--- a/www/app/hardware/setup/ZWave.html
+++ b/www/app/hardware/setup/ZWave.html
@@ -35,8 +35,7 @@
 								<button type="button" onclick="OnZWaveAbortReplace()" id="rzwd_abort" class="btn btn-info">Abort</button><br>
 							</div>
 							<div id="rzwd_result" style="display:none2;">
-								Included node: <b>{{ozw_node_id}}</b><br>
-								<b>{{ozw_node_desc}}</b><br>
+								Replaced NodeID: <b>{{ozw_node_id}}</b><br>
 								<br>
 								<button type="button" onclick="OnZWaveCloseReplace()" class="btn btn-default" data-dismiss="modal">Close</button>
 							</div>

--- a/www/app/hardware/setup/ZWave.html
+++ b/www/app/hardware/setup/ZWave.html
@@ -4,6 +4,50 @@
 }
 </style>
 <div id="hardwarecontent" class="container"></div>
+
+<div class="modal hide fade" id="ZWaveHasNodeFailedDialog" tabindex="-1" role="dialog" aria-labelledby="ZWaveHasNodeFailedDialog" aria-hidden="false">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3 class="modal-title" id="izwd_title">Has Node Failed</h3>
+			</div>
+			<div class="modal-body">
+				<form class="form-horizontal" name="modalForm">
+					<div class="control-group">
+						<center>
+							<div id="hzwd_waiting" style="display:none;">
+								<span data-i18n="Command executed, waiting for response..."></span><br>
+								<br>
+								<div class="sk-fading-circle" style="width: 48px; height: 48px;">
+									<div class="sk-circle1 sk-circle"></div>
+									<div class="sk-circle2 sk-circle"></div>
+									<div class="sk-circle3 sk-circle"></div>
+									<div class="sk-circle4 sk-circle"></div>
+									<div class="sk-circle5 sk-circle"></div>
+									<div class="sk-circle6 sk-circle"></div>
+									<div class="sk-circle7 sk-circle"></div>
+									<div class="sk-circle8 sk-circle"></div>
+									<div class="sk-circle9 sk-circle"></div>
+									<div class="sk-circle10 sk-circle"></div>
+									<div class="sk-circle11 sk-circle"></div>
+									<div class="sk-circle12 sk-circle"></div>
+								</div>
+								<br>
+								<button type="button" onclick="OnZWaveAbortHasNodeFailed()" id="hzwd_abort" class="btn btn-info">Abort</button><br>
+							</div>
+							<div id="hzwd_result" style="display:none2;">
+								Result: <b>{{hnf_result_text}}</b><br>
+								<br>
+								<button type="button" onclick="OnZWaveCloseHasNodeFailed()" class="btn btn-default" data-dismiss="modal">Close</button>
+							</div>
+						</center>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+
 <div class="modal hide fade" id="ReplaceZWaveDialog" tabindex="-1" role="dialog" aria-labelledby="ReplaceZWaveNodeDialog" aria-hidden="false">
 	<div class="modal-dialog">
 		<div class="modal-content">

--- a/www/app/hardware/setup/ZWave.html
+++ b/www/app/hardware/setup/ZWave.html
@@ -158,6 +158,8 @@
 									</td>
 									<td>
 										<a class="btnstyle3-dis" id="noderefresh" data-i18n="Refresh Node Info">Refresh Node Info</a>
+										<a class="btnstyle3-dis" id="hasnodefailed" data-i18n="Has Node Failed">Has Node Failed</a>
+										<a class="btnstyle3-dis" id="replacefailednode" data-i18n="Replace Failed Node">Replace Failed Node</a>
 									</td>
 									<td align="right">
 										<a class="btnstyle3" id="nodelistrefresh" data-i18n="Refresh" onclick="RefreshOpenZWaveNodeTable();">Refresh</a>

--- a/www/app/hardware/setup/ZWave.html
+++ b/www/app/hardware/setup/ZWave.html
@@ -4,6 +4,50 @@
 }
 </style>
 <div id="hardwarecontent" class="container"></div>
+<div class="modal hide fade" id="ReplaceZWaveDialog" tabindex="-1" role="dialog" aria-labelledby="ReplaceZWaveNodeDialog" aria-hidden="false">
+	<div class="modal-dialog">
+		<div class="modal-content">
+			<div class="modal-header">
+				<h3 class="modal-title" id="izwd_title">Replacing Failed ZWave Node</h3>
+			</div>
+			<div class="modal-body">
+				<form class="form-horizontal" name="modalForm">
+					<div class="control-group">
+						<center>
+							<div id="rzwd_waiting" style="display:none;">
+								<span>Press the include button on your new device...</span><br>
+								<br>
+								<div class="sk-fading-circle" style="width: 48px; height: 48px;">
+									<div class="sk-circle1 sk-circle"></div>
+									<div class="sk-circle2 sk-circle"></div>
+									<div class="sk-circle3 sk-circle"></div>
+									<div class="sk-circle4 sk-circle"></div>
+									<div class="sk-circle5 sk-circle"></div>
+									<div class="sk-circle6 sk-circle"></div>
+									<div class="sk-circle7 sk-circle"></div>
+									<div class="sk-circle8 sk-circle"></div>
+									<div class="sk-circle9 sk-circle"></div>
+									<div class="sk-circle10 sk-circle"></div>
+									<div class="sk-circle11 sk-circle"></div>
+									<div class="sk-circle12 sk-circle"></div>
+								</div>
+								<br>
+								<button type="button" onclick="OnZWaveAbortReplace()" id="rzwd_abort" class="btn btn-info">Abort</button><br>
+							</div>
+							<div id="rzwd_result" style="display:none2;">
+								Included node: <b>{{ozw_node_id}}</b><br>
+								<b>{{ozw_node_desc}}</b><br>
+								<br>
+								<button type="button" onclick="OnZWaveCloseReplace()" class="btn btn-default" data-dismiss="modal">Close</button>
+							</div>
+						</center>
+					</div>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+
 <div class="modal hide fade" id="IncludeZWaveDialog" tabindex="-1" role="dialog" aria-labelledby="IncludeZWaveNodeDialog" aria-hidden="false">
 	<div class="modal-dialog">
 		<div class="modal-content">

--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -343,7 +343,6 @@ define(['app'], function (app) {
 					if (data.result === true) {
 						//Node replaced 
 						$scope.ozw_node_id = data.node_id;
-						$scope.ozw_node_desc = data.node_product_name;
 						$("#ReplaceZWaveDialog #rzwd_waiting").hide();
 						$("#ReplaceZWaveDialog #rzwd_result").show();
 					}
@@ -639,7 +638,8 @@ define(['app'], function (app) {
 				async: true,
 				dataType: 'json'
 			}).then(function successCallback(response) {
-				bootbox.alert($.t('Node Failed Command executed. This could take some time!'));
+				bootbox.alert($.t('Has Node Failed Command succesfully sent to controller, this could take a while!'));
+				RefreshOpenZWaveNodeTable();
 			}, function errorCallback(response) {
 			});
 		};

--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -569,6 +569,82 @@ define(['app'], function (app) {
 			});
 		};
 
+		$scope.HasNodeFailedReady = function () {
+			if (typeof $scope.mytimer !== 'undefined') {
+				$interval.cancel($scope.mytimer);
+				$scope.mytimer = undefined;
+			}
+			$http({
+				url: "json.htm?type=command&param=zwaveishasnodefaileddone&idx=" + $.devIdx,
+				async: true,
+				dataType: 'json'
+			}).then(function successCallback(response) {
+				var data = response.data;
+				if (data.status === "OK") {
+					if (data.result === true) {
+						//has node failed is done
+						$scope.hnf_result_text = data.status_text;
+						$("#ZWaveHasNodeFailedDialog #hzwd_waiting").hide();
+						$("#ZWaveHasNodeFailedDialog #hzwd_result").show();
+					}
+					else {
+						//Not ready yet
+						$scope.mytimer = $interval(function () {
+							$scope.HasNodeFailedReady();
+						}, 1000);
+					}
+				}
+				else {
+					$scope.mytimer = $interval(function () {
+						$scope.HasNodeFailedReady();
+					}, 1000);
+				}
+			}, function errorCallback(response) {
+					$scope.mytimer = $interval(function () {
+						$scope.HasNodeFailedReady();
+					}, 1000);
+			});
+		};
+
+		OnZWaveAbortHasNodeFailed = function () {
+			$http({
+				url: "json.htm?type=command&param=zwavecancel&idx=" + $.devIdx,
+				async: true,
+				dataType: 'json'
+			}).then(function successCallback(response) {
+				$('#ZWaveHasNodeFailedDialog').modal('hide');
+			}, function errorCallback(response) {
+					$('#ZWaveHasNodeFailedDialog').modal('hide');
+			});
+		};
+
+		OnZWaveCloseHasNodeFailed = function () {
+			$('#ZWaveHasNodeFailedDialog').modal('hide');
+			RefreshOpenZWaveNodeTable();
+		};
+
+		HasNodeFailed = function (idx) {
+			if (typeof $scope.mytimer !== 'undefined') {
+				$interval.cancel($scope.mytimer);
+				$scope.mytimer = undefined;
+			}
+			$("#ZWaveHasNodeFailedDialog #hzwd_waiting").show();
+			$("#ZWaveHasNodeFailedDialog #hzwd_result").hide();
+			$http({
+				url: "json.htm?type=command&param=zwavehasnodefailed&idx=" + idx,
+				async: true,
+				dataType: 'json'
+			}).then(function successCallback(response) {
+				var data = response.data;
+				$scope.hnf_result_text = "-";
+				$('#ZWaveHasNodeFailedDialog').modal('show');
+				$scope.mytimer = $interval(function () {
+					$scope.HasNodeFailedReady();
+				}, 1000);
+			}, function errorCallback(response) {
+			});
+		};
+
 		DeleteNode = function (idx) {
 			if ($('#updelclr #nodedelete').attr("class") === "btnstyle3-dis") {
 				return;
@@ -624,22 +700,6 @@ define(['app'], function (app) {
 				dataType: 'json'
 			}).then(function successCallback(response) {
 				bootbox.alert($.t('Node Information Frame requested. This could take some time! (You might need to wake-up the node!)'));
-			}, function errorCallback(response) {
-			});
-		};
-
-		// Has Node Failed Commmand
-		HasNodeFailed = function (idx) {
-			if ($('#updelclr #hasnodefailed').attr("class") === "btnstyle3-dis") {
-				return;
-			}
-			$http({
-				url: "json.htm?type=command&param=zwavehasnodefailed&idx=" + idx,
-				async: true,
-				dataType: 'json'
-			}).then(function successCallback(response) {
-				bootbox.alert($.t('Has Node Failed Command succesfully sent to controller!'));
-				RefreshOpenZWaveNodeTable();
 			}, function errorCallback(response) {
 			});
 		};

--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -638,7 +638,7 @@ define(['app'], function (app) {
 				async: true,
 				dataType: 'json'
 			}).then(function successCallback(response) {
-				bootbox.alert($.t('Has Node Failed Command succesfully sent to controller, this could take a while!'));
+				bootbox.alert($.t('Has Node Failed Command succesfully sent to controller!'));
 				RefreshOpenZWaveNodeTable();
 			}, function errorCallback(response) {
 			});

--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -543,6 +543,36 @@ define(['app'], function (app) {
 			});
 		};
 
+		// Has Node Failed Commmand
+		HasNodeFailed = function (idx) {
+			if ($('#updelclr #hasnodefailed').attr("class") === "btnstyle3-dis") {
+				return;
+			}
+			$http({
+				url: "json.htm?type=command&param=zwavehasnodefailed&idx=" + idx,
+				async: true,
+				dataType: 'json'
+			}).then(function successCallback(response) {
+				bootbox.alert($.t('Has Node Failed Command executed. This could take some time! (Refresh screen after a few minutes)'));
+			}, function errorCallback(response) {
+			});
+		};
+
+		//Request Node Information Frame
+		ReplaceFailedNode = function (idx) {
+			if ($('#updelclr #replacefailednode').attr("class") === "btnstyle3-dis") {
+				return;
+			}
+			$http({
+				url: "json.htm?type=command&param=zwavereplacefailednode&idx=" + idx,
+				async: true,
+				dataType: 'json'
+			}).then(function successCallback(response) {
+				bootbox.alert($.t('Replace Failed Node command executed. This could take some time! (this CJ needs to be changed to be alike inclusion!)'));
+			}, function errorCallback(response) {
+			});
+		};
+
 		RequestZWaveConfiguration = function (idx) {
 			$http({
 				url: "json.htm?type=command&param=requestzwavenodeconfig&idx=" + idx,
@@ -690,6 +720,8 @@ define(['app'], function (app) {
 			$('#updelclr #nodeupdate').attr("class", "btnstyle3-dis");
 			$('#updelclr #nodedelete').attr("class", "btnstyle3-dis");
 			$('#updelclr #noderefresh').attr("class", "btnstyle3-dis");
+			$('#updelclr #hasnodefailed').attr("class", "btnstyle3-dis");
+			$('#updelclr #replacefailednode').attr("class", "btnstyle3-dis");
 
 			$("#hardwarecontent #configuration").html("");
 			$("#hardwarecontent #nodeparamstable #nodename").val("");
@@ -767,6 +799,8 @@ define(['app'], function (app) {
 					$('#updelclr #nodeupdate').attr("class", "btnstyle3-dis");
 					$('#updelclr #nodedelete').attr("class", "btnstyle3-dis");
 					$('#updelclr #noderefresh').attr("class", "btnstyle3-dis");
+					$('#updelclr #hasnodefailed').attr("class", "btnstyle3-dis");
+					$('#updelclr #replacefailednode').attr("class", "btnstyle3-dis");
 					$("#hardwarecontent #configuration").html("");
 					$("#hardwarecontent #nodeparamstable #nodename").val("");
 					$('#hardwarecontent #usercodegrp').hide();
@@ -778,6 +812,8 @@ define(['app'], function (app) {
 					$(this).addClass('row_selected');
 					$('#updelclr #nodeupdate').attr("class", "btnstyle3");
 					$('#updelclr #noderefresh').attr("class", "btnstyle3");
+					$('#updelclr #hasnodefailed').attr("class", "btnstyle3");
+					$('#updelclr #replacefailednode').attr("class", "btnstyle3");
 					var anSelected = fnGetSelected(oTable);
 					if (anSelected.length !== 0) {
 						var data = oTable.fnGetData(anSelected[0]);
@@ -785,6 +821,8 @@ define(['app'], function (app) {
 						var iNode = parseInt(data["NodeID"]);
 						$("#updelclr #nodeupdate").attr("href", "javascript:UpdateNode(" + idx + ")");
 						$('#updelclr #noderefresh').attr("href", "javascript:RefreshNode(" + idx + ")");
+						$('#updelclr #hasnodefailed').attr("href", "javascript:HasNodeFailed(" + idx + ")");
+						$('#updelclr #replacefailednode').attr("href", "javascript:ReplaceFailedNode(" + idx + ")");
 
 						$("#hardwarecontent #zwavecodemanagement").attr("href", "javascript:ZWaveUserCodeManagement(" + idx + ")");
 						if (iNode !== iOwnNodeId) {


### PR DESCRIPTION
I used the OZW CP a lot in case of failed nodes. which can be fixed in the combination of  "refresh node info", "has node failed""  and "replace failed node". Refresh node is already present in the ZWave screen. But Has node Failed and Replace Failed Node are not. resulting in the workaround to use to OZWCP. But i found out that domoticz becomes quite unstable when using the ozwcp. (segfaults and signal 11) 

so i made a PR to add these 2 functions to the OZW setup screen. (buttons are located next to the "refresh node"  button).

I tested a lot. Results:
1. The functionality works! 
2. Unstability (when switching to ozwcp) is gone.
3. but also found out that the "replace node" is not working as expected on OZW side.   I reported an [issue upstream](https://github.com/OpenZWave/open-zwave/issues/2293) for that problem. The code works around this issue, so from domoticz perspective is is OK now. 

