### PR TITLE
Custom panasonic remote buttons

### DIFF
--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -96,9 +96,9 @@ class CPanasonicNode : public StoppableTask
 		void			Clear();
 		std::string		LogMessage();
 		std::string		StatusMessage();
-		bool			LogRequired(CPanasonicStatus&);
-		bool			UpdateRequired(CPanasonicStatus&);
-		bool			OnOffRequired(CPanasonicStatus&);
+		bool			LogRequired(CPanasonicStatus& pPrevious);
+		bool			UpdateRequired(CPanasonicStatus& pPrevious);
+		bool			OnOffRequired(CPanasonicStatus& pPrevious);
 		bool			IsOn() { return (m_nStatus != MSTAT_OFF); };
 		void			Volume(int pVolume) { m_VolumeLevel = pVolume; };
 		void			Muted(bool pMuted) { m_Muted = pMuted; };
@@ -111,7 +111,8 @@ class CPanasonicNode : public StoppableTask
 	};
 
 public:
-  CPanasonicNode(int, int, int, const std::string &, const std::string &, const std::string &, const std::string &);
+  CPanasonicNode(const int pHwdID, const int PollIntervalsec, const int pTimeoutMs,
+	const std::string& pID, const std::string& pName, const std::string& pIP, const std::string& pPort);
   ~CPanasonicNode();
   void Do_Work();
   void SendCommand(const std::string &command);
@@ -136,13 +137,13 @@ protected:
 	bool			m_Stoppable;
 
 private:
-  bool handleConnect(boost::asio::ip::tcp::socket &, const boost::asio::ip::tcp::endpoint &, boost::system::error_code &);
-  std::string handleWriteAndRead(const std::string &);
-  int handleMessage(const std::string &);
-  std::string buildXMLStringRendCtl(const std::string &, const std::string &);
-  std::string buildXMLStringRendCtl(const std::string &, const std::string &, const std::string &);
-  std::string buildXMLStringNetCtl(const std::string &);
-  std::string buildXMLStringAppCtl(const std::string &);
+  bool handleConnect(boost::asio::ip::tcp::socket &socket, const boost::asio::ip::tcp::endpoint &endpoint, boost::system::error_code &ec);
+  std::string handleWriteAndRead(const std::string &pMessageToSend);
+  int handleMessage(const std::string &pMessage);
+  std::string buildXMLStringRendCtl(const std::string &action, const std::string &command);
+  std::string buildXMLStringRendCtl(const std::string &action, const std::string &command, const std::string &value);
+  std::string buildXMLStringNetCtl(const std::string &command);
+  std::string buildXMLStringAppCtl(const std::string &productId);
 
   int m_HwdID;
   char m_szDevID[40];

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -72,10 +72,10 @@ Possible Commands:
 "NRC_D0-ONOFF"        => "Digit 0",
 "NRC_P_NR-ONOFF"      => "P-NR (Noise reduction)",
 "NRC_R_TUNE-ONOFF"    => "Seems to do the same as INFO",
-"NRC_HDMI1"           => "Switch to HDMI input 1",
-"NRC_HDMI2"           => "Switch to HDMI input 2",
-"NRC_HDMI3"           => "Switch to HDMI input 3",
-"NRC_HDMI4"           => "Switch to HDMI input 4",
+"NRC_HDMI1-ONOFF"     => "Switch to HDMI input 1",
+"NRC_HDMI2-ONOFF"     => "Switch to HDMI input 2",
+"NRC_HDMI3-ONOFF"     => "Switch to HDMI input 3",
+"NRC_HDMI4-ONOFF"     => "Switch to HDMI input 4",
 
 
 */
@@ -142,6 +142,7 @@ private:
   std::string buildXMLStringRendCtl(const std::string &, const std::string &);
   std::string buildXMLStringRendCtl(const std::string &, const std::string &, const std::string &);
   std::string buildXMLStringNetCtl(const std::string &);
+  std::string buildXMLStringAppCtl(const std::string &);
 
   int m_HwdID;
   char m_szDevID[40];
@@ -526,6 +527,35 @@ std::string CPanasonicNode::buildXMLStringNetCtl(const std::string &command)
 
 }
 
