### PR TITLE
Add "from" field for Clickatell SMS notification

### DIFF
--- a/notifications/NotificationSMS.cpp
+++ b/notifications/NotificationSMS.cpp
@@ -40,7 +40,6 @@ bool CNotificationSMS::SendMessageImplementation(
 		return false;
 
 	std::string thisFrom = CURLEncode::URLDecode(_clickatellFrom);
-	_log.Log(LOG_NORM, "From: " + thisFrom);
 
 	stdreplace(thisFrom, "+", "");
 	stdreplace(thisFrom, " ", "");
@@ -81,18 +80,18 @@ bool CNotificationSMS::SendMessageImplementation(
 		<< "\"charset\": \"UTF-8\""
 		<< "}";
 
-	_log.Log(LOG_NORM, "Json params: " + sJsonPostData.str());
+	_log.Log(LOG_NORM, "Clickatell SMS notification json: " + sJsonPostData.str());
 
 	std::vector<std::string> ExtraHeaders;
 	ExtraHeaders.push_back("Authorization: " + _clickatellApi);
 	ExtraHeaders.push_back("Content-Type: application/json");
 	ExtraHeaders.push_back("Accept: application/json");
 	bRet |= HTTPClient::POST("https://platform.clickatell.com/messages", sJsonPostData.str(), ExtraHeaders, sResult);
+	_log.Log(LOG_NORM, "Clickatell SMS Gateway: %s", sResult.c_str());
 	if (sResult.find("ERR:") != std::string::npos)
 	{
 		//We have an error
 		bRet = false;
-		_log.Log(LOG_ERROR, "Clickatell SMS Gateway: %s", sResult.c_str());
 	}
 	return bRet;
 }

--- a/notifications/NotificationSMS.h
+++ b/notifications/NotificationSMS.h
@@ -20,4 +20,6 @@ private:
 	/* config vars */
 	std::string _clickatellApi;
 	std::string _clickatellTo;
+	std::string _clickatellFrom;
+
 };

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -36,6 +36,10 @@ define(['app'], function (app) {
 						return;
 					}
 					extraparams = "ClickatellAPI=" + ClickatellAPI + "&ClickatellTo=" + ClickatellTo;
+					var ClickatellFrom = encodeURIComponent($("#smstable #ClickatellFrom").val());
+					if (ClickatellFrom != "") {
+						extraparams = extraparams + "&ClickatellFrom=" + ClickatellFrom;
+					}
 					break;
 				case "http":
 					var HTTPField1 = encodeURIComponent($("#httptable #HTTPField1").val());
@@ -320,6 +324,9 @@ define(['app'], function (app) {
 					}
 					if (typeof data.ClickatellTo != 'undefined') {
 						$("#smstable #ClickatellTo").val(atob(data.ClickatellTo));
+					}
+					if (typeof data.ClickatellFrom != 'undefined') {
+						$("#smstable #ClickatellFrom").val(atob(data.ClickatellFrom));
 					}
 
 					if (typeof data.HTTPEnabled != 'undefined') {

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -585,24 +585,33 @@
                                     <div id="collapseOne7" class="collapse show" role="tabpanel" aria-labelledby="headingClickatell"
                                       data-parent="#accordionEx">
                                         <div class="card-body">
-                                        <table class="display" id="smstable" border="0" cellpadding="0" cellspacing="0">
-                                        <tr>
-                                            <td align="right" style="width:80px"><span data-i18n="Enabled"></span>:</td>
-                                            <td><input type="checkbox" id="ClickatellEnabled" name="ClickatellEnabled"/><label for="ClickatellEnabled"/></td>
-                                        </tr>
-                                        <tr>
-                                            <td align="right"><label for="ClickatellAPI"><span data-i18n="API Key">API Key</span>: </label></td>
-                                            <td><input type="input" id="ClickatellAPI" name="ClickatellAPI" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
-                                        </tr>
-                                        <tr>
-                                            <td align="right"><label for="ClickatellTo"><span data-i18n="To"></span>: </label></td>
-                                            <td><input type="input" id="ClickatellTo" name="ClickatellTo" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" />  <button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('clickatell')">Test</button></td>
-                                        </tr>
-                                        <tr>
-                                            <td></td>
-                                            <td><span data-i18n="(Separate by a semicolon, For Example"></span>: +3123456789;+44567890)</td>
-                                        </tr>
-                                        </table>
+											<table class="display" id="smstable" border="0" cellpadding="0" cellspacing="0">
+												<tr>
+													<td align="right" style="width:80px"><span data-i18n="Enabled"></span>:</td>
+													<td><input type="checkbox" id="ClickatellEnabled" name="ClickatellEnabled" /><label for="ClickatellEnabled" /></td>
+												</tr>
+												<tr>
+													<td align="right"><label for="ClickatellAPI"><span data-i18n="API Key">API Key</span>: </label></td>
+													<td><input type="input" id="ClickatellAPI" name="ClickatellAPI" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+												</tr>
+												<tr>
+													<td align="right"><label for="ClickatellTo"><span data-i18n="To"></span>: </label></td>
+													<td><input type="input" id="ClickatellTo" name="ClickatellTo" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" /></td>
+												</tr>
+												<tr>
+													<td></td>
+													<td><span data-i18n="(For Example"></span>: +3123456789)</td>
+												</tr>
+												<tr>
+													<td align="right"><label for="ClickatellFrom"><span data-i18n="From"></span>: </label></td>
+													<td><input type="input" id="ClickatellFrom" name="ClickatellFrom" style="width: 356px; padding: .2em;" class="text ui-widget-content ui-corner-all" />  <button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('clickatell')">Test</button></td>
+												</tr>
+												<tr>
+													<td></td>
+													<td><span data-i18n="(Optional - used in two way comunication"></span>: +3123456789)</td>
+												</tr>
+
+											</table>
                                         <span data-i18n="To get a free account/API key click"></span> <a class="norm-link" href="http://www.clickatell.com/" target="_blank"><span class="norm-link" data-i18n="Here"></span></a><br>
                                         <br />
                                         </div>

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -600,7 +600,7 @@
 												</tr>
 												<tr>
 													<td></td>
-													<td><span data-i18n="(For Example"></span>: +3123456789)</td>
+													<td><span data-i18n="(Separate by a semicolon, For Example"></span>: +3123456789;+44567890)</td>
 												</tr>
 												<tr>
 													<td align="right"><label for="ClickatellFrom"><span data-i18n="From"></span>: </label></td>


### PR DESCRIPTION
Hello

The only way to use Clicaktell in USA is two-way communication. This is restricted by law. So in this pull request I'm adding optional "from" field. 
Another change in this commit is to use GET method instead of POST. I don't know why but I was not able to make it work with POST (I think in general this functionality currently is not working). Also fixed copy to send texts to only one number. Currently used method (http) supports only one:
See https://docs.clickatell.com/channels/sms-channels/sms-api-reference/#operation/sendMessageHTTP

There are couple more things to improve:
- use REST api to send bulk messages
- fix error handling. Right now we have positive message regardless of result.

Please consider this changes. I will be happy to fix above things as well. 

Thanks!