### PR TITLE
Fix the sanity checking of Z-Wave power meter counter values. Fixes #4541.

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -481,11 +481,11 @@ void ZWaveBase::SendDevice2Domoticz(_tZWaveDevice* pDevice)
 		if (pDevice->lastSendValue != 0)
 		{
 			float floatChange = (pDevice->floatValue - pDevice->prevFloatValue) / pDevice->scaleMultiply;
-			if ((floatChange < 0) || (floatChange > m_sql.m_max_kwh_usage))
+			if ((floatChange < -m_sql.m_max_kwh_usage) || (floatChange > m_sql.m_max_kwh_usage))
 			{
 				if (pDevice->lastreceived - pDevice->lastSendValue < 3600)
 				{
-					// Seems wrong, counters should increase, and by a limited amount.
+					// Seems wrong, counters should change by a limited amount.
 					// If it persists, we will accept it after an hour.
 					_log.Log(LOG_STATUS,
 						 "OpenZwave: temporarily ignoring %s power meter counter (NodeID: %d, 0x%02x)",


### PR DESCRIPTION
As described in #4541, commit 7933f659d668a24d6e8eaf8a54998672f5ca63d9, while adding various sanity checks to catch erroneous counter values from power meters (caused by e.g. counter rollovers or meter resets), got one of these checks wrong, by comparing an unscaled counter representing the total accumulated power usage to a limit on the maximum acceptable rate of change of said counter. An attempt was made to allow a seeming discrepancy to be accepted if it persisted over time, but this would not always work, either.

This small change modifies the code in question to do what I believe to be the original author's actual intent. It also adds logging of the (temporary) suppression of what is judged to be possibly erroneous data.

I'm currently running with this modification locally, and have observed it to work correctly.