### PR TITLE
clang-format: don't put functions on the same line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,7 +13,7 @@ AllowAllConstructorInitializersOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Empty
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false


### PR DESCRIPTION
Codebase seems to not put the function body on the same line as the
declaration.

Signed-off-by: Rosen Penev <rosenp@gmail.com>