### PR TITLE
Fix "Invalid or missing integration API" error. 

### DIFF
--- a/notifications/NotificationSMS.cpp
+++ b/notifications/NotificationSMS.cpp
@@ -82,8 +82,9 @@ bool CNotificationSMS::SendMessageImplementation(
 
 	_log.Log(LOG_NORM, "Clickatell SMS notification json: " + sJsonPostData.str());
 
+	std::string apiKey = CURLEncode::URLDecode(_clickatellApi);
 	std::vector<std::string> ExtraHeaders;
-	ExtraHeaders.push_back("Authorization: " + _clickatellApi);
+	ExtraHeaders.push_back("Authorization: " + apiKey);
 	ExtraHeaders.push_back("Content-Type: application/json");
 	ExtraHeaders.push_back("Accept: application/json");
 	bRet |= HTTPClient::POST("https://platform.clickatell.com/messages", sJsonPostData.str(), ExtraHeaders, sResult);


### PR DESCRIPTION
Hello

It turns out that we still have a bug with Clickatell notification:

```
2020-09-21 15:44:51.886 Clickatell SMS Gateway: {"messages":[],"errorCode":108,"error":"Invalid or missing integration API Key.","errorDescription":"The integration API key is either incorrect or has not been included in the API call."}
```

I tested previous changes using "Test" button in Notification Settings. With real notification from sensor we have to decode all fields. ClickatellApi filed is not decoded thus we have invalid api key. This commit is fixing this issue. 
After changes it work fine:

```
2020-09-21 23:18:22.667  Status: Notification: test sensor notification
2020-09-21 23:18:22.667  Clickatell SMS notification json: {"content":"test sensor notification","to":["16503138646"],"from":"16507270996","binary": false,"charset": "UTF-8"}
2020-09-21 23:18:23.482  Clickatell SMS Gateway: {"messages":[{"apiMessageId":"c4edd6d6ca9847829f762feb7bb043d5","accepted":true,"to":"16503138646","errorCode":null,"error":null,"errorDescription":null}]}
2020-09-21 23:18:23.482  Notification sent (clickatell) => Success
```

Sorry for not testing this with notification from sensor before.