### PR TITLE
new links in new tab

### DIFF
--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4772,11 +4772,11 @@ define(['app'], function (app) {
 								var PluginParams = '<table class="display plugin" id="' + item.key + '" border="0" cellpadding="0" cellspacing="20"><tr><td> </td></tr>';
 								if (item.wikiURL.length > 0) {
 									PluginParams += '<tr><td align="right" style="width:110px"><span data-i18n="Wiki URL">Wiki URL</span>:</td>' +
-										'<td><a href="' + item.wikiURL + '">' + item.wikiURL + '</a></td></tr>';
+										'<td><a href="' + item.wikiURL + '" target="_blank">' + item.wikiURL + '</a></td></tr>';
 								}
 								if (item.externalURL.length > 0) {
 									PluginParams += '<tr><td align="right" style="width:110px"><span data-i18n="Product URL">Product URL</span>:</td>' +
-										'<td><a href="' + item.externalURL + '">' + item.externalURL + '</a></td></tr>';
+										'<td><a href="' + item.externalURL + '" target="_blank">' + item.externalURL + '</a></td></tr>';
 								}
 								if (item.description.length > 0) {
 									PluginParams += '<tr><td></td><td>' + item.description + '</td></tr>';


### PR DESCRIPTION
when follow a link in a Hardware plugin description it will open in a new Tab, because something you want to read about the plugin when you fill-in the config. To open the link in same Tab you may lost some already filled-in config