### PR TITLE
dzVents update to V3.0.15

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -21,8 +21,9 @@ Version 2020.xxxx (xxxx)
 - Implemented: Websocket notification for secondary/sub devices
 - Implemented: ZWave, Legend and tooltips in Neighbor�s overview
 - Implemented: AirconWithMe wifi module
-- Updated: dzVents version 3.0.14 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
+- Updated: dzVents version 3.0.15 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting#History )
 - Updated: eVehicles, added ODO meter, unlock/open alert, max charge level to Tesla module
+- Updated: MQTT, added publish schemes: device index, device name and implemented custom topics for in- and outbound messages
 - Updated: OpenZWave configuration files
 - Updated: Openweathermap has been improved
 - Updated: TTNMQTT, Better GPS/Locations handling, distance calculation (Geofencing)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -188,15 +188,15 @@ The `on` section tells dzVents *when* the execute function has to be executed. I
 The `on` section has many kinds of subsections that *can all be used simultaneously* :
 
 #### customEvents = { ... } <sup>3.0.0</sup>
-A list of one or more custom event triggers. This eventTrigger can be activate by a json/api call, a MQTT message (when domoticz is setup to listen to such messages on the hardware tab) or by the dzVents internal command domoticz.emitEvent 
- - The name of the custom-event 
- - The name of the custom-event followed by a time constraint, such as: 
+A list of one or more custom event triggers. This eventTrigger can be activate by a json/api call, a MQTT message (when domoticz is setup to listen to such messages on the hardware tab) or by the dzVents internal command domoticz.emitEvent
+ - The name of the custom-event
+ - The name of the custom-event followed by a time constraint, such as:
 	`['start']  = { 'at 15:*', 'at 22:* on sat, sun' }` The script will be executed if domoticz is started, **and** it is either between 15:00 and 16:00 or between 22:00 and 23:00 in the weekend. See [See time trigger rules](#timer_trigger_rules).
 
 ##### API
 	- curl: curl -d "{ 'a':10, 'b':20, 'some':'text', 'sub' : { 'x':10, 'y':20 } }" "http://<domoticzIP:domoticz port>/json.htm?type=command&param=customevent&event=<myCustomEvent>"
 	- JSON: **< domoticzIP : domoticz port >**/json.htm?type=command&param=customevent&event=<MyEvent>&data=myData
-	- MQTT simple:  {"command":"customevent", "event":"MyEvent","data":"myData"}  
+	- MQTT simple:  {"command":"customevent", "event":"MyEvent","data":"myData"}
 	- MQTT complex: {"command":"customevent","event":"MyEvent","data":"{\"idx\":29,\"test\":\"ok\"}" }
 	- emitEvent: domoticz.emitEvent('myCustomEvent' [,])
 		`domoticz.emitEvent('myEvent') -- no data`
@@ -341,7 +341,7 @@ The optional data section allows you to define local variables that will hold th
 The optional logging section allows you to override the global logging setting of dzVents as set in *Setup > Settings > Other > EventSystem > dzVents Log Level*. This can be handy when you only want this script to have extensive debug logging while the rest of your script executes silently. You have these options:
 
  - **level**: This is the log level you want for this script. Can be domoticz.LOG_INFO, domoticz.LOG_MODULE_EXEC_INFO, domoticz.LOG_DEBUG or domoticz.LOG_ERROR
- - **marker**: A string that is prefixed before each log message. That way you can easily create a filter in the Domoticz log to see just these messages. **marker** defaults to scriptname 
+ - **marker**: A string that is prefixed before each log message. That way you can easily create a filter in the Domoticz log to see just these messages. **marker** defaults to scriptname
 
 Example:
 ```Lua
@@ -579,7 +579,7 @@ There are several options for time triggers. It is important to know that Domoti
 			'every hour on sat',		-- you guessed it correctly
 			'at sunset',				-- uses sunset/sunrise/solarnoon info from Domoticz
 			'at sunrise',
-			'at solarnoon',				-- <sup>3.0.11</sup> 
+			'at solarnoon',				-- <sup>3.0.11</sup>
 			'at civiltwilightstart',	-- uses civil twilight start/end info from Domoticz
 			'at civiltwilightend',
 			'at sunset on sat,sun',
@@ -608,7 +608,7 @@ There are several options for time triggers. It is important to know that Domoti
 			'every even week',			-- odd or even numbered weeks
 			'on 23/11',					-- on 23rd of november (dd/mm)
 			'on 23/11-25/12',			-- between 23/11 and 25/12
-			'on 2/3-18/3',11/8,10/10-14/10',
+			'on 2/3-8/3,7/8,6/10-14/10',-- between march 2 and 8, on august 7 and between october 6 and 14.
 			'on */2,15/*',				-- every day in February or
 										-- every 15th day of the month
 			'on -3/4,4/7-',				-- before 3/4 or after 4/7
@@ -713,8 +713,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 		print(_u.rightPad('test',10) .. '|||') -- =>  test	  |||
 	```
 
-	- **\_.lodash**: This is an entire collection with very handy
-		Lua functions. Read more about
+	- **\_.lodashFunctions**: This is an entire collection with very handy Luafunctions. Read more about
 		[lodash](#lodash_for_Lua "wikilink").  E.g.:
 		``` {.lua}
 		domoticz.utils._.size({'abc', 'def'}))` Returns 2.
@@ -746,7 +745,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 	- **fromBase64(string)**: *Function*: <sup>2.5.2</sup>) Decode a base64 string
 	- **fromJSON(json, fallback <sup>2.4.16</sup>)**: *Function*. Turns a json string to a Lua table. Example: `local t = domoticz.utils.fromJSON('{ "a": 1 }')`. Followed by: `print( t.a )` will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.
 	- **fromXML(xml, fallback )**: *Function*: <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: `local t = domoticz.utils.fromXML('<testtag>What a nice feature!</testtag>') Followed by: `print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.
-	- **fuzzyLookup(string, parm)**: *Function*: <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.
+	- **fuzzyLookup([string|array of strings], parm)**: *Function*: <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.
 	 - **groupExists(parm)**: *Function*: <sup>2.4.28</sup> returns name when entered with a valid group ^3.0.12^ or groupID and return ID when entered with valid groupName or false when not a group, groupID or groupName of an existing group
 	 - **hardwareExists(parm)**: *Function*: <sup>3.0.7</sup> returns name when entered with valid hardwareID or ID when entered with valid hardwareName or false when not a hardwareID or hardwareName of an existing (and active  )hardware module
 	- **inTable(table, searchString)**: *Function*: <sup>2.4.21</sup> Returns `"key"` if table has searchString as a key, `"value"` if table has searchString as value and `false` otherwise.
@@ -864,14 +863,14 @@ The domoticz object has these constants available for use in your code e.g. `dom
 	if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end
 	```
 
- - **BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE**: for updating barometric values.
- - **EVENT_TYPE_DEVICE**, **EVENT_TYPE_VARIABLE**, **EVENT_TYPE_CUSTOM**<sup>3.0.0</sup>**EVENT_TYPE_SECURITY**,  **EVENT_TYPE_HTTPRESPONSE**, **EVENT_TYPE_SYSTEM**<sup>3.0.0</sup> **EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
- - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_TEMPORARY_OVERRIDE**, **EVOHOME_MODE_PERMANENT_OVERRIDE**, **EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
- - **EVOHOME_MODE_AUTO**, **EVOHOME_MODE_AUTOWITHRESET**, **EVOHOME_MODE_AUTOWITHECO**, **EVOHOME_MODE_AWAY**, **EVOHOME_MODE_DAYOFF**, **EVOHOME_MODE_CUSTOM**, **EVOHOME_MODE_HEATINGOFF** <sup>2.4.23</sup>: mode for EvoHome controller
- - **HUM_COMFORTABLE**, **HUM_DRY**, **HUM_NORMAL**, **HUM_WET**: constant for humidity status.
+ - **BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE, BARO_COMPUTE** : for updating barometric values.
+ - **EVENT_TYPE_DEVICE, EVENT_TYPE_VARIABLE, EVENT_TYPE_CUSTOM<sup>3.0.0</sup>EVENT_TYPE_SECURITY,  EVENT_TYPE_HTTPRESPONSE, EVENT_TYPE_SYSTEM<sup>3.0.0</sup> EVENT_TYPE_TIMER**: triggerInfo types passed to the execute function in your scripts.
+ - **EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE, EVOHOME_MODE_PERMANENT_OVERRIDE, EVOHOME_MODE_FOLLOW_SCHEDULE** <sup>2.4.9</sup>: mode for EvoHome system.
+ - **EVOHOME_MODE_AUTO, EVOHOME_MODE_AUTOWITHRESET, EVOHOME_MODE_AUTOWITHECO, EVOHOME_MODE_AWAY, EVOHOME_MODE_DAYOFF, EVOHOME_MODE_CUSTOM, EVOHOME_MODE_HEATINGOFF** <sup>2.4.23</sup>: mode for EvoHome controller
+ - **HUM_COMFORTABLE, HUM_DRY, HUM_NORMAL, HUM_WET, HUM_COMPUTE** <sup>3.0.15</sup>: constant for humidity status.
  - **INTEGER**, **FLOAT**, **STRING**, **DATE**, **TIME**: variable types.
  - **LOG_DEBUG**, **LOG_ERROR**, **LOG_INFO**, **LOG_FORCE**: for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
- - **NSS_FIREBASE**, **NSS_FIREBASE_CLOUD_MESSAGING**, **NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, **NSS_HTTP**, **NSS_KODI**, **NSS_LOGITECH_MEDIASERVER**, **NSS_NMA**,**NSS_PROWL**, **NSS_PUSHALOT**, **NSS_PUSHBULLET**, **NSS_PUSHOVER**, **NSS_PUSHSAFER**, **NSS_TELEGRAM** <sup>2.4.8</sup>, **NSS_GOOGLE_CLOUD_MESSAGING** <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
+ - **NSS_FIREBASE, NSS_FIREBASE_CLOUD_MESSAGING, NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, NSS_HTTP, NSS_KODI, NSS_LOGITECH_MEDIASERVER, NSS_NMA,NSS_PROWL, NSS_PUSHALOT, NSS_PUSHBULLET, NSS_PUSHOVER, NSS_PUSHSAFER, NSS_TELEGRAM <sup>2.4.8</sup>, NSS_GOOGLE_CLOUD_MESSAGING** <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
  - **PRIORITY_LOW**, **PRIORITY_MODERATE**, **PRIORITY_NORMAL**, **PRIORITY_HIGH**, **PRIORITY_EMERGENCY**: for notification priority.
  - **SECURITY_ARMEDAWAY**, **SECURITY_ARMEDHOME**, **SECURITY_DISARMED**: for security state.
  - **SOUND_ALIEN** , **SOUND_BIKE**, **SOUND_BUGLE**, **SOUND_CASH_REGISTER**, **SOUND_CLASSICAL**, **SOUND_CLIMB** , **SOUND_COSMIC**, **SOUND_DEFAULT** , **SOUND_ECHO**, **SOUND_FALLING**  , **SOUND_GAMELAN**, **SOUND_INCOMING**, **SOUND_INTERMISSION**, **SOUND_MAGIC** , **SOUND_MECHANICAL**, **SOUND_NONE**, **SOUND_PERSISTENT**, **SOUND_PIANOBAR** , **SOUND_SIREN** , **SOUND_SPACEALARM**, **SOUND_TUGBOAT**  , **SOUND_UPDOWN**: for notification sounds.
@@ -902,7 +901,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **icon**: *String*. Name of the icon in Domoticz GUI.
  - **id**: *Number*. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It's not truly an index but is unique enough for dzVents to be treated as an id.
  - **idx**: *Number*. Same as id: index of the device
- - **lastUpdate**: *[Time Object](#Time_object)*: Time when the device was updated.
+ - **lastUpdate**: *[Time Object](#Time_object)*: Time when the device was updated. **Note: The lastUpdate for devices that triggered the script at hand is in fact the previousUpdate time. The real lastUpdate time for these "script triggering" devices is the current time.
  - **name**: *String*. Name of the device.
  - **nValue**: *Number*. Numerical representation of the state.
  - **protected**: *Boolean*. <sup>2.4.27</sup> True when device / scene / group is protected. False otherwise.
@@ -913,7 +912,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **setDescription(description)**: *Function*. <sup>2.4.16</sup> Generic method to update the description for all devices, groups and scenes. E.g.: device.setDescription(device.description .. '/nChanged by '.. item.trigger .. 'at ' .. domoticz.time.raw). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **setIcon(iconNumber)**: *Function*. <sup>2.4.17</sup> method to update the icon for devices. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **setState(newState)**: *Function*. Generic update method for switch-like devices. E.g.: device.setState('On'). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
- - **setValues(nValue,[ sValue1, sValue2, ...])**: *Function*. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValues. Uses domoticz JSON API to force subsequent pushes like influxdb and MQTT. nValue required but when set to nil it defaults to current nValue. sValue parms are optional and can be many. <sup>3.0.8</sup> If one of sValue parms is 'parsetrigger', subsequent eventscripts will be triggered. 
+ - **setValues(nValue,[ sValue1, sValue2, ...])**: *Function*. <sup>2.4.17</sup> Generic alternative method to update device nValue, sValues. Uses domoticz JSON API to force subsequent pushes like influxdb and MQTT. nValue required but when set to nil it defaults to current nValue. sValue parms are optional and can be many. <sup>3.0.8</sup> If one of sValue parms is 'parsetrigger', subsequent eventscripts will be triggered.
  - **state**: *String*. For switches, holds the state like 'On' or 'Off'. For dimmers that are on, it is also 'On' but there is a level attribute holding the dimming level. **For selector switches** (Dummy switch) the state holds the *name* of the currently selected level. The corresponding numeric level of this state can be found in the **rawData** attribute: `device.rawData[1]`.
  - **signalLevel**: *Number* If applicable for that device then it will be from 0-100.
  - **switchType**: *String*. See Domoticz devices table in Domoticz GUI(Switches tab). E.g. 'On/Off', 'Door Contact', 'Motion Sensor' or 'Blinds'
@@ -922,7 +921,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **timedOut**: *Boolean*. Is true when the device couldn't be reached.
  - **unit**: *Number*. Device unit. See device list in Domoticz' settings for the unit.
  - **update(< params >)**: *Function*. Generic update method. Accepts any number of parameters that will be sent back to Domoticz. There is no need to pass the device.id here. It will be passed for you. Example to update a temperature: `device.update(0,12)`. This will eventually result in a commandArray entry `['UpdateDevice']='<idx>|0|12'`. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
-
+ 
 ### Device attributes and methods for specific devices
 Note that if you do not find your specific device type here you can always inspect what is in the `rawData` attribute. Please let us know that it is missing so we can write an adapter for it (or you can write your own and submit it). Calling `myDevice.dump()` will dump all attributes and values for myDevice to the Domoticz log.
 
@@ -1009,7 +1008,7 @@ Note that if you do not find your specific device type here you can always inspe
  - **isPythonPlugin**: *Boolean*
  - **type**: : *String*
  - **typeValue**: : *Number*
-  
+
 #### Humidity sensor
  - **humidity**: *Number*
  - **humidityStatus**: *String*
@@ -1083,7 +1082,7 @@ See switch below.
 
 #### Rain meter
  - **rain**: *Number* (please note that this does return the rain total for today)
- - **rainRate**: *Number* 
+ - **rainRate**: *Number*
  - **updateRain(rate, counter)**: *Function*. (rate in mm * 100 per hour, counter is total in mm) Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### RGBW(W) / Lighting Limitless/Applamp
@@ -1184,7 +1183,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **humidityStatus**: *String*
  - **humidityStatusValue**: *Number*. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
  - **temperature**: *Number*
- - **updateTempHumBaro(temperature, humidity, status, pressure, forecast)**: *Function*. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateTempHumBaro(temperature, humidity, status, pressure, forecast)**: *Function*. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET, HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Temperature, Humidity
  - **dewPoint**: *Number*
@@ -1192,7 +1191,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **humidityStatus**: *String*
  - **humidityStatusValue**: *Number*. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
  - **temperature**: *Number*
- - **updateTempHum(temperature, humidity, status)**: *Function*. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateTempHum(temperature, humidity [, status] )**: *Function*. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET or HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use `domoticz.toCelsius()` to convert a Fahrenheit temperature to Celsius. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Text
  - **text**: *String*
@@ -1201,6 +1200,12 @@ There are many switch-like devices. Not all methods are applicable for all switc
 #### Thermostat set point
  - **setPoint**: *Number*.
  - **updateSetPoint(setPoint)**:*Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+
+#### Thermostat type 3 (Mertik) <sup>3.0.15</sup>
+ - **mode**: *Number*. Current mode
+ - **modes**: *String*. List of all modes
+ - **modeString**: *String*. Current mode
+ - **updateMode(mode)**:*Function*. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### UV sensor
  - **uv**: *Number*. UV index.
@@ -1258,10 +1263,10 @@ Many dzVents device methods support extra options, like controlling a delay or a
 	-- switch on for 2 minutes after 10 seconds
 	device.switchOn().afterSec(10).forMin(2)
 
-	-- switch on at a specic time / day 
+	-- switch on at a specic time / day
 	device.switchOn().at('09:00')                 -- earliest moment it will be 09:00 hr.
-	device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30  
-	device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first) 
+	device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30
+	device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first)
 
 	-- switch on for 2 minutes after a randomized delay of 1-10 minutes
 	device.switchOff().withinMin(10).forMin(2)
@@ -1284,7 +1289,7 @@ Many dzVents device methods support extra options, like controlling a delay or a
 ```
 
 #### Options
- - **at(hh:mm[:ss][ on [ ddd|dddd ] )**: *Function*.<sup>3.0.1</sup> Activates the command at a certain time [ on a certain day] 
+ - **at(hh:mm[:ss][ on [ ddd|dddd ] )**: *Function*.<sup>3.0.1</sup> Activates the command at a certain time [ on a certain day]
  - **afterHour(hours), afterMin(minutes), afterSec(seconds)**: *Function*. Activates the command after a certain number of hours, minutes or seconds.
  - **cancelQueuedCommands()**: *Function*.  Cancels queued commands. E.g. you switch on a device after 10 minutes:  `myDevice.switchOn().afterMin(10)`. Within those 10 minutes you can cancel that command by calling:  `myDevice.cancelQueuedCommands()`.
  - **checkFirst()**: *Function*. Checks if the **current** state of the device is different than the desired new state. If the target state is the same, no command is sent. If you do `mySwitch.switchOn().checkFirst()`, then no switch command is sent if the switch is already on. This command only works with switch-like devices. It is not available for toggle and dim commands, either.
@@ -1413,7 +1418,7 @@ See table below
  - **Note 2**: for `domoticz.openURL()` only `at()`, `afterAAA()` and `withinAAA()` is available.
  - **Note 3**: Note 2 also applies for all commands depending on openURL (like rgbwwDevice.setAaa() commands).
  - **Note 4**: Including dimTo, switchSelector, setLevel and similar methods.
- 
+
 #### Follow-up event triggers
 Normally if you issue a command, Domoticz will immediately trigger follow-up events, and dzVents will automatically trigger defined event scripts. If you trigger a scene, all devices in that scene will issue a change event. If you have event triggers for these devices, they will be executed by dzVents. If you don't want this to happen, add `.silent()` to your commands (exception is updateSetPoint).
 
@@ -2470,479 +2475,10 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy.
 On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` and/or `::1` and you're good to go.
 
-# History
-
-## [3.0.14]
-- Add utils.fuzzyLookup
-- Made eventHelpers more resilient to coding errors in the on = section
-
-## [3.0.13]
-- Add utils.osCommand (caption)
-- Improved utils.stringSplit (implicit conversion to number on request)
-- Made log function more resilient when logitem is table with embedded function(s)
-- Improved domoticz.snapshot() to enable snapshot of multiple cameras (in one Email)
-
-## [3.0.12]
-- Add option to use device, camera, group, scene and variable objects as parm to deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods.
-
-## [3.0.11]
-- Add sensorValue attribute to custom sensor
-- Add solarnoon as moment in time (like sunrise / sunset ) 
-
-## [3.0.10]
-- Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
-- Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
-
-## [3.0.9]
-- Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
-- Add function toUTC to time object.
-- Allow table as parm to function makeTime
-
-## [3.0.8]
-- Allow IPv6 ::1 as localhost in domoticz settings 
-- Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
-- Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
-- Updated round.utils to correctly handle negative numbers and round to zero decimals
-
-## [3.0.7]
-- Add domoticz.hardware() as separate object class
-
-## [3.0.6]
-- Add hardwareInfo() function
-
-## [3.0.5]
-- Add dumpSelection() method 
-- Fixed settings.url
-
-## [3.0.4]
-- Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 
-- add isJSON, isXML functions to Utils 
-
-## [3.0.3]
-- add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object) 
-
-## [3.0.2]
-- Add `PUT` and `DELETE` support to `openURL`
-- Ensure sending integer in nValue in update function
-- Fix sValue for custom sensor
-
-## [3.0.1] 
-- Add option `at()` to the various commands/methods
-- Add stringToSeconds() function
-
-## [3.0.0]
- - Add system-events triggers as option to the on = { ... } section. Scripts can now be triggered based on these system-events:
-	 - start
-	 - stop
-	 - manualBackupFinished,
-	 - dailyBackupFinished
-	 - hourlyBackupFinished
-	 - monthlyBackupFinished
-
- - Add custom-events triggers as option to the on = { ... } section. You can now send an event trigger to start subscribed dzVents scripts. customEvents can be triggered by:
-	 - dzVents domoticz.emitEvent(name, data )  --  command  (data = optional)
-	 - JSON: json.htm?type=command&param=customevent&event=MyEvent&data=myData ( data = optional )
-	 - MQTT: {"command" : "customevent", "event" :    "MyEvent" , "data" : "myData" } ( data = opt ional )
- - Add method  domoticz.emitEvent()
- - Add attribute `mode` to Evohome controller
- - Add option to dumpTable() and ([device][uservariable][scene][group].dump() to os file
-
-## [2.5.7]
-- Add option checkFirst to switchSelector method
-
-## [2.5.6]
-- Add dayName, monthName, monthAbbrName and time as time attributes
-- Add \_.round, \_.isEqual functions to lodash.lua
-- Add testLodash.lua as testModule for lodash
-
-## [2.5.5]
-- Add Zwave fan to Zwave mode device adapter
-
-## [2.5.4]
-- Add minutesSinceMidnight to domoticz Time object
-- Add domoticz.time.addSeconds(), -.addMinutes(), -.addHours(), -.addDays(), -.makeTime()
-- Add string.sMatch to utils
-- Made wildcard handling more resilient when magic chars are part of script triggers
-
-## [2.5.3]
-- Add timealert / errors for long running scripts
-- Add triggerHTTPResponse()
-
-## [2.5.2]
-- Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
-- Add toBase64 and fromBase64 function in utils
-- Add setLogMarker function in utils
-- Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
-
-## [2.5.1]
-- Added `toXML` and `fromXML` methods to domoticz.utils.
-- Add attributes isXML, xmlVersion, xmlEncoding
-
-## [2.5.0]
-- Prepared for Lua 5.3
-
-## [2.4.29]
-- Add error message including affected module when module got corrupted on disk.
-- Add setLevel method for switchTypes.
-- Increased resilience against badly formatted type Time user-variables.
-- Use native domoticz command for increaseCounter method.
-- Set inverse of "set color" to Off to enable use of toggleSwitch for RGB type of devices.
-
-## [2.4.28]
-- Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils
-- increased httpResponse resilience against different use of Upper-, Lowercase in headers['content-type'] to ensure JSON conversion to Lua table
-
-## [2.4.27]
-- Add attribute protected for devices / scenes and groups
-- Add methods protectionOn and protectionOff for devices / scenes and groups
-- Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
-
-## [2.4.26]
-- Add Smoke Detector device (activate and reset functions )
-
-## [2.4.25]
-- Add rawDateTime
-- fix for combined device / civil[day|night]time trigger rule
-- fix for checkFirst on stopped status
-
-## [2.4.24]
-- Add method rename for devices, user-variables , scenes and groups
-
-## [2.4.23]
-- Add method setMode for evohome device
-- Add method incrementCounter for incremental counter
-- Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
-- fix wildcard device
-
-## [2.4.22]
-- selector.switchSelector method accepts levelNames
-- increased selector.switchSelector resilience
-- fix wildcard timerule
-
-## [2.4.21]
-- fixed wrong direction for open() and close() for some types of blinds
-- Add inTable function to domoticz.utils
-- Add sValue attribute to devices
-
-## [2.4.20]
-- Add quietOn() and quietOff() method to switchType devices
-
-## [2.4.19]
-- Add stringSplit function to domoticz.utils.
-- Add statusText and protocol to HTTPResponse
-
-## [2.4.18]
-- Add triggerIFTTT() to domoticz
-
-## [2.4.17]
-- Add dumpTable() to domoticz.utils
-- Add setValues for devices
-- Add setIcon for devices
-
-## [2.4.16]
-- Add method dump() to domoticz (dumps settings)
-- Add setHue, setColor, setHex, getColor for RGBW(W) devices
-- Add setDescription for devices, groups and scenes
-- Add volumeUp / volumeDown for Logitech Media Server (LMS)
-- Changed domoticz.utils.fromJSON (add optional fallback param)
-
-## [2.4.15]
-- Add option to use camera name in snapshot command
-- Add domoticz.settings.domoticzVersion
-- Add domoticz.settings.dzVentsVersion
-
-## [2.4.14]
-- Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
-- Added check for- and message when call to openURL cannot open local (127.0.0.1)
-- **BREAKING CHANGE** :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
-- prevent call to updateCounter with table
-
-## [2.4.13]
-- Added domoticz.settings.location (domoticz settings location Name)
-- Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
-
-## [2.4.12]
-- Added managed Counter (to counter)
-
-## [2.4.11]
-- Added snapshot command to send Email with camera snapshot ( afterAAA() and withinAAA() options available)
-
-## [2.4.10]
-- Added option to use afterAAA() and withinAAA() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup>
-- Changed function updateMode to display mode as string in domoticz log
-
-## [2.4.9]
-- Added evohome hotwater device (state, mode, untilDate and setHotWater function)
-- Added mode and untilDate for evohome zone devices
-- Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
-- Add speedMs and gustMs from wind devices
-- bugfix for youless device (0 handling)
-- bugfix for time ( twilightstart and twilightend handling)
-- Fixed some date-range rule checking
-
-## [2.4.8]
-- Added telegram as option for domoticz.notify
-
-## [2.4.7]
-- Added support for civil twilight in rules
-
-## [2.4.6]
-- Added Youless device
-- Added more to the documentation section for http requests
-- Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
-
-## [2.4.5]
-- Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&t=23109).
-
-## [2.4.4]
-- Fixed rawTime and rawData so it shows leading zeros when values are below 10.
-- Fixed one wildcard issue. Should now work as expected.
-- Fixed a problem in Domoticz where you couldn't change the state of some door contact-like switches using the API or dzVents. That seems to work now.
-
-## [2.4.3]
-- Fixed trigger wildcards. Now you can do `*aa*bb*cc` or `a*` which will require the target to start with an `a`
-- Added more EvoHome device types to the EvoHome device adapter.
-
-## [2.4.2]
-- Fixed RGBW device adapter
-- Fixed EvoHome device adapter
-- Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&t=21620&p=170469#p170469)
-
-## [2.4.1]
-- Fixed week number problems on Windows
-- Fixed 'on date' rules to support dd/mm format (e.g. 01/02)
-
-## [2.4.0]
-
-- **BREAKING CHANGE**: The second parameter passed to the execute function is no longer `nil` when the script was triggered by a timer or a security event. Please check your scripts. The second parameter has checks to determine the type. E.g. `execute = function(domoticz, item) .. end`. You can inspect `item` using: `item.isDevice`, `item.isTimer`, `item.isVariable`, `item.isScene`, `item.isGroup`, `item.isSecurity`, `item.isHTTPResponse`. Please read the documentation about the execute function.
-- Added ``.cancelQueuedCommands()`` to devices, groups, scenes and variables. Calling this method will cancel any scheduled future commands issued using for instance `.afterMin(10)` or `.repeatAfterMin(1, 4)`
-- Added `.devices()` collection to scenes and groups to iterate (`forEach`, `filter`, `reduce`, `find`) over the associated devices.
-- Added http response event triggers to be used in combination with `openURL`. You can now do `GET` and `POST` request and handle the response in your dzVents scripts **ASYNCHRONICALLY**. See the documentation. No more json parsing needed or complex `curl` shizzle.
-- Added a more consistent second parameter sent to the execute function. When a timer is triggered then the second parameter is a Timer object instead of nil. This way you can check the baseType of the second parameter and makes third parameter (triggerInfo) kind of obsolete. Every object bound to the second parameter now has a baseType.
-- Added locked/unlocked support for door-locks (locked == active).
-- Moved utility functions from the domoticz object to `domoticz.utils` object. You will see a deprecation warning when using the old function like `round()`, `toCelsius()` etc.
-- Added `lodash` as a method to `domoticz.utils`: `domoticz.utils._`
-- Added `toJSON` and `fromJSON` methods to domoticz.utils.
-- Added `afterAAA()` and `withinAAA()` support for device-update commands. E.g.: `myTextDevice.updateText('Zork').afterMin(2)`.
-- Added support for Logitech Media Server devices (thanks to Eoreh).
-- Added new timer rules: date rules: `on 13/07`, `on */03`, `on 12/*`, `on 12/04-22/09`, `on -24/03`, `on 19/11-`, week rules: `in week 12,15,19-23,-48,53-`, `every even week`, `every odd week`. See documentation.
-- Added historical data helper `delta2(fromIndex, toIndex, smoothRangeFrom, smoothRangeTo, default)` to have a bit more control over smoothing. You can specify if want to smooth either the start value (reference) and/or the to value (compared value).
-- Added historical data helper `deltaSinceOrOldest(timeAgo, smoothRangeFrom, smoothRangeTo, default)`. This will use the oldest data value when the data set is shorter than timeAgo.
-- Added support for Lighting Limitless/Applamp RGBW devices. You can now set Kelvin and RGB values, NightMode, WhiteMode and increase and decrease the brightness and discoMode. See the documentation.
-- Added device adapter for Onkyo receiver hardware.
-- Added `scriptName` to the triggerInfo object passed as the third parameter to the execute function. This holds the name of the script being executed.
-- Fixed bug in Domoticz where using forAAA() with selector switches didn't always work.
-- Fixed bug in Domoticz where improper states were passed to the event scripts. This may happen on slower machines where several devices may have been updated before the event-system had a change to operate on them. In that case the event scripts received the current final state instead of the state at the moment of the actual event.
-- Added support for webroot. dzVents will now use the proper API url when domoticz is started with the -webroot switch.
-- Added support for event-bursts. If (on slower machines) events get queued up in Domoticz, they will be sent to dzVents in one-package. This makes event processing significantly faster.
-- Added `domoticz.data.initialize(varName)`. This will re-initialize non-historical variables to the initial value as defined in the data section.
-- You now no longer have to provide an initial value for a persistent variable when you declare it. So you can do `data = { 'a', 'b', 'c'}` instead of `data = {a={initial = nil}, b={initial=nil}, c={initial=nil} }`. You have to quote the names though.
-- A filter can now accept a table with names/id's instead of only functions. You can now do `domoticz.devices().filter({ 'mySwitch', 'myPIR', 34, 35, 'livingLights'})` which will give you a collection of devices with these names and ids.
-- Added and documented `domoticz.settings.url`, `domoticz.settings.webRoot` and `domoticz.settings.serverPort`.
-- Removed fixed limit on historical variables if there is a limit specified.
-
-## [2.3.0]
-
- - Added `active` attribute to devices (more logical naming than the attribute 'bState'). `myDevice.active` is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like `if mySwitch.active then .. end`
- - Added `domoticz.urlEncode` method on the `domoticz` object so you can prepare a string before using it with `openURL()`.
- - Updating devices, user variables, scenes and groups now always trigger the event system for follow-up events.
- - Added support for groups and scenes change-event scripts. Use `on = { scenes = { 'myScene1', 'myScene2' }, groups = {'myGroup1'} }`
- - Added adapter for the new Temperature+Barometer device.
- - Added `domoticz.startTime` giving you the time at which the Domoticz service was started. Returns a Time object.
- - Added `domoticz.systemUptime` (in seconds) indicating the number of seconds the machine is running. Returns a Time object.
- - Added more options to the various commands/methods: e.g. `myDevice.switchOff().silent()`, `.forSec()`, `.forHour()`, `.afterHour()`, `.repeatAfterSec()`, `.repeatAfterMin()`, `.repeatAfterHour()`, `.withinHour()` and `.checkFirst()`. This now works not only for devices but also scenes, groups and user variables. See documentation about command options.
- - Added `.silent()` option to commands like `switchOn().afterSec(4).silent()` causing no follow-up events to be triggered. This also works when updating non-switch-like devices, scenes, groups and user variables. If you do not call `silent()``, a follow-up event is *always* triggered (for devices, scenes, groups and user variables).
- - Added time rule `between xx and yy`. You can now do things like: `between 16:34 and sunset` or `between 10 minutes before sunset and sunrise`. See the doc.
- - Added support for milliseconds in `Time` object. This also give a ms part in the time-stamp for historical persistent data. You can now do `msAgo()` on time stamp when you inspect a data point from an history variable.
- - Added `daysAgo()` to `Time` object.
- - Added `compare(time)` method to `Time` object to calculate the difference between them. Returns a table. See documentation.
- - Added `domoticz.round()` method to `domoticz` object.
- - Added `text` property to alert sensor.
- - `active` section is now optional in your dzVents script. If you don't specify an `active = true/false` then true is assumed (script is active). Handy for when you use Domoticz' GUI script editor as it has its own way of activating and deactivating scripts.
- - Added `humidityStatusValue` for humidity devices. This value matches with the values used for setting the humidity status.
- - `Time` object will initialize to current time if nothing is passed: `local current = Time()`.
- - Added the lua lodash library,	<!--  removed because of dead link http://axmat.github.io/lodash.lua/ , MIT license ).	-->
- - Fixed documentation about levelNames for selector switches and added the missing levelName.
- - Moved dzVents runtime code away from the `/path/to/domoticz/scripts/dzVents` folder as this scripts folder contains user stuff.
- - Added more trigger examples in the documentation.
- - You can now put your own non-dzVents modules in your scripts folder or write them with the Domoticz GUI editor. dzVents is no longer bothered by it. You can require your modules in Lua's standard way.
- - Added `/path/to/domoticz/scripts/dzVents/scripts/modules` and `/path/to/domoticz/scripts/dzVents/modules` to the Lua package path for custom modules. You can now place your modules in there and require them from anywhere in your scripts.
- - Added dzVents-specific boilerplate/templates for internal web editor.
- - Fixed the confusing setting for enabling/disabling dzVents event system in Domoticz settings.
- - Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn't executed.
-
-## [2.2.0]
-
- - Fixed typo in the doc WActual > WhActual.
- - Updated switch adapter to match more switch-like devices.
- - Added Z-Wave Thermostat mode device adapter.
- - Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
- - Added secondsSinceMidnight to time attributes (e.g. lastUpdate.secondsSinceMidnight)
- - Added 4 new time-rules: xx minutes before/after sunset/sunrise.
- - Added example script to fake user presence.
- - Fixed support for uservariables with spaces in their names.
- - Show a warning when an item's name isn't unique in the collection.
- - Added timing options for security methods armAway, armHome and disarm like device.armAway().afterSec(10).
- - Added idx, deviceId and unit to device objects. Don't confuse deviceId with device.id(x) which is actually the index of the device.
- - Added instructions on how to create a security panel device in Domoticz. This device now has a state that has the same value as domoticz.security.
- - Fixed bug in check battery levels example.
- - Fixed some irregularities with dimmer levels.
-
-## [2.1.1]
-
- - Fixed typo in the doc WActual > WhActual.
- - Updated switch adapter to match more switch-like devices.
- - Added Z-Wave Thermostat mode device adapter.
- - Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
-
-## [2.1.0]
-
- - Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
- - Added support for Ampère 1 and 3-phase devices
- - Added support for leaf wetness devices
- - Added support for scale weight devices
- - Added support for soil moisture devices
- - Added support for sound level devices
- - Added support for visibility devices
- - Added support for waterflow devices
- - Added missing color attribute to alert sensor devices
- - Added updateEnergy() to electric usage devices
- - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
- - Added toCelsius() helper method to domoticz object as the various update temperature methods all need Celsius.
- - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
- - Added integration tests for full round-trip Domoticz > dzVents > Domoticz > dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
- - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
- - Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it's own heartbeat.
- - avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
- - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
- - Use different api command for setting setPoints in the Thermostat setpoint device adapter.
-
-## [2.0.0] Domoticz integration
-
- - Almost a complete rewrite.
- - **BREAKING CHANGE**: Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing `domoticz.devices['myDevice']` you now have to call a function: `domoticz.devices('myDevice')`. This applies also for the other collections: `domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()`. If you want to loop over these collection **you can no longer use the standard Lua for..pairs or for..ipairs construct**. You have to use the iterators like forEach, filter and reduce: `domoticz.devices().forEach(function() .. end)` (see [Looping through the collections: iterators](#Looping_through_the_collections:_iterators)). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. **So please change your existing dzVents scripts!**
- - **BREAKING CHANGE**: after_sec, for_min, after_min, within_min methods have been renamed to the camel-cased variants afterSec, forMin, afterMin, withinMin. Please rename the calls in your script.
- - **BREAKING CHANGE**: There is no longer an option to check if an attribute was changed as this was quite useless. The device has a changed flag. You can use that. Please change your existing scripts.
- - **BREAKING CHANGE**: Many device attributes are now in the appropriate type (Number instead of Strings) so you can easily make calculations with them. Units are stripped from the values as much as possible. **Check your scripts as this may break stuff.**
- - **BREAKING CHANGE**: on-section now requires subsections for `devices`, `timer`, `variables`, and `security`. The old way no longer works! Please convert your existing scripts!
- - **BREAKING CHANGE**: Make sure that in Domoticz settings under **Local Networks (no username/password)** you add `127.0.0.1` so dzVents can use Domoticz api when needed.
- - dzVents now works on Windows machines!
- - dzVents is no longer a separate library that you have to get from GitHub. All integrated into Domoticz.
- - Added option to create shared utility/helper functions and have them available in all your scripts. Simply add a `helpers = { myFunction = function() ... end }` to the `global_data.lua` file in your scripts folder and you can access the function everywhere: `domoticz.helpers.myFunction()`.
- - Created a pluggable system for device adapters so people can easily contribute by creating specific adapters for specific devices. An adapter makes sure that you get the proper methods and attributes for that device. See `/path/to/domoticz/scripts/dzVents/runtime/device-adapters`.
- - Added a `reduce()` iterator to the collections in the domoticz object so you can now easily collect data about all your devices. See  [Looping through the collections: iterators](#Looping_through_the_collections:_iterators).
- - Added a `find()` iterator so you can easily find an item in one of the collection (devices, scenes, groups etc.). See  [Looping through the collections: iterators](#Looping_through_the_collections:_iterators).
- - Variables (uservariables) have more attributes. The `value` is now the same type as it is defined in Domoticz. So no more need for a converted nValue attribute. You can inspect the type using `myVar.type`. If it is a time variable or date variable you an extra `date` or `time` attribute with the same methods as with all other date/time related attributes like `lastUpdate`. .E.g. `myVar.date.minutesAgo`.
- - Settings are now moved to the Domoticz GUI (**Setup > Settings > Other**) and no longer in a settings file.
- - You can now override the log settings per script. So you can turn-off logging globally (see log level in the settings) and still have debug-level logging for that one script you are working on. You can even add a prefix string to the log messages for easy filtering in the Domoticz log. See the documentation about the `logging = { .. }` section.
- - No more need to do http-calls to get extended data from Domoticz. All relevant internal Domoticz state-data is now available inside your dzVents scripts. Thanks Scotty!!
- - Support for many many more device types and their specific methods. See the documentation for the list of attributes and events that are available. Note that device-type specific attributes are only available for those type of devices. You will receive an error in the log if you try to access an attribute that doesn't exist for that particular device. Hopefully you don't have to use the rawData table anymore. If you still do please file a report or create a device adapter yourself.
- - You can now write dzVents scripts using the internal editor in Domoticz. These scripts will be automatically exported to the filesystem (one-way only) so dzVents can execute them (generated_scripts folder).  Thanks again Scotty!
- - Support for variable change events (`on = { variables = { 'varA', 'varB'} }`)
- - Support for security change events (`on = { security = { domoticz.SECURITY_ARMEDAWAY } }`)
- - The triggerInfo passed to the execute function now includes information about which security state triggered the script if it was a security event.
- - Extended the timer-rule with time range e.g. `at 16:45-21:00` and `at nighttime` and `at daytime` and you can provide a custom function. See documentation for examples. The timer rules can be combined as well.
- - Timer rules for `every xx minutes` or `every xx hours` are now limited to intervals that will reach *:00 minutes or hours. So for minutes you can only do these intervals: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20 and 30. Likewise for hours.
- - The Time object (e.g. domoticz.time) now has a method `matchesRule(rule)`. `rule` is a string same as you use for timer options: `if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end`. The rule matches if the current system time matches with the rule.
- - A device trigger can have a time-rule constraint: ` on = { devices = { ['myDevice'] = { 'at nighttime' } }`. This only triggers the script when myDevice was changed **and** the time is after sunset and before sunrise.
- - Add support for subsystem selection for domoticz.notify function.
- - Fixed a bug where a new persistent variable wasn't picked up when that variable was added to an already existing data section.
-
-## [1.1.2]
-
- - More robust way of updating devices.lua
- - Added device level information for non-dimmer-like devices
-
-## [1.1.1]
-
- - Added support for a devices table in the 'on' section.
- - Added extra log level for only showing information about the execution of a script module.
- - Added example script for System-alive checker notifications (preventing false negatives).
-
-## [1.1]
-
- - Added example script for controlling the temperature in a room with hysteresis control.
- - Fixed updateLux (thanks to neutrino)
- - Added Kodi commands to the device methods.
- - Fixed updateCounter
- - Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled. See [Using dzVents with Domoticz](#Using_dzVents_with_Domoticz).
-
-## [1.0.2]
-
- - Added device description attribute.
- - Added support for setting the setpoint for opentherm gateway.
- - Added timedOut boolean attribute to devices. Requires http data fetching to be enabled. See [Using dzVents with Domoticz](#Using_dzVents_with_Domoticz).
- - Properly detects usage devices and their Wattage.
-
-## [1.0.1]
-
- - Added updateCustomSensor(value) method.
- - Fixed reset() for historical data.
-
-## [1.0][1.0-beta2]
-
- - Deprecated setNew(). Use add() instead. You can now add multiple values at once in a script by calling multiple add()s in succession.
- - Fixed printing device logs when a value was boolean or nil
- - Fixed WActual/total/today for energy devices.
- - Added updateSetPoint method on devices for dummy thermostat devices and EvoHome setpoint devices
- - Added couple of helper properties on Time object. See README.
- - Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don't overwrite your settings when you copy over a new version of dzVents to your system.
-
-## [1.0-beta1]
-
- - Added data persistence for scripts between script runs (see readme for more info)
- - Added a time-line based data type for you scripts with historical information and many statistical functions for retreiving information like average, minumum, maximum, delta, data smoothing (averaging values over neighbours) etc. See readme for more information.
- - Added SMS method to the domoticz object.
- - Added toggleSwitch() method to devices that support it.
- - Added more switch states that control device.bState (e.g. on == true, open == true 'all on' == true)
- - Added secondsAgo to the lastUpdate attribute
- - Added tests (test code coverage is above 96%!)
- - Refactored code significantly.
- - Made sure differently formulated but equal triggers in one script only execute the script only once (like MySensor and MySensor_Temperature).
- - Added trigger info as a third parameter (Lua table) that is passed to the execute method of a script containing information about what exactly triggered the script (type = EVENT_TYPE_TIMER/EVENT_TYPE_DEVICE, trigger=<timer rule>). See readme.
- - Added Lua time properties to domoticz.time property with all information about the current time (hours, minutes, seconds, etc.)
- - Added option to return false in a forEach iteratee function which will abort the forEach loop.
- - All devices not delivered by Domoticz to the event scripts are now added to domoticz.devices using the http data that is fetched every 30 minutes (by default).
- - Added scenes and groups collections to the domoticz object
- - Added Quick Reference Guide.
-
-## [0.9.13]
-
- - Fixed some timer functions
-
-## [0.9.12]
-
- - Fixed a bug with log level printing. Now errors are printed.
- - Added setPoint, heatingMode, lux, WhTotal, WhToday, WActual attributes to devices that support it. No need to access rawData for these anymore.
-
-## [0.9.11]
-
- - Added log method to domoticz object. Using this to log message in the Domoticz log will respect the log level setting in the settings file. [dannybloe]
- - Updated readme. Better overview, more attributes described.
- - Added iterator functions (forEach and filter) to domoticz.devices, domoticz.changedDevices and domoticz.variables to iterate or filter more easily over these collections.
- - Added a couple of example scripts.
-
-## [0.9.10]
-
- - A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
- - Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
- - Added support for sounds in domoticz.notify(). [WebStarVenlo]
-
-## [0.9.9]
-
- - Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy...
-
-## [0.9.8]
-
- - Fixed a bug where a device can have underscores in its name.
- - Added dimTo(percentage) method to control dimmers.
- - Modified the switch-like commands to allow for timing options: .for_min(), .within_min(), after_sec() and after_min() methods to control delays and durations. Removed the options argument to the switch functions. See readme.
- - Added switchSelector method on a device to set a selector switch.
- - Added wild-card option for triggers
- - Added http request data from Domoticz to devices. Now you can check the battery level and switch type and more. Make sure to edit dzVents_settings.lua file first and check the readme for install instructions!!!
- - Added log level setting in dzVents_settings.lua
-
-## [0.9.7]
-
- - Added domoticz object resource structure. Updated readme accordingly. No more (or hardly any) need for juggling with all the Domoticz Lua tables and commandArrays.
-
+# History [link to changes in previous versions](https://www.domoticz.com/wiki/DzVents_version_History).
+
+## [3.0.15]
+- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
+- Add device adapter for Thermostat type 3 devices (Mertik)
+- Add utils.humidityStatus
+- Add option to have dzVents compute humidity status

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -184,7 +184,7 @@ A list of one or more custom event triggers. This eventTrigger can be activate b
 
 <pre>- curl: curl -d &quot;{ 'a':10, 'b':20, 'some':'text', 'sub' : { 'x':10, 'y':20 } }&quot; &quot;http://&lt;domoticzIP:domoticz port&gt;/json.htm?type=command&amp;param=customevent&amp;event=&lt;myCustomEvent&gt;&quot;
 - JSON: **&lt; domoticzIP : domoticz port &gt;**/json.htm?type=command&amp;param=customevent&amp;event=&lt;MyEvent&gt;&amp;data=myData
-- MQTT simple:  {&quot;command&quot;:&quot;customevent&quot;, &quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;myData&quot;}  
+- MQTT simple:  {&quot;command&quot;:&quot;customevent&quot;, &quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;myData&quot;}
 - MQTT complex: {&quot;command&quot;:&quot;customevent&quot;,&quot;event&quot;:&quot;MyEvent&quot;,&quot;data&quot;:&quot;{\&quot;idx\&quot;:29,\&quot;test\&quot;:\&quot;ok\&quot;}&quot; }
 - emitEvent: domoticz.emitEvent('myCustomEvent' [,])
     `domoticz.emitEvent('myEvent') -- no data`
@@ -557,7 +557,7 @@ There are several options for time triggers. It is important to know that Domoti
             'every hour on sat',        -- you guessed it correctly
             'at sunset',                -- uses sunset/sunrise/solarnoon info from Domoticz
             'at sunrise',
-            'at solarnoon',             -- <sup>3.0.11</sup> 
+            'at solarnoon',             -- <sup>3.0.11</sup>
             'at civiltwilightstart',    -- uses civil twilight start/end info from Domoticz
             'at civiltwilightend',
             'at sunset on sat,sun',
@@ -586,7 +586,7 @@ There are several options for time triggers. It is important to know that Domoti
             'every even week',          -- odd or even numbered weeks
             'on 23/11',                 -- on 23rd of november (dd/mm)
             'on 23/11-25/12',           -- between 23/11 and 25/12
-            'on 2/3-18/3',11/8,10/10-14/10',
+            'on 2/3-8/3,7/8,6/10-14/10',-- between march 2 and 8, on august 7 and between october 6 and 14.
             'on */2,15/*',              -- every day in February or
                                         -- every 15th day of the month
             'on -3/4,4/7-',             -- before 3/4 or after 4/7
@@ -685,7 +685,7 @@ The domoticz object holds all information about your Domoticz system. It has glo
 <source lang="lua">  _u = domoticz.utils
   print(_u.rightPad('test',10) .. '|||') -- =>  test    |||</source>
 <ul>
-<li><p>'''_.lodash''': This is an entire collection with very handy Lua functions. Read more about [[#lodash_for_Lua|lodash]]. E.g.: <code>{.lua}      domoticz.utils._.size({'abc', 'def'}))` Returns 2.</code></p></li>
+<li><p>'''_.lodashFunctions''': This is an entire collection with very handy Luafunctions. Read more about [[#lodash_for_Lua|lodash]]. E.g.: <code>{.lua}      domoticz.utils._.size({'abc', 'def'}))` Returns 2.</code></p></li>
 <li><p>'''cameraExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid camera <sup>3.0.12</sup> or cameraID and return ID when entered with valid cameraName or false when not a camera, cameraID or cameraName of an existing camera</p></li>
 <li><p>'''deviceExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid device <sup>3.0.12</sup> or deviceID and returns ID when entered with valid deviceName or false when not a device, deviceID or deviceName of an existing (and active) device. Example:</p>
 <source lang="lua">local dz = domoticz
@@ -707,7 +707,7 @@ end</source></li>
 <li><p>'''fromBase64(string)''': ''Function'': <sup>2.5.2</sup>) Decode a base64 string</p></li>
 <li><p>'''fromJSON(json, fallback <sup>2.4.16</sup>)''': ''Function''. Turns a json string to a Lua table. Example: <code>local t = domoticz.utils.fromJSON('{ &quot;a&quot;: 1 }')</code>. Followed by: <code>print( t.a )</code> will print 1. Optional 2nd param fallback will be returned if json is nil or invalid.</p></li>
 <li><p>'''fromXML(xml, fallback )''': ''Function'': <sup>2.5.1</sup>. Turns a xml string to a Lua table. Example: <code>local t = domoticz.utils.fromXML('&lt;testtag&gt;What a nice feature!&lt;/testtag&gt;') Followed by:</code>print( t.texttag)` will print What a nice feature! Optional 2nd param fallback will be returned if xml is nil or invalid.</p></li>
-<li><p>'''fuzzyLookup(string, parm)''': ''Function'': <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.</p></li>
+<li><p>'''fuzzyLookup([string|array of strings], parm)''': ''Function'': <sup>3.0.14</sup>. Search fuzzy matching string in parm. If parm is string it returns a number (lower is better match). If parm is array of strings it returns the best matching string.</p></li>
 <li><p>'''groupExists(parm)''': ''Function'': <sup>2.4.28</sup> returns name when entered with a valid group <sup>3.0.12</sup> or groupID and return ID when entered with valid groupName or false when not a group, groupID or groupName of an existing group</p></li>
 <li><p>'''hardwareExists(parm)''': ''Function'': <sup>3.0.7</sup> returns name when entered with valid hardwareID or ID when entered with valid hardwareName or false when not a hardwareID or hardwareName of an existing (and active )hardware module</p></li>
 <li><p>'''inTable(table, searchString)''': ''Function'': <sup>2.4.21</sup> Returns <code>&quot;key&quot;</code> if table has searchString as a key, <code>&quot;value&quot;</code> if table has searchString as value and <code>false</code> otherwise.</p></li>
@@ -721,7 +721,7 @@ end</source></li>
         domoticz.utils.numDecimals (12.23,1,1) -- => 12.2,
         domoticz.utils.leadingZeros(domoticz.utils.numDecimals (12.23,4,4),9) -- => 0012.2300</source>
 <ul>
-<li><p>'''osCommand(cmd)''': ''Function'':<sup>3.0.13</sup> Execute an OS command and return result and returncode.</p></li>
+<li><p>'''osCommand(cmd)''': ''Function'': <sup>3.0.13</sup> Execute an OS command and return result and returncode.</p></li>
 <li><p>'''osExecute(cmd)''': ''Function'': Execute an OS command. (no return)</p></li>
 <li><p>'''rightPad(string, length [, character])''': ''Function'': <sup>2.4.27</sup> Succeed string with given character(s) (default = space) to given length.</p></li>
 <li><p>'''round(number, [decimalPlaces])''': ''Function''. Helper function to round numbers. Default decimalPlaces is 0.</p></li>
@@ -811,14 +811,14 @@ The domoticz object has these constants available for use in your code e.g. <co
 
 * '''ALERTLEVEL_GREY''', '''ALERTLEVEL_GREEN''', '''ALERTLEVEL_ORANGE''', '''ALERTLEVEL_RED''', '''ALERTLEVEL_YELLOW''': for updating text sensors.
 * '''BASETYPE_CUSTOM_EVENT''' <sup>3.0.0</sup>,'''BASETYPE_DEVICE''', '''BASETYPE_SCENE''', '''BASETYPE_GROUP''', '''BASETYPE_HARDWARE''' <sup>3.0.7</sup>, '''BASETYPE_VARIABLE''', '''BASETYPE_SECURITY''', '''BASETYPE_TIMER''', '''BASETYPE_HTTP_RESPONSE''', '''BASETYPE_SYSTEM'''<sup>3.0.0</sup>: indicators for the various object types that are passed as the second parameter to the execute function. E.g. you can check if an object is a device object: <code>Lua     if (item.baseType == domoticz.BASETYPE_DEVICE) then ... end</code>
-* '''BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE''': for updating barometric values.
-* '''EVENT_TYPE_DEVICE''', '''EVENT_TYPE_VARIABLE''', '''EVENT_TYPE_CUSTOM'''<sup>3.0.0</sup>'''EVENT_TYPE_SECURITY''', '''EVENT_TYPE_HTTPRESPONSE''', '''EVENT_TYPE_SYSTEM'''<sup>3.0.0</sup> '''EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
-* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_TEMPORARY_OVERRIDE''', '''EVOHOME_MODE_PERMANENT_OVERRIDE''', '''EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
-* '''EVOHOME_MODE_AUTO''', '''EVOHOME_MODE_AUTOWITHRESET''', '''EVOHOME_MODE_AUTOWITHECO''', '''EVOHOME_MODE_AWAY''', '''EVOHOME_MODE_DAYOFF''', '''EVOHOME_MODE_CUSTOM''', '''EVOHOME_MODE_HEATINGOFF''' <sup>2.4.23</sup>: mode for EvoHome controller
-* '''HUM_COMFORTABLE''', '''HUM_DRY''', '''HUM_NORMAL''', '''HUM_WET''': constant for humidity status.
+* '''BARO_CLOUDY, BARO_CLOUDY_RAIN, BARO_STABLE, BARO_SUNNY, BARO_THUNDERSTORM, BARO_NOINFO, BARO_UNSTABLE, BARO_COMPUTE''' : for updating barometric values.
+* '''EVENT_TYPE_DEVICE, EVENT_TYPE_VARIABLE, EVENT_TYPE_CUSTOM<sup>3.0.0</sup>EVENT_TYPE_SECURITY, EVENT_TYPE_HTTPRESPONSE, EVENT_TYPE_SYSTEM<sup>3.0.0</sup> EVENT_TYPE_TIMER''': triggerInfo types passed to the execute function in your scripts.
+* '''EVOHOME_MODE_AUTO, EVOHOME_MODE_TEMPORARY_OVERRIDE, EVOHOME_MODE_PERMANENT_OVERRIDE, EVOHOME_MODE_FOLLOW_SCHEDULE''' <sup>2.4.9</sup>: mode for EvoHome system.
+* '''EVOHOME_MODE_AUTO, EVOHOME_MODE_AUTOWITHRESET, EVOHOME_MODE_AUTOWITHECO, EVOHOME_MODE_AWAY, EVOHOME_MODE_DAYOFF, EVOHOME_MODE_CUSTOM, EVOHOME_MODE_HEATINGOFF''' <sup>2.4.23</sup>: mode for EvoHome controller
+* '''HUM_COMFORTABLE, HUM_DRY, HUM_NORMAL, HUM_WET, HUM_COMPUTE''' <sup>3.0.15</sup>: constant for humidity status.
 * '''INTEGER''', '''FLOAT''', '''STRING''', '''DATE''', '''TIME''': variable types.
 * '''LOG_DEBUG''', '''LOG_ERROR''', '''LOG_INFO''', '''LOG_FORCE''': for logging messages. LOG_FORCE is at the same level as LOG_ERROR.
-* '''NSS_FIREBASE''', '''NSS_FIREBASE_CLOUD_MESSAGING''', '''NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, '''NSS_HTTP''', '''NSS_KODI''', '''NSS_LOGITECH_MEDIASERVER''', '''NSS_NMA''','''NSS_PROWL''', '''NSS_PUSHALOT''', '''NSS_PUSHBULLET''', '''NSS_PUSHOVER''', '''NSS_PUSHSAFER''', '''NSS_TELEGRAM** <sup>2.4.8</sup>, '''NSS_GOOGLE_CLOUD_MESSAGING''' <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
+* '''NSS_FIREBASE, NSS_FIREBASE_CLOUD_MESSAGING, NSS_GOOGLE_DEVICES <sup>3.0.10</sup> <sup>Only with installed casting plugin</sup>, NSS_HTTP, NSS_KODI, NSS_LOGITECH_MEDIASERVER, NSS_NMA,NSS_PROWL, NSS_PUSHALOT, NSS_PUSHBULLET, NSS_PUSHOVER, NSS_PUSHSAFER, NSS_TELEGRAM <sup>2.4.8</sup>, NSS_GOOGLE_CLOUD_MESSAGING''' <sup>deprecated by Google and replaced by firebase</sup>: for notification subsystem
 * '''PRIORITY_LOW''', '''PRIORITY_MODERATE''', '''PRIORITY_NORMAL''', '''PRIORITY_HIGH''', '''PRIORITY_EMERGENCY''': for notification priority.
 * '''SECURITY_ARMEDAWAY''', '''SECURITY_ARMEDHOME''', '''SECURITY_DISARMED''': for security state.
 * '''SOUND_ALIEN''' , '''SOUND_BIKE''', '''SOUND_BUGLE''', '''SOUND_CASH_REGISTER''', '''SOUND_CLASSICAL''', '''SOUND_CLIMB''' , '''SOUND_COSMIC''', '''SOUND_DEFAULT''' , '''SOUND_ECHO''', '''SOUND_FALLING''' , '''SOUND_GAMELAN''', '''SOUND_INCOMING''', '''SOUND_INTERMISSION''', '''SOUND_MAGIC''' , '''SOUND_MECHANICAL''', '''SOUND_NONE''', '''SOUND_PERSISTENT''', '''SOUND_PIANOBAR''' , '''SOUND_SIREN''' , '''SOUND_SPACEALARM''', '''SOUND_TUGBOAT''' , '''SOUND_UPDOWN''': for notification sounds.
@@ -850,7 +850,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''icon''': ''String''. Name of the icon in Domoticz GUI.
 * '''id''': ''Number''. Index of the device. You can find the index in the device list (idx column) in Domoticz settings. It’s not truly an index but is unique enough for dzVents to be treated as an id.
 * '''idx''': ''Number''. Same as id: index of the device
-* '''lastUpdate''': ''[[#Time_object|Time Object]]'': Time when the device was updated.
+* '''lastUpdate''': ''[[#Time_object|Time Object]]'': Time when the device was updated. **Note: The lastUpdate for devices that triggered the script at hand is in fact the previousUpdate time. The real lastUpdate time for these “script triggering” devices is the current time.
 * '''name''': ''String''. Name of the device.
 * '''nValue''': ''Number''. Numerical representation of the state.
 * '''protected''': ''Boolean''. <sup>2.4.27</sup> True when device / scene / group is protected. False otherwise.
@@ -1173,7 +1173,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidityStatus''': ''String''
 * '''humidityStatusValue''': ''Number''. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
 * '''temperature''': ''Number''
-* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateTempHumBaro(temperature, humidity, status, pressure, forecast)''': ''Function''. forecast can be domoticz.BARO_NOINFO, BARO_SUNNY, BARO_PARTLY_CLOUDY, BARO_CLOUDY, BARO_RAIN. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET, HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Temperature, Humidity ====
 
@@ -1182,7 +1182,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''humidityStatus''': ''String''
 * '''humidityStatusValue''': ''Number''. Value matches with domoticz.HUM_NORMAL, -HUM_DRY, HUM_COMFORTABLE, -HUM_WET.
 * '''temperature''': ''Number''
-* '''updateTempHum(temperature, humidity, status)''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateTempHum(temperature, humidity [, status] )''': ''Function''. status can be domoticz.HUM_NORMAL, HUM_COMFORTABLE, HUM_DRY, HUM_WET or HUM_COMPUTE (let dzVents do the math)<sup>3.0.15</sup>. Note: temperature must be in Celsius. Use <code>domoticz.toCelsius()</code> to convert a Fahrenheit temperature to Celsius. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Text ====
 
@@ -1193,6 +1193,13 @@ There are many switch-like devices. Not all methods are applicable for all switc
 
 * '''setPoint''': ''Number''.
 * '''updateSetPoint(setPoint)''':''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+
+==== Thermostat type 3 (Mertik) <sup>3.0.15</sup> ====
+
+* '''mode''': ''Number''. Current mode
+* '''modes''': ''String''. List of all modes
+* '''modeString''': ''String''. Current mode
+* '''updateMode(mode)''':''Function''. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== UV sensor ====
 
@@ -1260,10 +1267,10 @@ Many dzVents device methods support extra options, like controlling a delay or a
     -- switch on for 2 minutes after 10 seconds
     device.switchOn().afterSec(10).forMin(2)
 
-    -- switch on at a specic time / day 
+    -- switch on at a specic time / day
     device.switchOn().at('09:00')                 -- earliest moment it will be 09:00 hr.
-    device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30  
-    device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first) 
+    device.switchOn().at('08:53:30 on fri')       -- earliest moment it will be Friday at 08:53:30
+    device.switchOn().at('08:53:30 on sat, sun')  -- earliest moment it will be Saturday or Sunday at 08:53:30 (whatever comes first)
 
     -- switch on for 2 minutes after a randomized delay of 1-10 minutes
     device.switchOff().withinMin(10).forMin(2)
@@ -2415,529 +2422,11 @@ Prior to 2.x you likely used the rawData attribute to get to certain device valu
 
 In 2.x it is no longer needed to make timed json calls to Domoticz to get extra device information into your scripts. Very handy. On the other hand, you have to make sure that dzVents can access the json without the need for a password because some commands are issued using json calls by dzVents. Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> and/or <code>::1</code> and you’re good to go.
 
-= History =
+= History [https://www.domoticz.com/wiki/DzVents_version_History link to changes in previous versions]. =
 
-== [3.0.14] ==
+== [3.0.15] ==
 
-* Add utils.fuzzyLookup
-* Made eventHelpers more resilient to coding errors in the on = section
-
-== [3.0.13] ==
-
-* Add utils.osCommand (caption)
-* Improved utils.stringSplit (implicit conversion to number on request)
-* Made log function more resilient when logitem is table with embedded function(s)
-* Improved domoticz.snapshot() to enable snapshot of multiple cameras (in one Email)
-
-== [3.0.12] ==
-
-* Add option to use device, camera, group, scene and variable objects as parm to deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods.
-
-== [3.0.11] ==
-
-* Add sensorValue attribute to custom sensor
-* Add solarnoon as moment in time (like sunrise / sunset )
-
-== [3.0.10] ==
-
-* Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
-* Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
-
-== [3.0.9] ==
-
-* Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time.
-* Add function toUTC to time object.
-* Allow table as parm to function makeTime
-
-== [3.0.8] ==
-
-* Allow IPv6 ::1 as localhost in domoticz settings
-* Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
-* Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
-* Updated round.utils to correctly handle negative numbers and round to zero decimals
-
-== [3.0.7] ==
-
-* Add domoticz.hardware() as separate object class
-
-== [3.0.6] ==
-
-* Add hardwareInfo() function
-
-== [3.0.5] ==
-
-* Add dumpSelection() method
-* Fixed settings.url
-
-== [3.0.4] ==
-
-* Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC
-* add isJSON, isXML functions to Utils
-
-== [3.0.3] ==
-
-* add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object)
-
-== [3.0.2] ==
-
-* Add <code>PUT</code> and <code>DELETE</code> support to <code>openURL</code>
-* Ensure sending integer in nValue in update function
-* Fix sValue for custom sensor
-
-== [3.0.1] ==
-
-* Add option <code>at()</code> to the various commands/methods
-* Add stringToSeconds() function
-
-== [3.0.0] ==
-
-* Add system-events triggers as option to the on = { … } section. Scripts can now be triggered based on these system-events:
-** start
-** stop
-** manualBackupFinished,
-** dailyBackupFinished
-** hourlyBackupFinished
-** monthlyBackupFinished
-* Add custom-events triggers as option to the on = { … } section. You can now send an event trigger to start subscribed dzVents scripts. customEvents can be triggered by:
-** dzVents domoticz.emitEvent(name, data ) – command (data = optional)
-** JSON: json.htm?type=command&amp;param=customevent&amp;event=MyEvent&amp;data=myData ( data = optional )
-** MQTT: {“command” : “customevent”, “event” : “MyEvent” , “data” : “myData” } ( data = opt ional )
-* Add method domoticz.emitEvent()
-* Add attribute <code>mode</code> to Evohome controller
-* Add option to dumpTable() and ([device][uservariable][[#group|scene]].dump() to os file
-
-== [2.5.7] ==
-
-* Add option checkFirst to switchSelector method
-
-== [2.5.6] ==
-
-* Add dayName, monthName, monthAbbrName and time as time attributes
-* Add _.round, _.isEqual functions to lodash.lua
-* Add testLodash.lua as testModule for lodash
-
-== [2.5.5] ==
-
-* Add Zwave fan to Zwave mode device adapter
-
-== [2.5.4] ==
-
-* Add minutesSinceMidnight to domoticz Time object
-* Add domoticz.time.addSeconds(), -.addMinutes(), -.addHours(), -.addDays(), -.makeTime()
-* Add string.sMatch to utils
-* Made wildcard handling more resilient when magic chars are part of script triggers
-
-== [2.5.3] ==
-
-* Add timealert / errors for long running scripts
-* Add triggerHTTPResponse()
-
-== [2.5.2] ==
-
-* Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
-* Add toBase64 and fromBase64 function in utils
-* Add setLogMarker function in utils
-* Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
-
-== [2.5.1] ==
-
-* Added <code>toXML</code> and <code>fromXML</code> methods to domoticz.utils.
-* Add attributes isXML, xmlVersion, xmlEncoding
-
-== [2.5.0] ==
-
-* Prepared for Lua 5.3
-
-== [2.4.29] ==
-
-* Add error message including affected module when module got corrupted on disk.
-* Add setLevel method for switchTypes.
-* Increased resilience against badly formatted type Time user-variables.
-* Use native domoticz command for increaseCounter method.
-* Set inverse of “set color” to Off to enable use of toggleSwitch for RGB type of devices.
-
-== [2.4.28] ==
-
-* Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils
-* increased httpResponse resilience against different use of Upper-, Lowercase in headers[‘content-type’] to ensure JSON conversion to Lua table
-
-== [2.4.27] ==
-
-* Add attribute protected for devices / scenes and groups
-* Add methods protectionOn and protectionOff for devices / scenes and groups
-* Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
-
-== [2.4.26] ==
-
-* Add Smoke Detector device (activate and reset functions )
-
-== [2.4.25] ==
-
-* Add rawDateTime
-* fix for combined device / civil[day|night]time trigger rule
-* fix for checkFirst on stopped status
-
-== [2.4.24] ==
-
-* Add method rename for devices, user-variables , scenes and groups
-
-== [2.4.23] ==
-
-* Add method setMode for evohome device
-* Add method incrementCounter for incremental counter
-* Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
-* fix wildcard device
-
-== [2.4.22] ==
-
-* selector.switchSelector method accepts levelNames
-* increased selector.switchSelector resilience
-* fix wildcard timerule
-
-== [2.4.21] ==
-
-* fixed wrong direction for open() and close() for some types of blinds
-* Add inTable function to domoticz.utils
-* Add sValue attribute to devices
-
-== [2.4.20] ==
-
-* Add quietOn() and quietOff() method to switchType devices
-
-== [2.4.19] ==
-
-* Add stringSplit function to domoticz.utils.
-* Add statusText and protocol to HTTPResponse
-
-== [2.4.18] ==
-
-* Add triggerIFTTT() to domoticz
-
-== [2.4.17] ==
-
-* Add dumpTable() to domoticz.utils
-* Add setValues for devices
-* Add setIcon for devices
-
-== [2.4.16] ==
-
-* Add method dump() to domoticz (dumps settings)
-* Add setHue, setColor, setHex, getColor for RGBW(W) devices
-* Add setDescription for devices, groups and scenes
-* Add volumeUp / volumeDown for Logitech Media Server (LMS)
-* Changed domoticz.utils.fromJSON (add optional fallback param)
-
-== [2.4.15] ==
-
-* Add option to use camera name in snapshot command
-* Add domoticz.settings.domoticzVersion
-* Add domoticz.settings.dzVentsVersion
-
-== [2.4.14] ==
-
-* Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
-* Added check for- and message when call to openURL cannot open local (127.0.0.1)
-* '''BREAKING CHANGE''' :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
-* prevent call to updateCounter with table
-
-== [2.4.13] ==
-
-* Added domoticz.settings.location (domoticz settings location Name)
-* Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
-
-== [2.4.12] ==
-
-* Added managed Counter (to counter)
-
-== [2.4.11] ==
-
-* Added snapshot command to send Email with camera snapshot ( afterAAA() and withinAAA() options available)
-
-== [2.4.10] ==
-
-* Added option to use afterAAA() and withinAAA() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup>
-* Changed function updateMode to display mode as string in domoticz log
-
-== [2.4.9] ==
-
-* Added evohome hotwater device (state, mode, untilDate and setHotWater function)
-* Added mode and untilDate for evohome zone devices
-* Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
-* Add speedMs and gustMs from wind devices
-* bugfix for youless device (0 handling)
-* bugfix for time ( twilightstart and twilightend handling)
-* Fixed some date-range rule checking
-
-== [2.4.8] ==
-
-* Added telegram as option for domoticz.notify
-
-== [2.4.7] ==
-
-* Added support for civil twilight in rules
-
-== [2.4.6] ==
-
-* Added Youless device
-* Added more to the documentation section for http requests
-* Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
-
-== [2.4.5] ==
-
-* Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&amp;t=23109).
-
-== [2.4.4] ==
-
-* Fixed rawTime and rawData so it shows leading zeros when values are below 10.
-* Fixed one wildcard issue. Should now work as expected.
-* Fixed a problem in Domoticz where you couldn’t change the state of some door contact-like switches using the API or dzVents. That seems to work now.
-
-== [2.4.3] ==
-
-* Fixed trigger wildcards. Now you can do <code>*aa*bb*cc</code> or <code>a*</code> which will require the target to start with an <code>a</code>
-* Added more EvoHome device types to the EvoHome device adapter.
-
-== [2.4.2] ==
-
-* Fixed RGBW device adapter
-* Fixed EvoHome device adapter
-* Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&amp;t=21620&amp;p=170469#p170469)
-
-== [2.4.1] ==
-
-* Fixed week number problems on Windows
-* Fixed ‘on date’ rules to support dd/mm format (e.g. 01/02)
-
-== [2.4.0] ==
-
-* '''BREAKING CHANGE''': The second parameter passed to the execute function is no longer <code>nil</code> when the script was triggered by a timer or a security event. Please check your scripts. The second parameter has checks to determine the type. E.g. <code>execute = function(domoticz, item) .. end</code>. You can inspect <code>item</code> using: <code>item.isDevice</code>, <code>item.isTimer</code>, <code>item.isVariable</code>, <code>item.isScene</code>, <code>item.isGroup</code>, <code>item.isSecurity</code>, <code>item.isHTTPResponse</code>. Please read the documentation about the execute function.
-* Added <code>.cancelQueuedCommands()</code> to devices, groups, scenes and variables. Calling this method will cancel any scheduled future commands issued using for instance <code>.afterMin(10)</code> or <code>.repeatAfterMin(1, 4)</code>
-* Added <code>.devices()</code> collection to scenes and groups to iterate (<code>forEach</code>, <code>filter</code>, <code>reduce</code>, <code>find</code>) over the associated devices.
-* Added http response event triggers to be used in combination with <code>openURL</code>. You can now do <code>GET</code> and <code>POST</code> request and handle the response in your dzVents scripts '''ASYNCHRONICALLY'''. See the documentation. No more json parsing needed or complex <code>curl</code> shizzle.
-* Added a more consistent second parameter sent to the execute function. When a timer is triggered then the second parameter is a Timer object instead of nil. This way you can check the baseType of the second parameter and makes third parameter (triggerInfo) kind of obsolete. Every object bound to the second parameter now has a baseType.
-* Added locked/unlocked support for door-locks (locked == active).
-* Moved utility functions from the domoticz object to <code>domoticz.utils</code> object. You will see a deprecation warning when using the old function like <code>round()</code>, <code>toCelsius()</code> etc.
-* Added <code>lodash</code> as a method to <code>domoticz.utils</code>: <code>domoticz.utils._</code>
-* Added <code>toJSON</code> and <code>fromJSON</code> methods to domoticz.utils.
-* Added <code>afterAAA()</code> and <code>withinAAA()</code> support for device-update commands. E.g.: <code>myTextDevice.updateText('Zork').afterMin(2)</code>.
-* Added support for Logitech Media Server devices (thanks to Eoreh).
-* Added new timer rules: date rules: <code>on 13/07</code>, <code>on */03</code>, <code>on 12/*</code>, <code>on 12/04-22/09</code>, <code>on -24/03</code>, <code>on 19/11-</code>, week rules: <code>in week 12,15,19-23,-48,53-</code>, <code>every even week</code>, <code>every odd week</code>. See documentation.
-* Added historical data helper <code>delta2(fromIndex, toIndex, smoothRangeFrom, smoothRangeTo, default)</code> to have a bit more control over smoothing. You can specify if want to smooth either the start value (reference) and/or the to value (compared value).
-* Added historical data helper <code>deltaSinceOrOldest(timeAgo, smoothRangeFrom, smoothRangeTo, default)</code>. This will use the oldest data value when the data set is shorter than timeAgo.
-* Added support for Lighting Limitless/Applamp RGBW devices. You can now set Kelvin and RGB values, NightMode, WhiteMode and increase and decrease the brightness and discoMode. See the documentation.
-* Added device adapter for Onkyo receiver hardware.
-* Added <code>scriptName</code> to the triggerInfo object passed as the third parameter to the execute function. This holds the name of the script being executed.
-* Fixed bug in Domoticz where using forAAA() with selector switches didn’t always work.
-* Fixed bug in Domoticz where improper states were passed to the event scripts. This may happen on slower machines where several devices may have been updated before the event-system had a change to operate on them. In that case the event scripts received the current final state instead of the state at the moment of the actual event.
-* Added support for webroot. dzVents will now use the proper API url when domoticz is started with the -webroot switch.
-* Added support for event-bursts. If (on slower machines) events get queued up in Domoticz, they will be sent to dzVents in one-package. This makes event processing significantly faster.
-* Added <code>domoticz.data.initialize(varName)</code>. This will re-initialize non-historical variables to the initial value as defined in the data section.
-* You now no longer have to provide an initial value for a persistent variable when you declare it. So you can do <code>data = { 'a', 'b', 'c'}</code> instead of <code>data = {a={initial = nil}, b={initial=nil}, c={initial=nil} }</code>. You have to quote the names though.
-* A filter can now accept a table with names/id’s instead of only functions. You can now do <code>domoticz.devices().filter({ 'mySwitch', 'myPIR', 34, 35, 'livingLights'})</code> which will give you a collection of devices with these names and ids.
-* Added and documented <code>domoticz.settings.url</code>, <code>domoticz.settings.webRoot</code> and <code>domoticz.settings.serverPort</code>.
-* Removed fixed limit on historical variables if there is a limit specified.
-
-== [2.3.0] ==
-
-* Added <code>active</code> attribute to devices (more logical naming than the attribute ‘bState’). <code>myDevice.active</code> is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like <code>if mySwitch.active then .. end</code>
-* Added <code>domoticz.urlEncode</code> method on the <code>domoticz</code> object so you can prepare a string before using it with <code>openURL()</code>.
-* Updating devices, user variables, scenes and groups now always trigger the event system for follow-up events.
-* Added support for groups and scenes change-event scripts. Use <code>on = { scenes = { 'myScene1', 'myScene2' }, groups = {'myGroup1'} }</code>
-* Added adapter for the new Temperature+Barometer device.
-* Added <code>domoticz.startTime</code> giving you the time at which the Domoticz service was started. Returns a Time object.
-* Added <code>domoticz.systemUptime</code> (in seconds) indicating the number of seconds the machine is running. Returns a Time object.
-* Added more options to the various commands/methods: e.g. <code>myDevice.switchOff().silent()</code>, <code>.forSec()</code>, <code>.forHour()</code>, <code>.afterHour()</code>, <code>.repeatAfterSec()</code>, <code>.repeatAfterMin()</code>, <code>.repeatAfterHour()</code>, <code>.withinHour()</code> and <code>.checkFirst()</code>. This now works not only for devices but also scenes, groups and user variables. See documentation about command options.
-* Added <code>.silent()</code> option to commands like <code>switchOn().afterSec(4).silent()</code> causing no follow-up events to be triggered. This also works when updating non-switch-like devices, scenes, groups and user variables. If you do not call `silent()``, a follow-up event is ''always'' triggered (for devices, scenes, groups and user variables).
-* Added time rule <code>between xx and yy</code>. You can now do things like: <code>between 16:34 and sunset</code> or <code>between 10 minutes before sunset and sunrise</code>. See the doc.
-* Added support for milliseconds in <code>Time</code> object. This also give a ms part in the time-stamp for historical persistent data. You can now do <code>msAgo()</code> on time stamp when you inspect a data point from an history variable.
-* Added <code>daysAgo()</code> to <code>Time</code> object.
-* Added <code>compare(time)</code> method to <code>Time</code> object to calculate the difference between them. Returns a table. See documentation.
-* Added <code>domoticz.round()</code> method to <code>domoticz</code> object.
-* Added <code>text</code> property to alert sensor.
-* <code>active</code> section is now optional in your dzVents script. If you don’t specify an <code>active = true/false</code> then true is assumed (script is active). Handy for when you use Domoticz’ GUI script editor as it has its own way of activating and deactivating scripts.
-* Added <code>humidityStatusValue</code> for humidity devices. This value matches with the values used for setting the humidity status.
-* <code>Time</code> object will initialize to current time if nothing is passed: <code>local current = Time()</code>.
-* Added the lua lodash library, <!--  removed because of dead link http://axmat.github.io/lodash.lua/ , MIT license ).  -->
-* Fixed documentation about levelNames for selector switches and added the missing levelName.
-* Moved dzVents runtime code away from the <code>/path/to/domoticz/scripts/dzVents</code> folder as this scripts folder contains user stuff.
-* Added more trigger examples in the documentation.
-* You can now put your own non-dzVents modules in your scripts folder or write them with the Domoticz GUI editor. dzVents is no longer bothered by it. You can require your modules in Lua’s standard way.
-* Added <code>/path/to/domoticz/scripts/dzVents/scripts/modules</code> and <code>/path/to/domoticz/scripts/dzVents/modules</code> to the Lua package path for custom modules. You can now place your modules in there and require them from anywhere in your scripts.
-* Added dzVents-specific boilerplate/templates for internal web editor.
-* Fixed the confusing setting for enabling/disabling dzVents event system in Domoticz settings.
-* Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn’t executed.
-
-== [2.2.0] ==
-
-* Fixed typo in the doc WActual &gt; WhActual.
-* Updated switch adapter to match more switch-like devices.
-* Added Z-Wave Thermostat mode device adapter.
-* Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
-* Added secondsSinceMidnight to time attributes (e.g. lastUpdate.secondsSinceMidnight)
-* Added 4 new time-rules: xx minutes before/after sunset/sunrise.
-* Added example script to fake user presence.
-* Fixed support for uservariables with spaces in their names.
-* Show a warning when an item’s name isn’t unique in the collection.
-* Added timing options for security methods armAway, armHome and disarm like device.armAway().afterSec(10).
-* Added idx, deviceId and unit to device objects. Don’t confuse deviceId with device.id(x) which is actually the index of the device.
-* Added instructions on how to create a security panel device in Domoticz. This device now has a state that has the same value as domoticz.security.
-* Fixed bug in check battery levels example.
-* Fixed some irregularities with dimmer levels.
-
-== [2.1.1] ==
-
-* Fixed typo in the doc WActual &gt; WhActual.
-* Updated switch adapter to match more switch-like devices.
-* Added Z-Wave Thermostat mode device adapter.
-* Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
-
-== [2.1.0] ==
-
-* Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
-* Added support for Ampère 1 and 3-phase devices
-* Added support for leaf wetness devices
-* Added support for scale weight devices
-* Added support for soil moisture devices
-* Added support for sound level devices
-* Added support for visibility devices
-* Added support for waterflow devices
-* Added missing color attribute to alert sensor devices
-* Added updateEnergy() to electric usage devices
-* Fixed casing for WhTotal, WhActual methods on kWh devices (Watt’s in a name?)
-* Added toCelsius() helper method to domoticz object as the various update temperature methods all need Celsius.
-* Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
-* Added integration tests for full round-trip Domoticz &gt; dzVents &gt; Domoticz &gt; dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
-* Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won’t get uservariable event scripts triggered in dzVents.
-* Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it’s own heartbeat.
-* avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
-* Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
-* Use different api command for setting setPoints in the Thermostat setpoint device adapter.
-
-== [2.0.0] Domoticz integration ==
-
-* Almost a complete rewrite.
-* '''BREAKING CHANGE''': Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing <code>domoticz.devices['myDevice']</code> you now have to call a function: <code>domoticz.devices('myDevice')</code>. This applies also for the other collections: <code>domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()</code>. If you want to loop over these collection '''you can no longer use the standard Lua for..pairs or for..ipairs construct'''. You have to use the iterators like forEach, filter and reduce: <code>domoticz.devices().forEach(function() .. end)</code> (see [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. '''So please change your existing dzVents scripts!'''
-* '''BREAKING CHANGE''': after_sec, for_min, after_min, within_min methods have been renamed to the camel-cased variants afterSec, forMin, afterMin, withinMin. Please rename the calls in your script.
-* '''BREAKING CHANGE''': There is no longer an option to check if an attribute was changed as this was quite useless. The device has a changed flag. You can use that. Please change your existing scripts.
-* '''BREAKING CHANGE''': Many device attributes are now in the appropriate type (Number instead of Strings) so you can easily make calculations with them. Units are stripped from the values as much as possible. '''Check your scripts as this may break stuff.'''
-* '''BREAKING CHANGE''': on-section now requires subsections for <code>devices</code>, <code>timer</code>, <code>variables</code>, and <code>security</code>. The old way no longer works! Please convert your existing scripts!
-* '''BREAKING CHANGE''': Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> so dzVents can use Domoticz api when needed.
-* dzVents now works on Windows machines!
-* dzVents is no longer a separate library that you have to get from GitHub. All integrated into Domoticz.
-* Added option to create shared utility/helper functions and have them available in all your scripts. Simply add a <code>helpers = { myFunction = function() ... end }</code> to the <code>global_data.lua</code> file in your scripts folder and you can access the function everywhere: <code>domoticz.helpers.myFunction()</code>.
-* Created a pluggable system for device adapters so people can easily contribute by creating specific adapters for specific devices. An adapter makes sure that you get the proper methods and attributes for that device. See <code>/path/to/domoticz/scripts/dzVents/runtime/device-adapters</code>.
-* Added a <code>reduce()</code> iterator to the collections in the domoticz object so you can now easily collect data about all your devices. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]].
-* Added a <code>find()</code> iterator so you can easily find an item in one of the collection (devices, scenes, groups etc.). See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]].
-* Variables (uservariables) have more attributes. The <code>value</code> is now the same type as it is defined in Domoticz. So no more need for a converted nValue attribute. You can inspect the type using <code>myVar.type</code>. If it is a time variable or date variable you an extra <code>date</code> or <code>time</code> attribute with the same methods as with all other date/time related attributes like <code>lastUpdate</code>. .E.g. <code>myVar.date.minutesAgo</code>.
-* Settings are now moved to the Domoticz GUI ('''Setup &gt; Settings &gt; Other''') and no longer in a settings file.
-* You can now override the log settings per script. So you can turn-off logging globally (see log level in the settings) and still have debug-level logging for that one script you are working on. You can even add a prefix string to the log messages for easy filtering in the Domoticz log. See the documentation about the <code>logging = { .. }</code> section.
-* No more need to do http-calls to get extended data from Domoticz. All relevant internal Domoticz state-data is now available inside your dzVents scripts. Thanks Scotty!!
-* Support for many many more device types and their specific methods. See the documentation for the list of attributes and events that are available. Note that device-type specific attributes are only available for those type of devices. You will receive an error in the log if you try to access an attribute that doesn’t exist for that particular device. Hopefully you don’t have to use the rawData table anymore. If you still do please file a report or create a device adapter yourself.
-* You can now write dzVents scripts using the internal editor in Domoticz. These scripts will be automatically exported to the filesystem (one-way only) so dzVents can execute them (generated_scripts folder). Thanks again Scotty!
-* Support for variable change events (<code>on = { variables = { 'varA', 'varB'} }</code>)
-* Support for security change events (<code>on = { security = { domoticz.SECURITY_ARMEDAWAY } }</code>)
-* The triggerInfo passed to the execute function now includes information about which security state triggered the script if it was a security event.
-* Extended the timer-rule with time range e.g. <code>at 16:45-21:00</code> and <code>at nighttime</code> and <code>at daytime</code> and you can provide a custom function. See documentation for examples. The timer rules can be combined as well.
-* Timer rules for <code>every xx minutes</code> or <code>every xx hours</code> are now limited to intervals that will reach *:00 minutes or hours. So for minutes you can only do these intervals: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20 and 30. Likewise for hours.
-* The Time object (e.g. domoticz.time) now has a method <code>matchesRule(rule)</code>. <code>rule</code> is a string same as you use for timer options: <code>if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end</code>. The rule matches if the current system time matches with the rule.
-* A device trigger can have a time-rule constraint: <code>on = { devices = { ['myDevice'] = { 'at nighttime' } }</code>. This only triggers the script when myDevice was changed '''and''' the time is after sunset and before sunrise.
-* Add support for subsystem selection for domoticz.notify function.
-* Fixed a bug where a new persistent variable wasn’t picked up when that variable was added to an already existing data section.
-
-== [1.1.2] ==
-
-* More robust way of updating devices.lua
-* Added device level information for non-dimmer-like devices
-
-== [1.1.1] ==
-
-* Added support for a devices table in the ‘on’ section.
-* Added extra log level for only showing information about the execution of a script module.
-* Added example script for System-alive checker notifications (preventing false negatives).
-
-== [1.1] ==
-
-* Added example script for controlling the temperature in a room with hysteresis control.
-* Fixed updateLux (thanks to neutrino)
-* Added Kodi commands to the device methods.
-* Fixed updateCounter
-* Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
-
-== [1.0.2] ==
-
-* Added device description attribute.
-* Added support for setting the setpoint for opentherm gateway.
-* Added timedOut boolean attribute to devices. Requires http data fetching to be enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
-* Properly detects usage devices and their Wattage.
-
-== [1.0.1] ==
-
-* Added updateCustomSensor(value) method.
-* Fixed reset() for historical data.
-
-== [1.0][1.0-beta2] ==
-
-* Deprecated setNew(). Use add() instead. You can now add multiple values at once in a script by calling multiple add()s in succession.
-* Fixed printing device logs when a value was boolean or nil
-* Fixed WActual/total/today for energy devices.
-* Added updateSetPoint method on devices for dummy thermostat devices and EvoHome setpoint devices
-* Added couple of helper properties on Time object. See README.
-* Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don’t overwrite your settings when you copy over a new version of dzVents to your system.
-
-== [1.0-beta1] ==
-
-* Added data persistence for scripts between script runs (see readme for more info)
-* Added a time-line based data type for you scripts with historical information and many statistical functions for retreiving information like average, minumum, maximum, delta, data smoothing (averaging values over neighbours) etc. See readme for more information.
-* Added SMS method to the domoticz object.
-* Added toggleSwitch() method to devices that support it.
-* Added more switch states that control device.bState (e.g. on == true, open == true ‘all on’ == true)
-* Added secondsAgo to the lastUpdate attribute
-* Added tests (test code coverage is above 96%!)
-* Refactored code significantly.
-* Made sure differently formulated but equal triggers in one script only execute the script only once (like MySensor and MySensor_Temperature).
-* Added trigger info as a third parameter (Lua table) that is passed to the execute method of a script containing information about what exactly triggered the script (type = EVENT_TYPE_TIMER/EVENT_TYPE_DEVICE, trigger=<timer rule>). See readme.
-* Added Lua time properties to domoticz.time property with all information about the current time (hours, minutes, seconds, etc.)
-* Added option to return false in a forEach iteratee function which will abort the forEach loop.
-* All devices not delivered by Domoticz to the event scripts are now added to domoticz.devices using the http data that is fetched every 30 minutes (by default).
-* Added scenes and groups collections to the domoticz object
-* Added Quick Reference Guide.
-
-== [0.9.13] ==
-
-* Fixed some timer functions
-
-== [0.9.12] ==
-
-* Fixed a bug with log level printing. Now errors are printed.
-* Added setPoint, heatingMode, lux, WhTotal, WhToday, WActual attributes to devices that support it. No need to access rawData for these anymore.
-
-== [0.9.11] ==
-
-* Added log method to domoticz object. Using this to log message in the Domoticz log will respect the log level setting in the settings file. [dannybloe]
-* Updated readme. Better overview, more attributes described.
-* Added iterator functions (forEach and filter) to domoticz.devices, domoticz.changedDevices and domoticz.variables to iterate or filter more easily over these collections.
-* Added a couple of example scripts.
-
-== [0.9.10] ==
-
-* A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
-* Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
-* Added support for sounds in domoticz.notify(). [WebStarVenlo]
-
-== [0.9.9] ==
-
-* Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy…
-
-== [0.9.8] ==
-
-* Fixed a bug where a device can have underscores in its name.
-* Added dimTo(percentage) method to control dimmers.
-* Modified the switch-like commands to allow for timing options: .for_min(), .within_min(), after_sec() and after_min() methods to control delays and durations. Removed the options argument to the switch functions. See readme.
-* Added switchSelector method on a device to set a selector switch.
-* Added wild-card option for triggers
-* Added http request data from Domoticz to devices. Now you can check the battery level and switch type and more. Make sure to edit dzVents_settings.lua file first and check the readme for install instructions!!!
-* Added log level setting in dzVents_settings.lua
-
-== [0.9.7] ==
-
-* Added domoticz object resource structure. Updated readme accordingly. No more (or hardly any) need for juggling with all the Domoticz Lua tables and commandArrays.
+* Fixed bug in domoticz.time.matchesRule (daterange was ignored when “on mon, tue” was also part of the rule)
+* Add device adapter for Thermostat type 3 devices (Mertik)
+* Add utils.humidityStatus
+* Add option to have dzVents compute humidity status

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,62 +1,71 @@
-[3.0.14]
+# [3.0]
+
+  [3.0.15]
+- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
+- Add device adapter for Thermostat type 3 devices (Mertik)
+- Add utils.humidityStatus
+- Add option to have dzVents compute humidity status
+
+  [3.0.14]
 - Add utils.fuzzyLookup
 - Made eventHelpers more resilient to coding errors in the on = section
 
-[3.0.13]
+  [3.0.13]
 - Add utils.osCommand (caption)
 - Improved utils.stringSplit (implicit conversion to number on request)
 - Made log function more resilient when logitem is table with embedded function(s)
 - Improved domoticz.snapshot() to enable snapshot of multiple cameras (in one Email)
 
-[3.0.12]
+  [3.0.12]
 - Add option to use device, camera, group, scene and variable objects as parm to deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods.
 
-[3.0.11]
+  [3.0.11]
 - Add sensorValue attribute to custom sensor
 - Add solarnoon as moment in time (like sunrise / sunset ) 
 
-[3.0.10]
+  [3.0.10]
 - Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
 - Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
 
-[3.0.9]
+  [3.0.9]
 - Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time. 
 - Add function toUTC to time object.
 - Allow table as parm to function makeTime
 
-[3.0.8]
+  [3.0.8]
 - Allow IPv6 ::1 as localhost in domoticz settings 
 - Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
 - Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
 - Updated round.utils to correctly handle negative numbers and round to zero decimals
 
-[3.0.7]
+  [3.0.7]
 - Add domoticz.hardware() as separate object class
 
-[3.0.6]
+  [3.0.6]
 - Add hardwareInfo() function
 
-[3.0.5]
-- add dumpSelection()
-- fixed settings.url
+  [3.0.5]
+- Add dumpSelection() method 
+- Fixed settings.url
 
-[3.0.4]
+  [3.0.4]
 - Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC 
 - add isJSON, isXML functions to Utils 
 
-[3.0.3]
+  [3.0.3]
 - add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object) 
 
