### PR TITLE
Revert "clang-tidy: replace bind calls with lambdas"

### DIFF
--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -5,6 +5,8 @@
 #include "../main/Logger.h"
 #include "../main/RFXtrx.h"
 
+using namespace boost::placeholders;
+
 /*
 	This driver allows Domoticz to control any I/O module from the MA-4xxx Family
 
@@ -92,7 +94,7 @@ bool Comm5Serial::StartHardware()
 		return false;
 	}
 	m_bIsStarted=true;
-	setReadCallback([this](const char *d, size_t l) { readCallBack(d, l); });
+	setReadCallback(boost::bind(&Comm5Serial::readCallBack, this, _1, _2));
 
 	sOnConnected(this);
 	return true;

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -8,9 +8,13 @@
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
 
-#include <ctime>
-#include <iostream>
 #include <string>
+#include <iostream>
+#include <boost/bind/bind.hpp>
+
+#include <ctime>
+
+using namespace boost::placeholders;
 
 //
 //Class CurrentCostMeterSerial
@@ -57,7 +61,7 @@ bool CurrentCostMeterSerial::StartHardware()
 		return false;
 	}
 	m_bIsStarted=true;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CurrentCostMeterSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/DavisLoggerSerial.cpp
+++ b/hardware/DavisLoggerSerial.cpp
@@ -8,11 +8,14 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 
 #include <ctime>
+
+using namespace boost::placeholders;
 
 #ifdef _DEBUG
 //#define DEBUG_DAVIS
@@ -85,7 +88,7 @@ bool CDavisLoggerSerial::OpenSerialDevice()
 		return false;
 	}
 	m_bIsStarted = true;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CDavisLoggerSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/DenkoviUSBDevices.cpp
+++ b/hardware/DenkoviUSBDevices.cpp
@@ -5,6 +5,8 @@
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 
+using namespace boost::placeholders;
+
 #define MAX_POLL_INTERVAL 3600*1000
 
 #define DAE_IO_TYPE_RELAY		2
@@ -66,8 +68,8 @@ bool CDenkoviUSBDevices::StartHardware()
 	m_thread = std::make_shared<std::thread>(&CDenkoviUSBDevices::Do_Work, this);
 
 	m_bIsStarted = true;
-	setReadCallback([this](const char *d, size_t l) { readCallBack(d, l); });
-
+	setReadCallback(boost::bind(&CDenkoviUSBDevices::readCallBack, this, _1, _2));
+	
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -8,12 +8,15 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <cmath>
 #include <ctime>
+
+using namespace boost::placeholders;
 
 #define ENOCEAN_RETRY_DELAY 30
 
@@ -1034,7 +1037,7 @@ bool CEnOceanESP2::OpenSerialDevice()
 	}
 	m_bIsStarted = true;
 	m_receivestate = ERS_SYNC1;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CEnOceanESP2::readCallback, this, _1, _2));
 	sOnConnected(this);
 
 	enocean_data_structure iframe;

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -8,12 +8,15 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include "hardwaretypes.h"
 #include "../main/localtime_r.h"
 
 #include <boost/exception/diagnostic_information.hpp>
 #include <cmath>
 #include <ctime>
+
+using namespace boost::placeholders;
 
 #if _DEBUG
 	#define ENOCEAN_BUTTON_DEBUG
@@ -580,7 +583,7 @@ bool CEnOceanESP3::OpenSerialDevice()
 	m_bIsStarted=true;
 
 	m_receivestate=ERS_SYNCBYTE;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CEnOceanESP3::readCallback, this, _1, _2));
 	sOnConnected(this);
 
 	uint8_t buf[100];

--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -23,6 +23,9 @@
 #include "../main/WebServer.h"
 #include "../webserver/cWebem.h"
 #include <json/json.h>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 extern std::string szUserDataFolder;
 
@@ -85,27 +88,28 @@ CEvohomeRadio::CEvohomeRadio(const int ID, const std::string& UserContID)
 		s_strid >> std::hex >> m_UControllerID;
 	}
 
-	RegisterDecoder(cmdZoneTemp, [this](CEvohomeMsg &msg) { return DecodeZoneTemp(msg); });
-	RegisterDecoder(cmdSetPoint, [this](CEvohomeMsg &msg) { return DecodeSetpoint(msg); });
-	RegisterDecoder(cmdSetpointOverride, [this](CEvohomeMsg &msg) { return DecodeSetpointOverride(msg); });
-	RegisterDecoder(cmdDHWState, [this](CEvohomeMsg &msg) { return DecodeDHWState(msg); });
-	RegisterDecoder(cmdDHWTemp, [this](CEvohomeMsg &msg) { return DecodeDHWTemp(msg); });
-	RegisterDecoder(cmdControllerMode, [this](CEvohomeMsg &msg) { return DecodeControllerMode(msg); });
-	RegisterDecoder(cmdSysInfo, [this](CEvohomeMsg &msg) { return DecodeSysInfo(msg); });
-	RegisterDecoder(cmdZoneName, [this](CEvohomeMsg &msg) { return DecodeZoneName(msg); });
-	RegisterDecoder(cmdZoneHeatDemand, [this](CEvohomeMsg &msg) { return DecodeHeatDemand(msg); });
-	RegisterDecoder(cmdOpenThermBridge, [this](CEvohomeMsg &msg) { return DecodeOpenThermBridge(msg); });
-	RegisterDecoder(cmdOpenThermSetpoint, [this](CEvohomeMsg &msg) { return DecodeOpenThermSetpoint(msg); });
-	RegisterDecoder(cmdZoneInfo, [this](CEvohomeMsg &msg) { return DecodeZoneInfo(msg); });
-	RegisterDecoder(cmdControllerHeatDemand, [this](CEvohomeMsg &msg) { return DecodeHeatDemand(msg); });
-	RegisterDecoder(cmdBinding, [this](CEvohomeMsg &msg) { return DecodeBinding(msg); });
-	RegisterDecoder(cmdActuatorState, [this](CEvohomeMsg &msg) { return DecodeActuatorState(msg); });
-	RegisterDecoder(cmdActuatorCheck, [this](CEvohomeMsg &msg) { return DecodeActuatorCheck(msg); });
-	RegisterDecoder(cmdZoneWindow, [this](CEvohomeMsg &msg) { return DecodeZoneWindow(msg); });
-	RegisterDecoder(cmdExternalSensor, [this](CEvohomeMsg &msg) { return DecodeExternalSensor(msg); });
-	RegisterDecoder(cmdDeviceInfo, [this](CEvohomeMsg &msg) { return DecodeDeviceInfo(msg); });
-	RegisterDecoder(cmdBatteryInfo, [this](CEvohomeMsg &msg) { return DecodeBatteryInfo(msg); });
-	RegisterDecoder(cmdSync, [this](CEvohomeMsg &msg) { return DecodeSync(msg); });
+	RegisterDecoder(cmdZoneTemp, boost::bind(&CEvohomeRadio::DecodeZoneTemp, this, _1));
+	RegisterDecoder(cmdSetPoint, boost::bind(&CEvohomeRadio::DecodeSetpoint, this, _1));
+	RegisterDecoder(cmdSetpointOverride, boost::bind(&CEvohomeRadio::DecodeSetpointOverride, this, _1));
+	RegisterDecoder(cmdDHWState, boost::bind(&CEvohomeRadio::DecodeDHWState, this, _1));
+	RegisterDecoder(cmdDHWTemp, boost::bind(&CEvohomeRadio::DecodeDHWTemp, this, _1));
+        RegisterDecoder(cmdDHWSettings, boost::bind(&CEvohomeRadio::DecodeDHWSettings, this, _1));
+	RegisterDecoder(cmdControllerMode, boost::bind(&CEvohomeRadio::DecodeControllerMode, this, _1));
+	RegisterDecoder(cmdSysInfo, boost::bind(&CEvohomeRadio::DecodeSysInfo, this, _1));
+	RegisterDecoder(cmdZoneName, boost::bind(&CEvohomeRadio::DecodeZoneName, this, _1));
+	RegisterDecoder(cmdZoneHeatDemand, boost::bind(&CEvohomeRadio::DecodeHeatDemand, this, _1));
+	RegisterDecoder(cmdOpenThermBridge, boost::bind(&CEvohomeRadio::DecodeOpenThermBridge, this, _1));
+	RegisterDecoder(cmdOpenThermSetpoint, boost::bind(&CEvohomeRadio::DecodeOpenThermSetpoint, this, _1));
+ 	RegisterDecoder(cmdZoneInfo, boost::bind(&CEvohomeRadio::DecodeZoneInfo, this, _1));
+	RegisterDecoder(cmdControllerHeatDemand, boost::bind(&CEvohomeRadio::DecodeHeatDemand, this, _1));
+	RegisterDecoder(cmdBinding, boost::bind(&CEvohomeRadio::DecodeBinding, this, _1));
+	RegisterDecoder(cmdActuatorState, boost::bind(&CEvohomeRadio::DecodeActuatorState, this, _1));
+	RegisterDecoder(cmdActuatorCheck, boost::bind(&CEvohomeRadio::DecodeActuatorCheck, this, _1));
+	RegisterDecoder(cmdZoneWindow, boost::bind(&CEvohomeRadio::DecodeZoneWindow, this, _1));
+	RegisterDecoder(cmdExternalSensor, boost::bind(&CEvohomeRadio::DecodeExternalSensor, this, _1));
+	RegisterDecoder(cmdDeviceInfo, boost::bind(&CEvohomeRadio::DecodeDeviceInfo, this, _1));
+	RegisterDecoder(cmdBatteryInfo, boost::bind(&CEvohomeRadio::DecodeBatteryInfo, this, _1));
+	RegisterDecoder(cmdSync, boost::bind(&CEvohomeRadio::DecodeSync, this, _1));
 }
 
 CEvohomeRadio::~CEvohomeRadio()

--- a/hardware/EvohomeSerial.cpp
+++ b/hardware/EvohomeSerial.cpp
@@ -7,6 +7,8 @@
 #include "../main/localtime_r.h"
 #include <boost/exception/diagnostic_information.hpp>
 
+using namespace boost::placeholders;
+
 CEvohomeSerial::CEvohomeSerial(const int ID, const std::string &szSerialPort, const int baudrate, const std::string &UserContID) :
 CEvohomeRadio(ID, UserContID)
 {
@@ -64,7 +66,7 @@ bool CEvohomeSerial::OpenSerialDevice()
 	}
 	m_nBufPtr=0;
 	m_bIsStarted=true;
-	setReadCallback([this](const char *d, size_t l) { ReadCallback(d, l); });
+	setReadCallback(boost::bind(&CEvohomeSerial::ReadCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -9,9 +9,12 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 
 #include <ctime>
+
+using namespace boost::placeholders;
 
 //#define DEBUG_KMTronic
 
@@ -128,7 +131,7 @@ bool KMTronic433::OpenSerialDevice()
 	}
 	m_bIsStarted = true;
 	m_bufferpos = 0;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&KMTronic433::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/KMTronicBase.cpp
+++ b/hardware/KMTronicBase.cpp
@@ -10,6 +10,8 @@
 #include <sstream>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
+
 #include <ctime>
 
 #define round(a) ( int ) ( a + .5 )

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -10,10 +10,13 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <ctime>
 
 //#define DEBUG_KMTronic
+
+using namespace boost::placeholders;
 
 #define RETRY_DELAY 30
 
@@ -129,7 +132,7 @@ bool KMTronicSerial::OpenSerialDevice()
 	}
 	m_bIsStarted = true;
 	m_bufferpos = 0;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&KMTronicSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -597,7 +597,7 @@ void CKodiNode::handleConnect()
 					UpdateStatus();
 				}
 				m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
-							  [this, ec](boost::system::error_code, size_t bytes) { shared_from_this()->handleRead(ec, bytes); });
+					boost::bind(&CKodiNode::handleRead, shared_from_this(), boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 				handleWrite(std::string(R"({"jsonrpc":"2.0","method":"System.GetProperties","params":{"properties":["canhibernate","cansuspend","canshutdown"]},"id":1007})"));
 			}
 			else
@@ -657,8 +657,11 @@ void CKodiNode::handleRead(const boost::system::error_code& e, std::size_t bytes
 
 		//ready for next read
 		if (!IsStopRequested(0) && m_Socket)
-			m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
-						  [this, &e, &bytes_transferred](const boost::system::error_code &, size_t) { shared_from_this()->handleRead(e, bytes_transferred); });
+			m_Socket->async_read_some(	boost::asio::buffer(m_Buffer, sizeof m_Buffer),
+										boost::bind(&CKodiNode::handleRead,
+										shared_from_this(),
+										boost::asio::placeholders::error,
+										boost::asio::placeholders::bytes_transferred));
 	}
 	else
 	{
@@ -987,7 +990,7 @@ void CKodi::Do_Work()
 				// Note that this is the only thread that handles async i/o so we don't
 				// need to worry about locking or concurrency issues when processing messages
 				_log.Log(LOG_NORM, "Kodi: Restarting I/O service thread.");
-				boost::thread bt([this] { m_ios.run(); });
+				boost::thread bt(boost::bind(&boost::asio::io_service::run, &m_ios));
 				SetThreadName(bt.native_handle(), "KodiIO");
 			}
 		}
@@ -1161,7 +1164,7 @@ void CKodi::ReloadNodes()
 		}
 		sleep_milliseconds(100);
 		_log.Log(LOG_NORM, "Kodi: Starting I/O service thread.");
-		boost::thread bt([this] { m_ios.run(); });
+		boost::thread bt(boost::bind(&boost::asio::io_service::run, &m_ios));
 		SetThreadName(bt.native_handle(), "KodiIO");
 	}
 }

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -342,7 +342,7 @@ void CLogitechMediaServer::Do_Work()
 					if (m_iThreadsRunning < 1000)
 					{
 						m_iThreadsRunning++;
-						boost::thread t([this, &node] { Do_Node_Work(node); });
+						boost::thread t(boost::bind(&CLogitechMediaServer::Do_Node_Work, this, node));
 						SetThreadName(t.native_handle(), "LogitechNode");
 						t.join();
 					}

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -11,6 +11,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+using namespace boost::placeholders;
+
 #define RETRY_DELAY 30
 
 #define CLIENTID	"Domoticz"
@@ -151,9 +153,8 @@ void MQTT::on_connect(int rc)
 			_log.Log(LOG_STATUS, "MQTT: connected to: %s:%d", m_szIPAddress.c_str(), m_usIPPort);
 			m_IsConnected = true;
 			sOnConnected(this);
-			m_sDeviceReceivedConnection =
-				m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *command) { SendDeviceInfo(id, idx, name, command); });
-			m_sSwitchSceneConnection = m_mainworker.sOnSwitchScene.connect([this](uint64_t scene, const std::string &name) { SendSceneInfo(scene, name); });
+			m_sDeviceReceivedConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&MQTT::SendDeviceInfo, this, _1, _2, _3, _4));
+			m_sSwitchSceneConnection = m_mainworker.sOnSwitchScene.connect(boost::bind(&MQTT::SendSceneInfo, this, _1, _2));
 		}
 		subscribe(nullptr, m_TopicIn.c_str());
 	}

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -9,10 +9,13 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include "../main/localtime_r.h"
 #include "../main/mainworker.h"
 
 #include <ctime>
+
+using namespace boost::placeholders;
 
 #define RETRY_DELAY 30
 
@@ -104,7 +107,7 @@ bool Meteostick::OpenSerialDevice()
 		m_ActRainCounter[ii]	= -1;
 		m_LastRainValue[ii]		= -1;
 	}
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&Meteostick::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -9,13 +9,15 @@
 #include "../main/WebServer.h"
 #include "../main/mainworker.h"
 #include "hardwaretypes.h"
-#include <ctime>
 #include <string>
 #include <sstream>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include "../webserver/cWebem.h"
 #include <json/json.h>
+
+#include <ctime>
 
 #define round(a) ( int ) ( a + .5 )
 #define MAX_PAYLOAD_LENGTH 25 //https://www.mysensors.org/download/serial_api_20

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -8,10 +8,13 @@
 #include "hardwaretypes.h"
 
 #include <algorithm>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <ctime>
 #include <iostream>
 #include <string>
+
+using namespace boost::placeholders;
 
 //#define DEBUG_MYSENSORS
 
@@ -183,7 +186,7 @@ bool MySensorsSerial::OpenSerialDevice()
 #endif
 	m_bIsStarted = true;
 	m_LineReceived.clear();
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&MySensorsSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 	}

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include <json/json.h>
 
 #include <ctime>

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -8,10 +8,13 @@
 #include "../main/localtime_r.h"
 
 #include <algorithm>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <ctime>
 #include <iostream>
 #include <string>
+
+using namespace boost::placeholders;
 
 #define RETRY_DELAY 30
 #define OTGW_READ_INTERVAL 10
@@ -95,7 +98,7 @@ bool OTGWSerial::OpenSerialDevice()
 	}
 	m_bIsStarted=true;
 	m_bufferpos=0;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&OTGWSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	m_bRequestVersion = true;
 	return true;

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -19,9 +19,12 @@ License: Public domain
 
 #include <algorithm>
 #include <ctime>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <iostream>
 #include <string>
+
+using namespace boost::placeholders;
 
 COpenWebNetUSB::COpenWebNetUSB(const int ID, const std::string& devname, unsigned int baud_rate)
 {
@@ -325,7 +328,7 @@ bool COpenWebNetUSB::sendCommand(bt_openwebnet& command, std::vector<bt_openwebn
 		return false;
 	}
 
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&COpenWebNetUSB::readCallback, this, _1, _2));
 	sOnConnected(this);
 	m_bIsStarted = true;
 

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -14,7 +14,11 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
+
 #include <ctime>
+
+using namespace boost::placeholders;
 
 #ifdef _DEBUG
 //#define DEBUG_P1_R
@@ -144,7 +148,7 @@ bool P1MeterSerial::StartHardware()
 	m_thread = std::make_shared<std::thread>(&P1MeterSerial::Do_Work, this);
 	SetThreadNameInt(m_thread->native_handle());
 
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&P1MeterSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 
 #ifdef DEBUG_P1_R

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -8,6 +8,8 @@
 #include "../tinyxpath/tinyxml.h"
 #include "hardwaretypes.h"
 
+using namespace boost::placeholders;
+
 //Rainforest RAVEn USB ZigBee Smart Meter Adapter
 //https://rainforestautomation.com/rfa-z106-raven/
 
@@ -42,7 +44,7 @@ bool RAVEn::StartHardware()
         _log.Log(LOG_ERROR, "RAVEn: Error opening serial port!!!");
         return false;
     }
-    setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+    setReadCallback(boost::bind(&RAVEn::readCallback, this, _1, _2));
     m_bIsStarted = true;
     sOnConnected(this);
 

--- a/hardware/RFLinkSerial.cpp
+++ b/hardware/RFLinkSerial.cpp
@@ -5,6 +5,8 @@
 #include "../main/localtime_r.h"
 #include <boost/exception/diagnostic_information.hpp>
 
+using namespace boost::placeholders;
+
 CRFLinkSerial::CRFLinkSerial(const int ID, const std::string& devname) :
 m_szSerialPort(devname)
 {
@@ -177,7 +179,7 @@ bool CRFLinkSerial::OpenSerialDevice()
 	m_rfbufferpos = 0;
 	m_LastReceivedTime = mytime(nullptr);
 
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CRFLinkSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 
 	return true;

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -12,6 +12,8 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
+
 #include <ctime>
 
 #ifndef WIN32
@@ -20,6 +22,8 @@
 #include <sys/types.h>
 #include <pwd.h>
 #endif
+
+using namespace boost::placeholders;
 
 #define RETRY_DELAY 30
 
@@ -188,7 +192,7 @@ bool RFXComSerial::OpenSerialDevice(const bool bIsFirmwareUpgrade)
 	}
 	m_bIsStarted = true;
 	m_rxbufferpos = 0;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&RFXComSerial::readCallback, this, _1, _2));
 	if (!bIsFirmwareUpgrade)
 		sOnConnected(this);
 	return true;

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -13,11 +13,15 @@
 // And the TaloLogger:
 // http://zil.olammi.iki.fi/sw/taloLogger/howto.php
 
-#include <ctime>
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 #include "hardwaretypes.h"
+
+#include <ctime>
+
+using namespace boost::placeholders;
 
 #define Rego6XX_RETRY_DELAY 30
 #define Rego6XX_COMMAND_DELAY 5
@@ -304,7 +308,7 @@ bool CRego6XXSerial::OpenSerialDevice()
 		return false;
 	}
 	m_bIsStarted=true;
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CRego6XXSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 	return true;
 }

--- a/hardware/S0MeterBase.cpp
+++ b/hardware/S0MeterBase.cpp
@@ -13,6 +13,7 @@
 #include <string>
 #include <algorithm>
 #include <iostream>
+#include <boost/bind/bind.hpp>
 
 #include <ctime>
 

--- a/hardware/S0MeterSerial.cpp
+++ b/hardware/S0MeterSerial.cpp
@@ -8,9 +8,12 @@
 
 #include <algorithm>
 #include <ctime>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <iostream>
 #include <string>
+
+using namespace boost::placeholders;
 
 #ifdef _DEBUG
 	//#define DEBUG_S0
@@ -85,7 +88,7 @@ bool S0MeterSerial::StartHardware()
 	}
 	write(sstr.str());
 	*/
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&S0MeterSerial::readCallback, this, _1, _2));
 	sOnConnected(this);
 
 #ifdef DEBUG_S0

