### PR TITLE
Fix PHP

### DIFF
--- a/webserver/fastcgi.cpp
+++ b/webserver/fastcgi.cpp
@@ -347,7 +347,7 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 		fcgi_params[rName] = CURLEncode::URLEncode(ittHeader->value);
 	}
 #ifdef WIN32
-	fullexecmd = "SET QUERY_STRING="+szQueryString + " & " + fullexecmd;
+	fullexecmd = "SET QUERY_STRING=\""+szQueryString + "\" & " + fullexecmd;
 #else
 	fullexecmd = "export QUERY_STRING='"+szQueryString + "' && " + fullexecmd;
 #endif

--- a/webserver/fastcgi.cpp
+++ b/webserver/fastcgi.cpp
@@ -346,8 +346,12 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 
 		fcgi_params[rName] = CURLEncode::URLEncode(ittHeader->value);
 	}
-
+#ifdef WIN32
+	fullexecmd = "SET QUERY_STRING="+szQueryString + " & " + fullexecmd;
+#else
 	fullexecmd = "export QUERY_STRING='"+szQueryString + "' && " + fullexecmd;
+#endif
+
 	_log.Debug(DEBUG_NORM, "[PHP] Command: %s", fullexecmd.c_str());
 	std::string pret = ExecuteCommandAndReturnRaw(fullexecmd);
 	if (pret.empty())

--- a/webserver/fastcgi.cpp
+++ b/webserver/fastcgi.cpp
@@ -173,10 +173,12 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 	std::multimap<std::string, std::string> parameters;
 
 	std::string request_path2 = req.uri; // we need the raw request string to parse the get-request
+	std::string szQueryString;
 	size_t paramPos = request_path2.find_first_of('?');
 	if (paramPos != std::string::npos)
 	{
 		std::string params = request_path2.substr(paramPos + 1);
+		szQueryString = request_path2.substr(paramPos + 1);
 		std::string name;
 		std::string value;
 
@@ -288,7 +290,6 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 	gfci.paddingLength = 0;
 	request_id_++;
 
-	std::string szQueryString;
 
 	std::string str_params;
 	std::multimap<std::string, std::string>::const_iterator itt;
@@ -300,12 +301,6 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 		str_params.append(itt->first);
 		str_params.append("=");
 		str_params.append(itt->second);
-
-		if (!szQueryString.empty())
-			szQueryString += "&";
-		szQueryString.append(itt->first);
-		szQueryString.append("=");
-		szQueryString.append(CURLEncode::URLEncode(itt->second));
 	}
 
 	std::string fullexecmd = settings.php_cgi_path + " " + full_path;
@@ -336,10 +331,10 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 
 	fullexecmd += " SERVER_SOFTWARE=Domoticz";
 	fullexecmd += " SERVER_NAME=localhost";
-	fullexecmd += " SERVER_ADDR=" + CURLEncode::URLEncode(settings.listening_address);
+	fullexecmd += " SERVER_ADDR='" + settings.listening_address + "'";
 	fullexecmd += " SERVER_PORT=" + settings.listening_port;
 	fullexecmd += " REMOTE_ADDR=" + req.host_address;
-	fullexecmd += " REMOTE_PORT=" + req.host_port;
+	fullexecmd += " QUERY_STRING='" + szQueryString + "'"; 
 
 	std::vector<header>::const_iterator ittHeader;
 	for (ittHeader = req.headers.begin(); ittHeader != req.headers.end(); ++ittHeader)
@@ -347,11 +342,13 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 		std::string rName = "HTTP_" + ittHeader->name;
 		stdreplace(rName, "-", "_");
 		stdupper(rName);
-		fullexecmd += " " + rName + "=" + CURLEncode::URLEncode(ittHeader->value);
+		fullexecmd += " " + rName + "='" + ittHeader->value + "'";
 
 		fcgi_params[rName] = CURLEncode::URLEncode(ittHeader->value);
 	}
 
+	fullexecmd = "export QUERY_STRING='"+szQueryString + "' && " + fullexecmd;
+	_log.Debug(DEBUG_NORM, "[PHP] Command: %s", fullexecmd.c_str());
 	std::string pret = ExecuteCommandAndReturnRaw(fullexecmd);
 	if (pret.empty())
 	{
@@ -363,6 +360,8 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 	bool bDoneWithHeaders = false;
 	while (!bDoneWithHeaders)
 	{
+		if (pret[0] == '\r') pret=pret.substr(1);	//Skip CR symbol if present
+		
 		size_t tpos = pret.find('\n');
 		if (tpos == std::string::npos)
 		{


### PR DESCRIPTION
PHP did not work with query strings.

The fix in this PR probably only works on Linux systems, because of setting the environment variable:

   fullexecmd = "export QUERY_STRING='"+szQueryString + "' && " + fullexecmd;

I can't test on Windows.

I also don't know whether this is the cleanest way to set the PHP variables, but it works on my system.