-[3.0.2]
+  [3.0.2]
 - Add `PUT` and `DELETE` support to `openURL`
 - Ensure sending integer in nValue in update function
 - Fix sValue for custom sensor
 
-[3.0.1] 
-- Add option 'at' to the various commands/methods
- 
-[3.0.0] 
- - Add system-events triggers as option to the on = { ... } section. Scripts can now be triggered based on these system-events: 
+  [3.0.1] 
+- Add option `at()` to the various commands/methods
+- Add stringToSeconds() function
+
+  [3.0.0]
+ - Add system-events triggers as option to the on = { ... } section. Scripts can now be triggered based on these system-events:
 	 - start
 	 - stop
 	 - manualBackupFinished,
@@ -72,178 +81,177 @@
  - Add attribute `mode` to Evohome controller
  - Add option to dumpTable() and ([device][uservariable][scene][group].dump() to os file
 
-[2.5.7]
+# [2.5]
+
+  [2.5.7]
 - Add option checkFirst to switchSelector method
 
-[2.5.6]
+  [2.5.6]
 - Add dayName, monthName, monthAbbrName and time as time attributes
-- Add _.round, _.isEqual functions to lodash.lua
-- Add testLodash.lua as testModule for lodash 
+- Add \_.round, \_.isEqual functions to lodash.lua
+- Add testLodash.lua as testModule for lodash
 
-[2.5.5]
+  [2.5.5]
 - Add Zwave fan to Zwave mode device adapter
 
-[2.5.4]
+  [2.5.4]
 - Add minutesSinceMidnight to domoticz Time object
-- Add domoticz.time.addSeconds(), -.addMinutes(), -.addHours(), -.addDays() , -.makeTime()
+- Add domoticz.time.addSeconds(), -.addMinutes(), -.addHours(), -.addDays(), -.makeTime()
 - Add string.sMatch to utils
 - Made wildcard handling more resilient when magic chars are part of script triggers
 
-[2.5.3] 
+  [2.5.3]
 - Add timealert / errors for long running scripts
 - Add triggerHTTPResponse()
 
-[2.5.2]
+  [2.5.2]
 - Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
 - Add toBase64 and fromBase64 function in utils
 - Add setLogMarker function in utils
-- Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and when used leave the device stateless)
+- Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
 
