### PR TITLE
dzVents openURL optimisation

### DIFF
--- a/dzVents/runtime/integration-tests/stage1.lua
+++ b/dzVents/runtime/integration-tests/stage1.lua
@@ -691,7 +691,7 @@ local testRGBW = function(name)
 		["timedOut"] = false;
 	})
 	dev.setRGB(15, 30, 60)
-	dev.dimTo(15)
+	dev.dimTo(15).afterSec(5)
 	tstMsg('Test RGBW device', res)
 	return res
 end

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3583,7 +3583,6 @@ void CSQLHelper::PerformThreadedAction(const _tTaskItem itt)
 		std::string callback = itt._ID;
 		std::string url = itt._sValue;
 		int method = itt._switchtype;
-		_log.Log(LOG_ERROR, "opening url: %s", url.c_str());
 
 		if (!itt._relatedEvent.empty())
 			StringSplit(itt._relatedEvent, "!#", extraHeaders);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3608,7 +3608,7 @@ void CSQLHelper::GetUrlThreaded(int method, std::string url,std::string postData
 
 	if (!ret)
 	{
-		_log.Log(LOG_ERROR, "Error opening url: %s", url);
+		_log.Log(LOG_ERROR, "Error opening url: %s", url.c_str());
 	}
 }
 
@@ -3760,18 +3760,18 @@ void CSQLHelper::Do_Work()
 			}
 			else if (itt->_ItemType == TITEM_EXECUTESHELLCOMMAND)
 			{
-				// int returncode=0;
 				std::string command = itt->_sValue;
 				std::string callback = itt->_ID;
 				std::string path = itt->_sUser;
 				int timeout = itt->_nValue;
+
 				std::thread shellcommandthread(&CSQLHelper::ExecuteScriptThreaded,this, command,callback,timeout,path);
 				shellcommandthread.detach();
 			}
 			else if (itt->_ItemType == TITEM_GETURL)
 			{
 				std::string response;
-				std::vector<std::string> headerData, extraHeaders;
+				std::vector<std::string> extraHeaders;
 				std::string postData = itt->_command;
 				std::string callback = itt->_ID;
 				std::string url = itt->_sValue;
@@ -3780,7 +3780,6 @@ void CSQLHelper::Do_Work()
 				if (!itt->_relatedEvent.empty())
 					StringSplit(itt->_relatedEvent, "!#", extraHeaders);
 
-				// CSQLHelper::GetUrlThreaded(method,url,postData,extraHeaders,callback);
 				std::thread geturlthread(&CSQLHelper::GetUrlThreaded,this,method,url,postData,extraHeaders,callback);
 				geturlthread.detach();
 			}

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -494,10 +494,10 @@ class CSQLHelper : public StoppableTask
 	bool StartThread();
 	void StopThread();
 	void Do_Work();
-
+#ifndef WIN32
 	void ManageExecuteScriptTimeout(int pid, int timeout, bool *stillRunning, bool *timeoutOccurred);
-	void ExecuteScriptThreaded(std::string command, std::string callback, int timeout, std::string path);
-	void GetUrlThreaded(int method, std::string url,std::string postData,std::vector<std::string> extraHeaders,std::string callback);
+#endif
+	void PerformThreadedAction(const _tTaskItem itt);
 	bool SwitchLightFromTasker(const std::string &idx, const std::string &switchcmd, const std::string &level, const std::string &color, const std::string &User);
 	bool SwitchLightFromTasker(uint64_t idx, const std::string &switchcmd, int level, _tColor color, const std::string &User);
 

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -497,6 +497,7 @@ class CSQLHelper : public StoppableTask
 
 	void ManageExecuteScriptTimeout(int pid, int timeout, bool *stillRunning, bool *timeoutOccurred);
 	void ExecuteScriptThreaded(std::string command, std::string callback, int timeout, std::string path);
+	void GetUrlThreaded(int method, std::string url,std::string postData,std::vector<std::string> extraHeaders,std::string callback);
 	bool SwitchLightFromTasker(const std::string &idx, const std::string &switchcmd, const std::string &level, const std::string &color, const std::string &User);
 	bool SwitchLightFromTasker(uint64_t idx, const std::string &switchcmd, int level, _tColor color, const std::string &User);
 


### PR DESCRIPTION
dzVents openURL processes http requests sequencially in the SQLHelper worker thread, blocking that thread in case of long running http requests or timeouts (which can take up to 120 sec). During that periode the SQL helper thread is blocked.

This PR fixes that by executing http requests on seperate threads

@rwaaren  ofcourse i already tested myself, but i cannot get the  the dzvents regression testscripts to run. Could you run those on this PR?     