### PR TITLE
Fix fancy checkboxes in default theme

### DIFF
--- a/www/app/log/GraphLog.html
+++ b/www/app/log/GraphLog.html
@@ -17,4 +17,4 @@
         chart-title="Last Year"
         range="year"></long-chart>
 
-<label><input type="checkbox" ng-model="$ctrl.autoRefresh"> {{ ::'Auto refresh on device update' | translate }}</label>
+<input type="checkbox" id="AutoRefresh" ng-model="$ctrl.autoRefresh">&nbsp;<label for="AutoRefresh" data-i18n="Auto refresh on device update"></label>

--- a/www/app/log/LightLog.html
+++ b/www/app/log/LightLog.html
@@ -22,4 +22,4 @@
 
 <device-level-chart ng-if="vm.isDimmer" class="device-log-chart device-log-chart_md" log="vm.log"></device-level-chart>
 
-<label><input type="checkbox" ng-model="vm.autoRefresh"> {{:: 'Auto refresh on device update' | translate }}</label>
+<input type="checkbox" id="AutoRefresh" ng-model="vm.autoRefresh">&nbsp;<label for="AutoRefresh" data-i18n="Auto refresh on device update"></label>

--- a/www/app/log/SceneLog.html
+++ b/www/app/log/SceneLog.html
@@ -7,10 +7,7 @@
     <table id="updelclr" border="0" cellpadding="0" cellspacing="0" width="100%">
         <tr>
             <td>
-                <label>
-                    <input type="checkbox" ng-model="vm.autoRefresh">
-                    {{:: 'Auto refresh on device update' | translate }}
-                </label>
+                <input type="checkbox" id="AutoRefresh" ng-model="vm.autoRefresh">&nbsp;<label for="AutoRefresh" data-i18n="Auto refresh on device update"></label>
             </td>
             <td align="right">
                 <button class="btnstyle3"

--- a/www/app/log/TemperatureLog.html
+++ b/www/app/log/TemperatureLog.html
@@ -22,4 +22,4 @@
         range="year">
 </temperature-log-chart>
 
-<label><input type="checkbox" ng-model="$ctrl.autoRefresh"> {{ ::'Auto refresh on device update' | translate }}</label>
+<input type="checkbox" id="AutoRefresh" ng-model="$ctrl.autoRefresh">&nbsp;<label for="AutoRefresh" data-i18n="Auto refresh on device update"></label>

--- a/www/app/log/TextLog.html
+++ b/www/app/log/TextLog.html
@@ -3,7 +3,7 @@
 <table id="updelclr" border="0" cellpadding="0" cellspacing="0" width="100%">
     <tr>
         <td>
-            <label><input type="checkbox" ng-model="vm.autoRefresh"> {{:: 'Auto refresh on device update' | translate }}</label>
+            <input type="checkbox" id="AutoRefresh" ng-model="vm.autoRefresh">&nbsp;<label for="AutoRefresh" data-i18n="Auto refresh on device update"></label>
         </td>
         <td align="right">
             <button class="btnstyle3"

--- a/www/styles/default/extras_and_animations.css
+++ b/www/styles/default/extras_and_animations.css
@@ -324,7 +324,7 @@ body{
 input[type='checkbox']:not(.noscheck) {
 	max-height: 0;
 	max-width: 0;
-	/* opacity: 0; */
+	opacity: 0;
 }
 
 	input[type='checkbox']:not(.noscheck) + label {


### PR DESCRIPTION
How checkboxes work in the gui. All checkboxes have (or should have) an id-bound label. Like:

`<input type="checkbox" id="yesorno"><label for="yesorno">Yes or no?</label>`

When using the default theme, the label is then automatically extended with a fancy toggle switch in front of the text and the checkbox is made invisible. I'm not sure how the toggle switch is made but the checkbox is made invisible by setting the css opacity to 0.

It is possible to make an exception for a particular checkbox and show the regular checkbox instead of the toggle switch. This is done by adding css class 'noscheck' to the input-tag. In that case, an id-bound label is no longer required. An example of this can be found on the page CustomTempLog.

This PR contains:

- Added label to checkbox where missing.
- Set css opacity back to 0 for checkboxes in the default theme.