### PR TITLE
Fix for Comm5 MA-4200 hardware

### DIFF
--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -262,9 +262,11 @@ void Comm5Serial::ParseData(const unsigned char* data, const size_t len)
 		case STFRAME_CRC2:
 			frame.push_back(data[i]);
 			frameCRC = crc16_update(frameCRC, 0);
-			readCRC =  (uint16_t)(frame.at(frame.size() - 2) << 8) | (frame.at(frame.size() - 1) & 0xFF);
+			readCRC = (static_cast<uint16_t>(frame.at(frame.size() - 2)) << 8) | frame.at(frame.size() - 1);
 			if (frameCRC == readCRC)
 				parseFrame(frame);
+			else
+				Log(LOG_ERROR, "Frame CRC error");			
 			currentState = STSTART_OCTET1;
 			frame.clear();
 			break;


### PR DESCRIPTION
Sometimes a CRC error can occur due to problem with signed char calculation.