### PR TITLE
Wind speed multiply

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10038,6 +10038,7 @@ namespace http {
 							if (dSubType != sTypeWIND5)
 							{
 								int intSpeed = atoi(strarray[2].c_str());
+								intSpeed *= AddjMulti;
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -10053,6 +10054,7 @@ namespace http {
 							//if (dSubType!=sTypeWIND6) //problem in RFXCOM firmware? gust=speed?
 							{
 								int intGust = atoi(strarray[3].c_str());
+								intGust *= AddjMulti;
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intGust) *m_sql.m_windscale);
@@ -14994,6 +14996,9 @@ namespace http {
 
 							int intSpeed = atoi(sd[1].c_str());
 							int intGust = atoi(sd[2].c_str());
+							intSpeed *= AddjMulti;
+							intGust *= AddjMulti;
+
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{
 								sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10038,7 +10038,6 @@ namespace http {
 							if (dSubType != sTypeWIND5)
 							{
 								int intSpeed = atoi(strarray[2].c_str());
-								intSpeed *= AddjMulti;
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -10054,7 +10053,6 @@ namespace http {
 							//if (dSubType!=sTypeWIND6) //problem in RFXCOM firmware? gust=speed?
 							{
 								int intGust = atoi(strarray[3].c_str());
-								intGust *= AddjMulti;
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intGust) *m_sql.m_windscale);
@@ -14996,8 +14994,6 @@ namespace http {
 
 							int intSpeed = atoi(sd[1].c_str());
 							int intGust = atoi(sd[2].c_str());
-							intSpeed *= AddjMulti;
-							intGust *= AddjMulti;
 
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3283,9 +3283,15 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 		strDirection = "---";
 
 	dDirection = round(dDirection);
-
+	
 	int intSpeed = (pResponse->WIND.av_speedh * 256) + pResponse->WIND.av_speedl;
 	int intGust = (pResponse->WIND.gusth * 256) + pResponse->WIND.gustl;
+
+	float AddjValue = 0.0f;
+	float AddjMulti = 1.0f;
+	m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
+	intSpeed *= AddjMulti;
+	intGust *= AddjMulti;
 
 	if (pResponse->WIND.subtype == sTypeWIND6)
 	{
@@ -3315,9 +3321,6 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 				return;
 			}
 
-			float AddjValue = 0.0f;
-			float AddjMulti = 1.0f;
-			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
 			temp += AddjValue;
 
 			if (!pResponse->WIND.chillsign)
@@ -3332,9 +3335,6 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 		}
 		else if (pResponse->WIND.subtype == sTypeWINDNoTemp)
 		{
-			float AddjValue = 0.0f;
-			float AddjMulti = 1.0f;
-			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
 			temp += AddjValue;
 
 			if (!pResponse->WIND.chillsign)

--- a/www/app/WeatherController.js
+++ b/www/app/WeatherController.js
@@ -39,11 +39,12 @@ define(['app', 'livesocket'], function (app) {
 			$("#dialog-editvisibilitydevice").dialog("open");
 		}
 
-		EditWeatherDevice = function (idx, name, description) {
+		EditWeatherDevice = function (idx, name, description, addjmulti) {
 			$.devIdx = idx;
 			$("#dialog-editweatherdevice #deviceidx").text(idx);
 			$("#dialog-editweatherdevice #devicename").val(unescape(name));
 			$("#dialog-editweatherdevice #devicedescription").val(unescape(description));
+			$("#dialog-editweatherdevice #multiply").val(addjmulti);
 			$("#dialog-editweatherdevice").i18n();
 			$("#dialog-editweatherdevice").dialog("open");
 		}
@@ -160,6 +161,7 @@ define(['app', 'livesocket'], function (app) {
 						url: "json.htm?type=setused&idx=" + $.devIdx +
 						'&name=' + encodeURIComponent($("#dialog-editweatherdevice #devicename").val()) +
 						'&description=' + encodeURIComponent($("#dialog-editweatherdevice #devicedescription").val()) +
+						'&addjmulti=' + $("#dialog-editweatherdevice #edittable #multiply").val() +
 						'&used=true',
 						async: false,
 						dataType: 'json',
@@ -526,7 +528,7 @@ define(['app', 'livesocket'], function (app) {
 					} else if (typeof item.Barometer != 'undefined') {
 						return EditBaroDevice(item.idx, escape(item.Name), escape(item.Description), item.AddjValue2);
 					} else {
-						return EditWeatherDevice(item.idx, escape(item.Name), escape(item.Description));
+						return EditWeatherDevice(item.idx, escape(item.Name), escape(item.Description), item.AddjMulti);
 					}
 				};
 

--- a/www/views/weather.html
+++ b/www/views/weather.html
@@ -13,6 +13,10 @@
 			<td align="right"><label for="devicedescription"><span data-i18n="Description"></span>: </label></td>
 			<td><textarea id="devicedescription" name="devicedescription" rows="4" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all"></textarea></td>
 		</tr>
+        <tr>
+			<td align="right"><label for="multiply"><span data-i18n="Multiply">Multiply</span>: </label></td>
+			<td><input type="text" id="multiply" style="width: 60px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+		</tr>		
 		</table>
     </form>
 </div>


### PR DESCRIPTION
Most wind anemometers require calibration to report correct windspeed. This PR adds a "Multiply" field to the weather edit screen to allow increase or decrease of reported windspeeds and its graphs. The default value is 1. In that case no adjustment and wind readings will be as in previous versions. If you set Multiply to 1.35 for example it will increase readings accordingly. Setting Multiply to 0.8 would lower the windspeed value.