### PR TITLE
Added option to Panasonic hardware to allow to send command even if off

### DIFF
--- a/hardware/PanasonicTV.h
+++ b/hardware/PanasonicTV.h
@@ -38,6 +38,7 @@ class CPanasonic : public CDomoticzHardwareBase
 	int m_iPollInterval;
 	int m_iPingTimeoutms;
 	bool m_bUnknownCommandAllowed;
+	bool m_bTryIfOff;
 	std::shared_ptr<std::thread> m_thread;
 	std::mutex m_mutex;
 	boost::asio::io_service m_ios;

--- a/www/app/hardware/setup/PanasonicTV.html
+++ b/www/app/hardware/setup/PanasonicTV.html
@@ -34,6 +34,13 @@
                 <br /><span data-i18n="Please note that even if the command are basically sanitized, activating this option may cause a security issue."></span>
             </td>
         </tr>
+        <tr valign="top">
+            <td align="right" style="width:110px"><label><span data-i18n="Allow send commands if Off">Allow send commands if Off</span>:</label></td>
+            <td>
+                <input type="checkbox" id="tryifoff" name="tryifoff"><label for="tryifoff"></label>
+                <br /><span data-i18n="This checkbox allows Domoticz to try to send commands to the TV even if it is not reported On. This can be useful if you need to send commands right after powering up the TV and the status is not already reported accordingly."></span>
+            </td>
+        </tr>
         <tr>
             <td></td>
             <td><a class="btn btn-danger sub-tabs-apply" onclick="SetPanasonicSettings();" data-i18n="Apply Settings">Apply Settings</a></td>

--- a/www/app/hardware/setup/PanasonicTV.js
+++ b/www/app/hardware/setup/PanasonicTV.js
@@ -16,6 +16,7 @@ define(['app'], function (app) {
             $("#hardwarecontent #panasonicsettingstable #pollinterval").val($ctrl.hardware.Mode1);
             $("#hardwarecontent #panasonicsettingstable #pingtimeout").val($ctrl.hardware.Mode2);
             $("#hardwarecontent #panasonicsettingstable #unknowncommands").prop('checked', $ctrl.hardware.Mode3 & 1);
+            $("#hardwarecontent #panasonicsettingstable #tryifoff").prop('checked', $ctrl.hardware.Mode3 & 2);
             $("#hardwarecontent #panasonicsettingstable #custombuttons").val($ctrl.hardware.Extra);
 
             $('#panasonicnodestable').dataTable({
@@ -225,6 +226,7 @@ define(['app'], function (app) {
                 Mode2 = 500;
             var Mode3 = 0;
             Mode3 |= ($("#hardwarecontent #panasonicsettingstable #unknowncommands").is(':checked'))?1:0;
+            Mode3 |= ($("#hardwarecontent #panasonicsettingstable #tryifoff").is(':checked'))?2:0;
             var Extra = $("#hardwarecontent #panasonicsettingstable #custombuttons").val();
             $.ajax({
                 url: "json.htm?type=command&param=panasonicsetmode" +


### PR DESCRIPTION
Very small PR, to add an option to Panasonic hardware to allow sending commands even if the domoticz status of the device is off.

This is useful when you want to send some commands just after powering up the TV  (by a script by example) and the status has not yet been updated (the notification system takes up to 60 seconds to update the state, but the TV is already able to receive commands)

This option is not enabled by default.