### PR TITLE
Implemented multiline parameters in python plugins

### DIFF
--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -466,7 +466,7 @@ namespace http {
 									ATTRIBUTE_VALUE(pXmlEle, "required", root[iPluginCnt]["parameters"][iParams]["required"]);
 									ATTRIBUTE_VALUE(pXmlEle, "default", root[iPluginCnt]["parameters"][iParams]["default"]);
 									ATTRIBUTE_VALUE(pXmlEle, "password", root[iPluginCnt]["parameters"][iParams]["password"]);
-									ATTRIBUTE_VALUE(pXmlEle, "multiline", root[iPluginCnt]["parameters"][iParams]["multiline"]);
+									ATTRIBUTE_VALUE(pXmlEle, "rows", root[iPluginCnt]["parameters"][iParams]["rows"]);
 
 									TiXmlNode* pXmlOptionsNode = pXmlEle->FirstChild("options");
 									int	iOptions = 0;

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -466,6 +466,7 @@ namespace http {
 									ATTRIBUTE_VALUE(pXmlEle, "required", root[iPluginCnt]["parameters"][iParams]["required"]);
 									ATTRIBUTE_VALUE(pXmlEle, "default", root[iPluginCnt]["parameters"][iParams]["default"]);
 									ATTRIBUTE_VALUE(pXmlEle, "password", root[iPluginCnt]["parameters"][iParams]["password"]);
+									ATTRIBUTE_VALUE(pXmlEle, "multiline", root[iPluginCnt]["parameters"][iParams]["multiline"]);
 
 									TiXmlNode* pXmlOptionsNode = pXmlEle->FirstChild("options");
 									int	iOptions = 0;

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4793,23 +4793,29 @@ define(['app'], function (app) {
 											});
 											PluginParams += '</select></td>';
 										} else {
-											var multiline=(typeof (param.multiline) != "undefined") && (param.multiline == "true")
+											var nbRows=-1;
+											if (typeof (param.rows) != "undefined") {
+												var n = Math.floor(Number(param.rows));
+												if(n !== Infinity && String(n) === param.rows && n >= 0) {
+													nbRows = n;
+												}
+											}
 											PluginParams += '<td>'
-											if ((typeof (param.password) != "undefined") && (param.password == "true"))
-												PluginParams += '<input type="password" ';
-											else if(multiline)
-												PluginParams += '<textarea ';
-											else
-												PluginParams += '<input type="text" ';
-											PluginParams += 'id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" '
-											if (typeof (param.default) != "undefined" && !multiline) PluginParams += 'value="' + param.default + '"';
-											if ((typeof (param.required) != "undefined") && (param.required == "true")) PluginParams += ' required';
-											if(multiline) {
-												PluginParams += ' >';
+											if (nbRows >= 0) {
+												PluginParams += '<textarea id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" rows="' + nbRows + '" ';
+												if ((typeof (param.required) != "undefined") && (param.required == "true")) PluginParams += 'required';
+												PluginParams += '>';
 												if (typeof (param.default) != "undefined") PluginParams +=  param.default;
-												PluginParams +='</textarea>';
+                                                                                                PluginParams +='</textarea>';
 											} else {
-                                                                                               PluginParams += ' />';
+												if ((typeof (param.password) != "undefined") && (param.password == "true"))
+													PluginParams += '<input type="password" ';
+												else
+													PluginParams += '<input type="text" ';
+												PluginParams += 'id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" '
+												if (typeof (param.default) != "undefined") PluginParams += 'value="' + param.default + '"';
+												if ((typeof (param.required) != "undefined") && (param.required == "true")) PluginParams += ' required';
+  												PluginParams += ' />';
 											}
 											PluginParams += '</td>';
 										}

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4796,6 +4796,8 @@ define(['app'], function (app) {
 											PluginParams += '<td>'
 											if ((typeof (param.password) != "undefined") && (param.password == "true"))
 												PluginParams += '<input type="password" ';
+											else if((typeof (param.multiline) != "undefined") && (param.multiline == "true"))
+												PluginParams += '<textarea type="text" ';
 											else
 												PluginParams += '<input type="text" ';
 											PluginParams += 'id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" '

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4793,20 +4793,14 @@ define(['app'], function (app) {
 											});
 											PluginParams += '</select></td>';
 										} else {
-											var nbRows=-1;
-											if (typeof (param.rows) != "undefined") {
-												var n = Math.floor(Number(param.rows));
-												if(n !== Infinity && String(n) === param.rows && n >= 0) {
-													nbRows = n;
-												}
-											}
 											PluginParams += '<td>'
+											var nbRows=parseInt(param.rows);
 											if (nbRows >= 0) {
 												PluginParams += '<textarea id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" rows="' + nbRows + '" ';
 												if ((typeof (param.required) != "undefined") && (param.required == "true")) PluginParams += 'required';
 												PluginParams += '>';
 												if (typeof (param.default) != "undefined") PluginParams +=  param.default;
-                                                                                                PluginParams +='</textarea>';
+												PluginParams +='</textarea>';
 											} else {
 												if ((typeof (param.password) != "undefined") && (param.password == "true"))
 													PluginParams += '<input type="password" ';

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4793,17 +4793,25 @@ define(['app'], function (app) {
 											});
 											PluginParams += '</select></td>';
 										} else {
+											var multiline=(typeof (param.multiline) != "undefined") && (param.multiline == "true")
 											PluginParams += '<td>'
 											if ((typeof (param.password) != "undefined") && (param.password == "true"))
 												PluginParams += '<input type="password" ';
-											else if((typeof (param.multiline) != "undefined") && (param.multiline == "true"))
-												PluginParams += '<textarea type="text" ';
+											else if(multiline)
+												PluginParams += '<textarea ';
 											else
 												PluginParams += '<input type="text" ';
 											PluginParams += 'id="' + param.field + '" style="width:' + param.width + '; padding: .2em;" class="text ui-widget-content ui-corner-all" '
-											if (typeof (param.default) != "undefined") PluginParams += 'value="' + param.default + '"';
+											if (typeof (param.default) != "undefined" && !multiline) PluginParams += 'value="' + param.default + '"';
 											if ((typeof (param.required) != "undefined") && (param.required == "true")) PluginParams += ' required';
-											PluginParams += ' /></td>';
+											if(multiline) {
+												PluginParams += ' >';
+												if (typeof (param.default) != "undefined") PluginParams +=  param.default;
+												PluginParams +='</textarea>';
+											} else {
+                                                                                               PluginParams += ' />';
+											}
+											PluginParams += '</td>';
 										}
 									}
 									else {


### PR DESCRIPTION
Python plugins only have a limited number of parameters and sometimes, ones need more. As a solution, I propose to add multiline parameters, so parameters can contains json, xml, or whatever parsable format and still being editable and readable in hardware configuration GUI.