-[2.5.1]
+  [2.5.1]
 - Added `toXML` and `fromXML` methods to domoticz.utils.
 - Add attributes isXML, xmlVersion, xmlEncoding
 
-[2.5.0]
+  [2.5.0]
 - Prepared for Lua 5.3
 
-[2.4.29]
+# [2.4]
+
+  [2.4.29]
 - Add error message including affected module when module got corrupted on disk.
 - Add setLevel method for switchTypes.
 - Increased resilience against badly formatted type Time user-variables.
 - Use native domoticz command for increaseCounter method.
 - Set inverse of "set color" to Off to enable use of toggleSwitch for RGB type of devices.
 
-[2.4.28]
-- Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods
+  [2.4.28]
+- Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils
 - increased httpResponse resilience against different use of Upper-, Lowercase in headers['content-type'] to ensure JSON conversion to Lua table
 
-[2.4.27]
-
-- Add protect attribute for devices / scenes and groups
-- Add methods protectOn and protectOff for devices / scenes and groups
+  [2.4.27]
+- Add attribute protected for devices / scenes and groups
+- Add methods protectionOn and protectionOff for devices / scenes and groups
 - Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
 
-[2.4.26]
-- Add Smoke detector
+  [2.4.26]
+- Add Smoke Detector device (activate and reset functions )
 
