### PR TITLE
Feature: Mercedes Me connected Vehicle

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ hardware/EnOceanESP3.cpp
 hardware/EnphaseAPI.cpp
 hardware/Ec3kMeterTCP.cpp
 hardware/eVehicles/TeslaApi.cpp
+hardware/eVehicles/MercApi.cpp
 hardware/eVehicles/eVehicle.cpp
 hardware/EvohomeBase.cpp
 hardware/EvohomeRadio.cpp

--- a/History.txt
+++ b/History.txt
@@ -1,4 +1,5 @@
 Version 2020.xxxx (xxxx)
+- Implemented: Mercedes Me API's (BYOCAR) as an (e)Vehicle supporting lock/open, odo, fuellevel
 - Implemented: Added optional parameter 'level' to addlogmessage JSON
 - Implemented: Allow complete IPv6 address in local network setting
 - Implemented: Counter meter type now supports a divider

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -548,11 +548,7 @@ bool CMercApi::SendToApi(const eApiMethod eMethod, const std::string& sUrl, cons
 			if (!HTTPClient::POST(sUrl, sPostData, _vExtraHeaders, sResponse, _vResponseHeaders))
 			{
 				_iHttpCode = (!_vResponseHeaders[0].empty() ? (uint16_t) std::stoi(_vResponseHeaders[0].substr(9,3).c_str()) : 9999);
-				for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) 
-					_ssResponseHeaderString << _vResponseHeaders[i];
-				_log.Debug(DEBUG_NORM, "MercApi: Failed to perform POST request to Api: (%i) %s; Response headers: %s", _iHttpCode, sResponse.c_str(), _ssResponseHeaderString.str().c_str());
-				_log.Log(LOG_STATUS, "Failed to perform POST request (%i)!", _iHttpCode);
-				return false;
+				_log.Log(LOG_ERROR, "Failed to perform POST request (%i)!", _iHttpCode);
 			}
 			break;
 