+std::string CPanasonicNode::buildXMLStringAppCtl(const std::string &productId)
+{
+	std::string head, body;
+	int size;
+
+	body = R"(<?xml version="1.0" encoding="utf-8"?>)";
+	body += R"(<s:Envelope s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">)";
+	body += "<s:Body>";
+	body += "<u:X_LaunchApp xmlns:u=\"urn:panasonic-com:service:p00NetworkControl:1\">";
+    body += "<X_AppType>vc_app</X_AppType>";
+    body += "<X_LaunchKeyword>product_id=" + productId + "</X_LaunchKeyword>";
+    body += "</u:X_LaunchApp>";
+	body += "</s:Body>";
+	body += "</s:Envelope>";
+
+	size = body.length();
+
+	head += "POST /nrc/control_0 HTTP/1.1\r\n";
+	head += "Host: " + m_IP + ":" + m_Port + "\r\n";
+	head += "SOAPACTION: \"urn:panasonic-com:service:p00NetworkControl:1#X_LaunchApp\"\r\n";
+	head += "Content-Type: text/xml; charset=\"utf-8\"\r\n";
+	head += "Content-Length: " + std::to_string(size) + "\r\n";
+	head += "\r\n";
+
+	return head + body;
+
+}
+
+
 
 void CPanasonicNode::Do_Work()
 {
@@ -655,13 +685,13 @@ void CPanasonicNode::SendCommand(const std::string &command)
 	else if (command == "0")
 		sPanasonicCall = buildXMLStringNetCtl("D0-ONOFF");
 	else if (command == "hdmi1")
-		sPanasonicCall = buildXMLStringNetCtl("HDMI1");
+		sPanasonicCall = buildXMLStringNetCtl("HDMI1-ONOFF");
 	else if (command == "hdmi2")
-		sPanasonicCall = buildXMLStringNetCtl("HDMI2");
+		sPanasonicCall = buildXMLStringNetCtl("HDMI2-ONOFF");
 	else if (command == "hdmi3")
-		sPanasonicCall = buildXMLStringNetCtl("HDMI3");
+		sPanasonicCall = buildXMLStringNetCtl("HDMI3-ONOFF");
 	else if (command == "hdmi4")
-		sPanasonicCall = buildXMLStringNetCtl("HDMI4");
+		sPanasonicCall = buildXMLStringNetCtl("HDMI4-ONOFF");
 	else if (command == "Rewind")
 		sPanasonicCall = buildXMLStringNetCtl("REW-ONOFF");
 	else if (command == "FastForward")
@@ -676,6 +706,41 @@ void CPanasonicNode::SendCommand(const std::string &command)
 		sPanasonicCall = buildXMLStringNetCtl("POWER-ONOFF");
 	else if (command == "ShowSubtitles")
 		sPanasonicCall = buildXMLStringNetCtl("STTL-ONOFF");
+	// Application Codes from : https://github.com/g30r93g/homebridge-panasonic#readme
+	//  and : https://forums.indigodomo.com/viewtopic.php?f=134&t=17875&start=15
+	else if (command == "Netflix")	sPanasonicCall = buildXMLStringAppCtl("0010000200000001");
+	else if (command == "YouTube")	sPanasonicCall = buildXMLStringAppCtl("0070000200170001");
+	else if (command == "Amazon Prime Video")	sPanasonicCall = buildXMLStringAppCtl("0010000100170001");
+	else if (command == "Plex")	sPanasonicCall = buildXMLStringAppCtl("0076010507000001");
+	else if (command == "BBC iPlayer")	sPanasonicCall = buildXMLStringAppCtl("0020000A00170010");
+	else if (command == "BBC News")	sPanasonicCall = buildXMLStringAppCtl("0020000A00170006");
+	else if (command == "BBC Sport")	sPanasonicCall = buildXMLStringAppCtl("0020000A00170007");
+	else if (command == "ITV Hub")	sPanasonicCall = buildXMLStringAppCtl("0387878700000124");
+	else if (command == "TuneIn")	sPanasonicCall = buildXMLStringAppCtl("0010001800000001");
+	else if (command == "AccuWeather")	sPanasonicCall = buildXMLStringAppCtl("0070000C00000001");
+	else if (command == "All 4")	sPanasonicCall = buildXMLStringAppCtl("0387878700000125");
+	else if (command == "Demand 5")	sPanasonicCall = buildXMLStringAppCtl("0020009300000002");
+	else if (command == "Rakuten TV")	sPanasonicCall = buildXMLStringAppCtl("0020002A00000001");
+	else if (command == "CHILI")	sPanasonicCall = buildXMLStringAppCtl("0020004700000001");
+	else if (command == "STV Player")	sPanasonicCall = buildXMLStringAppCtl("0387878700000132");
+	else if (command == "Digital Concert Hall")	sPanasonicCall = buildXMLStringAppCtl("0076002307170001");
+	else if (command == "Apps Market")	sPanasonicCall = buildXMLStringAppCtl("0387878700000102");
+	else if (command == "Browser")	sPanasonicCall = buildXMLStringAppCtl("0077777700160002");
+	else if (command == "Calendar")	sPanasonicCall = buildXMLStringAppCtl("0387878700150020");
+	else if (command == "VIERA Link")	sPanasonicCall = buildXMLStringAppCtl("0387878700000016");
+	else if (command == "Recorded TV")	sPanasonicCall = buildXMLStringAppCtl("0387878700000013");
+	else if (command == "Freeview Catch Up")	sPanasonicCall = buildXMLStringAppCtl("0387878700000109");
+	else if (command == "MediaPlayer")	sPanasonicCall = buildXMLStringAppCtl("0387878700000032");
+	else if (command == "DLNAPlayer")	sPanasonicCall = buildXMLStringAppCtl("0387878700000014");
+	else if (command == "TV")	sPanasonicCall = buildXMLStringAppCtl("0387878700000001");
+	else if (command == "AppsMenu")	sPanasonicCall = buildXMLStringAppCtl("0387878700000009");
+	else if (command == "WebBrowser")	sPanasonicCall = buildXMLStringAppCtl("0077777700000002");
+	else if (command == "Skype")	sPanasonicCall = buildXMLStringAppCtl("0070000600000001");
+	else if (command == "Mirroring")	sPanasonicCall = buildXMLStringAppCtl("0387878700000049");
+	else if (command == "TouchConnect")	sPanasonicCall = buildXMLStringAppCtl("0387878700000038");
+	else if (command == "Weather")	sPanasonicCall = buildXMLStringAppCtl("0070000900000001");
+	else if (command == "YouTube2")	sPanasonicCall = buildXMLStringAppCtl("0070000200000001");
+	
 	else if (command == "On" || command == "on")
 	{
 		if (m_PowerOnSupported)
@@ -689,8 +754,33 @@ void CPanasonicNode::SendCommand(const std::string &command)
 			UpdateStatus(true);
 		}
 	}
