### PR TITLE
dzVents update to 3.1.2

### DIFF
--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -933,6 +933,7 @@ If for some reason you miss a specific attribute or data for a device, then like
  - **batteryLevel**: *Number* If applicable for that device then it will be from 0-100.
  - **bState**: *Boolean*. Is true for some common states like 'On' or 'Open' or 'Motion'. Better to use active.
  - **changed**: *Boolean*. True if the device was updated. **Note**: This does not necessarily means the device state or value changed.
+ - **customImage**: *Number*. When customImage is used for the device-icon this will be the icon-number. It will be 0 if the icon was not changed.
  - **description**: *String*. Description of the device.
  - **deviceId**: *String*. Another identifier of devices in Domoticz. dzVents uses the id(x) attribute. See device list in Domoticz' settings table.
  - **deviceSubType**: *String*. See Domoticz devices table in Domoticz GUI.
@@ -2595,6 +2596,12 @@ _.print(_.indexOf({2, 3, 'x', 4}, 'x'))
 Check out the documentation [here](https://htmlpreview.github.io/?https://github.com/rwaaren/lodash.lua/blob/master/doc/index.html).
 
 # History [link to changes in previous versions](https://www.domoticz.com/wiki/DzVents_version_History).
+
+## [3.1.2] ##
+- Fixed issue with icon name
+- Add attribute customImage (icon number or 0)
+- Use level as brightness in getColor function
+- Allow booleans as value in header field of openURL
 
 ## [3.1.1] ##
 - Fixed issue that prevented dzVents from accessing the domoticz API when used in sslwww only mode

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -874,6 +874,7 @@ If for some reason you miss a specific attribute or data for a device, then like
 * '''batteryLevel''': ''Number'' If applicable for that device then it will be from 0-100.
 * '''bState''': ''Boolean''. Is true for some common states like ‘On’ or ‘Open’ or ‘Motion’. Better to use active.
 * '''changed''': ''Boolean''. True if the device was updated. '''Note''': This does not necessarily means the device state or value changed.
+* '''customImage''': ''Number''. When customImage is used for the device-icon this will be the icon-number. It will be 0 if the icon was not changed.
 * '''description''': ''String''. Description of the device.
 * '''deviceId''': ''String''. Another identifier of devices in Domoticz. dzVents uses the id(x) attribute. See device list in Domoticz’ settings table.
 * '''deviceSubType''': ''String''. See Domoticz devices table in Domoticz GUI.
@@ -2518,6 +2519,13 @@ _.print(_.indexOf({2, 3, 'x', 4}, 'x'))</source>
 Check out the documentation [https://htmlpreview.github.io/?https://github.com/rwaaren/lodash.lua/blob/master/doc/index.html here].
 
 = History [https://www.domoticz.com/wiki/DzVents_version_History link to changes in previous versions]. =
+
+== [3.1.2] ==
+
+* Fixed issue with icon name
+* Add attribute customImage (icon number or 0)
+* Use level as brightness in getColor function
+* Allow booleans as value in header field of openURL
 
 == [3.1.1] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,6 +1,12 @@
 ```{=mediawiki}
 __NOTOC__
 ```
+## [3.1.2] ##
+- Fixed issue with icon name
+- Add attribute customImage (icon number or 0)
+- Use level as brightness in getColor function
+- Allow booleans as value in header field of openURL
+
 ## [3.1.1] ##
 - Fixed issue that prevented dzVents from accessing the domoticz API when used in sslwww only mode
 

--- a/dzVents/documentation/history.wiki
+++ b/dzVents/documentation/history.wiki
@@ -1,4 +1,11 @@
 __NOTOC__
+== [3.1.2] ==
+
+* Fixed issue with icon name
+* Add attribute customImage (icon number or 0)
+* Use level as brightness in getColor function
+* Allow booleans as value in header field of openURL
+
 == [3.1.1] ==
 
 * Fixed issue that prevented dzVents from accessing the domoticz API when used in sslwww only mode

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -8,7 +8,7 @@ local self = {
 	LOG_INFO = 3,
 	LOG_WARNING = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '3.1.1',
+	DZVERSION = '3.1.2',
 }
 
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)

--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -120,6 +120,9 @@ return {
 					idx = data.id
 				})
 			end
+			if customImage and tonumber(customImage) and customImage >= 100 then
+				device.icon = device.Image
+			end
 
 			device.isDevice = true
 		end

--- a/dzVents/runtime/integration-tests/stage1.lua
+++ b/dzVents/runtime/integration-tests/stage1.lua
@@ -691,7 +691,7 @@ local testRGBW = function(name)
 		["timedOut"] = false;
 	})
 	dev.setRGB(15, 30, 60)
