### PR TITLE
Tado: fix compiler warning. Switched logger to HardwareBase

### DIFF
--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -102,7 +102,7 @@ bool CTado::WriteToHardware(const char * pdata, const unsigned char length)
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", 0, HomeIdx, ZoneIdx, ServiceIdx);
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: Node %s = home %s zone %s device %d", szIdx, m_TadoHomes[HomeIdx].Name.c_str(), m_TadoHomes[HomeIdx].Zones[ZoneIdx].Name.c_str(), ServiceIdx);
+	Debug(DEBUG_HARDWARE, "Node %s = home %s zone %s device %d", szIdx, m_TadoHomes[HomeIdx].Name.c_str(), m_TadoHomes[HomeIdx].Zones[ZoneIdx].Name.c_str(), ServiceIdx);
 
 	// ServiceIdx 1 = Away (Read only)
 	// ServiceIdx 2 = Setpoint => should be handled in SetSetPoint
@@ -130,7 +130,7 @@ bool CTado::WriteToHardware(const char * pdata, const unsigned char length)
 // An overlay can end automatically (TADO_MODE, TIMER) or manually (MANUAL).
 bool CTado::CreateOverlay(const int idx, const float temp, const bool heatingEnabled, const std::string &terminationType)
 {
-	_log.Log(LOG_NORM, "Tado: CreateOverlay() called with idx=%d, temp=%f, termination type=%s", idx, temp, terminationType.c_str());
+	Log(LOG_NORM, "CreateOverlay() called with idx=%d, temp=%f, termination type=%s", idx, temp, terminationType.c_str());
 
 	int HomeIdx = idx / 1000;
 	int ZoneIdx = (idx % 1000) / 100;
@@ -139,11 +139,11 @@ bool CTado::CreateOverlay(const int idx, const float temp, const bool heatingEna
 	// Check if the zone actually exists.
 	if (m_TadoHomes.size() == 0 || m_TadoHomes[HomeIdx].Zones.size() == 0)
 	{
-		_log.Log(LOG_ERROR, "Tado: no such home/zone combo found: %d/%d", HomeIdx, ZoneIdx);
+		Log(LOG_ERROR, "No such home/zone combo found: %d/%d", HomeIdx, ZoneIdx);
 		return false;
 	}
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: Node %d = home %s zone %s device %d", idx, m_TadoHomes[HomeIdx].Name.c_str(), m_TadoHomes[HomeIdx].Zones[ZoneIdx].Name.c_str(), ServiceIdx);
+	Debug(DEBUG_HARDWARE, "Node %d = home %s zone %s device %d", idx, m_TadoHomes[HomeIdx].Name.c_str(), m_TadoHomes[HomeIdx].Zones[ZoneIdx].Name.c_str(), ServiceIdx);
 
 	std::string _sUrl = m_TadoEnvironment["tgaRestApiV2Endpoint"] + "/homes/" + m_TadoHomes[HomeIdx].Id + "/zones/" + m_TadoHomes[HomeIdx].Zones[ZoneIdx].Id + "/overlay";
 	std::string _sResponse;
@@ -174,11 +174,11 @@ bool CTado::CreateOverlay(const int idx, const float temp, const bool heatingEna
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: Failed to set setpoint via Api: %s", what.c_str());
+		Log(LOG_ERROR, "Failed to set setpoint via Api: %s", what.c_str());
 		return false;
 	}
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: Response: %s", _sResponse.c_str());
+	Debug(DEBUG_HARDWARE, "Response: %s", _sResponse.c_str());
 
 	// Trigger a zone refresh
 	GetZoneState(HomeIdx, ZoneIdx, m_TadoHomes[HomeIdx], m_TadoHomes[HomeIdx].Zones[ZoneIdx]);
@@ -195,7 +195,7 @@ void CTado::SetSetpoint(const int id2, const int id3, const int id4, const float
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", 0, HomeIdx, ZoneIdx, ServiceIdx);
-	_log.Log(LOG_NORM, "Tado: SetSetpoint() called with idx=%d, temp=%f", szIdx, temp);
+	Log(LOG_NORM, "SetSetpoint() called with idx=%s, temp=%f", szIdx, temp);
 	
 	int _idx = (HomeIdx * 1000) + (ZoneIdx * 100) + ServiceIdx; 
 	CreateOverlay(_idx, temp, true, "TADO_MODE");
@@ -208,17 +208,17 @@ bool CTado::GetAuthToken(std::string &authtoken, std::string &refreshtoken, cons
 	{
 		if (m_TadoUsername.size() == 0 && !refreshUsingToken)
 		{
-			_log.Log(LOG_ERROR, "Tado: No username specified.");
+			Log(LOG_ERROR, "No username specified.");
 			return false;
 		}
 		if (m_TadoPassword.size() == 0 && !refreshUsingToken)
 		{
-			_log.Log(LOG_ERROR, "Tado: No password specified.");
+			Log(LOG_ERROR, "No password specified.");
 			return false;
 		}
 		if (m_bDoGetEnvironment)
 		{
-			_log.Log(LOG_ERROR, "Tado: Environment not (yet) set up.");
+			Log(LOG_ERROR, "Environment not (yet) set up.");
 			return false;
 		}
 
@@ -256,32 +256,32 @@ bool CTado::GetAuthToken(std::string &authtoken, std::string &refreshtoken, cons
 		catch (std::exception& e)
 		{
 			std::string what = e.what();
-			_log.Log(LOG_ERROR, "Tado: Failed to get token from Api: %s", what.c_str());
+			Log(LOG_ERROR, "Failed to get token from Api: %s", what.c_str());
 			return false;
 		}
 
 		authtoken = _jsRoot["access_token"].asString();
 		if (authtoken.size() == 0)
 		{
-			_log.Log(LOG_ERROR, "Tado: Received token is zero length.");
+			Log(LOG_ERROR, "Received token is zero length.");
 			return false;
 		}
 
 		refreshtoken = _jsRoot["refresh_token"].asString();
 		if (refreshtoken.size() == 0)
 		{
-			_log.Log(LOG_ERROR, "Tado: Received refresh token is zero length.");
+			Log(LOG_ERROR, "Received refresh token is zero length.");
 			return false;
 		}
 
-		_log.Log(LOG_STATUS, "Tado: Received access token from API.");
-		_log.Log(LOG_STATUS, "Tado: Received refresh token from API.");
+		Log(LOG_STATUS, "Received access token from API.");
+		Log(LOG_STATUS, "Received refresh token from API.");
 
 		return true;
 	}
 	catch (std::exception& e) {
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: GetAuthToken: %s", what.c_str());
+		Log(LOG_ERROR, "GetAuthToken: %s", what.c_str());
 		return false;
 	}
 }
@@ -302,7 +302,7 @@ bool CTado::GetZoneState(const int HomeIndex, const int ZoneIndex, const _tTadoH
 		catch (std::exception& e)
 		{
 			std::string what = e.what();
-			_log.Log(LOG_ERROR, "Tado: Failed to get information on zone '%s': %s", zone.Name.c_str(), what.c_str());
+			Log(LOG_ERROR, "Failed to get information on zone '%s': %s", zone.Name.c_str(), what.c_str());
 			return false;
 		}
 
@@ -378,7 +378,7 @@ bool CTado::GetZoneState(const int HomeIndex, const int ZoneIndex, const _tTadoH
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: GetZoneState: %s", what.c_str());
+		Log(LOG_ERROR, "GetZoneState: %s", what.c_str());
 		return false;
 	}
 }
@@ -398,7 +398,7 @@ bool CTado::GetHomeState(const int HomeIndex, _tTadoHome & home)
 		catch (std::exception& e)
 		{
 			std::string what = e.what();
-			_log.Log(LOG_ERROR, "Tado: Failed to get state information on home '%s': %s", home.Name.c_str(), what.c_str());
+			Log(LOG_ERROR, "Failed to get state information on home '%s': %s", home.Name.c_str(), what.c_str());
 			return false;
 		}
 
@@ -411,7 +411,7 @@ bool CTado::GetHomeState(const int HomeIndex, _tTadoHome & home)
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: GetZoneState: %s", what.c_str());
+		Log(LOG_ERROR, "GetZoneState: %s", what.c_str());
 		return false;
 	}
 }
@@ -490,7 +490,7 @@ void CTado::UpdateSwitch(const int Idx, const bool bOn, const std::string &defau
 // Removes any active overlay from a specific zone.
 bool CTado::CancelOverlay(const int Idx)
 {
-	_log.Debug(DEBUG_HARDWARE, "Tado: CancelSetpointOverlay() called with idx=%d", Idx);
+	Debug(DEBUG_HARDWARE, "CancelSetpointOverlay() called with idx=%d", Idx);
 
 	int HomeIdx = Idx / 1000;
 	int ZoneIdx = (Idx % 1000) / 100;
@@ -499,7 +499,7 @@ bool CTado::CancelOverlay(const int Idx)
 	// Check if the home and zone actually exist.
 	if (m_TadoHomes.size() == 0 || m_TadoHomes[HomeIdx].Zones.size() == 0)
 	{
-		_log.Log(LOG_ERROR, "Tado: no such home/zone combo found: %d/%d", HomeIdx, ZoneIdx);
+		Log(LOG_ERROR, "No such home/zone combo found: %d/%d", HomeIdx, ZoneIdx);
 		return false;
 	}
 
@@ -516,12 +516,12 @@ bool CTado::CancelOverlay(const int Idx)
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: error cancelling the setpoint overlay: %s", what.c_str());
+		Log(LOG_ERROR, "Error cancelling the setpoint overlay: %s", what.c_str());
 		return false;
 	}
 
 	// Trigger a zone refresh
-	_log.Log(LOG_STATUS, "Tado: Setpoint overlay cancelled.");
+	Log(LOG_STATUS, "Setpoint overlay cancelled.");
 	GetZoneState(HomeIdx, ZoneIdx, m_TadoHomes[HomeIdx], m_TadoHomes[HomeIdx].Zones[ZoneIdx]);
 
 	return true;
@@ -529,7 +529,7 @@ bool CTado::CancelOverlay(const int Idx)
 
 void CTado::Do_Work()
 {
-	_log.Log(LOG_STATUS, "Tado: Worker started. Will poll every %d seconds.", TADO_POLL_INTERVAL);
+	Log(LOG_STATUS, "Worker started. Will poll every %d seconds.", TADO_POLL_INTERVAL);
 	int iSecCounter = TADO_POLL_INTERVAL - 5;
 	int iTokenCycleCount = 0;
 
@@ -564,7 +564,7 @@ void CTado::Do_Work()
 				// If we fail to do so, abort.
 				if (!GetHomes())
 				{
-					_log.Log(LOG_ERROR, "Tado: Failed to get homes from Tado account.");
+					Log(LOG_ERROR, "Failed to get homes from Tado account.");
 					// Try to get homes next iteration. Other than that we can't do much now.
 					continue;
 				}
@@ -585,7 +585,7 @@ void CTado::Do_Work()
 					if (!GetZones(m_TadoHomes[i])){
 						// Something went wrong, indicate that we do need to collect zones next time.
 						m_bDoGetZones = true;
-						_log.Log(LOG_ERROR, "Tado: Failed to get zones for home '%s'", m_TadoHomes[i].Name.c_str());
+						Log(LOG_ERROR, "Failed to get zones for home '%s'", m_TadoHomes[i].Name.c_str());
 					}
 				}
 			}
@@ -593,9 +593,9 @@ void CTado::Do_Work()
 			// Check if the authentication token is still useable.
 			if (iTokenCycleCount++ > TADO_TOKEN_MAXLOOPS)
 			{
-				_log.Log(LOG_NORM, "Tado: refreshing token.");
+				Log(LOG_NORM, "Refreshing token.");
 				if (!GetAuthToken(m_TadoAuthToken, m_TadoRefreshToken, true)) {
-					_log.Log(LOG_ERROR, "Tado: failed to refresh authentication token. Skipping this cycle.");
+					Log(LOG_ERROR, "Failed to refresh authentication token. Skipping this cycle.");
 				}
 				// Reset the counter to its initial value.
 				else iTokenCycleCount = 0;
@@ -608,7 +608,7 @@ void CTado::Do_Work()
 
 				if (!GetHomeState(HomeIndex, m_TadoHomes[HomeIndex]))
 				{
-					_log.Log(LOG_ERROR, "Tado: Failed to get state for home '%s'", m_TadoHomes[HomeIndex].Name.c_str());
+					Log(LOG_ERROR, "Failed to get state for home '%s'", m_TadoHomes[HomeIndex].Name.c_str());
 					// Skip to the next home
 					continue;
 				}
@@ -617,13 +617,13 @@ void CTado::Do_Work()
 				{
 					if (!GetZoneState(HomeIndex, ZoneIndex, m_TadoHomes[HomeIndex], m_TadoHomes[HomeIndex].Zones[ZoneIndex]))
 					{
-						_log.Log(LOG_ERROR, "Tado: Failed to get state for home '%s', zone '%s'", m_TadoHomes[HomeIndex].Name.c_str(), m_TadoHomes[HomeIndex].Zones[ZoneIndex].Name.c_str());
+						Log(LOG_ERROR, "Failed to get state for home '%s', zone '%s'", m_TadoHomes[HomeIndex].Name.c_str(), m_TadoHomes[HomeIndex].Zones[ZoneIndex].Name.c_str());
 					}
 				}
 			}
 		}
 	}
