### PR TITLE
Open Weather Map: Add a delay toggle to lower the update interval to 30 minutes (instead of default 5 minutes)

### DIFF
--- a/hardware/OpenWeatherMap.h
+++ b/hardware/OpenWeatherMap.h
@@ -9,8 +9,8 @@
 class COpenWeatherMap : public CDomoticzHardwareBase
 {
 public:
-	COpenWeatherMap(const int ID, const std::string &APIKey, const std::string &Location, const int adddayforecast, const int addhourforecast);
-	~COpenWeatherMap(void);
+	COpenWeatherMap(const int ID, const std::string &APIKey, const std::string &Location, const int adddayforecast, const int addhourforecast, const int intervaldelay);
+	~COpenWeatherMap();
 	bool WriteToHardware(const char *pdata, const unsigned char length) override;
 	std::string GetForecastURL();
 private:
@@ -32,6 +32,8 @@ private:
 	bool m_itIsRaining = false;
 	bool m_add_dayforecast = false;
 	bool m_add_hourforecast = false;
+	uint8_t m_intervaldelay = 0;
+	uint16_t m_interval = 0;
 	double m_Lat = 0;
 	double m_Lon = 0;
 	std::shared_ptr<std::thread> m_thread;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1047,7 +1047,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new BleBox(ID, Mode1);
 		break;
 	case HTYPE_OpenWeatherMap:
-		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2);
+		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2, Mode3);
 		break;
 	case HTYPE_Ec3kMeterTCP:
 		pHardware = new Ec3kMeterTCP(ID, Address, Port);

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1005,6 +1005,10 @@
 				<td align="right" style="width:110px"><label for="addhourforecast"><span data-i18n="Hourly forecast">Hourly forecast</span>:</label></td>
 				<td><input type="checkbox" id="addhourforecast">&nbsp;<label for="addhourforecast">&nbsp;Forecast for each hour for 48 hours (if available).</label></td>
 			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label for="delayinterval"><span data-i18n="Delay updating">Delay updating</span>:</label></td>
+				<td><input type="checkbox" id="delayinterval">&nbsp;<label for="delayinterval">&nbsp;Delay updating to once every half hour.</label></td>
+			</tr>
 		</table>
 	</div>
 	<div id="divbuienradar">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -868,6 +868,7 @@ define(['app'], function (app) {
 				}
 				var adddayforecast = $("#hardwarecontent #divopenweathermap #adddayforecast").prop("checked") ? 1 : 0;
 				var addhourforecast = $("#hardwarecontent #divopenweathermap #addhourforecast").prop("checked") ? 1 : 0;
+				var delayinterval = $("#hardwarecontent #divopenweathermap #delayinterval").prop("checked") ? 6 : 0;
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&username=" + encodeURIComponent(apikey) +
@@ -876,7 +877,7 @@ define(['app'], function (app) {
 					"&enabled=" + bEnabled +
 					"&idx=" + idx +
 					"&datatimeout=" + datatimeout +
-					"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast + "&Mode3=" + Mode3 + "&Mode4=" + Mode4 + "&Mode5=" + Mode5 + "&Mode6=" + Mode6,
+					"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast + "&Mode3=" + delayinterval + "&Mode4=" + Mode4 + "&Mode5=" + Mode5 + "&Mode6=" + Mode6,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -2191,11 +2192,12 @@ define(['app'], function (app) {
 			}
 			var adddayforecast = $("#hardwarecontent #divopenweathermap #adddayforecast").prop("checked") ? 1 : 0;
 			var addhourforecast = $("#hardwarecontent #divopenweathermap #addhourforecast").prop("checked") ? 1 : 0;
+			var delayinterval = $("#hardwarecontent #divopenweathermap #delayinterval").prop("checked") ? 6 : 0;
 			$.ajax({
 				url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + 
 				"&username=" + encodeURIComponent(apikey) + "&password=" + encodeURIComponent(location) + 
 				"&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout +
-				"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast,
+				"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast + "&Mode3=" + delayinterval,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -3982,6 +3984,7 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamsopenweathermap #location").val(data["Password"]);
 							$("#hardwarecontent #hardwareparamsopenweathermap #adddayforecast").prop("checked", data["Mode1"] == 1);
 							$("#hardwarecontent #hardwareparamsopenweathermap #addhourforecast").prop("checked", data["Mode2"] == 1);
+							$("#hardwarecontent #hardwareparamsopenweathermap #delayinterval").prop("checked", data["Mode3"] == 6);
 						}
 						else if (data["Type"].indexOf("Buienradar") >= 0) {
 							var timeframe = parseInt(data["Mode1"]);


### PR DESCRIPTION
This PR adds an additional toggle to the Open Weather Map hardware module that delays the update frequency.
With this toggle 'active' the normal 5 minute interval will be delayed to a 30 minute interval (so 2x per hour).

Normally an instance of the OWM module refreshes its data every 5 minutes, which is fine for most use-cases.
But in some cases this update interval is to fast. 

Some people like to monitor the weather for multiple locations and therefor run multiple instances of the OWM module.
At the moment, the Free OWM API licence key has a limit of 1000 calls per day (30.000 per month).
When running at an interval of 5 minutes, which translates to 288 calls per day, no more than 3 OWM instances can run at the same time. Otherwise the modules will stop receiving data near the end of the day once the day limit is hit.
By activating the Delay toggle, an OWM module instance will only update once every 30 minutes resulting in 48 calls per day. With 48 calls per day for a single OWM module instance, one could run 20 OWM instances when all the instances have the Delay activated.

(And yes, one could request multiple Free API keys as a work-around.)

See also the 'suggestions' section on the forum for more details about the needs for a lower update frequency.

Any comments, suggestions, etc. always welcome.