-[2.4.25]
+  [2.4.25]
 - Add rawDateTime
-- fix for combined device / civil[day|night]time trigger rule 
+- fix for combined device / civil[day|night]time trigger rule
 - fix for checkFirst on stopped status
 
-[2.4.24]
+  [2.4.24]
 - Add method rename for devices, user-variables , scenes and groups
 
-[2.4.23]
+  [2.4.23]
 - Add method setMode for evohome device
 - Add method incrementCounter for incremental counter
 - Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
-- fix wildcard device 
+- fix wildcard device
 
-[2.4.22]
+  [2.4.22]
 - selector.switchSelector method accepts levelNames
 - increased selector.switchSelector resilience
-- fix wildcard timerule 
+- fix wildcard timerule
 
-[2.4.21]
+  [2.4.21]
 - fixed wrong direction for open() and close() for some types of blinds
 - Add inTable function to domoticz.utils
 - Add sValue attribute to devices
 
-[2.4.20]
-- Add quietOn() and quietOff() method to switchType devices 
+  [2.4.20]
+- Add quietOn() and quietOff() method to switchType devices
 
-[2.4.19]
+  [2.4.19]
 - Add stringSplit function to domoticz.utils.
 - Add statusText and protocol to HTTPResponse
 
-[2.4.18]
-- Add triggerIFTTT()
+  [2.4.18]
+- Add triggerIFTTT() to domoticz
 
