### PR TITLE
update to Plugwise scene selector and migration process for all stable and beta versions

### DIFF
--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -146,7 +146,7 @@ void CAnnaThermostat::Do_Work()
 			{
 				FixPresetUnit(); // making sure the preset is unit it  set to 0. Note to self dont mess with unit numbers
 				InitialMessageMigrateCheck();
-            	bFirstTime = false;
+				bFirstTime = false;
 			}
 			GetMeterDetails();
 		}
@@ -505,10 +505,10 @@ void CAnnaThermostat::GetMeterDetails()
 		}
 		for (pElem; pElem; pElem = pElem->NextSiblingElement())
 		{
-          
+
 			sname = GetElementChildValue(pElem, "type");
-		    //tmpstr = GetPeriodMeasurement(pElem);
-            //Log (LOG_NORM,"%s : %s ", sname.c_str(), tmpstr.c_str());
+			//tmpstr = GetPeriodMeasurement(pElem);
+			//Log (LOG_NORM,"%s : %s ", sname.c_str(), tmpstr.c_str());
 			if (sname == "temperature")
 			{
 				tmpstr = GetPeriodMeasurement(pElem);
@@ -783,7 +783,7 @@ bool CAnnaThermostat::AnnaGetLocation()
 
 bool CAnnaThermostat::InitialMessageMigrateCheck()
 {
-	bool retval = false;	
+	bool retval = false;
 	// Showing we are starting Annatherm and
 	// notify users in the log how to use the event system once per startup
 	Log(LOG_NORM, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
@@ -795,20 +795,20 @@ bool CAnnaThermostat::InitialMessageMigrateCheck()
 	Log(LOG_NORM, "Adjusting the Temp manually on the ANNA or via App, forces the ANNA to set Scenes to Off!!");
 	Log(LOG_NORM, "KNOWN ISSUE: The Gateway will not send an update  if the prvious scene is choosen again!");
 	Log(LOG_NORM, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
-    
+
 	if( MigrateSelectorSwitch(sAnnaPresets, 0, ANNA_LEVEL_NAMES, ANNA_LEVEL_ACTIONS,true)== 1)
 	{
 		Log(LOG_STATUS, "Scene Selector switch updated to Version: %s ! ", ANNA_VERSION.c_str());
-        retval = true;
+		retval = true;
 	}
-	return retval;	
+	return retval;
 }
 void CAnnaThermostat::FixPresetUnit()
 {   // This function will make sure that from now on  that the Preset switch in the Plugwise plugin will be using unit 0
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, 1);
 	if (result.empty())
-	    return;  // switch doen not exist yet
+		return;  // switch doen not exist yet
 	m_sql.safe_query("UPDATE DeviceStatus SET unit = 0 WHERE (HardwareID==%d) AND (DeviceID=='%08X' AND (Unit == '%d')", m_HwdID, sAnnaPresets, 1);
-	  
+
 }

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -33,9 +33,8 @@ const std::string ANNA_LEVEL_ACTIONS = "00|10|20|30|40|50";
 
 
 //#define _DEBUG // toggle for reading and writing local files
-
 #ifdef _DEBUG
-//define DEBUG_AnnaThermostat
+//#define DEBUG_AnnaThermostat
 #define DEBUG_ANNA_APPLIANCE_READ  "/tmp/anna/appliances.xml"
 #define DEBUG_ANNA_WRITE           "/tmp/anna/output.txt"
 #define DEBUG_ANNA_LOCATION_READ   "/tmp/anna/location.xml"
@@ -78,8 +77,6 @@ CAnnaThermostat::CAnnaThermostat(const int ID, const std::string& IPAddress, con
 {
 	m_HwdID = ID;
 	Init();
-//    GetMeterDetails();
-
 }
 
 CAnnaThermostat::~CAnnaThermostat(void)
@@ -675,7 +672,7 @@ void CAnnaThermostat::GetMeterDetails()
 				else strncpy(sPreset, "50", sizeof(sPreset));
 
 				std::string PresetName = "Anna Preset";
-				SendSelectorSwitch(sAnnaPresets,  0, sPreset , PresetName.c_str(), 16, false, ANNA_LEVEL_NAMES, ANNA_LEVEL_ACTIONS, true);
+				SendSelectorSwitch(sAnnaPresets,  1, sPreset , PresetName.c_str(), 16, false, ANNA_LEVEL_NAMES, ANNA_LEVEL_ACTIONS, true);
 			}
 		}
 		pAppliance = pAppliance->NextSiblingElement("appliance");
@@ -796,7 +793,7 @@ bool CAnnaThermostat::InitialMessageMigrateCheck()
 	Log(LOG_NORM, "KNOWN ISSUE: The Gateway will not send an update  if the prvious scene is choosen again!");
 	Log(LOG_NORM, "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
 
-	if( MigrateSelectorSwitch(sAnnaPresets, 0, ANNA_LEVEL_NAMES, ANNA_LEVEL_ACTIONS,true)== 1)
+	if( MigrateSelectorSwitch(sAnnaPresets, 1, ANNA_LEVEL_NAMES, ANNA_LEVEL_ACTIONS,true)== 1)
 	{
 		Log(LOG_STATUS, "Scene Selector switch updated to Version: %s ! ", ANNA_VERSION.c_str());
 		retval = true;
@@ -806,9 +803,8 @@ bool CAnnaThermostat::InitialMessageMigrateCheck()
 void CAnnaThermostat::FixPresetUnit()
 {   // This function will make sure that from now on  that the Preset switch in the Plugwise plugin will be using unit 0
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, 1);
+	result = m_sql.safe_query("SELECT Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, sAnnaPresets, 0);
 	if (result.empty())
 		return;  // switch doen not exist yet
-	m_sql.safe_query("UPDATE DeviceStatus SET unit = 0 WHERE (HardwareID==%d) AND (DeviceID=='%08X' AND (Unit == '%d')", m_HwdID, sAnnaPresets, 1);
-
+	m_sql.safe_query("UPDATE DeviceStatus SET unit = 1 WHERE (HardwareID==%d) AND (DeviceID=='%08X' AND (Unit == '%d')", m_HwdID, sAnnaPresets, 0);
 }

--- a/hardware/AnnaThermostat.h
+++ b/hardware/AnnaThermostat.h
@@ -30,6 +30,8 @@ private:
 	bool SetAway(const bool bIsAway);
 	bool AnnaToggleProximity(bool bToggle);
 	bool AnnaGetLocation();
+	bool InitialMessageMigrateCheck();
+	void FixPresetUnit();
 
 private:
 	std::string m_IPAddress;

--- a/hardware/AnnaThermostat.h
+++ b/hardware/AnnaThermostat.h
@@ -31,7 +31,7 @@ private:
 	bool AnnaToggleProximity(bool bToggle);
 	bool AnnaGetLocation();
 	bool InitialMessageMigrateCheck();
-	void FixPresetUnit();
+	void FixUnit();
 
 private:
 	std::string m_IPAddress;

--- a/hardware/AnnaThermostat.h
+++ b/hardware/AnnaThermostat.h
@@ -44,4 +44,3 @@ private:
 	std::shared_ptr<std::thread> m_thread;
 	AnnaLocationInfo m_AnnaLocation;
 };
-


### PR DESCRIPTION
Replacement for previous PR that had a typo.

This patch will correctly update the Scene preset switch to the latest version that is in used by the plugwise product suite.
It will make sure all unit are  having a correct value   which is a requirement for further planned upgrades.

Removed some old code that was commented out to get a cleaner code base.
Will run a migration check at initial start of the hardware,  and only migrate once
Has run for 18 hour on my mac and pi test platfrom
