### PR TITLE
Adding NSS_CLICKATELL

### DIFF
--- a/dzVents/runtime/constants.lua
+++ b/dzVents/runtime/constants.lua
@@ -65,6 +65,7 @@ return {
 	['NSS_PUSHOVER'] = 'pushover',
 	['NSS_PUSHSAFER'] = 'pushsafer',
 	['NSS_TELEGRAM'] = 'telegram',
+	['NSS_CLICKATELL'] = 'clickatell',
 	['PRIORITY_EMERGENCY'] = 2,
 	['PRIORITY_HIGH'] = 1,
 	['PRIORITY_LOW'] = -2,


### PR DESCRIPTION
Hello,

Since ojozef fixed the settings for clickatell [4350](https://github.com/domoticz/domoticz/pull/4350) we could now use this notification subsystem in dzVents by changing the constants.lua script.