-	else
-		_log.Log(LOG_ERROR, "Panasonic Plugin: (%s) Unknown command: '%s'.", m_Name.c_str(), command.c_str());
+	else {
+		CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(m_HwdID);
+		if (pBaseHardware == nullptr)
+			return;
+		if (pBaseHardware->HwdType != HTYPE_PanasonicTV)
+			return;
+		CPanasonic *pHardware = reinterpret_cast<CPanasonic*>(pBaseHardware);
+		if (pHardware->m_bUnknownCommandAllowed) {
+			// Sanitize command : keep only alphanumeric characters
+			std::string sanityze = command;
+			sanityze.erase(
+				std::remove_if(
+					sanityze.begin(), 
+					sanityze.end(), 
+					[]( char const& c ) -> bool { return ! (std::isalnum(c) || (std::string("_-+.:=").find(c) != std::string::npos)); } 
+				), sanityze.end());
+			_log.Log(LOG_STATUS, "Panasonic Plugin: (%s) Unknown command: '%s'. Trying anyway.", m_Name.c_str(), sanityze.c_str());
+			if (sanityze.rfind("app",0) == 0) {
+				sanityze.erase(0,3);
+				sPanasonicCall = buildXMLStringAppCtl(sanityze.c_str());
+			} else {
+				sPanasonicCall = buildXMLStringNetCtl(sanityze.c_str());
+			}
+		} else {
+			_log.Log(LOG_ERROR, "Panasonic Plugin: (%s) Unknown command: '%s'. ", m_Name.c_str(), command.c_str());
+		}
+	}
 
 	if (sPanasonicCall.length())
 	{
@@ -738,16 +828,16 @@ void CPanasonicNode::SetExecuteCommand(const std::string &command)
 
 std::vector<std::shared_ptr<CPanasonicNode> > CPanasonic::m_pNodes;
 
-CPanasonic::CPanasonic(const int ID, const int PollIntervalsec, const int PingTimeoutms)
+CPanasonic::CPanasonic(const int ID, const int PollIntervalsec, const int PingTimeoutms, const int mode3)
 {
 	m_HwdID = ID;
-	SetSettings(PollIntervalsec, PingTimeoutms);
+	SetSettings(PollIntervalsec, PingTimeoutms, mode3);
 }
 
 CPanasonic::CPanasonic(const int ID)
 {
 	m_HwdID = ID;
-	SetSettings(10, 3000);
+	SetSettings(10, 3000, 0);
 }
 
 CPanasonic::~CPanasonic()
@@ -818,16 +908,19 @@ void CPanasonic::Do_Work()
 	_log.Log(LOG_STATUS, "Panasonic Plugin: Worker stopped...");
 }
 
