### PR TITLE
Fix Tado Zone/Home limit, Setpoint mix-up

### DIFF
--- a/hardware/Tado.h
+++ b/hardware/Tado.h
@@ -16,7 +16,7 @@ class CTado : public CDomoticzHardwareBase
 		~CTado(void);
 		CTado(const int ID, const std::string &username, const std::string &password);
 		bool WriteToHardware(const char *pdata, const unsigned char length) override;
-		void SetSetpoint(const int idx, const float temp);
+		void SetSetpoint(const int id2, const int id3, const int id4, const float temp);
 	private:
 		void Init();
 		bool StartHardware() override;
@@ -64,8 +64,8 @@ class CTado : public CDomoticzHardwareBase
 		bool GetAuthToken(std::string & authtoken, std::string & refreshtoken, const bool refreshUsingToken);
 		bool GetZoneState(const int HomeIndex, const int ZoneIndex, const _tTadoHome &home, _tTadoZone & zone);
 		bool GetHomeState(const int HomeIndex, _tTadoHome & home);
-		void SendSetPointSensor(const unsigned char Idx, const float Temp, const std::string &defaultname);
-		void UpdateSwitch(const unsigned char Idx, const bool bOn, const std::string & defaultname);
+		void SendSetPointSensor(const int Idx, const float Temp, const std::string &defaultname);
+		void UpdateSwitch(const int Idx, const bool bOn, const std::string & defaultname);
 		bool CreateOverlay(const int idx, const float temp, const bool heatingenabled, const std::string &termination = "TADO_MODE");
 		bool CancelOverlay(const int Idx);
 		bool MatchValueFromJSKey(const std::string &sKeyName, const std::string &sJavascriptData, std::string & sValue);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12692,7 +12692,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		else if (pHardware->HwdType == HTYPE_Tado)
 		{
 			CTado* pGateway = reinterpret_cast<CTado*>(pHardware);
-			pGateway->SetSetpoint(ID4, TempValue);
+			pGateway->SetSetpoint(ID2, ID3, ID4, TempValue);
 		}
 		else if (pHardware->HwdType == HTYPE_Netatmo)
 		{


### PR DESCRIPTION
Fixes Tado.cpp's current limitation of 1 home and 3 zones at most. (It pushed IDs > 255 into unsigned char.) Moreover fixes the side-effect of setpoint mix-ups reported in issue #3764 . How to upgrade: It is recommend to delete all Tado switch and setpoint devices before enabling the Tado hardware.

This code was successfully tested with 1 home and 8 zones.