### PR TITLE
RTL433: Added X-10 Security support

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -7,6 +7,7 @@ Version 2020.xxxx (xxxx)
 - Implemented: RTL433, added RF Signal Strength in device tab based on reported SNR
 - Implemented: RTL433, added Pressure (PSI) type
 - Implemented: RTL433, added UV type
+- Implemented: RTL433, added X-10 Security support
 - Implemented: RTL433, switched to Json input
 - Implemented: The following sensor types now support RSSI: Distance Sensor, Moisture Sensor, Watt Meter, kWh Meter
 - Implemented: ZWave, Legend and tooltips in Neighbours overview

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -1030,3 +1030,21 @@ void CDomoticzHardwareBase::SendFanSensor(const int Idx, const int BatteryLevel,
 	gDevice.intval2 = FanSpeed;
 	sDecodeRXMessage(this, (const unsigned char*)& gDevice, defaultname.c_str(), BatteryLevel);
 }
+
+void CDomoticzHardwareBase::SendSecurity1Sensor(const int NodeID, const int DeviceSubType, const int BatteryLevel, const int Status, const std::string &defaultname, const int RssiLevel /* = 12 */)
+{
+	RBUF m_sec1;
+	memset(&m_sec1, 0, sizeof(RBUF));
+	
+	m_sec1.SECURITY1.packetlength = sizeof(m_sec1) -1;
+	m_sec1.SECURITY1.packettype = pTypeSecurity1;
+	m_sec1.SECURITY1.subtype = DeviceSubType;
+	m_sec1.SECURITY1.id1 = (NodeID & 0xFF0000) >> 16;
+	m_sec1.SECURITY1.id2 = (NodeID & 0xFF00) >> 8;
+	m_sec1.SECURITY1.id3 = (NodeID & 0xFF);
+	m_sec1.SECURITY1.status = Status;
+	m_sec1.SECURITY1.rssi = RssiLevel;
+	m_sec1.SECURITY1.battery_level = BatteryLevel;
+	
+	sDecodeRXMessage(this, (const unsigned char*)& m_sec1.SECURITY1, defaultname.c_str(), BatteryLevel);
+}

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -122,6 +122,7 @@ protected:
 	void SendCustomSensor(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const float CustomValue, const std::string &defaultname, const std::string &defaultLabel, const int RssiLevel = 12);
 	void SendZWaveAlarmSensor(const int NodeID, const uint8_t InstanceID, const int BatteryLevel, const uint8_t aType, const int aValue, const std::string& alarmLabel, const std::string &defaultname);
 	void SendFanSensor(const int Idx, const int BatteryLevel, const int FanSpeed, const std::string &defaultname);
+	void SendSecurity1Sensor(const int NodeID, const int DeviceSubType, const int BatteryLevel, const int Status, const std::string &defaultname, const int RssiLevel = 12);
 
 	int m_iHBCounter = { 0 };
 	bool m_bIsStarted = { false };

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -150,7 +150,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	float uvi = 0;
 
 	int snr = 12;  // Set to show "-" if no snr is received. rtl_433 uses automatic gain, better to use SNR instead of RSSI to report received RF Signal quality
-	
+
 	int code = 0;
 
 	if (FindField(data, "id"))
@@ -288,7 +288,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		if (snr > 11) snr = 11; // Domoticz RSSI field can only be 0-11, 12 is used for non-RF received devices
 		if (snr < 0) snr = 0; // In case snr actually was below 4 dB
 	}
-		if (FindField(data, "code"))
+	if (FindField(data, "code"))
 	{
 		code = strtoul(data["code"].c_str(), NULL, 16);
 	}
@@ -426,91 +426,93 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		// More X10 sensors can be added if their codes are known
 		uint8_t x10_device = 0;
 		uint8_t x10_status = 0;
-	
+
 		bHandled = true;