-void CPanasonic::SetSettings(const int PollIntervalsec, const int PingTimeoutms)
+void CPanasonic::SetSettings(const int PollIntervalsec, const int PingTimeoutms, const int iMode3)
 {
 	//Defaults
 	m_iPollInterval = 30;
 	m_iPingTimeoutms = 1000;
+	m_bUnknownCommandAllowed = 0;
 
 	if (PollIntervalsec > 1)
 		m_iPollInterval = PollIntervalsec;
 	if ((PingTimeoutms / 1000 < m_iPollInterval) && (PingTimeoutms != 0))
 		m_iPingTimeoutms = PingTimeoutms;
+
+	m_bUnknownCommandAllowed =  iMode3 & 1;
 }
 
 bool CPanasonic::WriteToHardware(const char *pdata, const unsigned char /*length*/)
@@ -1082,6 +1175,8 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			std::string mode1 = request::findValue(&req, "mode1");
 			std::string mode2 = request::findValue(&req, "mode2");
+			std::string mode3 = request::findValue(&req, "mode3");
+			std::string extra = request::findValue(&req, "extra");
 			if ((hwid.empty()) || (mode1.empty()) || (mode2.empty()))
 				return;
 			int iHardwareID = atoi(hwid.c_str());
@@ -1097,9 +1192,11 @@ namespace http {
 
 			int iMode1 = atoi(mode1.c_str());
 			int iMode2 = atoi(mode2.c_str());
+			int iMode3 = atoi(mode3.c_str());
 
-			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')", iMode1, iMode2, hwid.c_str());
-			pHardware->SetSettings(iMode1, iMode2);
+			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d, Mode3=%d, Extra='%s' WHERE (ID == '%q')", iMode1, iMode2, iMode3, extra.c_str(), hwid.c_str());
+
+			pHardware->SetSettings(iMode1, iMode2, iMode3);
 			pHardware->Restart();
 		}
 

--- a/hardware/PanasonicTV.h
+++ b/hardware/PanasonicTV.h
@@ -12,7 +12,7 @@ class CPanasonicNode;
 class CPanasonic : public CDomoticzHardwareBase
 {
       public:
-	CPanasonic(int ID, int PollIntervalsec, int PingTimeoutms);
+	CPanasonic(int ID, int PollIntervalsec, int PingTimeoutms, int Mode3);
 	explicit CPanasonic(int ID);
 	~CPanasonic() override;
 	bool WriteToHardware(const char *pdata, unsigned char length) override;
@@ -20,7 +20,7 @@ class CPanasonic : public CDomoticzHardwareBase
 	bool UpdateNode(int ID, const std::string &Name, const std::string &IPAddress, int Port);
 	void RemoveNode(int ID);
 	void RemoveAllNodes();
-	void SetSettings(int PollIntervalsec, int PingTimeoutms);
+	void SetSettings(int PollIntervalsec, int PingTimeoutms, int Mode3);
 	void SendCommand(int ID, const std::string &command);
 	bool SetExecuteCommand(int ID, const std::string &command);
 
@@ -37,7 +37,10 @@ class CPanasonic : public CDomoticzHardwareBase
 	static std::vector<std::shared_ptr<CPanasonicNode>> m_pNodes;
 	int m_iPollInterval;
 	int m_iPingTimeoutms;
+	bool m_bUnknownCommandAllowed;
 	std::shared_ptr<std::thread> m_thread;
 	std::mutex m_mutex;
 	boost::asio::io_service m_ios;
+
+	friend class CPanasonicNode; 
 };

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -839,7 +839,7 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_PanasonicTV:
 		//Panasonic Viera TV's
