### PR TITLE
Added Helper functions for selector switch

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -1035,7 +1035,7 @@ void CDomoticzHardwareBase::SendSecurity1Sensor(const int NodeID, const int Devi
 {
 	RBUF m_sec1;
 	memset(&m_sec1, 0, sizeof(RBUF));
-	
+
 	m_sec1.SECURITY1.packetlength = sizeof(m_sec1) -1;
 	m_sec1.SECURITY1.packettype = pTypeSecurity1;
 	m_sec1.SECURITY1.subtype = DeviceSubType;
@@ -1045,6 +1045,133 @@ void CDomoticzHardwareBase::SendSecurity1Sensor(const int NodeID, const int Devi
 	m_sec1.SECURITY1.status = Status;
 	m_sec1.SECURITY1.rssi = RssiLevel;
 	m_sec1.SECURITY1.battery_level = BatteryLevel;
-	
+
 	sDecodeRXMessage(this, (const unsigned char*)& m_sec1.SECURITY1, defaultname.c_str(), BatteryLevel);
+}
+/**
+ * SendSelectorSwitch
+ * 
+ * Helper function to create/update selector switch, validates sValue exist in the list of actions
+ *  
+ * @param  {int} NodeID               : As normal
+ * @param  {uint8_t} ChildID          : As normal
+ * @param  {int} sValue               : Int with the value of the action to take/show, must be present in LevelActions
+ * @param  {std::string} defaultname  : As normal
+ * @param  {int} customImage          : Int with the number of a custom image to use for the selector
+ * @param  {bool} bDropdown           : boolean: true will show a drop down, false will show a row of buttons
+ * @param  {std::string} LevelNames   : String with the labels to show for Actions, seperated with |. Example: "Off|Label 1|Label 2|Label 3"
+ * @param  {std::string} LevelActions : String with numbers, one for eacht Action, seperated with |.  Example: "00|10,|20|30"  - Off is 00
+ * @param  {bool} bHideOff            : Boolean: true will hide the off level, false will enable it.
+  */
+void CDomoticzHardwareBase::SendSelectorSwitch(const int NodeID, const uint8_t ChildID, const std::string sValue, const std::string& defaultname, const int customImage , const bool bDropdown, const std::string& LevelNames,const std::string& LevelActions, const bool bHideOff )
+{
+ 	if (std::size_t index = LevelActions.find(sValue.c_str()) == std::string::npos)
+	{ 
+	   Log(LOG_ERROR,"Value %s not supported by Selector Switch %s, it needs %s ",sValue.c_str() , defaultname.c_str(), LevelActions.c_str() ); 
+	   return; // did not find sValue in LevelAction string so exit with warning
+	}
+	_tGeneralSwitch xcmd;
+	xcmd.len = sizeof(_tGeneralSwitch) - 1;
+	xcmd.type = pTypeGeneralSwitch;
+	xcmd.subtype = sSwitchTypeSelector;
+	xcmd.id = NodeID;
+	xcmd.unitcode = ChildID; //Do we support multiple copies of the same selector switch ??
+	xcmd.level = std::stoi(sValue);
+
+	_eSwitchType switchtype;
+	switchtype = STYPE_Selector;
+
+	std::vector<std::vector<std::string> > result;
+	result = m_sql.safe_query("SELECT ID, sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, xcmd.unitcode);
+	bool bDoesExists = !result.empty();
+    
+	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  defaultname.c_str(), 255);  // will create the base switch if not exist
+
+	if (!bDoesExists)//Switch is new so  we need to update it with all relevant info
+	{
+		std::stringstream build_str; //building up selector option string
+		build_str << "SelectorStyle:";
+		if (bDropdown)
+			build_str << "1";
+		else
+			build_str << "0";
+		build_str << ";LevelNames:" << LevelNames.c_str() << ";LevelOffHidden:";
+		if (bHideOff)
+			build_str <<  "true";
+		else
+			build_str << "false";
+		build_str << ";LevelActions:" << LevelActions.c_str();
+		std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions( build_str.str(), false));
+		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', sValue=%i, SwitchType=%d, CustomImage=%i,options='%q' WHERE(HardwareID == %d) AND (DeviceID=='%08X') AND (Unit == '%d')", defaultname.c_str(), xcmd.level, (switchtype), customImage, options_str.c_str(), m_HwdID, NodeID, xcmd.unitcode);
+        // The Selector switch has been created
+	}
+	else
+	{ 
+		//Check Level
+		if ( xcmd.level == std::stoi(result[0][1].c_str()))
+			return; // no need to uodate
+		result = m_sql.safe_query("UPDATE DeviceStatus SET sValue=%i WHERE (HardwareID==%d) AND (DeviceID=='%08X')", xcmd.level, m_HwdID, NodeID);
+	}
+}
+                            
+/**
+ * MigrateSelectorSwitch
+ *
+ * Helper function to migrate selector switch,  validates if existing LevelActions match existing in the DB, if not migrate the switch based on bMigrate setting
+ *   
+ * @param  {int} NodeID               : As Usual
+ * @param  {uint8_t} ChildID          : As Usual
+ * @param  {std::string} LevelNames   : Will be updated together with LevelNames
+ * @param  {std::string} LevelActions : Checks if the selector switch in the db is in synch with these value, then trie4s to migrat if BMigrate is true
+ * @param  {bool} bMigrate            : true if  the selector may be upgraded if incorrect, false if you only want an  error if migration is needed
+ * @return {int}                      : 0 No need for migration /not yet exist| 1 Migration completed| -1 Need Migration
+ */
+int CDomoticzHardwareBase::MigrateSelectorSwitch(const int NodeID, const uint8_t ChildID,  const std::string& LevelNames, const std::string& LevelActions, const bool bMigrate )
+{
+	std::string options;
+	std::vector<std::vector<std::string> > result;
+	bool bUpdated = false;
+		
+	result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, ChildID);
+	if (result.empty())
+	    return 0;  // switch doen not exist yet
+	std::map<std::string, std::string> optionsMap;
+	optionsMap = m_sql.BuildDeviceOptions(result[0][0]);
+	int count = optionsMap.size();
+	if (count > 0) 
+	{
+		int i = 0;
+		std::stringstream ssoptions;
+		for (const auto& itt : optionsMap)
+		{
+			std::string optionName = itt.first.c_str();
+			std::string optionValue = itt.second.c_str();
+			if(strcmp(itt.first.c_str(),"LevelActions") == 0)
+			{
+				if(strcmp(itt.second.c_str(), LevelActions.c_str()) !=  0 )
+				{
+					bUpdated = true;  // the list of actions is not what we expected. flag  that Migration is required
+					optionValue = LevelActions.c_str();			
+				}
+			}
+			else if(strcmp(itt.first.c_str(),"LevelNames") == 0)
+			{
+					optionValue = LevelNames.c_str();	
+			}
+			ssoptions << optionName << ":" << optionValue;
+			if (i < count) {
+				ssoptions << ";";
+			}
+			options.assign(ssoptions.str());
+		}
+	}
+    if( bUpdated ) // the options map has been  migrated  do we migratre to warn? 
+	{
+		if(!bMigrate)
+			return -1;  // Signnal  selector switch is not latest version
+		std::string options_str = m_sql.FormatDeviceOptions(m_sql.BuildDeviceOptions( options.c_str(), false));
+		m_sql.safe_query("UPDATE DeviceStatus SET options='%q' WHERE (HardwareID==%d) AND (DeviceID=='%08X')", options_str.c_str(), m_HwdID, NodeID);
+	   return 1; // signal migratreion completed
+	}
+    return 0;	// signal no need for migration
 }

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -69,7 +69,7 @@ protected:
 	virtual bool StartHardware()=0;
 	virtual bool StopHardware()=0;
 
