### PR TITLE
Added ability to modify Thermostat SetPoints on Floorplan and use custom icons

### DIFF
--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -811,7 +811,8 @@ define(['app', 'livesocket'], function (app) {
 								status = "";
 							}
 							else if (((item.Type == "Thermostat") && (item.SubType == "SetPoint")) || (item.Type == "Radiator 1")) {
-								xhtm += '<img src="images/override.png" class="lcursor" onclick="ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ');" height="48" width="48" ></td>\n';
+								item.Image = (item.CustomImage == 0)  ? 'override.png' : item.Image + '48_On.png';
+								xhtm += '<img src="images/' + item.Image + '" class="lcursor" onclick="ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ');" height="48" width="48" ></td>\n';
 								status = "";
 							}
 							else if (item.SubType == "Thermostat Clock") {

--- a/www/js/domoticzdevices.js
+++ b/www/js/domoticzdevices.js
@@ -837,6 +837,8 @@ Device.create = function (item) {
         type = 'baro';
     } else if ((item.Type === 'General') && (item.SubType === 'Custom Sensor')) {
         type = 'custom';
+    } else if ((item.Type === 'Thermostat') && (item.SubType === 'SetPoint')) {
+        type = 'setpoint';  // Instead of the TypeImg (which changes when using custom images)
     } else if (
         (item.SwitchType === 'Dusk Sensor') ||
         (item.SwitchType === 'Selector')
@@ -919,6 +921,7 @@ Device.create = function (item) {
             break;
         case "override":
         case "override_mini":
+        case "setpoint":
             dev = new SetPoint(item);
             break;
         case "radiation":
@@ -1618,12 +1621,19 @@ Scene.inheritsFrom(Pushon);
 function SetPoint(item) {
     if (arguments.length != 0) {
         this.parent.constructor(item);
-        this.image = "images/override.png";
+        if (item.CustomImage != 0 && typeof item.Image != 'undefined') {
+            this.image = "images/" + item.Image + ".png";
+        } else {
+            this.image = "images/override.png";
+        }
         if ($.isNumeric(this.data)) this.data += '\u00B0' + $.myglobals.tempsign;
         if ($.isNumeric(this.status)) this.status += '\u00B0' + $.myglobals.tempsign;
         var pattern = new RegExp('\\d\\s' + $.myglobals.tempsign + '\\b');
         while (this.data.search(pattern) > 0) this.data = this.data.setCharAt(this.data.search(pattern) + 1, '\u00B0');
         while (this.status.search(pattern) > 0) this.status = this.status.setCharAt(this.status.search(pattern) + 1, '\u00B0');
+        this.imagetext = "Set Temp";
+        this.controlable = true;
+        this.onClick = 'ShowSetpointPopup(' + event + ', ' + this.index + ', ' + this.protected + ' , "' + this.data + '");';
     }
 }
 SetPoint.inheritsFrom(TemperatureSensor);


### PR DESCRIPTION
Based on discussions and tests on the forum (see https://www.domoticz.com/forum/viewtopic.php?f=34&t=13828&p=266190#p266190), this PR adds the ability on Floorplans to control the values for setpoint devices of Thermostats.

Thx to forum users **waltervl**, **Dnpwwo** (and other participants) for doing the hard work on locating where and what to change.

Recently multiple updates have been done on the ability to use custom-icons also on the utility-tab, etc. Now the Setpoint devices from a Thermostat can also use this.