-[2.4.17]
-- Add function dumpTable() to domoticz.utils
-- Add setValues() method to devices 
-- Add setIcon() method for devices
+  [2.4.17]
+- Add dumpTable() to domoticz.utils
+- Add setValues for devices
+- Add setIcon for devices
 
-[2.4.16]
-- Add option dump() to domoticz.settings
-- Add domoticz.hsbToRGB method for converting hue to rgb
+  [2.4.16]
+- Add method dump() to domoticz (dumps settings)
 - Add setHue, setColor, setHex, getColor for RGBW(W) devices
 - Add setDescription for devices, groups and scenes
 - Add volumeUp / volumeDown for Logitech Media Server (LMS)
-- Changed domoticz.utils.fromJSON (add optional fallback param) 
+- Changed domoticz.utils.fromJSON (add optional fallback param)
 
-[2.4.15] 
+  [2.4.15]
 - Add option to use camera name in snapshot command
 - Add domoticz.settings.domoticzVersion
 - Add domoticz.settings.dzVentsVersion
 
-[2.4.14]
-- Added domoticz.settings.location.longitude and domoticz.settings.location.latitude 
+  [2.4.14]
+- Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
 - Added check for- and message when call to openURL cannot open local (127.0.0.1)
-- **BREAKING CHANGE** :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name) 
+- **BREAKING CHANGE** :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
 - prevent call to updateCounter with table
 
-[2.4.13]
-- Added domoticz.settings.location (domoticz settings location Name) 
-- Added domoticz.urlDecode method to convert an urlEncoded string to human readable format
+  [2.4.13]
+- Added domoticz.settings.location (domoticz settings location Name)
+- Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
 
-[2.4.12]
-- Added Managed counter (to counter)
+  [2.4.12]
+- Added managed Counter (to counter)
 
-[2.4.11]
-- Added snapshot command to send Email with camera snapshot ( afterXXX() and withinXXX() options available)
+  [2.4.11]
+- Added snapshot command to send Email with camera snapshot ( afterAAA() and withinAAA() options available)
 
-[2.4.10]
-- Added option to use afterXXX() and withinXXX() functions to updateSetPoint()
-- Changed parm from integer to string in call to device.update in function updateMode of device adapter zwave_thermostat_mode_device
+  [2.4.10]
+- Added option to use afterAAA() and withinAAA() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup>
+- Changed function updateMode to display mode as string in domoticz log
 
-[2.4.9]
+  [2.4.9]
 - Added evohome hotwater device (state, mode, untilDate and setHotWater function)
-- Added mode and untilDate for evohome zone devices 
+- Added mode and untilDate for evohome zone devices
 - Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
-- Add speedMs and gustMs from wind devices 
+- Add speedMs and gustMs from wind devices
 - bugfix for youless device (0 handling)
 - bugfix for time ( twilightstart and twilightend handling)
-- Added tests for twilight and device functions (hotwater) and attributes (evohome- and wind devices)
 - Fixed some date-range rule checking
-- Fixed integration tests by changing API call for creating a domoticz variable (saveuservariable was changed to adduservariable)
-- Fixed combined timer where one part of the combination is even or odd week. 
-- Added tests for combined timer with even/odd week 
 
-[2.4.8]
+  [2.4.8]
 - Added telegram as option for domoticz.notify
 
-[2.4.7]
+  [2.4.7]
 - Added support for civil twilight in rules
 
-[2.4.6]
+  [2.4.6]
 - Added Youless device
 - Added more to the documentation section for http requests
 - Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
 
-[2.4.5]
+  [2.4.5]
 - Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&t=23109).
 
-[2.4.4]
+  [2.4.4]
 - Fixed rawTime and rawData so it shows leading zeros when values are below 10.
 - Fixed one wildcard issue. Should now work as expected.
 - Fixed a problem in Domoticz where you couldn't change the state of some door contact-like switches using the API or dzVents. That seems to work now.
 
-[2.4.3]
+  [2.4.3]
 - Fixed trigger wildcards. Now you can do `*aa*bb*cc` or `a*` which will require the target to start with an `a`
 - Added more EvoHome device types to the EvoHome device adapter.
 
-[2.4.2]
+  [2.4.2]
 - Fixed RGBW device adapter
 - Fixed EvoHome device adapter
 - Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&t=21620&p=170469#p170469)
 
-[2.4.1]
+  [2.4.1]
 - Fixed week number problems on Windows
 - Fixed 'on date' rules to support dd/mm format (e.g. 01/02)
 
-[2.4.0]
+  [2.4.0]
+
 - **BREAKING CHANGE**: The second parameter passed to the execute function is no longer `nil` when the script was triggered by a timer or a security event. Please check your scripts. The second parameter has checks to determine the type. E.g. `execute = function(domoticz, item) .. end`. You can inspect `item` using: `item.isDevice`, `item.isTimer`, `item.isVariable`, `item.isScene`, `item.isGroup`, `item.isSecurity`, `item.isHTTPResponse`. Please read the documentation about the execute function.
 - Added ``.cancelQueuedCommands()`` to devices, groups, scenes and variables. Calling this method will cancel any scheduled future commands issued using for instance `.afterMin(10)` or `.repeatAfterMin(1, 4)`
 - Added `.devices()` collection to scenes and groups to iterate (`forEach`, `filter`, `reduce`, `find`) over the associated devices.