-    //Heartbeat thread for classes that can not provide this themselves
+	//Heartbeat thread for classes that can not provide this themselves
 	void StartHeartbeatThread();
 	void StartHeartbeatThread(const char* ThreadName);
 	void StopHeartbeatThread();
@@ -123,11 +123,12 @@ protected:
 	void SendZWaveAlarmSensor(const int NodeID, const uint8_t InstanceID, const int BatteryLevel, const uint8_t aType, const int aValue, const std::string& alarmLabel, const std::string &defaultname);
 	void SendFanSensor(const int Idx, const int BatteryLevel, const int FanSpeed, const std::string &defaultname);
 	void SendSecurity1Sensor(const int NodeID, const int DeviceSubType, const int BatteryLevel, const int Status, const std::string &defaultname, const int RssiLevel = 12);
-
+	void SendSelectorSwitch(const int NodeID, const uint8_t ChildID, const std::string sValue, const std::string& defaultname, const int customImage , const bool nDropdown, const std::string& LevelNames,const std::string& LevelActions, const bool bHideOff);
+	int  MigrateSelectorSwitch(const int NodeID, const uint8_t ChildID, const std::string& LevelNames, const std::string& LevelActions,const bool bMigrate );
 	int m_iHBCounter = { 0 };
 	bool m_bIsStarted = { false };
 private:
-    void Do_Heartbeat_Work();
+	void Do_Heartbeat_Work();
 
 	volatile bool m_stopHeartbeatrequested = { false };
 	std::shared_ptr<std::thread> m_Heartbeatthread = { nullptr };


### PR DESCRIPTION
Added two functions :
SendSelectorSwitch:   Use case:  Simplify the way to create and update a selector switch similar to other existing helper functions.  For detail see comments for the function

MigrateSelectorSwitch: function to test and migrate the names and actions of a selector switch. 
Usecase: allow developers to update or add/remove level actions and names on existing   selector switches
This is useful if your plugin  needs to add or remove actions from a selector switch, leaving the look and feel as the current version.   Main reason is to stop people to  require to  remove and add  hardware plugins to get the new selector switch

Intended to be run  once at init or at begin of do work() for usage  see comments for the function
The changes in the Plugwise  plugwise Annatherm.ccp   are the  to make use of the above functions.

This wil allow people to change from stable or earlier beta's to the latest beta without selector switch issues