### PR TITLE
Hardware Monitor, more code cleanup and less system/compiletime specific code

### DIFF
--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -137,7 +137,7 @@ bool CHardwareMonitor::StopHardware()
 
 void CHardwareMonitor::Do_Work()
 {
-	Log(LOG_STATUS, "Hardware Monitor: Started (OStype %d)", m_OStype);
+	Log(LOG_STATUS, "Hardware Monitor: Started (OStype %s)", TranslateOSTypeToString(m_OStype).c_str());
 
 	int msec_counter = 0;
 	int64_t sec_counter = 140 - 2;	// Start at a moment that is close to most devicecheck intervals
@@ -461,6 +461,40 @@ bool CHardwareMonitor::GetOSType(nOSType &OStype)
 	if (OStype == OStype_Unknown)
 		return false;
 	return true;
+}
+
+std::string CHardwareMonitor::TranslateOSTypeToString(nOSType OSType)
+{
+	std::string sOSType = "Unknown";
+
+	switch (OSType)
+	{
+		case OStype_Linux:
+			sOSType = "Linux";
+			break;
+		case OStype_Rpi:
+			sOSType = "Raspberry Pi Linux";
+			break;
+		case OStype_WSL:
+			sOSType = "WSL Linux";
+			break;
+		case OStype_CYGWIN:
+			sOSType = "CYGWIN Linux";
+			break;
+		case OStype_FreeBSD:
+			sOSType = "FreeBSD";
+			break;
+		case OStype_OpenBSD:
+			sOSType = "OpenBSD";
+			break;
+		case OStype_Windows:
+			sOSType = "Windows";
+			break;
+		case OStype_Apple:
+			sOSType = "Apple";
+			break;
+	}
+	return sOSType;
 }
 
 void CHardwareMonitor::FetchCPU()
@@ -1041,7 +1075,6 @@ void CHardwareMonitor::CheckForOnboardSensors()
 	returncode == 0 ?
 		m_dfcommand = "df -x nfs -x tmpfs -x devtmpfs" :
 		m_dfcommand = "df";
-
 #endif
 
 #if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__)
@@ -1105,6 +1138,10 @@ void CHardwareMonitor::CheckForOnboardSensors()
 	{
 		Debug(DEBUG_NORM,"System does not seem to be a Raspberry Pi");
 	}
+	else
+	{
+		m_OStype = OStype_Rpi;
+	}
 
 	if (!bHasInternalTemperature)
 	{
@@ -1154,7 +1191,6 @@ void CHardwareMonitor::CheckForOnboardSensors()
 	bHasInternalTemperature = true;
 	szInternalVoltageCommand = "sysctl hw.sensors.acpibat0.volt1|sed -e 's/.*volt1/volt/'|cut -d ' ' -f 1";
 	bHasInternalVoltage = true;
-	//bHasInternalCurrent = true;
 #endif
 
 }

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -28,6 +28,7 @@ public:
 	~CHardwareMonitor(void);
 	bool WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/) override { return false; };
 	bool GetOSType(nOSType &OStype);
+	std::string TranslateOSTypeToString(nOSType);
 private:
 	bool StartHardware() override;
 	bool StopHardware() override;

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -43,8 +43,14 @@ private:
 	void FetchUnixMemory();
 	void FetchUnixDisk();
 	void CheckForOnboardSensors();
+	double time_so_far();
 #if defined (__linux__)
 	float GetProcessMemUsage();
+	float GetMemUsageLinux();
+	bool IsWSL();
+#endif
+#if defined (__FreeBSD__) || defined(__OpenBSD__)
+	float GetMemUsageOpenBSD();
 #endif
 	long long m_lastloadcpu;
 	int m_totcpu;

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -50,6 +50,7 @@ private:
 	void CheckForOnboardSensors();
 	void UpdateSystemSensor(const std::string& qType, const int dindex, const std::string& devName, const std::string& devValue);
 	void SendCurrent(const unsigned long Idx, const float Curr, const std::string &defaultname);
