### PR TITLE
MercedesMe: Improve handling of API responses (partial 403's)

### DIFF
--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -362,7 +362,6 @@ bool CMercApi::GetCustomData(tCustomData& data)
 {
 	Json::Value reply;
 	std::vector<std::string> strarray;
-	bool bCustom = true;
 
 	if (m_capabilities.has_custom_data)
 	{
@@ -411,7 +410,7 @@ bool CMercApi::GetCustomData(tCustomData& data)
 		}
 	}
 
-	return bCustom;
+	return true;
 }
 
 void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -215,6 +215,14 @@ bool CMercApi::GetChargeData(CVehicleApi::tChargeData& data)
 			}
 		}
 	}
+	else
+	{
+		if (m_httpresultcode == 403)
+		{
+			_log.Log(LOG_STATUS, "Access has been denied to the ElectricVehicle data!");
+			bData = true;	// We should see if we can continue with the rest
+		}
+	}
 
 	return bData;
 }
@@ -308,6 +316,14 @@ bool CMercApi::GetVehicleData(tVehicleData& data)
 			}
 		}
 	}
+	else
+	{
+		if (m_httpresultcode == 403)
+		{
+			_log.Log(LOG_STATUS, "Access has been denied to the VehicleLockStatus data!");
+			bData = true;	// We should see if we can continue with the rest
+		}
+	}
 
 	reply.clear();
 
@@ -328,6 +344,14 @@ bool CMercApi::GetVehicleData(tVehicleData& data)
 				GetVehicleData(reply, data);
 				bData = true;
 			}
+		}
+	}
+	else
+	{
+		if (m_httpresultcode == 403)
+		{
+			_log.Log(LOG_STATUS, "Access has been denied to the PayAsYouDrive data!");
+			bData = true;	// We should see if we can continue with the rest
 		}
 	}
 

--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -63,4 +63,5 @@ private:
 	uint32_t m_crc;
 	std::string m_fields;
 	int16_t m_fieldcnt;
+	uint16_t m_httpresultcode;
 };


### PR DESCRIPTION
The Mercedes API's seem sometimes to give a 403 - Access denied error even when Authentication and Authorization for these API's have been succesful.

This is unexpected and previously stopped further processing of data. Although unexpected, other API's can be available and so we like to process them anyway. So now when an API returns a 403, this API is skipped but processing of others is continued.

These unexpected 403 - Access Denied errors are now reported in the Status logging.