### PR TITLE
make clang-format file more similar to the codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,12 +22,13 @@ AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: MultiLine
 BasedOnStyle: WebKit
+BreakBeforeBraces: Allman
 ColumnLimit:     140
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
-Cpp11BracedListStyle: true
+Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 FixNamespaceComments: true
 IncludeBlocks: Regroup


### PR DESCRIPTION
Reduces clang-format changes

Signed-off-by: Rosen Penev <rosenp@gmail.com>