@@ -253,7 +261,7 @@
 - Moved utility functions from the domoticz object to `domoticz.utils` object. You will see a deprecation warning when using the old function like `round()`, `toCelsius()` etc.
 - Added `lodash` as a method to `domoticz.utils`: `domoticz.utils._`
 - Added `toJSON` and `fromJSON` methods to domoticz.utils.
-- Added `afterXXX()` and `withinXXX()` support for device-update commands. E.g.: `myTextDevice.updateText('Zork').afterMin(2)`.
+- Added `afterAAA()` and `withinAAA()` support for device-update commands. E.g.: `myTextDevice.updateText('Zork').afterMin(2)`.
 - Added support for Logitech Media Server devices (thanks to Eoreh).
 - Added new timer rules: date rules: `on 13/07`, `on */03`, `on 12/*`, `on 12/04-22/09`, `on -24/03`, `on 19/11-`, week rules: `in week 12,15,19-23,-48,53-`, `every even week`, `every odd week`. See documentation.
 - Added historical data helper `delta2(fromIndex, toIndex, smoothRangeFrom, smoothRangeTo, default)` to have a bit more control over smoothing. You can specify if want to smooth either the start value (reference) and/or the to value (compared value).
@@ -261,7 +269,7 @@
 - Added support for Lighting Limitless/Applamp RGBW devices. You can now set Kelvin and RGB values, NightMode, WhiteMode and increase and decrease the brightness and discoMode. See the documentation.
 - Added device adapter for Onkyo receiver hardware.
 - Added `scriptName` to the triggerInfo object passed as the third parameter to the execute function. This holds the name of the script being executed.
-- Fixed bug in Domoticz where using forXXX() with selector switches didn't always work.
+- Fixed bug in Domoticz where using forAAA() with selector switches didn't always work.
 - Fixed bug in Domoticz where improper states were passed to the event scripts. This may happen on slower machines where several devices may have been updated before the event-system had a change to operate on them. In that case the event scripts received the current final state instead of the state at the moment of the actual event.
 - Added support for webroot. dzVents will now use the proper API url when domoticz is started with the -webroot switch.
 - Added support for event-bursts. If (on slower machines) events get queued up in Domoticz, they will be sent to dzVents in one-package. This makes event processing significantly faster.
@@ -271,7 +279,10 @@
 - Added and documented `domoticz.settings.url`, `domoticz.settings.webRoot` and `domoticz.settings.serverPort`.
 - Removed fixed limit on historical variables if there is a limit specified.
 
-[2.3.0]
+# [2.3]
+
+
+  [2.3.0]
 
  - Added `active` attribute to devices (more logical naming than the attribute 'bState'). `myDevice.active` is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like `if mySwitch.active then .. end`
  - Added `domoticz.urlEncode` method on the `domoticz` object so you can prepare a string before using it with `openURL()`.
@@ -291,7 +302,7 @@
  - `active` section is now optional in your dzVents script. If you don't specify an `active = true/false` then true is assumed (script is active). Handy for when you use Domoticz' GUI script editor as it has its own way of activating and deactivating scripts.
  - Added `humidityStatusValue` for humidity devices. This value matches with the values used for setting the humidity status.
  - `Time` object will initialize to current time if nothing is passed: `local current = Time()`.
