### PR TITLE
Improvement Weather forecast screen and functionality

### DIFF
--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -71,7 +71,7 @@ COpenWeatherMap::~COpenWeatherMap(void)
 {
 }
 
-bool COpenWeatherMap::ResolveLocation(const std::string& Location, double& latitude, double& longitude, const bool IsCityName)
+bool COpenWeatherMap::ResolveLocation(const std::string& Location, double& latitude, double& longitude, uint32_t& cityid, const bool IsCityName)
 {
 	std::string sResult;
 	std::stringstream sURL;
@@ -118,15 +118,22 @@ bool COpenWeatherMap::ResolveLocation(const std::string& Location, double& latit
 		return false;
 	}
 
-	// Process current
-	if (root["coord"].empty())
+	if (root["cod"].empty() || root["id"].empty() || root["coord"].empty())
 	{
-		Log(LOG_ERROR, "Invalid data received, could not find current weather data!");
+		Log(LOG_ERROR, "Invalid data received, missing relevant fields (cod, id, coord)!");
 		return false;
 	}
 
+	if (root["cod"].asString() != "200")
+	{
+		Log(LOG_ERROR, "Error code received (%s)!", root["cod"].asString().c_str());
+		return false;
+	}
+
+	// Process current
 	latitude = root["coord"]["lat"].asDouble();
 	longitude = root["coord"]["lon"].asDouble();
+	cityid = root["id"].asUInt();
 
 	return true;
 }