-	
+
 		switch (code & 0xfe) // The last bit is indicating low battery and is already handled
 		{
-			case 0x00 :
-				x10_status = sStatusAlarmDelayed; // Door open, Delay switch set to MAX on DS18
-				x10_device = sTypeSecX10;
-				break;
-			case 0x04 :
-				x10_status = sStatusAlarm;  // Door open, Delay switch set to MIN on DS18
-				x10_device = sTypeSecX10;
-				break;
-			case 0x40 :
-				x10_status = sStatusAlarmDelayedTamper;
-				x10_device = sTypeSecX10;
-				break;
-			case 0x44 :
-				x10_status = sStatusAlarmTamper;
-				x10_device = sTypeSecX10;
-				break;
-			case 0x80 :
-				x10_status = sStatusNormalDelayed;
-				x10_device = sTypeSecX10;
-				break;
-			case 0x84 :
-				x10_status = sStatusNormal;
-				x10_device = sTypeSecX10;
-				break;
-			case 0xc0 :
-				x10_status = sStatusNormalDelayedTamper;
-				x10_device = sTypeSecX10;
-				break;
-			case 0xc4 :
-				x10_status = sStatusNormalTamper;
-				x10_device = sTypeSecX10;
-				break;
-			case 0x8c :
-				x10_status = sStatusNoMotion;
-				x10_device = sTypeSecX10M;
-				break;
-			case 0xcc :
-				x10_status = sStatusNoMotionTamper;
-				x10_device = sTypeSecX10M;
-				break;
-			case 0x0c :
-				x10_status = sStatusMotion;
-				x10_device = sTypeSecX10M;
-				break;
-			case 0x4c :
-				x10_status = sStatusMotionTamper;
-				x10_device = sTypeSecX10M;
-				break;
-			case 0x26 :
-			case 0x88 :
-			case 0x98 :
-				x10_status = sStatusPanic;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0x42 :
-				x10_status = sStatusLightOn;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0x46 :
-				x10_status = sStatusLight2On;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0xc2 :
-				x10_status = sStatusLightOff;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0xc6 :
-				x10_status = sStatusLight2Off;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0x06 :
-				x10_status = sStatusArmAway;
-				x10_device = sTypeSecX10R;
-				break;
-			case 0x82 :
-			case 0x86 :
-				x10_status = sStatusDisarm;
-				x10_device = sTypeSecX10R;
-				break;
-			default : bHandled = false;
+		case 0x00:
+			x10_status = sStatusAlarmDelayed; // Door open, Delay switch set to MAX on DS18
+			x10_device = sTypeSecX10;
+			break;
+		case 0x04:
+			x10_status = sStatusAlarm;  // Door open, Delay switch set to MIN on DS18
+			x10_device = sTypeSecX10;
+			break;
+		case 0x40:
+			x10_status = sStatusAlarmDelayedTamper;
+			x10_device = sTypeSecX10;
+			break;
+		case 0x44:
+			x10_status = sStatusAlarmTamper;
+			x10_device = sTypeSecX10;
+			break;
+		case 0x80:
+			x10_status = sStatusNormalDelayed;
+			x10_device = sTypeSecX10;
+			break;
+		case 0x84:
+			x10_status = sStatusNormal;
+			x10_device = sTypeSecX10;
+			break;
+		case 0xc0:
+			x10_status = sStatusNormalDelayedTamper;
+			x10_device = sTypeSecX10;
+			break;
+		case 0xc4:
+			x10_status = sStatusNormalTamper;
+			x10_device = sTypeSecX10;
+			break;
+		case 0x8c:
+			x10_status = sStatusNoMotion;
+			x10_device = sTypeSecX10M;
+			break;
+		case 0xcc:
+			x10_status = sStatusNoMotionTamper;
+			x10_device = sTypeSecX10M;
+			break;
+		case 0x0c:
+			x10_status = sStatusMotion;
+			x10_device = sTypeSecX10M;
+			break;
+		case 0x4c:
+			x10_status = sStatusMotionTamper;
+			x10_device = sTypeSecX10M;
+			break;
+		case 0x26:
+		case 0x88:
+		case 0x98:
+			x10_status = sStatusPanic;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0x42:
+			x10_status = sStatusLightOn;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0x46:
+			x10_status = sStatusLight2On;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0xc2:
+			x10_status = sStatusLightOff;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0xc6:
+			x10_status = sStatusLight2Off;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0x06:
+			x10_status = sStatusArmAway;
+			x10_device = sTypeSecX10R;
+			break;
+		case 0x82:
+		case 0x86:
+			x10_status = sStatusDisarm;
+			x10_device = sTypeSecX10R;
+			break;
+		default:
+			bHandled = false;
+			break;
 		}
 		if (bHandled) SendSecurity1Sensor(strtoul(data["id"].c_str(), NULL, 16), x10_device, batterylevel, x10_status, model, snr);
 	} // End of X10-Security section

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -150,6 +150,8 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	float uvi = 0;
 
 	int snr = 12;  // Set to show "-" if no snr is received. rtl_433 uses automatic gain, better to use SNR instead of RSSI to report received RF Signal quality