-		pHardware = new CPanasonic(ID, Mode1, Mode2);
+		pHardware = new CPanasonic(ID, Mode1, Mode2, Mode3);
 		break;
 	case HTYPE_Mochad:
 		//LAN

--- a/www/app/hardware/setup/PanasonicTV.html
+++ b/www/app/hardware/setup/PanasonicTV.html
@@ -17,6 +17,23 @@
             <td align="right" style="width:110px"><label for="pingtimeout"><span data-i18n="Ping Timeout"></span>:</label></td>
             <td><input type="text" id="pingtimeout" style="width: 80px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;(<span data-i18n="Milliseconds"></span>)</td>
         </tr>
+        <tr valign="top">
+            <td align="right" style="width:110px"><label for="custombuttons"><span data-i18n="Custom buttons"></span>:</label></td>
+            <td><input type="text" id="custombuttons" style="width: 600px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;
+            <br /><span data-i18n="Button with Title:command, separated by ',', and lines separated by ';'"></span>
+            <br /><span data-i18n="Full Example: HDMI1:hdmi1,HDMI2:hdmi2,HDMI3:hdmi3,TV:inputtv;YouTube:YouTube2,DLNA:DLNAPlayer,Record:app0387878700000013,Apps:APPS-ONOFF;EPG:guide,3D:3D-ONOFF,Ratio:DISP_MODE-ONOFF,CEC:VIERA_LINK-ONOFF,AV:inputav"></span>
+            <br /><span data-i18n="See source code of domoticz hardware/PanasonicTC.cpp for list of supported commands and applications codes."></span>
+            <br /><span data-i18n="To be able to use unknown commands, please check the option in settings. The command will be prefixed by 'NRC_'."></span>
+            <br /><span data-i18n="With this option, you may also use unknown application codes with prefixing the application code with app."></span>
+            </td>
+        </tr>
+        <tr valign="top">
+            <td align="right" style="width:110px"><label><span data-i18n="Allow unknown commands">Allow unknown commands</span>:</label></td>
+            <td>
+                <input type="checkbox" id="unknowncommands" name="unknowncommands"><label for="unknowncommands"></label>
+                <br /><span data-i18n="Please note that even if the command are basically sanitized, activating this option may cause a security issue."></span>
+            </td>
+        </tr>
         <tr>
             <td></td>
             <td><a class="btn btn-danger sub-tabs-apply" onclick="SetPanasonicSettings();" data-i18n="Apply Settings">Apply Settings</a></td>