-	_log.Log(LOG_STATUS, "Tado: Worker stopped.");
+	Log(LOG_STATUS, "Worker stopped.");
 }
 
 // Splits a string inputString by delimiter. If specified returns up to maxelements elements.
@@ -667,11 +667,11 @@ bool CTado::MatchValueFromJSKey(const std::string &sKeyName, const std::string &
 	// Get the javascript response and split its lines
 	StringSplit(sJavascriptData, "\n", _sJavascriptDataLines);
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: MatchValueFromJSKey: Got %zu lines from javascript data.", _sJavascriptDataLines.size());
+	Debug(DEBUG_HARDWARE, "MatchValueFromJSKey: Got %zu lines from javascript data.", _sJavascriptDataLines.size());
 
 	if (_sJavascriptDataLines.size() <= 0)
 	{
-		_log.Log(LOG_ERROR, "Tado: Failed to get any lines from javascript environment file.");
+		Log(LOG_ERROR, "Failed to get any lines from javascript environment file.");
 		return false;
 	}
 
@@ -680,7 +680,7 @@ bool CTado::MatchValueFromJSKey(const std::string &sKeyName, const std::string &
 	{
 		std::string _sLine = _sJavascriptDataLines[i];
 
-		_log.Debug(DEBUG_HARDWARE, "Tado: MatchValueFromJSKey: Processing line: '%s'", _sLine.c_str());
+		Debug(DEBUG_HARDWARE, "MatchValueFromJSKey: Processing line: '%s'", _sLine.c_str());
 
 		std::string _sLineKey = "";
 		std::string _sLineValue = "";
@@ -715,7 +715,7 @@ bool CTado::MatchValueFromJSKey(const std::string &sKeyName, const std::string &
 				// Now that we've got both a key and a value put it in the map
 				_mEnvironmentKeys[_sLineKey] = _sLineValue;
 
-				_log.Debug(DEBUG_HARDWARE, "Tado: MatchValueFromJSKey: Line: '%s':'%s'", _sLineKey.c_str(), _sLineValue.c_str());
+				Debug(DEBUG_HARDWARE, "MatchValueFromJSKey: Line: '%s':'%s'", _sLineKey.c_str(), _sLineValue.c_str());
 			}
 		}
 	}
@@ -724,14 +724,14 @@ bool CTado::MatchValueFromJSKey(const std::string &sKeyName, const std::string &
 	// Check the map to get the value we were looking for in the first place.
 	if (_mEnvironmentKeys[sKeyName].empty())
 	{
-		_log.Log(LOG_ERROR, "Tado: Failed to grab %s from the javascript data.", sKeyName.c_str());
+		Log(LOG_ERROR, "Failed to grab %s from the javascript data.", sKeyName.c_str());
 		return false;
 	}
 
 	sValue = _mEnvironmentKeys[sKeyName];
 	if (sValue.size() == 0)
 	{
-		_log.Log(LOG_ERROR, "Tado: Value for key %s is zero length.", sKeyName.c_str());
+		Log(LOG_ERROR, "Value for key %s is zero length.", sKeyName.c_str());
 		return false;
 	}
 	return true;
@@ -740,7 +740,7 @@ bool CTado::MatchValueFromJSKey(const std::string &sKeyName, const std::string &
 // Grabs the web app environment file
 bool CTado::GetTadoApiEnvironment(std::string sUrl)
 {
-	_log.Debug(DEBUG_HARDWARE, "Tado: GetTadoApiEnvironment called with sUrl=%s", sUrl.c_str());
+	Debug(DEBUG_HARDWARE, "GetTadoApiEnvironment called with sUrl=%s", sUrl.c_str());
 
 	// This is a bit of a special case. Since we pretend to be the web
 	// application (my.tado.com) we have to play by its rules. It works
@@ -752,7 +752,7 @@ bool CTado::GetTadoApiEnvironment(std::string sUrl)
 
 	// Download the API environment file
 	if (!HTTPClient::GET(sUrl, _sResponse, false)) {
-		_log.Log(LOG_ERROR, "Tado: Failed to retrieve API environment from %s", sUrl.c_str());
+		Log(LOG_ERROR, "Failed to retrieve API environment from %s", sUrl.c_str());
 		return false;
 	}
 
@@ -772,12 +772,12 @@ bool CTado::GetTadoApiEnvironment(std::string sUrl)
 		// Value is stored in m_TadoEnvironment[keyName]
 		std::string _sKeyName = _vKeysToFetch[i];
 		if (!MatchValueFromJSKey(_sKeyName, _sResponse, m_TadoEnvironment[_sKeyName])) {
-			_log.Log(LOG_ERROR, "Tado: Failed to retrieve/match key '%s' from the API environment.", _sKeyName.c_str());
+			Log(LOG_ERROR, "Failed to retrieve/match key '%s' from the API environment.", _sKeyName.c_str());
 			return false;
 		}
 	}
 
-	_log.Log(LOG_STATUS, "Tado: Retrieved webapp environment from API.");
+	Log(LOG_STATUS, "Retrieved webapp environment from API.");
 
 	// Mark this action as completed.
 	m_bDoGetEnvironment = false;
@@ -787,7 +787,7 @@ bool CTado::GetTadoApiEnvironment(std::string sUrl)
 // Sets up the environment and grabs an auth token.
 bool CTado::Login()
 {
-	_log.Log(LOG_NORM, "Tado: Attempting login.");
+	Log(LOG_NORM, "Attempting login.");
 
 	if (m_bDoGetEnvironment) {
 		// First get information about the environment of the web application.
@@ -803,7 +803,7 @@ bool CTado::Login()
 		return false;
 	}
 
-	_log.Log(LOG_NORM, "Tado: Login succesful.");
+	Log(LOG_NORM, "Login succesful.");
 
 	return true;
 }
@@ -811,7 +811,7 @@ bool CTado::Login()
 // Gets all the homes in the account.
 bool CTado::GetHomes() {
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: GetHomes() called.");
+	Debug(DEBUG_HARDWARE, "GetHomes() called.");
 
 	std::stringstream _sstr;
 	_sstr << m_TadoEnvironment["tgaRestApiV2Endpoint"] << "/me";
@@ -827,7 +827,7 @@ bool CTado::GetHomes() {
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: failed to get homes: %s", what.c_str());
+		Log(LOG_ERROR, "Failed to get homes: %s", what.c_str());
 		return false;
 	}
 
@@ -836,7 +836,7 @@ bool CTado::GetHomes() {
 
 	Json::Value _jsAllHomes = _jsRoot["homes"];
 
-	_log.Debug(DEBUG_HARDWARE, "Tado: Found %d homes.", _jsAllHomes.size());
+	Debug(DEBUG_HARDWARE, "Found %d homes.", _jsAllHomes.size());
 
 	for (int i = 0; i < (int)_jsAllHomes.size(); i++) {
 		// Store the tado home information in a map.
@@ -848,7 +848,7 @@ bool CTado::GetHomes() {
 		_structTadoHome.Id = _jsAllHomes[i]["id"].asString();
 		m_TadoHomes.push_back(_structTadoHome);
 
-		_log.Log(LOG_STATUS, "Tado: Registered Home '%s' with id %s", _structTadoHome.Name.c_str(), _structTadoHome.Id.c_str());
+		Log(LOG_STATUS, "Registered Home '%s' with id %s", _structTadoHome.Name.c_str(), _structTadoHome.Id.c_str());
 	}
 	// Sort the homes so they end up in the same order every time.
 	sort(m_TadoHomes.begin(), m_TadoHomes.end());
@@ -874,7 +874,7 @@ bool CTado::GetZones(_tTadoHome &tTadoHome) {
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: Failed to get zones from API for Home %s: %s", tTadoHome.Id.c_str(), what.c_str());
+		Log(LOG_ERROR, "Failed to get zones from API for Home %s: %s", tTadoHome.Id.c_str(), what.c_str());
 		return false;
 	}
 
@@ -888,7 +888,7 @@ bool CTado::GetZones(_tTadoHome &tTadoHome) {
 		_TadoZone.Type = _jsRoot[zoneIdx]["type"].asString();
 		_TadoZone.OpenWindowDetectionSupported = _jsRoot[zoneIdx]["openWindowDetection"]["supported"].asBool();
 
-		_log.Log(LOG_STATUS, "Tado: Registered Zone %s '%s' of type %s", _TadoZone.Id.c_str(), _TadoZone.Name.c_str(), _TadoZone.Type.c_str());
+		Log(LOG_STATUS, "Registered Zone %s '%s' of type %s", _TadoZone.Id.c_str(), _TadoZone.Name.c_str(), _TadoZone.Type.c_str());
 
 		tTadoHome.Zones.push_back(_TadoZone);
 	}
@@ -908,7 +908,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 		// If there is no token stored then there is no point in doing a request. Unless we specifically
 		// decide not to do authentication.
 		if (m_TadoAuthToken.size() == 0 && bSendAuthHeaders) {
-			_log.Log(LOG_ERROR, "Tado: No access token available.");
+			Log(LOG_ERROR, "No access token available.");
 			return false;
 		}
 
@@ -934,7 +934,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 			case Put:
 				if (!HTTPClient::PUT(sUrl, sPostData, _vExtraHeaders, sResponse, bIgnoreEmptyResponse))
 				{
-					_log.Log(LOG_ERROR, "Tado: Failed to perform PUT request to Tado Api: %s", sResponse.c_str());
+					Log(LOG_ERROR, "Failed to perform PUT request to Tado Api: %s", sResponse.c_str());
 					return false;
 				}
 				break;
@@ -943,7 +943,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 				if (!HTTPClient::POST(sUrl, sPostData, _vExtraHeaders, sResponse, _vResponseHeaders, true, bIgnoreEmptyResponse))
 				{
 					for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) _ssResponseHeaderString << _vResponseHeaders[i];
-					_log.Log(LOG_ERROR, "Tado: Failed to perform POST request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
+					Log(LOG_ERROR, "Failed to perform POST request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
 					return false;
 				}
 				break;
@@ -952,7 +952,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 				if (!HTTPClient::GET(sUrl, _vExtraHeaders, sResponse, _vResponseHeaders, bIgnoreEmptyResponse))
 				{
 					for (unsigned int i = 0; i < _vResponseHeaders.size(); i++) _ssResponseHeaderString << _vResponseHeaders[i];
-					_log.Log(LOG_ERROR, "Tado: Failed to perform GET request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
+					Log(LOG_ERROR, "Failed to perform GET request to Tado Api: %s; Response headers: %s", sResponse.c_str(), _ssResponseHeaderString.str().c_str());
 					return false;
 				}
 				break;
@@ -960,7 +960,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 			case Delete:
 				if (!HTTPClient::Delete(sUrl, sPostData, _vExtraHeaders, sResponse, bIgnoreEmptyResponse)) {
 					{
-						_log.Log(LOG_ERROR, "Tado: Failed to perform DELETE request to Tado Api: %s", sResponse.c_str());
+						Log(LOG_ERROR, "Failed to perform DELETE request to Tado Api: %s", sResponse.c_str());
 						return false;
 					}
 				}
@@ -968,7 +968,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 
 			default:
 				{
-					_log.Log(LOG_ERROR, "Tado: Unknown method specified.");
+					Log(LOG_ERROR, "Unknown method specified.");
 					return false;
 				}
 		}
@@ -976,14 +976,14 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 		if (sResponse.size() == 0)
 		{
 			if (!bIgnoreEmptyResponse) {
-				_log.Log(LOG_ERROR, "Tado: Received an empty response from Api.");
+				Log(LOG_ERROR, "Received an empty response from Api.");
 				return false;
 			}
 		}
 
 		if (bDecodeJsonResponse) {
 			if (!ParseJSon(sResponse, jsDecodedResponse)) {
-				_log.Log(LOG_ERROR, "Tado: Failed to decode Json response from Api.");
+				Log(LOG_ERROR, "Failed to decode Json response from Api.");
 				return false;
 			}
 		}
@@ -991,7 +991,7 @@ bool CTado::SendToTadoApi(const eTadoApiMethod eMethod, const std::string &sUrl,
 	catch (std::exception& e)
 	{
 		std::string what = e.what();
-		_log.Log(LOG_ERROR, "Tado: Error sending information to Tado API: %s", what.c_str());
+		Log(LOG_ERROR, "Error sending information to Tado API: %s", what.c_str());
 		return false;
 	}
 	return true;


### PR DESCRIPTION
Fixed compiler warning. 

Also (as I was editing anyway) switched logger from logger class to DomoticzHardwareBase class as that seems to be the (new?) preferred way of logging now.