-	dev.dimTo(15)
+	dev.dimTo(15).afterSec(5)
 	tstMsg('Test RGBW device', res)
 	return res
 end

--- a/dzVents/runtime/tests/testDevice.lua
+++ b/dzVents/runtime/tests/testDevice.lua
@@ -33,7 +33,8 @@ local function getDevice_(
 	dummyLogger,
 	batteryLevel,
 	signalLevel,
-	nValue)
+	nValue,
+	customImage)
 
 	local Device = require('Device')
 
@@ -64,6 +65,7 @@ local function getDevice_(
 	{
 		["id"] = 1,
 		["name"] = name,
+		["customImage"] = 102,
 		["description"] = "Description 1",
 		["batteryLevel"] = batteryLevel and batteryLevel or 50,
 		["protected"] = true,
@@ -119,7 +121,8 @@ local function getDevice(domoticz, options)
 		options.dummyLogger,
 		options.batteryLevel,
 		options.signalLevel,
-		options.nValue)
+		options.nValue,
+		options.customImage)
 
 end
 
@@ -180,6 +183,7 @@ describe('device', function()
 			['name'] = 'myDevice',
 			['type'] = 'Light/Switch',
 			['state'] = 'On',
+			['customImage'] = 102,
 			['changed'] = true,
 		})
 		utils = device._getUtilsInstance()