@@ -560,11 +556,7 @@ bool CMercApi::SendToApi(const eApiMethod eMethod, const std::string& sUrl, cons
 			if (!HTTPClient::GET(sUrl, _vExtraHeaders, sResponse, _vResponseHeaders, true))
 			{
 				_iHttpCode = (!_vResponseHeaders[0].empty() ? (uint16_t) std::stoi(_vResponseHeaders[0].substr(9,3).c_str()) : 9999);
-				for (unsigned int i = 0; i < _vResponseHeaders.size(); i++)
-					_ssResponseHeaderString << _vResponseHeaders[i];
-				_log.Debug(DEBUG_NORM, "MercApi: Failed to perform GET request to Api: (%i) %s; Response headers: %s", _iHttpCode, sResponse.c_str(), _ssResponseHeaderString.str().c_str());
-				_log.Log(LOG_STATUS, "Failed to perform GET request (%i)!", _iHttpCode);
-				return false;
+				_log.Log(LOG_ERROR, "Failed to perform GET request (%i)!", _iHttpCode);
 			}
 			break;
 

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -186,21 +186,49 @@ void CMercApi::GetClimateData(Json::Value& jsondata, tClimateData& data)
 bool CMercApi::GetVehicleData(tVehicleData& data)
 {
 	Json::Value reply;
+	bool bData = false;
 
 	if (GetData("vehiclelockstatus", reply))
 	{
 		if (reply.size() == 0)
-			return true;	// This occurs when the API call return a 204 (No Content). So everything is valid/ok, just no data
-
-		if (!reply.isArray())
 		{
-			_log.Log(LOG_ERROR, "MercApi: Unexpected reply from VehicleLockStatus.");
-			return false;
+			bData = true;	// This occurs when the API call return a 204 (No Content). So everything is valid/ok, just no data
 		}
-		GetVehicleData(reply, data);
-		return true;
+		else
+		{
+			if (!reply.isArray())
+			{
+				_log.Log(LOG_ERROR, "MercApi: Unexpected reply from VehicleLockStatus.");
+			}
+			else
+			{
+				GetVehicleData(reply, data);
+				bData = true;
+			}
+		}
 	}
-	return false;
+
+	if (GetData("payasyoudrive", reply))
+	{
+		if (reply.size() == 0)
+		{
+			bData = true;	// This occurs when the API call return a 204 (No Content). So everything is valid/ok, just no data
+		}
+		else
+		{
+			if (!reply.isArray())
+			{
+				_log.Log(LOG_ERROR, "MercApi: Unexpected reply from PayasyouDrive.");
+			}
+			else
+			{
+				GetVehicleData(reply, data);
+				bData = true;
+			}
+		}
+	}
+
+	return bData;
 }
 
 void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
@@ -226,6 +254,16 @@ void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
 						_log.Debug(DEBUG_NORM, "MercApi: DoorLockStatusVehicle has value %s", iter2["value"].asString().c_str());
 						data.car_open = (iter2["value"].asString() == "1" || iter2["value"].asString() == "2" ? false : true);
 						data.car_open_message = (data.car_open ? "Your Mercedes is open" : "Your Mercedes is locked");
+					}
+				}
+				if (id == "odo")
+				{
+					Json::Value iter2;
+					iter2 = iter[id];
+					if(!iter2["value"].empty())
+					{
+						_log.Debug(DEBUG_NORM, "MercApi: Odo has value %s", iter2["value"].asString().c_str());
+						data.odo = atof(iter2["value"].asString().c_str());
 					}
 				}
 			}

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -1,0 +1,573 @@
+/************************************************************************
+
+Merceded implementation of VehicleApi baseclass
+Author: KidDigital (github.com/kiddigital)
+
+24/07/2020 1.0 Creation
+
+License: Public domain
+
+************************************************************************/
+#include "stdafx.h"
+#include "MercApi.h"
+#include "VehicleApi.h"
+#include "../../main/Logger.h"
+#include "../../httpclient/UrlEncode.h"
+#include "../../httpclient/HTTPClient.h"
+#include "../../main/json_helper.h"
+#include <sstream>
+#include <iomanip>
+
+// based on TESLA API as described on https://tesla-api.timdorr.com/
+#define TESLA_URL "https://owner-api.teslamotors.com"
+#define TESLA_API "/api/1/vehicles"
+#define TESLA_API_COMMAND "/command/"
+#define TESLA_API_REQUEST "/data_request/"
+#define TESLA_API_AUTH "/oauth/token"
+
+#define TESLA_CLIENT_ID "81527cff06843c8634fdc09e8ac0abefb46ac849f38fe1e431c2ef2106796384"
+#define TESLA_CLIENT_SECRET "c7257eb71a564034f9419ee651c7d0e5f7aa6bfbd18bafb5c5c033b093bb2fa3"
+
+#define TLAPITIMEOUT (25)
+
+CMercApi::CMercApi(const std::string username, const std::string password, const std::string vinnr)
+{
+	m_username = username;
+	m_password = password;
+	m_VIN = vinnr;
+	m_authtoken = "";
+	m_refreshtoken = "";
+	m_carid = 0;
+	m_config.car_name = "";
+	m_config.unit_miles = false;
+	m_config.distance_unit = "km";
+
+	m_capabilities.has_battery_level = true;
+	m_capabilities.has_charge_command = true;
+	m_capabilities.has_climate_command = true;
+	m_capabilities.has_defrost_command = true;
+	m_capabilities.has_inside_temp = true;
+	m_capabilities.has_outside_temp = true;
+	m_capabilities.has_odo = true;
+	m_capabilities.has_lock_status = true;
+	m_capabilities.has_charge_limit = true;
+	m_capabilities.sleep_interval = 20;
+}
+
+CMercApi::~CMercApi()
+{
+}
+
+bool CMercApi::Login()
+{
+	_log.Log(LOG_NORM, "MercApi: Attempting login.");
+	if (GetAuthToken(m_username, m_password, false))
+	{
+		if(FindCarInAccount())
+		{
+			_log.Log(LOG_NORM, "MercApi: Login successful.");
+			return true;
+		}
+	}
+
+	_log.Log(LOG_NORM, "MercApi: Failed to login.");
+	m_authtoken = "";
+	m_refreshtoken = "";
+	return false;
+}
+
+bool CMercApi::RefreshLogin()
+{
+	_log.Log(LOG_NORM, "MercApi: Refreshing login credentials.");
+	if (GetAuthToken("", "", true))
+	{	
+		_log.Log(LOG_NORM, "MercApi: Refresh successful.");
+		return true;
+	}
+
+	_log.Log(LOG_ERROR, "MercApi: Failed to refresh login credentials.");
+	m_authtoken = "";
+	m_refreshtoken = "";
+	return false;
+}
+
+bool CMercApi::GetAllData(tAllCarData& data)
+{
+	Json::Value reply;
+
+	if (GetData("vehicle_data", reply))
+	{
+		GetUnitData(reply["response"]["gui_settings"], m_config);
+		GetLocationData(reply["response"]["drive_state"], data.location);
+		GetChargeData(reply["response"]["charge_state"], data.charge);
+		GetClimateData(reply["response"]["climate_state"], data.climate);
+		GetVehicleData(reply["response"]["vehicle_state"], data.vehicle);
+		return true;
+	}
+	return false;
+}
+
+bool CMercApi::GetLocationData(tLocationData& data)
+{
+	Json::Value reply;
+
+	if (GetData("drive_state", reply))
+	{
+		GetLocationData(reply["response"], data);
+		return true;
+	}
+	return false;
+}
+
+void CMercApi::GetLocationData(Json::Value& jsondata, tLocationData& data)
+{
+	std::string CarLatitude = jsondata["latitude"].asString();
+	std::string CarLongitude = jsondata["longitude"].asString();
+	data.speed = jsondata["speed"].asInt();
+	data.is_driving = data.speed > 0;
+	data.latitude = std::stod(CarLatitude);
+	data.longitude = std::stod(CarLongitude);
+}
+
+bool CMercApi::GetChargeData(CVehicleApi::tChargeData& data)
+{
+	Json::Value reply;
+
+	if (GetData("charge_state", reply))
+	{
+		GetChargeData(reply["response"], data);
+		return true;
+	}
+	return false;
+}
+
+void CMercApi::GetChargeData(Json::Value& jsondata, CVehicleApi::tChargeData& data)
+{
+	data.battery_level = jsondata["battery_level"].asFloat();
+	data.status_string = jsondata["charging_state"].asString();
+	data.is_connected = (data.status_string != "Disconnected");
+	data.is_charging = (data.status_string == "Charging") || (data.status_string == "Starting");
+	data.charge_limit = jsondata["charge_limit_soc"].asInt();
+
+	if(data.status_string == "Disconnected")
+		data.status_string = "Charge Cable Disconnected";
+
+	if (data.is_charging)
+	{
+		data.status_string.append(" (until ");
+		data.status_string.append(std::to_string(data.charge_limit));
+		data.status_string.append("%)");
+	}
+}
+
+bool CMercApi::GetClimateData(tClimateData& data)
+{
+	Json::Value reply;
+
+	if (GetData("climate_state", reply))
+	{
+		GetClimateData(reply["response"], data);
+		return true;
+	}
+	return false;
+}
+
+void CMercApi::GetClimateData(Json::Value& jsondata, tClimateData& data)
+{
+	data.inside_temp = jsondata["inside_temp"].asFloat();
+	data.outside_temp = jsondata["outside_temp"].asFloat();
+	data.is_climate_on = jsondata["is_climate_on"].asBool();
+	data.is_defrost_on = (jsondata["defrost_mode"].asInt() != 0);
+}
+
+bool CMercApi::GetVehicleData(tVehicleData& data)
+{
+	Json::Value reply;
+
+	if (GetData("vehicle_state", reply))
+	{
+		GetVehicleData(reply["response"], data);
+		return true;
+	}
+	return false;
+}
+
+void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
+{
+	data.odo = (jsondata["odometer"].asFloat());
+	if (!m_config.unit_miles)
+		data.odo = data.odo * (float)1.60934;
+
+	if (jsondata["df"].asBool() ||
+		jsondata["pf"].asBool() ||
+		jsondata["pr"].asBool() ||
+		jsondata["dr"].asBool())
+	{
+		data.car_open = true;
+		data.car_open_message = "Door open";
+	}
+	else if (
+		jsondata["ft"].asBool() ||
+		jsondata["rt"].asBool())
+	{
+		data.car_open = true;
+		data.car_open_message = "Trunk open";
+	}
+	else if (
+		jsondata["fd_window"].asBool() ||
+		jsondata["fp_window"].asBool() ||
+		jsondata["rp_window"].asBool() ||
+		jsondata["rd_window"].asBool())
+	{
+		data.car_open = true;
+		data.car_open_message = "Window open";
+	}
+	else if (
+		!jsondata["locked"].asBool())
+	{
+		data.car_open = true;
+		data.car_open_message = "Unlocked";
+	}
+	else
+	{
+		data.car_open = false;
+		data.car_open_message = "Locked";
+	}
+}
+
+void CMercApi::GetUnitData(Json::Value& jsondata, tConfigData &config)
+{
+	std::string sUnit = jsondata["gui_distance_units"].asString();
+	config.unit_miles = (sUnit == "mi/hr");
+	if (config.unit_miles)
+		config.distance_unit = "mi";
+	else
+		config.distance_unit = "km";
+
+	_log.Debug(DEBUG_NORM, "MercApi: unit found %s, report in miles = %s.", sUnit.c_str(), config.unit_miles ? "true":"false");
+}
+
+bool CMercApi::GetData(std::string datatype, Json::Value& reply)
+{
+	std::stringstream ss;
+	if(datatype == "vehicle_data")
+		ss << TESLA_URL << TESLA_API << "/" << m_carid << "/" << datatype;
+	else
+		ss << TESLA_URL << TESLA_API << "/" << m_carid << TESLA_API_REQUEST << datatype;
+	std::string _sUrl = ss.str();
+	std::string _sResponse;
+
+	if (!SendToApi(Get, _sUrl, "", _sResponse, *(new std::vector<std::string>()), reply, true))
+	{
+		_log.Log(LOG_ERROR, "MercApi: Failed to get data %s.", datatype.c_str());
+		return false;
+	}
+
+	//_log.Log(LOG_NORM, "MercApi: Get data %s received reply: %s", datatype.c_str(), _sResponse.c_str());
+	_log.Debug(DEBUG_NORM, "MercApi: Get data %s received reply: %s", datatype.c_str(), _sResponse.c_str());
+
+	return true;
+}
+
+bool CMercApi::FindCarInAccount()
+{
+	std::stringstream ss;
+	ss << TESLA_URL << TESLA_API;
+	std::string _sUrl = ss.str();
+	std::string _sResponse;
+	Json::Value _jsRoot;
+	bool car_found = false;
+
+	if (!SendToApi(Get, _sUrl, "", _sResponse, *(new std::vector<std::string>()), _jsRoot, true))
+	{
+		_log.Log(LOG_ERROR, "MercApi: Failed to get car from account.");
+		return false;
+	}
+
+	_log.Debug(DEBUG_NORM, "MercApi: Received %d vehicles from API: %s", _jsRoot["count"].asInt(), _sResponse.c_str());
+	for (int i = 0; i < _jsRoot["count"].asInt(); i++)
+	{
+		if (_jsRoot["response"][i]["vin"].asString() == m_VIN)
+		{
+			m_carid = _jsRoot["response"][i]["id"].asInt64();
+			m_config.car_name = _jsRoot["response"][i]["display_name"].asString();
+			car_found = true;
+			_log.Log(LOG_NORM, "MercApi: Car found in account: VIN %s NAME %s", m_VIN.c_str(), m_config.car_name.c_str());
+			return true;
+		}
+	}
+
+	_log.Log(LOG_ERROR, "MercApi: Car with VIN number %s NOT found in account.", m_VIN.c_str());
+	return car_found;
+}
+
+bool CMercApi::IsAwake()
+{
+	std::stringstream ss;
+	ss << TESLA_URL << TESLA_API << "/" << m_carid;
+	std::string _sUrl = ss.str();
+	std::string _sResponse;
+	Json::Value _jsRoot;
+	bool is_awake = false;
+	int nr_retry = 0;
+
+	while (!SendToApi(Get, _sUrl, "", _sResponse, *(new std::vector<std::string>()), _jsRoot, true, 10))
+	{
+		nr_retry++;
+		if (nr_retry == 4)
+		{
+			_log.Log(LOG_ERROR, "MercApi: Failed to get awake state.");
+			return false;
+		}
+	}
+
+	_log.Debug(DEBUG_NORM, "Awake state: %s", _jsRoot["response"]["state"].asString().c_str());
+	is_awake = (_jsRoot["response"]["state"] == "online");
+	return(is_awake);
+}
+
+bool CMercApi::SendCommand(eCommandType command, std::string parameter)
+{
+	std::string command_string;
+	Json::Value reply;
+	std::string parameters = "";
+
+	switch (command)
+	{
+	case Charge_Start:
+		command_string = "charge_start";
+		break;
+	case Charge_Stop:
+		command_string = "charge_stop";
+		break;
+	case Climate_Off:
+		command_string = "auto_conditioning_stop";
+		break;
+	case Climate_On:
+		command_string = "auto_conditioning_start";
+		break;
+	case Climate_Defrost:
+		command_string = "set_preconditioning_max";
+		parameters = "on=true";
+		break;
+	case Climate_Defrost_Off:
+		command_string = "set_preconditioning_max";
+		parameters = "on=false";
+		break;
+	case Wake_Up:
+		command_string = "wake_up";
+		break;
+	case Set_Charge_Limit:
+		if (parameter == "0")
+			command_string = "charge_standard";
+		else if(parameter == "100")
+			command_string = "charge_max_range";
+		else
+		{
+			command_string = "set_charge_limit";
+			parameters = "percent=" + parameter;
+		}
+		break;
+	}
+
+	if (SendCommand(command_string, reply, parameters))
+	{
+		if (command == Wake_Up)
+		{
+			if (reply["response"]["state"].asString() == "online")
+				return true;
+		}
+		else
+		{
+			if (reply["response"]["result"].asString() == "true")
+				return true;
+		}
+	}
+
+	return false;
+}
+
+bool CMercApi::SendCommand(std::string command, Json::Value& reply, std::string parameters)
+{
+	std::stringstream ss;
+	if (command == "wake_up")
+		ss << TESLA_URL << TESLA_API << "/" << m_carid << "/" << command;
+	else
+		ss << TESLA_URL << TESLA_API << "/" << m_carid << TESLA_API_COMMAND << command;
+
+	std::string _sUrl = ss.str();
+	std::string _sResponse;
+
+	std::stringstream parss;
+	parss << parameters;
+	std::string sPostData = parss.str();
+
+	if (!SendToApi(Post, _sUrl, sPostData, _sResponse, *(new std::vector<std::string>()), reply, true))
+	{
+		_log.Log(LOG_ERROR, "MercApi: Failed to send command %s.", command.c_str());
+		return false;
+	}
+
+	//_log.Log(LOG_NORM, "MercApi: Command %s received reply: %s", command.c_str(), _sResponse.c_str());
+	_log.Debug(DEBUG_NORM, "MercApi: Command %s received reply: %s", command.c_str(), _sResponse.c_str());
+
+	return true;
+}
+
+// Requests an authentication token from the Tesla OAuth Api.
+bool CMercApi::GetAuthToken(const std::string username, const std::string password, const bool refreshUsingToken)
+{
+	if (username.size() == 0 && !refreshUsingToken)
+	{
+		_log.Log(LOG_ERROR, "MercApi: No username specified.");
+		return false;
+	}
+	if (username.size() == 0 && !refreshUsingToken)
+	{
+		_log.Log(LOG_ERROR, "MercApi: No password specified.");
+		return false;
+	}
+
+	std::stringstream ss;
+	ss << TESLA_URL << TESLA_API_AUTH;
+	std::string _sUrl = ss.str();
+	std::ostringstream s;
+	std::string _sGrantType = (refreshUsingToken ? "refresh_token" : "password");
+
+	s << "client_id=" << TESLA_CLIENT_ID << "&grant_type=";
+	s << _sGrantType << "&client_secret=";
+	s << TESLA_CLIENT_SECRET;
+
+	if (refreshUsingToken)
+	{
+		s << "&refresh_token=" << m_refreshtoken;
+	}
+	else
+	{
+		s << "&password=" << CURLEncode::URLEncode(password);
+		s << "&email=" << CURLEncode::URLEncode(username);
+	}
+
+	std::string sPostData = s.str();
+
+	std::string _sResponse;
+	std::vector<std::string> _vExtraHeaders;
+	_vExtraHeaders.push_back("Content-Type: application/x-www-form-urlencoded");
+
+	Json::Value _jsRoot;
+
+	if (!SendToApi(Post, _sUrl, sPostData, _sResponse, _vExtraHeaders, _jsRoot, false))
+	{
+		_log.Log(LOG_ERROR, "MercApi: Failed to get token.");
+		return false;
+	}
+
+	m_authtoken = _jsRoot["access_token"].asString();
+	if (m_authtoken.size() == 0)
+	{
+		_log.Log(LOG_ERROR, "MercApi: Received token is zero length.");
+		return false;
+	}
+
+	m_refreshtoken = _jsRoot["refresh_token"].asString();
+	if (m_refreshtoken.size() == 0)
+	{
+		_log.Log(LOG_ERROR, "MercApi: Received refresh token is zero length.");
+		return false;
+	}
+
+	_log.Debug(DEBUG_NORM, "MercApi: Received access token from API.");
+
+	return true;
+}
+
+// Sends a request to the Tesla API.
+bool CMercApi::SendToApi(const eApiMethod eMethod, const std::string& sUrl, const std::string& sPostData,
+	std::string& sResponse, const std::vector<std::string>& vExtraHeaders, Json::Value& jsDecodedResponse, const bool bSendAuthHeaders, const int timeout)
+{
+	try 
+	{
+		// If there is no token stored then there is no point in doing a request. Unless we specifically
+		// decide not to do authentication.
+		if (m_authtoken.size() == 0 && bSendAuthHeaders) 
+		{
+			_log.Log(LOG_ERROR, "MercApi: No access token available.");
+			return false;
+		}
+
+		// Prepare the headers. Copy supplied vector.
+		std::vector<std::string> _vExtraHeaders = vExtraHeaders;
+
+		// If the supplied postdata validates as json, add an appropriate content type header
+		if (sPostData.size() > 0)
+			if (ParseJSon(sPostData, *(new Json::Value))) 
+				_vExtraHeaders.push_back("Content-Type: application/json");
+
+		// Prepare the authentication headers if requested.
+		if (bSendAuthHeaders) 
+			_vExtraHeaders.push_back("Authorization: Bearer " + m_authtoken);
+
+		// Increase default timeout, tesla is slow
+		if(timeout == 0)
+		{
+			HTTPClient::SetConnectionTimeout(TLAPITIMEOUT);
+			HTTPClient::SetTimeout(TLAPITIMEOUT);
+		}
+		else
+		{
+			HTTPClient::SetConnectionTimeout(timeout);
+			HTTPClient::SetTimeout(timeout);
+		}
+
+		std::vector<std::string> _vResponseHeaders;
+		std::stringstream _ssResponseHeaderString;
+
+		switch (eMethod)
+		{
+		case Post:
+			if (!HTTPClient::POST(sUrl, sPostData, _vExtraHeaders, sResponse, _vResponseHeaders))
+			{
+				for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) 
+					_ssResponseHeaderString << _vResponseHeaders[i];
+				_log.Debug(DEBUG_NORM, "MercApi: Failed to perform POST request to Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
+				return false;
+			}
+			break;
+
+		case Get:
+			if (!HTTPClient::GET(sUrl, _vExtraHeaders, sResponse, _vResponseHeaders))
+			{
+				for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) 
+					_ssResponseHeaderString << _vResponseHeaders[i];
+				_log.Debug(DEBUG_NORM, "MercApi: Failed to perform GET request to Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
+				return false;
+			}
+			break;
+
+		default:
+		{
+			_log.Log(LOG_ERROR, "MercApi: Unknown method specified.");
+			return false;
+		}
+		}
+
+		if (sResponse.size() == 0)
+		{
+			_log.Log(LOG_ERROR, "MercApi: Received an empty response from Api.");
+			return false;
+		}
+
+		if (!ParseJSon(sResponse, jsDecodedResponse))
+		{
+			_log.Log(LOG_ERROR, "MercApi: Failed to decode Json response from Api.");
+			return false;
+		}
+	}
+	catch (std::exception & e)
+	{
+		std::string what = e.what();
+		_log.Log(LOG_ERROR, "MercApi: Error sending information to Api: %s", what.c_str());
+		return false;
+	}
+	return true;
+}

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -39,7 +39,6 @@ private:
 	void GetChargeData(Json::Value& jsondata, tChargeData& data);
 	void GetClimateData(Json::Value& jsondata, tClimateData& data);
 	void GetVehicleData(Json::Value& jsondata, tVehicleData& data);
