### PR TITLE
MercApi: Request one resource per cycle to make module more responsive.

### DIFF
--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -59,4 +59,5 @@ private:
 	uint64_t m_carid;
 	uint32_t m_crc;
 	std::string m_fields;
+	int16_t m_fieldcnt;
 };


### PR DESCRIPTION
PR to make the module more responsive. Previously multiple resources were requested using multiple API calls. Each API call can takes seconds (or many seconds before timing out) adding up to total processing time of tens of seconds leading to Domoticz (or at least the eVehicle/MercApi module) being less responsive.