--- a/www/app/hardware/setup/PanasonicTV.js
+++ b/www/app/hardware/setup/PanasonicTV.js
@@ -15,6 +15,8 @@ define(['app'], function (app) {
 
             $("#hardwarecontent #panasonicsettingstable #pollinterval").val($ctrl.hardware.Mode1);
             $("#hardwarecontent #panasonicsettingstable #pingtimeout").val($ctrl.hardware.Mode2);
+            $("#hardwarecontent #panasonicsettingstable #unknowncommands").prop('checked', $ctrl.hardware.Mode3 & 1);
+            $("#hardwarecontent #panasonicsettingstable #custombuttons").val($ctrl.hardware.Extra);
 
             $('#panasonicnodestable').dataTable({
                 "sDom": '<"H"lfrC>t<"F"ip>',
@@ -221,11 +223,16 @@ define(['app'], function (app) {
             var Mode2 = parseInt($("#hardwarecontent #panasonicsettingstable #pingtimeout").val());
             if (Mode2 < 500)
                 Mode2 = 500;
+            var Mode3 = 0;
+            Mode3 |= ($("#hardwarecontent #panasonicsettingstable #unknowncommands").is(':checked'))?1:0;
+            var Extra = $("#hardwarecontent #panasonicsettingstable #custombuttons").val();
             $.ajax({
                 url: "json.htm?type=command&param=panasonicsetmode" +
                 "&idx=" + $.devIdx +
                 "&mode1=" + Mode1 +
-                "&mode2=" + Mode2,
+                "&mode2=" + Mode2 +
+                "&mode3=" + Mode3 +
+                "&extra=" + Extra ,
                 async: false,
                 dataType: 'json',
                 success: function (data) {

--- a/www/index.html
+++ b/www/index.html
@@ -858,6 +858,7 @@ $(document).ready(function() {
 						<path d="m 450 960 0,80 40,-40 m 10 -35 l0 70 l15 0 l0 -70 m 10 0 l0 70 l15 0 l0 -70 z" class="remoteshadow" />
 					</g>
 				</g>
+				<g id="MediaRemote-custom-buttons"></g>
 			</g>
 		</svg>
 	</div>

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -1424,11 +1424,11 @@ function ShowMediaRemote(Name, devIdx, HWType) {
 	var vBox = $(svgId).prop("viewBox").baseVal;
 	var svgRatio = (vBox.width - vBox.x) / (vBox.height - vBox.y);
 	var dheight = $(window).height() * 0.85;
-	var dwidth = dheight * svgRatio;
+	var dwidth = dheight * svgRatio ;
 	// for v2.0, if screen is wide enough add room to show media at the side of the remote
 	$(divId).dialog({
 		resizable: false,
-		show: "blind",
+		//show: "blind", // effects are causing issue with changing the height during the animation
 		hide: "blind",
 		width: dwidth,
 		height: dheight,
@@ -1441,6 +1441,79 @@ function ShowMediaRemote(Name, devIdx, HWType) {
 			$(divId).attr("HardwareType", HWType);
 			$(svgId).css("-ms-overflow-style", "none");
 			$(divId).bind('touchstart', function () { });
+			if ( HWType.indexOf('Panasonic') >= 0) {
+				// Here is a little painful because we need to get hardware id  first...
+				$.ajax({
+					url: "json.htm?type=devices&rid=" + devIdx,
+					async: true,
+					dataType: 'json',
+					success: function (data) { 
+						hwId = data.result[0].HardwareID;
+						$.ajax({
+							url: "json.htm?type=hardware",
+							async: true,
+							dataType: 'json',
+							success: function (data) { 
+								// Need to iterate over all hardware to find the good one
+								for(var i in data.result) {
+									var hw = data.result[i];
+									if (hw.idx == hwId) {
+										if (hw.Extra !== null && hw.Extra !== '') {
+											// We finally have the custombuttons string, process!
+											var bspacing = 20;
+											var bvspacing = 20;
+											var bheight = 100;
+											var bindex = 0;
+											// Reset buttons
+											$("#MediaRemote-custom-buttons").html('');
+											$(svgId).prop("viewBox").baseVal.height = 1875;
+											// Loop lines
+											hw.Extra.split(';').forEach(function (line) {
+												// Add line
+												var vBox = $(svgId).prop("viewBox").baseVal;
+												var bvline = vBox.y + vBox.height +  bvspacing;
+												$(svgId).prop("viewBox").baseVal.height = vBox.height + bheight + bvspacing;
+												var buttons = line.split(',');
+												var bwidth = (vBox.width + bspacing) / buttons.length - bspacing; 
+												// Loop buttons
+												buttons.forEach(function (val, index) {
+													var tokens = val.split(':');
+													var btitle = tokens[0];
+													var bcommand = tokens[1];
+													var buttonSVG = "";
+													bindex++;
+													bx = $(svgId).prop("viewBox").baseVal.x + index * (bwidth+bspacing);
+													// Button shadow
+													buttonSVG += '<rect id="toto" class="remoteshadow" x="'+bx+'" y="'+(bvline+10)+'" width="'+bwidth+'" height="'+bheight+'" rx="50" ry="50"></rect>';
+													// Button 
+													buttonSVG += '<rect class="remotehoverable" fill="url(#grad1)" x="'+bx+'" y="'+(bvline)+'" width="'+bwidth+'" height="'+bheight+'"  rx="50" ry="50" ';
+													buttonSVG += 'onclick="javascript: click_media_remote(\'' + bcommand + '\');" ';
+													buttonSVG += '><title id="dialog-media-remote-opt1-title">' + btitle + '</title></rect>';
+													// Button text
+													buttonSVG += '<text text-anchor="middle" x="'+(bx+bwidth/2)+'" y="'+(bvline+bheight*0.55)+'" class="remotetext" ';
+													buttonSVG += 'fill="black"  style="font-size: 60px; font-weight: bold;">' + btitle + '</text>';
+													// Add button
+													$("#MediaRemote-custom-buttons").append(buttonSVG);
+												});
+											});
+
+											// Refresh SVG
+											$(svgId).parent().html($(svgId).parent().html());
+											// Ajust dialog width
+											var vBox = $(svgId).prop("viewBox").baseVal;
+											var svgRatio = (vBox.width - vBox.x) / (vBox.height - vBox.y);
+											var dheight = $(window).height() * 0.85;
+											var dwidth = dheight * svgRatio;
+											$(divId).dialog( "option", "width", dwidth);
+											$(divId).dialog( "option", "height", dheight);
+										}
+									}
+								}
+							}
+						});
+					}
+				});
+			}
 		},
 		close: function () {
 			if (typeof $.myglobals.refreshTimer != 'undefined') {


### PR DESCRIPTION
Hello again,

This is the custom panasonic buttons part of my previous PR #4531 (while struggling with splitting the two it seems it closed the previous one, sorry about that).

It adds customizable buttons to the default remote for Panasonic TVs:

![domoticz_pana_remote_custombuttons](https://user-images.githubusercontent.com/3126751/102908895-6a975900-4478-11eb-86dc-9644f7c030bf.png)


The buttons are customizable in the Panasonic hardware settings:

![domoticz_pana_remote_settings](https://user-images.githubusercontent.com/3126751/102908949-7e42bf80-4478-11eb-981b-a6ee4acf0cba.png)

To be able to use codes that are not known of the plugin there is an option to allow sending unknown commands. There is basic sanitization but as it may cause a security issue there is also a setting to allow or not this behavior.


**To answer the questions you made on PR #4531:** 


About the custom buttons, there is some use cases where in my opinion it is very useful to have the buttons you use in domoticz in addition to the physical remote:
- you can add it in scene and automate for instance the input or app on your TV (in a 'back to home' scene for instance), and add also voice automation with voice assistants
- the original remote does not have the corresponding buttons and involves a lot of buttons pressed (that is my case for direct HDMI selection, and app running that I use most of the time)
- these buttons may not work any more on the original physical remote and not included in cheap replacement (if you don't want to spend the ridiculously high price for an original remote)

I fully agree that maybe not everybody need this and those needing this will also have different needs. That is why I made this fully customizable in settings and will default to original look. Having the buttons included in the original domoticz remote will in my opinion overload unnecessarily users that are happy with the current remote (but it is definitely easier to do ;-) ; it is the case in fact in the first commits) 

To answer your questions about the original look of the remote, below are screenshots of the full remote:

Original remote:
![Capture d’écran 2020-12-23 113938](https://user-images.githubusercontent.com/3126751/102988294-05914100-4514-11eb-99e3-c93c93efeb13.png)

Example of heavily customized remote:
![Capture d’écran 2020-12-23 114134](https://user-images.githubusercontent.com/3126751/102988353-180b7a80-4514-11eb-9df2-e6f769d69ac6.png)

And example of a lighter customization:
![Capture d’écran 2020-12-23 114218](https://user-images.githubusercontent.com/3126751/102988492-4426fb80-4514-11eb-9e36-6287a8c8c63f.png)

And without customization (default value), you have exactly the original remote above.

Hope that you will have a more clear idea about these modifications and that will be OK for you.
Thanks

