### PR TITLE
Made the selector switch inside able to be updated if the option string is different (plugwise plugin)

### DIFF
--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -701,16 +701,16 @@ void CAnnaThermostat::GetMeterDetails()
 				std::vector<std::vector<std::string> > result;
 				std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Home|Away|Night|Vacation|Frost;LevelOffHidden:true;LevelActions:00|10|20|30|40|50", false));
 				result = m_sql.safe_query("SELECT ID , sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, xcmd.unitcode);
-   	            int bUpdateOptions = -1;
+   				int bUpdateOptions = -1;
 				 	if (!result.empty()){
 						bUpdateOptions = strcmp (options_str.c_str(), result[0][2].c_str());
 							if(bUpdateOptions != 0)
-							{ 
+							{
 								Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
 								//Log(LOG_STATUS, "New value is : %s", result[0][2].c_str());
-               					//Log(LOG_STATUS, "Old value is : %s", result[0][2].c_str());
-               				}
-			        }
+			   					//Log(LOG_STATUS, "Old value is : %s", result[0][2].c_str());
+			   				}
+					}
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  PresetName.c_str(), 255);
 				if (result.empty() || bUpdateOptions != 0 )//Switch is new or has older look and feel  so update it
 				{

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -701,18 +701,18 @@ void CAnnaThermostat::GetMeterDetails()
 				std::vector<std::vector<std::string> > result;
 				std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Home|Away|Night|Vacation|Frost;LevelOffHidden:true;LevelActions:00|10|20|30|40|50", false));
 				result = m_sql.safe_query("SELECT ID , sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, xcmd.unitcode);
-   	            bool bUpdateOptions = true;
+   	            int bUpdateOptions = -1;
 				 	if (!result.empty()){
 						bUpdateOptions = strcmp (options_str.c_str(), result[0][2].c_str());
-							if(bUpdateOptions)
+							if(bUpdateOptions != 0)
 							{ 
 								Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
 								//Log(LOG_STATUS, "New value is : %s", result[0][2].c_str());
                					//Log(LOG_STATUS, "Old value is : %s", result[0][2].c_str());
-               					}
+               				}
 			        }
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  PresetName.c_str(), 255);
-				if (result.empty() || bUpdateOptions )//Switch is new or has older look and feel  so update it
+				if (result.empty() || bUpdateOptions != 0 )//Switch is new or has older look and feel  so update it
 				{
 						//m_sql.safe_query(
 					//    "INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, CustomImage, Options) "

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -701,12 +701,13 @@ void CAnnaThermostat::GetMeterDetails()
 				std::vector<std::vector<std::string> > result;
 				std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Home|Away|Night|Vacation|Frost;LevelOffHidden:true;LevelActions:00|10|20|30|40|50", false));
 				result = m_sql.safe_query("SELECT ID , sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, xcmd.unitcode);
-   	                        bool bUpdateOptions =  strcmp (options_str.c_str(), result[0][2].c_str());
+   	            bool bUpdateOptions = true;
 				Log(LOG_STATUS, "Option str: %s", options_str.c_str());
 		         	if (!result.empty()){
-					Log(LOG_STATUS, "Result is : %s", result[0][2].c_str());
+						bUpdateOptions = strcmp (options_str.c_str(), result[0][2].c_str());
+						Log(LOG_STATUS, "Result is : %s", result[0][2].c_str());
                				if(bUpdateOptions)
-                                           Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
+                                Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
 			        }
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  PresetName.c_str(), 255);
 				if (result.empty() || bUpdateOptions )//Switch is new or has older look and feel  so update it

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -702,12 +702,14 @@ void CAnnaThermostat::GetMeterDetails()
 				std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Home|Away|Night|Vacation|Frost;LevelOffHidden:true;LevelActions:00|10|20|30|40|50", false));
 				result = m_sql.safe_query("SELECT ID , sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, xcmd.unitcode);
    	            bool bUpdateOptions = true;
-				Log(LOG_STATUS, "Option str: %s", options_str.c_str());
-		         	if (!result.empty()){
+				 	if (!result.empty()){
 						bUpdateOptions = strcmp (options_str.c_str(), result[0][2].c_str());
-						Log(LOG_STATUS, "Result is : %s", result[0][2].c_str());
-               				if(bUpdateOptions)
-                                Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
+							if(bUpdateOptions)
+							{ 
+								Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
+								//Log(LOG_STATUS, "New value is : %s", result[0][2].c_str());
+               					//Log(LOG_STATUS, "Old value is : %s", result[0][2].c_str());
+               					}
 			        }
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  PresetName.c_str(), 255);
 				if (result.empty() || bUpdateOptions )//Switch is new or has older look and feel  so update it

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -701,12 +701,15 @@ void CAnnaThermostat::GetMeterDetails()
 				std::vector<std::vector<std::string> > result;
 				std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Home|Away|Night|Vacation|Frost;LevelOffHidden:true;LevelActions:00|10|20|30|40|50", false));
 				result = m_sql.safe_query("SELECT ID , sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, xcmd.unitcode);
-	            Log(LOG_STATUS, "Option str: %s", options_str.c_str());
-			    if (!result.empty())
+   	                        bool bUpdateOptions =  strcmp (options_str.c_str(), result[0][2].c_str());
+				Log(LOG_STATUS, "Option str: %s", options_str.c_str());
+		         	if (!result.empty()){
 					Log(LOG_STATUS, "Result is : %s", result[0][2].c_str());
-			
+               				if(bUpdateOptions)
+                                           Log(LOG_STATUS, "The layout of %s has been changed - Updating..", PresetName.c_str());
+			        }
 				m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  PresetName.c_str(), 255);
-				if (result.empty() ||  (strcmp (options_str.c_str(), result[0][2].c_str()) != 0) )//Switch is new or has older look and feel  so update it
+				if (result.empty() || bUpdateOptions )//Switch is new or has older look and feel  so update it
 				{
 						//m_sql.safe_query(
 					//    "INSERT INTO DeviceStatus (HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, CustomImage, Options) "


### PR DESCRIPTION
Added code that checks the old option string vs the one currently used in the code for the selector switched in the plugwise plugin.
If they are different the new one will be applied, causing tit to adapt the new look.
This is done  to allow people to migrate to the new version without having to reload the plugin  messing up scripts etc.
Also opens the selector switch  to be "user configurable in a later stage - drop done vs button row)