### PR TITLE
Removed obsolete code as function has moved to HardwareMonitor module

### DIFF
--- a/main/Helper.h
+++ b/main/Helper.h
@@ -104,9 +104,6 @@ int SetThreadName(const std::thread::native_handle_type &thread, const char *nam
 #if !defined(WIN32)
 	bool IsDebuggerPresent(void);
 #endif
-#if defined(__linux__)
-	bool IsWSL(void); //Detects if running under Windows Subsystem for Linux (WSL)
-#endif
 
 std::string GenerateUUID();
 double round_digits(double dIn, const int totDigits);


### PR DESCRIPTION
Found some leftover code in main/Helper.h that should not be there anymore as this function is now a private method of the HardwareMonitor module.