--- a/hardware/TCPProxy/tcpproxy_server.cpp
+++ b/hardware/TCPProxy/tcpproxy_server.cpp
@@ -15,6 +15,8 @@
 #include "stdafx.h"
 #include "tcpproxy_server.h"
 
+using namespace boost::placeholders;
+
 #if BOOST_VERSION >= 107000
 #define GET_IO_SERVICE(s) ((boost::asio::io_context&)(s).get_executor().context())
 #else
@@ -56,19 +58,30 @@ namespace tcp_proxy
 		}
 		else
 			end=*i;
-
-		upstream_socket_.async_connect(end, [this](const boost::system::error_code &err) { shared_from_this()->handle_upstream_connect(err); });
+		upstream_socket_.async_connect(
+			end,
+			boost::bind(&bridge::handle_upstream_connect,
+				shared_from_this(),
+				boost::asio::placeholders::error));
 	}
 
 	void bridge::handle_upstream_connect(const boost::system::error_code& error)
 	{
 		if (!error)
 		{
-			upstream_socket_.async_read_some(boost::asio::buffer(upstream_data_, max_data_length),
-							 [this, &error](const boost::system::error_code &, size_t bytes) { shared_from_this()->handle_upstream_read(error, bytes); });
+		upstream_socket_.async_read_some(
+				boost::asio::buffer(upstream_data_,max_data_length),
+				boost::bind(&bridge::handle_upstream_read,
+					shared_from_this(),
+					boost::asio::placeholders::error,
+					boost::asio::placeholders::bytes_transferred));
 
-			downstream_socket_.async_read_some(boost::asio::buffer(downstream_data_, max_data_length),
-							   [this, &error](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_downstream_read(error, bytes); });
+		downstream_socket_.async_read_some(
+				boost::asio::buffer(downstream_data_,max_data_length),
+				boost::bind(&bridge::handle_downstream_read,
+					shared_from_this(),
+					boost::asio::placeholders::error,
+					boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		close();
@@ -78,8 +91,12 @@ namespace tcp_proxy
 	{
 		if (!error)
 		{
-			upstream_socket_.async_read_some(boost::asio::buffer(upstream_data_, max_data_length),
-							 [this, &error](const boost::system::error_code &, size_t bytes) { shared_from_this()->handle_upstream_read(error, bytes); });
+		upstream_socket_.async_read_some(
+				boost::asio::buffer(upstream_data_,max_data_length),
+				boost::bind(&bridge::handle_upstream_read,
+					shared_from_this(),
+					boost::asio::placeholders::error,
+					boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		close();
@@ -91,8 +108,11 @@ namespace tcp_proxy
 		{
 			//std::unique_lock<std::mutex> lock(mutex_);
 			sDownstreamData(reinterpret_cast<unsigned char*>(&downstream_data_[0]),static_cast<size_t>(bytes_transferred));
-			async_write(upstream_socket_, boost::asio::buffer(downstream_data_, bytes_transferred),
-				    [this, &error, &bytes_transferred](const boost::system::error_code &, const size_t &) { shared_from_this()->handle_downstream_read(error, bytes_transferred); });
+			async_write(upstream_socket_,
+					boost::asio::buffer(downstream_data_,bytes_transferred),
+					boost::bind(&bridge::handle_upstream_write,
+						shared_from_this(),
+						boost::asio::placeholders::error));
 		}
 		else
 			close();
@@ -102,8 +122,12 @@ namespace tcp_proxy
 	{
 		if (!error)
 		{
-			downstream_socket_.async_read_some(boost::asio::buffer(downstream_data_, max_data_length),
-							   [this, &error](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_downstream_read(error, bytes); });
+			downstream_socket_.async_read_some(
+					boost::asio::buffer(downstream_data_,max_data_length),
+					boost::bind(&bridge::handle_downstream_read,
+						shared_from_this(),
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 		}
 		else
 			close();
@@ -117,8 +141,11 @@ namespace tcp_proxy
 			//std::unique_lock<std::mutex> lock(mutex_);
 			sUpstreamData(reinterpret_cast<unsigned char*>(&upstream_data_[0]),static_cast<size_t>(bytes_transferred));
 
-			async_write(downstream_socket_, boost::asio::buffer(upstream_data_, bytes_transferred),
-				    [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_downstream_read(err, bytes); });
+			async_write(downstream_socket_,
+					boost::asio::buffer(upstream_data_,bytes_transferred),
+					boost::bind(&bridge::handle_downstream_write,
+						shared_from_this(),
+						boost::asio::placeholders::error));
 		}
 		else
 			close();
@@ -153,10 +180,13 @@ namespace tcp_proxy
 		try
 		{
 			session_ = std::make_shared<bridge>(io_service_);
-			session_->sDownstreamData.connect([this](const unsigned char *d, size_t l) { OnDownstreamData(d, l); });
-			session_->sUpstreamData.connect([this](const unsigned char *d, size_t l) { OnUpstreamData(d, l); });
+			session_->sDownstreamData.connect( boost::bind( &acceptor::OnDownstreamData, this, _1, _2 ) );
+			session_->sUpstreamData.connect( boost::bind( &acceptor::OnUpstreamData, this, _1, _2 ) );
 
-			acceptor_.async_accept(session_->downstream_socket(), [this](const boost::system::error_code &err) { handle_accept(err); });
+			acceptor_.async_accept(session_->downstream_socket(),
+				boost::bind(&acceptor::handle_accept,
+						this,
+						boost::asio::placeholders::error));
 		}
 		catch(...)
 		{
@@ -182,7 +212,7 @@ namespace tcp_proxy
 		m_bDoStop=true;
 		// Post a call to the stop function so that server::stop() is safe to call
 		// from any thread.
-		io_service_.post([this] { handle_stop(); });
+		io_service_.post(boost::bind(&acceptor::handle_stop, this));
 		return true;
 	}
 

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -28,7 +28,10 @@ History :
 #include "../main/localtime_r.h"
 #include "../main/Logger.h"
 
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
+
+using namespace boost::placeholders;
 
 CTeleinfoSerial::CTeleinfoSerial(const int ID, const std::string& devname, const int datatimeout, unsigned int baud_rate, const bool disable_crc, const int ratelimit)
 {
@@ -99,7 +102,7 @@ bool CTeleinfoSerial::StartHardware()
 	}
 	StartHeartbeatThread();
 
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CTeleinfoSerial::readCallback, this, _1, _2));
 	m_bIsStarted = true;
 	sOnConnected(this);
 

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -27,12 +27,15 @@ History :
 #include "../main/SQLHelper.h"
 
 #include <algorithm>
+#include <boost/bind/bind.hpp>
 #include <boost/exception/diagnostic_information.hpp>
 #include <cstdlib>
 #include <ctime>
 #include <iostream>
 #include <string>
 #include <time.h>
+
+using namespace boost::placeholders;
 
 #define USBTIN_BAUD_RATE         115200
 #define USBTIN_PARITY            boost::asio::serial_port_base::parity::none
@@ -222,7 +225,7 @@ bool USBtin::OpenSerialDevice()
 	m_bIsStarted = true;
 	m_USBtinBufferpos = 0;
 	memset(&m_USBtinBuffer,0,sizeof(m_USBtinBuffer));
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&USBtin::readCallback, this, _1, _2));
 
 	sOnConnected(this);
 

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/exception/diagnostic_information.hpp>
 
+using namespace boost::placeholders;
+
 #define ZiBlue_RETRY_DELAY 30
 
 CZiBlueSerial::CZiBlueSerial(const int ID, const std::string& devname) :
@@ -131,7 +133,7 @@ bool CZiBlueSerial::OpenSerialDevice()
 	m_rfbufferpos = 0;
 	m_LastReceivedTime = mytime(nullptr);
 
-	setReadCallback([this](const char *d, size_t l) { readCallback(d, l); });
+	setReadCallback(boost::bind(&CZiBlueSerial::readCallback, this, _1, _2));
 
 	sOnConnected(this);
 

--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -188,9 +188,9 @@ void MyNode::addValue(OpenZWave::ValueID id)
  */
 void MyNode::removeValue(OpenZWave::ValueID id)
 {
-	values.erase(std::remove_if(values.begin(), values.end(), [id](MyValue *value) { return value->id == id; }), values.end());
+	values.erase(std::remove_if(values.begin(), values.end(), [=](MyValue *value) { return value->id == id; }), values.end());
 
-	bool found = std::any_of(values.begin(), values.end(), [id](MyValue *value) { return value->id == id; });
+	bool found = std::any_of(values.begin(), values.end(), [=](MyValue *value) { return value->id == id; });
 	if (!found)
 	{
 #ifdef OZW_WRITE_LOG
@@ -293,7 +293,7 @@ void MyNode::updateGroup(uint8 node, uint8 grp, char* glist)
 #ifdef OZW_WRITE_LOG
 	Log::Write(LogLevel_Info, "updateGroup: node %d group %d\n", node, grp);
 #endif
-	auto it = std::find_if(groups.begin(), groups.end(), [grp](MyGroup *group) { return group->groupid == grp; });
+	auto it = std::find_if(groups.begin(), groups.end(), [=](MyGroup *group) { return group->groupid == grp; });
 	if (it == groups.end()) {
 #ifdef OZW_WRITE_LOG
 		Log::Write(LogLevel_Error, "updateGroup: node %d group %d not found\n", node, grp);

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -13,6 +13,8 @@
 #include "icmp_header.hpp"
 #include "ipv4_header.hpp"
 
+using namespace boost::placeholders;
+
 namespace Plugins {
 
 	void CPluginTransport::handleRead(const boost::system::error_code& e, std::size_t bytes_transferred)
@@ -67,7 +69,7 @@ namespace Plugins {
 				//
 				//	Async resolve/connect based on http://www.boost.org/doc/libs/1_45_0/doc/html/boost_asio/example/http/client/async_client.cpp
 				//
-				m_Resolver.async_resolve(query, [this](const boost::system::error_code &err, boost::asio::ip::tcp::resolver::iterator end) { handleAsyncResolve(err, end); });
+				m_Resolver.async_resolve(query, boost::bind(&CPluginTransportTCP::handleAsyncResolve, this, boost::asio::placeholders::error, boost::asio::placeholders::iterator));
 			}
 		}
 		catch (std::exception& e)
@@ -90,7 +92,7 @@ namespace Plugins {
 		if (!err)
 		{
 			boost::asio::ip::tcp::endpoint endpoint = *endpoint_iterator;
-			m_Socket->async_connect(endpoint, [this, endpoint_iterator](const boost::system::error_code &err) mutable { handleAsyncConnect(err, ++endpoint_iterator); });
+			m_Socket->async_connect(endpoint, boost::bind(&CPluginTransportTCP::handleAsyncConnect, this, boost::asio::placeholders::error, ++endpoint_iterator));
 		}
 		else
 		{
@@ -116,7 +118,8 @@ namespace Plugins {
 		{
 			m_bConnected = true;
 			m_tLastSeen = time(nullptr);
-			m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+			m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
+				boost::bind(&CPluginTransportTCP::handleRead, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		{
@@ -147,7 +150,7 @@ namespace Plugins {
 				//	Acceptor based on http://www.boost.org/doc/libs/1_62_0/doc/html/boost_asio/tutorial/tutdaytime3/src.html
 				//
 				boost::asio::ip::tcp::socket*	pSocket = new boost::asio::ip::tcp::socket(ios);
-				m_Acceptor->async_accept((boost::asio::ip::tcp::socket &)*pSocket, [this, pSocket](const boost::system::error_code &err) { handleAsyncAccept(pSocket, err); });
+				m_Acceptor->async_accept((boost::asio::ip::tcp::socket&)*pSocket, boost::bind(&CPluginTransportTCP::handleAsyncAccept, this, pSocket, boost::asio::placeholders::error));
 				m_bConnecting = true;
 			}
 		}
@@ -213,7 +216,7 @@ namespace Plugins {
 			}
 
 			pTcpTransport->m_Socket->async_read_some(boost::asio::buffer(pTcpTransport->m_Buffer, sizeof pTcpTransport->m_Buffer),
-								 [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+				boost::bind(&CPluginTransportTCP::handleRead, pTcpTransport, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 
 			// Requeue listener
 			if (m_Acceptor)
@@ -245,7 +248,11 @@ namespace Plugins {
 
 			//ready for next read
 			if (m_Socket)
-				m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+				m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
+					boost::bind(&CPluginTransportTCP::handleRead,
+						this,
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		{
@@ -391,7 +398,7 @@ namespace Plugins {
 
 			m_TLSSock->set_verify_mode(boost::asio::ssl::verify_none);
 			m_TLSSock->set_verify_callback(boost::asio::ssl::rfc2818_verification(m_IP));
-			// m_TLSSock->set_verify_callback([this](bool v, boost::asio::ssl::verify_context &c){VerifyCertificate(v, c);});
+			//m_TLSSock->set_verify_callback(boost::bind(&CPluginTransportTCPSecure::VerifyCertificate, this, _1, _2));
 			try
 			{
 #ifdef WWW_ENABLE_SSL
@@ -403,7 +410,8 @@ namespace Plugins {
 				pPlugin->MessagePlugin(new onConnectCallback(pPlugin, m_pConnection, err.value(), err.message()));
 
 				m_tLastSeen = time(nullptr);
-				m_TLSSock->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+				m_TLSSock->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
+					boost::bind(&CPluginTransportTCP::handleRead, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 			}
 			catch (boost::system::system_error se)
 			{
@@ -460,7 +468,11 @@ namespace Plugins {
 
 			//ready for next read
 			if (m_TLSSock)
-				m_TLSSock->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+				m_TLSSock->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer),
+					boost::bind(&CPluginTransportTCPSecure::handleRead,
+						this,
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		{
@@ -523,7 +535,9 @@ namespace Plugins {
 			}
 
 			m_Socket->async_receive_from(boost::asio::buffer(m_Buffer, sizeof m_Buffer), m_remote_endpoint,
-						     [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+											boost::bind(&CPluginTransportUDP::handleRead, this,
+												boost::asio::placeholders::error,
+												boost::asio::placeholders::bytes_transferred));
 
 			m_bConnected = true;
 		}
@@ -698,7 +712,9 @@ namespace Plugins {
 			handleWrite(vBody);
 
 			m_Socket->async_receive_from(boost::asio::buffer(m_Buffer, sizeof m_Buffer), m_Endpoint,
-						     [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+				boost::bind(&CPluginTransportICMP::handleRead, this,
+					boost::asio::placeholders::error,
+					boost::asio::placeholders::bytes_transferred));
 		}
 		else
 		{
@@ -726,12 +742,14 @@ namespace Plugins {
 				//
 				//	Async resolve/connect based on http://www.boost.org/doc/libs/1_51_0/doc/html/boost_asio/example/icmp/ping.cpp
 				//
-				m_Resolver.async_resolve(query, [this](const boost::system::error_code &err, boost::asio::ip::icmp::resolver::iterator i) { handleAsyncResolve(err, i); });
+				m_Resolver.async_resolve(query, boost::bind(&CPluginTransportICMP::handleAsyncResolve, this, boost::asio::placeholders::error, boost::asio::placeholders::iterator));
 			}
 			else
 			{
 				m_Socket->async_receive_from(boost::asio::buffer(m_Buffer, sizeof m_Buffer), m_Endpoint,
-							     [this](const boost::system::error_code &err, size_t bytes) { handleRead(err, bytes); });
+					boost::bind(&CPluginTransportICMP::handleRead, this,
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 			}
 		}
 		catch (std::exception& e)
@@ -851,7 +869,7 @@ namespace Plugins {
 			m_Timer = new boost::asio::deadline_timer(ios);
 		}
 		m_Timer->expires_from_now(boost::posix_time::seconds(5));
-		m_Timer->async_wait([this](const boost::system::error_code &err) { handleTimeout(err); });
+		m_Timer->async_wait(boost::bind(&CPluginTransportICMP::handleTimeout, this, boost::asio::placeholders::error));
 
 		// Create an ICMP header for an echo request.
 		icmp_header echo_request;
@@ -954,7 +972,7 @@ namespace Plugins {
 				if (m_bConnected)
 				{
 					pPlugin->MessagePlugin(new onConnectCallback(pPlugin, m_pConnection, 0, "SerialPort " + m_Port + " opened successfully."));
-					setReadCallback([this](const char *err, size_t bytes) { handleRead(err, bytes); });
+					setReadCallback(boost::bind(&CPluginTransportSerial::handleRead, this, _1, _2));
 				}
 				else
 				{

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3107,7 +3107,7 @@ void CEventSystem::EvaluateLua(const std::vector<_tEventQueue> &items, const std
 	{
 		lua_sethook(lua_state, luaStop, LUA_MASKCOUNT, 10000000);
 
-		boost::thread luaThread([this, lua_state, filename] { CEventSystem::luaThread(lua_state, filename); });
+		boost::thread luaThread(boost::bind(&CEventSystem::luaThread, this, lua_state, filename));
 		SetThreadName(luaThread.native_handle(), "luaThread");
 
 		if (!luaThread.timed_join(boost::posix_time::seconds(10)))

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -343,11 +343,13 @@ std::list<CLogger::_tLogLineStruct> CLogger::GetLog(const _eLogLevel level, cons
 		if (m_lastlog.find(level) == m_lastlog.end())
 			return mlist;
 
-		std::copy_if(std::begin(m_lastlog[level]), std::end(m_lastlog[level]), std::back_inserter(mlist), [lastlogtime](const _tLogLineStruct &l) { return l.logtime > lastlogtime; });
+		std::copy_if(std::begin(m_lastlog[level]), std::end(m_lastlog[level]), std::back_inserter(mlist),
+			     [=](const _tLogLineStruct &l) { return l.logtime > lastlogtime; });
 	}
 	else
 		for (const auto &l : m_lastlog)
-			std::copy_if(l.second.begin(), l.second.end(), std::back_inserter(mlist), [lastlogtime](const _tLogLineStruct &l2) { return l2.logtime > lastlogtime; });
+			std::copy_if(l.second.begin(), l.second.end(), std::back_inserter(mlist),
+				     [=](const _tLogLineStruct &l2) { return l2.logtime > lastlogtime; });
 
 	//Sort by time
 	mlist.sort(compareLogByTime);

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -187,7 +187,7 @@ bool CLuaHandler::executeLuaScript(const std::string &script, const std::string 
 	if (status == 0)
 	{
 		lua_sethook(lua_state, luaStop, LUA_MASKCOUNT, 10000000);
-		boost::thread aluaThread([this, lua_state, fullfilename] { luaThread(lua_state, fullfilename); });
+		boost::thread aluaThread(boost::bind(&CLuaHandler::luaThread, this, lua_state, fullfilename));
 		SetThreadName(aluaThread.native_handle(), "aluaThread");
 		aluaThread.timed_join(boost::posix_time::seconds(10));
 		return true;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "WebServer.h"
 #include "WebServerHelper.h"
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include <fstream>
 #include "mainworker.h"
@@ -66,7 +67,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-using namespace std::placeholders;
+using namespace boost::placeholders;
 
 #define round(a) ( int ) ( a + .5 )
 
@@ -311,339 +312,341 @@ namespace http {
 			}
 
 			//register callbacks
-			m_pWebEm->RegisterIncludeCode("switchtypes", std::bind(&CWebServer::DisplaySwitchTypesCombo, this, _1));
-			m_pWebEm->RegisterIncludeCode("metertypes", std::bind(&CWebServer::DisplayMeterTypesCombo, this, _1));
-			m_pWebEm->RegisterIncludeCode("timertypes", std::bind(&CWebServer::DisplayTimerTypesCombo, this, _1));
-			m_pWebEm->RegisterIncludeCode("combolanguage", std::bind(&CWebServer::DisplayLanguageCombo, this, _1));
+			m_pWebEm->RegisterIncludeCode("switchtypes", boost::bind(&CWebServer::DisplaySwitchTypesCombo, this, _1));
+			m_pWebEm->RegisterIncludeCode("metertypes", boost::bind(&CWebServer::DisplayMeterTypesCombo, this, _1));
+			m_pWebEm->RegisterIncludeCode("timertypes", boost::bind(&CWebServer::DisplayTimerTypesCombo, this, _1));
+			m_pWebEm->RegisterIncludeCode("combolanguage", boost::bind(&CWebServer::DisplayLanguageCombo, this, _1));
 
-			m_pWebEm->RegisterPageCode("/json.htm", std::bind(&CWebServer::GetJSonPage, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/uploadcustomicon", std::bind(&CWebServer::Post_UploadCustomIcon, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/html5.appcache", std::bind(&CWebServer::GetAppCache, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/camsnapshot.jpg", std::bind(&CWebServer::GetCameraSnapshot, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/backupdatabase.php", std::bind(&CWebServer::GetDatabaseBackup, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/raspberry.cgi", std::bind(&CWebServer::GetInternalCameraSnapshot, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/uvccapture.cgi", std::bind(&CWebServer::GetInternalCameraSnapshot, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/images/floorplans/plan", std::bind(&CWebServer::GetFloorplanImage, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/json.htm", boost::bind(&CWebServer::GetJSonPage, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/uploadcustomicon", boost::bind(&CWebServer::Post_UploadCustomIcon, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/html5.appcache", boost::bind(&CWebServer::GetAppCache, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/camsnapshot.jpg", boost::bind(&CWebServer::GetCameraSnapshot, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/backupdatabase.php", boost::bind(&CWebServer::GetDatabaseBackup, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/raspberry.cgi", boost::bind(&CWebServer::GetInternalCameraSnapshot, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/uvccapture.cgi", boost::bind(&CWebServer::GetInternalCameraSnapshot, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/images/floorplans/plan", boost::bind(&CWebServer::GetFloorplanImage, this, _1, _2, _3));
 
-			m_pWebEm->RegisterPageCode("/storesettings", std::bind(&CWebServer::PostSettings, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("setrfxcommode", std::bind(&CWebServer::SetRFXCOMMode, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("rfxupgradefirmware", std::bind(&CWebServer::RFXComUpgradeFirmware, this, _1, _2, _3));
-			RegisterCommandCode("rfxfirmwaregetpercentage", std::bind(&CWebServer::Cmd_RFXComGetFirmwarePercentage, this, _1, _2, _3), true);
-			m_pWebEm->RegisterActionCode("setrego6xxtype", std::bind(&CWebServer::SetRego6XXType, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("sets0metertype", std::bind(&CWebServer::SetS0MeterType, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("setlimitlesstype", std::bind(&CWebServer::SetLimitlessType, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/storesettings", boost::bind(&CWebServer::PostSettings, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("setrfxcommode", boost::bind(&CWebServer::SetRFXCOMMode, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("rfxupgradefirmware", boost::bind(&CWebServer::RFXComUpgradeFirmware, this, _1, _2, _3));
+			RegisterCommandCode("rfxfirmwaregetpercentage", boost::bind(&CWebServer::Cmd_RFXComGetFirmwarePercentage, this, _1, _2, _3), true);
+			m_pWebEm->RegisterActionCode("setrego6xxtype", boost::bind(&CWebServer::SetRego6XXType, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("sets0metertype", boost::bind(&CWebServer::SetS0MeterType, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("setlimitlesstype", boost::bind(&CWebServer::SetLimitlessType, this, _1, _2, _3));
 
-			m_pWebEm->RegisterActionCode("uploadfloorplanimage", std::bind(&CWebServer::UploadFloorplanImage, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("uploadfloorplanimage", boost::bind(&CWebServer::UploadFloorplanImage, this, _1, _2, _3));
 
-			m_pWebEm->RegisterActionCode("setopenthermsettings", std::bind(&CWebServer::SetOpenThermSettings, this, _1, _2, _3));
-			RegisterCommandCode("sendopenthermcommand", std::bind(&CWebServer::Cmd_SendOpenThermCommand, this, _1, _2, _3), true);
 
-			m_pWebEm->RegisterActionCode("reloadpiface", std::bind(&CWebServer::ReloadPiFace, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("setcurrentcostmetertype", std::bind(&CWebServer::SetCurrentCostUSBType, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("restoredatabase", std::bind(&CWebServer::RestoreDatabase, this, _1, _2, _3));
-			m_pWebEm->RegisterActionCode("sbfspotimportolddata", std::bind(&CWebServer::SBFSpotImportOldData, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("setopenthermsettings", boost::bind(&CWebServer::SetOpenThermSettings, this, _1, _2, _3));
+			RegisterCommandCode("sendopenthermcommand", boost::bind(&CWebServer::Cmd_SendOpenThermCommand, this, _1, _2, _3), true);
 
-			m_pWebEm->RegisterActionCode("event_create", std::bind(&CWebServer::EventCreate, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("reloadpiface", boost::bind(&CWebServer::ReloadPiFace, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("setcurrentcostmetertype", boost::bind(&CWebServer::SetCurrentCostUSBType, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("restoredatabase", boost::bind(&CWebServer::RestoreDatabase, this, _1, _2, _3));
+			m_pWebEm->RegisterActionCode("sbfspotimportolddata", boost::bind(&CWebServer::SBFSpotImportOldData, this, _1, _2, _3));
 
-			RegisterCommandCode("getlanguage", std::bind(&CWebServer::Cmd_GetLanguage, this, _1, _2, _3), true);
-			RegisterCommandCode("getthemes", std::bind(&CWebServer::Cmd_GetThemes, this, _1, _2, _3), true);
-			RegisterCommandCode("gettitle", std::bind(&CWebServer::Cmd_GetTitle, this, _1, _2, _3), true);
+			m_pWebEm->RegisterActionCode("event_create", boost::bind(&CWebServer::EventCreate, this, _1, _2, _3));
 
-			RegisterCommandCode("logincheck", std::bind(&CWebServer::Cmd_LoginCheck, this, _1, _2, _3), true);
-			m_pWebEm->RegisterPageCode("/logincheck", std::bind(&CWebServer::PostLoginCheck, this, _1, _2, _3), true);
+			RegisterCommandCode("getlanguage", boost::bind(&CWebServer::Cmd_GetLanguage, this, _1, _2, _3), true);
+			RegisterCommandCode("getthemes", boost::bind(&CWebServer::Cmd_GetThemes, this, _1, _2, _3), true);
+			RegisterCommandCode("gettitle", boost::bind(&CWebServer::Cmd_GetTitle, this, _1, _2, _3), true);
 
-			RegisterCommandCode("getversion", std::bind(&CWebServer::Cmd_GetVersion, this, _1, _2, _3), true);
-			RegisterCommandCode("getlog", std::bind(&CWebServer::Cmd_GetLog, this, _1, _2, _3));
-			RegisterCommandCode("clearlog", std::bind(&CWebServer::Cmd_ClearLog, this, _1, _2, _3));
-			RegisterCommandCode("getauth", std::bind(&CWebServer::Cmd_GetAuth, this, _1, _2, _3), true);
-			RegisterCommandCode("getuptime", std::bind(&CWebServer::Cmd_GetUptime, this, _1, _2, _3), true);
+			RegisterCommandCode("logincheck", boost::bind(&CWebServer::Cmd_LoginCheck, this, _1, _2, _3), true);
+			m_pWebEm->RegisterPageCode("/logincheck", boost::bind(&CWebServer::PostLoginCheck, this, _1, _2, _3), true);
 
-			RegisterCommandCode("gethardwaretypes", std::bind(&CWebServer::Cmd_GetHardwareTypes, this, _1, _2, _3));
-			RegisterCommandCode("addhardware", std::bind(&CWebServer::Cmd_AddHardware, this, _1, _2, _3));
-			RegisterCommandCode("updatehardware", std::bind(&CWebServer::Cmd_UpdateHardware, this, _1, _2, _3));
-			RegisterCommandCode("deletehardware", std::bind(&CWebServer::Cmd_DeleteHardware, this, _1, _2, _3));
+			RegisterCommandCode("getversion", boost::bind(&CWebServer::Cmd_GetVersion, this, _1, _2, _3), true);
+			RegisterCommandCode("getlog", boost::bind(&CWebServer::Cmd_GetLog, this, _1, _2, _3));
+			RegisterCommandCode("clearlog", boost::bind(&CWebServer::Cmd_ClearLog, this, _1, _2, _3));
+			RegisterCommandCode("getauth", boost::bind(&CWebServer::Cmd_GetAuth, this, _1, _2, _3), true);
+			RegisterCommandCode("getuptime", boost::bind(&CWebServer::Cmd_GetUptime, this, _1, _2, _3), true);
 
-			RegisterCommandCode("addcamera", std::bind(&CWebServer::Cmd_AddCamera, this, _1, _2, _3));
-			RegisterCommandCode("updatecamera", std::bind(&CWebServer::Cmd_UpdateCamera, this, _1, _2, _3));
-			RegisterCommandCode("deletecamera", std::bind(&CWebServer::Cmd_DeleteCamera, this, _1, _2, _3));
 
-			RegisterCommandCode("wolgetnodes", std::bind(&CWebServer::Cmd_WOLGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("woladdnode", std::bind(&CWebServer::Cmd_WOLAddNode, this, _1, _2, _3));
-			RegisterCommandCode("wolupdatenode", std::bind(&CWebServer::Cmd_WOLUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("wolremovenode", std::bind(&CWebServer::Cmd_WOLRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("wolclearnodes", std::bind(&CWebServer::Cmd_WOLClearNodes, this, _1, _2, _3));
+			RegisterCommandCode("gethardwaretypes", boost::bind(&CWebServer::Cmd_GetHardwareTypes, this, _1, _2, _3));
+			RegisterCommandCode("addhardware", boost::bind(&CWebServer::Cmd_AddHardware, this, _1, _2, _3));
+			RegisterCommandCode("updatehardware", boost::bind(&CWebServer::Cmd_UpdateHardware, this, _1, _2, _3));
+			RegisterCommandCode("deletehardware", boost::bind(&CWebServer::Cmd_DeleteHardware, this, _1, _2, _3));
 
-			RegisterCommandCode("mysensorsgetnodes", std::bind(&CWebServer::Cmd_MySensorsGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("mysensorsgetchilds", std::bind(&CWebServer::Cmd_MySensorsGetChilds, this, _1, _2, _3));
-			RegisterCommandCode("mysensorsupdatenode", std::bind(&CWebServer::Cmd_MySensorsUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("mysensorsremovenode", std::bind(&CWebServer::Cmd_MySensorsRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("mysensorsremovechild", std::bind(&CWebServer::Cmd_MySensorsRemoveChild, this, _1, _2, _3));
-			RegisterCommandCode("mysensorsupdatechild", std::bind(&CWebServer::Cmd_MySensorsUpdateChild, this, _1, _2, _3));
+			RegisterCommandCode("addcamera", boost::bind(&CWebServer::Cmd_AddCamera, this, _1, _2, _3));
+			RegisterCommandCode("updatecamera", boost::bind(&CWebServer::Cmd_UpdateCamera, this, _1, _2, _3));
+			RegisterCommandCode("deletecamera", boost::bind(&CWebServer::Cmd_DeleteCamera, this, _1, _2, _3));
 
-			RegisterCommandCode("pingersetmode", std::bind(&CWebServer::Cmd_PingerSetMode, this, _1, _2, _3));
-			RegisterCommandCode("pingergetnodes", std::bind(&CWebServer::Cmd_PingerGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("pingeraddnode", std::bind(&CWebServer::Cmd_PingerAddNode, this, _1, _2, _3));
-			RegisterCommandCode("pingerupdatenode", std::bind(&CWebServer::Cmd_PingerUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("pingerremovenode", std::bind(&CWebServer::Cmd_PingerRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("pingerclearnodes", std::bind(&CWebServer::Cmd_PingerClearNodes, this, _1, _2, _3));
+			RegisterCommandCode("wolgetnodes", boost::bind(&CWebServer::Cmd_WOLGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("woladdnode", boost::bind(&CWebServer::Cmd_WOLAddNode, this, _1, _2, _3));
+			RegisterCommandCode("wolupdatenode", boost::bind(&CWebServer::Cmd_WOLUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("wolremovenode", boost::bind(&CWebServer::Cmd_WOLRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("wolclearnodes", boost::bind(&CWebServer::Cmd_WOLClearNodes, this, _1, _2, _3));
 
-			RegisterCommandCode("kodisetmode", std::bind(&CWebServer::Cmd_KodiSetMode, this, _1, _2, _3));
-			RegisterCommandCode("kodigetnodes", std::bind(&CWebServer::Cmd_KodiGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("kodiaddnode", std::bind(&CWebServer::Cmd_KodiAddNode, this, _1, _2, _3));
-			RegisterCommandCode("kodiupdatenode", std::bind(&CWebServer::Cmd_KodiUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("kodiremovenode", std::bind(&CWebServer::Cmd_KodiRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("kodiclearnodes", std::bind(&CWebServer::Cmd_KodiClearNodes, this, _1, _2, _3));
-			RegisterCommandCode("kodimediacommand", std::bind(&CWebServer::Cmd_KodiMediaCommand, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsgetnodes", boost::bind(&CWebServer::Cmd_MySensorsGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsgetchilds", boost::bind(&CWebServer::Cmd_MySensorsGetChilds, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsupdatenode", boost::bind(&CWebServer::Cmd_MySensorsUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsremovenode", boost::bind(&CWebServer::Cmd_MySensorsRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsremovechild", boost::bind(&CWebServer::Cmd_MySensorsRemoveChild, this, _1, _2, _3));
+			RegisterCommandCode("mysensorsupdatechild", boost::bind(&CWebServer::Cmd_MySensorsUpdateChild, this, _1, _2, _3));
 
-			RegisterCommandCode("panasonicsetmode", std::bind(&CWebServer::Cmd_PanasonicSetMode, this, _1, _2, _3));
-			RegisterCommandCode("panasonicgetnodes", std::bind(&CWebServer::Cmd_PanasonicGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("panasonicaddnode", std::bind(&CWebServer::Cmd_PanasonicAddNode, this, _1, _2, _3));
-			RegisterCommandCode("panasonicupdatenode", std::bind(&CWebServer::Cmd_PanasonicUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("panasonicremovenode", std::bind(&CWebServer::Cmd_PanasonicRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("panasonicclearnodes", std::bind(&CWebServer::Cmd_PanasonicClearNodes, this, _1, _2, _3));
-			RegisterCommandCode("panasonicmediacommand", std::bind(&CWebServer::Cmd_PanasonicMediaCommand, this, _1, _2, _3));
+			RegisterCommandCode("pingersetmode", boost::bind(&CWebServer::Cmd_PingerSetMode, this, _1, _2, _3));
+			RegisterCommandCode("pingergetnodes", boost::bind(&CWebServer::Cmd_PingerGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("pingeraddnode", boost::bind(&CWebServer::Cmd_PingerAddNode, this, _1, _2, _3));
+			RegisterCommandCode("pingerupdatenode", boost::bind(&CWebServer::Cmd_PingerUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("pingerremovenode", boost::bind(&CWebServer::Cmd_PingerRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("pingerclearnodes", boost::bind(&CWebServer::Cmd_PingerClearNodes, this, _1, _2, _3));
 
-			RegisterCommandCode("heossetmode", std::bind(&CWebServer::Cmd_HEOSSetMode, this, _1, _2, _3));
-			RegisterCommandCode("heosmediacommand", std::bind(&CWebServer::Cmd_HEOSMediaCommand, this, _1, _2, _3));
+			RegisterCommandCode("kodisetmode", boost::bind(&CWebServer::Cmd_KodiSetMode, this, _1, _2, _3));
+			RegisterCommandCode("kodigetnodes", boost::bind(&CWebServer::Cmd_KodiGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("kodiaddnode", boost::bind(&CWebServer::Cmd_KodiAddNode, this, _1, _2, _3));
+			RegisterCommandCode("kodiupdatenode", boost::bind(&CWebServer::Cmd_KodiUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("kodiremovenode", boost::bind(&CWebServer::Cmd_KodiRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("kodiclearnodes", boost::bind(&CWebServer::Cmd_KodiClearNodes, this, _1, _2, _3));
+			RegisterCommandCode("kodimediacommand", boost::bind(&CWebServer::Cmd_KodiMediaCommand, this, _1, _2, _3));
 
-			RegisterCommandCode("onkyoeiscpcommand", std::bind(&CWebServer::Cmd_OnkyoEiscpCommand, this, _1, _2, _3));
+			RegisterCommandCode("panasonicsetmode", boost::bind(&CWebServer::Cmd_PanasonicSetMode, this, _1, _2, _3));
+			RegisterCommandCode("panasonicgetnodes", boost::bind(&CWebServer::Cmd_PanasonicGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("panasonicaddnode", boost::bind(&CWebServer::Cmd_PanasonicAddNode, this, _1, _2, _3));
+			RegisterCommandCode("panasonicupdatenode", boost::bind(&CWebServer::Cmd_PanasonicUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("panasonicremovenode", boost::bind(&CWebServer::Cmd_PanasonicRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("panasonicclearnodes", boost::bind(&CWebServer::Cmd_PanasonicClearNodes, this, _1, _2, _3));
+			RegisterCommandCode("panasonicmediacommand", boost::bind(&CWebServer::Cmd_PanasonicMediaCommand, this, _1, _2, _3));
 
-			RegisterCommandCode("bleboxsetmode", std::bind(&CWebServer::Cmd_BleBoxSetMode, this, _1, _2, _3));
-			RegisterCommandCode("bleboxgetnodes", std::bind(&CWebServer::Cmd_BleBoxGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("bleboxaddnode", std::bind(&CWebServer::Cmd_BleBoxAddNode, this, _1, _2, _3));
-			RegisterCommandCode("bleboxremovenode", std::bind(&CWebServer::Cmd_BleBoxRemoveNode, this, _1, _2, _3));
-			RegisterCommandCode("bleboxclearnodes", std::bind(&CWebServer::Cmd_BleBoxClearNodes, this, _1, _2, _3));
-			RegisterCommandCode("bleboxautosearchingnodes", std::bind(&CWebServer::Cmd_BleBoxAutoSearchingNodes, this, _1, _2, _3));
-			RegisterCommandCode("bleboxupdatefirmware", std::bind(&CWebServer::Cmd_BleBoxUpdateFirmware, this, _1, _2, _3));
+			RegisterCommandCode("heossetmode", boost::bind(&CWebServer::Cmd_HEOSSetMode, this, _1, _2, _3));
+			RegisterCommandCode("heosmediacommand", boost::bind(&CWebServer::Cmd_HEOSMediaCommand, this, _1, _2, _3));
 
-			RegisterCommandCode("lmssetmode", std::bind(&CWebServer::Cmd_LMSSetMode, this, _1, _2, _3));
-			RegisterCommandCode("lmsgetnodes", std::bind(&CWebServer::Cmd_LMSGetNodes, this, _1, _2, _3));
-			RegisterCommandCode("lmsgetplaylists", std::bind(&CWebServer::Cmd_LMSGetPlaylists, this, _1, _2, _3));
-			RegisterCommandCode("lmsmediacommand", std::bind(&CWebServer::Cmd_LMSMediaCommand, this, _1, _2, _3));
-			RegisterCommandCode("lmsdeleteunuseddevices", std::bind(&CWebServer::Cmd_LMSDeleteUnusedDevices, this, _1, _2, _3));
+			RegisterCommandCode("onkyoeiscpcommand", boost::bind(&CWebServer::Cmd_OnkyoEiscpCommand, this, _1, _2, _3));
 
-			RegisterCommandCode("savefibarolinkconfig", std::bind(&CWebServer::Cmd_SaveFibaroLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getfibarolinkconfig", std::bind(&CWebServer::Cmd_GetFibaroLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getfibarolinks", std::bind(&CWebServer::Cmd_GetFibaroLinks, this, _1, _2, _3));
-			RegisterCommandCode("savefibarolink", std::bind(&CWebServer::Cmd_SaveFibaroLink, this, _1, _2, _3));
-			RegisterCommandCode("deletefibarolink", std::bind(&CWebServer::Cmd_DeleteFibaroLink, this, _1, _2, _3));
+			RegisterCommandCode("bleboxsetmode", boost::bind(&CWebServer::Cmd_BleBoxSetMode, this, _1, _2, _3));
+			RegisterCommandCode("bleboxgetnodes", boost::bind(&CWebServer::Cmd_BleBoxGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("bleboxaddnode", boost::bind(&CWebServer::Cmd_BleBoxAddNode, this, _1, _2, _3));
+			RegisterCommandCode("bleboxremovenode", boost::bind(&CWebServer::Cmd_BleBoxRemoveNode, this, _1, _2, _3));
+			RegisterCommandCode("bleboxclearnodes", boost::bind(&CWebServer::Cmd_BleBoxClearNodes, this, _1, _2, _3));
+			RegisterCommandCode("bleboxautosearchingnodes", boost::bind(&CWebServer::Cmd_BleBoxAutoSearchingNodes, this, _1, _2, _3));
+			RegisterCommandCode("bleboxupdatefirmware", boost::bind(&CWebServer::Cmd_BleBoxUpdateFirmware, this, _1, _2, _3));
 
-			RegisterCommandCode("saveinfluxlinkconfig", std::bind(&CWebServer::Cmd_SaveInfluxLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getinfluxlinkconfig", std::bind(&CWebServer::Cmd_GetInfluxLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getinfluxlinks", std::bind(&CWebServer::Cmd_GetInfluxLinks, this, _1, _2, _3));
-			RegisterCommandCode("saveinfluxlink", std::bind(&CWebServer::Cmd_SaveInfluxLink, this, _1, _2, _3));
-			RegisterCommandCode("deleteinfluxlink", std::bind(&CWebServer::Cmd_DeleteInfluxLink, this, _1, _2, _3));
+			RegisterCommandCode("lmssetmode", boost::bind(&CWebServer::Cmd_LMSSetMode, this, _1, _2, _3));
+			RegisterCommandCode("lmsgetnodes", boost::bind(&CWebServer::Cmd_LMSGetNodes, this, _1, _2, _3));
+			RegisterCommandCode("lmsgetplaylists", boost::bind(&CWebServer::Cmd_LMSGetPlaylists, this, _1, _2, _3));
+			RegisterCommandCode("lmsmediacommand", boost::bind(&CWebServer::Cmd_LMSMediaCommand, this, _1, _2, _3));
+			RegisterCommandCode("lmsdeleteunuseddevices", boost::bind(&CWebServer::Cmd_LMSDeleteUnusedDevices, this, _1, _2, _3));
 
-			RegisterCommandCode("savehttplinkconfig", std::bind(&CWebServer::Cmd_SaveHttpLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("gethttplinkconfig", std::bind(&CWebServer::Cmd_GetHttpLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("gethttplinks", std::bind(&CWebServer::Cmd_GetHttpLinks, this, _1, _2, _3));
-			RegisterCommandCode("savehttplink", std::bind(&CWebServer::Cmd_SaveHttpLink, this, _1, _2, _3));
-			RegisterCommandCode("deletehttplink", std::bind(&CWebServer::Cmd_DeleteHttpLink, this, _1, _2, _3));
+			RegisterCommandCode("savefibarolinkconfig", boost::bind(&CWebServer::Cmd_SaveFibaroLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getfibarolinkconfig", boost::bind(&CWebServer::Cmd_GetFibaroLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getfibarolinks", boost::bind(&CWebServer::Cmd_GetFibaroLinks, this, _1, _2, _3));
+			RegisterCommandCode("savefibarolink", boost::bind(&CWebServer::Cmd_SaveFibaroLink, this, _1, _2, _3));
+			RegisterCommandCode("deletefibarolink", boost::bind(&CWebServer::Cmd_DeleteFibaroLink, this, _1, _2, _3));
 
-			RegisterCommandCode("savegooglepubsublinkconfig", std::bind(&CWebServer::Cmd_SaveGooglePubSubLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getgooglepubsublinkconfig", std::bind(&CWebServer::Cmd_GetGooglePubSubLinkConfig, this, _1, _2, _3));
-			RegisterCommandCode("getgooglepubsublinks", std::bind(&CWebServer::Cmd_GetGooglePubSubLinks, this, _1, _2, _3));
-			RegisterCommandCode("savegooglepubsublink", std::bind(&CWebServer::Cmd_SaveGooglePubSubLink, this, _1, _2, _3));
-			RegisterCommandCode("deletegooglepubsublink", std::bind(&CWebServer::Cmd_DeleteGooglePubSubLink, this, _1, _2, _3));
+			RegisterCommandCode("saveinfluxlinkconfig", boost::bind(&CWebServer::Cmd_SaveInfluxLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getinfluxlinkconfig", boost::bind(&CWebServer::Cmd_GetInfluxLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getinfluxlinks", boost::bind(&CWebServer::Cmd_GetInfluxLinks, this, _1, _2, _3));
+			RegisterCommandCode("saveinfluxlink", boost::bind(&CWebServer::Cmd_SaveInfluxLink, this, _1, _2, _3));
+			RegisterCommandCode("deleteinfluxlink", boost::bind(&CWebServer::Cmd_DeleteInfluxLink, this, _1, _2, _3));
 
-			RegisterCommandCode("getdevicevalueoptions", std::bind(&CWebServer::Cmd_GetDeviceValueOptions, this, _1, _2, _3));
-			RegisterCommandCode("getdevicevalueoptionwording", std::bind(&CWebServer::Cmd_GetDeviceValueOptionWording, this, _1, _2, _3));
+			RegisterCommandCode("savehttplinkconfig", boost::bind(&CWebServer::Cmd_SaveHttpLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("gethttplinkconfig", boost::bind(&CWebServer::Cmd_GetHttpLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("gethttplinks", boost::bind(&CWebServer::Cmd_GetHttpLinks, this, _1, _2, _3));
+			RegisterCommandCode("savehttplink", boost::bind(&CWebServer::Cmd_SaveHttpLink, this, _1, _2, _3));
+			RegisterCommandCode("deletehttplink", boost::bind(&CWebServer::Cmd_DeleteHttpLink, this, _1, _2, _3));
 
-			RegisterCommandCode("adduservariable", std::bind(&CWebServer::Cmd_AddUserVariable, this, _1, _2, _3));
-			RegisterCommandCode("updateuservariable", std::bind(&CWebServer::Cmd_UpdateUserVariable, this, _1, _2, _3));
-			RegisterCommandCode("deleteuservariable", std::bind(&CWebServer::Cmd_DeleteUserVariable, this, _1, _2, _3));
-			RegisterCommandCode("getuservariables", std::bind(&CWebServer::Cmd_GetUserVariables, this, _1, _2, _3));
-			RegisterCommandCode("getuservariable", std::bind(&CWebServer::Cmd_GetUserVariable, this, _1, _2, _3));
+			RegisterCommandCode("savegooglepubsublinkconfig", boost::bind(&CWebServer::Cmd_SaveGooglePubSubLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getgooglepubsublinkconfig", boost::bind(&CWebServer::Cmd_GetGooglePubSubLinkConfig, this, _1, _2, _3));
+			RegisterCommandCode("getgooglepubsublinks", boost::bind(&CWebServer::Cmd_GetGooglePubSubLinks, this, _1, _2, _3));
+			RegisterCommandCode("savegooglepubsublink", boost::bind(&CWebServer::Cmd_SaveGooglePubSubLink, this, _1, _2, _3));
+			RegisterCommandCode("deletegooglepubsublink", boost::bind(&CWebServer::Cmd_DeleteGooglePubSubLink, this, _1, _2, _3));
 
-			RegisterCommandCode("allownewhardware", std::bind(&CWebServer::Cmd_AllowNewHardware, this, _1, _2, _3));
+			RegisterCommandCode("getdevicevalueoptions", boost::bind(&CWebServer::Cmd_GetDeviceValueOptions, this, _1, _2, _3));
+			RegisterCommandCode("getdevicevalueoptionwording", boost::bind(&CWebServer::Cmd_GetDeviceValueOptionWording, this, _1, _2, _3));
 
-			RegisterCommandCode("addplan", std::bind(&CWebServer::Cmd_AddPlan, this, _1, _2, _3));
-			RegisterCommandCode("updateplan", std::bind(&CWebServer::Cmd_UpdatePlan, this, _1, _2, _3));
-			RegisterCommandCode("deleteplan", std::bind(&CWebServer::Cmd_DeletePlan, this, _1, _2, _3));
-			RegisterCommandCode("getunusedplandevices", std::bind(&CWebServer::Cmd_GetUnusedPlanDevices, this, _1, _2, _3));
-			RegisterCommandCode("addplanactivedevice", std::bind(&CWebServer::Cmd_AddPlanActiveDevice, this, _1, _2, _3));
-			RegisterCommandCode("getplandevices", std::bind(&CWebServer::Cmd_GetPlanDevices, this, _1, _2, _3));
-			RegisterCommandCode("deleteplandevice", std::bind(&CWebServer::Cmd_DeletePlanDevice, this, _1, _2, _3));
-			RegisterCommandCode("setplandevicecoords", std::bind(&CWebServer::Cmd_SetPlanDeviceCoords, this, _1, _2, _3));
-			RegisterCommandCode("deleteallplandevices", std::bind(&CWebServer::Cmd_DeleteAllPlanDevices, this, _1, _2, _3));
-			RegisterCommandCode("changeplanorder", std::bind(&CWebServer::Cmd_ChangePlanOrder, this, _1, _2, _3));
-			RegisterCommandCode("changeplandeviceorder", std::bind(&CWebServer::Cmd_ChangePlanDeviceOrder, this, _1, _2, _3));
+			RegisterCommandCode("adduservariable", boost::bind(&CWebServer::Cmd_AddUserVariable, this, _1, _2, _3));
+			RegisterCommandCode("updateuservariable", boost::bind(&CWebServer::Cmd_UpdateUserVariable, this, _1, _2, _3));
+			RegisterCommandCode("deleteuservariable", boost::bind(&CWebServer::Cmd_DeleteUserVariable, this, _1, _2, _3));
+			RegisterCommandCode("getuservariables", boost::bind(&CWebServer::Cmd_GetUserVariables, this, _1, _2, _3));
+			RegisterCommandCode("getuservariable", boost::bind(&CWebServer::Cmd_GetUserVariable, this, _1, _2, _3));
 
-			RegisterCommandCode("gettimerplans", std::bind(&CWebServer::Cmd_GetTimerPlans, this, _1, _2, _3));
-			RegisterCommandCode("addtimerplan", std::bind(&CWebServer::Cmd_AddTimerPlan, this, _1, _2, _3));
-			RegisterCommandCode("updatetimerplan", std::bind(&CWebServer::Cmd_UpdateTimerPlan, this, _1, _2, _3));
-			RegisterCommandCode("deletetimerplan", std::bind(&CWebServer::Cmd_DeleteTimerPlan, this, _1, _2, _3));
-			RegisterCommandCode("duplicatetimerplan", std::bind(&CWebServer::Cmd_DuplicateTimerPlan, this, _1, _2, _3));
+			RegisterCommandCode("allownewhardware", boost::bind(&CWebServer::Cmd_AllowNewHardware, this, _1, _2, _3));
 
-			RegisterCommandCode("getactualhistory", std::bind(&CWebServer::Cmd_GetActualHistory, this, _1, _2, _3));
-			RegisterCommandCode("getnewhistory", std::bind(&CWebServer::Cmd_GetNewHistory, this, _1, _2, _3));
+			RegisterCommandCode("addplan", boost::bind(&CWebServer::Cmd_AddPlan, this, _1, _2, _3));
+			RegisterCommandCode("updateplan", boost::bind(&CWebServer::Cmd_UpdatePlan, this, _1, _2, _3));
+			RegisterCommandCode("deleteplan", boost::bind(&CWebServer::Cmd_DeletePlan, this, _1, _2, _3));
+			RegisterCommandCode("getunusedplandevices", boost::bind(&CWebServer::Cmd_GetUnusedPlanDevices, this, _1, _2, _3));
+			RegisterCommandCode("addplanactivedevice", boost::bind(&CWebServer::Cmd_AddPlanActiveDevice, this, _1, _2, _3));
+			RegisterCommandCode("getplandevices", boost::bind(&CWebServer::Cmd_GetPlanDevices, this, _1, _2, _3));
+			RegisterCommandCode("deleteplandevice", boost::bind(&CWebServer::Cmd_DeletePlanDevice, this, _1, _2, _3));
+			RegisterCommandCode("setplandevicecoords", boost::bind(&CWebServer::Cmd_SetPlanDeviceCoords, this, _1, _2, _3));
+			RegisterCommandCode("deleteallplandevices", boost::bind(&CWebServer::Cmd_DeleteAllPlanDevices, this, _1, _2, _3));
+			RegisterCommandCode("changeplanorder", boost::bind(&CWebServer::Cmd_ChangePlanOrder, this, _1, _2, _3));
+			RegisterCommandCode("changeplandeviceorder", boost::bind(&CWebServer::Cmd_ChangePlanDeviceOrder, this, _1, _2, _3));
 
-			RegisterCommandCode("getconfig", std::bind(&CWebServer::Cmd_GetConfig, this, _1, _2, _3), true);
-			RegisterCommandCode("getlocation", std::bind(&CWebServer::Cmd_GetLocation, this, _1, _2, _3));
-			RegisterCommandCode("getforecastconfig", std::bind(&CWebServer::Cmd_GetForecastConfig, this, _1, _2, _3));
-			RegisterCommandCode("sendnotification", std::bind(&CWebServer::Cmd_SendNotification, this, _1, _2, _3));
-			RegisterCommandCode("emailcamerasnapshot", std::bind(&CWebServer::Cmd_EmailCameraSnapshot, this, _1, _2, _3));
-			RegisterCommandCode("udevice", std::bind(&CWebServer::Cmd_UpdateDevice, this, _1, _2, _3));
-			RegisterCommandCode("udevices", std::bind(&CWebServer::Cmd_UpdateDevices, this, _1, _2, _3));
-			RegisterCommandCode("thermostatstate", std::bind(&CWebServer::Cmd_SetThermostatState, this, _1, _2, _3));
-			RegisterCommandCode("system_shutdown", std::bind(&CWebServer::Cmd_SystemShutdown, this, _1, _2, _3));
-			RegisterCommandCode("system_reboot", std::bind(&CWebServer::Cmd_SystemReboot, this, _1, _2, _3));
-			RegisterCommandCode("execute_script", std::bind(&CWebServer::Cmd_ExcecuteScript, this, _1, _2, _3));
-			RegisterCommandCode("getcosts", std::bind(&CWebServer::Cmd_GetCosts, this, _1, _2, _3));
-			RegisterCommandCode("checkforupdate", std::bind(&CWebServer::Cmd_CheckForUpdate, this, _1, _2, _3));
-			RegisterCommandCode("downloadupdate", std::bind(&CWebServer::Cmd_DownloadUpdate, this, _1, _2, _3));
-			RegisterCommandCode("downloadready", std::bind(&CWebServer::Cmd_DownloadReady, this, _1, _2, _3));
-			RegisterCommandCode("update_application", std::bind(&CWebServer::Cmd_UpdateApplication, this, _1, _2, _3));
-			RegisterCommandCode("deletedatapoint", std::bind(&CWebServer::Cmd_DeleteDatePoint, this, _1, _2, _3));
-			RegisterCommandCode("customevent", std::bind(&CWebServer::Cmd_CustomEvent, this, _1, _2, _3));
+			RegisterCommandCode("gettimerplans", boost::bind(&CWebServer::Cmd_GetTimerPlans, this, _1, _2, _3));
+			RegisterCommandCode("addtimerplan", boost::bind(&CWebServer::Cmd_AddTimerPlan, this, _1, _2, _3));
+			RegisterCommandCode("updatetimerplan", boost::bind(&CWebServer::Cmd_UpdateTimerPlan, this, _1, _2, _3));
+			RegisterCommandCode("deletetimerplan", boost::bind(&CWebServer::Cmd_DeleteTimerPlan, this, _1, _2, _3));
+			RegisterCommandCode("duplicatetimerplan", boost::bind(&CWebServer::Cmd_DuplicateTimerPlan, this, _1, _2, _3));
 
-			RegisterCommandCode("setactivetimerplan", std::bind(&CWebServer::Cmd_SetActiveTimerPlan, this, _1, _2, _3));
-			RegisterCommandCode("addtimer", std::bind(&CWebServer::Cmd_AddTimer, this, _1, _2, _3));
-			RegisterCommandCode("updatetimer", std::bind(&CWebServer::Cmd_UpdateTimer, this, _1, _2, _3));
-			RegisterCommandCode("deletetimer", std::bind(&CWebServer::Cmd_DeleteTimer, this, _1, _2, _3));
-			RegisterCommandCode("enabletimer", std::bind(&CWebServer::Cmd_EnableTimer, this, _1, _2, _3));
-			RegisterCommandCode("disabletimer", std::bind(&CWebServer::Cmd_DisableTimer, this, _1, _2, _3));
-			RegisterCommandCode("cleartimers", std::bind(&CWebServer::Cmd_ClearTimers, this, _1, _2, _3));
+			RegisterCommandCode("getactualhistory", boost::bind(&CWebServer::Cmd_GetActualHistory, this, _1, _2, _3));
+			RegisterCommandCode("getnewhistory", boost::bind(&CWebServer::Cmd_GetNewHistory, this, _1, _2, _3));
 
-			RegisterCommandCode("addscenetimer", std::bind(&CWebServer::Cmd_AddSceneTimer, this, _1, _2, _3));
-			RegisterCommandCode("updatescenetimer", std::bind(&CWebServer::Cmd_UpdateSceneTimer, this, _1, _2, _3));
-			RegisterCommandCode("deletescenetimer", std::bind(&CWebServer::Cmd_DeleteSceneTimer, this, _1, _2, _3));
-			RegisterCommandCode("enablescenetimer", std::bind(&CWebServer::Cmd_EnableSceneTimer, this, _1, _2, _3));
-			RegisterCommandCode("disablescenetimer", std::bind(&CWebServer::Cmd_DisableSceneTimer, this, _1, _2, _3));
-			RegisterCommandCode("clearscenetimers", std::bind(&CWebServer::Cmd_ClearSceneTimers, this, _1, _2, _3));
-			RegisterCommandCode("getsceneactivations", std::bind(&CWebServer::Cmd_GetSceneActivations, this, _1, _2, _3));
-			RegisterCommandCode("addscenecode", std::bind(&CWebServer::Cmd_AddSceneCode, this, _1, _2, _3));
-			RegisterCommandCode("removescenecode", std::bind(&CWebServer::Cmd_RemoveSceneCode, this, _1, _2, _3));
-			RegisterCommandCode("clearscenecodes", std::bind(&CWebServer::Cmd_ClearSceneCodes, this, _1, _2, _3));
-			RegisterCommandCode("renamescene", std::bind(&CWebServer::Cmd_RenameScene, this, _1, _2, _3));
+			RegisterCommandCode("getconfig", boost::bind(&CWebServer::Cmd_GetConfig, this, _1, _2, _3), true);
+			RegisterCommandCode("getlocation", boost::bind(&CWebServer::Cmd_GetLocation, this, _1, _2, _3));
+			RegisterCommandCode("getforecastconfig", boost::bind(&CWebServer::Cmd_GetForecastConfig, this, _1, _2, _3));
+			RegisterCommandCode("sendnotification", boost::bind(&CWebServer::Cmd_SendNotification, this, _1, _2, _3));
+			RegisterCommandCode("emailcamerasnapshot", boost::bind(&CWebServer::Cmd_EmailCameraSnapshot, this, _1, _2, _3));
+			RegisterCommandCode("udevice", boost::bind(&CWebServer::Cmd_UpdateDevice, this, _1, _2, _3));
+			RegisterCommandCode("udevices", boost::bind(&CWebServer::Cmd_UpdateDevices, this, _1, _2, _3));
+			RegisterCommandCode("thermostatstate", boost::bind(&CWebServer::Cmd_SetThermostatState, this, _1, _2, _3));
+			RegisterCommandCode("system_shutdown", boost::bind(&CWebServer::Cmd_SystemShutdown, this, _1, _2, _3));
+			RegisterCommandCode("system_reboot", boost::bind(&CWebServer::Cmd_SystemReboot, this, _1, _2, _3));
+			RegisterCommandCode("execute_script", boost::bind(&CWebServer::Cmd_ExcecuteScript, this, _1, _2, _3));
+			RegisterCommandCode("getcosts", boost::bind(&CWebServer::Cmd_GetCosts, this, _1, _2, _3));
+			RegisterCommandCode("checkforupdate", boost::bind(&CWebServer::Cmd_CheckForUpdate, this, _1, _2, _3));
+			RegisterCommandCode("downloadupdate", boost::bind(&CWebServer::Cmd_DownloadUpdate, this, _1, _2, _3));
+			RegisterCommandCode("downloadready", boost::bind(&CWebServer::Cmd_DownloadReady, this, _1, _2, _3));
+			RegisterCommandCode("update_application", boost::bind(&CWebServer::Cmd_UpdateApplication, this, _1, _2, _3));
+			RegisterCommandCode("deletedatapoint", boost::bind(&CWebServer::Cmd_DeleteDatePoint, this, _1, _2, _3));
+			RegisterCommandCode("customevent", boost::bind(&CWebServer::Cmd_CustomEvent, this, _1, _2, _3));
 
-			RegisterCommandCode("setsetpoint", std::bind(&CWebServer::Cmd_SetSetpoint, this, _1, _2, _3));
-			RegisterCommandCode("addsetpointtimer", std::bind(&CWebServer::Cmd_AddSetpointTimer, this, _1, _2, _3));
-			RegisterCommandCode("updatesetpointtimer", std::bind(&CWebServer::Cmd_UpdateSetpointTimer, this, _1, _2, _3));
-			RegisterCommandCode("deletesetpointtimer", std::bind(&CWebServer::Cmd_DeleteSetpointTimer, this, _1, _2, _3));
-			RegisterCommandCode("enablesetpointtimer", std::bind(&CWebServer::Cmd_EnableSetpointTimer, this, _1, _2, _3));
-			RegisterCommandCode("disablesetpointtimer", std::bind(&CWebServer::Cmd_DisableSetpointTimer, this, _1, _2, _3));
-			RegisterCommandCode("clearsetpointtimers", std::bind(&CWebServer::Cmd_ClearSetpointTimers, this, _1, _2, _3));
+			RegisterCommandCode("setactivetimerplan", boost::bind(&CWebServer::Cmd_SetActiveTimerPlan, this, _1, _2, _3));
+			RegisterCommandCode("addtimer", boost::bind(&CWebServer::Cmd_AddTimer, this, _1, _2, _3));
+			RegisterCommandCode("updatetimer", boost::bind(&CWebServer::Cmd_UpdateTimer, this, _1, _2, _3));
+			RegisterCommandCode("deletetimer", boost::bind(&CWebServer::Cmd_DeleteTimer, this, _1, _2, _3));
+			RegisterCommandCode("enabletimer", boost::bind(&CWebServer::Cmd_EnableTimer, this, _1, _2, _3));
+			RegisterCommandCode("disabletimer", boost::bind(&CWebServer::Cmd_DisableTimer, this, _1, _2, _3));
+			RegisterCommandCode("cleartimers", boost::bind(&CWebServer::Cmd_ClearTimers, this, _1, _2, _3));
 
-			RegisterCommandCode("serial_devices", std::bind(&CWebServer::Cmd_GetSerialDevices, this, _1, _2, _3));
-			RegisterCommandCode("devices_list", std::bind(&CWebServer::Cmd_GetDevicesList, this, _1, _2, _3));
-			RegisterCommandCode("devices_list_onoff", std::bind(&CWebServer::Cmd_GetDevicesListOnOff, this, _1, _2, _3));
+			RegisterCommandCode("addscenetimer", boost::bind(&CWebServer::Cmd_AddSceneTimer, this, _1, _2, _3));
+			RegisterCommandCode("updatescenetimer", boost::bind(&CWebServer::Cmd_UpdateSceneTimer, this, _1, _2, _3));
+			RegisterCommandCode("deletescenetimer", boost::bind(&CWebServer::Cmd_DeleteSceneTimer, this, _1, _2, _3));
+			RegisterCommandCode("enablescenetimer", boost::bind(&CWebServer::Cmd_EnableSceneTimer, this, _1, _2, _3));
+			RegisterCommandCode("disablescenetimer", boost::bind(&CWebServer::Cmd_DisableSceneTimer, this, _1, _2, _3));
+			RegisterCommandCode("clearscenetimers", boost::bind(&CWebServer::Cmd_ClearSceneTimers, this, _1, _2, _3));
+			RegisterCommandCode("getsceneactivations", boost::bind(&CWebServer::Cmd_GetSceneActivations, this, _1, _2, _3));
+			RegisterCommandCode("addscenecode", boost::bind(&CWebServer::Cmd_AddSceneCode, this, _1, _2, _3));
+			RegisterCommandCode("removescenecode", boost::bind(&CWebServer::Cmd_RemoveSceneCode, this, _1, _2, _3));
+			RegisterCommandCode("clearscenecodes", boost::bind(&CWebServer::Cmd_ClearSceneCodes, this, _1, _2, _3));
+			RegisterCommandCode("renamescene", boost::bind(&CWebServer::Cmd_RenameScene, this, _1, _2, _3));
 
-			RegisterCommandCode("registerhue", std::bind(&CWebServer::Cmd_PhilipsHueRegister, this, _1, _2, _3));
+			RegisterCommandCode("setsetpoint", boost::bind(&CWebServer::Cmd_SetSetpoint, this, _1, _2, _3));
+			RegisterCommandCode("addsetpointtimer", boost::bind(&CWebServer::Cmd_AddSetpointTimer, this, _1, _2, _3));
+			RegisterCommandCode("updatesetpointtimer", boost::bind(&CWebServer::Cmd_UpdateSetpointTimer, this, _1, _2, _3));
+			RegisterCommandCode("deletesetpointtimer", boost::bind(&CWebServer::Cmd_DeleteSetpointTimer, this, _1, _2, _3));
+			RegisterCommandCode("enablesetpointtimer", boost::bind(&CWebServer::Cmd_EnableSetpointTimer, this, _1, _2, _3));
+			RegisterCommandCode("disablesetpointtimer", boost::bind(&CWebServer::Cmd_DisableSetpointTimer, this, _1, _2, _3));
+			RegisterCommandCode("clearsetpointtimers", boost::bind(&CWebServer::Cmd_ClearSetpointTimers, this, _1, _2, _3));
 
-			RegisterCommandCode("getcustomiconset", std::bind(&CWebServer::Cmd_GetCustomIconSet, this, _1, _2, _3));
-			RegisterCommandCode("deletecustomicon", std::bind(&CWebServer::Cmd_DeleteCustomIcon, this, _1, _2, _3));
-			RegisterCommandCode("updatecustomicon", std::bind(&CWebServer::Cmd_UpdateCustomIcon, this, _1, _2, _3));
+			RegisterCommandCode("serial_devices", boost::bind(&CWebServer::Cmd_GetSerialDevices, this, _1, _2, _3));
+			RegisterCommandCode("devices_list", boost::bind(&CWebServer::Cmd_GetDevicesList, this, _1, _2, _3));
+			RegisterCommandCode("devices_list_onoff", boost::bind(&CWebServer::Cmd_GetDevicesListOnOff, this, _1, _2, _3));
 
-			RegisterCommandCode("renamedevice", std::bind(&CWebServer::Cmd_RenameDevice, this, _1, _2, _3));
-			RegisterCommandCode("setunused", std::bind(&CWebServer::Cmd_SetUnused, this, _1, _2, _3));
+			RegisterCommandCode("registerhue", boost::bind(&CWebServer::Cmd_PhilipsHueRegister, this, _1, _2, _3));
 
-			RegisterCommandCode("addlogmessage", std::bind(&CWebServer::Cmd_AddLogMessage, this, _1, _2, _3));
-			RegisterCommandCode("clearshortlog", std::bind(&CWebServer::Cmd_ClearShortLog, this, _1, _2, _3));
-			RegisterCommandCode("vacuumdatabase", std::bind(&CWebServer::Cmd_VacuumDatabase, this, _1, _2, _3));
+			RegisterCommandCode("getcustomiconset", boost::bind(&CWebServer::Cmd_GetCustomIconSet, this, _1, _2, _3));
+			RegisterCommandCode("deletecustomicon", boost::bind(&CWebServer::Cmd_DeleteCustomIcon, this, _1, _2, _3));
+			RegisterCommandCode("updatecustomicon", boost::bind(&CWebServer::Cmd_UpdateCustomIcon, this, _1, _2, _3));
 
-			RegisterCommandCode("addmobiledevice", std::bind(&CWebServer::Cmd_AddMobileDevice, this, _1, _2, _3));
-			RegisterCommandCode("updatemobiledevice", std::bind(&CWebServer::Cmd_UpdateMobileDevice, this, _1, _2, _3));
-			RegisterCommandCode("deletemobiledevice", std::bind(&CWebServer::Cmd_DeleteMobileDevice, this, _1, _2, _3));
+			RegisterCommandCode("renamedevice", boost::bind(&CWebServer::Cmd_RenameDevice, this, _1, _2, _3));
+			RegisterCommandCode("setunused", boost::bind(&CWebServer::Cmd_SetUnused, this, _1, _2, _3));
 
-			RegisterCommandCode("addyeelight", std::bind(&CWebServer::Cmd_AddYeeLight, this, _1, _2, _3));
+			RegisterCommandCode("addlogmessage", boost::bind(&CWebServer::Cmd_AddLogMessage, this, _1, _2, _3));
+			RegisterCommandCode("clearshortlog", boost::bind(&CWebServer::Cmd_ClearShortLog, this, _1, _2, _3));
+			RegisterCommandCode("vacuumdatabase", boost::bind(&CWebServer::Cmd_VacuumDatabase, this, _1, _2, _3));
 
-			RegisterCommandCode("addArilux", std::bind(&CWebServer::Cmd_AddArilux, this, _1, _2, _3));
+			RegisterCommandCode("addmobiledevice", boost::bind(&CWebServer::Cmd_AddMobileDevice, this, _1, _2, _3));
+			RegisterCommandCode("updatemobiledevice", boost::bind(&CWebServer::Cmd_UpdateMobileDevice, this, _1, _2, _3));
+			RegisterCommandCode("deletemobiledevice", boost::bind(&CWebServer::Cmd_DeleteMobileDevice, this, _1, _2, _3));
 
-			RegisterRType("graph", std::bind(&CWebServer::RType_HandleGraph, this, _1, _2, _3));
-			RegisterRType("lightlog", std::bind(&CWebServer::RType_LightLog, this, _1, _2, _3));
-			RegisterRType("textlog", std::bind(&CWebServer::RType_TextLog, this, _1, _2, _3));
-			RegisterRType("scenelog", std::bind(&CWebServer::RType_SceneLog, this, _1, _2, _3));
-			RegisterRType("settings", std::bind(&CWebServer::RType_Settings, this, _1, _2, _3));
-			RegisterRType("events", std::bind(&CWebServer::RType_Events, this, _1, _2, _3));
+			RegisterCommandCode("addyeelight", boost::bind(&CWebServer::Cmd_AddYeeLight, this, _1, _2, _3));
 
-			RegisterRType("hardware", std::bind(&CWebServer::RType_Hardware, this, _1, _2, _3));
-			RegisterRType("devices", std::bind(&CWebServer::RType_Devices, this, _1, _2, _3));
-			RegisterRType("deletedevice", std::bind(&CWebServer::RType_DeleteDevice, this, _1, _2, _3));
-			RegisterRType("cameras", std::bind(&CWebServer::RType_Cameras, this, _1, _2, _3));
-			RegisterRType("cameras_user", std::bind(&CWebServer::RType_CamerasUser, this, _1, _2, _3));
-			RegisterRType("users", std::bind(&CWebServer::RType_Users, this, _1, _2, _3));
-			RegisterRType("mobiles", std::bind(&CWebServer::RType_Mobiles, this, _1, _2, _3));
+			RegisterCommandCode("addArilux", boost::bind(&CWebServer::Cmd_AddArilux, this, _1, _2, _3));
 
-			RegisterRType("timers", std::bind(&CWebServer::RType_Timers, this, _1, _2, _3));
-			RegisterRType("scenetimers", std::bind(&CWebServer::RType_SceneTimers, this, _1, _2, _3));
-			RegisterRType("setpointtimers", std::bind(&CWebServer::RType_SetpointTimers, this, _1, _2, _3));
+			RegisterRType("graph", boost::bind(&CWebServer::RType_HandleGraph, this, _1, _2, _3));
+			RegisterRType("lightlog", boost::bind(&CWebServer::RType_LightLog, this, _1, _2, _3));
+			RegisterRType("textlog", boost::bind(&CWebServer::RType_TextLog, this, _1, _2, _3));
+			RegisterRType("scenelog", boost::bind(&CWebServer::RType_SceneLog, this, _1, _2, _3));
+			RegisterRType("settings", boost::bind(&CWebServer::RType_Settings, this, _1, _2, _3));
+			RegisterRType("events", boost::bind(&CWebServer::RType_Events, this, _1, _2, _3));
 
-			RegisterRType("gettransfers", std::bind(&CWebServer::RType_GetTransfers, this, _1, _2, _3));
-			RegisterRType("transferdevice", std::bind(&CWebServer::RType_TransferDevice, this, _1, _2, _3));
-			RegisterRType("notifications", std::bind(&CWebServer::RType_Notifications, this, _1, _2, _3));
-			RegisterRType("schedules", std::bind(&CWebServer::RType_Schedules, this, _1, _2, _3));
-			RegisterRType("getshareduserdevices", std::bind(&CWebServer::RType_GetSharedUserDevices, this, _1, _2, _3));
-			RegisterRType("setshareduserdevices", std::bind(&CWebServer::RType_SetSharedUserDevices, this, _1, _2, _3));
-			RegisterRType("setused", std::bind(&CWebServer::RType_SetUsed, this, _1, _2, _3));
-			RegisterRType("scenes", std::bind(&CWebServer::RType_Scenes, this, _1, _2, _3));
-			RegisterRType("addscene", std::bind(&CWebServer::RType_AddScene, this, _1, _2, _3));
-			RegisterRType("deletescene", std::bind(&CWebServer::RType_DeleteScene, this, _1, _2, _3));
-			RegisterRType("updatescene", std::bind(&CWebServer::RType_UpdateScene, this, _1, _2, _3));
-			RegisterRType("createvirtualsensor", std::bind(&CWebServer::RType_CreateMappedSensor, this, _1, _2, _3));
-			RegisterRType("createdevice", std::bind(&CWebServer::RType_CreateDevice, this, _1, _2, _3));
+			RegisterRType("hardware", boost::bind(&CWebServer::RType_Hardware, this, _1, _2, _3));
+			RegisterRType("devices", boost::bind(&CWebServer::RType_Devices, this, _1, _2, _3));
+			RegisterRType("deletedevice", boost::bind(&CWebServer::RType_DeleteDevice, this, _1, _2, _3));
+			RegisterRType("cameras", boost::bind(&CWebServer::RType_Cameras, this, _1, _2, _3));
+			RegisterRType("cameras_user", boost::bind(&CWebServer::RType_CamerasUser, this, _1, _2, _3));
+			RegisterRType("users", boost::bind(&CWebServer::RType_Users, this, _1, _2, _3));
+			RegisterRType("mobiles", boost::bind(&CWebServer::RType_Mobiles, this, _1, _2, _3));
 
-			RegisterRType("createevohomesensor", std::bind(&CWebServer::RType_CreateEvohomeSensor, this, _1, _2, _3));
-			RegisterRType("bindevohome", std::bind(&CWebServer::RType_BindEvohome, this, _1, _2, _3));
-			RegisterRType("createrflinkdevice", std::bind(&CWebServer::RType_CreateRFLinkDevice, this, _1, _2, _3));
+			RegisterRType("timers", boost::bind(&CWebServer::RType_Timers, this, _1, _2, _3));
+			RegisterRType("scenetimers", boost::bind(&CWebServer::RType_SceneTimers, this, _1, _2, _3));
+			RegisterRType("setpointtimers", boost::bind(&CWebServer::RType_SetpointTimers, this, _1, _2, _3));
 
-			RegisterRType("custom_light_icons", std::bind(&CWebServer::RType_CustomLightIcons, this, _1, _2, _3));
-			RegisterRType("plans", std::bind(&CWebServer::RType_Plans, this, _1, _2, _3));
-			RegisterRType("floorplans", std::bind(&CWebServer::RType_FloorPlans, this, _1, _2, _3));
+			RegisterRType("gettransfers", boost::bind(&CWebServer::RType_GetTransfers, this, _1, _2, _3));
+			RegisterRType("transferdevice", boost::bind(&CWebServer::RType_TransferDevice, this, _1, _2, _3));
+			RegisterRType("notifications", boost::bind(&CWebServer::RType_Notifications, this, _1, _2, _3));
+			RegisterRType("schedules", boost::bind(&CWebServer::RType_Schedules, this, _1, _2, _3));
+			RegisterRType("getshareduserdevices", boost::bind(&CWebServer::RType_GetSharedUserDevices, this, _1, _2, _3));
+			RegisterRType("setshareduserdevices", boost::bind(&CWebServer::RType_SetSharedUserDevices, this, _1, _2, _3));
+			RegisterRType("setused", boost::bind(&CWebServer::RType_SetUsed, this, _1, _2, _3));
+			RegisterRType("scenes", boost::bind(&CWebServer::RType_Scenes, this, _1, _2, _3));
+			RegisterRType("addscene", boost::bind(&CWebServer::RType_AddScene, this, _1, _2, _3));
+			RegisterRType("deletescene", boost::bind(&CWebServer::RType_DeleteScene, this, _1, _2, _3));
+			RegisterRType("updatescene", boost::bind(&CWebServer::RType_UpdateScene, this, _1, _2, _3));
+			RegisterRType("createvirtualsensor", boost::bind(&CWebServer::RType_CreateMappedSensor, this, _1, _2, _3));
+			RegisterRType("createdevice", boost::bind(&CWebServer::RType_CreateDevice, this, _1, _2, _3));
+
+			RegisterRType("createevohomesensor", boost::bind(&CWebServer::RType_CreateEvohomeSensor, this, _1, _2, _3));
+			RegisterRType("bindevohome", boost::bind(&CWebServer::RType_BindEvohome, this, _1, _2, _3));
+			RegisterRType("createrflinkdevice", boost::bind(&CWebServer::RType_CreateRFLinkDevice, this, _1, _2, _3));
+
+			RegisterRType("custom_light_icons", boost::bind(&CWebServer::RType_CustomLightIcons, this, _1, _2, _3));
+			RegisterRType("plans", boost::bind(&CWebServer::RType_Plans, this, _1, _2, _3));
+			RegisterRType("floorplans", boost::bind(&CWebServer::RType_FloorPlans, this, _1, _2, _3));
 #ifdef WITH_OPENZWAVE
 			//ZWave
-			RegisterCommandCode("updatezwavenode", std::bind(&CWebServer::Cmd_ZWaveUpdateNode, this, _1, _2, _3));
-			RegisterCommandCode("deletezwavenode", std::bind(&CWebServer::Cmd_ZWaveDeleteNode, this, _1, _2, _3));
-			RegisterCommandCode("zwaveinclude", std::bind(&CWebServer::Cmd_ZWaveInclude, this, _1, _2, _3));
-			RegisterCommandCode("zwaveexclude", std::bind(&CWebServer::Cmd_ZWaveExclude, this, _1, _2, _3));
+			RegisterCommandCode("updatezwavenode", boost::bind(&CWebServer::Cmd_ZWaveUpdateNode, this, _1, _2, _3));
+			RegisterCommandCode("deletezwavenode", boost::bind(&CWebServer::Cmd_ZWaveDeleteNode, this, _1, _2, _3));
+			RegisterCommandCode("zwaveinclude", boost::bind(&CWebServer::Cmd_ZWaveInclude, this, _1, _2, _3));
+			RegisterCommandCode("zwaveexclude", boost::bind(&CWebServer::Cmd_ZWaveExclude, this, _1, _2, _3));
 
-			RegisterCommandCode("zwaveisnodeincluded", std::bind(&CWebServer::Cmd_ZWaveIsNodeIncluded, this, _1, _2, _3));
-			RegisterCommandCode("zwaveisnodeexcluded", std::bind(&CWebServer::Cmd_ZWaveIsNodeExcluded, this, _1, _2, _3));
-			RegisterCommandCode("zwaveisnodereplaced", std::bind(&CWebServer::Cmd_ZWaveIsNodeReplaced, this, _1, _2, _3));
-			RegisterCommandCode("zwaveishasnodefaileddone", std::bind(&CWebServer::Cmd_ZWaveIsHasNodeFailedDone, this, _1, _2, _3));
+			RegisterCommandCode("zwaveisnodeincluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeIncluded, this, _1, _2, _3));
+			RegisterCommandCode("zwaveisnodeexcluded", boost::bind(&CWebServer::Cmd_ZWaveIsNodeExcluded, this, _1, _2, _3));
+			RegisterCommandCode("zwaveisnodereplaced", boost::bind(&CWebServer::Cmd_ZWaveIsNodeReplaced, this, _1, _2, _3));
+			RegisterCommandCode("zwaveishasnodefaileddone", boost::bind(&CWebServer::Cmd_ZWaveIsHasNodeFailedDone, this, _1, _2, _3));
 
-			RegisterCommandCode("zwavesoftreset", std::bind(&CWebServer::Cmd_ZWaveSoftReset, this, _1, _2, _3));
-			RegisterCommandCode("zwavehardreset", std::bind(&CWebServer::Cmd_ZWaveHardReset, this, _1, _2, _3));
-			RegisterCommandCode("zwavenetworkheal", std::bind(&CWebServer::Cmd_ZWaveNetworkHeal, this, _1, _2, _3));
-			RegisterCommandCode("zwavenodeheal", std::bind(&CWebServer::Cmd_ZWaveNodeHeal, this, _1, _2, _3));
-			RegisterCommandCode("zwavenetworkinfo", std::bind(&CWebServer::Cmd_ZWaveNetworkInfo, this, _1, _2, _3));
-			RegisterCommandCode("zwaveremovegroupnode", std::bind(&CWebServer::Cmd_ZWaveRemoveGroupNode, this, _1, _2, _3));
-			RegisterCommandCode("zwaveaddgroupnode", std::bind(&CWebServer::Cmd_ZWaveAddGroupNode, this, _1, _2, _3));
-			RegisterCommandCode("zwavegroupinfo", std::bind(&CWebServer::Cmd_ZWaveGroupInfo, this, _1, _2, _3));
-			RegisterCommandCode("zwavecancel", std::bind(&CWebServer::Cmd_ZWaveCancel, this, _1, _2, _3));
-			RegisterCommandCode("applyzwavenodeconfig", std::bind(&CWebServer::Cmd_ApplyZWaveNodeConfig, this, _1, _2, _3));
-			RegisterCommandCode("zwavehasnodefailed", std::bind(&CWebServer::Cmd_ZWaveHasNodeFailed, this, _1, _2, _3));
-			RegisterCommandCode("zwavereplacefailednode", std::bind(&CWebServer::Cmd_ZWaveReplaceFailedNode, this, _1, _2, _3));
-			RegisterCommandCode("requestzwavenodeconfig", std::bind(&CWebServer::Cmd_ZWaveRequestNodeConfig, this, _1, _2, _3));
-			RegisterCommandCode("requestzwavenodeinfo", std::bind(&CWebServer::Cmd_ZWaveRequestNodeInfo, this, _1, _2, _3));
-			RegisterCommandCode("zwavestatecheck", std::bind(&CWebServer::Cmd_ZWaveStateCheck, this, _1, _2, _3));
-			RegisterCommandCode("zwavereceiveconfigurationfromothercontroller", std::bind(&CWebServer::Cmd_ZWaveReceiveConfigurationFromOtherController, this, _1, _2, _3));
-			RegisterCommandCode("zwavesendconfigurationtosecondcontroller", std::bind(&CWebServer::Cmd_ZWaveSendConfigurationToSecondaryController, this, _1, _2, _3));
-			RegisterCommandCode("zwavetransferprimaryrole", std::bind(&CWebServer::Cmd_ZWaveTransferPrimaryRole, this, _1, _2, _3));
-			RegisterCommandCode("zwavestartusercodeenrollmentmode", std::bind(&CWebServer::Cmd_ZWaveSetUserCodeEnrollmentMode, this, _1, _2, _3));
-			RegisterCommandCode("zwavegetusercodes", std::bind(&CWebServer::Cmd_ZWaveGetNodeUserCodes, this, _1, _2, _3));
-			RegisterCommandCode("zwaveremoveusercode", std::bind(&CWebServer::Cmd_ZWaveRemoveUserCode, this, _1, _2, _3));
-			RegisterCommandCode("zwavegetbatterylevels", std::bind(&CWebServer::Cmd_ZWaveGetBatteryLevels, this, _1, _2, _3));
+			RegisterCommandCode("zwavesoftreset", boost::bind(&CWebServer::Cmd_ZWaveSoftReset, this, _1, _2, _3));
+			RegisterCommandCode("zwavehardreset", boost::bind(&CWebServer::Cmd_ZWaveHardReset, this, _1, _2, _3));
+			RegisterCommandCode("zwavenetworkheal", boost::bind(&CWebServer::Cmd_ZWaveNetworkHeal, this, _1, _2, _3));
+			RegisterCommandCode("zwavenodeheal", boost::bind(&CWebServer::Cmd_ZWaveNodeHeal, this, _1, _2, _3));
+			RegisterCommandCode("zwavenetworkinfo", boost::bind(&CWebServer::Cmd_ZWaveNetworkInfo, this, _1, _2, _3));
+			RegisterCommandCode("zwaveremovegroupnode", boost::bind(&CWebServer::Cmd_ZWaveRemoveGroupNode, this, _1, _2, _3));
+			RegisterCommandCode("zwaveaddgroupnode", boost::bind(&CWebServer::Cmd_ZWaveAddGroupNode, this, _1, _2, _3));
+			RegisterCommandCode("zwavegroupinfo", boost::bind(&CWebServer::Cmd_ZWaveGroupInfo, this, _1, _2, _3));
+			RegisterCommandCode("zwavecancel", boost::bind(&CWebServer::Cmd_ZWaveCancel, this, _1, _2, _3));
+			RegisterCommandCode("applyzwavenodeconfig", boost::bind(&CWebServer::Cmd_ApplyZWaveNodeConfig, this, _1, _2, _3));
+			RegisterCommandCode("zwavehasnodefailed", boost::bind(&CWebServer::Cmd_ZWaveHasNodeFailed, this, _1, _2, _3));
+			RegisterCommandCode("zwavereplacefailednode", boost::bind(&CWebServer::Cmd_ZWaveReplaceFailedNode, this, _1, _2, _3));
+			RegisterCommandCode("requestzwavenodeconfig", boost::bind(&CWebServer::Cmd_ZWaveRequestNodeConfig, this, _1, _2, _3));
+			RegisterCommandCode("requestzwavenodeinfo", boost::bind(&CWebServer::Cmd_ZWaveRequestNodeInfo, this, _1, _2, _3));
+			RegisterCommandCode("zwavestatecheck", boost::bind(&CWebServer::Cmd_ZWaveStateCheck, this, _1, _2, _3));
+			RegisterCommandCode("zwavereceiveconfigurationfromothercontroller", boost::bind(&CWebServer::Cmd_ZWaveReceiveConfigurationFromOtherController, this, _1, _2, _3));
+			RegisterCommandCode("zwavesendconfigurationtosecondcontroller", boost::bind(&CWebServer::Cmd_ZWaveSendConfigurationToSecondaryController, this, _1, _2, _3));
+			RegisterCommandCode("zwavetransferprimaryrole", boost::bind(&CWebServer::Cmd_ZWaveTransferPrimaryRole, this, _1, _2, _3));
+			RegisterCommandCode("zwavestartusercodeenrollmentmode", boost::bind(&CWebServer::Cmd_ZWaveSetUserCodeEnrollmentMode, this, _1, _2, _3));
+			RegisterCommandCode("zwavegetusercodes", boost::bind(&CWebServer::Cmd_ZWaveGetNodeUserCodes, this, _1, _2, _3));
+			RegisterCommandCode("zwaveremoveusercode", boost::bind(&CWebServer::Cmd_ZWaveRemoveUserCode, this, _1, _2, _3));
+			RegisterCommandCode("zwavegetbatterylevels", boost::bind(&CWebServer::Cmd_ZWaveGetBatteryLevels, this, _1, _2, _3));
 
-			m_pWebEm->RegisterPageCode("/zwavegetconfig.php", std::bind(&CWebServer::ZWaveGetConfigFile, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/zwavegetconfig.php", boost::bind(&CWebServer::ZWaveGetConfigFile, this, _1, _2, _3));
 
-			m_pWebEm->RegisterPageCode("/ozwcp/poll.xml", std::bind(&CWebServer::ZWaveCPPollXml, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/cp.html", std::bind(&CWebServer::ZWaveCPIndex, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/confparmpost.html", std::bind(&CWebServer::ZWaveCPNodeGetConf, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/refreshpost.html", std::bind(&CWebServer::ZWaveCPNodeGetValues, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/valuepost.html", std::bind(&CWebServer::ZWaveCPNodeSetValue, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/buttonpost.html", std::bind(&CWebServer::ZWaveCPNodeSetButton, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/admpost.html", std::bind(&CWebServer::ZWaveCPAdminCommand, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/nodepost.html", std::bind(&CWebServer::ZWaveCPNodeChange, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/thpost.html", std::bind(&CWebServer::ZWaveCPTestHeal, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/topopost.html", std::bind(&CWebServer::ZWaveCPGetTopo, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/statpost.html", std::bind(&CWebServer::ZWaveCPGetStats, this, _1, _2, _3));
-			m_pWebEm->RegisterPageCode("/ozwcp/grouppost.html", std::bind(&CWebServer::ZWaveCPSetGroup, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/poll.xml", boost::bind(&CWebServer::ZWaveCPPollXml, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/cp.html", boost::bind(&CWebServer::ZWaveCPIndex, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/confparmpost.html", boost::bind(&CWebServer::ZWaveCPNodeGetConf, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/refreshpost.html", boost::bind(&CWebServer::ZWaveCPNodeGetValues, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/valuepost.html", boost::bind(&CWebServer::ZWaveCPNodeSetValue, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/buttonpost.html", boost::bind(&CWebServer::ZWaveCPNodeSetButton, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/admpost.html", boost::bind(&CWebServer::ZWaveCPAdminCommand, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/nodepost.html", boost::bind(&CWebServer::ZWaveCPNodeChange, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/thpost.html", boost::bind(&CWebServer::ZWaveCPTestHeal, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/topopost.html", boost::bind(&CWebServer::ZWaveCPGetTopo, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/statpost.html", boost::bind(&CWebServer::ZWaveCPGetStats, this, _1, _2, _3));
+			m_pWebEm->RegisterPageCode("/ozwcp/grouppost.html", boost::bind(&CWebServer::ZWaveCPSetGroup, this, _1, _2, _3));
 			//
 			//pollpost.html
-			RegisterRType("openzwavenodes", std::bind(&CWebServer::RType_OpenZWaveNodes, this, _1, _2, _3));
+			RegisterRType("openzwavenodes", boost::bind(&CWebServer::RType_OpenZWaveNodes, this, _1, _2, _3));
 #endif
-			RegisterCommandCode("tellstickApplySettings", std::bind(&CWebServer::Cmd_TellstickApplySettings, this, _1, _2, _3));
+			RegisterCommandCode("tellstickApplySettings", boost::bind(&CWebServer::Cmd_TellstickApplySettings, this, _1, _2, _3));
 
 			m_pWebEm->RegisterWhitelistURLString("/html5.appcache");
 			m_pWebEm->RegisterWhitelistURLString("/images/floorplans/plan");

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -178,6 +178,8 @@
 #include <fstream>
 #endif
 
+using namespace boost::placeholders;
+
 #define round(a) ( int ) ( a + .5 )
 
 extern std::string szStartupFolder;
@@ -346,8 +348,8 @@ void MainWorker::AddDomoticzHardware(CDomoticzHardwareBase* pHardware)
 	if (devidx != -1) //it is already there!, remove it
 		RemoveDomoticzHardware(m_hardwaredevices[devidx]);
 	std::lock_guard<std::mutex> l(m_devicemutex);
-	pHardware->sDecodeRXMessage.connect([this](const CDomoticzHardwareBase *hw, const uint8_t *rx, const char *name, int battery) { DecodeRXMessage(hw, rx, name, battery); });
-	pHardware->sOnConnected.connect([this](CDomoticzHardwareBase *hw) { OnHardwareConnected(hw); });
+	pHardware->sDecodeRXMessage.connect(boost::bind(&MainWorker::DecodeRXMessage, this, _1, _2, _3, _4));
+	pHardware->sOnConnected.connect(boost::bind(&MainWorker::OnHardwareConnected, this, _1));
 	m_hardwaredevices.push_back(pHardware);
 }
 
@@ -1180,7 +1182,7 @@ bool MainWorker::Start()
 	{
 		char szPort[100];
 		sprintf(szPort, "%d", rnvalue);
-		m_sharedserver.sDecodeRXMessage.connect([this](const CDomoticzHardwareBase *hw, const uint8_t *rx, const char *name, int battery) { DecodeRXMessage(hw, rx, name, battery); });
+		m_sharedserver.sDecodeRXMessage.connect(boost::bind(&MainWorker::DecodeRXMessage, this, _1, _2, _3, _4));
 		m_sharedserver.StartServer("::", szPort);
 
 		LoadSharedUsers();
@@ -1524,7 +1526,7 @@ void MainWorker::ParseRFXLogFile()
 	if (pHardware == NULL)
 	{
 		pHardware = new CDummy(HWID);
-		// pHardware->sDecodeRXMessage.connect(std::bind(&MainWorker::DecodeRXMessage, this, _1, _2, _3, _4));
+		//pHardware->sDecodeRXMessage.connect(boost::bind(&MainWorker::DecodeRXMessage, this, _1, _2, _3, _4));
 		AddDomoticzHardware(pHardware);
 	}
 

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -136,7 +136,9 @@ bool CNotificationHelper::SendMessageEx(
 			{
 				if (bThread)
 				{
-					boost::thread SendMessageEx([=] { m_notifier.second->SendMessageEx(Idx, Name, Subject, Text, ExtraData, Priority, Sound, bFromNotification); });
+					boost::thread SendMessageEx(boost::bind(&CNotificationBase::SendMessageEx, m_notifier.second, Idx,
+										Name, Subject, Text, ExtraData, Priority, Sound,
+										bFromNotification));
 					SetThreadName(SendMessageEx.native_handle(), "SendMessageEx");
 				}
 				else

--- a/push/FibaroPush.cpp
+++ b/push/FibaroPush.cpp
@@ -14,6 +14,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+using namespace boost::placeholders;
+
 CFibaroPush::CFibaroPush()
 {
 	m_PushType = PushType::PUSHTYPE_FIBARO;
@@ -23,7 +25,7 @@ CFibaroPush::CFibaroPush()
 void CFibaroPush::Start()
 {
 	UpdateActive();
-	m_sConnection = m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *rx) { OnDeviceReceived(id, idx, name, rx); });
+	m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&CFibaroPush::OnDeviceReceived, this, _1, _2, _3, _4));
 }
 
 void CFibaroPush::Stop()

--- a/push/GooglePubSubPush.cpp
+++ b/push/GooglePubSubPush.cpp
@@ -21,6 +21,8 @@ extern "C" {
 #include <boost/python.hpp>
 #endif
 
+using namespace boost::placeholders;
+
 extern std::string szUserDataFolder;
 
 // this should be filled in by the preprocessor
@@ -39,7 +41,7 @@ CGooglePubSubPush::CGooglePubSubPush()
 void CGooglePubSubPush::Start()
 {
 	UpdateActive();
-	m_sConnection = m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *rx) { OnDeviceReceived(id, idx, name, rx); });
+	m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&CGooglePubSubPush::OnDeviceReceived, this, _1, _2, _3, _4));
 }
 
 void CGooglePubSubPush::Stop()

--- a/push/HttpPush.cpp
+++ b/push/HttpPush.cpp
@@ -15,6 +15,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+using namespace boost::placeholders;
+
 CHttpPush::CHttpPush()
 {
 	m_PushType = PushType::PUSHTYPE_HTTP;
@@ -24,7 +26,7 @@ CHttpPush::CHttpPush()
 void CHttpPush::Start()
 {
 	UpdateActive();
-	m_sConnection = m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *rx) { OnDeviceReceived(id, idx, name, rx); });
+	m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&CHttpPush::OnDeviceReceived, this, _1, _2, _3, _4));
 }
 
 void CHttpPush::Stop()

--- a/push/InfluxPush.cpp
+++ b/push/InfluxPush.cpp
@@ -15,6 +15,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+using namespace boost::placeholders;
+
 CInfluxPush::CInfluxPush()
 {
 	m_PushType = PushType::PUSHTYPE_INFLUXDB;
@@ -32,7 +34,7 @@ bool CInfluxPush::Start()
 	m_thread = std::make_shared<std::thread>(&CInfluxPush::Do_Work, this);
 	SetThreadName(m_thread->native_handle(), "InfluxPush");
 
-	m_sConnection = m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *rx) { OnDeviceReceived(id, idx, name, rx); });
+	m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&CInfluxPush::OnDeviceReceived, this, _1, _2, _3, _4));
 
 	return (m_thread != nullptr);
 }

--- a/push/WebsocketPush.cpp
+++ b/push/WebsocketPush.cpp
@@ -3,7 +3,10 @@
 #include "../webserver/WebsocketHandler.h"
 #include "../main/mainworker.h"
 
+using namespace boost::placeholders;
+
 extern boost::signals2::signal<void(const std::string &Subject, const std::string &Text, const std::string &ExtraData, const int Priority, const std::string & Sound, const bool bFromNotification)> sOnNotificationReceived;
+
 
 CWebSocketPush::CWebSocketPush(http::server::CWebsocketHandler *sock)
 {
@@ -19,11 +22,10 @@ void CWebSocketPush::Start()
 	if (isStarted) {
 		return;
 	}
-	m_sConnection = m_mainworker.sOnDeviceReceived.connect([this](int id, uint64_t idx, const std::string &name, const unsigned char *rx) { OnDeviceReceived(id, idx, name, rx); });
-	m_sDeviceUpdate = m_mainworker.sOnDeviceUpdate.connect([this](int id, uint64_t idx) { OnDeviceUpdate(id, idx); });
-	m_sNotification = sOnNotificationReceived.connect(
-		[this](const std::string &s, const std::string &t, const std::string &e, int p, const std::string &sound, bool n) { OnNotificationReceived(s, t, e, p, sound, n); });
-	m_sSceneChanged = m_mainworker.sOnSwitchScene.connect([this](uint64_t idx, const std::string &name) { OnSceneChange(idx, name); });
+	m_sConnection = m_mainworker.sOnDeviceReceived.connect(boost::bind(&CWebSocketPush::OnDeviceReceived, this, _1, _2, _3, _4));
+	m_sDeviceUpdate = m_mainworker.sOnDeviceUpdate.connect(boost::bind(&CWebSocketPush::OnDeviceUpdate, this, _1, _2));
+	m_sNotification = sOnNotificationReceived.connect(boost::bind(&CWebSocketPush::OnNotificationReceived, this, _1, _2, _3, _4, _5, _6));
+	m_sSceneChanged = m_mainworker.sOnSwitchScene.connect(boost::bind(&CWebSocketPush::OnSceneChange, this, _1, _2));
 	isStarted = true;
 }
 

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -5,6 +5,7 @@
 //Modified, extended etc by Robbert E. Peters/RTSS B.V.
 #include "stdafx.h"
 #include "cWebem.h"
+#include <boost/bind/bind.hpp>
 #include "reply.hpp"
 #include "request.hpp"
 #include "mime_types.hpp"
@@ -52,8 +53,8 @@ namespace http {
 			, m_session_clean_timer(m_io_service, boost::posix_time::minutes(1))
 		{
 			// associate handler to timer and schedule the first iteration
-			m_session_clean_timer.async_wait([this](const boost::system::error_code &) { CleanSessions(); });
-			m_io_service_thread = std::make_shared<std::thread>([this] { m_io_service.run(); });
+			m_session_clean_timer.async_wait(boost::bind(&cWebem::CleanSessions, this));
+			m_io_service_thread = std::make_shared<std::thread>(boost::bind(&boost::asio::io_service::run, &m_io_service));
 			SetThreadName(m_io_service_thread->native_handle(), "Webem_ssncleaner");
 		}
 
@@ -1205,7 +1206,7 @@ namespace http {
 			}
 			// Schedule next cleanup
 			m_session_clean_timer.expires_at(m_session_clean_timer.expires_at() + boost::posix_time::minutes(15));
-			m_session_clean_timer.async_wait([this](const boost::system::error_code &) { CleanSessions(); });
+			m_session_clean_timer.async_wait(boost::bind(&cWebem::CleanSessions, this));
 		}
 
 		// Return 1 on success. Always initializes the ah structure.

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -9,12 +9,15 @@
 //
 #include "stdafx.h"
 #include "connection.hpp"
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string.hpp>
 #include "connection_manager.hpp"
 #include "request_handler.hpp"
 #include "mime_types.hpp"
 #include "../main/localtime_r.h"
 #include "../main/Logger.h"
+
+using namespace boost::placeholders;
 
 namespace http {
 	namespace server {
@@ -33,7 +36,7 @@ namespace http {
 			, request_handler_(handler)
 			, status_(INITIALIZING)
 			, default_max_requests_(20)
-			, websocket_parser([this](const std::string &r) { MyWrite(r); }, handler.Get_myWebem(), [this](const std::string &r) { WS_Write(r); })
+			, websocket_parser(boost::bind(&connection::MyWrite, this, _1), handler.Get_myWebem(), boost::bind(&connection::WS_Write, this, _1))
 		{
 			secure_ = false;
 			keepalive_ = false;
@@ -58,7 +61,7 @@ namespace http {
 			, request_handler_(handler)
 			, status_(INITIALIZING)
 			, default_max_requests_(20)
-			, websocket_parser([this](const std::string &r) { MyWrite(r); }, handler.Get_myWebem(), [this](const std::string &r) { WS_Write(r); })
+			, websocket_parser(boost::bind(&connection::MyWrite, this, _1), handler.Get_myWebem(), boost::bind(&connection::WS_Write, this, _1))
 		{
 			secure_ = true;
 			keepalive_ = false;
@@ -108,7 +111,9 @@ namespace http {
 #ifdef WWW_ENABLE_SSL
 				status_ = WAITING_HANDSHAKE;
 				// with ssl, we first need to complete the handshake before reading
-				sslsocket_->async_handshake(boost::asio::ssl::stream_base::server, [this](const boost::system::error_code &err) { shared_from_this()->handle_handshake(err); });
+				sslsocket_->async_handshake(boost::asio::ssl::stream_base::server,
+					boost::bind(&connection::handle_handshake, shared_from_this(),
+						boost::asio::placeholders::error));
 #endif
 			}
 			else {
@@ -202,12 +207,18 @@ namespace http {
 			if (secure_) {
 #ifdef WWW_ENABLE_SSL
 				// Perform secure read
-				sslsocket_->async_read_some(buf, [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_read(err, bytes); });
+				sslsocket_->async_read_some(buf,
+					boost::bind(&connection::handle_read, shared_from_this(),
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 #endif
 			}
 			else {
 				// Perform plain read
-				socket_->async_read_some(buf, [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_read(err, bytes); });
+				socket_->async_read_some(buf,
+					boost::bind(&connection::handle_read, shared_from_this(),
+						boost::asio::placeholders::error,
+						boost::asio::placeholders::bytes_transferred));
 			}
 		}
 
@@ -221,13 +232,11 @@ namespace http {
 			write_buffer = buf;
 			if (secure_) {
 #ifdef WWW_ENABLE_SSL
-				boost::asio::async_write(*sslsocket_, boost::asio::buffer(write_buffer),
-							 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write(err, bytes); });
+				boost::asio::async_write(*sslsocket_, boost::asio::buffer(write_buffer), boost::bind(&connection::handle_write, shared_from_this(), boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 #endif
 			}
 			else {
-				boost::asio::async_write(*socket_, boost::asio::buffer(write_buffer),
-							 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write(err, bytes); });
+				boost::asio::async_write(*socket_, boost::asio::buffer(write_buffer), boost::bind(&connection::handle_write, shared_from_this(), boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 			}
 
 		}
@@ -277,13 +286,11 @@ namespace http {
 				};
 				if (secure_) {
 #ifdef WWW_ENABLE_SSL
-					boost::asio::async_write(*sslsocket_, boost::asio::buffer(send_buffer_, bread),
-								 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write_file(err, bytes); });
+					boost::asio::async_write(*sslsocket_, boost::asio::buffer(send_buffer_, bread), boost::bind(&connection::handle_write_file, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 #endif
 				}
 				else {
-					boost::asio::async_write(*socket_, boost::asio::buffer(send_buffer_, bread),
-								 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write_file(err, bytes); });
+					boost::asio::async_write(*socket_, boost::asio::buffer(send_buffer_, bread), boost::bind(&connection::handle_write_file, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 				}
 				return;
 			}
@@ -343,13 +350,11 @@ namespace http {
 
 			if (secure_) {
 #ifdef WWW_ENABLE_SSL
-				boost::asio::async_write(*sslsocket_, boost::asio::buffer(write_buffer),
-							 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write_file(err, bytes); });
+				boost::asio::async_write(*sslsocket_, boost::asio::buffer(write_buffer), boost::bind(&connection::handle_write_file, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 #endif
 			}
 			else {
-				boost::asio::async_write(*socket_, boost::asio::buffer(write_buffer),
-							 [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_write_file(err, bytes); });
+				boost::asio::async_write(*socket_, boost::asio::buffer(write_buffer), boost::bind(&connection::handle_write_file, this, boost::asio::placeholders::error, boost::asio::placeholders::bytes_transferred));
 			}
 			return true;
 		}
@@ -561,7 +566,7 @@ This does not seem to print the correct request
 		// schedule read timeout timer
 		void connection::set_read_timeout() {
 			read_timer_.expires_from_now(boost::posix_time::seconds(read_timeout_));
-			read_timer_.async_wait([this](const boost::system::error_code &err) { shared_from_this()->handle_read_timeout(err); });
+			read_timer_.async_wait(boost::bind(&connection::handle_read_timeout, shared_from_this(), boost::asio::placeholders::error));
 		}
 
 		/// simply cancel read timeout timer
@@ -604,7 +609,7 @@ This does not seem to print the correct request
 		/// schedule abandoned timeout timer
 		void connection::set_abandoned_timeout() {
 			abandoned_timer_.expires_from_now(boost::posix_time::seconds(default_abandoned_timeout_));
-			abandoned_timer_.async_wait([this](const boost::system::error_code &err) { shared_from_this()->handle_abandoned_timeout(err); });
+			abandoned_timer_.async_wait(boost::bind(&connection::handle_abandoned_timeout, shared_from_this(), boost::asio::placeholders::error));
 		}
 
 		/// simply cancel abandoned timeout timer

--- a/webserver/connection_manager.cpp
+++ b/webserver/connection_manager.cpp
@@ -10,8 +10,11 @@
 #include "stdafx.h"
 #include "connection_manager.hpp"
 #include <algorithm>
+#include <boost/bind/bind.hpp>
 #include <iostream>
 #include "../main/Logger.h"
+
+using namespace boost::placeholders;
 
 namespace http {
 namespace server {
@@ -54,7 +57,8 @@ namespace server {
 
 void connection_manager::stop_all()
 {
-	std::for_each(connections_.begin(), connections_.end(), [](const std::shared_ptr<http::server::connection> &con) { con->stop(); });
+	std::for_each(connections_.begin(), connections_.end(),
+			boost::bind(&connection::stop, _1));
 	connections_.clear();
 }
 

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -10,6 +10,8 @@
 #include "../tcpserver/TCPServer.h"
 #include "sha1.hpp"
 
+using namespace boost::placeholders;
+
 // RK: some defines to make mydomoticz also work when openssl not compiled in
 #ifdef WWW_ENABLE_SSL
 #define PROXY_PORT 443
@@ -352,7 +354,7 @@ namespace http {
 			// todo: make a map of websocket connections. There can be more than one.
 			// open new virtual websocket connection
 			// todo: different request_url's can have different websocket handlers
-			websocket_handlers[pdu->m_requestid] = new CWebsocketHandler(m_pWebEm, [this, &pdu](const std::string &d) { WS_Write(pdu->m_requestid, d); });
+			websocket_handlers[pdu->m_requestid] = new CWebsocketHandler(m_pWebEm, boost::bind(&CProxyClient::WS_Write, this, pdu->m_requestid, _1));
 			websocket_handlers[pdu->m_requestid]->Start();
 		}
 


### PR DESCRIPTION
Reverts domoticz/domoticz#4417

Needed because it crashed in

connection.cpp
line 210

```
			else {
				// Perform plain read
				socket_->async_read_some(buf, [this](const boost::system::error_code &err, size_t bytes) { shared_from_this()->handle_read(err, bytes); });
			}

```