### PR TITLE
eVehicles: Create switches instead of textsensor for boolean custom values

### DIFF
--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -207,15 +207,23 @@ void CeVehicle::SendCounter(int countType, float value)
 		SendCustomSensor(VEHICLE_COUNTER_ODO, 1, 255, value, m_Name + " Odometer", m_api->m_config.distance_unit);
 }
 
-void CeVehicle::SendCustom(int countType, int ChildId, float value, const std::string &label)
+void CeVehicle::SendCustom(int customType, int ChildId, float value, const std::string &label)
 {
-	if ((countType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
+	if ((customType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
 		SendCustomSensor(VEHICLE_CUSTOM, ChildId, 255, value, m_Name + " " + label, "");
 }
 
-void CeVehicle::SendText(int countType, int ChildId, const std::string &value, const std::string &label)
+void CeVehicle::SendCustomSwitch(int customType, int ChildId, bool value, const std::string &label)
 {
-	if ((countType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
+	if ((customType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
+		{
+			CDomoticzHardwareBase::SendGeneralSwitch(((VEHICLE_CUSTOM << 8) | ChildId), 1, 255, value, 0, m_Name + " " + label, m_Name);
+		}
+}
+
+void CeVehicle::SendCustomText(int customType, int ChildId, const std::string &value, const std::string &label)
+{
+	if ((customType == VEHICLE_CUSTOM) && m_api->m_capabilities.has_custom_data)
 		SendTextSensor(VEHICLE_CUSTOM, ChildId, 255, value, m_Name + " " + label);
 }
 
@@ -854,17 +862,39 @@ void CeVehicle::UpdateCustomVehicleData(CVehicleApi::tCustomData& data)
 						Json::Value jValue = iter["value"];
 						std::string sLabel = iter["label"].asString();
 						std::string sValue = jValue.asString();
+						bool isBool = jValue.isBool();
+						bool bValue = false;
 
-						_log.Debug(DEBUG_NORM, "Processing custom data %d - %s - %s", iChildID, sValue.c_str(), sLabel.c_str());
+						// Determine if Value might a boolean value
+						if(isBool)
+						{
+							bValue = jValue.asBool();
+						}
+						else	// Not a native JSON boolean anyway
+						{
+							std::string sBoolValue = sValue;
+							stdlower(sBoolValue);
+							if(sBoolValue.compare("true") == 0 || sBoolValue.compare("false") == 0)
+							{
+								isBool = true;
+								bValue = (sBoolValue.compare("true") == 0 ? true : false);
+							}
+						}
+
+						_log.Debug(DEBUG_NORM, "Processing custom data %d - %s - %s (%s)", iChildID, sValue.c_str(), sLabel.c_str(), (isBool ? "Boolean" : (is_number(sValue) ? "Number": "Text" )));
 
 						if (is_number(sValue))
 						{
 							float fValue = static_cast<float>(std::atof(sValue.c_str()));
 							SendCustom(VEHICLE_CUSTOM, iChildID, fValue, sLabel);
 						}
+						else if (isBool)
+						{
+							SendCustomSwitch(VEHICLE_CUSTOM, iChildID, bValue, sLabel);
+						}
 						else
 						{
-							SendText(VEHICLE_CUSTOM, iChildID, sValue, sLabel);
+							SendCustomText(VEHICLE_CUSTOM, iChildID, sValue, sLabel);
 						}
 				}
 				cnt++;

--- a/hardware/eVehicles/eVehicle.h
+++ b/hardware/eVehicles/eVehicle.h
@@ -113,8 +113,9 @@ public:
 	void SendTemperature(int tempType, float value);
 	void SendPercentage(int percType, float value);
 	void SendCounter(int countType, float value);
-	void SendCustom(int countType, int ChildId, float value, const std::string &label);
-	void SendText(int countType, int ChildId, const std::string &value, const std::string &label);
+	void SendCustom(int customType, int ChildId, float value, const std::string &label);
+	void SendCustomSwitch(int customType, int ChildId, bool value, const std::string &label);
+	void SendCustomText(int customType, int ChildId, const std::string &value, const std::string &label);
 
 	bool StartHardware() override;
 	bool StopHardware() override;


### PR DESCRIPTION
When retrieving custom values from a vehicle's API, most returned values where converted to either a text sensor (containing text) or a generic sensor (containing a number). But when the API returned a 'boolean' value, these were converted to text (in case of 'true'  or 'false') or a generic sensor (in case of 0 or 1 or real booleans) as well.

Now additional checking is done trying to convert a boolean value into a real boolean and putting it into a Switchtype sensor. This way proper Switches become available for boolean type variables like 'left frontdoor open/closed' or 'carlights on/off', etc.