### PR TITLE
Updated Mainworker.cpp for better handling of Zwave blinds

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12339,22 +12339,28 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			}
 		}
 		else if (
-			(
 				(switchtype == STYPE_BlindsPercentage)
 				|| (switchtype == STYPE_BlindsPercentageInverted)
 				|| (switchtype == STYPE_VenetianBlindsUS)
 				|| (switchtype == STYPE_VenetianBlindsEU)
 				)
-			&& (gswitch.cmnd == gswitch_sSetLevel) && (level == 100)
-		) {
-			if (pHardware->HwdType == HTYPE_OpenZWave)
+		 {
+			if (((gswitch.cmnd == gswitch_sSetLevel) && (level == 100)) || (gswitch.cmnd == gswitch_sOn))
 			{
-				//For Multilevel switches, 255 (0xFF) means Restore to most recent (non-zero) level,
-				//which is perfect for dimmers, but for blinds (and using the slider), we set it to 99%
-				level = 99;
+				if (pHardware->HwdType == HTYPE_OpenZWave)
+				{
+					//For Multilevel switches, 255 (0xFF) means Restore to most recent (non-zero) level,
+					//which is perfect for dimmers, but for blinds (and using the slider), we set it to 99%
+					level = 99;
+
+					if (gswitch.cmnd == gswitch_sOn)
+					{
+					  	gswitch.cmnd = gswitch_sSetLevel;
+					}
+				}
+				else
+					gswitch.cmnd = gswitch_sOn;
 			}
-			else
-				gswitch.cmnd = gswitch_sOn;
 		}
 
 		gswitch.level = (uint8_t)level;


### PR DESCRIPTION
As described in issue #4379, Zwave blind were not handled in a proper way,  as when pushing the open button, Domoticz was sending level 255, which means go back the last position. Together with Gizmocuz, we found a clever way to solve this.