- - Added the lua Lodash library (http://axmat.github.io/lodash.lua, MIT license).
+ - Added the lua lodash library,	<!--  removed because of dead link http://axmat.github.io/lodash.lua/ , MIT license ).	-->
  - Fixed documentation about levelNames for selector switches and added the missing levelName.
  - Moved dzVents runtime code away from the `/path/to/domoticz/scripts/dzVents` folder as this scripts folder contains user stuff.
  - Added more trigger examples in the documentation.
@@ -301,7 +312,9 @@
  - Fixed the confusing setting for enabling/disabling dzVents event system in Domoticz settings.
  - Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn't executed.
 
-[2.2.0]
+# [2.2]
+
+  [2.2.0]
 
  - Fixed typo in the doc WActual > WhActual.
  - Updated switch adapter to match more switch-like devices.
@@ -318,7 +331,16 @@
  - Fixed bug in check battery levels example.
  - Fixed some irregularities with dimmer levels.
 
-[2.1.0]
+# [2.1]
+
+  [2.1.1]
+
+ - Fixed typo in the doc WActual > WhActual.
+ - Updated switch adapter to match more switch-like devices.
+ - Added Z-Wave Thermostat mode device adapter.
+ - Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
+
+  [2.1.0]
 
  - Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
  - Added support for Ampère 1 and 3-phase devices
@@ -329,9 +351,9 @@
  - Added support for visibility devices
  - Added support for waterflow devices
  - Added missing color attribute to alert sensor devices
- - Added updateEnergy() to electric us./dage devices
+ - Added updateEnergy() to electric usage devices
  - Fixed casing for WhTotal, WhActual methods on kWh devices (Watt's in a name?)
- - Added toCelsius() helper method to domoticz object as the various update temperature methods all need celsius.
+ - Added toCelsius() helper method to domoticz object as the various update temperature methods all need Celsius.
  - Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
  - Added integration tests for full round-trip Domoticz > dzVents > Domoticz > dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
  - Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won't get uservariable event scripts triggered in dzVents.
@@ -340,10 +362,13 @@
  - Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
  - Use different api command for setting setPoints in the Thermostat setpoint device adapter.
 
-[2.0.0] Domoticz integration
+# [2.0]
+
+
+  [2.0.0] Domoticz integration
 
  - Almost a complete rewrite.
- - **BREAKING CHANGE**: Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing `domoticz.devices['myDevice']` you now have to call a function: `domoticz.devices('myDevice')`. This applies also for the other collections: `domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()`. If you want to loop over these collection **you can no longer use the standard Lua for..pairs or for..ipairs construct**. You have to use the iterators like forEach, filter and reduce: `domoticz.devices().forEach(function() .. end)` (see [Iterators](#Iterators)). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. **So please change your existing dzVents scripts!**
+ - **BREAKING CHANGE**: Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing `domoticz.devices['myDevice']` you now have to call a function: `domoticz.devices('myDevice')`. This applies also for the other collections: `domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()`. If you want to loop over these collection **you can no longer use the standard Lua for..pairs or for..ipairs construct**. You have to use the iterators like forEach, filter and reduce: `domoticz.devices().forEach(function() .. end)` (see [Looping through the collections: iterators](#Looping_through_the_collections:_iterators)). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. **So please change your existing dzVents scripts!**
  - **BREAKING CHANGE**: after_sec, for_min, after_min, within_min methods have been renamed to the camel-cased variants afterSec, forMin, afterMin, withinMin. Please rename the calls in your script.
  - **BREAKING CHANGE**: There is no longer an option to check if an attribute was changed as this was quite useless. The device has a changed flag. You can use that. Please change your existing scripts.
  - **BREAKING CHANGE**: Many device attributes are now in the appropriate type (Number instead of Strings) so you can easily make calculations with them. Units are stripped from the values as much as possible. **Check your scripts as this may break stuff.**
@@ -353,8 +378,8 @@
  - dzVents is no longer a separate library that you have to get from GitHub. All integrated into Domoticz.
  - Added option to create shared utility/helper functions and have them available in all your scripts. Simply add a `helpers = { myFunction = function() ... end }` to the `global_data.lua` file in your scripts folder and you can access the function everywhere: `domoticz.helpers.myFunction()`.
  - Created a pluggable system for device adapters so people can easily contribute by creating specific adapters for specific devices. An adapter makes sure that you get the proper methods and attributes for that device. See `/path/to/domoticz/scripts/dzVents/runtime/device-adapters`.
- - Added a `reduce()` iterator to the collections in the domoticz object so you can now easily collect data about all your devices. See  [Iterators](#Iterators).
- - Added a `find()` iterator so you can easily find an item in one of the collection (devices, scenes, groups etc.). See  [Iterators](#Iterators).
+ - Added a `reduce()` iterator to the collections in the domoticz object so you can now easily collect data about all your devices. See  [Looping through the collections: iterators](#Looping_through_the_collections:_iterators).
+ - Added a `find()` iterator so you can easily find an item in one of the collection (devices, scenes, groups etc.). See  [Looping through the collections: iterators](#Looping_through_the_collections:_iterators).
  - Variables (uservariables) have more attributes. The `value` is now the same type as it is defined in Domoticz. So no more need for a converted nValue attribute. You can inspect the type using `myVar.type`. If it is a time variable or date variable you an extra `date` or `time` attribute with the same methods as with all other date/time related attributes like `lastUpdate`. .E.g. `myVar.date.minutesAgo`.
  - Settings are now moved to the Domoticz GUI (**Setup > Settings > Other**) and no longer in a settings file.
  - You can now override the log settings per script. So you can turn-off logging globally (see log level in the settings) and still have debug-level logging for that one script you are working on. You can even add a prefix string to the log messages for easy filtering in the Domoticz log. See the documentation about the `logging = { .. }` section.
@@ -367,42 +392,46 @@
  - Extended the timer-rule with time range e.g. `at 16:45-21:00` and `at nighttime` and `at daytime` and you can provide a custom function. See documentation for examples. The timer rules can be combined as well.
  - Timer rules for `every xx minutes` or `every xx hours` are now limited to intervals that will reach *:00 minutes or hours. So for minutes you can only do these intervals: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20 and 30. Likewise for hours.
  - The Time object (e.g. domoticz.time) now has a method `matchesRule(rule)`. `rule` is a string same as you use for timer options: `if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end`. The rule matches if the current system time matches with the rule.
- - A device trigger can have a time-rule constraint: ` on = { devices = { ['myDevice'] = 'at nighttime' } }`. This only triggers the script when myDevice was changed **and** the time is after sunset and before sunrise.
+ - A device trigger can have a time-rule constraint: ` on = { devices = { ['myDevice'] = { 'at nighttime' } }`. This only triggers the script when myDevice was changed **and** the time is after sunset and before sunrise.
  - Add support for subsystem selection for domoticz.notify function.
  - Fixed a bug where a new persistent variable wasn't picked up when that variable was added to an already existing data section.
 
-[1.1.2]
+# [1.1]
+
+  [1.1.2]
 
  - More robust way of updating devices.lua
  - Added device level information for non-dimmer-like devices
 
-[1.1.1]
+  [1.1.1]
 
  - Added support for a devices table in the 'on' section.
  - Added extra log level for only showing information about the execution of a script module.
  - Added example script for System-alive checker notifications (preventing false negatives).
 
-[1.1]
+  [1.1]
 
  - Added example script for controlling the temperature in a room with hysteresis control.
  - Fixed updateLux (thanks to neutrino)
  - Added Kodi commands to the device methods.
  - Fixed updateCounter
- - Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled.
+ - Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled. See [Using dzVents with Domoticz](#Using_dzVents_with_Domoticz).
 
-[1.0.2]
+# [1.0]
+
+  [1.0.2]
 
  - Added device description attribute.
  - Added support for setting the setpoint for opentherm gateway.
- - Added timedOut boolean attribute to devices. Requires http data fetching to be anabled.
+ - Added timedOut boolean attribute to devices. Requires http data fetching to be enabled. See [Using dzVents with Domoticz](#Using_dzVents_with_Domoticz).
  - Properly detects usage devices and their Wattage.
 
-[1.0.1]
+  [1.0.1]
 
  - Added updateCustomSensor(value) method.
  - Fixed reset() for historical data.
 
-[1.0][1.0-beta2]
+  [1.0][1.0-beta2]
 
  - Deprecated setNew(). Use add() instead. You can now add multiple values at once in a script by calling multiple add()s in succession.
  - Fixed printing device logs when a value was boolean or nil
@@ -411,7 +440,7 @@
  - Added couple of helper properties on Time object. See README.
  - Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don't overwrite your settings when you copy over a new version of dzVents to your system.
 
-[1.0-beta1]
+  [1.0-beta1]
 
  - Added data persistence for scripts between script runs (see readme for more info)
  - Added a time-line based data type for you scripts with historical information and many statistical functions for retreiving information like average, minumum, maximum, delta, data smoothing (averaging values over neighbours) etc. See readme for more information.
@@ -429,33 +458,35 @@
  - Added scenes and groups collections to the domoticz object
  - Added Quick Reference Guide.
 
-[0.9.13]
+# [0.9]
+
+  [0.9.13]
 
  - Fixed some timer functions
 
-[0.9.12]
+  [0.9.12]
 
  - Fixed a bug with log level printing. Now errors are printed.
  - Added setPoint, heatingMode, lux, WhTotal, WhToday, WActual attributes to devices that support it. No need to access rawData for these anymore.
 
-[0.9.11]
+  [0.9.11]
 
  - Added log method to domoticz object. Using this to log message in the Domoticz log will respect the log level setting in the settings file. [dannybloe]
  - Updated readme. Better overview, more attributes described.
  - Added iterator functions (forEach and filter) to domoticz.devices, domoticz.changedDevices and domoticz.variables to iterate or filter more easily over these collections.
  - Added a couple of example scripts.
 
-[0.9.10]
+  [0.9.10]
 
  - A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
  - Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
- - Added support for sounds in domiticz.notify(). [WebStarVenlo]
+ - Added support for sounds in domoticz.notify(). [WebStarVenlo]
 
-[0.9.9]
+  [0.9.9]
 
  - Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy...
 
-[0.9.8]
+  [0.9.8]
 
  - Fixed a bug where a device can have underscores in its name.
  - Added dimTo(percentage) method to control dimmers.
@@ -465,6 +496,8 @@
  - Added http request data from Domoticz to devices. Now you can check the battery level and switch type and more. Make sure to edit dzVents_settings.lua file first and check the readme for install instructions!!!
  - Added log level setting in dzVents_settings.lua
 
-[0.9.7]
+  [0.9.7]
 
  - Added domoticz object resource structure. Updated readme accordingly. No more (or hardly any) need for juggling with all the Domoticz Lua tables and commandArrays.
+
+= [Back to dzVents wiki](https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting) =

--- a/dzVents/documentation/history.wiki
+++ b/dzVents/documentation/history.wiki
@@ -1,0 +1,546 @@
+= [3.0] =
+
+  [3.0.14]
+
+* Add utils.fuzzyLookup
+* Made eventHelpers more resilient to coding errors in the on = section
+
+  [3.0.13]
+
+* Add utils.osCommand (caption)
+* Improved utils.stringSplit (implicit conversion to number on request)
+* Made log function more resilient when logitem is table with embedded function(s)
+* Improved domoticz.snapshot() to enable snapshot of multiple cameras (in one Email)
+
+  [3.0.12]
+
+* Add option to use device, camera, group, scene and variable objects as parm to deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods.
+
+  [3.0.11]
+
+* Add sensorValue attribute to custom sensor
+* Add solarnoon as moment in time (like sunrise / sunset )
+
+  [3.0.10]
+
+* Add NSS_GOOGLE_DEVICES for notification casting to Google home / Google chromecast
+* Add optional parm delay to domoticz.sendCommand, domoticz.email, domoticz.sms and domoticz.notify
+
+  [3.0.9]
+
+* Add dump() as function to object types: camera-, customEvent, hardware, systemEvent, HTTPResponse, security and time.
+* Add function toUTC to time object.
+* Allow table as parm to function makeTime
+
+  [3.0.8]
+
+* Allow IPv6 ::1 as localhost in domoticz settings
+* Fixed bug that occurred when using a decimal number in afterSec (openURL and emitEvent)
+* Implement optional use of parsetrigger parm in setValues to trigger any subsequent eventscripts
+* Updated round.utils to correctly handle negative numbers and round to zero decimals
+
+  [3.0.7]
+
+* Add domoticz.hardware() as separate object class
+
+  [3.0.6]
+
+* Add hardwareInfo() function
+
+  [3.0.5]
+
+* Add dumpSelection() method
+* Fixed settings.url
+
+  [3.0.4]
+
+* Convert HTTPResponse data to JSON / XML even when HTTPResponse does not fully comply with RFC
+* add isJSON, isXML functions to Utils
+
+  [3.0.3]
+
+* add isJSON, isXML, json, xml and customEvent attributes to customEvent object (consistent with response object)
+
+  [3.0.2]
+
+* Add <code>PUT</code> and <code>DELETE</code> support to <code>openURL</code>
+* Ensure sending integer in nValue in update function
+* Fix sValue for custom sensor
+
+  [3.0.1]
+
+* Add option <code>at()</code> to the various commands/methods
+* Add stringToSeconds() function
+
+  [3.0.0]
+
+* Add system-events triggers as option to the on = { … } section. Scripts can now be triggered based on these system-events:
+** start
+** stop
+** manualBackupFinished,
+** dailyBackupFinished
+** hourlyBackupFinished
+** monthlyBackupFinished
+* Add custom-events triggers as option to the on = { … } section. You can now send an event trigger to start subscribed dzVents scripts. customEvents can be triggered by:
+** dzVents domoticz.emitEvent(name, data ) – command (data = optional)
+** JSON: json.htm?type=command&amp;param=customevent&amp;event=MyEvent&amp;data=myData ( data = optional )
+** MQTT: {“command” : “customevent”, “event” : “MyEvent” , “data” : “myData” } ( data = opt ional )
+* Add method domoticz.emitEvent()
+* Add attribute <code>mode</code> to Evohome controller
+* Add option to dumpTable() and ([device][uservariable][scene][group].dump() to os file
+
+= [2.5] =
+
+  [2.5.7]
+
+* Add option checkFirst to switchSelector method
+
+  [2.5.6]
+
+* Add dayName, monthName, monthAbbrName and time as time attributes
+* Add _.round, _.isEqual functions to lodash.lua
+* Add testLodash.lua as testModule for lodash
+
+  [2.5.5]
+
+* Add Zwave fan to Zwave mode device adapter
+
+  [2.5.4]
+
+* Add minutesSinceMidnight to domoticz Time object
+* Add domoticz.time.addSeconds(), -.addMinutes(), -.addHours(), -.addDays(), -.makeTime()
+* Add string.sMatch to utils
+* Made wildcard handling more resilient when magic chars are part of script triggers
+
+  [2.5.3]
+
+* Add timealert / errors for long running scripts
+* Add triggerHTTPResponse()
+
+  [2.5.2]
+
+* Add actualWatt to replace WhActual (left in WhActual for compatibility reasons)
+* Add toBase64 and fromBase64 function in utils
+* Add setLogMarker function in utils
+* Deprecated increaseBrightness(), decreaseBrightness(), discomode methods (only available for Yeelight and left devices stateless)
+
+  [2.5.1]
+
+* Added <code>toXML</code> and <code>fromXML</code> methods to domoticz.utils.
+* Add attributes isXML, xmlVersion, xmlEncoding
+
+  [2.5.0]
+
+* Prepared for Lua 5.3
+
+= [2.4] =
+
+  [2.4.29]
+
+* Add error message including affected module when module got corrupted on disk.
+* Add setLevel method for switchTypes.
+* Increased resilience against badly formatted type Time user-variables.
+* Use native domoticz command for increaseCounter method.
+* Set inverse of “set color” to Off to enable use of toggleSwitch for RGB type of devices.
+
+  [2.4.28]
+
+* Add deviceExists(), groupExists(), sceneExists(), variableExists(), cameraExists() methods in utils
+* increased httpResponse resilience against different use of Upper-, Lowercase in headers[‘content-type’] to ensure JSON conversion to Lua table
+
+  [2.4.27]
+
+* Add attribute protected for devices / scenes and groups
+* Add methods protectionOn and protectionOff for devices / scenes and groups
+* Add functions rightPad, leftPad, centerPad, leadingZeros, numDecimals in utils
+
+  [2.4.26]
+
+* Add Smoke Detector device (activate and reset functions )
+
+  [2.4.25]
+
+* Add rawDateTime
+* fix for combined device / civil[day|night]time trigger rule
+* fix for checkFirst on stopped status
+
+  [2.4.24]
+
+* Add method rename for devices, user-variables , scenes and groups
+
+  [2.4.23]
+
+* Add method setMode for evohome device
+* Add method incrementCounter for incremental counter
+* Prepared for Firebase notifications. Firebase (fcm) is the replacement for Google Cloud Messaging gcm)
+* fix wildcard device
+
+  [2.4.22]
+
+* selector.switchSelector method accepts levelNames
+* increased selector.switchSelector resilience
+* fix wildcard timerule
+
+  [2.4.21]
+
+* fixed wrong direction for open() and close() for some types of blinds
+* Add inTable function to domoticz.utils
+* Add sValue attribute to devices
+
+  [2.4.20]
+
+* Add quietOn() and quietOff() method to switchType devices
+
+  [2.4.19]
+
+* Add stringSplit function to domoticz.utils.
+* Add statusText and protocol to HTTPResponse
+
+  [2.4.18]
+
+* Add triggerIFTTT() to domoticz
+
+  [2.4.17]
+
+* Add dumpTable() to domoticz.utils
+* Add setValues for devices
+* Add setIcon for devices
+
+  [2.4.16]
+
+* Add method dump() to domoticz (dumps settings)
+* Add setHue, setColor, setHex, getColor for RGBW(W) devices
+* Add setDescription for devices, groups and scenes
+* Add volumeUp / volumeDown for Logitech Media Server (LMS)
+* Changed domoticz.utils.fromJSON (add optional fallback param)
+
+  [2.4.15]
+
+* Add option to use camera name in snapshot command
+* Add domoticz.settings.domoticzVersion
+* Add domoticz.settings.dzVentsVersion
+
+  [2.4.14]
+
+* Added domoticz.settings.location.longitude and domoticz.settings.location.latitude
+* Added check for- and message when call to openURL cannot open local (127.0.0.1)
+* '''BREAKING CHANGE''' :Changed domoticz.settings.location to domoticz.settings.location.name (domoticz settings location Name)
+* prevent call to updateCounter with table
+
+  [2.4.13]
+
+* Added domoticz.settings.location (domoticz settings location Name)
+* Added domoticz.utils.urlDecode method to convert a string with escaped chars (%20, %3A and the likes) to human readable format
+
+  [2.4.12]
+
+* Added managed Counter (to counter)
+
+  [2.4.11]
+
+* Added snapshot command to send Email with camera snapshot ( afterAAA() and withinAAA() options available)
+
+  [2.4.10]
+
+* Added option to use afterAAA() and withinAAA() functions to updateSetPoint() <sup>needs domoticz V4.10360 or newer</sup>
+* Changed function updateMode to display mode as string in domoticz log
+
+  [2.4.9]
+
+* Added evohome hotwater device (state, mode, untilDate and setHotWater function)
+* Added mode and untilDate for evohome zone devices
+* Added EVOHOME_MODE_FOLLOW_SCHEDULE as mode for evohome devices
+* Add speedMs and gustMs from wind devices
+* bugfix for youless device (0 handling)
+* bugfix for time ( twilightstart and twilightend handling)
+* Fixed some date-range rule checking
+
+  [2.4.8]
+
+* Added telegram as option for domoticz.notify
+
+  [2.4.7]
+
+* Added support for civil twilight in rules
+
+  [2.4.6]
+
+* Added Youless device
+* Added more to the documentation section for http requests
+* Made sure global_data is the first module to process. This fixes some unexpected issues if you need some globals initialized before the other scripts are loaded.
+
+  [2.4.5]
+
+* Fixed a bug in date ranges for timer triggers (http://domoticz.com/forum/viewtopic.php?f=59&amp;t=23109).
+
+  [2.4.4]
+
+* Fixed rawTime and rawData so it shows leading zeros when values are below 10.
+* Fixed one wildcard issue. Should now work as expected.
+* Fixed a problem in Domoticz where you couldn’t change the state of some door contact-like switches using the API or dzVents. That seems to work now.
+
+  [2.4.3]
+
+* Fixed trigger wildcards. Now you can do <code>*aa*bb*cc</code> or <code>a*</code> which will require the target to start with an <code>a</code>
+* Added more EvoHome device types to the EvoHome device adapter.
+
+  [2.4.2]
+
+* Fixed RGBW device adapter
+* Fixed EvoHome device adapter
+* Changed param ordering opentherm gateway command (https://www.domoticz.com/forum/viewtopic.php?f=59&amp;t=21620&amp;p=170469#p170469)
+
+  [2.4.1]
+
+* Fixed week number problems on Windows
+* Fixed ‘on date’ rules to support dd/mm format (e.g. 01/02)
+
+  [2.4.0]
+
+* '''BREAKING CHANGE''': The second parameter passed to the execute function is no longer <code>nil</code> when the script was triggered by a timer or a security event. Please check your scripts. The second parameter has checks to determine the type. E.g. <code>execute = function(domoticz, item) .. end</code>. You can inspect <code>item</code> using: <code>item.isDevice</code>, <code>item.isTimer</code>, <code>item.isVariable</code>, <code>item.isScene</code>, <code>item.isGroup</code>, <code>item.isSecurity</code>, <code>item.isHTTPResponse</code>. Please read the documentation about the execute function.
+* Added <code>.cancelQueuedCommands()</code> to devices, groups, scenes and variables. Calling this method will cancel any scheduled future commands issued using for instance <code>.afterMin(10)</code> or <code>.repeatAfterMin(1, 4)</code>
+* Added <code>.devices()</code> collection to scenes and groups to iterate (<code>forEach</code>, <code>filter</code>, <code>reduce</code>, <code>find</code>) over the associated devices.
+* Added http response event triggers to be used in combination with <code>openURL</code>. You can now do <code>GET</code> and <code>POST</code> request and handle the response in your dzVents scripts '''ASYNCHRONICALLY'''. See the documentation. No more json parsing needed or complex <code>curl</code> shizzle.
+* Added a more consistent second parameter sent to the execute function. When a timer is triggered then the second parameter is a Timer object instead of nil. This way you can check the baseType of the second parameter and makes third parameter (triggerInfo) kind of obsolete. Every object bound to the second parameter now has a baseType.
+* Added locked/unlocked support for door-locks (locked == active).
+* Moved utility functions from the domoticz object to <code>domoticz.utils</code> object. You will see a deprecation warning when using the old function like <code>round()</code>, <code>toCelsius()</code> etc.
+* Added <code>lodash</code> as a method to <code>domoticz.utils</code>: <code>domoticz.utils._</code>
+* Added <code>toJSON</code> and <code>fromJSON</code> methods to domoticz.utils.
+* Added <code>afterAAA()</code> and <code>withinAAA()</code> support for device-update commands. E.g.: <code>myTextDevice.updateText('Zork').afterMin(2)</code>.
+* Added support for Logitech Media Server devices (thanks to Eoreh).
+* Added new timer rules: date rules: <code>on 13/07</code>, <code>on */03</code>, <code>on 12/*</code>, <code>on 12/04-22/09</code>, <code>on -24/03</code>, <code>on 19/11-</code>, week rules: <code>in week 12,15,19-23,-48,53-</code>, <code>every even week</code>, <code>every odd week</code>. See documentation.
+* Added historical data helper <code>delta2(fromIndex, toIndex, smoothRangeFrom, smoothRangeTo, default)</code> to have a bit more control over smoothing. You can specify if want to smooth either the start value (reference) and/or the to value (compared value).
+* Added historical data helper <code>deltaSinceOrOldest(timeAgo, smoothRangeFrom, smoothRangeTo, default)</code>. This will use the oldest data value when the data set is shorter than timeAgo.
+* Added support for Lighting Limitless/Applamp RGBW devices. You can now set Kelvin and RGB values, NightMode, WhiteMode and increase and decrease the brightness and discoMode. See the documentation.
+* Added device adapter for Onkyo receiver hardware.
+* Added <code>scriptName</code> to the triggerInfo object passed as the third parameter to the execute function. This holds the name of the script being executed.
+* Fixed bug in Domoticz where using forAAA() with selector switches didn’t always work.
+* Fixed bug in Domoticz where improper states were passed to the event scripts. This may happen on slower machines where several devices may have been updated before the event-system had a change to operate on them. In that case the event scripts received the current final state instead of the state at the moment of the actual event.
+* Added support for webroot. dzVents will now use the proper API url when domoticz is started with the -webroot switch.
+* Added support for event-bursts. If (on slower machines) events get queued up in Domoticz, they will be sent to dzVents in one-package. This makes event processing significantly faster.
+* Added <code>domoticz.data.initialize(varName)</code>. This will re-initialize non-historical variables to the initial value as defined in the data section.
+* You now no longer have to provide an initial value for a persistent variable when you declare it. So you can do <code>data = { 'a', 'b', 'c'}</code> instead of <code>data = {a={initial = nil}, b={initial=nil}, c={initial=nil} }</code>. You have to quote the names though.
+* A filter can now accept a table with names/id’s instead of only functions. You can now do <code>domoticz.devices().filter({ 'mySwitch', 'myPIR', 34, 35, 'livingLights'})</code> which will give you a collection of devices with these names and ids.
+* Added and documented <code>domoticz.settings.url</code>, <code>domoticz.settings.webRoot</code> and <code>domoticz.settings.serverPort</code>.
+* Removed fixed limit on historical variables if there is a limit specified.
+
+= [2.3] =
+
+  [2.3.0]
+
+* Added <code>active</code> attribute to devices (more logical naming than the attribute ‘bState’). <code>myDevice.active</code> is true or false depending on a set of known state values (like On, Off, Open, Closed etc). Use like <code>if mySwitch.active then .. end</code>
+* Added <code>domoticz.urlEncode</code> method on the <code>domoticz</code> object so you can prepare a string before using it with <code>openURL()</code>.
+* Updating devices, user variables, scenes and groups now always trigger the event system for follow-up events.
+* Added support for groups and scenes change-event scripts. Use <code>on = { scenes = { 'myScene1', 'myScene2' }, groups = {'myGroup1'} }</code>
+* Added adapter for the new Temperature+Barometer device.
+* Added <code>domoticz.startTime</code> giving you the time at which the Domoticz service was started. Returns a Time object.
+* Added <code>domoticz.systemUptime</code> (in seconds) indicating the number of seconds the machine is running. Returns a Time object.
+* Added more options to the various commands/methods: e.g. <code>myDevice.switchOff().silent()</code>, <code>.forSec()</code>, <code>.forHour()</code>, <code>.afterHour()</code>, <code>.repeatAfterSec()</code>, <code>.repeatAfterMin()</code>, <code>.repeatAfterHour()</code>, <code>.withinHour()</code> and <code>.checkFirst()</code>. This now works not only for devices but also scenes, groups and user variables. See documentation about command options.
+* Added <code>.silent()</code> option to commands like <code>switchOn().afterSec(4).silent()</code> causing no follow-up events to be triggered. This also works when updating non-switch-like devices, scenes, groups and user variables. If you do not call `silent()``, a follow-up event is ''always'' triggered (for devices, scenes, groups and user variables).
+* Added time rule <code>between xx and yy</code>. You can now do things like: <code>between 16:34 and sunset</code> or <code>between 10 minutes before sunset and sunrise</code>. See the doc.
+* Added support for milliseconds in <code>Time</code> object. This also give a ms part in the time-stamp for historical persistent data. You can now do <code>msAgo()</code> on time stamp when you inspect a data point from an history variable.
+* Added <code>daysAgo()</code> to <code>Time</code> object.
+* Added <code>compare(time)</code> method to <code>Time</code> object to calculate the difference between them. Returns a table. See documentation.
+* Added <code>domoticz.round()</code> method to <code>domoticz</code> object.
+* Added <code>text</code> property to alert sensor.
+* <code>active</code> section is now optional in your dzVents script. If you don’t specify an <code>active = true/false</code> then true is assumed (script is active). Handy for when you use Domoticz’ GUI script editor as it has its own way of activating and deactivating scripts.
+* Added <code>humidityStatusValue</code> for humidity devices. This value matches with the values used for setting the humidity status.
+* <code>Time</code> object will initialize to current time if nothing is passed: <code>local current = Time()</code>.
+* Added the lua lodash library, <!--  removed because of dead link http://axmat.github.io/lodash.lua/ , MIT license ).  -->
+* Fixed documentation about levelNames for selector switches and added the missing levelName.
+* Moved dzVents runtime code away from the <code>/path/to/domoticz/scripts/dzVents</code> folder as this scripts folder contains user stuff.
+* Added more trigger examples in the documentation.
+* You can now put your own non-dzVents modules in your scripts folder or write them with the Domoticz GUI editor. dzVents is no longer bothered by it. You can require your modules in Lua’s standard way.
+* Added <code>/path/to/domoticz/scripts/dzVents/scripts/modules</code> and <code>/path/to/domoticz/scripts/dzVents/modules</code> to the Lua package path for custom modules. You can now place your modules in there and require them from anywhere in your scripts.
+* Added dzVents-specific boilerplate/templates for internal web editor.
+* Fixed the confusing setting for enabling/disabling dzVents event system in Domoticz settings.
+* Fixed a problem where if you have two scripts for a device and one script uses the name and the other uses the id as trigger, the id-based script wasn’t executed.
+
+= [2.2] =
+
+  [2.2.0]
+
+* Fixed typo in the doc WActual &gt; WhActual.
+* Updated switch adapter to match more switch-like devices.
+* Added Z-Wave Thermostat mode device adapter.
+* Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
+* Added secondsSinceMidnight to time attributes (e.g. lastUpdate.secondsSinceMidnight)
+* Added 4 new time-rules: xx minutes before/after sunset/sunrise.
+* Added example script to fake user presence.
+* Fixed support for uservariables with spaces in their names.
+* Show a warning when an item’s name isn’t unique in the collection.
+* Added timing options for security methods armAway, armHome and disarm like device.armAway().afterSec(10).
+* Added idx, deviceId and unit to device objects. Don’t confuse deviceId with device.id(x) which is actually the index of the device.
+* Added instructions on how to create a security panel device in Domoticz. This device now has a state that has the same value as domoticz.security.
+* Fixed bug in check battery levels example.
+* Fixed some irregularities with dimmer levels.
+
+= [2.1] =
+
+  [2.1.1]
+
+* Fixed typo in the doc WActual &gt; WhActual.
+* Updated switch adapter to match more switch-like devices.
+* Added Z-Wave Thermostat mode device adapter.
+* Fixed a problem with thermostat setpoint devices to issue the proper url when updating.
+
+  [2.1.0]
+
+* Added support for switching RGB(W) devices (including Philips/Hue) to have toggleSwitch(), switchOn() and switchOff() and a proper level attribute.
+* Added support for Ampère 1 and 3-phase devices
+* Added support for leaf wetness devices
+* Added support for scale weight devices
+* Added support for soil moisture devices
+* Added support for sound level devices
+* Added support for visibility devices
+* Added support for waterflow devices
+* Added missing color attribute to alert sensor devices
+* Added updateEnergy() to electric usage devices
+* Fixed casing for WhTotal, WhActual methods on kWh devices (Watt’s in a name?)
+* Added toCelsius() helper method to domoticz object as the various update temperature methods all need Celsius.
+* Added lastLevel for dimmers so you can see the level of the dimmer just before it was switched off (and while is it still on).
+* Added integration tests for full round-trip Domoticz &gt; dzVents &gt; Domoticz &gt; dzVents tests (100 tests). Total tests (unit+integration) now counts 395!
+* Fixed setting uservariables. It still uses json calls to update the variable in Domoticz otherwise you won’t get uservariable event scripts triggered in dzVents.
+* Added dzVents version information in the Domoticz settings page for easy checking what dzVents version is being used in your Domoticz built. Eventhough it is integrated with Domoticz, it is handy for dzVents to have it’s own heartbeat.
+* avg(), avgSince(), sum() and sumSince() now return 0 instead of nil for empty history sets. Makes more sense.
+* Fixed boiler example to fallback to the current temperature when there is no history data yet when it calculates the average temperature.
+* Use different api command for setting setPoints in the Thermostat setpoint device adapter.
+
+= [2.0] =
+
+  [2.0.0] Domoticz integration
+
+* Almost a complete rewrite.
+* '''BREAKING CHANGE''': Accessing a device, scene, group, variable, changedDevice, or changedVariable has been changed: instead of doing <code>domoticz.devices['myDevice']</code> you now have to call a function: <code>domoticz.devices('myDevice')</code>. This applies also for the other collections: <code>domoticz.scenes(), domoticz.groups(), domoticz.changedDevices(), domoticz.changedVariables()</code>. If you want to loop over these collection '''you can no longer use the standard Lua for..pairs or for..ipairs construct'''. You have to use the iterators like forEach, filter and reduce: <code>domoticz.devices().forEach(function() .. end)</code> (see [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]]). This was a necessary change to make dzVents a whole lot faster in processing your event scripts. '''So please change your existing dzVents scripts!'''
+* '''BREAKING CHANGE''': after_sec, for_min, after_min, within_min methods have been renamed to the camel-cased variants afterSec, forMin, afterMin, withinMin. Please rename the calls in your script.
+* '''BREAKING CHANGE''': There is no longer an option to check if an attribute was changed as this was quite useless. The device has a changed flag. You can use that. Please change your existing scripts.
+* '''BREAKING CHANGE''': Many device attributes are now in the appropriate type (Number instead of Strings) so you can easily make calculations with them. Units are stripped from the values as much as possible. '''Check your scripts as this may break stuff.'''
+* '''BREAKING CHANGE''': on-section now requires subsections for <code>devices</code>, <code>timer</code>, <code>variables</code>, and <code>security</code>. The old way no longer works! Please convert your existing scripts!
+* '''BREAKING CHANGE''': Make sure that in Domoticz settings under '''Local Networks (no username/password)''' you add <code>127.0.0.1</code> so dzVents can use Domoticz api when needed.
+* dzVents now works on Windows machines!
+* dzVents is no longer a separate library that you have to get from GitHub. All integrated into Domoticz.
+* Added option to create shared utility/helper functions and have them available in all your scripts. Simply add a <code>helpers = { myFunction = function() ... end }</code> to the <code>global_data.lua</code> file in your scripts folder and you can access the function everywhere: <code>domoticz.helpers.myFunction()</code>.
+* Created a pluggable system for device adapters so people can easily contribute by creating specific adapters for specific devices. An adapter makes sure that you get the proper methods and attributes for that device. See <code>/path/to/domoticz/scripts/dzVents/runtime/device-adapters</code>.
+* Added a <code>reduce()</code> iterator to the collections in the domoticz object so you can now easily collect data about all your devices. See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]].
+* Added a <code>find()</code> iterator so you can easily find an item in one of the collection (devices, scenes, groups etc.). See [[#Looping_through_the_collections:_iterators|Looping through the collections: iterators]].
+* Variables (uservariables) have more attributes. The <code>value</code> is now the same type as it is defined in Domoticz. So no more need for a converted nValue attribute. You can inspect the type using <code>myVar.type</code>. If it is a time variable or date variable you an extra <code>date</code> or <code>time</code> attribute with the same methods as with all other date/time related attributes like <code>lastUpdate</code>. .E.g. <code>myVar.date.minutesAgo</code>.
+* Settings are now moved to the Domoticz GUI ('''Setup &gt; Settings &gt; Other''') and no longer in a settings file.
+* You can now override the log settings per script. So you can turn-off logging globally (see log level in the settings) and still have debug-level logging for that one script you are working on. You can even add a prefix string to the log messages for easy filtering in the Domoticz log. See the documentation about the <code>logging = { .. }</code> section.
+* No more need to do http-calls to get extended data from Domoticz. All relevant internal Domoticz state-data is now available inside your dzVents scripts. Thanks Scotty!!
+* Support for many many more device types and their specific methods. See the documentation for the list of attributes and events that are available. Note that device-type specific attributes are only available for those type of devices. You will receive an error in the log if you try to access an attribute that doesn’t exist for that particular device. Hopefully you don’t have to use the rawData table anymore. If you still do please file a report or create a device adapter yourself.
+* You can now write dzVents scripts using the internal editor in Domoticz. These scripts will be automatically exported to the filesystem (one-way only) so dzVents can execute them (generated_scripts folder). Thanks again Scotty!
+* Support for variable change events (<code>on = { variables = { 'varA', 'varB'} }</code>)
+* Support for security change events (<code>on = { security = { domoticz.SECURITY_ARMEDAWAY } }</code>)
+* The triggerInfo passed to the execute function now includes information about which security state triggered the script if it was a security event.
+* Extended the timer-rule with time range e.g. <code>at 16:45-21:00</code> and <code>at nighttime</code> and <code>at daytime</code> and you can provide a custom function. See documentation for examples. The timer rules can be combined as well.
+* Timer rules for <code>every xx minutes</code> or <code>every xx hours</code> are now limited to intervals that will reach *:00 minutes or hours. So for minutes you can only do these intervals: 1, 2, 3, 4, 5, 6, 10, 12, 15, 20 and 30. Likewise for hours.
+* The Time object (e.g. domoticz.time) now has a method <code>matchesRule(rule)</code>. <code>rule</code> is a string same as you use for timer options: <code>if (domoticz.time.matchesRule('at 16:32-21:33 on mon,tue,wed')) then ... end</code>. The rule matches if the current system time matches with the rule.
+* A device trigger can have a time-rule constraint: <code>on = { devices = { ['myDevice'] = { 'at nighttime' } }</code>. This only triggers the script when myDevice was changed '''and''' the time is after sunset and before sunrise.
+* Add support for subsystem selection for domoticz.notify function.
+* Fixed a bug where a new persistent variable wasn’t picked up when that variable was added to an already existing data section.
+
+= [1.1] =
+
+  [1.1.2]
+
+* More robust way of updating devices.lua
+* Added device level information for non-dimmer-like devices
+
+  [1.1.1]
+
+* Added support for a devices table in the ‘on’ section.
+* Added extra log level for only showing information about the execution of a script module.
+* Added example script for System-alive checker notifications (preventing false negatives).
+
+  [1.1]
+
+* Added example script for controlling the temperature in a room with hysteresis control.
+* Fixed updateLux (thanks to neutrino)
+* Added Kodi commands to the device methods.
+* Fixed updateCounter
+* Added counterToday and counterTotal attributes for counter devices. Only available when http fetching is enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
+
+= [1.0] =
+
+  [1.0.2]
+
+* Added device description attribute.
+* Added support for setting the setpoint for opentherm gateway.
+* Added timedOut boolean attribute to devices. Requires http data fetching to be enabled. See [[#Using_dzVents_with_Domoticz|Using dzVents with Domoticz]].
+* Properly detects usage devices and their Wattage.
+
+  [1.0.1]
+
+* Added updateCustomSensor(value) method.
+* Fixed reset() for historical data.
+
+  [1.0][1.0-beta2]
+
+* Deprecated setNew(). Use add() instead. You can now add multiple values at once in a script by calling multiple add()s in succession.
+* Fixed printing device logs when a value was boolean or nil
+* Fixed WActual/total/today for energy devices.
+* Added updateSetPoint method on devices for dummy thermostat devices and EvoHome setpoint devices
+* Added couple of helper properties on Time object. See README.
+* Renamed the file dzVents_settings.lua to dzVents_settings_example.lua so you don’t overwrite your settings when you copy over a new version of dzVents to your system.
+
+  [1.0-beta1]
+
+* Added data persistence for scripts between script runs (see readme for more info)
+* Added a time-line based data type for you scripts with historical information and many statistical functions for retreiving information like average, minumum, maximum, delta, data smoothing (averaging values over neighbours) etc. See readme for more information.
+* Added SMS method to the domoticz object.
+* Added toggleSwitch() method to devices that support it.
+* Added more switch states that control device.bState (e.g. on == true, open == true ‘all on’ == true)
+* Added secondsAgo to the lastUpdate attribute
+* Added tests (test code coverage is above 96%!)
+* Refactored code significantly.
+* Made sure differently formulated but equal triggers in one script only execute the script only once (like MySensor and MySensor_Temperature).
+* Added trigger info as a third parameter (Lua table) that is passed to the execute method of a script containing information about what exactly triggered the script (type = EVENT_TYPE_TIMER/EVENT_TYPE_DEVICE, trigger=<timer rule>). See readme.
+* Added Lua time properties to domoticz.time property with all information about the current time (hours, minutes, seconds, etc.)
+* Added option to return false in a forEach iteratee function which will abort the forEach loop.
+* All devices not delivered by Domoticz to the event scripts are now added to domoticz.devices using the http data that is fetched every 30 minutes (by default).
+* Added scenes and groups collections to the domoticz object
+* Added Quick Reference Guide.
+
+= [0.9] =
+
+  [0.9.13]
+
+* Fixed some timer functions
+
+  [0.9.12]
+
+* Fixed a bug with log level printing. Now errors are printed.
+* Added setPoint, heatingMode, lux, WhTotal, WhToday, WActual attributes to devices that support it. No need to access rawData for these anymore.
+
+  [0.9.11]
+
+* Added log method to domoticz object. Using this to log message in the Domoticz log will respect the log level setting in the settings file. [dannybloe]
+* Updated readme. Better overview, more attributes described.
+* Added iterator functions (forEach and filter) to domoticz.devices, domoticz.changedDevices and domoticz.variables to iterate or filter more easily over these collections.
+* Added a couple of example scripts.
+
+  [0.9.10]
+
+* A little less verbose debug logging. Domoticz seems not to print all message in the log. If there are too many they may get lost. [dannybloe]
+* Added method fetchHttpDomoticzData to domoticz object so you can manually trigger getting device information from Domoticz through http. [dannybloe]
+* Added support for sounds in domoticz.notify(). [WebStarVenlo]
+
+  [0.9.9]
+
+* Fixed a bug where every trigger name was treated as a wild-carded name. Oopsidayzy…
+
+  [0.9.8]
+
+* Fixed a bug where a device can have underscores in its name.
+* Added dimTo(percentage) method to control dimmers.
+* Modified the switch-like commands to allow for timing options: .for_min(), .within_min(), after_sec() and after_min() methods to control delays and durations. Removed the options argument to the switch functions. See readme.
+* Added switchSelector method on a device to set a selector switch.
+* Added wild-card option for triggers
+* Added http request data from Domoticz to devices. Now you can check the battery level and switch type and more. Make sure to edit dzVents_settings.lua file first and check the readme for install instructions!!!
+* Added log level setting in dzVents_settings.lua
+
+  [0.9.7]
+
+* Added domoticz object resource structure. Updated readme accordingly. No more (or hardly any) need for juggling with all the Domoticz Lua tables and commandArrays.
+
+= [https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting Back to dzVents wiki] =

--- a/dzVents/documentation/pandoc.md
+++ b/dzVents/documentation/pandoc.md
@@ -3,3 +3,4 @@
 Make sure you have pandoc installed, then run in this folder:
 
 pandoc -r markdown README.md -t mediawiki -o README.wiki
+pandoc -r markdown history.md -t mediawiki -o history.wiki

--- a/dzVents/runtime/Time.lua
+++ b/dzVents/runtime/Time.lua
@@ -443,8 +443,8 @@ local function Time(sDate, isUTC, _testMS)
 
 	-- returns true if self.day is on the rule: on day1,day2...
 	function self.ruleIsOnDay(rule)
-		
-        local days = string.match(rule, '%s+on%s+(.+)$') or string.match(rule, '^%s*on%s+(.+)$')
+
+		local days = string.match(rule, '%s+on%s+(.+)$') or string.match(rule, '^%s*on%s+(.+)$')
 		if (isEmpty(days)) then
 			return nil
 		end
@@ -473,7 +473,6 @@ local function Time(sDate, isUTC, _testMS)
 		end
 		return nil -- no 'on <days>' was specified in the rule
 	end
-
 
 	-- returns true if self.week matches rule in week 1,3,4 / every odd-week, every even-week, in week 5-12,23,44
 	function self.ruleIsInWeek(rule)
@@ -524,7 +523,7 @@ local function Time(sDate, isUTC, _testMS)
 
 	function self.ruleIsOnDate(rule)
 
-		local dates = string.match(rule, 'on% ([0-9%*%/%,% %-]*)')
+		local dates = rule:gsub('(on%s+[%a+])',''):match('on%s+([0-9%*%/%,% %-]*)') -- strip on ddd before matching rule
 		if (isEmpty(dates)) then
 			return nil
 		end

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -8,7 +8,7 @@ local self = {
 	LOG_INFO = 3,
 	LOG_WARNING = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '3.0.14',
+	DZVERSION = '3.0.15',
 }
 
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)
@@ -62,7 +62,7 @@ self.fuzzyLookup = function (search, target) -- search must be string/number, ta
 		local lowestFuzzyValue = math.maxinteger
 		local lowestFuzzyKey = ''
 		for _, targetString in ipairs(target) do
-			local fuzzyValue =  self.fuzzyLookup(search, targetString) 
+			local fuzzyValue =  self.fuzzyLookup(search, targetString)
 			if  fuzzyValue < lowestFuzzyValue then
 				lowestFuzzyKey = targetString
 				lowestFuzzyValue = fuzzyValue
@@ -613,6 +613,21 @@ function self.hsbToRGB(h, s, v)
 	g = (g1+m) * 255
 	b = (b1+m) * 255
 	return r, g, b
+
+end
+
+ function self.humidityStatus (temperature, humidity)
+	local constants = domoticz or require('constants')
+	local temperature = tonumber(temperature)
+	local humidity = tonumber(humidity)
+
+	if humidity <= 30 then return constants.HUM_DRY
+	elseif humidity >= 70 then return constants.HUM_WET
+	elseif  humidity >= 35 and
+			humidity <= 65 and
+			temperature >= 22 and
+			temperature <= 26 then return constants.HUM_COMFORTABLE
+	else return constants.HUM_NORMAL end
 
 end
 

--- a/dzVents/runtime/constants.lua
+++ b/dzVents/runtime/constants.lua
@@ -5,6 +5,7 @@ return {
 	['ALERTLEVEL_RED'] = 4,
 	['ALERTLEVEL_YELLOW'] = 2,
 	['BARO_CLOUDY'] = 'cloudy',	   -- true mapping to numbers is done in the device adapters for baro and temphumbaro devices
+	['BARO_COMPUTE'] = 'compute',
 	['BARO_NOINFO'] = 'noinfo',
 	['BARO_PARTLYCLOUDY'] = 'partlycloudy',
 	['BARO_RAIN'] = 'rain',
@@ -43,6 +44,7 @@ return {
 	['EVOHOME_MODE_TEMPORARY_OVERRIDE'] = 'TemporaryOverride',
 	['FLOAT'] = 'float',
 	['HUM_COMFORTABLE'] = 1,
+	['HUM_COMPUTE'] = -1,
 	['HUM_DRY'] = 2,
 	['HUM_NORMAL'] = 0,
 	['HUM_WET'] = 3,

--- a/dzVents/runtime/device-adapters/Adapters.lua
+++ b/dzVents/runtime/device-adapters/Adapters.lua
@@ -37,6 +37,7 @@ local deviceAdapters = {
 	'soundlevel_device',
 	'switch_device',
 	'thermostat_setpoint_device',
+	'thermostat_type_3_device',
 	'temperature_device',
 	'temperature_barometer_device',
 	'temperature_humidity_device',

--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -80,6 +80,12 @@ return {
 		device.isHTTPResponse = false
 		device.isSecurity = false
 
+		-- All baseTypes
+		device['changed'] = data.changed
+		device['protected'] = data.protected
+		device['description'] = data.description
+		device['lastUpdate'] = Time(data.lastUpdate)
+
 		if (data.baseType == 'device') then
 
 			local bat
@@ -88,8 +94,6 @@ return {
 			if (data.batteryLevel <= 100) then bat = data.batteryLevel end
 			if (data.signalLevel <= 100) then sig = data.signalLevel end
 
-			device['changed'] = data.changed
-			device['description'] = data.description
 			device['deviceType'] = data.deviceType
 			device['hardwareName'] = data.data.hardwareName
 			device['hardwareType'] = data.data.hardwareType
@@ -103,7 +107,6 @@ return {
 			device['batteryLevel'] = bat
 			device['signalLevel'] = sig
 			device['deviceSubType'] = data.subType
-			device['lastUpdate'] = Time(data.lastUpdate)
 			device['rawData'] = data.rawData
 			device['nValue'] = data.data._nValue
 			device['sValue'] = data.data._state or ( table.concat(device.rawData,';') ~= '' and  table.concat(device.rawData,';') ) or nil
@@ -118,18 +121,13 @@ return {
 		end
 
 		if (data.baseType == 'group' or data.baseType == 'scene') then
-			device['description'] = data.description
-			device['protected'] = data.protected
-			device['lastUpdate'] = Time(data.lastUpdate)
 			device['rawData'] = { [1] = data.data._state }
-			device['changed'] = data.changed
 			device['cancelQueuedCommands'] = function()
 				domoticz.sendCommand('Cancel', {
 					type = 'scene',
 					idx = data.id
 				})
 			end
-
 		end
 
 		setStateAttribute(data.data._state, device, _states)

--- a/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
+++ b/dzVents/runtime/device-adapters/temperature_humidity_barometer_device.lua
@@ -13,7 +13,6 @@ local humidityMapping = {
 	['wet'] = 3
 }
 
-
 return {
 
 	baseType = 'device',
@@ -36,13 +35,14 @@ return {
 		local humVal = humidityMapping[string.lower(device.humidityStatus or '')] or -1
 		device.humidityStatusValue = humVal
 
-
 		function device.updateTempHumBaro(temperature, humidity, status, pressure, forecast)
 
 			if (status == nil) then
 				-- when no status is provided, domoticz will not set the device obviously
 				utils.log('No status provided. Temperature + humidity not set', utils.LOG_ERROR)
 				return
+			elseif status == -1 then
+				status = utils.humidityStatus(temperature, humidity) -- HUM_COMPUTE
 			end
 
 			forecast = forecast ~= nil and constMapping[forecast] or 5

--- a/dzVents/runtime/device-adapters/temperature_humidity_device.lua
+++ b/dzVents/runtime/device-adapters/temperature_humidity_device.lua
@@ -23,18 +23,13 @@ return {
 
 		-- from data: dewPoint, humidity, humidityStatus, temperature
 
-		local humVal = humidityMapping[string.lower(device.humidityStatus or '')] or -1
-		device.humidityStatusValue = humVal
-
+		device.humidityStatusValue = humidityMapping[string.lower(device.humidityStatus or '')] or -1
 
 		function device.updateTempHum(temperature, humidity, status)
-			if (status == nil) then
-				-- when no status is provided, domoticz will not set the device obviously
-				utils.log('No status provided. Temperature + humidity not set', utils.LOG_ERROR)
-				return
-			end
+			if status == nil or status == -1 then status = utils.humidityStatus(temperature, humidity) end -- HUM_COMPUTE or nil
 
-			local value = tostring(temperature) .. ';' .. tostring(humidity) .. ';' .. tostring(status)
+			local value = temperature .. ';' .. humidity .. ';' .. status
+
 			return device.update(0, value)
 		end
 

--- a/dzVents/runtime/device-adapters/thermostat_type_3_device.lua
+++ b/dzVents/runtime/device-adapters/thermostat_type_3_device.lua
@@ -1,0 +1,33 @@
+return {
+
+	baseType = 'device',
+
+	name = 'Thermostat type 3 device adapter',
+
+	matches = function (device, adapterManager)
+		local res = device.deviceSubType:find('Mertik') and device.deviceType == 'Thermostat 3'
+		if (not res) then
+			adapterManager.addDummyMethod(device, 'updateMode')
+		end
+		return res
+	end,
+
+	process = function (device, data, domoticz, utils, adapterManager)
+
+		local modes = {'Off','On','Up','Down','Run Up','Run Down','Stop'}
+
+		device.mode = device.nValue
+		device.modeString = modes[ device.nValue + 1 ]
+		device.modes = table.concat(modes,',')
+
+		device.sValue = '' -- sValue is reported wrong it's empty
+
+		function device.updateMode(mode)
+			local mode = mode:gsub(' ','%%20')
+			local url = domoticz.settings['Domoticz url'] .. '/json.htm?type=command&param=switchlight&idx=' .. device.id  ..'&switchcmd=' .. mode
+			return domoticz.openURL(url)
+		end
+
+	end
+
+}

--- a/dzVents/runtime/integration-tests/stage2.lua
+++ b/dzVents/runtime/integration-tests/stage2.lua
@@ -61,9 +61,7 @@ end
 local testSwitch = function(name)
 	local dev = dz.devices(name)
 	local res = true
-	res = res and checkAttributes(dev, {
-		["state"] = "On",
-	})
+	res = res and checkAttributes(dev, {["state"] = "On",})
 	handleResult ('Test switch device', res)
 	return res
 end
@@ -536,7 +534,7 @@ local testGroup = function(name)
 		["id"] = 2,
 		["name"] = name,
 		['state'] = 'On',
-		['baseType'] = 'group'
+		['baseType'] = 'group',
 	})
 	handleResult('Test group', res)
 	return res

--- a/dzVents/runtime/misc/testdzVents.sh
+++ b/dzVents/runtime/misc/testdzVents.sh
@@ -134,7 +134,7 @@ function fillTimes
 
 function fillNumberOfTests
 	{
-		Device_ExpectedTests=115
+		Device_ExpectedTests=116
 		Domoticz_ExpectedTests=80
 		EventHelpers_ExpectedTests=32
 		EventHelpersStorage_ExpectedTests=50
@@ -142,7 +142,7 @@ function fillNumberOfTests
 		Lodash_ExpectedTests=100
 		ScriptdzVentsDispatching_ExpectedTests=2
 		TimedCommand_ExpectedTests=46
-		Time_ExpectedTests=357
+		Time_ExpectedTests=360
 		Utils_ExpectedTests=36
 		Variable_ExpectedTests=15
 		ContactDoorLockInvertedSwitch_ExpectedTests=2

--- a/dzVents/runtime/tests/testTime.lua
+++ b/dzVents/runtime/tests/testTime.lua
@@ -1824,6 +1824,21 @@ describe('Time', function()
 
 		describe('combis', function()
 
+			it('WIKI example: at daytime on mon,thu', function()
+				_G.timeofday = { ['Daytime'] = false }
+				local t = Time('2020-10-15 01:04:00')
+				assert.is_false(t.matchesRule('at daytime on mon,thu'))
+				assert.is_true(t.matchesRule('at nighttime on mon,thu'))
+			end)
+
+			it('WIKI example: every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11', function()
+				_G.timeofday = { ['SunsetInMinutes'] = 1220 , ['SunriseInMinutes'] = 480 }
+				local t = Time('2020-10-15 08:10:00')
+				assert.is_true(t.matchesRule('every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11'))
+				local t = Time('2020-10-15 08:11:00')
+				assert.is_false(t.matchesRule('every 10 minutes between 20 minutes before sunset and 30 minutes after sunrise on mon,thu on 20/9-18/11'))
+			end)
+
 			it('should return false when not on every second sunday between 1:00 and 1:30', function()
 				local t = Time('2018-12-30 01:04:00') -- on Sunday, odd week at 01:04
 				assert.is_false(t.matchesRule('between 1:00 and 1:30 on sun every odd week'))
@@ -1839,6 +1854,16 @@ describe('Time', function()
 
 				assert.is_false(t.matchesRule('every minute on tue'))
 
+			end)
+
+			it('should return false when outside date window', function() -- double on
+				local t = Time('2020-10-15 03:00:00')
+				assert.is_true(t.matchesRule('at 3:00 on mon,thu,fri,sun on 20/04-16/10'))
+				assert.is_true(t.matchesRule('at 3:00 on mon,thu,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:01 on mon,thu,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,wed,fri,sun on 2/4-2/11'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,thu,fri,sun on 2/4-16/9'))
+				assert.is_false(t.matchesRule('at 3:00 on mon,thu,fri,sun on 20/04-16/09'))
 			end)
 
 			it('at sunset on mon', function()

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -25,7 +25,7 @@ extern http::server::CWebServerHelper m_webservers;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents(void) :
-	m_version("3.0.14")
+	m_version("3.0.15")
 {
 	m_bdzVentsExist = false;
 }

--- a/www/app/devices/deviceFactory.js
+++ b/www/app/devices/deviceFactory.js
@@ -5,7 +5,7 @@ define(function () {
 
         function DeviceIcon(device) {
             this.isConfigurable = function() {
-                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort'].includes(device.Type) &&
+                return ['Light/Switch', 'Lighting 1', 'Lighting 2', 'Lighting 5','Lighting 6','Color Switch','Home Confort','Thermostat 3'].includes(device.Type) &&
                     [0, 2, 7, 9, 10, 11, 17, 18, 19, 20].includes(device.SwitchTypeVal);
             };
 


### PR DESCRIPTION
```
======== domoticz V2020.2 (12496), dzVents V3.0.15 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        116      OK            116         0      0.2912
00:00:02  Domoticz                                      1         80      OK             80         0      0.4831
00:00:03  EventHelpers                                  1         32      OK             32         0      0.9060
00:00:04  EventHelpersStorage                           1         50      OK             50         0      1.0708
00:00:05  HTTPResponse                                  1          6      OK              6         0      0.0156
00:00:06  Lodash                                        1        100      OK            100         0      0.1716
00:00:06  ScriptdzVentsDispatching                      1          2      OK              2         0      0.2138
00:00:06  TimedCommand                                  1         46      OK             46         0      0.1061
00:00:06  Time                                          3        360      OK            360         0      0.7850
00:00:07  Utils                                         1         36      OK             36         0      0.0799
00:00:07  Variable                                      1         15      OK             15         0      0.0313
00:00:08  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.1892
00:00:11  DelayedVariableScene                          8          2      OK              2         0      7.1734
00:00:18  EventState                                   19          2      OK              2         0     18.2156
00:00:36  Integration                                  34        222      OK            222         0     30.5803
00:01:07  SelectorSwitch                               10          2      OK              2         0      9.5967
00:01:23  SystemAndCustomEvents                         1          7      OK              7         0      0.0881

Total tests: 1080
Wed 21 Oct 2020 02:04:37 PM CEST; dzVents version 3.0.15 tested without errors after 00:01:24

```
[3.0.15]
- Fixed bug in domoticz.time.matchesRule (daterange was ignored when "on mon, tue" was also part of the rule)
- Add device adapter for Thermostat type 3 devices (Mertik)
- Add utils.humidityStatus
- Add option to have dzVents compute humidity status