+	
+	int code = 0;
 
 	if (FindField(data, "id"))
 	{
@@ -286,6 +288,10 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		if (snr > 11) snr = 11; // Domoticz RSSI field can only be 0-11, 12 is used for non-RF received devices
 		if (snr < 0) snr = 0; // In case snr actually was below 4 dB
 	}
+		if (FindField(data, "code"))
+	{
+		code = strtoul(data["code"].c_str(), NULL, 16);
+	}
 
 	std::string model = data["model"]; // new model format normalized from the 201 different devices presently supported by rtl_433
 
@@ -415,6 +421,99 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		bHandled = true;
 	}
 
+	if (!strcmp(model.c_str(), "X10-Security"))
+	{
+		// More X10 sensors can be added if their codes are known
+		uint8_t x10_device = 0;
+		uint8_t x10_status = 0;
+	
+		bHandled = true;
+	
+		switch (code & 0xfe) // The last bit is indicating low battery and is already handled
+		{
+			case 0x00 :
+				x10_status = sStatusAlarmDelayed; // Door open, Delay switch set to MAX on DS18
+				x10_device = sTypeSecX10;
+				break;
+			case 0x04 :
+				x10_status = sStatusAlarm;  // Door open, Delay switch set to MIN on DS18
+				x10_device = sTypeSecX10;
+				break;
+			case 0x40 :
+				x10_status = sStatusAlarmDelayedTamper;
+				x10_device = sTypeSecX10;
+				break;
+			case 0x44 :
+				x10_status = sStatusAlarmTamper;
+				x10_device = sTypeSecX10;
+				break;
+			case 0x80 :
+				x10_status = sStatusNormalDelayed;
+				x10_device = sTypeSecX10;
+				break;
+			case 0x84 :
+				x10_status = sStatusNormal;
+				x10_device = sTypeSecX10;
+				break;
+			case 0xc0 :
+				x10_status = sStatusNormalDelayedTamper;
+				x10_device = sTypeSecX10;
+				break;
+			case 0xc4 :
+				x10_status = sStatusNormalTamper;
+				x10_device = sTypeSecX10;
+				break;
+			case 0x8c :
+				x10_status = sStatusNoMotion;
+				x10_device = sTypeSecX10M;
+				break;
+			case 0xcc :
+				x10_status = sStatusNoMotionTamper;
+				x10_device = sTypeSecX10M;
+				break;
+			case 0x0c :
+				x10_status = sStatusMotion;
+				x10_device = sTypeSecX10M;
+				break;
+			case 0x4c :
+				x10_status = sStatusMotionTamper;
+				x10_device = sTypeSecX10M;
+				break;
+			case 0x26 :
+			case 0x88 :
+			case 0x98 :
+				x10_status = sStatusPanic;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0x42 :
+				x10_status = sStatusLightOn;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0x46 :
+				x10_status = sStatusLight2On;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0xc2 :
+				x10_status = sStatusLightOff;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0xc6 :
+				x10_status = sStatusLight2Off;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0x06 :
+				x10_status = sStatusArmAway;
+				x10_device = sTypeSecX10R;
+				break;
+			case 0x82 :
+			case 0x86 :
+				x10_status = sStatusDisarm;
+				x10_device = sTypeSecX10R;
+				break;
+			default : bHandled = false;
+		}
+		if (bHandled) SendSecurity1Sensor(strtoul(data["id"].c_str(), NULL, 16), x10_device, batterylevel, x10_status, model, snr);
+	} // End of X10-Security section
 
 	return bHandled; //not handled (Yet!)
 }


### PR DESCRIPTION
Added support for X-10 Security using the RTL-SDR usb stick. Tested OK with DS18 (Door/Window sensor), KR18 (Key Fob) and MS18 (Motion Sensor).

Please check my code so it matches your standard. I am fairly new to Domoticz and might have missunderstood or overlooked something. 

NodeID in X-10 Security is two bytes only, why ID1 will always be 0x00. However, X-10 Security is not the only type using Security1, so I tried to keep the code as generic as possible.