-	void GetUnitData(Json::Value& jsondata, tConfigData& data);
 	bool GetAuthToken(const std::string username, const std::string password, const bool refreshUsingToken = false);
 	bool SendToApi(const eApiMethod eMethod, const std::string& sUrl, const std::string& sPostData, std::string& sResponse, const std::vector<std::string>& vExtraHeaders, Json::Value& jsDecodedResponse, const bool bSendAuthHeaders = true, const int timeout = 0);
 
@@ -50,4 +49,5 @@ private:
 	std::string m_authtoken;
 	std::string m_refreshtoken;
 	int64_t m_carid;
+	bool m_authenticating;
 };

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -35,7 +35,6 @@ private:
 	};
 	bool GetData(std::string datatype, Json::Value& reply);
 	bool SendCommand(std::string command, Json::Value& reply, std::string parameters = "");
-	bool FindCarInAccount();
 	void GetLocationData(Json::Value& jsondata, tLocationData& data);
 	void GetChargeData(Json::Value& jsondata, tChargeData& data);
 	void GetClimateData(Json::Value& jsondata, tClimateData& data);

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -27,6 +27,7 @@ public:
 	bool GetChargeData(tChargeData& data) override;
 	bool GetClimateData(tClimateData& data) override;
 	bool GetVehicleData(tVehicleData& data) override;
