### PR TITLE
eVehicle: Performance optimisation. Query home location only during startup

### DIFF
--- a/hardware/eVehicles/eVehicle.h
+++ b/hardware/eVehicles/eVehicle.h
@@ -125,6 +125,8 @@ private:
 	int m_defaultinterval;
 	int m_activeinterval;
 	bool m_allowwakeup;
+	double m_home_lat;
+	double m_home_lon;
 
 	tVehicle m_car;
 	CVehicleApi *m_api;


### PR DESCRIPTION
Small PR to optimise SQLite query load. Instead of querying the settings every time, now only during Hardware setup the Home Location data of Domoticz is retrieved. This way saving a lot of query executions.

@MrHobbes74 , hopefully you are happy with this as well and can really test this better with the Tesla (I still don't have one ;) )