### PR TITLE
Support windspeed received in miles per hour

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -236,6 +236,11 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		wind_speed = (float)atof(data["wind_avg_m_s"].c_str());
 		haveWind_Speed = true;
 	}
+	if (FindField(data, "wind_avg_mi_h")) // wind speed average (converting mph to m/s)
+	{
+		wind_speed = ((float)atof(data["wind_avg_mi_h"].c_str())) * 0.44704f;
+		haveWind_Speed = true;
+	}
 	if (FindField(data, "wind_dir_deg"))
 	{
 		wind_dir = atoi(data["wind_dir_deg"].c_str()); // does domoticz assume it is degree ? (and not rad or something else)
@@ -249,6 +254,11 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	if (FindField(data, "wind_max_m_s"))
 	{
 		wind_gust = (float)atof(data["wind_max_m_s"].c_str());
+		haveWind_Gust = true;
+	}
+	if (FindField(data, "wind_max_mi_h")) // wind gusts (converting mph to m/s)
+	{
+		wind_gust = ((float)atof(data["wind_max_mi_h"].c_str())) * 0.44704f;
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "moisture"))

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -238,7 +238,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "wind_avg_mi_h")) // wind speed average (converting mph to m/s)
 	{
-		wind_speed = ((float)atof(data["wind_avg_mi_h"].c_str())) * 0.44704f;
+		wind_speed = ((float)atof(data["wind_avg_mi_h"].c_str())) / 2.2f;
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_dir_deg"))
@@ -258,7 +258,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "wind_max_mi_h")) // wind gusts (converting mph to m/s)
 	{
-		wind_gust = ((float)atof(data["wind_max_mi_h"].c_str())) * 0.44704f;
+		wind_gust = ((float)atof(data["wind_max_mi_h"].c_str())) / 2.2f;
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "moisture"))


### PR DESCRIPTION
Support RTL433 windspeed, received in miles per hour. 

Background: The TFA 30.3149 wireless 433mhz wind sensor reports wind in miles per hour using "wind_avg_mi_h" and "wind_max_mi_h" keys . For use by Domoticz these values are internally converted to meters per second. This windspeed, winddirection & temperature sensor is used by several stations. For example by TFA Nexus and Sinus, 35.1075, 35.1095, 35.1100, but also others.

Sample of the data send by the TFA Dostmann 30.3149:
{"time" : "2020-07-27 03:11:55", "model" : "Hideki-Wind", "id" : 10, "channel" : 4, "battery_ok" : 1, "temperature_C" : 12.100, "wind_avg_mi_h" : 4.500, "wind_max_mi_h" : 7.100, "wind_approach" : 0, "wind_dir_deg" : 202.500, "mic" : "CRC"}

Note: I have tested the code using the actual hardware, it works fine and gives expected results.