+	bool GetCustomData(tCustomData& data) override;
 	bool IsAwake() override;
 private:
 	enum eApiMethod {
@@ -34,6 +35,7 @@ private:
 		Get
 	};
 	bool GetData(std::string datatype, Json::Value& reply);
+	bool GetResourceData(std::string datatype, Json::Value& reply);
 	bool SendCommand(std::string command, Json::Value& reply, std::string parameters = "");
 	void GetLocationData(Json::Value& jsondata, tLocationData& data);
 	void GetChargeData(Json::Value& jsondata, tChargeData& data);
@@ -41,6 +43,7 @@ private:
 	void GetVehicleData(Json::Value& jsondata, tVehicleData& data);
 	bool GetAuthToken(const std::string username, const std::string password, const bool refreshUsingToken = false);
 	bool SendToApi(const eApiMethod eMethod, const std::string& sUrl, const std::string& sPostData, std::string& sResponse, const std::vector<std::string>& vExtraHeaders, Json::Value& jsDecodedResponse, const bool bSendAuthHeaders = true, const int timeout = 0);
+	bool ProcessAvailableResources(Json::Value& jsondata);
 
 	std::string m_username;
 	std::string m_password;
@@ -50,4 +53,6 @@ private:
 	std::string m_refreshtoken;
 	int64_t m_carid;
 	bool m_authenticating;
+	uint32_t m_crc;
+	std::string m_fields;
 };

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -36,6 +36,7 @@ private:
 	};
 	bool GetData(std::string datatype, Json::Value& reply);
 	bool GetResourceData(std::string datatype, Json::Value& reply);
+	bool ProcessAvailableResources(Json::Value& jsondata);
 	bool SendCommand(std::string command, Json::Value& reply, std::string parameters = "");
 	void GetLocationData(Json::Value& jsondata, tLocationData& data);
 	void GetChargeData(Json::Value& jsondata, tChargeData& data);
@@ -43,16 +44,19 @@ private:
 	void GetVehicleData(Json::Value& jsondata, tVehicleData& data);
 	bool GetAuthToken(const std::string username, const std::string password, const bool refreshUsingToken = false);
 	bool SendToApi(const eApiMethod eMethod, const std::string& sUrl, const std::string& sPostData, std::string& sResponse, const std::vector<std::string>& vExtraHeaders, Json::Value& jsDecodedResponse, const bool bSendAuthHeaders = true, const int timeout = 0);
-	bool ProcessAvailableResources(Json::Value& jsondata);
 
 	std::string m_username;
 	std::string m_password;
 	std::string m_VIN;
 
-	std::string m_authtoken;
-	std::string m_refreshtoken;
-	int64_t m_carid;
 	bool m_authenticating;
