### PR TITLE
eVehicle: Handle wrong or empty battery readings

### DIFF
--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -32,7 +32,6 @@ License: Public domain
 // so use the following 5 scope's: mb:vehicle:mbdata:vehiclestatus mb:vehicle:mbdata:fuelstatus mb:vehicle:mbdata:payasyoudrive mb:vehicle:mbdata:vehiclelock mb:vehicle:mbdata:evstatus
 // and we need the additional scope to get a refresh token: offline_access
 #define MERC_URL_AUTH "https://id.mercedes-benz.com"
-#define MERC_API_AUTH "as/authorization.oauth2"
 #define MERC_API_TOKEN "/as/token.oauth2"
 #define MERC_URL "https://api.mercedes-benz.com"
 #define MERC_API "/vehicledata/v2/vehicles"
@@ -198,6 +197,7 @@ bool CMercApi::GetChargeData(CVehicleApi::tChargeData& data)
 
 	if (GetData("electricvehicle", reply))
 	{
+		data.battery_level = 255.0f;	// Initialize at 'no reading'
 		if (reply.empty())
 		{
 			bData = true;	// This occurs when the API call return a 204 (No Content). So everything is valid/ok, just no data
@@ -276,10 +276,12 @@ bool CMercApi::GetClimateData(tClimateData& data)
 
 void CMercApi::GetClimateData(Json::Value& jsondata, tClimateData& data)
 {
+	/*
 	data.inside_temp = jsondata["inside_temp"].asFloat();
 	data.outside_temp = jsondata["outside_temp"].asFloat();
 	data.is_climate_on = jsondata["is_climate_on"].asBool();
 	data.is_defrost_on = (jsondata["defrost_mode"].asInt() != 0);
+	*/
 }
 
 bool CMercApi::GetVehicleData(tVehicleData& data)

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -189,7 +189,16 @@ void CeVehicle::SendTemperature(int tempType, float value)
 void CeVehicle::SendPercentage(int percType, float value)
 {
 	if ((percType == VEHICLE_LEVEL_BATTERY) && m_api->m_capabilities.has_battery_level)
-		SendPercentageSensor(VEHICLE_LEVEL_BATTERY, 1, static_cast<int>(value), value, m_Name + " Battery Level");
+	{
+		int iBattLevel = static_cast<int>(value);
+		float fBattLevel = value;
+		if (fBattLevel < 0.0f || fBattLevel > 100.0f)	// Filter out wrong readings
+		{
+			fBattLevel = 0.0f;
+			iBattLevel = 255;	// Means no batterylevel available (and hides batterylevel indicator in UI)
+		}
+		SendPercentageSensor(VEHICLE_LEVEL_BATTERY, 1, iBattLevel, fBattLevel, m_Name + " Battery Level");
+	}
 }
 
 void CeVehicle::SendCounter(int countType, float value)


### PR DESCRIPTION
When no- or bad readings of the batterystatus was received, the value become random due to not initialized variables. This is now fixed by a) initializing the variable and b) checking/correcting incoming values before storing