### PR TITLE
prevent crash on invalid sValue with a gas meter

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10747,7 +10747,14 @@ namespace http {
 							std::vector<std::string> sd2 = result2[0];
 
 							uint64_t total_min_gas = std::stoull(sd2[0]);
-							uint64_t gasactual = std::stoull(sValue);
+							uint64_t gasactual;
+							try {
+								 gasactual = std::stoull(sValue);
+							}
+							catch( std::invalid_argument e ) {
+								_log.Log(LOG_ERROR, "Gas - invalid value: '%s'", sValue.c_str());
+								continue;
+							}
 							uint64_t total_real_gas = gasactual - total_min_gas;
 
 							double musage = double(gasactual) / divider;


### PR DESCRIPTION
## Description

Some time ago i found that `domoticz` crashing when reading gas meter. I was not able to identify the problem, but with `lldb` i found that cause is that sometime my ebus lua script returns error instead of real value. I fixed script already, but i think domoticz should also handle this w/o crash. This patch fixing that.

## LLDB crash

```
* thread #12, stop reason = signal SIGABRT
    frame #0: 0x00007fff7133833a libsystem_kernel.dylib`__pthread_kill + 10
libsystem_kernel.dylib`__pthread_kill:
->  0x7fff7133833a <+10>: jae    0x7fff71338344            ; <+20>
    0x7fff7133833c <+12>: movq   %rax, %rdi
    0x7fff7133833f <+15>: jmp    0x7fff71332629            ; cerror_nocancel
    0x7fff71338344 <+20>: retq
Target 0: (domoticz) stopped.
(lldb) frame select 10
frame #10: 0x000000010030d746 domoticz`http::server::CWebServer::GetJSonDevices(this=0x0000000106515340, root=0x000070000aedf560, rused="", rfilter="", order="", rowid="10", planID="", floorID="", bDisplayHidden=true, bDisplayDisabled=false, bFetchFavorites=false, LastUpdate=0, username="", hardwareid="") at WebServer.cpp:10714:29
   10711								std::vector<std::string> sd2 = result2[0];
   10712
   10713								uint64_t total_min_gas = std::stoull(sd2[0]);
-> 10714								uint64_t gasactual = std::stoull(sValue);
   10715								uint64_t total_real_gas = gasactual - total_min_gas;
   10716
   10717								double musage = double(gasactual) / divider;
```