@@ -135,6 +142,7 @@ bool COpenWeatherMap::StartHardware()
 {
 	std::string sValue, sLatitude, sLongitude;
 	std::vector<std::string> strarray;
+	uint32_t cityid;
 	Debug(DEBUG_NORM, "Got location parameter %s", m_Location.c_str());
 	Debug(DEBUG_NORM, "Starting with setting %d, %d", m_add_dayforecast, m_add_hourforecast);
 
@@ -185,20 +193,26 @@ bool COpenWeatherMap::StartHardware()
 
 				char* p;
 				double converted = strtod(sLatitude.c_str(), &p);
-				if (*p) {
+				if (*p)
+				{
 					// conversion failed because the input wasn't a number
 					// assume it is a city/country combination
 					Log(LOG_STATUS, "Using specified location (City %s)!", m_Location.c_str());
 					double lat, lon;
-					if (!ResolveLocation(m_Location, lat, lon))
+					if (!ResolveLocation(m_Location, lat, lon, cityid))
 					{
 						Log(LOG_ERROR, "Unable to resolve City to Latitude/Longitude, please use Latitude,Longitude directly in hardware setup!)");
 					}
-					Log(LOG_STATUS, "City -> Lat/Long = %g,%g", lat, lon);
-					m_Lat = lat;
-					m_Lon = lon;
+					else
+					{
+						Log(LOG_STATUS, "City (%d)-> Lat/Long = %g,%g", cityid, lat, lon);
+						m_Lat = lat;
+						m_Lon = lon;
+						m_CityID = cityid;
+					}
 				}
-				else {
+				else
+				{
 					m_Lat = std::stod(sLatitude);
 					m_Lon = std::stod(sLongitude);
 
@@ -230,27 +244,48 @@ bool COpenWeatherMap::StartHardware()
 				char* p;
 				long converted = strtol(m_Location.c_str(), &p, 10);
 				double lat, lon;
-				if (*p) {
+				if (*p)
+				{
 					//City
 					Log(LOG_STATUS, "Using specified location (City %s)!", m_Location.c_str());
-					if (!ResolveLocation(m_Location, lat, lon))
+					if (!ResolveLocation(m_Location, lat, lon, cityid))
 					{
 						Log(LOG_ERROR, "Unable to resolve City to Latitude/Longitude, please use Latitude,Longitude directly in hardware setup!)");
 					}
+					else
+					{
+						Log(LOG_STATUS, "City (%d)-> Lat/Long = %g,%g", cityid, lat, lon);
+						m_Lat = lat;
+						m_Lon = lon;
+						m_CityID = cityid;
+					}
 				}
-				else {
+				else
+				{
 					//Station ID
 					Log(LOG_STATUS, "Using specified location (Station ID %s)!", m_Location.c_str());
-					if (!ResolveLocation(m_Location, lat, lon, false))
+					if (!ResolveLocation(m_Location, lat, lon, cityid, false))
 					{
 						Log(LOG_ERROR, "Unable to resolve City to Latitude/Longitude, please use Latitude,Longitude directly in hardware setup!)");
 					}
+					else
+					{
+						Log(LOG_STATUS, "City (%d)-> Lat/Long = %g,%g", cityid, lat, lon);
+						m_Lat = lat;
+						m_Lon = lon;
+						m_CityID = cityid;
+					}
 				}
-				Log(LOG_STATUS, "City -> Lat/Long = %g,%g", lat, lon);
-				m_Lat = lat;
-				m_Lon = lon;
 			}
 		}
+	}
+
+	//Forecast URL
+	if (m_CityID > 0)
+	{
+		std::stringstream ss;
+		ss << OWM_forecast_URL << m_CityID;
+		m_ForecastURL = ss.str();
 	}
 
 	RequestStart();
@@ -309,6 +344,21 @@ bool COpenWeatherMap::WriteToHardware(const char* /*pdata*/, const unsigned char
 std::string COpenWeatherMap::GetForecastURL()
 {
 	return m_ForecastURL;
+}
+
+Json::Value COpenWeatherMap::GetForecastData()
+{
+	Json::Value root;
+
+	root["url"] = m_ForecastURL;
+	root["location"] = m_Location;
+	root["lat"] = m_Lat;
+	root["lon"] = m_Lon;
+	root["appid"] = m_APIKey;
+	root["cityid"] = m_CityID;
+
+	Debug(DEBUG_NORM, "GetForecastData: \n%s", root.toStyledString().c_str());
+	return root;
 }
 
 std::string COpenWeatherMap::GetHourFromUTCtimestamp(const uint8_t hournr, std::string UTCtimestamp)
@@ -818,11 +868,4 @@ void COpenWeatherMap::GetMeterDetails()
 		while (!hourlyfc[iHour].empty());
 		Debug(DEBUG_NORM, "Processed %d hourly forecasts",iHour);
 	}
-
-	//Forecast URL
-	if (!root["lat"].empty())
-	{
-		m_ForecastURL = "https://openweathermap.org";// OWM_forecast_URL + root["lat"].asString();
-	}
-
 }

--- a/hardware/OpenWeatherMap.h
+++ b/hardware/OpenWeatherMap.h
@@ -13,6 +13,7 @@ public:
 	~COpenWeatherMap(void);
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	std::string GetForecastURL();
+	Json::Value GetForecastData();
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;
@@ -23,7 +24,7 @@ private:
 	std::string GetHourFromUTCtimestamp(const uint8_t hournr, std::string UTCtimestamp);
 	bool ProcessForecast(Json::Value &forecast, const std::string period, const std::string periodname, const uint8_t count, const int startNodeID);
 
-	bool ResolveLocation(const std::string& Location, double& latitude, double& longitude, const bool IsCityName = true);
+	bool ResolveLocation(const std::string& Location, double& latitude, double& longitude, uint32_t& cityid, const bool IsCityName = true);
 
 	std::string m_APIKey;
 	std::string m_Location;
@@ -34,5 +35,6 @@ private:
 	bool m_add_hourforecast = false;
 	double m_Lat = 0;
 	double m_Lon = 0;
+	uint32_t m_CityID = 0;
 	std::shared_ptr<std::thread> m_thread;
 };

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5053,7 +5053,6 @@ bool CSQLHelper::GetPreferencesVar(const std::string& Key, std::string& sValue)
 	if (!m_dbase)
 		return false;
 
-
 	std::vector<std::vector<std::string> > result;
 	result = safe_query("SELECT sValue FROM Preferences WHERE (Key='%q')",
 		Key.c_str());
@@ -5066,7 +5065,6 @@ bool CSQLHelper::GetPreferencesVar(const std::string& Key, std::string& sValue)
 
 bool CSQLHelper::GetPreferencesVar(const std::string& Key, double& Value)
 {
-
 	std::string sValue;
 	int nValue;
 	Value = 0;
@@ -5097,6 +5095,7 @@ bool CSQLHelper::GetPreferencesVar(const std::string& Key, int& nValue)
 	std::string sValue;
 	return GetPreferencesVar(Key, nValue, sValue);
 }
+
 void CSQLHelper::DeletePreferencesVar(const std::string& Key)
 {
 	std::string sValue;
@@ -8423,6 +8422,22 @@ void CSQLHelper::DeleteUserVariable(const std::string& idx)
 	}
 }
 
