### PR TITLE
dzVents update to V3.0.15 (updatedBy)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -21,8 +21,9 @@ Version 2020.xxxx (xxxx)
 - Implemented: Websocket notification for secondary/sub devices
 - Implemented: ZWave, Legend and tooltips in Neighbor�s overview
 - Implemented: AirconWithMe wifi module
-- Updated: dzVents version 3.0.14 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
+- Updated: dzVents version 3.0.15 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
 - Updated: eVehicles, added ODO meter, unlock/open alert, max charge level to Tesla module
+- Updated: MQTT, added publish schemes: device index, device name and implemented custom topics for in- and outbound messages
 - Updated: OpenZWave configuration files
 - Updated: Openweathermap has been improved
 - Updated: TTNMQTT, Better GPS/Locations handling, distance calculation (Geofencing)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -188,15 +188,15 @@ The `on` section tells dzVents *when* the execute function has to be executed. I
 The `on` section has many kinds of subsections that *can all be used simultaneously* :
 
 #### customEvents = { ... } <sup>3.0.0</sup>
-A list of one or more custom event triggers. This eventTrigger can be activate by a json/api call, a MQTT message (when domoticz is setup to listen to such messages on the hardware tab) or by the dzVents internal command domoticz.emitEvent 
- - The name of the custom-event 
- - The name of the custom-event followed by a time constraint, such as: 
+A list of one or more custom event triggers. This eventTrigger can be activate by a json/api call, a MQTT message (when domoticz is setup to listen to such messages on the hardware tab) or by the dzVents internal command domoticz.emitEvent
+ - The name of the custom-event
+ - The name of the custom-event followed by a time constraint, such as:
 	`['start']  = { 'at 15:*', 'at 22:* on sat, sun' }` The script will be executed if domoticz is started, **and** it is either between 15:00 and 16:00 or between 22:00 and 23:00 in the weekend. See [See time trigger rules](#timer_trigger_rules).
 
 ##### API
 	- curl: curl -d "{ 'a':10, 'b':20, 'some':'text', 'sub' : { 'x':10, 'y':20 } }" "http://<domoticzIP:domoticz port>/json.htm?type=command&param=customevent&event=<myCustomEvent>"
 	- JSON: **< domoticzIP : domoticz port >**/json.htm?type=command&param=customevent&event=<MyEvent>&data=myData
-	- MQTT simple:  {"command":"customevent", "event":"MyEvent","data":"myData"}  
+	- MQTT simple:  {"command":"customevent", "event":"MyEvent","data":"myData"}
 	- MQTT complex: {"command":"customevent","event":"MyEvent","data":"{\"idx\":29,\"test\":\"ok\"}" }
 	- emitEvent: domoticz.emitEvent('myCustomEvent' [,])
 		`domoticz.emitEvent('myEvent') -- no data`
@@ -341,7 +341,7 @@ The optional data section allows you to define local variables that will hold th
 The optional logging section allows you to override the global logging setting of dzVents as set in *Setup > Settings > Other > EventSystem > dzVents Log Level*. This can be handy when you only want this script to have extensive debug logging while the rest of your script executes silently. You have these options:
 
  - **level**: This is the log level you want for this script. Can be domoticz.LOG_INFO, domoticz.LOG_MODULE_EXEC_INFO, domoticz.LOG_DEBUG or domoticz.LOG_ERROR
- - **marker**: A string that is prefixed before each log message. That way you can easily create a filter in the Domoticz log to see just these messages. **marker** defaults to scriptname 
+ - **marker**: A string that is prefixed before each log message. That way you can easily create a filter in the Domoticz log to see just these messages. **marker** defaults to scriptname
 
 Example:
 ```Lua
@@ -579,7 +579,7 @@ There are several options for time triggers. It is important to know that Domoti
 			'every hour on sat',		-- you guessed it correctly
 			'at sunset',				-- uses sunset/sunrise/solarnoon info from Domoticz
 			'at sunrise',
-			'at solarnoon',				-- <sup>3.0.11</sup> 
+			'at solarnoon',				-- <sup>3.0.11</sup>
 			'at civiltwilightstart',	-- uses civil twilight start/end info from Domoticz
 			'at civiltwilightend',
 			'at sunset on sat,sun',
@@ -608,7 +608,7 @@ There are several options for time triggers. It is important to know that Domoti
 			'every even week',			-- odd or even numbered weeks
 			'on 23/11',					-- on 23rd of november (dd/mm)
 			'on 23/11-25/12',			-- between 23/11 and 25/12
-			'on 2/3-18/3',11/8,10/10-14/10',
+			'on 2/3-8/3,7/8,6/10-14/10',-- between march 2 and 8, on august 7 and between october 6 and 14.
 			'on */2,15/*',				-- every day in February or
 										-- every 15th day of the month
 			'on -3/4,4/7-',				-- before 3/4 or after 4/7
@@ -713,8 +713,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 		print(_u.rightPad('test',10) .. '|||') -- =>  test	  |||
 	```
 
-	- **\_.lodash**: This is an entire collection with very handy
-		Lua functions. Read more about
+	- **\_.lodashFunctions**: This is an entire collection with very handy Luafunctions. Read more about
 		[lodash](#lodash_for_Lua "wikilink").  E.g.:
 		``` {.lua}
 		domoticz.utils._.size({'abc', 'def'}))` Returns 2.
@@ -746,7 +745,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 	- **fromBase64(string)**: *Function*: <sup>2.5.2</sup>) Decode a base64 string
 	- **fromJSON(json, fallback <sup>2.4.16</sup>)**: *Function*. Turns a json string to a Lua table. Example: `local t = domoticz.utils.fromJSON('{ "a": 1 }')`. Followed by: `print( t.a )` will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.
 	- **fromXML(xml, fallback )**: *Function*: <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: `local t = domoticz.utils.fromXML('<testtag>What a nice feature!</testtag>') Followed by: `print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.
-	- **fuzzyLookup(string, parm)**: *Function*: <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.
+	- **fuzzyLookup([string|array of strings], parm)**: *Function*: <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.
 	 - **groupExists(parm)**: *Function*: <sup>2.4.28</sup> returns name when entered with a valid group ^3.0.12^ or groupID and return ID when entered with valid groupName or false when not a group, groupID or groupName of an existing group
 	 - **hardwareExists(parm)**: *Function*: <sup>3.0.7</sup> returns name when entered with valid hardwareID or ID when entered with valid hardwareName or false when not a hardwareID or hardwareName of an existing (and active  )hardware module
 	- **inTable(table, searchString)**: *Function*: <sup>2.4.21</sup> Returns `"key"` if table has searchString as a key, `"value"` if table has searchString as value and `false` otherwise.
@@ -864,14 +863,14 @@ The domoticz object has these constants available for use in your code e.g. `dom
 	if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end
 	```
 
- - **BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE**: for updating barometric values.
- - **EVENT_TYPE_DEVICE**, **EVENT_TYPE_VARIABLE**, **EVENT_TYPE_CUSTOM**<sup>3.0.0</sup>**EVENT_TYPE_SECURITY**,  **EVENT_TYPE_HTTPRESPONSE**, **EVENT_TYPE_SYSTEM**<sup>3.0.0</sup> **EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
- - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_TEMPORARY_OVERRIDE**, **EVOHOME_MODE_PERMANENT_OVERRIDE**, **EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
- - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_AUTOWITHRESET**, **EVOHOME_MODE_AUTOWITHECO**, **EVOHOME_MODE_AWAY**, **EVOHOME_MODE_DAYOFF**, **EVOHOME_MODE_CUSTOM**, **EVOHOME_MODE_HEATINGOFF** <sup>2.4.23</sup>: mode for EvoHome controller
- - **HUM_COMFORTABLE**, **HUM_DRY**, **HUM_NORMAL**, **HUM_WET**: constant for humidity status.
+ - **BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE, BARO_COMPUTE** : for updating barometric values.
+ - **EVENT_TYPE_DEVICE, EVENT_TYPE_VARIABLE, EVENT_TYPE_CUSTOM<sup>3.0.0</sup>EVENT_TYPE_SECURITY,  EVENT_TYPE_HTTPRESPONSE, EVENT_TYPE_SYSTEM<sup>3.0.0</sup> EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
+ - **EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE, EVOHOME_MODE_PERMANENT_OVERRIDE, EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
+ - **EVOHOME_MODE_AUTO, EVOHOME_MODE_AUTOWITHRESET, EVOHOME_MODE_AUTOWITHECO, EVOHOME_MODE_AWAY, EVOHOME_MODE_DAYOFF, EVOHOME_MODE_CUSTOM, EVOHOME_MODE_HEATINGOFF** <sup>2.4.23</sup>: mode for EvoHome controller
+ - **HUM_COMFORTABLE, HUM_DRY, HUM_NORMAL, HUM_WET, HUM_COMPUTE** <sup>3.0.15</sup>: constant for humidity status.
  - **INTEGER**, **FLOAT**, **STRING**, **DATE**, **TIME**: variable types.
  - **LOG_DEBUG**, **LOG_ERROR**, **LOG_INFO**, **LOG_FORCE**: for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
- - **NSS_FIREBASE**, **NSS_FIREBASE_CLOUD_MESSAGING**, **NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>, **NSS_GOOGLE_CLOUD_MESSAGING** <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
+ - **NSS_FIREBASE, NSS_FIREBASE_CLOUD_MESSAGING, NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, NSS_HTTP, NSS_KODI, NSS_LOGITECH_MEDIASERVER, NSS_NMA,NSS_PROWL, NSS_PUSHALOT, NSS_PUSHBULLET, NSS_PUSHOVER, NSS_PUSHSAFER, NSS_TELEGRAM <sup>2.4.8</sup>, NSS_GOOGLE_CLOUD_MESSAGING** <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
  - **PRIORITY_LOW**, **PRIORITY_MODERATE**, **PRIORITY_NORMAL**, **PRIORITY_HIGH**, **PRIORITY_EMERGENCY**: for notification priority.
  - **SECURITY_ARMEDAWAY**, **SECURITY_ARMEDHOME**, **SECURITY_DISARMED**: for security state.
  - **SOUND_ALIEN** , **SOUND_BIKE**, **SOUND_BUGLE**, **SOUND_CASH_REGISTER**, **SOUND_CLASSICAL**, **SOUND_CLIMB** , **SOUND_COSMIC**, **SOUND_DEFAULT** , **SOUND_ECHO**, **SOUND_FALLING**  , **SOUND_GAMELAN**, **SOUND_INCOMING**, **SOUND_INTERMISSION**, **SOUND_MAGIC** , **SOUND_MECHANICAL**, **SOUND_NONE**, **SOUND_PERSISTENT**, **SOUND_PIANOBAR** , **SOUND_SIREN** , **SOUND_SPACEALARM**, **SOUND_TUGBOAT**  , **SOUND_UPDOWN**: for notification sounds.
@@ -902,7 +901,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **icon**: *String*. Name of the icon in Domoticz GUI.
  - **id**: *Number*. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It's not truly an index but is unique enough for dzVents to be treated as an id.
  - **idx**: *Number*. Same as id: index of the device
- - **lastUpdate**: *[Time Object](#Time_object)*: Time when the device was updated.
+ - **lastUpdate**: *[Time Object](#Time_object)*: Time when the device was updated. **Note: The lastUpdate for devices that triggered the script at hand is in fact the previousUpdate time. The real lastUpdate time for these "script triggering" devices is the current time.
  - **name**: *String*. Name of the device.
  - **nValue**: *Number*. Numerical representation of the state.
  - **protected**: *Boolean*. <sup>2.4.27</sup> True when device / scene / group is protected. False otherwise.
@@ -913,7 +912,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **setDescription(description)**: *Function*. <sup>2.4.16</sup> Generic method to update the description for all devices, groups and scenes. E.g.: device.setDescription(device.description .. '/nChanged by '.. item.trigger .. 'at ' .. domoticz.time.raw). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **setIcon(iconNumber)**: *Function*. <sup>2.4.17</sup> method to update the icon for devices. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **setState(newState)**: *Function*. Generic update method for switch-like devices. E.g.: device.setState('On'). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- - **setValues(nValue,[ sValue1, sValue2, ...])**: *Function*. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValues. Uses domoticz JSON API to force subsequent pushes like influxdb and MQTT. nValue required but when set to nil it defaults to current nValue. sValue parms are optional and can be many. <sup>3.0.8</sup> If one of sValue parms is 'parsetrigger', subsequent eventscripts will be triggered. 
+ - **setValues(nValue,[ sValue1, sValue2, ...])**: *Function*. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValues. Uses domoticz JSON API to force subsequent pushes like influxdb and MQTT. nValue required but when set to nil it defaults to current nValue. sValue parms are optional and can be many. <sup>3.0.8</sup> If one of sValue parms is 'parsetrigger', subsequent eventscripts will be triggered.
  - **state**: *String*. For switches, holds the state like 'On' or 'Off'. For dimmers that are on, it is also 'On' but there is a level attribute holding the dimming level. **For selector switches** (Dummy switch) the state holds the *name* of the currently selected level. The corresponding numeric level of this state can be found in the **rawData** attribute: `device.rawData[1]`.
  - **signalLevel**: *Number* If applicable for that device then it will be from 0-100.
  - **switchType**: *String*. See Domoticz devices table in Domoticz GUI(Switches tab). E.g. 'On/Off', 'Door Contact', 'Motion Sensor' or 'Blinds'
@@ -922,6 +921,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **timedOut**: *Boolean*. Is true when the device couldn't be reached.
  - **unit**: *Number*. Device unit. See device list in Domoticz' settings for the unit.
  - **update(< params >)**: *Function*. Generic update method. Accepts any number of parameters that will be sent back to Domoticz. There is no need to pass the device.id here. It will be passed for you. Example to update a temperature: `device.update(0,12)`. This will eventually result in a commandArray entry `['UpdateDevice']='<idx>|0|12'`. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updatedBy**: *String*: <sup>3.0.15</sup> user- or scriptname who/that last updated a type switch device or group/ scene. For other types or for devices where user is not- or no longer available it will return n/a. The information is available for max the number of days in the past as you set the number of available days in Log History for Light/ Switches 
 
 ### Device attributes and methods for specific devices
 Note that if you do not find your specific device type here you can always inspect what is in the `rawData` attribute. Please let us know that it is missing so we can write an adapter for it (or you can write your own and submit it). Calling `myDevice.dump()` will dump all attributes and values for myDevice to the Domoticz log.
@@ -1009,7 +1009,7 @@ Note that if you do not find your specific device type here you can always inspe
  - **isPythonPlugin**: *Boolean*
  - **type**: : *String*
  - **typeValue**: : *Number*
-  
+
 #### Humidity sensor
  - **humidity**: *Number*
  - **humidityStatus**: *String*
@@ -1083,7 +1083,7 @@ See switch below.
 
 #### Rain meter
  - **rain**: *Number* (please note that this does return the rain total for today)
- - **rainRate**: *Number* 
+ - **rainRate**: *Number*
  - **updateRain(rate, counter)**: *Function*. (rate in mm * 100 per hour, counter is total in mm) Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### RGBW(W) / Lighting Limitless/Applamp
@@ -1184,7 +1184,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **humidityStatus**: *String*
  - **humidityStatusValue**: *Number*. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
  - **temperature**: *Number*
- - **updateTempHumBaro(temperature, humidity, status, pressure, forecast)**: *Function*. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateTempHumBaro(temperature, humidity, status, pressure, forecast)**: *Function*. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET, HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Temperature, Humidity
  - **dewPoint**: *Number*
@@ -1192,7 +1192,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **humidityStatus**: *String*
  - **humidityStatusValue**: *Number*. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
  - **temperature**: *Number*
- - **updateTempHum(temperature, humidity, status)**: *Function*. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateTempHum(temperature, humidity [, status] )**: *Function*. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET or HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Text
  - **text**: *String*
@@ -1201,6 +1201,12 @@ There are many switch-like devices. Not all methods are applicable for all switc
 #### Thermostat set point
  - **setPoint**: *Number*.
  - **updateSetPoint(setPoint)**:*Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+
+#### Thermostat type 3 (Mertik) <sup>3.0.15</sup>
+ - **mode**: *Number*. Current mode
+ - **modes**: *String*. List of all modes
+ - **modeString**: *String*. Current mode
+ - **updateMode(mode)**:*Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### UV sensor
  - **uv**: *Number*. UV index.
@@ -1258,10 +1264,10 @@ Many dzVents device methods support extra options, like controlling a delay or a
 	-- switch on for 2 minutes after 10 seconds
 	device.switchOn().afterSec(10).forMin(2)
 
-	-- switch on at a specic time / day 
+	-- switch on at a specic time / day
 	device.switchOn().at('09:00')                 -- earliest moment it will be 09:00 hr.
-	device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30  
-	device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first) 
+	device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30
+	device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first)
 
 	-- switch on for 2 minutes after a randomized delay of 1-10 minutes
 	device.switchOff().withinMin(10).forMin(2)
@@ -1284,7 +1290,7 @@ Many dzVents device methods support extra options, like controlling a delay or a
 ```
 
 #### Options
- - **at(hh:mm[:ss][ on [ ddd|dddd ] )**: *Function*.<sup>3.0.1</sup> Activates the command at a certain time [ on a certain day] 
+ - **at(hh:mm[:ss][ on [ ddd|dddd ] )**: *Function*.<sup>3.0.1</sup> Activates the command at a certain time [ on a certain day]
  - **afterHour(hours), afterMin(minutes), afterSec(seconds)**: *Function*. Activates the command after a certain number of hours, minutes or seconds.
  - **cancelQueuedCommands()**: *Function*.  Cancels queued commands. E.g. you switch on a device after 10 minutes:  `myDevice.switchOn().afterMin(10)`. Within those 10 minutes you can cancel that command by calling:  `myDevice.cancelQueuedCommands()`.
  - **checkFirst()**: *Function*. Checks if the **current** state of the device is different than the desired new state. If the target state is the same, no command is sent. If you do `mySwitch.switchOn().checkFirst()`, then no switch command is sent if the switch is already on. This command only works with switch-like devices. It is not available for toggle and dim commands, either.
@@ -1413,7 +1419,7 @@ See table below
  - **Note 2**: for `domoticz.openURL()` only `at()`, `afterAAA()` and `withinAAA()` is available.
  - **Note 3**: Note 2 also applies for all commands depending on openURL (like rgbwwDevice.setAaa() commands).
  - **Note 4**: Including dimTo, switchSelector, setLevel and similar methods.
- 
+
 #### Follow-up event triggers
 Normally if you issue a command, Domoticz will immediately trigger follow-up events, and dzVents will automatically trigger defined event scripts. If you trigger a scene, all devices in that scene will issue a change event. If you have event triggers for these devices, they will be executed by dzVents. If you don't want this to happen, add `.silent()` to your commands (exception is updateSetPoint).
 
@@ -2472,6 +2478,13 @@ On the other hand, you have to make sure that dzVents can access the json withou
 
 # History
 
+## [3.0.15]
+- Add updatedBy attribute to switchType devices-, scenes- and groups.
+- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
+- Add device adapter for Thermostat type 3 devices (Mertik)
+- Add utils.humidityStatus
+- Add option to have dzVents compute humidity status
+
 ## [3.0.14]
 - Add utils.fuzzyLookup
 - Made eventHelpers more resilient to coding errors in the on = section
@@ -2487,19 +2500,19 @@ On the other hand, you have to make sure that dzVents can access the json withou
 
 ## [3.0.11]
 - Add sensorValue attribute to custom sensor
-- Add solarnoon as moment in time (like sunrise / sunset ) 
+- Add solarnoon as moment in time (like sunrise / sunset )
 
 ## [3.0.10]
 - Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
 - Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
 
 ## [3.0.9]
-- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
+- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time.
 - Add function toUTC to time object.
 - Allow table as parm to function makeTime
 
 ## [3.0.8]
-- Allow IPv6 ::1 as localhost in domoticz settings 
+- Allow IPv6 ::1 as localhost in domoticz settings
 - Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
 - Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
 - Updated round.utils to correctly handle negative numbers and round to zero decimals
@@ -2511,22 +2524,22 @@ On the other hand, you have to make sure that dzVents can access the json withou
 - Add hardwareInfo() function
 
 ## [3.0.5]
-- Add dumpSelection() method 
+- Add dumpSelection() method
 - Fixed settings.url
 
 ## [3.0.4]
-- Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 
-- add isJSON, isXML functions to Utils 
+- Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC
+- add isJSON, isXML functions to Utils
 
 ## [3.0.3]
-- add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object) 
+- add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object)
 
 ## [3.0.2]
 - Add `PUT` and `DELETE` support to `openURL`
 - Ensure sending integer in nValue in update function
 - Fix sValue for custom sensor
 
-## [3.0.1] 
+## [3.0.1]
 - Add option `at()` to the various commands/methods
 - Add stringToSeconds() function
 

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -184,7 +184,7 @@ A list of one or more custom event triggers. This eventTrigger can be activate b
 
 <pre>- curl: curl -d &quot;{ 'a':10, 'b':20, 'some':'text', 'sub' : { 'x':10, 'y':20 } }&quot; &quot;http://&lt;domoticzIP:domoticz port&gt;/json.htm?type=command&amp;param=customevent&amp;event=&lt;myCustomEvent&gt;&quot;
 - JSON: **&lt; domoticzIP : domoticz port &gt;**/json.htm?type=command&amp;param=customevent&amp;event=&lt;MyEvent&gt;&amp;data=myData
-- MQTT simple:  {&quot;command&quot;:&quot;customevent&quot;, &quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;myData&quot;}  
+- MQTT simple:  {&quot;command&quot;:&quot;customevent&quot;, &quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;myData&quot;}
 - MQTT complex: {&quot;command&quot;:&quot;customevent&quot;,&quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;{\&quot;idx\&quot;:29,\&quot;test\&quot;:\&quot;ok\&quot;}&quot; }
 - emitEvent: domoticz.emitEvent('myCustomEvent' [,])
     `domoticz.emitEvent('myEvent') -- no data`
@@ -557,7 +557,7 @@ There are several options for time triggers. It is important to know that Domoti
             'every hour on sat',        -- you guessed it correctly
             'at sunset',                -- uses sunset/sunrise/solarnoon info from Domoticz
             'at sunrise',
-            'at solarnoon',             -- <sup>3.0.11</sup> 
+            'at solarnoon',             -- <sup>3.0.11</sup>
             'at civiltwilightstart',    -- uses civil twilight start/end info from Domoticz
             'at civiltwilightend',
             'at sunset on sat,sun',
@@ -586,7 +586,7 @@ There are several options for time triggers. It is important to know that Domoti
             'every even week',          -- odd or even numbered weeks
             'on 23/11',                 -- on 23rd of november (dd/mm)
             'on 23/11-25/12',           -- between 23/11 and 25/12
-            'on 2/3-18/3',11/8,10/10-14/10',
+            'on 2/3-8/3,7/8,6/10-14/10',-- between march 2 and 8, on august 7 and between october 6 and 14.
             'on */2,15/*',              -- every day in February or
                                         -- every 15th day of the month
             'on -3/4,4/7-',             -- before 3/4 or after 4/7
@@ -685,7 +685,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 <source lang="lua">  _u = domoticz.utils
   print(_u.rightPad('test',10) .. '|||') -- =>  test    |||</source>
 <ul>
-<li><p>'''_.lodash''': This is an entire collection with very handy Lua functions. Read more about [[#lodash_for_Lua|lodash]]. E.g.: <code>{.lua}      domoticz.utils._.size({'abc', 'def'}))` Returns 2.</code></p></li>
+<li><p>'''_.lodashFunctions''': This is an entire collection with very handy Luafunctions. Read more about [[#lodash_for_Lua|lodash]]. E.g.: <code>{.lua}      domoticz.utils._.size({'abc', 'def'}))` Returns 2.</code></p></li>
 <li><p>'''cameraExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid camera <sup>3.0.12</sup> or cameraID and return ID when entered with valid cameraName or false when not a camera, cameraID or cameraName of an existing camera</p></li>
 <li><p>'''deviceExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid device <sup>3.0.12</sup> or deviceID and returns ID when entered with valid deviceName or false when not a device, deviceID or deviceName of an existing (and active) device. Example:</p>
 <source lang="lua">local dz = domoticz
@@ -707,7 +707,7 @@ end</source></li>
 <li><p>'''fromBase64(string)''': ''Function'': <sup>2.5.2</sup>) Decode a base64 string</p></li>
 <li><p>'''fromJSON(json, fallback <sup>2.4.16</sup>)''': ''Function''. Turns a json string to a Lua table. Example: <code>local t = domoticz.utils.fromJSON('{ &quot;a&quot;: 1 }')</code>. Followed by: <code>print( t.a )</code> will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.</p></li>
 <li><p>'''fromXML(xml, fallback )''': ''Function'': <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: <code>local t = domoticz.utils.fromXML('&lt;testtag&gt;What a nice feature!&lt;/testtag&gt;') Followed by:</code>print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.</p></li>
-<li><p>'''fuzzyLookup(string, parm)''': ''Function'': <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.</p></li>
+<li><p>'''fuzzyLookup([string|array of strings], parm)''': ''Function'': <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.</p></li>
 <li><p>'''groupExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid group <sup>3.0.12</sup> or groupID and return ID when entered with valid groupName or false when not a group, groupID or groupName of an existing group</p></li>
 <li><p>'''hardwareExists(parm)''': ''Function'': <sup>3.0.7</sup> returns name when entered with valid hardwareID or ID when entered with valid hardwareName or false when not a hardwareID or hardwareName of an existing (and active )hardware module</p></li>
 <li><p>'''inTable(table, searchString)''': ''Function'': <sup>2.4.21</sup> Returns <code>&quot;key&quot;</code> if table has searchString as a key, <code>&quot;value&quot;</code> if table has searchString as value and <code>false</code> otherwise.</p></li>
@@ -721,7 +721,7 @@ end</source></li>
         domoticz.utils.numDecimals (12.23,1,1) -- => 12.2,
         domoticz.utils.leadingZeros(domoticz.utils.numDecimals (12.23,4,4),9) -- => 0012.2300</source>
 <ul>
-<li><p>'''osCommand(cmd)''': ''Function'':<sup>3.0.13</sup> Execute an OS command and return result and returncode.</p></li>
+<li><p>'''osCommand(cmd)''': ''Function'': <sup>3.0.13</sup> Execute an OS command and return result and returncode.</p></li>
 <li><p>'''osExecute(cmd)''': ''Function'': Execute an OS command. (no return)</p></li>
 <li><p>'''rightPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Succeed string with given character(s) (default = space) to given length.</p></li>
 <li><p>'''round(number, [decimalPlaces])''': ''Function''. Helper function to round numbers. Default decimalPlaces is 0.</p></li>
@@ -811,14 +811,14 @@ The domoticz object has these constants available for use in your code e.g. <co
 
 * '''ALERTLEVEL_GREY''', '''ALERTLEVEL_GREEN''', '''ALERTLEVEL_ORANGE''', '''ALERTLEVEL_RED''', '''ALERTLEVEL_YELLOW''': for updating text sensors.
 * '''BASETYPE_CUSTOM_EVENT''' <sup>3.0.0</sup>,'''BASETYPE_DEVICE''', '''BASETYPE_SCENE''', '''BASETYPE_GROUP''', '''BASETYPE_HARDWARE''' <sup>3.0.7</sup>, '''BASETYPE_VARIABLE''', '''BASETYPE_SECURITY''', '''BASETYPE_TIMER''', '''BASETYPE_HTTP_RESPONSE''', '''BASETYPE_SYSTEM'''<sup>3.0.0</sup>: indicators for the various object types that are passed as the second parameter to the execute function. E.g. you can check if an object is a device object: <code>Lua     if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end</code>
-* '''BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE''': for updating barometric values.
-* '''EVENT_TYPE_DEVICE''', '''EVENT_TYPE_VARIABLE''', '''EVENT_TYPE_CUSTOM'''<sup>3.0.0</sup>'''EVENT_TYPE_SECURITY''', '''EVENT_TYPE_HTTPRESPONSE''', '''EVENT_TYPE_SYSTEM'''<sup>3.0.0</sup> '''EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
-* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_TEMPORARY_OVERRIDE''', '''EVOHOME_MODE_PERMANENT_OVERRIDE''', '''EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
-* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_AUTOWITHRESET''', '''EVOHOME_MODE_AUTOWITHECO''', '''EVOHOME_MODE_AWAY''', '''EVOHOME_MODE_DAYOFF''', '''EVOHOME_MODE_CUSTOM''', '''EVOHOME_MODE_HEATINGOFF''' <sup>2.4.23</sup>: mode for EvoHome controller
-* '''HUM_COMFORTABLE''', '''HUM_DRY''', '''HUM_NORMAL''', '''HUM_WET''': constant for humidity status.
+* '''BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE, BARO_COMPUTE''' : for updating barometric values.
+* '''EVENT_TYPE_DEVICE, EVENT_TYPE_VARIABLE, EVENT_TYPE_CUSTOM<sup>3.0.0</sup>EVENT_TYPE_SECURITY, EVENT_TYPE_HTTPRESPONSE, EVENT_TYPE_SYSTEM<sup>3.0.0</sup> EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
+* '''EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE, EVOHOME_MODE_PERMANENT_OVERRIDE, EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
+* '''EVOHOME_MODE_AUTO, EVOHOME_MODE_AUTOWITHRESET, EVOHOME_MODE_AUTOWITHECO, EVOHOME_MODE_AWAY, EVOHOME_MODE_DAYOFF, EVOHOME_MODE_CUSTOM, EVOHOME_MODE_HEATINGOFF''' <sup>2.4.23</sup>: mode for EvoHome controller
+* '''HUM_COMFORTABLE, HUM_DRY, HUM_NORMAL, HUM_WET, HUM_COMPUTE''' <sup>3.0.15</sup>: constant for humidity status.
 * '''INTEGER''', '''FLOAT''', '''STRING''', '''DATE''', '''TIME''': variable types.
 * '''LOG_DEBUG''', '''LOG_ERROR''', '''LOG_INFO''', '''LOG_FORCE''': for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
-* '''NSS_FIREBASE''', '''NSS_FIREBASE_CLOUD_MESSAGING''', '''NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM** <sup>2.4.8</sup>, '''NSS_GOOGLE_CLOUD_MESSAGING''' <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
+* '''NSS_FIREBASE, NSS_FIREBASE_CLOUD_MESSAGING, NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, NSS_HTTP, NSS_KODI, NSS_LOGITECH_MEDIASERVER, NSS_NMA,NSS_PROWL, NSS_PUSHALOT, NSS_PUSHBULLET, NSS_PUSHOVER, NSS_PUSHSAFER, NSS_TELEGRAM <sup>2.4.8</sup>, NSS_GOOGLE_CLOUD_MESSAGING''' <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
 * '''PRIORITY_LOW''', '''PRIORITY_MODERATE''', '''PRIORITY_NORMAL''', '''PRIORITY_HIGH''', '''PRIORITY_EMERGENCY''': for notification priority.
 * '''SECURITY_ARMEDAWAY''', '''SECURITY_ARMEDHOME''', '''SECURITY_DISARMED''': for security state.
 * '''SOUND_ALIEN''' , '''SOUND_BIKE''', '''SOUND_BUGLE''', '''SOUND_CASH_REGISTER''', '''SOUND_CLASSICAL''', '''SOUND_CLIMB''' , '''SOUND_COSMIC''', '''SOUND_DEFAULT''' , '''SOUND_ECHO''', '''SOUND_FALLING''' , '''SOUND_GAMELAN''', '''SOUND_INCOMING''', '''SOUND_INTERMISSION''', '''SOUND_MAGIC''' , '''SOUND_MECHANICAL''', '''SOUND_NONE''', '''SOUND_PERSISTENT''', '''SOUND_PIANOBAR''' , '''SOUND_SIREN''' , '''SOUND_SPACEALARM''', '''SOUND_TUGBOAT''' , '''SOUND_UPDOWN''': for notification sounds.
@@ -850,7 +850,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''icon''': ''String''. Name of the icon in Domoticz GUI.
 * '''id''': ''Number''. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It’s not truly an index but is unique enough for dzVents to be treated as an id.
 * '''idx''': ''Number''. Same as id: index of the device
-* '''lastUpdate''': ''[[#Time_object|Time Object]]'': Time when the device was updated.
+* '''lastUpdate''': ''[[#Time_object|Time Object]]'': Time when the device was updated. **Note: The lastUpdate for devices that triggered the script at hand is in fact the previousUpdate time. The real lastUpdate time for these “script triggering” devices is the current time.
 * '''name''': ''String''. Name of the device.
 * '''nValue''': ''Number''. Numerical representation of the state.
 * '''protected''': ''Boolean''. <sup>2.4.27</sup> True when device / scene / group is protected. False otherwise.
@@ -870,6 +870,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''timedOut''': ''Boolean''. Is true when the device couldn’t be reached.
 * '''unit''': ''Number''. Device unit. See device list in Domoticz’ settings for the unit.
 * '''update(&lt; params &gt;)''': ''Function''. Generic update method. Accepts any number of parameters that will be sent back to Domoticz. There is no need to pass the device.id here. It will be passed for you. Example to update a temperature: <code>device.update(0,12)</code>. This will eventually result in a commandArray entry <code>['UpdateDevice']='&lt;idx&gt;|0|12'</code>. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updatedBy''': ''String'': <sup>3.0.15</sup> user- or scriptname who/that last updated a type switch device or group/ scene. For other types or for devices where user is not- or no longer available it will return n/a. The information is available for max the number of days in the past as you set the number of available days in Log History for Light/ Switches
 
 === Device attributes and methods for specific devices ===
 
@@ -1173,7 +1174,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidityStatus''': ''String''
 * '''humidityStatusValue''': ''Number''. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
 * '''temperature''': ''Number''
-* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET, HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Temperature, Humidity ====
 
@@ -1182,7 +1183,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidityStatus''': ''String''
 * '''humidityStatusValue''': ''Number''. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
 * '''temperature''': ''Number''
-* '''updateTempHum(temperature, humidity, status)''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateTempHum(temperature, humidity [, status] )''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET or HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Text ====
 
@@ -1193,6 +1194,13 @@ There are many switch-like devices. Not all methods are applicable for all switc
 
 * '''setPoint''': ''Number''.
 * '''updateSetPoint(setPoint)''':''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+
+==== Thermostat type 3 (Mertik) <sup>3.0.15</sup> ====
+
+* '''mode''': ''Number''. Current mode
+* '''modes''': ''String''. List of all modes
+* '''modeString''': ''String''. Current mode
+* '''updateMode(mode)''':''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== UV sensor ====
 
@@ -1260,10 +1268,10 @@ Many dzVents device methods support extra options, like controlling a delay or a
     -- switch on for 2 minutes after 10 seconds
     device.switchOn().afterSec(10).forMin(2)
 
-    -- switch on at a specic time / day 
+    -- switch on at a specic time / day
     device.switchOn().at('09:00')                 -- earliest moment it will be 09:00 hr.
-    device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30  
-    device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first) 
+    device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30
+    device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first)
 
     -- switch on for 2 minutes after a randomized delay of 1-10 minutes
     device.switchOff().withinMin(10).forMin(2)
@@ -2416,6 +2424,14 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and/or <code>::1</code> and you’re good to go.
 
 = History =
+
+== [3.0.15] ==
+
+* Add updatedBy attribute to switchType devices-, scenes- and groups.
+* Fixed bug in domoticz.time.matchesRule (daterange was ignored when “on mon, tue” was also part of the rule)
+* Add device adapter for Thermostat type 3 devices (Mertik)
+* Add utils.humidityStatus
+* Add option to have dzVents compute humidity status
 
 == [3.0.14] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,3 +1,10 @@
+[3.0.15]
+- Add updatedBy attribute to switchType devices-, scenes- and groups.
+- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
+- Add device adapter for Thermostat type 3 devices (Mertik)
+- Add utils.humidityStatus
+- Add option to have dzVents compute humidity status
+
 [3.0.14]
 - Add utils.fuzzyLookup
 - Made eventHelpers more resilient to coding errors in the on = section
@@ -13,19 +20,19 @@
 
 [3.0.11]
 - Add sensorValue attribute to custom sensor
-- Add solarnoon as moment in time (like sunrise / sunset ) 
+- Add solarnoon as moment in time (like sunrise / sunset )
 
 [3.0.10]
 - Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
 - Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
 
 [3.0.9]
-- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
+- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time.
 - Add function toUTC to time object.
 - Allow table as parm to function makeTime
 
 [3.0.8]
-- Allow IPv6 ::1 as localhost in domoticz settings 
+- Allow IPv6 ::1 as localhost in domoticz settings
 - Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
 - Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
 - Updated round.utils to correctly handle negative numbers and round to zero decimals
@@ -41,22 +48,22 @@
 - fixed settings.url
 
 [3.0.4]
-- Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 
-- add isJSON, isXML functions to Utils 
+- Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC
+- add isJSON, isXML functions to Utils
 
 [3.0.3]
-- add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object) 
+- add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object)
 
 [3.0.2]
 - Add `PUT` and `DELETE` support to `openURL`
 - Ensure sending integer in nValue in update function
 - Fix sValue for custom sensor
 
-[3.0.1] 
+[3.0.1]
 - Add option 'at' to the various commands/methods
- 
-[3.0.0] 
- - Add system-events triggers as option to the on = { ... } section. Scripts can now be triggered based on these system-events: 
+
+[3.0.0]
+ - Add system-events triggers as option to the on = { ... } section. Scripts can now be triggered based on these system-events:
 	 - start
 	 - stop
 	 - manualBackupFinished,
@@ -78,7 +85,7 @@
 [2.5.6]
 - Add dayName, monthName, monthAbbrName and time as time attributes
 - Add _.round, _.isEqual functions to lodash.lua
-- Add testLodash.lua as testModule for lodash 
+- Add testLodash.lua as testModule for lodash
 
 [2.5.5]
 - Add Zwave fan to Zwave mode device adapter
@@ -89,7 +96,7 @@
 - Add string.sMatch to utils
 - Made wildcard handling more resilient when magic chars are part of script triggers
 
-[2.5.3] 
+[2.5.3]
 - Add timealert / errors for long running scripts
 - Add triggerHTTPResponse()
 
@@ -128,7 +135,7 @@
 
 [2.4.25]
 - Add rawDateTime
-- fix for combined device / civil[day|night]time trigger rule 
+- fix for combined device / civil[day|night]time trigger rule
 - fix for checkFirst on stopped status
 
 [2.4.24]
@@ -138,12 +145,12 @@
 - Add method setMode for evohome device
 - Add method incrementCounter for incremental counter
 - Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
-- fix wildcard device 
+- fix wildcard device
 
 [2.4.22]
 - selector.switchSelector method accepts levelNames
 - increased selector.switchSelector resilience
-- fix wildcard timerule 
+- fix wildcard timerule
 
 [2.4.21]
 - fixed wrong direction for open() and close() for some types of blinds
@@ -151,7 +158,7 @@
 - Add sValue attribute to devices
 
 [2.4.20]
-- Add quietOn() and quietOff() method to switchType devices 
+- Add quietOn() and quietOff() method to switchType devices
 
 [2.4.19]
 - Add stringSplit function to domoticz.utils.
@@ -162,7 +169,7 @@
 
 [2.4.17]
 - Add function dumpTable() to domoticz.utils
-- Add setValues() method to devices 
+- Add setValues() method to devices
 - Add setIcon() method for devices
 
 [2.4.16]
@@ -171,21 +178,21 @@
 - Add setHue, setColor, setHex, getColor for RGBW(W) devices
 - Add setDescription for devices, groups and scenes
 - Add volumeUp / volumeDown for Logitech Media Server (LMS)
-- Changed domoticz.utils.fromJSON (add optional fallback param) 
+- Changed domoticz.utils.fromJSON (add optional fallback param)
 
-[2.4.15] 
+[2.4.15]
 - Add option to use camera name in snapshot command
 - Add domoticz.settings.domoticzVersion
 - Add domoticz.settings.dzVentsVersion
 
 [2.4.14]
-- Added domoticz.settings.location.longitude and domoticz.settings.location.latitude 
+- Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
 - Added check for- and message when call to openURL cannot open local (127.0.0.1)
-- **BREAKING CHANGE** :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name) 
+- **BREAKING CHANGE** :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
 - prevent call to updateCounter with table
 
 [2.4.13]
-- Added domoticz.settings.location (domoticz settings location Name) 
+- Added domoticz.settings.location (domoticz settings location Name)
 - Added domoticz.urlDecode method to convert an urlEncoded string to human readable format
 
 [2.4.12]
@@ -200,16 +207,16 @@
 
 [2.4.9]
 - Added evohome hotwater device (state, mode, untilDate and setHotWater function)
-- Added mode and untilDate for evohome zone devices 
+- Added mode and untilDate for evohome zone devices
 - Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
-- Add speedMs and gustMs from wind devices 
+- Add speedMs and gustMs from wind devices
 - bugfix for youless device (0 handling)
 - bugfix for time ( twilightstart and twilightend handling)
 - Added tests for twilight and device functions (hotwater) and attributes (evohome- and wind devices)
 - Fixed some date-range rule checking
 - Fixed integration tests by changing API call for creating a domoticz variable (saveuservariable was changed to adduservariable)
-- Fixed combined timer where one part of the combination is even or odd week. 
-- Added tests for combined timer with even/odd week 
+- Fixed combined timer where one part of the combination is even or odd week.
+- Added tests for combined timer with even/odd week
 
 [2.4.8]
 - Added telegram as option for domoticz.notify

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -443,8 +443,8 @@ local function Time(sDate, isUTC, _testMS)
 
 	-- returns true if self.day is on the rule: on day1,day2...
 	function self.ruleIsOnDay(rule)
-		
-        local days = string.match(rule, '%s+on%s+(.+)$') or string.match(rule, '^%s*on%s+(.+)$')
+
+		local days = string.match(rule, '%s+on%s+(.+)$') or string.match(rule, '^%s*on%s+(.+)$')
 		if (isEmpty(days)) then
 			return nil
 		end
@@ -473,7 +473,6 @@ local function Time(sDate, isUTC, _testMS)
 		end
 		return nil -- no 'on <days>' was specified in the rule
 	end
-
 
 	-- returns true if self.week matches rule in week 1,3,4 / every odd-week, every even-week, in week 5-12,23,44
 	function self.ruleIsInWeek(rule)
@@ -524,7 +523,7 @@ local function Time(sDate, isUTC, _testMS)
 
 	function self.ruleIsOnDate(rule)
 
-		local dates = string.match(rule, 'on% ([0-9%*%/%,% %-]*)')
+		local dates = rule:gsub('(on%s+[%a+])',''):match('on%s+([0-9%*%/%,% %-]*)') -- strip on ddd before matching rule
 		if (isEmpty(dates)) then
 			return nil
 		end

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -8,7 +8,7 @@ local self = {
 	LOG_INFO = 3,
 	LOG_WARNING = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '3.0.14',
+	DZVERSION = '3.0.15',
 }
 
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)
@@ -62,7 +62,7 @@ self.fuzzyLookup = function (search, target) -- search must be string/number, ta
 		local lowestFuzzyValue = math.maxinteger
 		local lowestFuzzyKey = ''
 		for _, targetString in ipairs(target) do
-			local fuzzyValue =  self.fuzzyLookup(search, targetString) 
+			local fuzzyValue =  self.fuzzyLookup(search, targetString)
 			if  fuzzyValue < lowestFuzzyValue then
 				lowestFuzzyKey = targetString
 				lowestFuzzyValue = fuzzyValue
@@ -613,6 +613,21 @@ function self.hsbToRGB(h, s, v)
 	g = (g1+m) * 255
 	b = (b1+m) * 255
 	return r, g, b
+
+end
+
+ function self.humidityStatus (temperature, humidity)
+	local constants = domoticz or require('constants')
+	local temperature = tonumber(temperature)
+	local humidity = tonumber(humidity)
+
+	if humidity <= 30 then return constants.HUM_DRY
+	elseif humidity >= 70 then return constants.HUM_WET
+	elseif  humidity >= 35 and
+			humidity <= 65 and
+			temperature >= 22 and
+			temperature <= 26 then return constants.HUM_COMFORTABLE
+	else return constants.HUM_NORMAL end
 
 end
 

--- a/dzVents/runtime/constants.lua
+++ b/dzVents/runtime/constants.lua
@@ -5,6 +5,7 @@ return {
 	['ALERTLEVEL_RED'] = 4,
 	['ALERTLEVEL_YELLOW'] = 2,
 	['BARO_CLOUDY'] = 'cloudy',	   -- true mapping to numbers is done in the device adapters for baro and temphumbaro devices
+	['BARO_COMPUTE'] = 'compute',
 	['BARO_NOINFO'] = 'noinfo',
 	['BARO_PARTLYCLOUDY'] = 'partlycloudy',
 	['BARO_RAIN'] = 'rain',
@@ -43,6 +44,7 @@ return {
 	['EVOHOME_MODE_TEMPORARY_OVERRIDE'] = 'TemporaryOverride',
 	['FLOAT'] = 'float',
 	['HUM_COMFORTABLE'] = 1,
+	['HUM_COMPUTE'] = -1,
 	['HUM_DRY'] = 2,
 	['HUM_NORMAL'] = 0,
 	['HUM_WET'] = 3,

--- a/dzVents/runtime/device-adapters/Adapters.lua
+++ b/dzVents/runtime/device-adapters/Adapters.lua
@@ -37,6 +37,7 @@ local deviceAdapters = {
 	'soundlevel_device',
 	'switch_device',
 	'thermostat_setpoint_device',
+	'thermostat_type_3_device',
 	'temperature_device',
 	'temperature_barometer_device',
 	'temperature_humidity_device',

--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -80,6 +80,17 @@ return {
 		device.isHTTPResponse = false
 		device.isSecurity = false
 
+        -- All baseTypes
+        device['changed'] = data.changed
+        device['protected'] = data.protected
+        device['description'] = data.description
+        device['lastUpdate'] = Time(data.lastUpdate)
+        device['updatedBy'] = data.updatedBy or 'n/a'
+        if device.updatedBy == '' then device.updatedBy = 'n/a'
+        elseif device.updatedBy == 'Admin' then device.updatedBy = 'Admin (or userless login)'
+        elseif device.updatedBy:find('EventSystem') and device.updatedBy:find('dzVents') then device.updatedBy = 'dzVents'
+        end
+
 		if (data.baseType == 'device') then
 
 			local bat
@@ -88,8 +99,6 @@ return {
 			if (data.batteryLevel <= 100) then bat = data.batteryLevel end
 			if (data.signalLevel <= 100) then sig = data.signalLevel end
 
-			device['changed'] = data.changed
-			device['description'] = data.description
 			device['deviceType'] = data.deviceType
 			device['hardwareName'] = data.data.hardwareName
 			device['hardwareType'] = data.data.hardwareType
@@ -103,7 +112,6 @@ return {
 			device['batteryLevel'] = bat
 			device['signalLevel'] = sig
 			device['deviceSubType'] = data.subType
-			device['lastUpdate'] = Time(data.lastUpdate)
 			device['rawData'] = data.rawData
 			device['nValue'] = data.data._nValue
 			device['sValue'] = data.data._state or ( table.concat(device.rawData,';') ~= '' and  table.concat(device.rawData,';') ) or nil
@@ -118,18 +126,13 @@ return {
 		end
 
 		if (data.baseType == 'group' or data.baseType == 'scene') then
-			device['description'] = data.description
-			device['protected'] = data.protected
-			device['lastUpdate'] = Time(data.lastUpdate)
 			device['rawData'] = { [1] = data.data._state }
-			device['changed'] = data.changed
 			device['cancelQueuedCommands'] = function()
 				domoticz.sendCommand('Cancel', {
 					type = 'scene',
 					idx = data.id
 				})
 			end
-
 		end
 
 		setStateAttribute(data.data._state, device, _states)

--- a/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
+++ b/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
@@ -13,7 +13,6 @@ local humidityMapping = {
 	['wet'] = 3
 }
 
-
 return {
 
 	baseType = 'device',
@@ -36,13 +35,14 @@ return {
 		local humVal = humidityMapping[string.lower(device.humidityStatus or '')] or -1
 		device.humidityStatusValue = humVal
 
-
 		function device.updateTempHumBaro(temperature, humidity, status, pressure, forecast)
 
 			if (status == nil) then
 				-- when no status is provided, domoticz will not set the device obviously
 				utils.log('No status provided. Temperature + humidity not set', utils.LOG_ERROR)
 				return
+			elseif status == -1 then
+				status = utils.humidityStatus(temperature, humidity) -- HUM_COMPUTE
 			end
 
 			forecast = forecast ~= nil and constMapping[forecast] or 5

--- a/dzVents/runtime/device-adapters/temperature_humidity_device.lua
+++ b/dzVents/runtime/device-adapters/temperature_humidity_device.lua
@@ -23,18 +23,13 @@ return {
 
 		-- from data: dewPoint, humidity, humidityStatus, temperature
 
-		local humVal = humidityMapping[string.lower(device.humidityStatus or '')] or -1
-		device.humidityStatusValue = humVal
-
+		device.humidityStatusValue = humidityMapping[string.lower(device.humidityStatus or '')] or -1
 
 		function device.updateTempHum(temperature, humidity, status)
-			if (status == nil) then
-				-- when no status is provided, domoticz will not set the device obviously
-				utils.log('No status provided. Temperature + humidity not set', utils.LOG_ERROR)
-				return
-			end
+			if status == nil or status == -1 then status = utils.humidityStatus(temperature, humidity) end -- HUM_COMPUTE or nil
 
-			local value = tostring(temperature) .. ';' .. tostring(humidity) .. ';' .. tostring(status)
+			local value = temperature .. ';' .. humidity .. ';' .. status
+
 			return device.update(0, value)
 		end
 

--- a/dzVents/runtime/device-adapters/thermostat_type_3_device.lua
+++ b/dzVents/runtime/device-adapters/thermostat_type_3_device.lua
@@ -1,0 +1,33 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Thermostat type 3 device adapter',
+
+	matches = function (device, adapterManager)
+		local res = device.deviceSubType:find('Mertik') and device.deviceType == 'Thermostat 3'
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateMode')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		local modes = {'Off','On','Up','Down','Run Up','Run Down','Stop'}
+
+		device.mode = device.nValue
+		device.modeString = modes[ device.nValue + 1 ]
+		device.modes = table.concat(modes,',')
+
+		device.sValue = '' -- sValue is reported wrong it's empty
+
+		function device.updateMode(mode)
+			local mode = mode:gsub(' ','%%20')
+			local url = domoticz.settings['Domoticz url'] .. '/json.htm?type=command&param=switchlight&idx=' .. device.id  ..'&switchcmd=' .. mode
+			return domoticz.openURL(url)
+		end
+
+	end
+
+}

--- a/dzVents/runtime/integration-tests/stage2.lua
+++ b/dzVents/runtime/integration-tests/stage2.lua
@@ -61,9 +61,9 @@ end
 local testSwitch = function(name)
 	local dev = dz.devices(name)
 	local res = true
-	res = res and checkAttributes(dev, {
-		["state"] = "On",
-	})
+	res = res and checkAttributes(dev, {["state"] = "On",})
+	handleResult ('Test switch device', res)
+	res = res and checkAttributes(dev, {["updatedBy"] = "dzVents",})
 	handleResult ('Test switch device', res)
 	return res
 end
@@ -536,7 +536,7 @@ local testGroup = function(name)
 		["id"] = 2,
 		["name"] = name,
 		['state'] = 'On',
-		['baseType'] = 'group'
+		['baseType'] = 'group',
 	})
 	handleResult('Test group', res)
 	return res
@@ -768,6 +768,8 @@ local testSceneDumps = function(name)
 	res = res and ( sc.dumpSelection('attributes') == nil )
 	res = res and ( sc.dumpSelection('functions') == nil )
 	res = res and ( sc.dumpSelection('tables') == nil )
+    utils.log('updatedBy is ' .. sc.updatedBy, utils.LOG_FORCE)
+    res = res and checkAttributes(sc, {["updatedBy"] = "dzVents",})
 	handleResult('Test scene dumps', res)
 	return res
 end

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -134,7 +134,7 @@ function fillTimes
 
 function fillNumberOfTests
 	{
-		Device_ExpectedTests=115
+		Device_ExpectedTests=119
 		Domoticz_ExpectedTests=80
 		EventHelpers_ExpectedTests=32
 		EventHelpersStorage_ExpectedTests=50
@@ -142,7 +142,7 @@ function fillNumberOfTests
 		Lodash_ExpectedTests=100
 		ScriptdzVentsDispatching_ExpectedTests=2
 		TimedCommand_ExpectedTests=46
-		Time_ExpectedTests=357
+		Time_ExpectedTests=360
 		Utils_ExpectedTests=36
 		Variable_ExpectedTests=15
 		ContactDoorLockInvertedSwitch_ExpectedTests=2

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -32,7 +32,8 @@ local function getDevice_(
 	baseType,
 	dummyLogger,
 	batteryLevel,
-	signalLevel)
+	signalLevel,
+	nValue)
 
 	local Device = require('Device')
 
@@ -81,11 +82,11 @@ local function getDevice_(
 		["hardwareTypeValue"] = hardwareTypeValue,
 		["hardwareID"] = 1,
 		['protected'] = true,
-		['_nValue'] = 123,
+		['_nValue'] = nValue or 123,
 		['unit'] = 1
 		},
 		["rawData"] = rawData,
-		["baseType"] = baseType ~= nil and baseType or "device",
+		["baseType"] = baseType or "device",
 		["changed"] = changed,
 		["changedAttribute"] = 'temperature' --tbd
 	}
@@ -117,7 +118,8 @@ local function getDevice(domoticz, options)
 		options.baseType,
 		options.dummyLogger,
 		options.batteryLevel,
-		options.signalLevel)
+		options.signalLevel,
+		options.nValue)
 
 end
 
@@ -162,6 +164,8 @@ describe('device', function()
 			['currentTime'] = '2017-08-17 12:13:14.123'
 		}
 
+		_G.domoticzData = {}
+
 		TimedCommand = require('TimedCommand')
 
 		Device = require('Device')
@@ -198,7 +202,8 @@ describe('device', function()
 				subType = 'sub',
 				hardwareType = 'hwtype',
 				hardwareTypeValue = 'hvalue',
-				state = 'bla'
+				state = 'bla',
+				id = 1,
 			})
 
 			assert.is_same(true, device.changed)
@@ -871,6 +876,34 @@ describe('device', function()
 
 		end)
 
+		it('should detect a Thermostat type 3 device', function()
+
+			local device = getDevice(domoticz, {
+				['name'] = 'myDevice',
+				['type'] = 'Thermostat 3',
+				['subType'] = 'Mertik some type',
+				['nValue'] = 2;
+				['_nValue'] = 2;
+				}
+			)
+
+			domoticz.openURL = function(url)
+				return url;
+			end
+
+			assert.is_same( { 'Off', 'On', 'Up', 'Down', 'Run Up', 'Run Down', 'Stop' } , utils.stringSplit(device.modes,',') )
+			assert.is_same(2, device.mode)
+			assert.is_same('Up', device.modeString)
+
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Off', device.updateMode('Off'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=On', device.updateMode('On'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Up', device.updateMode('Up'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Down', device.updateMode('Down'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Run%20Up', device.updateMode('Run Up'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Run%20Down', device.updateMode('Run Down'))
+			assert.is_same( 'http://127.0.0.1:8080/json.htm?type=command&param=switchlight&idx=1&switchcmd=Stop', device.updateMode('Stop'))
+		end)
+
 		it('should detect a wind device', function()
 			local device = getDevice(domoticz, {
 				['name'] = 'myDevice',
@@ -955,6 +988,16 @@ describe('device', function()
 			device.updateTempHum(10, 12, 'wet')
 			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="10;12;wet", _trigger=true} } }, commandArray)
 			assert.is_same(2, device.humidityStatusValue)
+
+			commandArray = {}
+			device.updateTempHum(10, 12)
+			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="10;12;2", _trigger=true} } }, commandArray)
+			assert.is_same(2, device.humidityStatusValue)
+
+			commandArray = {}
+			device.updateTempHum(24, 52)
+			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="24;52;1", _trigger=true} } }, commandArray)
+			assert.is_same(2, device.humidityStatusValue)
 		end)
 
 		it('should detect a temp+humidity+barometer device', function()
@@ -966,8 +1009,18 @@ describe('device', function()
 				}
 			})
 
-			device.updateTempHumBaro(10, 12, 'wet', 1000, 'rain')
-			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="10;12;wet;1000;4", _trigger=true} } }, commandArray)
+			device.updateTempHumBaro(10, 12, 2, 1000, 'rain')
+			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="10;12;2;1000;4", _trigger=true} } }, commandArray)
+			assert.is_same(1, device.humidityStatusValue)
+
+			commandArray = {}
+			device.updateTempHumBaro(10, 12, -1, 1000, 'rain')
+			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="10;12;2;1000;4", _trigger=true} } }, commandArray)
+			assert.is_same(1, device.humidityStatusValue)
+
+			commandArray = {}
+			device.updateTempHumBaro(24, 52, -1, 1000, 'rain')
+			assert.is_same({ { ["UpdateDevice"] = {idx=1, nValue=0, sValue="24;52;1;1000;4", _trigger=true} } }, commandArray)
 			assert.is_same(1, device.humidityStatusValue)
 		end)
 
@@ -1946,6 +1999,29 @@ describe('device', function()
 				assert.is_true(device.active)
 			end
 		end)
+	end)
+
+	it('Device should have a updatedBy', function()
+		device = getDevice_(domoticz, 'myDevice', 'On', false)
+		assert.is_same(device.updatedBy,'n/a')
+	end)
+
+	it('Group should have a updatedBy', function()
+		local group = getDevice(domoticz, {
+					['baseType'] = 'group',
+					['name'] = 'myGroup',
+					['state'] = 'On'
+				})
+		assert.is_same(group.updatedBy,'n/a')
+	end)
+
+	it('Scene should have a updatedBy', function()
+		local scene = getDevice(domoticz, {
+					['baseType'] = 'scene',
+					['name'] = 'myScene',
+					['state'] = 'On'
+				})
+		assert.is_same(scene.updatedBy,'n/a')
 	end)
 
 	it('should set the state', function()

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1824,6 +1824,21 @@ describe('Time', function()
 
 		describe('combis', function()
 
+			it('WIKI example: at daytime on mon,thu', function()
+				_G.timeofday = { ['Daytime'] = false }
+				local t = Time('2020-10-15 01:04:00')
+				assert.is_false(t.matchesRule('at daytime on mon,thu'))
+				assert.is_true(t.matchesRule('at nighttime on mon,thu'))
+			end)
+
+			it('WIKI example: every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11', function()
+				_G.timeofday = { ['SunsetInMinutes'] = 1220 , ['SunriseInMinutes'] = 480 }
+				local t = Time('2020-10-15 08:10:00')
+				assert.is_true(t.matchesRule('every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11'))
+				local t = Time('2020-10-15 08:11:00')
+				assert.is_false(t.matchesRule('every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11'))
+			end)
+
 			it('should return false when not on every second sunday between 1:00 and 1:30', function()
 				local t = Time('2018-12-30 01:04:00') -- on Sunday, odd week at 01:04
 				assert.is_false(t.matchesRule('between 1:00 and 1:30 on sun every odd week'))
@@ -1839,6 +1854,16 @@ describe('Time', function()
 
 				assert.is_false(t.matchesRule('every minute on tue'))
 
+			end)
+
+			it('should return false when outside date window', function() -- double on
+				local t = Time('2020-10-15 03:00:00')
+				assert.is_true(t.matchesRule('at 3:00 on mon,thu,fri,sun on 20/04-16/10'))
+				assert.is_true(t.matchesRule('at 3:00 on mon,thu,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:01 on mon,thu,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,wed,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,thu,fri,sun on 2/4-16/9'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,thu,fri,sun on 20/04-16/09'))
 			end)
 
 			it('at sunset on mon', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -25,7 +25,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("3.0.14")
+	m_version("3.0.15")
 {
 	m_bdzVentsExist = false;
 }
@@ -770,6 +770,7 @@ void CdzVents::ExportHardwareData(CLuaTable &luaTable, int& index, const std::ve
 void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<CEventSystem::_tEventQueue> &items)
 {
 	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_mainworker.m_eventsystem.m_devicestatesMutex);
+	std::vector<std::vector<std::string> > result;
 	int index = 1;
 	time_t now = mytime(NULL);
 	struct tm tm1;
@@ -777,14 +778,30 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 	struct tm tLastUpdate;
 	localtime_r(&now, &tLastUpdate);
 	int SensorTimeOut = 60;
-	m_sql.GetPreferencesVar("SensorTimeout", SensorTimeOut);
-
+	std::map<int, std::string> mResult;
 	struct tm ntime;
 	time_t checktime;
 
+	m_sql.GetPreferencesVar("SensorTimeout", SensorTimeOut);
+
+	//Get "lastUpdated by"  from devices and from scenes in result
+	result = m_sql.safe_query("SELECT T1.DeviceRowID ID, User FROM LightingLog T1 WHERE T1.Date IS (SELECT MAX(T2.Date) FROM LightingLog T2 WHERE T2.DeviceRowID = ID ) UNION SELECT T3.SceneRowid+1000000 ID, User FROM SceneLog T3 WHERE T3.Date IS (SELECT MAX(T4.Date) FROM SceneLog T4 WHERE T4.SceneRowID+1000000 = ID ) ORDER BY ID");
+
+	// store result vector in map to improve key, value search
+	if (!result.empty())
+	{
+		for (const auto& itr : result)
+		{
+			std::vector<std::string> sd = itr;
+			mResult.insert(std::pair<int, std::string>(atoi(sd[0].c_str()), sd[1] ));
+			index++;
+		}
+	}
+
 	CLuaTable luaTable(lua_state, "domoticzData");
 
-	// First export all the devices.
+	// Export all the devices.
+	index = 1;
 	std::map<uint64_t, CEventSystem::_tDeviceStatus>::iterator iterator;
 	for (iterator = m_mainworker.m_eventsystem.m_devicestates.begin(); iterator != m_mainworker.m_eventsystem.m_devicestates.end(); ++iterator)
 	{
@@ -818,20 +835,21 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		ParseSQLdatetime(checktime, ntime, sitem.lastUpdate, tm1.tm_isdst);
 		bool timed_out = (now - checktime >= SensorTimeOut * 60);
 
-		luaTable.OpenSubTableEntry(index, 1, 12);
+		luaTable.OpenSubTableEntry(index, 1, 13);
 
-		luaTable.AddString("name", sitem.deviceName);
+		luaTable.AddBool("changed", triggerDevice);
 		luaTable.AddBool("protected", (sitem.protection == 1) );
+		luaTable.AddBool("timedOut", timed_out);
 		luaTable.AddInteger("id", sitem.ID);
+		luaTable.AddInteger("lastLevel", sitem.lastLevel);
+		luaTable.AddInteger("switchTypeValue", sitem.switchtype);
 		luaTable.AddString("baseType","device");
 		luaTable.AddString("deviceType", dev_type);
+		luaTable.AddString("lastUpdate", sitem.lastUpdate);
+		luaTable.AddString("updatedBy", mResult[sitem.ID].c_str());
+		luaTable.AddString("name", sitem.deviceName);
 		luaTable.AddString("subType", sub_type);
 		luaTable.AddString("switchType", Switch_Type_Desc((_eSwitchType)sitem.switchtype));
-		luaTable.AddInteger("switchTypeValue", sitem.switchtype);
-		luaTable.AddString("lastUpdate", sitem.lastUpdate);
-		luaTable.AddInteger("lastLevel", sitem.lastLevel);
-		luaTable.AddBool("changed", triggerDevice);
-		luaTable.AddBool("timedOut", timed_out);
 
 		//get all svalues separate
 		std::vector<std::string> strarray;
@@ -925,7 +943,6 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 	boost::shared_lock<boost::shared_mutex> scenesgroupsMutexLock(m_mainworker.m_eventsystem.m_scenesgroupsMutex);
 
 	std::map<uint64_t, CEventSystem::_tScenesGroups>::const_iterator ittScenes;
-	std::vector<std::vector<std::string> > result;
 
 	for (ittScenes = m_mainworker.m_eventsystem.m_scenesgroups.begin(); ittScenes != m_mainworker.m_eventsystem.m_scenesgroups.end(); ++ittScenes)
 	{
@@ -942,13 +959,13 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 			}
 		}
 
-		result = m_sql.safe_query("SELECT Description FROM Scenes WHERE (ID=='%d')", sgitem.ID);
+		result = m_sql.safe_query("SELECT Description FROM Scenes WHERE (ID=='%u')", sgitem.ID);
 		if (result.empty())
 			description = "";
 		else
 			description = result[0][0].c_str();
 
-		luaTable.OpenSubTableEntry(index, 1, 7);
+		luaTable.OpenSubTableEntry(index, 1, 8);
 
 		luaTable.AddString("name", sgitem.scenesgroupName);
 		luaTable.AddInteger("id", sgitem.ID);
@@ -956,6 +973,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		luaTable.AddString("baseType", (sgitem.scenesgroupType == 0) ? "scene" : "group");
 		luaTable.AddBool("protected", (lua_Number)sgitem.protection == 1);
 		luaTable.AddString("lastUpdate", sgitem.lastUpdate);
+		luaTable.AddString("updatedBy", mResult[sgitem.ID + 1000000].c_str());
 		luaTable.AddBool("changed", triggerScene);
 
 		luaTable.OpenSubTableEntry("data", 0, 0);

--- a/www/app/devices/deviceFactory.js
+++ b/www/app/devices/deviceFactory.js
@@ -5,7 +5,7 @@ define(function () {
 
         function DeviceIcon(device) {
             this.isConfigurable = function() {
-                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort'].includes(device.Type) &&
+                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort','Thermostat 3'].includes(device.Type) &&
                     [0, 2, 7, 9, 10, 11, 17, 18, 19, 20].includes(device.SwitchTypeVal);
             };
 


### PR DESCRIPTION
```

======== domoticz V2020.2 (12485), dzVents V3.0.15 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        119      OK            119         0      0.3022
00:00:02  Domoticz                                      1         80      OK             80         0      0.3224
00:00:03  EventHelpers                                  1         32      OK             32         0      0.2101
00:00:03  EventHelpersStorage                           1         50      OK             50         0      0.2240
00:00:03  HTTPResponse                                  1          6      OK              6         0      0.0152
00:00:03  Lodash                                        1        100      OK            100         0      0.1549
00:00:04  ScriptdzVentsDispatching                      1          2      OK              2         0      0.0646
00:00:04  TimedCommand                                  1         46      OK             46         0      0.1070
00:00:04  Time                                          3        360      OK            360         0      0.7500
00:00:05  Utils                                         1         36      OK             36         0      0.0747
00:00:05  Variable                                      1         15      OK             15         0      0.0347
00:00:05  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.0641
00:00:08  DelayedVariableScene                          8          2      OK              2         0      7.0628
00:00:15  EventState                                   19          2      OK              2         0     18.0753
00:00:33  Integration                                  34        222      OK            222         0     28.6426
00:01:02  SelectorSwitch                               10          2      OK              2         0      9.1839
00:01:18  SystemAndCustomEvents                         1          7      OK              7         0      0.0390


Total tests: 1083
Mon 19 Oct 2020 08:48:41 AM CEST; dzVents version 3.0.15 tested without errors after 00:01:18

```

[3.0.15]
- Add updatedBy attribute to switchType devices-, scenes- and groups.
- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
- Add device adapter for Thermostat type 3 devices (Mertik)
- Add utils.humidityStatus
- Add option to have dzVents compute humidity status
