### PR TITLE
MercApi: Added Status message for non-standard HTTP results

### DIFF
--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -903,7 +903,7 @@ uint16_t CMercApi::ExtractHTTPResultCode(const std::string& sResponseHeaderLine0
 				iHttpCode = (uint16_t)std::stoi(sResponseHeaderLine0.substr(iHttpCodeStartPos, 3));
 				if (iHttpCode < 100 || iHttpCode > 599)		// Check valid resultcode range
 				{
-					iHttpCode = 9999;
+					_log.Log(LOG_STATUS, "Found non-standard resultcode (%d) in HTTP response statusline: %s", iHttpCode, sResponseHeaderLine0.c_str());
 				}
 			}
 		}


### PR DESCRIPTION
Sometimes the Mercedes API's do respond but with a non-standard HTTP result-code. Made this visible in Status logging so no need to restart Domoticz in debug mode to find out anymore.