### PR TITLE
Fix warnings

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3290,8 +3290,8 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	float AddjValue = 0.0f;
 	float AddjMulti = 1.0f;
 	m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
-	intSpeed *= AddjMulti;
-	intGust *= AddjMulti;
+	intSpeed = int(float(intSpeed) * AddjMulti);
+	intGust = int(float(intGust) * AddjMulti);
 
 	if (pResponse->WIND.subtype == sTypeWIND6)
 	{


### PR DESCRIPTION
I noticed the build gave warnings in code of my PR #4300. Fixed with minimal changes. Sorry about that.

Details: 
mainworker.cpp
C:\projects\domoticz\main\mainworker.cpp(3293,23): warning C4244: '*=': conversion from 'float' to 'int', possible loss of data [C:\projects\domoticz\msbuild\domoticz.vcxproj]
C:\projects\domoticz\main\mainworker.cpp(3294,22): warning C4244: '*=': conversion from 'float' to 'int', possible loss of data [C:\projects\domoticz\msbuild\domoticz.vcxproj]