@@ -1853,13 +1857,13 @@ describe('device', function()
 			it('should handle setColor method correctly',function()
 				commandArray = {}
 				assert.is_nil(device.setColor(15,31,44))
-				assert.is_same({'http://127.0.0.1:8080/json.htm?type=command&param=setcolbrightnessvalue&idx=1&brightness=100&color={"m":3,"t":0,"cw":0,"ww":0,"r":15,"g":31,"b":44}'},commandArray)
+				assert.is_same({'http://127.0.0.1:8080/json.htm?type=command&param=setcolbrightnessvalue&idx=1&brightness=1&color={"m":3,"t":0,"cw":0,"ww":0,"r":15,"g":31,"b":44}'},commandArray)
 			end)
 
 			it('should handle setColorBrightness method correctly',function()
 				commandArray = {}
 				assert.is_nil(device.setColorBrightness(15,31,44))
-				assert.is_same({'http://127.0.0.1:8080/json.htm?type=command&param=setcolbrightnessvalue&idx=1&brightness=100&color={"m":3,"t":0,"cw":0,"ww":0,"r":15,"g":31,"b":44}'},commandArray)
+				assert.is_same({'http://127.0.0.1:8080/json.htm?type=command&param=setcolbrightnessvalue&idx=1&brightness=1&color={"m":3,"t":0,"cw":0,"ww":0,"r":15,"g":31,"b":44}'},commandArray)
 			end)
 
 			it('should handle setDiscomode method correctly',function()

--- a/dzVents/runtime/tests/testDomoticz.lua
+++ b/dzVents/runtime/tests/testDomoticz.lua
@@ -381,7 +381,7 @@ describe('Domoticz', function()
 				method = 'POST',
 				callback = 'trigger1',
 				headers = {
-					['X-Apikey'] = '12345ABC_',
+					['Auth-Required'] = false ,
 				},
 				postData = {
 					a = 1, b = 2
@@ -392,7 +392,7 @@ describe('Domoticz', function()
 					['OpenURL'] = {
 						URL = 'some url',
 						method = 'POST',
-						headers = '!#X-Apikey: 12345ABC_',
+						headers = '!#Auth-Required: false',
 						_trigger = 'trigger1',
 						postdata = '{"a":1,"b":2}'
 					}

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -78,6 +78,7 @@ const CEventSystem::_tJsonMap CEventSystem::JsonMap[] = {
 	{ "CounterDelivToday", "counterDeliveredToday", JTYPE_STRING },
 	{ "CounterToday", "counterToday", JTYPE_STRING },
 	{ "Current", "current", JTYPE_FLOAT },
+	{ "CustomImage", "customImage", JTYPE_INT },
 	{ "DewPoint", "dewPoint", JTYPE_FLOAT },
 	{ "Direction", "direction", JTYPE_FLOAT },
 	{ "DirectionStr", "directionString", JTYPE_STRING },
@@ -88,6 +89,7 @@ const CEventSystem::_tJsonMap CEventSystem::JsonMap[] = {
 	{ "HardwareTypeVal", "hardwareTypeValue", JTYPE_INT },
 	{ "Humidity", "humidity", JTYPE_INT },
 	{ "HumidityStatus", "humidityStatus", JTYPE_STRING },
+	{ "Image", "Image", JTYPE_STRING },
 	{ "InternalState", "internalState", JTYPE_STRING }, // door contact
 	{ "LevelActions", "levelActions", JTYPE_STRING },
 	{ "LevelInt", "levelVal", JTYPE_INT },

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -75,6 +75,8 @@ public:
 		float AddjMulti;
 		float AddjValue2;
 		float AddjMulti2;
+		uint8_t customImage;
+		std::string image;
 		std::map<uint8_t, int> JsonMapInt;
 		std::map<uint8_t, float> JsonMapFloat;
 		std::map<uint8_t, bool> JsonMapBool;

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -30,7 +30,7 @@ extern http::server::ssl_server_settings secure_webserver_settings;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents()
-	: m_version("3.1.1")
+	: m_version("3.1.2")
 {
 	m_bdzVentsExist = false;
 }
@@ -869,11 +869,13 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		bool timed_out = (now - checktime >= SensorTimeOut * 60);
 		if (sitem.ID > 0)
 		{
-			luaTable.OpenSubTableEntry(index, 1, 12);
+			luaTable.OpenSubTableEntry(index, 1, 14);
 
 			luaTable.AddString("name", sitem.deviceName);
 			luaTable.AddBool("protected", (sitem.protection == 1) );
 			luaTable.AddInteger("id", sitem.ID);
+			luaTable.AddInteger("iconNumber", sitem.customImage);
+			luaTable.AddString("image", sitem.image);
 			luaTable.AddString("baseType","device");
 			luaTable.AddString("deviceType", dev_type);
 			luaTable.AddString("subType", sub_type);


### PR DESCRIPTION
* Fixed issue with icon name
* Add attribute customImage (icon number or 0)
* Use level as brightness in getColor function
* Allow booleans as value in header field of openURL
```

======== domoticz V2020.2 (12865), dzVents V3.1.2 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        118      OK            118         0      0.6024
00:00:03  Domoticz                                      1         82      OK             82         0      0.6408
00:00:04  EventHelpers                                  1         33      OK             33         0      0.6777
00:00:05  EventHelpersStorage                           1         50      OK             50         0      0.4855
00:00:05  HTTPResponse                                  1          6      OK              6         0      0.0300
00:00:06  Lodash                                        1        100      OK            100         0      0.3304
00:00:06  ScriptdzVentsDispatching                      1          2      OK              2         0      0.1697
00:00:06  Time                                          3        369      OK            369         0      1.4262
00:00:08  TimedCommand                                  1         46      OK             46         0      0.2206
00:00:08  Utils                                         1         36      OK             36         0      0.1498
00:00:09  Variable                                      1         15      OK             15         0      0.0577
00:00:09  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.1552
00:00:12  DelayedVariableScene                          8          2      OK              2         0      7.1282
00:00:20  EventState                                   19          2      OK              2         0     18.1455
00:00:38  Integration                                  34        222      OK            222         0     30.5308
00:01:09  SelectorSwitch                               10          2      OK              2         0      9.3948
00:01:28  SystemAndCustomEvents                         1          7      OK              7         0      0.0801


Total tests: 1094
Thu Jan 21 00:38:40 CET 2021; dzVents version 3.1.2 tested without errors after 00:01:29
```