+	std::string m_authtoken;
+	std::string m_accesstoken;
+	std::string m_refreshtoken;
+	std::string m_uservar_refreshtoken;
+	uint64_t m_uservar_refreshtoken_idx;
+
+	uint64_t m_carid;
 	uint32_t m_crc;
 	std::string m_fields;
 };

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -1,0 +1,54 @@
+/************************************************************************
+
+Merceded implementation of VehicleApi baseclass
+Author: KidDigital (github.com/kiddigital)
+
+24/07/2020 1.0 Creation
+
+License: Public domain
+
+************************************************************************/
+#pragma once
+
+#include "../../main/json_helper.h"
+#include "VehicleApi.h"
+
+class CMercApi: public CVehicleApi
+{
+public:
+	CMercApi(const std::string username, const std::string password, const std::string vin);
+	~CMercApi();
+
+	bool Login() override;
+	bool RefreshLogin() override;
+	bool SendCommand(eCommandType command, std::string parameter) override;
+	bool GetAllData(tAllCarData& data) override;
+	bool GetLocationData(tLocationData& data) override;
+	bool GetChargeData(tChargeData& data) override;
+	bool GetClimateData(tClimateData& data) override;
+	bool GetVehicleData(tVehicleData& data) override;
+	bool IsAwake() override;
+private:
+	enum eApiMethod {
+		Post,
+		Get
+	};
+	bool GetData(std::string datatype, Json::Value& reply);
+	bool SendCommand(std::string command, Json::Value& reply, std::string parameters = "");
+	bool FindCarInAccount();
+	void GetLocationData(Json::Value& jsondata, tLocationData& data);
+	void GetChargeData(Json::Value& jsondata, tChargeData& data);
+	void GetClimateData(Json::Value& jsondata, tClimateData& data);
+	void GetVehicleData(Json::Value& jsondata, tVehicleData& data);
+	void GetUnitData(Json::Value& jsondata, tConfigData& data);
+	bool GetAuthToken(const std::string username, const std::string password, const bool refreshUsingToken = false);
+	bool SendToApi(const eApiMethod eMethod, const std::string& sUrl, const std::string& sPostData, std::string& sResponse, const std::vector<std::string>& vExtraHeaders, Json::Value& jsDecodedResponse, const bool bSendAuthHeaders = true, const int timeout = 0);
+
+	std::string m_username;
+	std::string m_password;
+	std::string m_VIN;
+
+	std::string m_authtoken;
+	std::string m_refreshtoken;
+	int64_t m_carid;
+};

--- a/hardware/eVehicles/TeslaApi.cpp
+++ b/hardware/eVehicles/TeslaApi.cpp
@@ -53,6 +53,7 @@ CTeslaApi::CTeslaApi(const std::string username, const std::string password, con
 	m_capabilities.has_odo = true;
 	m_capabilities.has_lock_status = true;
 	m_capabilities.has_charge_limit = true;
+	m_capabilities.has_custom_data = false;
 	m_capabilities.sleep_interval = 20;
 }
 
@@ -235,6 +236,11 @@ void CTeslaApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
 		data.car_open = false;
 		data.car_open_message = "Locked";
 	}
+}
+
+bool CTeslaApi::GetCustomData(tCustomData& data)
+{
+	return true;
 }
 
 void CTeslaApi::GetUnitData(Json::Value& jsondata, tConfigData &config)

--- a/hardware/eVehicles/TeslaApi.h
+++ b/hardware/eVehicles/TeslaApi.h
@@ -53,6 +53,6 @@ private:
 
 	std::string m_authtoken;
 	std::string m_refreshtoken;
-	int64_t m_carid;
+	uint64_t m_carid;
 };
 

--- a/hardware/eVehicles/TeslaApi.h
+++ b/hardware/eVehicles/TeslaApi.h
@@ -29,6 +29,7 @@ public:
 	bool GetChargeData(tChargeData& data) override;
 	bool GetClimateData(tClimateData& data) override;
 	bool GetVehicleData(tVehicleData& data) override;
+	bool GetCustomData(tCustomData& data) override;
 	bool IsAwake() override;
 private:
 	enum eApiMethod {

--- a/hardware/eVehicles/VehicleApi.h
+++ b/hardware/eVehicles/VehicleApi.h
@@ -37,6 +37,7 @@ public:
 		bool has_lock_status;
 		bool has_battery_level;
 		bool has_charge_limit;
+		bool has_custom_data;
 		int  sleep_interval;
 	};
 
@@ -68,6 +69,10 @@ public:
 		std::string car_open_message;
 	};
 
+	struct tCustomData {
+		Json::Value customdata;	
+	};
+
 	struct tConfigData {
 		std::string distance_unit;
 		bool unit_miles;
@@ -79,6 +84,7 @@ public:
 		tChargeData charge;
 		tClimateData climate;
 		tVehicleData vehicle;
+		tCustomData custom;
 	};
 
 	virtual bool Login() = 0;
@@ -90,6 +96,7 @@ public:
 	virtual bool GetChargeData(tChargeData& data) = 0;
 	virtual bool GetClimateData(tClimateData& data) = 0;
 	virtual bool GetVehicleData(tVehicleData& data) = 0;
+	virtual bool GetCustomData(tCustomData& data) = 0;
 	
 	tCapabilities m_capabilities;
 	tConfigData m_config;

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -6,6 +6,7 @@ Author: MrHobbes74 (github.com/MrHobbes74)
 21/02/2020 1.0 Creation
 13/03/2020 1.1 Added keep asleep support
 28/04/2020 1.2 Added new devices (odometer, lock alert, max charge switch)
+24/07/2020 1.3 Added new Mercedes Class (KidDigital)
 
 License: Public domain
 
@@ -13,6 +14,7 @@ License: Public domain
 #include "stdafx.h"
 #include "eVehicle.h"
 #include "TeslaApi.h"
+#include "MercApi.h"
 #include "../../main/Helper.h"
 #include "../../main/Logger.h"
 #include "../hardwaretypes.h"