+	bool IsWSL();
 
 	struct _tDUsageStruct
 	{
@@ -93,7 +94,6 @@ private:
 #if defined (__linux__)
 	float GetProcessMemUsage();
 	float GetMemUsageLinux();
-	bool IsWSL();
 #endif
 #if defined (__FreeBSD__) || defined(__OpenBSD__)
 	float GetMemUsageOpenBSD();

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1126,7 +1126,6 @@ std::string SafeHtml(const std::string &txt)
     return sRet;
 }
 
-
 #if defined WIN32
 //FILETIME of Jan 1 1970 00:00:00
 static const uint64_t epoch = (const uint64_t)(116444736000000000);
@@ -1406,44 +1405,6 @@ bool IsDebuggerPresent(void)
 	return false;
 #	endif
 #endif
-}
-#endif
-
-#if defined(__linux__)
-bool IsWSL(void)
-{
-	// Detect WSL according to https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
-	bool is_wsl = false;
-
-	char buf[1024];
-
-	int status_fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
-	if (status_fd == -1)
-		return is_wsl;
-
-	ssize_t num_read = read(status_fd, buf, sizeof(buf) - 1);
-
-	if (num_read > 0)
-	{
-		buf[num_read] = 0;
-		is_wsl |= (strstr(buf, "Microsoft") != NULL);
-		is_wsl |= (strstr(buf, "WSL") != NULL);
-	}
-
-	status_fd = open("/proc/version", O_RDONLY);
-	if (status_fd == -1)
-		return is_wsl;
-
-	num_read = read(status_fd, buf, sizeof(buf) - 1);
-
-	if (num_read > 0)
-	{
-		buf[num_read] = 0;
-		is_wsl |= (strstr(buf, "Microsoft") != NULL);
-		is_wsl |= (strstr(buf, "WSL") != NULL);
-	}
-
-	return is_wsl;
 }
 #endif
 

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -470,112 +470,6 @@ void GetAppVersion()
 	szAppDate = szTmp;
 }
 