+bool CSQLHelper::GetUserVariable(const std::string& varname, const _eUsrVariableType eVartype, std::string& varvalue)
+{
+	std::string errorMessage;
+	std::vector<std::vector<std::string> > result;
+	result = safe_query("SELECT ValueType, Value FROM UserVariables WHERE (Name=='%q')", varname.c_str());
+	if (!result.empty())
+	{
+		if(CheckUserVariable(eVartype, result[0][1], errorMessage))
+		{
+			varvalue = result[0][1];
+			return true;
+		}
+	}
+	return false;
+}
+
 bool CSQLHelper::AddUserVariable(const std::string& varname, const _eUsrVariableType eVartype, const std::string& varvalue, std::string& errorMessage)
 {
 	std::vector<std::vector<std::string> > result;
@@ -8472,7 +8487,6 @@ bool CSQLHelper::UpdateUserVariable(const std::string& idx, const std::string& v
 
 bool CSQLHelper::CheckUserVariable(const _eUsrVariableType eVartype, const std::string& varvalue, std::string& errorMessage)
 {
-
 	if (varvalue.size() > 200) {
 		errorMessage = "String exceeds maximum size";
 		return false;

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -401,6 +401,7 @@ public:
 	bool AddUserVariable(const std::string &varname, const _eUsrVariableType eVartype, const std::string &varvalue, std::string &errorMessage);
 	bool UpdateUserVariable(const std::string &idx, const std::string &varname, const _eUsrVariableType eVartype, const std::string &varvalue, const bool eventtrigger, std::string &errorMessage);
 	void DeleteUserVariable(const std::string &idx);
+	bool GetUserVariable(const std::string& varname, const _eUsrVariableType eVartype, std::string& varvalue);
 	bool CheckUserVariable(const _eUsrVariableType eVartype, const std::string &varvalue, std::string &errorMessage);
 
 	uint64_t CreateDevice(const int HardwareID, const int SensorType, const int SensorSubType, std::string &devname, const unsigned long nid, const std::string &soptions);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2947,23 +2947,23 @@ namespace http {
 				sValue.clear();
 			}
 
-			root["Forecastdevice"] = "0";
-			if (m_sql.GetUserVariable("forecastdevice", USERVARTYPE_INTEGER, sValue))
+			root["Forecasthardware"] = "0";
+			if (m_sql.GetUserVariable("forecasthardware", USERVARTYPE_INTEGER, sValue))
 			{
-				root["Forecastdevice"] = sValue;
+				root["Forecasthardware"] = sValue;
 				sValue = "";
 				sValue.clear();
 			}
 
-			if (root["Forecastdevice"] != "0")
+			if (root["Forecasthardware"] != "0")
 			{
-				int iHardwareID = atoi(root["Forecastdevice"].asString().c_str());
+				int iHardwareID = atoi(root["Forecasthardware"].asString().c_str());
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 				if (pHardware != NULL)
 				{
 					if (pHardware->HwdType == HTYPE_OpenWeatherMap)
 					{
-						root["Forecastdevicetype"] = HTYPE_OpenWeatherMap;
+						root["Forecasthardwaretype"] = HTYPE_OpenWeatherMap;
 						COpenWeatherMap *pWHardware = reinterpret_cast<COpenWeatherMap*>(pHardware);
 						forecast_url = pWHardware->GetForecastURL();
 						if (forecast_url != "")
@@ -2979,7 +2979,7 @@ namespace http {
 					}
 					else if (pHardware->HwdType == HTYPE_BuienRadar)
 					{
-						root["Forecastdevicetype"] = HTYPE_BuienRadar;
+						root["Forecasthardwaretype"] = HTYPE_BuienRadar;
 						CBuienRadar *pWHardware = reinterpret_cast<CBuienRadar*>(pHardware);
 						forecast_url = pWHardware->GetForecastURL();
 						if (forecast_url != "")
@@ -2989,17 +2989,17 @@ namespace http {
 					}
 					else
 					{
-						root["Forecastdevice"] = "0";	// reset to 0
+						root["Forecasthardware"] = "0";	// reset to 0
 					}
 				}
 				else
 				{
-					_log.Debug(DEBUG_WEBSERVER, "Forecastconfig: Could not find hardware (not active?) for ID %s!", root["Forecastdevice"].asString().c_str());
-					root["Forecastdevice"] = "0";	// reset to 0
+					_log.Debug(DEBUG_WEBSERVER, "Forecastconfig: Could not find hardware (not active?) for ID %s!", root["Forecasthardware"].asString().c_str());
+					root["Forecasthardware"] = "0";	// reset to 0
 				}
 			}
 
-			if (root["Forecastdevice"] == "0" && iSucces == 1)
+			if (root["Forecasthardware"] == "0" && iSucces == 1)
 			{
 				// No forecast device, but we have geo coords, so enough for fallback
 				iSucces++;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2971,6 +2971,11 @@ namespace http {
 							sFURL = forecast_url;
 							iFrame = false;
 						}
+						Json::Value forecast_data = pWHardware->GetForecastData();
+						if (!forecast_data.empty())
+						{
+							root["Forecastdata"] = forecast_data;
+						}
 					}
 					else if (pHardware->HwdType == HTYPE_BuienRadar)
 					{
@@ -2996,30 +3001,12 @@ namespace http {
 
 			if (root["Forecastdevice"] == "0" && iSucces == 1)
 			{
-				// This is the fallback URL at the moment (DarkSky)
-				sURL << "//forecast.io/embed/#lat=";
-				sURL << Latitude << "&lon=" << Longitude;
-				sURL << "&units=ca&color=#00aaff";
-
-				sFURL = ss.str();
+				// No forecast device, but we have geo coords, so enough for fallback
+				iSucces++;
 			}
-
-			if (!sFURL.empty())
+			else if (!sFURL.empty())
 			{
-				if (iFrame)
-				{
-					ss << "<iframe style=" << "\"" << "background: #fff; height:245px;" << "\"";
-					ss << " class=" << "\"" << "cIFrameLarge" << "\"";
-					ss << " id=" << "\"" << "IMain" << "\"";
-					ss << " src=" << "\"" << sFURL << "\"" << ">"; 
-					ss << "</iframe>";
-				}
-				else
-				{
-					ss << sFURL;
-				}
-
-				root["Forecasturl"] = ss.str();
+				root["Forecasturl"] = sFURL;
 				iSucces++;
 			}
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2939,6 +2939,12 @@ namespace http {
 			root["Longitude"] = Longitude;
 
 			root["Forecastdevice"] = "0";
+			sValue = "";
+			sValue.clear();
+			if (m_sql.GetUserVariable("forecastdevice", USERVARTYPE_INTEGER, sValue))
+			{
+				root["Forecastdevice"] = sValue;
+			}
 		}
 
 		void CWebServer::Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -516,6 +516,7 @@ namespace http {
 
 			RegisterCommandCode("getconfig", boost::bind(&CWebServer::Cmd_GetConfig, this, _1, _2, _3), true);
 			RegisterCommandCode("getlocation", boost::bind(&CWebServer::Cmd_GetLocation, this, _1, _2, _3));
+			RegisterCommandCode("getforecastconfig", boost::bind(&CWebServer::Cmd_GetForecastConfig, this, _1, _2, _3));
 			RegisterCommandCode("sendnotification", boost::bind(&CWebServer::Cmd_SendNotification, this, _1, _2, _3));
 			RegisterCommandCode("emailcamerasnapshot", boost::bind(&CWebServer::Cmd_EmailCameraSnapshot, this, _1, _2, _3));
 			RegisterCommandCode("udevice", boost::bind(&CWebServer::Cmd_UpdateDevice, this, _1, _2, _3));
@@ -2883,6 +2884,7 @@ namespace http {
 			}
 		}
 
+		// Could now be obsolete as only 1 usage was found in Forecast screen, which now uses other command
 		void CWebServer::Cmd_GetLocation(WebEmSession& session, const request& req, Json::Value& root)
 		{
 			if (session.rights == -1)
@@ -2890,6 +2892,7 @@ namespace http {
 				session.reply_status = reply::forbidden;
 				return;//Only auth user allowed
 			}
+			root["title"] = "GetLocation";
 			std::string Latitude = "1";
 			std::string Longitude = "1";
 			std::string sValue;
@@ -2902,10 +2905,40 @@ namespace http {
 				{
 					Latitude = strarray[0];
 					Longitude = strarray[1];
+					root["status"] = "OK";
 				}
 			}
 			root["Latitude"] = Latitude;
 			root["Longitude"] = Longitude;
+		}
+
+		void CWebServer::Cmd_GetForecastConfig(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			if (session.rights == -1)
+			{
+				session.reply_status = reply::forbidden;
+				return;//Only auth user allowed
+			}
+			root["title"] = "GetForecastConfig";
+			std::string Latitude = "1";
+			std::string Longitude = "1";
+			std::string sValue;
+			if (m_sql.GetPreferencesVar("Location", sValue))
+			{
+				std::vector<std::string> strarray;
+				StringSplit(sValue, ";", strarray);
+
+				if (strarray.size() == 2)
+				{
+					Latitude = strarray[0];
+					Longitude = strarray[1];
+					root["status"] = "OK";
+				}
+			}
+			root["Latitude"] = Latitude;
+			root["Longitude"] = Longitude;
+
+			root["Forecastdevice"] = "0";
 		}
 
 		void CWebServer::Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2925,6 +2925,7 @@ namespace http {
 			std::string sValue, sFURL, forecast_url;
 			std::stringstream ss, sURL;
 			uint8_t iSucces = 0;
+			bool iFrame = true;
 
 			root["title"] = "GetForecastConfig";
 			root["status"] = "Error";
@@ -2968,6 +2969,7 @@ namespace http {
 						if (forecast_url != "")
 						{
 							sFURL = forecast_url;
+							iFrame = false;
 						}
 					}
 					else if (pHardware->HwdType == HTYPE_BuienRadar)
@@ -2994,6 +2996,7 @@ namespace http {
 
 			if (root["Forecastdevice"] == "0" && iSucces == 1)
 			{
+				// This is the fallback URL at the moment (DarkSky)
 				sURL << "//forecast.io/embed/#lat=";
 				sURL << Latitude << "&lon=" << Longitude;
 				sURL << "&units=ca&color=#00aaff";
@@ -3003,11 +3006,19 @@ namespace http {
 
 			if (!sFURL.empty())
 			{
-				ss << "<iframe style=" << "\"" << "background: #fff; height:245px;" << "\"";
-				ss << " class=" << "\"" << "cIFrameLarge" << "\"";
-				ss << " id=" << "\"" << "IMain" << "\"";
-				ss << " src=" << "\"" << sFURL << "\"" << ">"; 
-				ss << "</iframe>";
+				if (iFrame)
+				{
+					ss << "<iframe style=" << "\"" << "background: #fff; height:245px;" << "\"";
+					ss << " class=" << "\"" << "cIFrameLarge" << "\"";
+					ss << " id=" << "\"" << "IMain" << "\"";
+					ss << " src=" << "\"" << sFURL << "\"" << ">"; 
+					ss << "</iframe>";
+				}
+				else
+				{
+					ss << sFURL;
+				}
+
 				root["Forecasturl"] = ss.str();
 				iSucces++;
 			}

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -189,6 +189,7 @@ private:
 	void Cmd_GetNewHistory(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetConfig(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_GetLocation(WebEmSession& session, const request& req, Json::Value& root);
+	void Cmd_GetForecastConfig(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_SendNotification(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_EmailCameraSnapshot(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateDevice(WebEmSession & session, const request& req, Json::Value &root);

--- a/www/app/ForecastController.js
+++ b/www/app/ForecastController.js
@@ -15,17 +15,43 @@ define(['app'], function (app) {
 			}).then(function successCallback(response) {
 				var data = response.data;
 				var htmlcontent = '<b>Error loading config or incorrect config data!</b>';
+
 				if (typeof data.status != 'undefined' && data.status == 'OK') {
-					if (typeof data.Forecasturl != 'undefined' && data.Forecasturl != '') {
-						htmlcontent = data.Forecasturl;
-					} else if (typeof data.Forecastdata != 'undefined' ) {
-						htmlcontent = 'Using forecastdevice ' + data.Forecastdata;
-					} else {
-						htmlcontent = 'Neither a forecast URL or valid forecast data provided!';
+					var fallbackurl = "//forecast.io/embed/#lat=" + data.Latitude + "&lon=" + data.Longitude + "&units=ca&color=#00aaff";
+					var fallbackhtml = '<iframe style="background: #fff; height:245px;" class="cIFrame" id="IMain" src="' + fallbackurl + '"></iframe>';
+					if (typeof data.Forecastdata != 'undefined' ) {
+						if (data.Forecastdevicetype == 83) { // OpenWeatherMap
+							htmlcontent = 'Using forecastdevice ' + data.Forecastdata;
+							htmlcontent = '<script src="//openweathermap.org/themes/openweathermap/assets/vendor/owm/js/d3.min.js"></script>';
+							htmlcontent += '<script>window.myWidgetParam ? window.myWidgetParam : window.myWidgetParam = [];';
+							htmlcontent += 'window.myWidgetParam.push({id: 21,cityid: ' + data.Forecastdata.cityid + ',appid: "' + data.Forecastdata.appid + '",units: "metric",containerid: "openweathermap-widget-21",  });';
+							htmlcontent += ' (function() {var script = document.createElement("script");script.async = true;script.charset = "utf-8";script.src = "//openweathermap.org/themes/openweathermap/assets/vendor/owm/js/weather-widget-generator.js";';
+							htmlcontent += 'var s = document.getElementsByTagName("script")[0];s.parentNode.insertBefore(script, s);  })();</script>';
+							$('#openweathermap-widget-21').html(htmlcontent);
+							$('#openweathermap-widget-21').i18n();
+							$scope.showOWM = true;
+						} else {
+							htmlcontent = 'Forecastdata for devicetype ' + data.Forecastdevicetype + ' is not supported!';
+							$scope.showFallback = true;
+						}
+					} else if (typeof data.Forecasturl != 'undefined' && data.Forecasturl != '') {
+						if (data.Forecasturl.substr(0,4) == 'http') {
+							htmlcontent = '<iframe class="cIFrame" id="IMain" src="' + data.Forecasturl + '"></iframe>';
+						} else {
+							htmlcontent = data.Forecasturl;
+						}
+						$scope.showFallback = true;
+					} else  {
+						htmlcontent = fallbackhtml;
+						$scope.showFallback = true;
 					}
+					$('#fallback').html(htmlcontent);
+					$('#fallback').i18n();
+				} else {
+					$scope.showFallback = true;
+					$('#fallback').html(htmlcontent);
+					$('#fallback').i18n();
 				}
-				$('#maincontent').html(htmlcontent);
-				$('#maincontent').i18n();
 			});
 		};
 	}]);

--- a/www/app/ForecastController.js
+++ b/www/app/ForecastController.js
@@ -5,31 +5,32 @@ define(['app'], function (app) {
 		function init() {
 			$scope.MakeGlobalConfig();
 			$http({
-				url: "json.htm?type=command&param=getlocation",
+				url: "json.htm?type=command&param=getforecastconfig",
 				async: true,
 				dataType: 'json'
 			}).then(function successCallback(response) {
 				var data = response.data;
-				if (typeof data.Latitude != 'undefined') {
-					var htmlcontent = '';
-					var units = "ca24";
-					if ($rootScope.config.TempSign == "F") {
-						units = "us12";
+				var htmlcontent = '<b>Error loading config</b>';
+				if (typeof data.status != 'undefined' && data.status == 'OK') {
+					if (typeof data.Forecastdevice == 'undefined' || (typeof data.Forecastdevice != 'undefined' && data.Forecastdevice == 0)) {
+						var units = "ca24";
+						if ($rootScope.config.TempSign == "F") {
+							units = "us12";
+						} else {
+							if ($rootScope.config.WindSign == "m/s")
+								units = "si24";
+							else if ($rootScope.config.WindSign == "km/h")
+								units = "ca24";
+							else if ($rootScope.config.WindSign == "mph")
+								units = "uk224";
+						}
+						htmlcontent = '<iframe style="background: #fff; height:245px;" class="cIFrameLarge" id="IMain" src="//forecast.io/embed/#lat=' + data.Latitude + '&lon=' + data.Longitude + '&units=ca&color=#00aaff"></iframe>';
 					} else {
-						if ($rootScope.config.WindSign == "m/s")
-							units = "si24";
-						else if ($rootScope.config.WindSign == "km/h")
-							units = "ca24";
-						else if ($rootScope.config.WindSign == "mph")
-							units = "uk224";
+						htmlcontent = 'Using forecastdevice ' + data.Forecastdevice;
 					}
-					//htmlcontent += '<iframe class="cIFrameLarge" id="IMain" src="//darksky.net/forecast/' + data.Latitude + ',' + data.Longitude + '/' + units + '/' + $rootScope.config.language + '"></iframe>';
-					htmlcontent += '<iframe style="background: #fff; height:245px;" class="cIFrameLarge" id="IMain" src="//forecast.io/embed/#lat=' + data.Latitude + '&lon=' + data.Longitude + '&units=ca&color=#00aaff"></iframe>';
-					//htmlcontent += '<iframe class="cIFrameLarge" id="IMain" src="//forecast.io/embed/#lat=42.3583&lon=-71.0603&color=#00aaff&units=ca"></iframe>';
-					//console.log(htmlcontent);
-					$('#maincontent').html(htmlcontent);
-					$('#maincontent').i18n();
 				}
+				$('#maincontent').html(htmlcontent);
+				$('#maincontent').i18n();
 			});
 		};
 	}]);

--- a/www/app/ForecastController.js
+++ b/www/app/ForecastController.js
@@ -10,23 +10,14 @@ define(['app'], function (app) {
 				dataType: 'json'
 			}).then(function successCallback(response) {
 				var data = response.data;
-				var htmlcontent = '<b>Error loading config</b>';
+				var htmlcontent = '<b>Error loading config or incorrect config data!</b>';
 				if (typeof data.status != 'undefined' && data.status == 'OK') {
-					if (typeof data.Forecastdevice == 'undefined' || (typeof data.Forecastdevice != 'undefined' && data.Forecastdevice == 0)) {
-						var units = "ca24";
-						if ($rootScope.config.TempSign == "F") {
-							units = "us12";
-						} else {
-							if ($rootScope.config.WindSign == "m/s")
-								units = "si24";
-							else if ($rootScope.config.WindSign == "km/h")
-								units = "ca24";
-							else if ($rootScope.config.WindSign == "mph")
-								units = "uk224";
-						}
-						htmlcontent = '<iframe style="background: #fff; height:245px;" class="cIFrameLarge" id="IMain" src="//forecast.io/embed/#lat=' + data.Latitude + '&lon=' + data.Longitude + '&units=ca&color=#00aaff"></iframe>';
+					if (typeof data.Forecasturl != 'undefined' && data.Forecasturl != '') {
+						htmlcontent = data.Forecasturl;
+					} else if (typeof data.Forecastdata != 'undefined' ) {
+						htmlcontent = 'Using forecastdevice ' + data.Forecastdata;
 					} else {
-						htmlcontent = 'Using forecastdevice ' + data.Forecastdevice;
+						htmlcontent = 'Neither a forecast URL or valid forecast data provided!';
 					}
 				}
 				$('#maincontent').html(htmlcontent);

--- a/www/app/ForecastController.js
+++ b/www/app/ForecastController.js
@@ -2,6 +2,10 @@ define(['app'], function (app) {
 	app.controller('ForecastController', ['$scope', '$rootScope', '$location', '$http', '$interval', function ($scope, $rootScope, $location, $http, $interval) {
 		init();
 
+		goBack = function () {
+			SwitchLayout("Dashboard");
+		}
+
 		function init() {
 			$scope.MakeGlobalConfig();
 			$http({

--- a/www/app/ForecastController.js
+++ b/www/app/ForecastController.js
@@ -3,7 +3,7 @@ define(['app'], function (app) {
 		init();
 
 		goBack = function () {
-			SwitchLayout("Dashboard");
+			SwitchLayout("Weather");
 		}
 
 		function init() {
@@ -20,37 +20,39 @@ define(['app'], function (app) {
 					var fallbackurl = "//forecast.io/embed/#lat=" + data.Latitude + "&lon=" + data.Longitude + "&units=ca&color=#00aaff";
 					var fallbackhtml = '<iframe style="background: #fff; height:245px;" class="cIFrame" id="IMain" src="' + fallbackurl + '"></iframe>';
 					if (typeof data.Forecastdata != 'undefined' ) {
-						if (data.Forecastdevicetype == 83) { // OpenWeatherMap
-							htmlcontent = 'Using forecastdevice ' + data.Forecastdata;
-							htmlcontent = '<script src="//openweathermap.org/themes/openweathermap/assets/vendor/owm/js/d3.min.js"></script>';
+						if (data.Forecasthardwaretype == 83) { // OpenWeatherMap
+							htmlcontent = '<div id="openweathermap-widget-21"></div>';
+							htmlcontent += '<script src="https://openweathermap.org/themes/openweathermap/assets/vendor/owm/js/d3.min.js"></script>';
 							htmlcontent += '<script>window.myWidgetParam ? window.myWidgetParam : window.myWidgetParam = [];';
 							htmlcontent += 'window.myWidgetParam.push({id: 21,cityid: ' + data.Forecastdata.cityid + ',appid: "' + data.Forecastdata.appid + '",units: "metric",containerid: "openweathermap-widget-21",  });';
-							htmlcontent += ' (function() {var script = document.createElement("script");script.async = true;script.charset = "utf-8";script.src = "//openweathermap.org/themes/openweathermap/assets/vendor/owm/js/weather-widget-generator.js";';
+							htmlcontent += ' (function() {var script = document.createElement("script");script.async = true;script.charset = "utf-8";script.src = "https://openweathermap.org/themes/openweathermap/assets/vendor/owm/js/weather-widget-generator.js";';
 							htmlcontent += 'var s = document.getElementsByTagName("script")[0];s.parentNode.insertBefore(script, s);  })();</script>';
-							$('#openweathermap-widget-21').html(htmlcontent);
-							$('#openweathermap-widget-21').i18n();
+							$('#openweathermap').html(htmlcontent);
+							$('#openweathermap').i18n();
 							$scope.showOWM = true;
 						} else {
-							htmlcontent = 'Forecastdata for devicetype ' + data.Forecastdevicetype + ' is not supported!';
+							htmlcontent = 'Forecastdata for hardwaretype ' + data.Forecasthardwaretype + ' is not supported!';
+							$('#fallback').html(htmlcontent);
+							$('#fallback').i18n();
 							$scope.showFallback = true;
 						}
-					} else if (typeof data.Forecasturl != 'undefined' && data.Forecasturl != '') {
-						if (data.Forecasturl.substr(0,4) == 'http') {
-							htmlcontent = '<iframe class="cIFrame" id="IMain" src="' + data.Forecasturl + '"></iframe>';
-						} else {
-							htmlcontent = data.Forecasturl;
-						}
-						$scope.showFallback = true;
-					} else  {
+					} else { 
 						htmlcontent = fallbackhtml;
+						if (typeof data.Forecasturl != 'undefined' && data.Forecasturl != '') {
+							if (data.Forecasturl.substr(0,4) == 'http') {
+								htmlcontent = '<iframe class="cIFrame" id="IMain" src="' + data.Forecasturl + '"></iframe>';
+							} else {
+								htmlcontent = data.Forecasturl;
+							}
+						}
+						$('#fallback').html(htmlcontent);
+						$('#fallback').i18n();
 						$scope.showFallback = true;
 					}
-					$('#fallback').html(htmlcontent);
-					$('#fallback').i18n();
 				} else {
-					$scope.showFallback = true;
 					$('#fallback').html(htmlcontent);
 					$('#fallback').i18n();
+					$scope.showFallback = true;
 				}
 			});
 		};

--- a/www/views/forecast.html
+++ b/www/views/forecast.html
@@ -15,8 +15,6 @@
 		<h2>No forecast information available. Please check settings.</h2>
 	</div>
 
-	<div id="openweathermap" ng-show="showOWM" class="ng-hide">
-		<div id="openweathermap-widget-21">Here the OpenWeatherMap widget of your location should be shown!</div>
-	</div>
+	<div id="openweathermap" ng-show="showOWM" class="ng-hide">Here the OpenWeatherMap widget of your location should be shown!</div>
 
 </div>

--- a/www/views/forecast.html
+++ b/www/views/forecast.html
@@ -1,2 +1,16 @@
-<div id="maincontent">
+<div class="container">
+
+	<div id="forecasttophtm">
+		<table class="bannav" id="bannav" border="0" cellpadding="0" cellspacing="0" width="100%">
+			<tr>
+				<td align="left" valign="top" id="timesun"></td>
+				<td ng-show="config.Latitude!=''" style="width: 150px;" align="right">
+					<a id="Back" class="btnstyle" onclick="goBack()" data-i18n="Back">Back</a>
+				</td>
+			</tr>
+		</table>
+	</div>
+
+    <div id="maincontent" align="center"><h2>No forecast information available. Please check settings.</h2></div>
+
 </div>

--- a/www/views/forecast.html
+++ b/www/views/forecast.html
@@ -11,6 +11,12 @@
 		</table>
 	</div>
 
-    <div id="maincontent" align="center"><h2>No forecast information available. Please check settings.</h2></div>
+	<div id="fallback" align="center" ng-show="showFallback">
+		<h2>No forecast information available. Please check settings.</h2>
+	</div>
+
+	<div id="openweathermap" ng-show="showOWM" class="ng-hide">
+		<div id="openweathermap-widget-21">Here the OpenWeatherMap widget of your location should be shown!</div>
+	</div>
 
 </div>


### PR DESCRIPTION
This PR tries to improve the currently very limited Weather forecast screen in the Domoticz UI. It was limited to just show the DarkSky 7 day forecast of the Domoticz home location (from the settings).

Most of the Weather hardware modules (AccuWeather, DarkSky, OpenWeatherMap, BuienRadar, etc.) have a 'GetForecastURL' method implemented but that isn't used (anymore? Maybe once was, but now it isn't as far as I could find).

This PR covers the following:

- UI: Forecast controller tries to make smart use of the Forecast information from the Webserver

- UI: Forecast view shows a back button and supports different divs per hardware module and has a fallback (still DarkSky)

- Webserver: Now support a new (JSON command) call 'getforecastconfig' which return a JSON object with weather forecast data from a configured active hardware module

- Webserver: The 'getforecastconfig' command now looks for an optional UserVariable called 'forecasthardware' (integer) which should hold the hardware index number of a Weather hardware module. If found, the Weather hardware that this variable points to, will be used to get the Forecast information from.

- Webserver: For the hardware modules Buienradar and OpenWeatherMap, the new 'getforecastconfig' command retrieves the available forecast data. For not (yet) supported modules, it defaults to only basic Domoticz home location data as before. (Used by the currently default DarkSky fallback).

- Webserver: Fixed _broken_ 'getlocation' command. It did work, but also returned status ERROR instead of OK. Now it works again, but it seemed only used by the 'forecast controller' which now uses the new function. So maybe this function/command can be removed from the Webserver as I did not find any other usages of this command? (@gizmocuz any ideas?)

- OpenWeatherMap: Implemented a new public function 'getForecastData' that returns not only a possible URL, but more details like the location as configured by the module (which could be different than the Domoticz home location), cityid if available, location name, hardwaretype (OpenWeatherMap), etc. for use by the UI (forecastcontroller)


NOTE: this PR can be seen as Beta as not everything works as it should. As I am not a UI/AngularJS wizard, I definitely could use some help on that part (@michahagg, @gizmocuz ?).
BUT: it does at least work as good (or bad ;)) as the existing functionality so it is not a step back :)

New NOTE (19-10-2020): **out-of-Beta** :) OpenWeatherMap widget or Buienradar widget shown when hardware module is selected. 

To-do (or should/could):

- _Get the OpenWeatherMap widget working by having Angular pass the variables in a correct way_ -> **Fixed**

- Instead of using a UserVariable, make the selection of a Weather hardware device to use for Forecast data, something that can be done in the settings tab (and make it a PreferencesVariable).