@@ -50,6 +52,9 @@ CeVehicle::CeVehicle(const int ID, eVehicleType vehicletype, const std::string& 
 	{
 	case Tesla:
 		m_api = new CTeslaApi(username, password, carid);
+		break;
+	case Mercedes:
+		m_api = new CMercApi(username, password, carid);
 		break;
 	default:
 		Log(LOG_ERROR, "Unsupported vehicle type.");

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -725,7 +725,7 @@ void CeVehicle::UpdateLocationData(CVehicleApi::tLocationData& data)
 			m_car.home_state = NotAtHome;
 	}
 
-	Log(LOG_NORM, "Location: %f %f Speed: %d Home: %s", data.latitude, data.longitude, data.speed, (m_car.home_state == AtHome) ? "true" : "false");
+	Debug(DEBUG_NORM, "Location: %f %f Speed: %d Home: %s", data.latitude, data.longitude, data.speed, (m_car.home_state == AtHome) ? "true" : "false");
 
 	m_car.is_driving = data.is_driving;
 }

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -198,7 +198,7 @@ void CeVehicle::SendCounter(int countType, float value)
 void CeVehicle::SendCustom(int countType, int ChildId, float value, std::string label)
 {
 	if ((countType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
-		SendCustomSensor(VEHICLE_CUSTOM, ChildId, 255, value, m_Name + " Custom", label.c_str());
+		SendCustomSensor(VEHICLE_CUSTOM, ChildId, 255, value, m_Name + " " + label.c_str(), "");
 }
 
 void CeVehicle::SendText(int countType, int ChildId, std::string value, std::string label)
@@ -213,7 +213,7 @@ bool CeVehicle::ConditionalReturn(bool commandOK, eApiCommandType command)
 	{
 		m_command_nr_tries = 0;
 		SendAlert();
-		return(true);
+		return true;
 	}
 	else if(m_command_nr_tries > VEHICLE_MAXTRIES)
 	{
@@ -226,7 +226,7 @@ bool CeVehicle::ConditionalReturn(bool commandOK, eApiCommandType command)
 		Log(LOG_ERROR, "Multiple tries requesting %s. Assuming car asleep.", GetCommandString(command).c_str());
 		m_car.wake_state = Asleep;
 		SendAlert();
-		return(false);
+		return false;
 	}
 	else
 	{
@@ -240,7 +240,7 @@ bool CeVehicle::ConditionalReturn(bool commandOK, eApiCommandType command)
 		m_command_nr_tries++;
 	}
 
-	return(true);
+	return true;
 }
 
 bool CeVehicle::StartHardware()
@@ -811,7 +811,7 @@ void CeVehicle::UpdateCustomVehicleData(CVehicleApi::tCustomData& data)
 
 				iter = data.customdata[cnt];
 
-				//_log.Debug(DEBUG_NORM, "Starting to process custom data %i - %s", cnt, iter.asString().c_str());
+				//_log.Debug(DEBUG_NORM, "Starting to process custom data %d - %s", cnt, iter.asString().c_str());
 
 				if (!(iter["id"].empty() || iter["value"].empty() || iter["label"].empty()))
 				{
@@ -820,11 +820,12 @@ void CeVehicle::UpdateCustomVehicleData(CVehicleApi::tCustomData& data)
 						std::string sLabel = iter["label"].asString();
 						std::string sValue = jValue.asString();
 
-						_log.Debug(DEBUG_NORM, "Processing custom data %i - %s - %s", iChildID, sValue.c_str(), sLabel.c_str());
+						_log.Debug(DEBUG_NORM, "Processing custom data %d - %s - %s", iChildID, sValue.c_str(), sLabel.c_str());
 
-						if (jValue.asFloat() != 0.0f)
+						if (is_number(sValue))
 						{
-							SendCustom(VEHICLE_CUSTOM, iChildID, jValue.asFloat(), sLabel);
+							float fValue = std::atof(sValue.c_str());
+							SendCustom(VEHICLE_CUSTOM, iChildID, fValue, sLabel);
 						}
 						else
 						{

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -297,6 +297,7 @@ std::string CeVehicle::GetCommandString(const eApiCommandType command)
 void CeVehicle::Do_Work()
 {
 	int sec_counter = 0;
+	int fail_counter = 0;
 	int interval = 1000;
 	bool initial_check = true;
 	Log(LOG_STATUS, "Worker started...");
@@ -315,6 +316,17 @@ void CeVehicle::Do_Work()
 		if (!m_loggedin || (sec_counter % 68400 == 0))
 		{
 			Login();
+			if(!m_loggedin)
+			{
+				fail_counter++;
+
+				if(fail_counter > 3)
+				{
+					Log(LOG_STATUS, "Aborting due to too many failed authentication attempts (and prevent getting blocked)!");
+					break;
+				}
+			}
+
 			sec_counter = 1;
 			continue;
 		}

--- a/hardware/eVehicles/eVehicle.h
+++ b/hardware/eVehicles/eVehicle.h
@@ -6,6 +6,7 @@ Author: MrHobbes74 (github.com/MrHobbes74)
 21/02/2020 1.0 Creation
 13/03/2020 1.1 Added keep asleep support
 28/04/2020 1.2 Added new devices (odometer, lock alert, max charge switch)
+24/07/2020 1.3 Added new Mercedes Class (KidDigital)
 
 License: Public domain
 
@@ -20,7 +21,8 @@ class CeVehicle : public CDomoticzHardwareBase
 {
 public:
 	enum eVehicleType {
-		Tesla
+		Tesla,
+		Mercedes
 	};
 
 	CeVehicle(const int ID, const eVehicleType vehicletype, const std::string& username, const std::string& password, int defaultinterval, int activeinterval, bool allowwakeup, const std::string& carid);
@@ -130,4 +132,3 @@ private:
 	eAlertType m_currentalert;
 	std::string m_currentalerttext;
 };
-

--- a/hardware/eVehicles/eVehicle.h
+++ b/hardware/eVehicles/eVehicle.h
@@ -98,6 +98,7 @@ private:
 	bool GetClimateState();
 	void UpdateClimateData(CVehicleApi::tClimateData& data);
 	void UpdateVehicleData(CVehicleApi::tVehicleData& data);
+	void UpdateCustomVehicleData(CVehicleApi::tCustomData& data);
 	bool DoSetCommand(tApiCommand command);
 
 	void AddCommand(eApiCommandType command_type, std::string command_parameter = "");
@@ -111,6 +112,8 @@ private:
 	void SendTemperature(int tempType, float value);
 	void SendPercentage(int percType, float value);
 	void SendCounter(int countType, float value);
+	void SendCustom(int countType, int ChildId, float value, std::string label);
+	void SendText(int countType, int ChildId, std::string value, std::string label);
 
 	bool StartHardware() override;
 	bool StopHardware() override;

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -245,6 +245,7 @@ static const STR_TABLE_SINGLE	HardwareTypeTable[] =
 	{ HTYPE_BuienRadar, "Buienradar (Dutch Weather Information)",					"BuienRadar" },
 	{ HTYPE_AccuWeather, "AccuWeather (Weather Lookup)",							"AccuWeather" },
 	{ HTYPE_Tesla, "Tesla Model S/3/X",												"Tesla" },
+	{ HTYPE_Mercedes, "Mercedes ME Connect",										"Mercedes" },
 	{ HTYPE_BleBox, "BleBox devices",												"BleBox" },
 	{ HTYPE_Ec3kMeterTCP, "Energy Count 3000/ NETBSEM4/ La Crosse RT-10 LAN",		"Ec3kMeter" },
 	{ HTYPE_OpenWeatherMap, "Open Weather Map",										"OpenWeatherMap" },

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -216,6 +216,7 @@ enum _eHardwareTypes {
 	HTYPE_OctoPrint,			//119
 	HTYPE_Tesla,                //120
 	HTYPE_Meteorologisk,        //121
+	HTYPE_Mercedes,				//122
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1024,8 +1024,7 @@ namespace http {
 						bDoAdd = false;
 					}
 #endif
-
-		}
+				}
 #endif
 #endif
 #ifndef WITH_OPENZWAVE
@@ -1045,9 +1044,11 @@ namespace http {
 #endif
 				if (ii == HTYPE_PythonPlugin)
 					bDoAdd = false;
+
 				if (bDoAdd)
 					_htypes[Hardware_Type_Desc(ii)] = ii;
-	}
+			}
+
 			//return a sorted hardware list
 			int ii = 0;
 			for (const auto & itt : _htypes)
@@ -1257,6 +1258,7 @@ namespace http {
 				(htype == HTYPE_THERMOSMART) ||
 				(htype == HTYPE_Tado) ||
 				(htype == HTYPE_Tesla) ||
+				(htype == HTYPE_Mercedes) ||
 				(htype == HTYPE_Netatmo)
 				)
 			{
@@ -1654,6 +1656,7 @@ namespace http {
 				(htype == HTYPE_THERMOSMART) ||
 				(htype == HTYPE_Tado) ||
 				(htype == HTYPE_Tesla) ||
+				(htype == HTYPE_Mercedes) ||
 				(htype == HTYPE_Netatmo)
 				)
 			{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -983,6 +983,9 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_Tesla:
 		pHardware = new CeVehicle(ID, CeVehicle::Tesla, Username, Password, Mode1, Mode2, Mode3, Extra);
 		break;
+	case HTYPE_Mercedes:
+		pHardware = new CeVehicle(ID, CeVehicle::Mercedes, Username, Password, Mode1, Mode2, Mode3, Extra);
+		break;
 	case HTYPE_Honeywell:
 		pHardware = new CHoneywell(ID, Username, Password, Extra);
 		break;

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -593,6 +593,7 @@
     <ClInclude Include="..\hardware\ETH8020.h" />
     <ClInclude Include="..\hardware\eVehicles\eVehicle.h" />
     <ClInclude Include="..\hardware\eVehicles\TeslaApi.h" />
+    <ClInclude Include="..\hardware\eVehicles\MercApi.h" />
     <ClInclude Include="..\hardware\eVehicles\VehicleApi.h" />
     <ClInclude Include="..\hardware\EvohomeBase.h" />
     <ClInclude Include="..\hardware\EvohomeRadio.h" />
@@ -890,6 +891,7 @@
     <ClCompile Include="..\hardware\ETH8020.cpp" />
     <ClCompile Include="..\hardware\eVehicles\eVehicle.cpp" />
     <ClCompile Include="..\hardware\eVehicles\TeslaApi.cpp" />
+    <ClCompile Include="..\hardware\eVehicles\MercApi.cpp" />
     <ClCompile Include="..\hardware\EvohomeBase.cpp" />
     <ClCompile Include="..\hardware\EvohomeRadio.cpp" />
     <ClCompile Include="..\hardware\EvohomeScript.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -2177,6 +2177,9 @@
     <ClInclude Include="..\hardware\eVehicles\TeslaApi.h">
       <Filter>Devices\eVehicles</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\eVehicles\MercApi.h">
+      <Filter>Devices\eVehicles</Filter>
+    </ClInclude>
     <ClInclude Include="..\hardware\eVehicles\VehicleApi.h">
       <Filter>Devices\eVehicles</Filter>
     </ClInclude>
@@ -2921,6 +2924,9 @@
       <Filter>Devices\OctoPrint</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\eVehicles\TeslaApi.cpp">
+      <Filter>Devices\eVehicles</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\eVehicles\MercApi.cpp">
       <Filter>Devices\eVehicles</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\eVehicles\eVehicle.cpp">

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1143,7 +1143,7 @@
 				<td><input type="text" id="activeinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="1" />&nbsp;(<span data-i18n="Minutes"></span>).</td>
 			</tr>
 			<tr>
-				<td></td>
+				<td><input type="hidden" id="comboallowwakeup" value="1" /></td>
 				<td>
 					Two interval types need to be specified:<ul>
 						<li>Default interval is used when the car is not at home, or home but not charging or using climate controls<br />
@@ -1152,6 +1152,7 @@
 					</ul>
 				</td>
 			</tr>
+			<!--
 			<tr>
 				<td align="right" style="width:110px"><label id="lblallowwakeup" for="name"><span data-i18n="Allow wake up"></span>:</label></td>
 				<td>
@@ -1165,14 +1166,19 @@
 				<td></td>
 				<td>
 					<span>
-					Not used, here for compatibility reasons. <br />
-					<br />
+					Not used, here for compatibility reasons.
+					</span>
+				</td>
+			</tr>
+			-->
+			<tr>
+				<td></td>
+				<td>
 					For entering the Username/Password below:<ul>
 						<li>Username : This should be <i>[client_id]:[client_secret]</i> as provided via the Developers Console from Mercedes.</li>
 						<li>Password: This should be a valid <i>Oauth2 Authorisation code</i> provided after completing the authorisation process.</li>
 						<span>(the <i>code</i> part of the localhost URL you have been redirected to.)</span>
 					</ul>
-					</span>
 				</td>
 			</tr>
 		</table>

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1169,7 +1169,8 @@
 					<br />
 					For entering the Username/Password below:<ul>
 						<li>Username : This should be <i>[client_id]:[client_secret]</i> as provided via the Developers Console from Mercedes.</li>
-						<li>Password: This should be a valid <i>Oauth2 Refreshtoken</i> after executing a Authorisation Code grant (using Postman for example)</li>
+						<li>Password: This should be a valid <i>Oauth2 Authorisation code</i> provided after completing the authorisation process.</li>
+						<span>(the <i>code</i> part of the localhost URL you have been redirected to.)</span>
 					</ul>
 					</span>
 				</td>

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1147,8 +1147,8 @@
 				<td>
 					Two interval types need to be specified:<ul>
 						<li>Default interval is used when the car is not at home, or home but not charging or using climate controls<br />
-							Note that a too low interval (less than 20 minutes) will prevent the car to sleep.</li>
-						<li>Active interval is used when the car is home, and charging or using climate controls</li>
+							Note: Mercedes Me does not support a 'sleep' state, so the default interval can be anything (> 2 minutes to prevent hitting limits).</li>
+						<li>Active interval is used when the car is home, and charging or using climate controls (not implemented at the moment)</li>
 					</ul>
 				</td>
 			</tr>
@@ -1164,10 +1164,14 @@
 			<tr>
 				<td></td>
 				<td>
-					If not allowed, the Mercedes will not be woken up when polled for status information to avoid battery drain. Exceptions:<ul>
-						<li>Commands sent to the car will always wake up the car</li>
-						<li>While the car is connected to a charger (home or not home), the car will always be woken up</li>
+					<span>
+					Not used, here for compatibility reasons. <br />
+					<br />
+					For entering the Username/Password below:<ul>
+						<li>Username : This should be <i>[client_id]:[client_secret]</i> as provided via the Developers Console from Mercedes.</li>
+						<li>Password: This should be a valid <i>Oauth2 Refreshtoken</i> after executing a Authorisation Code grant (using Postman for example)</li>
 					</ul>
+					</span>
 				</td>
 			</tr>
 		</table>

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1127,6 +1127,51 @@
 			</tr>
 		</table>
 	</div>
+	<div id="divmercedes">
+		<br>
+		<table class="display" id="hardwareparamsmercedes" border="0" cellpadding="0" cellspacing="20">
+			<tr>
+				<td align="right" style="width:110px"><label><span data-i18n="VIN"></span>:</label></td>
+				<td><input type="text" id="vinnr" style="width: 300px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label><span data-i18n="Default interval"></span>:</label></td>
+				<td><input type="text" id="defaultinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="10" />&nbsp;(<span data-i18n="Minutes"></span>)</td>
+			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label for="awayinterval"><span data-i18n="Active interval"></span>:</label></td>
+				<td><input type="text" id="activeinterval" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="1" />&nbsp;(<span data-i18n="Minutes"></span>).</td>
+			</tr>
+			<tr>
+				<td></td>
+				<td>
+					Two interval types need to be specified:<ul>
+						<li>Default interval is used when the car is not at home, or home but not charging or using climate controls<br />
+							Note that a too low interval (less than 20 minutes) will prevent the car to sleep.</li>
+						<li>Active interval is used when the car is home, and charging or using climate controls</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label id="lblallowwakeup" for="name"><span data-i18n="Allow wake up"></span>:</label></td>
+				<td>
+					<select id="comboallowwakeup" style="width:60px" class="combobox ui-corner-all">
+						<option value="0">False</option>
+						<option value="1">True</option>
+					</select>
+				</td>
+			</tr>
+			<tr>
+				<td></td>
+				<td>
+					If not allowed, the Mercedes will not be woken up when polled for status information to avoid battery drain. Exceptions:<ul>
+						<li>Commands sent to the car will always wake up the car</li>
+						<li>While the car is connected to a charger (home or not home), the car will always be woken up</li>
+					</ul>
+				</td>
+			</tr>
+		</table>
+	</div>
 	<div id="divlocation">
 		<br>
 		<table class="display" id="hardwareparamslocation" border="0" cellpadding="0" cellspacing="20">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -1038,6 +1038,41 @@ define(['app'], function (app) {
 					}
 				});
 			}
+			else if (text.indexOf("Mercedes") >= 0) {
+				var username = $("#hardwarecontent #divlogin #username").val();
+				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var vinnr = $("#hardwarecontent #divmercedes #vinnr").val();
+				var activeinterval = parseInt($("#hardwarecontent #divmercedes #activeinterval").val());
+				if (activeinterval < 1) {
+					activeinterval = 1;
+				}
+				var defaultinterval = parseInt($("#hardwarecontent #divmercedes #defaultinterval").val());
+				if (defaultinterval < 1) {
+					defaultinterval = 20;
+				}
+				var allowwakeup = $("#hardwarecontent #divmercedes #comboallowwakeup").val();
+				$.ajax({
+					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
+					"&username=" + encodeURIComponent(username) +
+					"&password=" + encodeURIComponent(password) +
+					"&name=" + encodeURIComponent(name) +
+					"&enabled=" + bEnabled +
+					"&idx=" + idx +
+					"&datatimeout=" + datatimeout +
+					"&extra=" + vinnr +
+					"&Mode1=" + defaultinterval +
+					"&Mode2=" + activeinterval + 
+					"&Mode3=" + allowwakeup,
+					async: false,
+					dataType: 'json',
+					success: function (data) {
+						RefreshHardwareTable();
+					},
+					error: function () {
+						ShowNotify($.t('Problem updating hardware!'), 2500, true);
+					}
+				});
+			}
 			else if (
 				(text.indexOf("ICY") >= 0) ||
 				(text.indexOf("Atag") >= 0) ||
@@ -2346,6 +2381,40 @@ define(['app'], function (app) {
 					defaultinterval = 20;
 				}
 				var allowwakeup = $("#hardwarecontent #divtesla #comboallowwakeup").val();
+				$.ajax({
+					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
+					"&username=" + encodeURIComponent(username) +
+					"&password=" + encodeURIComponent(password) +
+					"&name=" + encodeURIComponent(name) +
+					"&enabled=" + bEnabled +
+					"&datatimeout=" + datatimeout +
+					"&extra=" + vinnr +
+					"&Mode1=" + defaultinterval +
+					"&Mode2=" + activeinterval +
+					"&Mode3=" + allowwakeup,
+					async: false,
+					dataType: 'json',
+					success: function (data) {
+						RefreshHardwareTable();
+					},
+					error: function () {
+						ShowNotify($.t('Problem adding hardware!'), 2500, true);
+					}
+				});
+			}
+			else if (text.indexOf("Mercedes") >= 0) {
+				var username = $("#hardwarecontent #divlogin #username").val();
+				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var vinnr = encodeURIComponent($("#hardwarecontent #divmercedes #vinnr").val());
+				var activeinterval = parseInt($("#hardwarecontent #divmercedes #activeinterval").val());
+				if (activeinterval < 1) {
+					activeinterval = 1;
+				}
+				var defaultinterval = parseInt($("#hardwarecontent #divmercedes #defaultinterval").val());
+				if (defaultinterval < 1) {
+					defaultinterval = 20;
+				}
+				var allowwakeup = $("#hardwarecontent #divmercedes #comboallowwakeup").val();
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&username=" + encodeURIComponent(username) +
@@ -3886,6 +3955,12 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamstesla #activeinterval").val(data["Mode2"]);
 							$("#hardwarecontent #hardwareparamstesla #comboallowwakeup").val(data["Mode3"]);
 						}
+						else if (data["Type"].indexOf("Mercedes") >= 0) {
+							$("#hardwarecontent #hardwareparamsmercedes #vinnr").val(data["Extra"]);
+							$("#hardwarecontent #hardwareparamsmercedes #defaultinterval").val(data["Mode1"]);
+							$("#hardwarecontent #hardwareparamsmercedes #activeinterval").val(data["Mode2"]);
+							$("#hardwarecontent #hardwareparamsmercedes #comboallowwakeup").val(data["Mode3"]);
+						}
 						else if (data["Type"].indexOf("Satel Integra") >= 0) {
 							$("#hardwarecontent #hardwareparamspollinterval #pollinterval").val(data["Mode1"]);
 						}
@@ -3990,6 +4065,7 @@ define(['app'], function (app) {
 							(data["Type"].indexOf("Thermosmart") >= 0) ||
                             (data["Type"].indexOf("Tado") >= 0) ||
                             (data["Type"].indexOf("Tesla") >= 0) ||
+                            (data["Type"].indexOf("Mercedes") >= 0) ||
 							(data["Type"].indexOf("Logitech Media Server") >= 0) ||
 							(data["Type"].indexOf("HEOS by DENON") >= 0) ||
 							(data["Type"].indexOf("Razberry") >= 0) ||
@@ -4149,6 +4225,7 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divnestoauthapi").hide();
 			$("#hardwarecontent #divenecotoon").hide();
 			$("#hardwarecontent #divtesla").hide();
+			$("#hardwarecontent #divmercedes").hide();
 			$("#hardwarecontent #div1wire").hide();
 			$("#hardwarecontent #divgoodweweb").hide();
 			$("#hardwarecontent #divi2clocal").hide();
@@ -4330,6 +4407,10 @@ define(['app'], function (app) {
 			else if (text.indexOf("Tesla") >= 0) {
 				$("#hardwarecontent #divlogin").show();
 				$("#hardwarecontent #divtesla").show();
+			}
+			else if (text.indexOf("Mercedes") >= 0) {
+				$("#hardwarecontent #divlogin").show();
+				$("#hardwarecontent #divmercedes").show();
 			}
 			else if (text.indexOf("SBFSpot") >= 0) {
 				$("#hardwarecontent #divlocation").show();


### PR DESCRIPTION
This is a PR for the beta implementation for the (Connected) Mercedes Me.

It utilizes the Daimler/Mercedes API's to retrieve data from your own Mercedes and make it available in Domoticz.

As there is/was nothing available in Domoticz that represented Vehicles except the 'eVehicle' implementation by @MrHobbes74, I implemented the Mercedes Me as an eVehicle (although mine is neither an Electric or Hybrid Mercedes).

It is hard to test if everything is still working for the Tesla implementation (unless someone wants to donate a Tesla for testing purposes ? :) ).

At the moment because the Mercedes Me API's only support the standard OAuth2 grant type using redirection, it is a little cumber sum to get the hardware up-and-running because you need to supply a valid OAuth2 Refresh-token (next to the client_id and client_secret).

To register you own Mercedes, you have to register with your existing Mercedes Me account at 'https://developer.mercedes-benz.com/' and request access for all 5 BYOCAR API's. Each of those API's has its own scope, so within the request for an access- and refresh token, all 5 scopes have to be supplied (space separated).

Hopefully others can test this (beta) implementation and also validate if the Tesla one is still working as it should.

Question, suggestions, additions, etc, please put them in the comments below.