-/*
-#if !defined WIN32
-void CheckForOnboardSensors()
-{
-	//Check if we are running on a RaspberryPi
-	std::string sLine = "";
-	std::ifstream infile;
-
-#if defined(__FreeBSD__)
-	infile.open("/compat/linux/proc/cpuinfo");
-#else
-	infile.open("/proc/cpuinfo");
-#endif
-	if (infile.is_open())
-	{
-		while (!infile.eof())
-		{
-			getline(infile, sLine);
-			if (
-				(sLine.find("BCM2708") != std::string::npos) ||
-				(sLine.find("BCM2709") != std::string::npos) ||
-				(sLine.find("BCM2711") != std::string::npos) ||
-				(sLine.find("BCM2835") != std::string::npos)
-
-				)
-			{
-				_log.Log(LOG_STATUS, "System: Raspberry Pi");
-				//Check if we have vcgencmd (are running on a RaspberryPi)
-				//
-				int returncode = 0;
-				std::vector<std::string> ret = ExecuteCommandAndReturn(VCGENCMDTEMPCOMMAND, returncode);
-
-				if (ret.empty()) {
-					_log.Log(LOG_STATUS,"It seems vcgencmd is not installed. If you would like use the hardware monitor, consider installing this!");
-				}
-				else {
-					std::string tmpline = ret[0];
-					if (tmpline.find("temp=") == std::string::npos) {
-						_log.Log(LOG_STATUS, "It seems vcgencmd is not installed. If you would like use the hardware monitor, consider installing this!");
-					}
-					else {
-						//Core temperature of BCM2835 SoC
-						szInternalTemperatureCommand = VCGENCMDTEMPCOMMAND;
-						bHasInternalTemperature = true;
-
-						//PI Clock speeds	
-						szInternalARMSpeedCommand = VCGENCMDARMSPEEDCOMMAND;
-						szInternalV3DSpeedCommand = VCGENCMDV3DSPEEDCOMMAND;
-						szInternalCoreSpeedCommand = VCGENCMDCORESPEEDCOMMAND;
-						bHasInternalClockSpeeds = true;
-					}
-				}
-			}
-		}
-		infile.close();
-	}
-
-	if (!bHasInternalTemperature)
-	{
-		if (file_exist("/sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input"))
-		{
-			_log.Log(LOG_STATUS, "System: Cubieboard/Cubietruck");
-			szInternalTemperatureCommand = "cat /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input | awk '{ printf (\"temp=%0.2f\\n\",$1/1000); }'";
-			bHasInternalTemperature = true;
-		}
-		else if (file_exist("/sys/devices/virtual/thermal/thermal_zone0/temp"))
-		{
-			//_log.Log(LOG_STATUS,"System: ODroid");
-			szInternalTemperatureCommand = "cat /sys/devices/virtual/thermal/thermal_zone0/temp | awk '{ if ($1 < 100) printf(\"temp=%d\\n\",$1); else printf (\"temp=%0.2f\\n\",$1/1000); }'";
-			bHasInternalTemperature = true;
-		}
-	}
-	if (file_exist("/sys/class/power_supply/ac/voltage_now"))
-	{
-		szInternalVoltageCommand = "cat /sys/class/power_supply/ac/voltage_now | awk '{ printf (\"volt=%0.2f\\n\",$1/1000000); }'";
-		bHasInternalVoltage = true;
-	}
-	if (file_exist("/sys/class/power_supply/ac/current_now"))
-	{
-		szInternalCurrentCommand = "cat /sys/class/power_supply/ac/current_now | awk '{ printf (\"curr=%0.2f\\n\",$1/1000000); }'";
-		bHasInternalCurrent = true;
-	}
-	//New Armbian Kernal 4.14+
-	if (file_exist("/sys/class/power_supply/axp20x-ac/voltage_now"))
-	{
-		szInternalVoltageCommand = "cat /sys/class/power_supply/axp20x-ac/voltage_now | awk '{ printf (\"volt=%0.2f\\n\",$1/1000000); }'";
-		bHasInternalVoltage = true;
-	}
-	if (file_exist("/sys/class/power_supply/axp20x-ac/current_now"))
-	{
-		szInternalCurrentCommand = "cat /sys/class/power_supply/axp20x-ac/current_now | awk '{ printf (\"curr=%0.2f\\n\",$1/1000000); }'";
-		bHasInternalCurrent = true;
-	}
-
-#if defined (__OpenBSD__)
-	szInternalTemperatureCommand = "sysctl hw.sensors.acpitz0.temp0|sed -e 's/.*temp0/temp/'|cut -d ' ' -f 1";
-	bHasInternalTemperature = true;
-	szInternalVoltageCommand = "sysctl hw.sensors.acpibat0.volt1|sed -e 's/.*volt1/volt/'|cut -d ' ' -f 1";
-	bHasInternalVoltage = true;
-	//bHasInternalCurrent = true;
-
-#endif
-}
-#endif
-*/
-
 bool GetConfigBool(std::string szValue)
 {
 	stdlower(szValue);
@@ -847,9 +741,6 @@ int main(int argc, char**argv)
 	GetAppVersion();
 	DisplayAppVersion();
 
-//#if !defined WIN32
-//	CheckForOnboardSensors();
-//#endif
 	if (!szStartupFolder.empty())
 		_log.Log(LOG_STATUS, "Startup Path: %s", szStartupFolder.c_str());
 


### PR DESCRIPTION
This PR is a followup on #4389 

- Removed (commented out) code from main domoticz and helper (left over from previous PR) 

- HardwareMonitor code has been cleaned further. Moved global variables and functions to be private.

- HardwareMonitor generic module code (like Do_work, etc) does not have any system/compiletime specific code anymore. Moved to system specific functions.

- Some small improvement like better debugging messages, quicker to first run of reading (and adding) sensors, etc.

- There now is a public method 'GetOSType' which can be used to retrieve the detected OS (system) type.

Hopefully, the code cleanup and refactoring makes the module code better readable and easier to maintain and/or extend

NOTE: I am not able to test this module on all the different hardware/OS platform it could/should support.
Based on the code, it should work on:
* Linux -> _tested_
* Linux on Windows Subsystem for Linux (WSL)
* Raspberry Pi (Linux)
* FreeBSD
* OpenBSD
* Cygwin (sort of WSL but older)
* Apple
* Windows (Using openhardwaremonitor.org module and WMI)

Hopefully others can test and confirm it works
