### PR TITLE
treewide: remove most uses of static_cast

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -440,7 +440,7 @@ void C1Wire::ReportWiper(const std::string& deviceId, const int wiper)
 	DeviceIdToByteArray(deviceId, deviceIdByteArray);
 
 	int NodeID = (deviceIdByteArray[0] << 24) | (deviceIdByteArray[1] << 16) | (deviceIdByteArray[2] << 8) | (deviceIdByteArray[3]);
-	unsigned int value = static_cast<int>(wiper * (100.0 / 255.0));
+	unsigned int value = int(wiper * (100.0 / 255.0));
 	SendSwitch(NodeID, 0, 255, wiper > 0, value, "Wiper", m_Name);
 }
 
@@ -506,7 +506,7 @@ void C1Wire::ReportCounter(const std::string& deviceId, const int unit, const un
 	unsigned char deviceIdByteArray[DEVICE_ID_SIZE] = { 0 };
 	DeviceIdToByteArray(deviceId, deviceIdByteArray);
 
-	SendMeterSensor(deviceIdByteArray[0], deviceIdByteArray[1] + unit, 255, (const float)counter / 1000.0F, "Counter");
+	SendMeterSensor(deviceIdByteArray[0], deviceIdByteArray[1] + unit, 255, float(counter) / 1000.0F, "Counter");
 }
 
 void C1Wire::ReportVoltage(const std::string& /*deviceId*/, const int unit, const int voltage)
@@ -521,11 +521,11 @@ void C1Wire::ReportVoltage(const std::string& /*deviceId*/, const int unit, cons
 	tsen.RFXSENSOR.packettype = pTypeRFXSensor;
 	tsen.RFXSENSOR.subtype = sTypeRFXSensorVolt;
 	tsen.RFXSENSOR.rssi = 12;
-	tsen.RFXSENSOR.id = (uint8_t)(unit + 1);
+	tsen.RFXSENSOR.id = uint8_t(unit + 1);
 
-	tsen.RFXSENSOR.msg1 = (BYTE)(voltage / 256);
-	tsen.RFXSENSOR.msg2 = (BYTE)(voltage - (tsen.RFXSENSOR.msg1 * 256));
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXSENSOR, nullptr, 255, nullptr);
+	tsen.RFXSENSOR.msg1 = BYTE(voltage / 256);
+	tsen.RFXSENSOR.msg2 = BYTE(voltage - (tsen.RFXSENSOR.msg1 * 256));
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXSENSOR), nullptr, 255, nullptr);
 }
 
 void C1Wire::ReportIlluminance(const std::string& deviceId, const float illuminescence)

--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -392,7 +392,7 @@ float C1WireByKernel::ThreadReadRawDataHighPrecisionDigitalThermometer(const std
 	if (bFoundCrcOk)
 	{
 		if (is_number(data))
-			return (float)atoi(data.c_str()) / 1000.0F; // Temperature given by kernel is in thousandths of degrees
+			return float(atoi(data.c_str())) / 1000.0F; // Temperature given by kernel is in thousandths of degrees
 	}
 
 	throw OneWireReadErrorException(deviceFileName);
@@ -409,7 +409,7 @@ bool C1WireByKernel::sendAndReceiveByRwFile(std::string path, const unsigned cha
 	{
 		if (file.write((char*)cmd, cmdSize))
 		{
-			if (file.read((char*)answer, answerSize))
+			if (file.read(reinterpret_cast<char *>(answer), answerSize))
 				ok = true;
 		}
 		file.close();
@@ -530,15 +530,13 @@ void C1WireByKernel::ThreadWriteRawData8ChannelAddressableSwitch(const std::stri
 	// Check for transmission errors
 	// Expected first byte = 0xAA
 	// Expected second Byte = inverted new pio state
-	if (answer[0] != 0xAA || answer[1] != (unsigned char)(~newPioState))
+	if (answer[0] != 0xAA || answer[1] != uint8_t(~newPioState))
 		throw OneWireWriteErrorException(deviceFileName);
 }
 
 inline void std_to_upper(const std::string& str, std::string& converted)
 {
-	converted = "";
-	for (char c : str)
-		converted += (char)toupper(c);
+	std::transform(str.begin(), str.end(), converted.begin(), ::toupper);
 }
 
 void C1WireByKernel::GetDevice(const std::string& deviceName, /*out*/_t1WireDevice& device) const

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -154,22 +154,22 @@ void C1WireByOWFS::SetLightState(const std::string& sId,int unit,bool value, con
       {
          if (unit<0 || unit>1)
             return;
-         writeData(device,std::string("PIO.").append(1,'A'+(char)unit),value?"yes":"no");
-         break;
+	 writeData(device, std::string("PIO.").append(1, 'A' + char(unit)), value ? "yes" : "no");
+	 break;
       }
    case _8_channel_addressable_switch:
       {
          if (unit<0 || unit>7)
             return;
-         writeData(device,std::string("PIO.").append(1,'0'+(char)unit),value?"yes":"no");
-         break;
+	 writeData(device, std::string("PIO.").append(1, '0' + char(unit)), value ? "yes" : "no");
+	 break;
       }
    case _4k_EEPROM_with_PIO:
       {
          if (unit<0 || unit>1)
             return;
-         writeData(device,std::string("PIO.").append(1,'0'+(char)unit),value?"yes":"no");
-         break;
+	 writeData(device, std::string("PIO.").append(1, '0' + char(unit)), value ? "yes" : "no");
+	 break;
       }
    case microlan_coupler:
       {
@@ -180,7 +180,7 @@ void C1WireByOWFS::SetLightState(const std::string& sId,int unit,bool value, con
    case digital_potentiometer:
    {
 	   writeData(device, "chargepump", "1");
-	   unsigned int wiper = static_cast<unsigned int>(level * (255.0 / 15.0));
+	   uint32_t wiper = uint32_t(level * (255.0 / 15.0));
 	   writeData(device, "wiper", std::to_string(wiper));
 	   break;
    }
@@ -198,7 +198,7 @@ float C1WireByOWFS::GetTemperature(const _t1WireDevice& device) const
 
    if (readValue.empty())
       return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return float(atof(readValue.c_str()));
 }
 
 float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
@@ -209,7 +209,7 @@ float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
 
    if (readValue.empty())
 	   return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return float(atof(readValue.c_str()));
 }
 
 float C1WireByOWFS::GetPressure(const _t1WireDevice& device) const
@@ -219,7 +219,7 @@ float C1WireByOWFS::GetPressure(const _t1WireDevice& device) const
    std::string readValue=readRawData(std::string(realFilename+"/pressure"));
    if (readValue.empty())
 	   return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return float(atof(readValue.c_str()));
 }
 
 bool C1WireByOWFS::GetLightState(const _t1WireDevice& device,int unit) const
@@ -239,22 +239,22 @@ bool C1WireByOWFS::GetLightState(const _t1WireDevice& device,int unit) const
       {
          if (unit<0 || unit>1)
             return false;
-         fileName.append("/sensed.").append(1,'A'+(char)unit);
-         break;
+	 fileName.append("/sensed.").append(1, 'A' + char(unit));
+	 break;
       }
    case _8_channel_addressable_switch:
       {
          if (unit<0 || unit>7)
             return false;
-         fileName.append("/sensed.").append(1,'0'+(char)unit);
-         break;
+	 fileName.append("/sensed.").append(1, '0' + char(unit));
+	 break;
       }
    case _4k_EEPROM_with_PIO:
       {
          if (unit<0 || unit>1)
             return false;
-         fileName.append("/sensed.").append(1,'0'+(char)unit);
-         break;
+	 fileName.append("/sensed.").append(1, '0' + char(unit));
+	 break;
       }
    case microlan_coupler:
       {
@@ -303,12 +303,12 @@ unsigned int C1WireByOWFS::GetNbChannels(const _t1WireDevice& device) const
 unsigned long C1WireByOWFS::GetCounter(const _t1WireDevice& device,int unit) const
 {
    // Depending on OWFS version, file can be "counter" or "counters". So try both.
-   std::string readValue=readRawData(std::string(device.filename+"/counter.").append(1,'A'+(char)unit));
+   std::string readValue = readRawData(std::string(device.filename + "/counter.").append(1, 'A' + char(unit)));
    if (readValue.empty())
-      readValue=readRawData(std::string(device.filename+"/counters.").append(1,'A'+(char)unit));
+	   readValue = readRawData(std::string(device.filename + "/counters.").append(1, 'A' + char(unit)));
    if (readValue.empty())
 	   return 0;
-   return (unsigned long)atol(readValue.c_str());
+   return std::atol(readValue.c_str());
 }
 
 int C1WireByOWFS::GetVoltage(const _t1WireDevice& device,int unit) const
@@ -327,15 +327,15 @@ int C1WireByOWFS::GetVoltage(const _t1WireDevice& device,int unit) const
       }
    default:
       {
-         fileName.append("/volt.").append(1, static_cast<char>('A'+unit));
-         break;
+	   fileName.append("/volt.").append(1, char('A' + unit));
+	   break;
       }
    }
 
    std::string readValue=readRawData(fileName);
    if (readValue.empty())
 	   return -1000;
-   return static_cast<int>((atof(readValue.c_str())*1000.0));
+   return int(atof(readValue.c_str()) * 1000.0);
 }
 
 float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
@@ -346,7 +346,7 @@ float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
       readValue=readRawData(std::string(device.filename+"/S3-R1-A/illumination"));
    if (readValue.empty())
 	   return -1000.0;
-   return (float)(atof(readValue.c_str())*1000.0);
+   return float(atof(readValue.c_str()) * 1000.0);
 }
 
 int C1WireByOWFS::GetWiper(const _t1WireDevice& device) const

--- a/hardware/1Wire/1WireCommon.cpp
+++ b/hardware/1Wire/1WireCommon.cpp
@@ -14,7 +14,7 @@ _e1WireFamilyType ToFamily(const std::string& str)
 	if (!(ss >> xID))
 		return _e1WireFamilyTypeUnknown;
 
-	return (_e1WireFamilyType)xID;
+	return _e1WireFamilyType(xID);
 }
 
 void DeviceIdToByteArray(const std::string& deviceId,/*out*/unsigned char* byteArray)
@@ -33,7 +33,7 @@ void DeviceIdToByteArray(const std::string& deviceId,/*out*/unsigned char* byteA
 		ss << std::hex << str.substr(2 * idx, 2);
 		if (!(ss >> i))
 			byteArray[DEVICE_ID_SIZE - idx - 1] = 0;
-		byteArray[DEVICE_ID_SIZE - idx - 1] = (uint8_t)i;
+		byteArray[DEVICE_ID_SIZE - idx - 1] = uint8_t(i);
 	}
 }
 
@@ -41,7 +41,7 @@ std::string ByteArrayToDeviceId(const unsigned char* byteArray)
 {
 	std::stringstream sID;
 	for (size_t idx = DEVICE_ID_SIZE; idx > 0; idx--)
-		sID << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << (unsigned int)byteArray[idx - 1];
+		sID << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << uint32_t(byteArray[idx - 1]);
 	return sID.str();
 }
 

--- a/hardware/1Wire/1WireForWindows.cpp
+++ b/hardware/1Wire/1WireForWindows.cpp
@@ -55,7 +55,7 @@ SOCKET ConnectToService()
       }
 
       // Connect to server
-	  if (connect(theSocket, ptr->ai_addr, static_cast<int>(ptr->ai_addrlen)) == SOCKET_ERROR)
+      if (connect(theSocket, ptr->ai_addr, int(ptr->ai_addrlen)) == SOCKET_ERROR)
       {
          Log(LOG_ERROR,"1Wire: connect function failed with error: %ld\n", WSAGetLastError());
          closesocket(theSocket);

--- a/hardware/ASyncTCP.cpp
+++ b/hardware/ASyncTCP.cpp
@@ -278,7 +278,7 @@ void ASyncTCP::cb_read_done(const boost::system::error_code& error, size_t bytes
 
 void ASyncTCP::write(const uint8_t* pData, size_t length)
 {
-	write(std::string((const char*)pData, length));
+	write(std::string(reinterpret_cast<const char *>(pData), length));
 }
 
 void ASyncTCP::write(const std::string& msg)

--- a/hardware/AccuWeather.cpp
+++ b/hardware/AccuWeather.cpp
@@ -313,7 +313,7 @@ void CAccuWeather::GetMeterDetails()
 		if (barometric != 0)
 		{
 			//Add temp+hum+baro device
-			SendTempHumBaroSensor(1, 255, temp, humidity, static_cast<float>(barometric), barometric_forcast, "THB");
+			SendTempHumBaroSensor(1, 255, temp, humidity, float(barometric), barometric_forcast, "THB");
 		}
 		else if (humidity != 0)
 		{
@@ -363,7 +363,7 @@ void CAccuWeather::GetMeterDetails()
 		//UV
 		if (!root["UVIndex"].empty())
 		{
-			float UV = static_cast<float>(atof(root["UVIndex"].asString().c_str()));
+			float UV = float(atof(root["UVIndex"].asString().c_str()));
 			if ((UV < 16) && (UV >= 0))
 			{
 				SendUVSensor(0, 1, 255, UV, "UV");
@@ -375,7 +375,7 @@ void CAccuWeather::GetMeterDetails()
 		{
 			if (!root["PrecipitationSummary"]["Precipitation"].empty())
 			{
-				float RainCount = static_cast<float>(atof(root["PrecipitationSummary"]["Precipitation"]["Metric"]["Value"].asString().c_str()));
+				float RainCount = float(atof(root["PrecipitationSummary"]["Precipitation"]["Metric"]["Value"].asString().c_str()));
 				if ((RainCount != -9999.00F) && (RainCount >= 0.00F))
 				{
 					RBUF tsen;
@@ -393,23 +393,23 @@ void CAccuWeather::GetMeterDetails()
 
 					if (!root["PrecipitationSummary"]["PastHour"].empty())
 					{
-						float rainrateph = static_cast<float>(atof(root["PrecipitationSummary"]["PastHour"]["Metric"]["Value"].asString().c_str()));
+						float rainrateph = float(atof(root["PrecipitationSummary"]["PastHour"]["Metric"]["Value"].asString().c_str()));
 						if (rainrateph != -9999.00F)
 						{
 							int at10 = round(std::abs(rainrateph * 10.0F));
-							tsen.RAIN.rainrateh = (BYTE)(at10 / 256);
+							tsen.RAIN.rainrateh = BYTE(at10 / 256);
 							at10 -= (tsen.RAIN.rainrateh * 256);
-							tsen.RAIN.rainratel = (BYTE)(at10);
+							tsen.RAIN.rainratel = BYTE(at10);
 						}
 					}
 
 					int tr10 = int((float(RainCount) * 10.0F));
 					tsen.RAIN.raintotal1 = 0;
-					tsen.RAIN.raintotal2 = (BYTE)(tr10 / 256);
+					tsen.RAIN.raintotal2 = BYTE(tr10 / 256);
 					tr10 -= (tsen.RAIN.raintotal2 * 256);
-					tsen.RAIN.raintotal3 = (BYTE)(tr10);
+					tsen.RAIN.raintotal3 = BYTE(tr10);
 
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.RAIN, nullptr, 255, nullptr);
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RAIN), nullptr, 255, nullptr);
 				}
 			}
 		}
@@ -425,7 +425,7 @@ void CAccuWeather::GetMeterDetails()
 					_tGeneralDevice gdevice;
 					gdevice.subtype = sTypeVisibility;
 					gdevice.floatval1 = visibility;
-					sDecodeRXMessage(this, (const unsigned char *)&gdevice, nullptr, 255, nullptr);
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), nullptr, 255, nullptr);
 				}
 			}
 		}

--- a/hardware/AirconWithMe.cpp
+++ b/hardware/AirconWithMe.cpp
@@ -309,7 +309,7 @@ bool CAirconWithMe::GetInfo()
 			if (info[it.mName].isInt())
 			{
 				int32_t value = info[it.mName].asInt();
-				SendCustomSensor(it.mUID / 256, it.mUID, 255, static_cast<float>(value), it.mDescription, "");
+				SendCustomSensor(it.mUID / 256, it.mUID, 255, float(value), it.mDescription, "");
 			}
 		}
 		if (it.mDomoticzType == NDT_STRING)
@@ -347,7 +347,7 @@ void CAirconWithMe::UpdateDomoticzWithValue(int32_t uid, int32_t value)
 		break;
 
 	case NDT_THERMOSTAT:
-		SendSetPointSensor(0, uid / 256, uid % 256, static_cast<float>(value) / 10.0F, valueInfo.mDefaultName);
+		SendSetPointSensor(0, uid / 256, uid % 256, float(value) / 10.0F, valueInfo.mDefaultName);
 		break;
 
 	case NDT_SELECTORSWITCH:
@@ -355,15 +355,15 @@ void CAirconWithMe::UpdateDomoticzWithValue(int32_t uid, int32_t value)
 		break;
 
 	case NDT_THERMOMETER:
-		SendTempSensor(uid, 255, static_cast<float>(value) / 10.0F, valueInfo.mDefaultName);
+		SendTempSensor(uid, 255, float(value) / 10.0F, valueInfo.mDefaultName);
 		break;
 
 	case NDT_NUMBER:
-		SendCustomSensor(0, uid, 255, static_cast<float>(value), valueInfo.mDefaultName, "");
+		SendCustomSensor(0, uid, 255, float(value), valueInfo.mDefaultName, "");
 		break;
 
 	case NDT_HOUR:
-		SendCustomSensor(0, uid, 255, static_cast<float>(value), valueInfo.mDefaultName, "Hour");
+		SendCustomSensor(0, uid, 255, float(value), valueInfo.mDefaultName, "Hour");
 		break;
 
 	}
@@ -392,7 +392,7 @@ void CAirconWithMe::UpdateSelectorSwitch(const int32_t uid, const int32_t value,
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, xcmd.id, xcmd.unitcode);
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char*)&xcmd, valueInfo.mDefaultName.c_str(), xcmd.battery_level, m_Name.c_str());
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&xcmd), valueInfo.mDefaultName.c_str(), xcmd.battery_level, m_Name.c_str());
 	if (result.empty())
 	{
 		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', SwitchType=%d, CustomImage=%i WHERE(HardwareID == %d) AND (DeviceID == '%08X') AND (Unit == '%d')", valueInfo.mDefaultName.c_str(), (STYPE_Selector), 0, m_HwdID, xcmd.id, xcmd.unitcode);
@@ -443,7 +443,7 @@ bool CAirconWithMe::WriteToHardware(const char* pdata, const unsigned char lengt
 		if (mDeviceInfo.find(uid) == mDeviceInfo.end())
 			return false;
 
-		int32_t value = static_cast<int32_t>(pThemostat->temp * 10);
+		int32_t value = int32_t(pThemostat->temp * 10);
 		SendValueToAirco(uid, value);
 	}
 

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -158,7 +158,7 @@ void CAnnaThermostat::SendSetPointSensor(const unsigned char Idx, const float Te
 	thermos.id4 = Idx;
 	thermos.dunit = 1;
 	thermos.temp = Temp;
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), 255, nullptr);
 }
 
 bool CAnnaThermostat::WriteToHardware(const char* pdata, const unsigned char /*length*/)
@@ -507,7 +507,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendTempSensor(1, 255, temperature, sname);
 				}
 			}
@@ -516,7 +516,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float illuminance = (float)atof(tmpstr.c_str());
+					float illuminance = float(atof(tmpstr.c_str()));
 					SendLuxSensor(2, 1, 255, illuminance, sname);
 				}
 			}
@@ -525,7 +525,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendSetPointSensor(3, temperature, sname);
 				}
 			}
@@ -534,7 +534,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendTempSensor(4, 255, temperature, sname);
 				}
 			}
@@ -543,7 +543,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendTempSensor(5, 255, temperature, sname);
 				}
 			}
@@ -552,7 +552,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendTempSensor(6, 255, temperature, sname);
 				}
 			}
@@ -561,7 +561,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = float(atof(tmpstr.c_str()));
 					SendTempSensor(7, 255, temperature, sname);
 				}
 			}

--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -94,12 +94,12 @@ void Arilux::InsertUpdateSwitch(const std::string &lightName, const int subType,
 	{
 		Log(LOG_STATUS, "New controller added (%s/%s)", location.c_str(), lightName.c_str());
 		_tColorSwitch ycmd;
-		ycmd.subtype = (uint8_t)subType;
+		ycmd.subtype = uint8_t(subType);
 		ycmd.id = sID;
 		ycmd.dunit = 0;
 		ycmd.value = 0;
 		ycmd.command = Color_LedOff;
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&ycmd, nullptr, -1, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&ycmd), nullptr, -1, m_Name.c_str());
 		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', switchType=%d WHERE(HardwareID == %d) AND (DeviceID == '%q')", lightName.c_str(), STYPE_Dimmer, m_HwdID, szDeviceID);
 	}
 }
@@ -111,7 +111,7 @@ bool Arilux::SendTCPCommand(uint32_t ip,std::vector<unsigned char> &command)
 	//Add checksum calculation
 	int sum = std::accumulate(command.begin(), command.end(), 0);
 	sum = sum & 0xFF;
-	command.push_back((unsigned char)sum);
+	command.push_back(uint8_t(sum));
 
 	boost::asio::io_service io_service;
 	boost::asio::ip::tcp::socket sendSocket(io_service);
@@ -189,10 +189,10 @@ bool Arilux::WriteToHardware(const char *pdata, const unsigned char /*length*/)
 		}
 		// No break, fall through to send combined color + brightness command
 	case Color_SetBrightnessLevel:
-		Arilux_RGBCommand_Command[1] = static_cast<uint8_t>(m_color.r * pLed->value / 100);
-		Arilux_RGBCommand_Command[2] = static_cast<uint8_t>(m_color.g * pLed->value / 100);
-		Arilux_RGBCommand_Command[3] = static_cast<uint8_t>(m_color.b * pLed->value / 100);
-		Arilux_RGBCommand_Command[4] = static_cast<uint8_t>(m_color.ww * pLed->value / 100);
+		Arilux_RGBCommand_Command[1] = uint8_t(m_color.r * pLed->value / 100);
+		Arilux_RGBCommand_Command[2] = uint8_t(m_color.g * pLed->value / 100);
+		Arilux_RGBCommand_Command[3] = uint8_t(m_color.b * pLed->value / 100);
+		Arilux_RGBCommand_Command[4] = uint8_t(m_color.ww * pLed->value / 100);
 		return SendTCPCommand(pLed->id, Arilux_RGBCommand_Command);
 	}
 	Log(LOG_STATUS, "This command is unhandled, if you have a suggestion for what it should do, please post on the Domoticz forum");

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -386,21 +386,21 @@ void CAtagOne::GetMeterDetails()
 		Log(LOG_ERROR, "Invalid/no data received...");
 		return;
 	}
-	root["roomTemperature"] = static_cast<float>(atof(sret.c_str()));
+	root["roomTemperature"] = float(atof(sret.c_str()));
 	root["deviceAlias"] = GetHTMLPageValue(sResult, "Apparaat alias", "Device alias", false);
 	root["latestReportTime"] = GetHTMLPageValue(sResult, "Laatste rapportagetijd", "Latest report time", false);
 	root["connectedTo"] = GetHTMLPageValue(sResult, "Verbonden met", "Connected to", false);
-	root["burningHours"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Branduren", "Burning hours", true).c_str()));
+	root["burningHours"] = float(atof(GetHTMLPageValue(sResult, "Branduren", "Burning hours", true).c_str()));
 	root["boilerHeatingFor"] = GetHTMLPageValue(sResult, "Ketel in bedrijf voor", "Boiler heating for", false);
 	sret= GetHTMLPageValue(sResult, "Brander status", "Flame status", false);
 	root["flameStatus"] = ((sret == "Aan") || (sret == "On")) ? true : false;
-	root["outsideTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Buitentemperatuur", "Outside temperature", true).c_str()));
-	root["dhwSetpoint"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Setpoint warmwater", "DHW setpoint", true).c_str()));
-	root["dhwWaterTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Warmwatertemperatuur", "DHW water temperature", true).c_str()));
-	root["chSetpoint"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Setpoint cv", "CH setpoint", true).c_str()));
-	root["chWaterTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur", "CH water temperature", true).c_str()));
-	root["chWaterPressure"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV-waterdruk", "CH water pressure", true).c_str()));
-	root["chReturnTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV retourtemperatuur", "CH return temperature", true).c_str()));
+	root["outsideTemperature"] = float(atof(GetHTMLPageValue(sResult, "Buitentemperatuur", "Outside temperature", true).c_str()));
+	root["dhwSetpoint"] = float(atof(GetHTMLPageValue(sResult, "Setpoint warmwater", "DHW setpoint", true).c_str()));
+	root["dhwWaterTemperature"] = float(atof(GetHTMLPageValue(sResult, "Warmwatertemperatuur", "DHW water temperature", true).c_str()));
+	root["chSetpoint"] = float(atof(GetHTMLPageValue(sResult, "Setpoint cv", "CH setpoint", true).c_str()));
+	root["chWaterTemperature"] = float(atof(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur", "CH water temperature", true).c_str()));
+	root["chWaterPressure"] = float(atof(GetHTMLPageValue(sResult, "CV-waterdruk", "CH water pressure", true).c_str()));
+	root["chReturnTemperature"] = float(atof(GetHTMLPageValue(sResult, "CV retourtemperatuur", "CH return temperature", true).c_str()));
 
 #ifdef DEBUG_AtagOneThermostat_read
 	sResult = ReadFile("E:\\AtagOne_gettargetsetpoint.txt");
@@ -430,54 +430,54 @@ void CAtagOne::GetMeterDetails()
 		Log(LOG_ERROR, "Invalid/no data received...");
 		return;
 	}
-	root["targetTemperature"] = static_cast<float>(atof(root2["targetTemp"].asString().c_str()));
+	root["targetTemperature"] = float(atof(root2["targetTemp"].asString().c_str()));
 	root["currentMode"] = root2["currentMode"].asString();
 	root["vacationPlanned"] = root2["vacationPlanned"].asBool();
 
 	//Handle the Values
 	float temperature;
-	temperature = (float)root["targetTemperature"].asFloat();
+	temperature = root["targetTemperature"].asFloat();
 	SendSetPointSensor(0, 0, 1, temperature, "Room Setpoint");
 
-	temperature = (float)root["roomTemperature"].asFloat();
+	temperature = root["roomTemperature"].asFloat();
 	SendTempSensor(2, 255, temperature, "room Temperature");
 
 	if (!root["outsideTemperature"].empty())
 	{
-		temperature = (float)root["outsideTemperature"].asFloat();
+		temperature = root["outsideTemperature"].asFloat();
 		SendTempSensor(3, 255, temperature, "outside Temperature");
 	}
 
 	//DHW
 	if (!root["dhwSetpoint"].empty())
 	{
-		temperature = (float)root["dhwSetpoint"].asFloat();
+		temperature = root["dhwSetpoint"].asFloat();
 		SendSetPointSensor(0, 0, 2, temperature, "DHW Setpoint");
 	}
 	if (!root["dhwWaterTemperature"].empty())
 	{
-		temperature = (float)root["dhwWaterTemperature"].asFloat();
+		temperature = root["dhwWaterTemperature"].asFloat();
 		SendTempSensor(4, 255, temperature, "DHW Temperature");
 	}
 	//CH
 	if (!root["chSetpoint"].empty())
 	{
-		temperature = (float)root["chSetpoint"].asFloat();
+		temperature = root["chSetpoint"].asFloat();
 		SendSetPointSensor(0, 0, 3, temperature, "CH Setpoint");
 	}
 	if (!root["chWaterTemperature"].empty())
 	{
-		temperature = (float)root["chWaterTemperature"].asFloat();
+		temperature = root["chWaterTemperature"].asFloat();
 		SendTempSensor(5, 255, temperature, "CH Temperature");
 	}
 	if (!root["chWaterPressure"].empty())
 	{
-		float pressure = (float)root["chWaterPressure"].asFloat();
+		float pressure = root["chWaterPressure"].asFloat();
 		SendPressureSensor(1, 1, 255, pressure, "Pressure");
 	}
 	if (!root["chReturnTemperature"].empty())
 	{
-		temperature = (float)root["chReturnTemperature"].asFloat();
+		temperature = root["chReturnTemperature"].asFloat();
 		SendTempSensor(6, 255, temperature, "CH Return Temperature");
 	}
 
@@ -538,7 +538,7 @@ void CAtagOne::SetSetpoint(const int idx, const float temp)
 #ifdef DEBUG_AtagOneThermostat
 	SaveString2Disk(sResult, "E:\\AtagOne_setsetpoint.txt");
 #endif
-	SendSetPointSensor(0,0, (const uint8_t)idx, dtemp, "");
+	SendSetPointSensor(0, 0, uint8_t(idx), dtemp, "");
 }
 
 void CAtagOne::SetPauseStatus(const bool /*bIsPause*/)

--- a/hardware/BleBox.cpp
+++ b/hardware/BleBox.cpp
@@ -143,7 +143,7 @@ void BleBox::GetDevicesState()
 					const std::string currentColor = root["light"]["currentColor"].asString();
 					unsigned int hexNumber;
 					sscanf(currentColor.c_str(), "%x", &hexNumber);
-					int level = (int)(hexNumber / (255.0 / 100.0));
+					int level = int(hexNumber / (255.0 / 100.0));
 
 					SendSwitch(IP, 0, 255, level > 0, level, DevicesType[device.second].name);
 					break;
@@ -176,7 +176,7 @@ void BleBox::GetDevicesState()
 						break;
 
 					const int currentPos = root["dimmer"]["currentBrightness"].asInt();
-					int level = (int)(currentPos / (255.0 / 100.0));
+					int level = int(currentPos / (255.0 / 100.0));
 
 					SendSwitch(IP, 0, 255, level > 0, level, DevicesType[device.second].name);
 					break;
@@ -191,7 +191,7 @@ void BleBox::GetDevicesState()
 					{
 						if ((DoesNodeExists(relay, "relay") == false) || (DoesNodeExists(relay, "state") == false))
 							break;
-						uint8_t relayNumber = (uint8_t)relay["relay"].asInt(); // 0 or 1
+						uint8_t relayNumber = uint8_t(relay["relay"].asInt()); // 0 or 1
 						bool currentState = relay["state"].asBool();	       // 0 or 1
 						// std::string name = DevicesType[device.second].name + " " + relay["state"].asString();
 						SendSwitch(IP, relayNumber, 255, currentState, 0, DevicesType[device.second].name);
@@ -216,7 +216,7 @@ void BleBox::GetDevicesState()
 						Json::Value sensor = sensors[index];
 						if ((DoesNodeExists(sensor, "type") == false) || (DoesNodeExists(sensor, "value") == false))
 							break;
-						uint8_t value = (uint8_t)sensor["value"].asInt();
+						uint8_t value = uint8_t(sensor["value"].asInt());
 						std::string type = sensor["type"].asString();
 
 						// TODO - how save IP address ??
@@ -248,8 +248,7 @@ void BleBox::GetDevicesState()
 						}
 
 						std::string temperature = sensor["value"].asString(); // xxxx (xx.xx = temperature)
-						float ftemp = static_cast<float>(std::stoi(temperature.substr(0, 2))
-										 + std::stoi(temperature.substr(2, 2)) / 100.0);
+						float ftemp = float(std::stoi(temperature.substr(0, 2)) + std::stoi(temperature.substr(2, 2)) / 100.0);
 
 						// TODO - how save IP address ??
 						SendTempSensor(IP, 255, ftemp, DevicesType[device.second].name);
@@ -311,8 +310,8 @@ std::string BleBox::IPToHex(const std::string & IPAddress, const int type)
 	// because exists inconsistency when comparing deviceID in method decode_xxx in mainworker(Limitless uses small letter, lighting2 etc uses capital letter)
 	if (type != pTypeColorSwitch)
 	{
-		uint32_t sID = (uint32_t)(atoi(strarray[0].c_str()) << 24) | (uint32_t)(atoi(strarray[1].c_str()) << 16) | (atoi(strarray[2].c_str()) << 8) | atoi(strarray[3].c_str());
-		sprintf(szIdx, "%08X", (unsigned int)sID);
+		uint32_t sID = uint32_t(atoi(strarray[0].c_str()) << 24) | uint32_t(atoi(strarray[1].c_str()) << 16) | (atoi(strarray[2].c_str()) << 8) | atoi(strarray[3].c_str());
+		sprintf(szIdx, "%08X", uint32_t(sID));
 	}
 	else
 	{
@@ -383,7 +382,7 @@ bool BleBox::WriteToHardware(const char* pdata, const unsigned char /*length*/)
 					}
 					else
 					{
-						uint8_t percentage = static_cast<uint8_t>(output->LIGHTING2.level * 255 / 15);
+						uint8_t percentage = uint8_t(output->LIGHTING2.level * 255 / 15);
 
 						char value[4];
 						sprintf(value, "%x", percentage);
@@ -420,7 +419,7 @@ bool BleBox::WriteToHardware(const char* pdata, const unsigned char /*length*/)
 					}
 					else
 					{
-						uint8_t percentage = static_cast<uint8_t>(output->LIGHTING2.level * 255 / 15);
+						uint8_t percentage = uint8_t(output->LIGHTING2.level * 255 / 15);
 
 						char value[4];
 						sprintf(value, "%x", percentage);
@@ -602,8 +601,8 @@ bool BleBox::WriteToHardware(const char* pdata, const unsigned char /*length*/)
 			// No break, fall through to send combined color + brightness command
 		}
 		case Color_SetBrightnessLevel: {
-			int BrightnessBase = (int)pLed->value;
-			int dMax_Send = (int)(round((255.0F / 100.0F) * float(BrightnessBase)));
+			int BrightnessBase = int(pLed->value);
+			int dMax_Send = int(round((255.0F / 100.0F) * float(BrightnessBase)));
 
 			m_RGBWbrightnessState = dMax_Send;
 
@@ -687,13 +686,13 @@ void BleBox::SetSettings(const int pollIntervalSec)
 void BleBox::SendSwitch(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string & defaultname)
 { //TODO - remove this method, when in DomoticzHardware bug is fix (15 instead 16)
 	double rlevel = (15.0 / 100.0) * Level;
-	uint8_t level = (uint8_t)(rlevel);
+	uint8_t level = uint8_t(rlevel);
 
 	//make device ID
-	unsigned char ID1 = (unsigned char)((NodeID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((NodeID & 0xFF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((NodeID & 0xFF00) >> 8);
-	unsigned char ID4 = (unsigned char)NodeID & 0xFF;
+	uint8_t ID1 = uint8_t((NodeID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((NodeID & 0xFF0000) >> 16);
+	uint8_t ID3 = uint8_t((NodeID & 0xFF00) >> 8);
+	uint8_t ID4 = uint8_t(NodeID) & 0xFF;
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
@@ -740,7 +739,7 @@ void BleBox::SendSwitch(const int NodeID, const uint8_t ChildID, const int Batte
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), BatteryLevel, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), BatteryLevel, m_Name.c_str());
 }
 
 
@@ -1058,9 +1057,9 @@ std::string BleBox::GetUptime(const std::string & IPAddress)
 	else
 		return "unknown";
 
-	int days = static_cast<int>(total_minutes / (24 * 60));
-	int hours = static_cast<int>(total_minutes / 60 - days * 24);
-	int mins = static_cast<int>(total_minutes - days * 24 * 60 - hours * 60);   //sec / 60 - day * (24 * 60) - hour * 60;
+	int days = int(total_minutes / (24 * 60));
+	int hours = int(total_minutes / 60 - days * 24);
+	int mins = int(total_minutes - days * 24 * 60 - hours * 60); // sec / 60 - day * (24 * 60) - hour * 60;
 
 	char timestring[32];
 	sprintf(timestring, "%d:%02d:%02d", days, hours, mins);
@@ -1096,19 +1095,19 @@ void BleBox::AddNode(const std::string & name, const std::string & IPAddress, bo
 
 	if (deviceType.unit == 4) // gatebox
 	{
-		m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 1, (uint8_t)deviceType.deviceID, deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
+		m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 1, uint8_t(deviceType.deviceID), deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
 		m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 2, pTypeGeneralSwitch, sTypeAC, STYPE_PushOn, 0, "Unavailable", name);
 		m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 3, pTypeGeneralSwitch, sTypeAC, STYPE_PushOn, 0, "Unavailable", name);
 	}
 	else
 		if (deviceType.unit == 6) // switchboxd
 		{
-			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 0, (uint8_t)deviceType.deviceID, deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
-			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 1, (uint8_t)deviceType.deviceID, deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
+			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 0, uint8_t(deviceType.deviceID), deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
+			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 1, uint8_t(deviceType.deviceID), deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
 		}
 		else
 		{
-			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 0, (uint8_t)deviceType.deviceID, deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
+			m_sql.InsertDevice(m_HwdID, szIdx.c_str(), 0, uint8_t(deviceType.deviceID), deviceType.subType, deviceType.switchType, 0, "Unavailable", name);
 		}
 
 	if (reloadNodes)

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -156,7 +156,7 @@ void CBuienRadar::Do_Work()
 			if ((m_rainShowerLeadTime > 0) && (sec_counter % 60 == 0))
 			{
 				m_rainShowerLeadTime--;
-				SendCustomSensor(RAINSHOWER_LEADTIME, 1, 255, static_cast<float>(m_rainShowerLeadTime), "Expected Rainshower Leadtime", "minutes");
+				SendCustomSensor(RAINSHOWER_LEADTIME, 1, 255, float(m_rainShowerLeadTime), "Expected Rainshower Leadtime", "minutes");
 			}
 		}
 	}
@@ -623,7 +623,7 @@ void CBuienRadar::GetRainPrediction()
 						else
 						{
 							// add stats
-							double rain_rate = pow(10, ((double)(rain_value - 109) / 32));
+							double rain_rate = pow(10, (double(rain_value - 109) / 32));
 							total_rainvalues_in_next_rainshower++;
 							total_rainmmh_in_next_rainshower += rain_rate;
 							if (rain_rate > max_rainmmh_in_next_rainshower)
@@ -640,7 +640,7 @@ void CBuienRadar::GetRainPrediction()
 					shower_detected = true;
 
 					// add stats
-					double rain_rate = pow(10, ((double)(rain_value - 109) / 32));
+					double rain_rate = pow(10, (double(rain_value - 109) / 32));
 
 					total_rainvalues_in_next_rainshower++;
 					total_rainmmh_in_next_rainshower += rain_rate;
@@ -696,24 +696,24 @@ void CBuienRadar::GetRainPrediction()
 		}
 
 		m_rainShowerLeadTime = start_of_rainshower - startTime;
-		SendCustomSensor(RAINSHOWER_LEADTIME, 1, 255, static_cast<float>(round_digits(m_rainShowerLeadTime, 1)), "Next Rainshower Leadtime", "min");
-		SendCustomSensor(RAINSHOWER_DURATION, 1, 255, static_cast<float>(round_digits(end_of_rainshower - start_of_rainshower, 1)), "Next Rainshower Duration", "min");
-		SendCustomSensor(RAINSHOWER_AVERAGE_MMH, 1, 255, static_cast<float>(round_digits(avg_rainmmh_in_next_rainshower, 1)), "Next Rainshower Avg Rainrate", "mm/h");
-		SendCustomSensor(RAINSHOWER_MAX_MMH, 1, 255, static_cast<float>(round_digits(max_rainmmh_in_next_rainshower, 1)), "Next Rainshower Max Rainrate", "mm/h");
+		SendCustomSensor(RAINSHOWER_LEADTIME, 1, 255, float(round_digits(m_rainShowerLeadTime, 1)), "Next Rainshower Leadtime", "min");
+		SendCustomSensor(RAINSHOWER_DURATION, 1, 255, float(round_digits(end_of_rainshower - start_of_rainshower, 1)), "Next Rainshower Duration", "min");
+		SendCustomSensor(RAINSHOWER_AVERAGE_MMH, 1, 255, float(round_digits(avg_rainmmh_in_next_rainshower, 1)), "Next Rainshower Avg Rainrate", "mm/h");
+		SendCustomSensor(RAINSHOWER_MAX_MMH, 1, 255, float(round_digits(max_rainmmh_in_next_rainshower, 1)), "Next Rainshower Max Rainrate", "mm/h");
 
 		if (total_rain_values_in_duration)
 		{
 			double rain_avg = total_rain_in_duration / total_rain_values_in_duration;
 			//double rain_mm_hour = pow(10, ((rain_avg - 109) / 32));
 			double rain_perc = (rain_avg == 0) ? 0 : (rain_avg * 0.392156862745098);
-			SendPercentageSensor(1, 1, 255, static_cast<float>(rain_perc), "Rain Intensity");
+			SendPercentageSensor(1, 1, 255, float(rain_perc), "Rain Intensity");
 			SendSwitch(2, 1, 255, (rain_perc >= m_iThreshold), 0, "Possible Rain", m_Name);
 		}
 		if (total_rain_values_next_hour)
 		{
 			double rain_avg = total_rain_next_hour / total_rain_values_next_hour;
 			double rain_mm_hour = (rain_avg == 0) ? 0 : pow(10, ((rain_avg - 109) / 32));
-			SendCustomSensor(1, 1, 255, static_cast<float>(round_digits(rain_mm_hour, 1)), "Rainfall next Hour", "mm/h");
+			SendCustomSensor(1, 1, 255, float(round_digits(rain_mm_hour, 1)), "Rainfall next Hour", "mm/h");
 		}
 	}
 	else

--- a/hardware/ColorSwitch.cpp
+++ b/hardware/ColorSwitch.cpp
@@ -64,12 +64,12 @@ void _tColor::fromJSON(const Json::Value &root)
 		int tmp = root.get("m", 0).asInt();
 		if (tmp == ColorModeNone || tmp > ColorModeLast) return;
 		mode = ColorMode(tmp);
-		t = (uint8_t)root.get("t", 0).asInt();
-		r = (uint8_t)root.get("r", 0).asInt();
-		g = (uint8_t)root.get("g", 0).asInt();
-		b = (uint8_t)root.get("b", 0).asInt();
-		cw = (uint8_t)root.get("cw", 0).asInt();
-		ww = (uint8_t)root.get("ww", 0).asInt();
+		t = uint8_t(root.get("t", 0).asInt());
+		r = uint8_t(root.get("r", 0).asInt());
+		g = uint8_t(root.get("g", 0).asInt());
+		b = uint8_t(root.get("b", 0).asInt());
+		cw = uint8_t(root.get("cw", 0).asInt());
+		ww = uint8_t(root.get("ww", 0).asInt());
 		//level = root.get("l", 0).asInt();
 	}
 	catch (...) {
@@ -128,7 +128,7 @@ std::string _tColor::toString() const
 	// Return the empty string if the color is not valid
 	if (mode == ColorModeNone || mode > ColorModeLast) return "{INVALID}";
 
-	snprintf(tmp, sizeof(tmp), "{m: %u, RGB: %02x%02x%02x, CWWW: %02x%02x, CT: %u}", (unsigned int)mode, r, g, b, cw, ww, t);
+	snprintf(tmp, sizeof(tmp), "{m: %u, RGB: %02x%02x%02x, CWWW: %02x%02x, CT: %u}", uint32_t(mode), r, g, b, cw, ww, t);
 
 	return std::string(tmp);
 }

--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -109,7 +109,7 @@ void Comm5SMTCP::Do_Work()
 
 void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 {
-	buffer.append((const char*)data, len);
+	buffer.append(reinterpret_cast<const char *>(data), len);
 
 	if (buffer.find('\n') == std::string::npos)
 		return; // Incomplete lines
@@ -124,7 +124,7 @@ void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			float temperature = static_cast<float>(atof(tokens[1].c_str()));
+			float temperature = float(atof(tokens[1].c_str()));
 			SendTempSensor(1, 255, temperature, "TEMPERATURE");
 		}
 		else if (startsWith(line, "281")) {
@@ -140,13 +140,13 @@ void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			float baro = static_cast<float>(atof(tokens[1].c_str()));
+			float baro = float(atof(tokens[1].c_str()));
 			SendBaroSensor(1, 0, 255, baro, 0, "BAROMETRIC");
 		}
 	}
 
 	// Trim consumed bytes.
-	buffer.erase(0, buffer.length() - static_cast<unsigned int>(stream.rdbuf()->in_avail()));
+	buffer.erase(0, buffer.length() - uint32_t(stream.rdbuf()->in_avail()));
 }
 
 void Comm5SMTCP::querySensorState()

--- a/hardware/Comm5Serial.cpp
+++ b/hardware/Comm5Serial.cpp
@@ -177,7 +177,7 @@ void Comm5Serial::readCallBack(const char * data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData((const unsigned char*)data, static_cast<int>(len));
+	ParseData(reinterpret_cast<const unsigned char *>(data), int(len));
 }
 
 uint16_t Comm5Serial::crc16_update(uint16_t crc, const uint8_t data)
@@ -185,11 +185,11 @@ uint16_t Comm5Serial::crc16_update(uint16_t crc, const uint8_t data)
 #define POLYNOME 0x13D65
 	int i;
 
-	crc = crc ^ ((uint16_t)data << 8);
+	crc = crc ^ (uint16_t(data) << 8);
 	for (i = 0; i<8; i++)
 	{
 		if (crc & 0x8000)
-			crc = (uint16_t)((crc << 1) ^ POLYNOME);
+			crc = uint16_t((crc << 1) ^ POLYNOME);
 		else
 			crc <<= 1;
 	}
@@ -260,7 +260,7 @@ void Comm5Serial::ParseData(const unsigned char* data, const size_t len)
 		case STFRAME_CRC2:
 			frame.push_back(data[i]);
 			frameCRC = crc16_update(frameCRC, 0);
-			readCRC = (static_cast<uint16_t>(frame.at(frame.size() - 2)) << 8) | frame.at(frame.size() - 1);
+			readCRC = uint16_t((frame.at(frame.size() - 2)) << 8) | frame.at(frame.size() - 1);
 			if (frameCRC == readCRC)
 				parseFrame(frame);
 			else
@@ -290,7 +290,7 @@ void Comm5Serial::parseFrame(const std::string & mframe)
 
 bool Comm5Serial::writeFrame(const std::string & data)
 {
-	char length = (uint8_t)data.size();
+	char length = uint8_t(data.size());
 	std::string mframe("\x05\x64", 2);
 	mframe.push_back(length);
 	mframe.push_back(0x00);

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -133,7 +133,7 @@ void Comm5TCP::processSensorData(const std::string& line)
 
 void Comm5TCP::ParseData(const unsigned char* data, const size_t len)
 {
-	buffer.append((const char*)data, len);
+	buffer.append(reinterpret_cast<const char *>(data), len);
 
 	std::stringstream stream(buffer);
 	std::string line;
@@ -157,7 +157,7 @@ void Comm5TCP::ParseData(const unsigned char* data, const size_t len)
 	}
 
 	// Trim consumed bytes.
-	buffer.erase(0, buffer.length() - static_cast<unsigned int>(stream.rdbuf()->in_avail()));
+	buffer.erase(0, buffer.length() - uint32_t(stream.rdbuf()->in_avail()));
 }
 
 void Comm5TCP::queryRelayState()

--- a/hardware/CurrentCostMeterBase.cpp
+++ b/hardware/CurrentCostMeterBase.cpp
@@ -110,7 +110,7 @@ void CurrentCostMeterBase::ExtractReadings()
 			// create a suitable default name
 			// there can only be 8 sensors so this
 			// method is OK and should be faster
-			char sensorInt(static_cast<char>(sensor));
+			char sensorInt((char(sensor)));
 			std::string sensorName("CC Sensor 0 Power");
 			sensorName[10] += sensorInt;
 			SendWattMeter(2 + sensorInt, 1, 255, totalPower, sensorName);
@@ -131,7 +131,7 @@ void CurrentCostMeterBase::ExtractReadings()
 		if (consumption != 0.0)
 		{
 			consumption /= ipu;
-			char sensorInt(static_cast<char>(sensor));
+			char sensorInt((char(sensor)));
 			std::string sensorName("CC Sensor 0 kWh consumption");
 			sensorName[10] += sensorInt;
 			SendKwhMeter(2 + sensorInt, 2, 255, 0, consumption, sensorName);

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -80,7 +80,7 @@ void CurrentCostMeterSerial::readCallback(const char *data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData(data, static_cast<int>(len));
+	ParseData(data, int(len));
 }
 
 bool CurrentCostMeterSerial::WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/)

--- a/hardware/CurrentCostMeterTCP.cpp
+++ b/hardware/CurrentCostMeterTCP.cpp
@@ -83,7 +83,7 @@ bool CurrentCostMeterTCP::ConnectInternal()
 
 	// connect to the server
 	int nRet;
-	nRet = connect(m_socket,(const sockaddr*)&m_addr, sizeof(m_addr));
+	nRet = connect(m_socket, reinterpret_cast<const sockaddr *>(&m_addr), sizeof(m_addr));
 	if (nRet == SOCKET_ERROR)
 	{
 		closesocket(m_socket);

--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -241,9 +241,9 @@ void CDaikin::UpdateSwitchNew(const unsigned char Idx, const int /*SubUnit*/, co
 		gswitch.cmnd = gswitch_sOff;
 	else
 		gswitch.cmnd = gswitch_sOn;
-	gswitch.level = static_cast<uint8_t>(Level);
+	gswitch.level = uint8_t(Level);
 	gswitch.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&gswitch, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 void CDaikin::GetMeterDetails()
@@ -417,7 +417,7 @@ void CDaikin::GetControlInfo()
 			if (m_otemp != results2[1])
 			{
 				m_otemp = results2[1];
-				SendTempSensor(10, -1, static_cast<float>(atof(results2[1].c_str())), "Outside Temperature");
+				SendTempSensor(10, -1, float(atof(results2[1].c_str())), "Outside Temperature");
 			}
 		}
 		else if (results2[0] == "stemp")
@@ -425,7 +425,7 @@ void CDaikin::GetControlInfo()
 			if (m_stemp != results2[1])
 			{
 				m_stemp = results2[1];
-				SendSetPointSensor(20, 1, 1, static_cast<float>(atof(results2[1].c_str())), "Target Temperature");
+				SendSetPointSensor(20, 1, 1, float(atof(results2[1].c_str())), "Target Temperature");
 			}
 		}
 		else if (results2[0] == "f_rate")
@@ -546,17 +546,16 @@ void CDaikin::GetSensorInfo()
 			continue;
 		if (results2[0] == "htemp")
 		{
-			htemp = static_cast<float>(atof(results2[1].c_str()));
+			htemp = float(atof(results2[1].c_str()));
 		}
 		else if (results2[0] == "hhum")
 		{
 			if (results2[1] != "-")
-				hhum = static_cast<int>(atoi(results2[1].c_str()));
+				hhum = int(atoi(results2[1].c_str()));
 		}
 		else if (results2[0] == "otemp")
 		{
-			SendTempSensor(10, -1, static_cast<float>(atof(results2[1].c_str())), "Outside Temperature");
-
+			SendTempSensor(10, -1, float(atof(results2[1].c_str())), "Outside Temperature");
 		}
 	}
 	if (htemp != -1)
@@ -720,7 +719,7 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx, const bool bIs
 
 	xcmd.subtype = sSwitchTypeSelector;
 	if (level > 0) {
-		xcmd.level = (uint8_t)level;
+		xcmd.level = uint8_t(level);
 	}
 
 	//check if this switch is already in the database
@@ -734,7 +733,7 @@ void CDaikin::InsertUpdateSwitchSelector(const unsigned char Idx, const bool bIs
 	}
 
 	result = m_sql.safe_query("SELECT nValue, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='0000000%d') AND (Type==%d) AND (Unit == '%d')", m_HwdID, sID, xcmd.type, xcmd.unitcode);
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char*)&xcmd, defaultname.c_str(), 255, m_Name.c_str());
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&xcmd), defaultname.c_str(), 255, m_Name.c_str());
 	if (result.empty())
 	{
 		// New Hardware -> Create the corresponding devices Selector

--- a/hardware/DarkSky.cpp
+++ b/hardware/DarkSky.cpp
@@ -214,7 +214,7 @@ void CDarkSky::GetMeterDetails()
 	if (barometric!=0)
 	{
 		//Add temp+hum+baro device
-		SendTempHumBaroSensor(1, 255, temp, humidity, static_cast<float>(barometric), barometric_forcast, "THB");
+		SendTempHumBaroSensor(1, 255, temp, humidity, float(barometric), barometric_forcast, "THB");
 	}
 	else if (humidity!=0)
 	{
@@ -244,7 +244,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["windSpeed"] != "N/A") && (root["currently"]["windSpeed"] != "--"))
 		{
-			float temp_wind_mph = static_cast<float>(atof(root["currently"]["windSpeed"].asString().c_str()));
+			float temp_wind_mph = float(atof(root["currently"]["windSpeed"].asString().c_str()));
 			if (temp_wind_mph != -9999.00F)
 			{
 				//convert to m/s
@@ -256,7 +256,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["windGust"] != "N/A") && (root["currently"]["windGust"] != "--"))
 		{
-			float temp_wind_gust_mph = static_cast<float>(atof(root["currently"]["windGust"].asString().c_str()));
+			float temp_wind_gust_mph = float(atof(root["currently"]["windGust"].asString().c_str()));
 			if (temp_wind_gust_mph != -9999.00F)
 			{
 				//convert to m/s
@@ -268,7 +268,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["apparentTemperature"] != "N/A") && (root["currently"]["apparentTemperature"] != "--"))
 		{
-			wind_chill = static_cast<float>(atof(root["currently"]["apparentTemperature"].asString().c_str()));
+			wind_chill = float(atof(root["currently"]["apparentTemperature"].asString().c_str()));
 			//Convert to celcius
 			wind_chill=float((wind_chill-32)*(5.0/9.0));
 		}
@@ -287,23 +287,23 @@ void CDarkSky::GetMeterDetails()
 
 		float winddir=float(wind_degrees);
 		int aw=round(winddir);
-		tsen.WIND.directionh=(BYTE)(aw/256);
+		tsen.WIND.directionh = BYTE(aw / 256);
 		aw-=(tsen.WIND.directionh*256);
-		tsen.WIND.directionl=(BYTE)(aw);
+		tsen.WIND.directionl = BYTE(aw);
 
 		tsen.WIND.av_speedh=0;
 		tsen.WIND.av_speedl=0;
 		int sw = round(windspeed_ms * 10.0F);
-		tsen.WIND.av_speedh=(BYTE)(sw/256);
+		tsen.WIND.av_speedh = BYTE(sw / 256);
 		sw-=(tsen.WIND.av_speedh*256);
-		tsen.WIND.av_speedl=(BYTE)(sw);
+		tsen.WIND.av_speedl = BYTE(sw);
 
 		tsen.WIND.gusth=0;
 		tsen.WIND.gustl=0;
 		int gw = round(windgust_ms * 10.0F);
-		tsen.WIND.gusth=(BYTE)(gw/256);
+		tsen.WIND.gusth = BYTE(gw / 256);
 		gw-=(tsen.WIND.gusth*256);
-		tsen.WIND.gustl=(BYTE)(gw);
+		tsen.WIND.gustl = BYTE(gw);
 
 		//this is not correct, why no wind temperature? and only chill?
 		tsen.WIND.chillh=0;
@@ -313,17 +313,17 @@ void CDarkSky::GetMeterDetails()
 
 		tsen.WIND.tempsign=(wind_temp>=0)?0:1;
 		int at10 = round(std::abs(wind_temp * 10.0F));
-		tsen.WIND.temperatureh=(BYTE)(at10/256);
+		tsen.WIND.temperatureh = BYTE(at10 / 256);
 		at10-=(tsen.WIND.temperatureh*256);
-		tsen.WIND.temperaturel=(BYTE)(at10);
+		tsen.WIND.temperaturel = BYTE(at10);
 
 		tsen.WIND.chillsign=(wind_chill>=0)?0:1;
 		at10 = round(std::abs(wind_chill * 10.0F));
-		tsen.WIND.chillh=(BYTE)(at10/256);
+		tsen.WIND.chillh = BYTE(at10 / 256);
 		at10-=(tsen.WIND.chillh*256);
-		tsen.WIND.chilll=(BYTE)(at10);
+		tsen.WIND.chilll = BYTE(at10);
 
-		sDecodeRXMessage(this, (const unsigned char *)&tsen.WIND, nullptr, 255, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.WIND), nullptr, 255, nullptr);
 	}
 
 	//UV
@@ -344,7 +344,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["precipIntensity"] != "N/A") && (root["currently"]["precipIntensity"] != "--"))
 		{
-			float rainrateph = static_cast<float>(atof(root["currently"]["precipIntensity"].asString().c_str())) * 25.4F; // inches to mm
+			float rainrateph = float(atof(root["currently"]["precipIntensity"].asString().c_str())) * 25.4F; // inches to mm
 			if ((rainrateph != -9999.00F) && (rainrateph >= 0.00F))
 			{
 				SendRainRateSensor(1, 255, rainrateph, "Rain");
@@ -357,13 +357,13 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["visibility"] != "N/A") && (root["currently"]["visibility"] != "--"))
 		{
-			float visibility = static_cast<float>(atof(root["currently"]["visibility"].asString().c_str())) * 1.60934F; // miles to km
+			float visibility = float(atof(root["currently"]["visibility"].asString().c_str())) * 1.60934F; // miles to km
 			if (visibility>=0)
 			{
 				_tGeneralDevice gdevice;
 				gdevice.subtype=sTypeVisibility;
 				gdevice.floatval1=visibility;
-				sDecodeRXMessage(this, (const unsigned char *)&gdevice, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), nullptr, 255, nullptr);
 			}
 		}
 	}
@@ -372,7 +372,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["ozone"] != "N/A") && (root["currently"]["ozone"] != "--"))
 		{
-			float radiation = static_cast<float>(atof(root["currently"]["ozone"].asString().c_str()));
+			float radiation = float(atof(root["currently"]["ozone"].asString().c_str()));
 			if (radiation >= 0.0F)
 			{
 				SendCustomSensor(1, 0, 255, radiation, "Ozone Sensor", "DU"); //(dobson units)
@@ -384,7 +384,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["cloudCover"] != "N/A") && (root["currently"]["cloudCover"] != "--"))
 		{
-			float cloudcover = static_cast<float>(atof(root["currently"]["cloudCover"].asString().c_str()));
+			float cloudcover = float(atof(root["currently"]["cloudCover"].asString().c_str()));
 			if (cloudcover >= 0.0F)
 			{
 				SendPercentageSensor(1, 0, 255, cloudcover * 100.0F, "Cloud Cover");

--- a/hardware/DenkoviDevices.cpp
+++ b/hardware/DenkoviDevices.cpp
@@ -439,7 +439,7 @@ bool CDenkoviDevices::WriteToHardware(const char *pdata, const unsigned char /*l
 			szURL << "0";
 		else if (command== light2_sSetLevel) {
 			double lvl = level*10.34;
-			int iLvl = (int)lvl;
+			int iLvl = int(lvl);
 			szURL << std::to_string(iLvl);
 		}
 		else
@@ -598,7 +598,7 @@ float CDenkoviDevices::DenkoviGetFloatParameter(std::string tmpstr, const std::s
 		tmpstr = tmpstr.substr(pos1 + strlen(parameter.c_str()));
 		pos1 = tmpstr.find('<');
 		if (pos1 != std::string::npos)
-			value = static_cast<float>(atof(tmpstr.substr(0, pos1).c_str()));
+			value = float(atof(tmpstr.substr(0, pos1).c_str()));
 	}
 	return value;
 }
@@ -639,7 +639,7 @@ uint8_t CDenkoviDevices::DAEnetIP2GetIoPort(const std::string &tmpstr, const int
 		pos2 = tmpstr.find(',', pos1);
 		ss << std::hex << tmpstr.substr(pos1 + 3, pos2 - (pos1 + 3)).c_str();
 		ss >> b;
-		return (uint8_t)b;
+		return uint8_t(b);
 	}
 	if (port == DAENETIP2_PORT_5_VAL)
 	{
@@ -647,7 +647,7 @@ uint8_t CDenkoviDevices::DAEnetIP2GetIoPort(const std::string &tmpstr, const int
 		pos2 = tmpstr.find(',', pos1 + 3);
 		ss << std::hex << tmpstr.substr(pos1 + 3, pos2 - (pos1 + 3)).c_str();
 		ss >> b;
-		return (uint8_t)b;
+		return uint8_t(b);
 	}
 	return 0;
 }
@@ -674,16 +674,16 @@ uint16_t CDenkoviDevices::DAEnetIP2GetAiValue(const std::string &tmpstr, const i
 	pos2 = tmpstr.find(',', pos1 + 2);
 	ss << std::hex << tmpstr.substr(pos1 + 2, pos2 - (pos1 + 2)).c_str();
 	ss >> b;
-	return (uint16_t)b;
+	return uint16_t(b);
 }
 
 float CDenkoviDevices::DAEnetIP2CalculateAi(int adc, const int &valType) {
 	if (valType == DAENETIP2_AI_TEMPERATURE) {
-		return static_cast<float>(10000 * ((1.2*204.8)*adc / (120 * 1024) + 0) / 100);
+		return float(10000 * ((1.2 * 204.8) * adc / (120 * 1024) + 0) / 100);
 	}
 	if (valType == DAENETIP2_AI_VOLTAGE)
 	{
-		return static_cast<float>(10000 * ((1.2*0.377)*adc / (4.7 * 1024) + 0) / 100);
+		return float(10000 * ((1.2 * 0.377) * adc / (4.7 * 1024) + 0) / 100);
 	}
 	return 0.0F;
 }
@@ -801,7 +801,7 @@ void CDenkoviDevices::GetMeterDetails()
 		bool bHaveAnalogInput = false;
 		bool bHaveTemperatureInput = false;
 		bool bHaveRelay = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -845,8 +845,8 @@ void CDenkoviDevices::GetMeterDetails()
 
 			if (bHaveDigitalInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_STATE_DEF)) != -1))
 			{
-				name = "Digital Input " + std::to_string(Idx) + " (" + name + ")"; 
-				SendSwitch(DIOType_DI, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
+				name = "Digital Input " + std::to_string(Idx) + " (" + name + ")";
+				SendSwitch(DIOType_DI, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
 				Idx = -1;
 				bHaveDigitalInput = false;
 				continue;
@@ -858,13 +858,13 @@ void CDenkoviDevices::GetMeterDetails()
 				StringSplit(tmpMeasure, " ", vMeasure); 
 				int len = tmpMeasure.length() - tmpMeasure.find_first_of('.', 0) - 2;
 				std::string units = tmpMeasure.substr(tmpMeasure.find_first_of('.',0)+2, len);
-				SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled (" + name + ")", units);
+				SendCustomSensor(Idx, 1, 255, float(atof(vMeasure[0].c_str())), "Analog Input Scaled (" + name + ")", units);
 
 				std::vector<std::string> vRaw;
 				tmpstr = results[ii - 1];
 				std::string tmpRawValue = DenkoviGetStrParameter(tmpstr, DAE_VALUE_DEF);
 				StringSplit(tmpRawValue, " ", vRaw);
-				SendCustomSensor(Idx+1, 1, 255, static_cast<float>(atof(vRaw[0].c_str())), "Analog Input (" + name + ")", "");
+				SendCustomSensor(Idx + 1, 1, 255, float(atof(vRaw[0].c_str())), "Analog Input (" + name + ")", "");
 
 				Idx = -1;
 				bHaveAnalogInput = false;
@@ -876,9 +876,9 @@ void CDenkoviDevices::GetMeterDetails()
 				name = "Temperature Input (" + name + ")";
 				std::vector<std::string> vMeasure;
 				StringSplit(tmpMeasure, " ", vMeasure);
-				tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+				tmpTiValue = float(atof(tmpMeasure.c_str()));
 				if (tmpMeasure.find('F') != std::string::npos)
-					tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
+					tmpTiValue = float(ConvertToCelsius(double(tmpTiValue)));
 				SendTempSensor(Idx, 255, tmpTiValue, name);
 
 				Idx = -1;
@@ -889,7 +889,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHaveRelay && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_STATE_DEF)) != -1))
 			{
 				name = "Relay " + std::to_string(Idx) + " (" + name + ")";
-				SendSwitch(DIOType_Relay, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
+				SendSwitch(DIOType_Relay, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
 				Idx = -1;
 				bHaveRelay = false;
 				continue;
@@ -905,7 +905,7 @@ void CDenkoviDevices::GetMeterDetails()
 					tmpValue = blinds_sClose;
 				else
 					tmpValue = 0x11;
-				SendSwitch(DIOType_MCD, (uint8_t)Idx, 255, tmpValue, 0, tmpN, m_Name);
+				SendSwitch(DIOType_MCD, uint8_t(Idx), 255, tmpValue, 0, tmpN, m_Name);
 				ii = ii + 4;
 				tmpstr = stdstring_trim(results[ii]);
 				tmpMeasure = DenkoviGetStrParameter(tmpstr, DAE_LASTO_DEF);
@@ -928,20 +928,20 @@ void CDenkoviDevices::GetMeterDetails()
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 1);
 			name = "Digital IO " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_DIO, (uint8_t)(ii + 1), 255, ((port3 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_DIO, uint8_t(ii + 1), 255, ((port3 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 		for (ii = 0; ii < 8; ii++)//8 digital inputs/outputs from port5
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 8 + 1);
 			name = "Relay " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_Relay, (uint8_t)(ii + 8 + 1), 255, ((port5 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_Relay, uint8_t(ii + 8 + 1), 255, ((port5 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 		for (ii = 0; ii < 8; ii++)//8 analog inputs
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 16 + 1);
 			tmpValue = DAEnetIP2GetAiValue(sResult, ii + 1);
 			name = "Analog Input " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendCustomSensor(DIOType_AI, (uint8_t)(ii + 16 + 1), 255, static_cast<float>(tmpValue), name, "");
+			SendCustomSensor(DIOType_AI, uint8_t(ii + 16 + 1), 255, float(tmpValue), name, "");
 			//float voltageValue = (float)(10.44*(tmpValue / 1024));
 			float voltageValue = DAEnetIP2CalculateAi(tmpValue, DAENETIP2_AI_VOLTAGE);
 			SendVoltageSensor(DIOType_AI, ii + 24 + 1, 255, voltageValue, name);
@@ -958,20 +958,20 @@ void CDenkoviDevices::GetMeterDetails()
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 1);
 			name = "Digital IO " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_DIO, (uint8_t)(ii + 1), 255, ((port3 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_DIO, uint8_t(ii + 1), 255, ((port3 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 		for (ii = 0; ii < 8; ii++)//8 digital inputs/outputs from port5
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 8 + 1);
 			name = "Digital IO " + std::to_string(ii + 8 + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_DIO, (uint8_t)(ii + 8 + 1), 255, ((port5 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_DIO, uint8_t(ii + 8 + 1), 255, ((port5 & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 		for (ii = 0; ii < 8; ii++)//8 analog inputs
 		{
 			tmpName = DAEnetIP2GetName(sResult, ii + 16 + 1);
 			tmpValue = DAEnetIP2GetAiValue(sResult, ii + 1);
 			name = "Analog Input " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendCustomSensor(DIOType_AI, (uint8_t)(ii + 16 + 1), 255, static_cast<float>(tmpValue), name, "");
+			SendCustomSensor(DIOType_AI, uint8_t(ii + 16 + 1), 255, float(tmpValue), name, "");
 		}
 		break;
 	}
@@ -983,7 +983,7 @@ void CDenkoviDevices::GetMeterDetails()
 			io << std::uppercase << std::hex << ii;
 			tmpName = DAEnetIP3GetIo(sResult, DAENETIP3_PORTA_SNAME_DEF + io.str());
 			name = "Digital Output " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_DO, (uint8_t)(ii + 1), 255, ((pins & (0x0001 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_DO, uint8_t(ii + 1), 255, ((pins & (0x0001 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 
 		pins = std::stoul(DAEnetIP3GetIo(sResult, DAENETIP3_PORTB_MDI_DEF), nullptr, 16);
@@ -993,22 +993,22 @@ void CDenkoviDevices::GetMeterDetails()
 			io << std::uppercase << std::hex << ii;
 			tmpName = DAEnetIP3GetIo(sResult2, DAENETIP3_PORTB_SNAME_DEF + io.str());
 			name = "Digital Input " + std::to_string(ii + 1) + " (" + tmpName + ")";
-			SendSwitch(DIOType_DI, (uint8_t)(ii + 1), 255, ((pins & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
+			SendSwitch(DIOType_DI, uint8_t(ii + 1), 255, ((pins & (0x01 << ii)) != 0) ? true : false, 0, name, m_Name);
 		} 
 
 		for (ii = 0; ii < 8; ii++)//8 analog inputs
 		{
 			tmpMeasure = DAEnetIP3GetAi(sResult, (DAENETIP3_PORTC_SVAL_DEF + std::to_string(ii)), DAENETIP3_AI_VALUE);
 			tmpstr = DAEnetIP3GetAi(sResult, (DAENETIP3_PORTC_SVAL_DEF + std::to_string(ii)), DAENETIP3_AI_DIMENSION);
-			tmpName = DAEnetIP3GetIo(sResult2, DAENETIP3_PORTC_SNAME_DEF + std::to_string(ii)); 
-			SendCustomSensor(DIOType_AI, (uint8_t)(ii + 1), 255, static_cast<float>(atoi(tmpMeasure.c_str())), "Analog Input Scaled " + std::to_string(ii + 1) + " (" + tmpName + ")", tmpstr);
+			tmpName = DAEnetIP3GetIo(sResult2, DAENETIP3_PORTC_SNAME_DEF + std::to_string(ii));
+			SendCustomSensor(DIOType_AI, uint8_t(ii + 1), 255, float(atoi(tmpMeasure.c_str())), "Analog Input Scaled " + std::to_string(ii + 1) + " (" + tmpName + ")", tmpstr);
 		}
 	}
 	case DDEV_SmartDEN_IP_16_R_MT://has only relays
 	case DDEV_SmartDEN_IP_16_R_MQ:  
 	case DDEV_SmartDEN_IP_16_Relays: {//has only relays
 		bool bHaveRelays = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1028,7 +1028,7 @@ void CDenkoviDevices::GetMeterDetails()
 			{
 				std::stringstream sstr;
 				sstr << "Relay " << Idx << " (" << name << ")";
-				SendSwitch(DIOType_Relay, (uint8_t)Idx, 255, (tmpState == 1) ? true : false, 0, sstr.str(), m_Name);
+				SendSwitch(DIOType_Relay, uint8_t(Idx), 255, (tmpState == 1) ? true : false, 0, sstr.str(), m_Name);
 				Idx = -1;
 				bHaveRelays = false;
 				continue;
@@ -1038,7 +1038,7 @@ void CDenkoviDevices::GetMeterDetails()
 	}
 	case DDEV_SmartDEN_IP_Watchdog: {//has only relays
 		bool bHaveRelays = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1057,7 +1057,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHaveRelays && (Idx != -1) && ((tmpState = DenkoviGetIntParameter(tmpstr, DAE_RSTATE_DEF)) != -1))
 			{
 				name = "Relay " + std::to_string(Idx) + "(" + name + ")";
-				SendSwitch(DIOType_Relay, (uint8_t)Idx, 255, (tmpState == 1) ? true : false, 0, name, m_Name);
+				SendSwitch(DIOType_Relay, uint8_t(Idx), 255, (tmpState == 1) ? true : false, 0, name, m_Name);
 				Idx = -1;
 				bHaveRelays = false;
 				continue;
@@ -1070,7 +1070,7 @@ void CDenkoviDevices::GetMeterDetails()
 		bool bHaveDigitalInput = false;
 		bool bHaveAnalogInput = false;
 		bool bHaveTemperatureInput = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1101,8 +1101,8 @@ void CDenkoviDevices::GetMeterDetails()
 			}
 
 			if (bHaveDigitalInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
-			{ 
-				SendSwitch(DIOType_DI, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
+			{
+				SendSwitch(DIOType_DI, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
 
 				//Check if there is counter
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1117,7 +1117,7 @@ void CDenkoviDevices::GetMeterDetails()
 
 			if (bHaveAnalogInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
-				SendCustomSensor(Idx + 8, 1, 255, static_cast<float>(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
+				SendCustomSensor(Idx + 8, 1, 255, float(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
 
 				//Check if there is sclaed value
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1127,7 +1127,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, float(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;
@@ -1143,10 +1143,10 @@ void CDenkoviDevices::GetMeterDetails()
 				
 				if ((tmpMeasure.find("---") == std::string::npos))
 				{
-					tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+					tmpTiValue = float(atof(tmpMeasure.c_str()));
 
 					if (tmpMeasure[tmpMeasure.size() - 1] == -119)//Check if F is found
-						tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
+						tmpTiValue = float(ConvertToCelsius(double(tmpTiValue)));
 				}
 				else
 					tmpTiValue = 0; 
@@ -1163,7 +1163,7 @@ void CDenkoviDevices::GetMeterDetails()
 		bool bHaveDigitalInput = false;
 		bool bHaveAnalogInput = false;
 		bool bHaveTemperatureInput = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1195,7 +1195,7 @@ void CDenkoviDevices::GetMeterDetails()
 
 			if (bHaveDigitalInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
-				SendSwitch(DIOType_DI, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
+				SendSwitch(DIOType_DI, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
 
 				//Check if there is counter
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1210,7 +1210,7 @@ void CDenkoviDevices::GetMeterDetails()
 						
 			if (bHaveAnalogInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
-				SendCustomSensor(Idx+8, 1, 255, static_cast<float>(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
+				SendCustomSensor(Idx + 8, 1, 255, float(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
 
 				//Check if there is sclaed value
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1220,7 +1220,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, float(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;
@@ -1235,10 +1235,10 @@ void CDenkoviDevices::GetMeterDetails()
 
 				if ((tmpMeasure.find("---") == std::string::npos))
 				{
-					tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+					tmpTiValue = float(atof(tmpMeasure.c_str()));
 
 					if (tmpMeasure[tmpMeasure.size() - 1] == -119)//Check if F is found
-						tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
+						tmpTiValue = float(ConvertToCelsius(double(tmpTiValue)));
 				}
 				else
 					tmpTiValue = 0;
@@ -1257,7 +1257,7 @@ void CDenkoviDevices::GetMeterDetails()
 		bool bHaveAnalogOutput = false;
 		bool bHaveAnalogInput = false;
 		bool bHaveRelay = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1296,7 +1296,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHaveDigitalInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{	//Value
 				name = "Digital Input " + std::to_string(Idx) + " (" + name + ")";
-				SendSwitch(DIOType_DI, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
+				SendSwitch(DIOType_DI, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
 				//Counter
 				tmp_counter = stdstring_trim(results[ii+1]);
 				SendDenkoviTextSensor(DIOType_TXT, Idx + 8, 255, DenkoviGetStrParameter(tmp_counter, DAE_COUNT_DEF), name + " Counter");
@@ -1311,8 +1311,8 @@ void CDenkoviDevices::GetMeterDetails()
 				StringSplit(tmpMeasure, " ", vMeasure);
 				if (Idx <= 4)
 				{
-					//scaled value				 
-					SendCustomSensor(Idx, DIOType_AI, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+					// scaled value
+					SendCustomSensor(Idx, DIOType_AI, 255, float(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					//raw value					
 					tmp_adc_raw_value = stdstring_trim(results[ii-1]);
 					SendCustomSensor(Idx+8, DIOType_AI, 255, DenkoviGetFloatParameter(tmp_adc_raw_value, DAE_VALUE_DEF), "Analog Input Raw " + std::to_string(Idx) + " (" + name + ")","");
@@ -1321,9 +1321,9 @@ void CDenkoviDevices::GetMeterDetails()
 				else {
 					name = "Analog Input " + std::to_string(Idx) + " (" + name + ")";
 					if (vMeasure.size() == 2) {
-						tmpTiValue = static_cast<float>(atof(vMeasure[0].c_str()));
+						tmpTiValue = float(atof(vMeasure[0].c_str()));
 						if (vMeasure[1] == "degF")
-							tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
+							tmpTiValue = float(ConvertToCelsius(double(tmpTiValue)));
 						SendTempSensor(Idx, 255, tmpTiValue, name);
 					}
 					else
@@ -1337,7 +1337,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHaveRelay && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
 				name = "Relay " + std::to_string(Idx) + " (" + name + ")";
-				SendSwitch(DIOType_Relay, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
+				SendSwitch(DIOType_Relay, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
 				Idx = -1;
 				bHaveRelay = false;
 				continue;
@@ -1347,7 +1347,7 @@ void CDenkoviDevices::GetMeterDetails()
 			{
 				name = "Analog Output " + std::to_string(Idx) + " (" + name + ")";
 				double val = (100 * tmpValue) / 1023;
-				SendGeneralSwitch(DIOType_AO, Idx, 255, (tmpValue > 0) ? true : false, (uint8_t)val, name, m_Name);
+				SendGeneralSwitch(DIOType_AO, Idx, 255, (tmpValue > 0) ? true : false, uint8_t(val), name, m_Name);
 				Idx = -1;
 				bHaveAnalogOutput = false;
 				continue;
@@ -1360,7 +1360,7 @@ void CDenkoviDevices::GetMeterDetails()
 		bool bHaveDigitalOutput = false;
 		bool bHaveAnalogInput = false;
 		bool bHavePWM = false;
-		for (ii = 1; ii < (int)results.size(); ii++)
+		for (ii = 1; ii < int(results.size()); ii++)
 		{
 			tmpstr = stdstring_trim(results[ii]);
 
@@ -1398,7 +1398,7 @@ void CDenkoviDevices::GetMeterDetails()
 
 			if (bHaveDigitalInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
-				SendSwitch(DIOType_DI, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
+				SendSwitch(DIOType_DI, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, "Digital Input " + std::to_string(Idx) + " (" + name + ")", m_Name);
 
 				//Check if there is counter
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1413,7 +1413,7 @@ void CDenkoviDevices::GetMeterDetails()
 						
 			if (bHaveAnalogInput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
-				SendCustomSensor(Idx + 8, 1, 255, static_cast<float>(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
+				SendCustomSensor(Idx + 8, 1, 255, float(tmpValue), "Analog Input " + std::to_string(Idx) + " (" + name + ")", "");
 
 				//Check if there is sclaed value
 				tmpstr = stdstring_trim(results[ii + 1]);
@@ -1423,7 +1423,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, float(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;
@@ -1434,7 +1434,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHaveDigitalOutput && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
 				name = "Digital Output " + std::to_string(Idx) + " (" + name + ")";
-				SendSwitch(DIOType_DO, (uint8_t)Idx, 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
+				SendSwitch(DIOType_DO, uint8_t(Idx), 255, (tmpValue == 1) ? true : false, 0, name, m_Name);
 				Idx = -1;
 				bHaveDigitalOutput = false;
 				continue;
@@ -1443,7 +1443,7 @@ void CDenkoviDevices::GetMeterDetails()
 			if (bHavePWM && (Idx != -1) && ((tmpValue = DenkoviGetIntParameter(tmpstr, DAE_VALUE_DEF)) != -1))
 			{
 				name = "PWM " + std::to_string(Idx) + " (" + name + ")";
-				SendGeneralSwitch(DIOType_PWM, Idx, 255, (tmpValue > 0) ? true : false, (uint8_t)tmpValue, name, m_Name);
+				SendGeneralSwitch(DIOType_PWM, Idx, 255, (tmpValue > 0) ? true : false, uint8_t(tmpValue), name, m_Name);
 				Idx = -1;
 				bHavePWM = false;
 				continue;

--- a/hardware/DenkoviSmartdenIPInOut.cpp
+++ b/hardware/DenkoviSmartdenIPInOut.cpp
@@ -385,7 +385,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 						StringSplit(sMeasure, " ", vMeasure);
 						if (vMeasure.size() == 2)
 						{
-							SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), name, vMeasure[1]);
+							SendCustomSensor(Idx, 1, 255, float(atof(vMeasure[0].c_str())), name, vMeasure[1]);
 						}
 					}
 					Idx = -1;
@@ -407,7 +407,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 					pos1 = tmpstr.find('<');
 					if (pos1 != std::string::npos)
 					{
-						SendTempSensor(Idx, 255, static_cast<float>(atof(tmpstr.substr(0, pos1).c_str())), name);
+						SendTempSensor(Idx, 255, float(atof(tmpstr.substr(0, pos1).c_str())), name);
 					}
 					Idx = -1;
 					bHaveTemperatureInput = false;

--- a/hardware/DenkoviTCPDevices.cpp
+++ b/hardware/DenkoviTCPDevices.cpp
@@ -103,8 +103,8 @@ void CDenkoviTCPDevices::OnData(const unsigned char * pData, size_t length)
 		if (m_Cmd == _eDaeTcpState::DAE_WIFI16_ASK_CMD) {
 			uint8_t firstEight, secondEight;
 			if (length == 2) {
-				firstEight = (unsigned char)pData[0];
-				secondEight = (unsigned char)pData[1];
+				firstEight = pData[0];
+				secondEight = pData[1];
 			}
 			else {
 				Log(LOG_ERROR, "%s: Response error!",szDenkoviHardwareNamesTCP[m_iModel]);
@@ -122,8 +122,8 @@ void CDenkoviTCPDevices::OnData(const unsigned char * pData, size_t length)
 	}
 	case DDEV_SmartDEN_IP_16_R_MT_MODBUS:
 	case DDEV_WIFI_16R_Modbus: {
-		m_respBuff.append((const char * )pData, length);
-		m_uiReceivedDataLength += (uint16_t)length;
+		m_respBuff.append(reinterpret_cast<const char *>(pData), length);
+		m_uiReceivedDataLength += uint16_t(length);
 
 		if (m_Cmd == _eDaeTcpState::DAE_READ_COILS_CMD && m_uiReceivedDataLength >= READ_COILS_CMD_LENGTH) {
 			ConvertResponse(m_respBuff, m_uiReceivedDataLength);
@@ -138,8 +138,8 @@ void CDenkoviTCPDevices::OnData(const unsigned char * pData, size_t length)
 				break;
 			}
 			uint8_t firstEight, secondEight;
-			firstEight = (uint8_t)m_pResp.data[0];
-			secondEight = (uint8_t)m_pResp.data[1];
+			firstEight = m_pResp.data[0];
+			secondEight = m_pResp.data[1];
 			for (uint8_t ii = 1; ii < 9; ii++) {
 				SendSwitch(DAE_IO_TYPE_RELAY, ii, 255, (((firstEight >> (ii - 1)) & 0x01) != 0) ? true : false, 0, "Relay " + std::to_string(ii), m_Name);
 			}
@@ -263,11 +263,11 @@ bool CDenkoviTCPDevices::WriteToHardware(const char *pdata, const unsigned char 
 		m_pReq.prId[0] = 0;
 		m_pReq.prId[1] = 0;
 		m_uiTransactionCounter++;
-		m_pReq.trId[0] = (uint8_t)(m_uiTransactionCounter >> 8);
-		m_pReq.trId[1] = (uint8_t)(m_uiTransactionCounter);
-		m_pReq.unitId = (uint8_t)m_slaveId;
+		m_pReq.trId[0] = uint8_t(m_uiTransactionCounter >> 8);
+		m_pReq.trId[1] = uint8_t(m_uiTransactionCounter);
+		m_pReq.unitId = uint8_t(m_slaveId);
 		m_pReq.address[0] = 0;
-		m_pReq.address[1] = (uint8_t)(io - 1);
+		m_pReq.address[1] = uint8_t(io - 1);
 		m_pReq.fc = DMODBUS_WRITE_SINGLE_COIL;
 		m_pReq.length[0] = 0;
 		m_pReq.length[1] = 6;
@@ -306,14 +306,14 @@ void CDenkoviTCPDevices::GetMeterDetails()
 		m_pReq.prId[0] = 0;
 		m_pReq.prId[1] = 0;
 		m_uiTransactionCounter++;
-		m_pReq.trId[0] = (uint8_t)(m_uiTransactionCounter >> 8);
-		m_pReq.trId[1] = (uint8_t)(m_uiTransactionCounter);
+		m_pReq.trId[0] = uint8_t(m_uiTransactionCounter >> 8);
+		m_pReq.trId[1] = uint8_t(m_uiTransactionCounter);
 		m_pReq.address[0] = 0;
 		m_pReq.address[1] = 0;
 		m_pReq.fc = DMODBUS_READ_COILS;
 		m_pReq.length[0] = 0;
 		m_pReq.length[1] = 6;
-		m_pReq.unitId = (uint8_t)m_slaveId;
+		m_pReq.unitId = uint8_t(m_slaveId);
 		m_pReq.data[0] = 0;
 		m_pReq.data[1] = 16;
 		size_t dataLength = m_pReq.length[1] + 6;

--- a/hardware/DenkoviUSBDevices.cpp
+++ b/hardware/DenkoviUSBDevices.cpp
@@ -83,8 +83,8 @@ void CDenkoviUSBDevices::readCallBack(const char * data, size_t len)
 		if (m_Cmd == _edaeUsbState::DAE_USB16_ASK_CMD) {
 			uint8_t firstEight, secondEight;
 			if (len == 2) {
-				firstEight = (unsigned char)data[0];
-				secondEight = (unsigned char)data[1];
+				firstEight = uint8_t(data[0]);
+				secondEight = uint8_t(data[1]);
 			}
 			else {
 				_log.Log(LOG_ERROR, "USB 16 Relays-VCP: Response error.");

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -127,7 +127,7 @@ int CDomoticzHardwareBase::SetThreadNameInt(const std::thread::native_handle_typ
 #define MAX_LOG_LINE_LENGTH (2048*3)
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const std::string& sLogline)
 {
-	if (!(m_LogLevelEnabled & (uint32_t)level))
+	if (!(m_LogLevelEnabled & uint32_t(level)))
 		return; //this type of log is disabled
 
 	_log.Log(level, "%s: %s", m_ShortName.c_str(), sLogline.c_str());
@@ -135,7 +135,7 @@ void CDomoticzHardwareBase::Log(const _eLogLevel level, const std::string& sLogl
 
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const char* logline, ...)
 {
-	if (!(m_LogLevelEnabled & (uint32_t)level))
+	if (!(m_LogLevelEnabled & uint32_t(level)))
 		return; // this type of log is disabled
 
 	va_list argList;
@@ -175,10 +175,10 @@ void CDomoticzHardwareBase::SendTempSensor(const int NodeID, const int BatteryLe
 	tsen.TEMP.id2 = NodeID & 0xFF;
 	tsen.TEMP.tempsign = (temperature >= 0) ? 0 : 1;
 	int at10 = round(std::abs(temperature * 10.0F));
-	tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.TEMP.temperaturel = (BYTE)(at10);
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP, defaultname.c_str(), BatteryLevel, nullptr);
+	tsen.TEMP.temperaturel = BYTE(at10);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendHumiditySensor(const int NodeID, const int BatteryLevel, const int humidity, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -192,9 +192,9 @@ void CDomoticzHardwareBase::SendHumiditySensor(const int NodeID, const int Batte
 	tsen.HUM.rssi = RssiLevel;
 	tsen.HUM.id1 = (NodeID & 0xFF00) >> 8;
 	tsen.HUM.id2 = NodeID & 0xFF;
-	tsen.HUM.humidity = (BYTE)humidity;
+	tsen.HUM.humidity = BYTE(humidity);
 	tsen.HUM.humidity_status = Get_Humidity_Level(tsen.HUM.humidity);
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.HUM, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.HUM), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendBaroSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float pressure, const int forecast, const std::string& defaultname)
@@ -204,7 +204,7 @@ void CDomoticzHardwareBase::SendBaroSensor(const int NodeID, const int ChildID, 
 	gdevice.intval1 = (NodeID << 8) | ChildID;
 	gdevice.intval2 = forecast;
 	gdevice.floatval1 = pressure;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendTempHumSensor(const int NodeID, const int BatteryLevel, const float temperature, const int humidity, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -221,13 +221,13 @@ void CDomoticzHardwareBase::SendTempHumSensor(const int NodeID, const int Batter
 
 	tsen.TEMP_HUM.tempsign = (temperature >= 0) ? 0 : 1;
 	int at10 = round(std::abs(temperature * 10.0F));
-	tsen.TEMP_HUM.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP_HUM.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP_HUM.temperatureh * 256);
-	tsen.TEMP_HUM.temperaturel = (BYTE)(at10);
-	tsen.TEMP_HUM.humidity = (BYTE)humidity;
+	tsen.TEMP_HUM.temperaturel = BYTE(at10);
+	tsen.TEMP_HUM.humidity = BYTE(humidity);
 	tsen.TEMP_HUM.humidity_status = Get_Humidity_Level(tsen.TEMP_HUM.humidity);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP_HUM, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP_HUM), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendTempHumBaroSensor(const int NodeID, const int BatteryLevel, const float temperature, const int humidity, const float pressure, int forecast, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -244,20 +244,20 @@ void CDomoticzHardwareBase::SendTempHumBaroSensor(const int NodeID, const int Ba
 
 	tsen.TEMP_HUM_BARO.tempsign = (temperature >= 0) ? 0 : 1;
 	int at10 = round(std::abs(temperature * 10.0F));
-	tsen.TEMP_HUM_BARO.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP_HUM_BARO.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP_HUM_BARO.temperatureh * 256);
-	tsen.TEMP_HUM_BARO.temperaturel = (BYTE)(at10);
-	tsen.TEMP_HUM_BARO.humidity = (BYTE)humidity;
+	tsen.TEMP_HUM_BARO.temperaturel = BYTE(at10);
+	tsen.TEMP_HUM_BARO.humidity = BYTE(humidity);
 	tsen.TEMP_HUM_BARO.humidity_status = Get_Humidity_Level(tsen.TEMP_HUM.humidity);
 
 	int ab10 = round(pressure);
-	tsen.TEMP_HUM_BARO.baroh = (BYTE)(ab10 / 256);
+	tsen.TEMP_HUM_BARO.baroh = BYTE(ab10 / 256);
 	ab10 -= (tsen.TEMP_HUM_BARO.baroh * 256);
-	tsen.TEMP_HUM_BARO.barol = (BYTE)(ab10);
+	tsen.TEMP_HUM_BARO.barol = BYTE(ab10);
 
-	tsen.TEMP_HUM_BARO.forecast = (BYTE)forecast;
+	tsen.TEMP_HUM_BARO.forecast = BYTE(forecast);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP_HUM_BARO, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP_HUM_BARO), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendTempHumBaroSensorFloat(const int NodeID, const int BatteryLevel, const float temperature, const int humidity, const float pressure, const uint8_t forecast, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -274,19 +274,19 @@ void CDomoticzHardwareBase::SendTempHumBaroSensorFloat(const int NodeID, const i
 
 	tsen.TEMP_HUM_BARO.tempsign = (temperature >= 0) ? 0 : 1;
 	int at10 = round(std::abs(temperature * 10.0F));
-	tsen.TEMP_HUM_BARO.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP_HUM_BARO.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP_HUM_BARO.temperatureh * 256);
-	tsen.TEMP_HUM_BARO.temperaturel = (BYTE)(at10);
-	tsen.TEMP_HUM_BARO.humidity = (BYTE)humidity;
+	tsen.TEMP_HUM_BARO.temperaturel = BYTE(at10);
+	tsen.TEMP_HUM_BARO.humidity = BYTE(humidity);
 	tsen.TEMP_HUM_BARO.humidity_status = Get_Humidity_Level(tsen.TEMP_HUM.humidity);
 
 	int ab10 = round(pressure * 10.0F);
-	tsen.TEMP_HUM_BARO.baroh = (BYTE)(ab10 / 256);
+	tsen.TEMP_HUM_BARO.baroh = BYTE(ab10 / 256);
 	ab10 -= (tsen.TEMP_HUM_BARO.baroh * 256);
-	tsen.TEMP_HUM_BARO.barol = (BYTE)(ab10);
+	tsen.TEMP_HUM_BARO.barol = BYTE(ab10);
 	tsen.TEMP_HUM_BARO.forecast = forecast;
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP_HUM_BARO, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP_HUM_BARO), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendTempBaroSensor(const uint8_t NodeID, const int BatteryLevel, const float temperature, const float pressure, const std::string& defaultname)
@@ -309,7 +309,7 @@ void CDomoticzHardwareBase::SendTempBaroSensor(const uint8_t NodeID, const int B
 		tsensor.forecast = baroForecastPartlyCloudy;
 	else
 		tsensor.forecast = baroForecastSunny;
-	sDecodeRXMessage(this, (const unsigned char *)&tsensor, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsensor), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendSetPointSensor(const uint8_t NodeID, const uint8_t ChildID, const unsigned char SensorID, const float Temp, const std::string& defaultname)
@@ -324,7 +324,7 @@ void CDomoticzHardwareBase::SendSetPointSensor(const uint8_t NodeID, const uint8
 
 	thermos.temp = Temp;
 
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), -1, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), -1, nullptr);
 }
 
 
@@ -335,7 +335,7 @@ void CDomoticzHardwareBase::SendDistanceSensor(const int NodeID, const int Child
 	gdevice.intval1 = (NodeID << 8) | ChildID;
 	gdevice.floatval1 = distance;
 	gdevice.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendTextSensor(const int NodeID, const int ChildID, const int BatteryLevel, const std::string& textMessage, const std::string& defaultname)
@@ -347,7 +347,7 @@ void CDomoticzHardwareBase::SendTextSensor(const int NodeID, const int ChildID, 
 	if (sstatus.size() > 63)
 		sstatus = sstatus.substr(0, 63);
 	strcpy(gdevice.text, sstatus.c_str());
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 std::string CDomoticzHardwareBase::GetTextSensorText(const int NodeID, const int ChildID, bool& bExists)
@@ -387,12 +387,12 @@ void CDomoticzHardwareBase::SendRainSensor(const int NodeID, const int BatteryLe
 
 	uint64_t tr10 = int((float(RainCounter) * 10.0F));
 
-	tsen.RAIN.raintotal1 = (BYTE)(tr10 / 65535);
+	tsen.RAIN.raintotal1 = BYTE(tr10 / 65535);
 	tr10 -= (tsen.RAIN.raintotal1 * 65535);
-	tsen.RAIN.raintotal2 = (BYTE)(tr10 / 256);
+	tsen.RAIN.raintotal2 = BYTE(tr10 / 256);
 	tr10 -= (tsen.RAIN.raintotal2 * 256);
-	tsen.RAIN.raintotal3 = (BYTE)(tr10);
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.RAIN, defaultname.c_str(), BatteryLevel, nullptr);
+	tsen.RAIN.raintotal3 = BYTE(tr10);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RAIN), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendRainSensorWU(const int NodeID, const int BatteryLevel, const float RainCounter, const float LastHour, const std::string& defaultname, const int RssiLevel)
@@ -413,18 +413,18 @@ void CDomoticzHardwareBase::SendRainSensorWU(const int NodeID, const int Battery
 	if (LastHour != 0)
 	{
 		uint64_t at10 = int((float(LastHour) * 10.0F));
-		tsen.RAIN.rainrateh = (BYTE)(at10 / 256);
+		tsen.RAIN.rainrateh = BYTE(at10 / 256);
 		at10 -= (tsen.RAIN.rainrateh * 256);
-		tsen.RAIN.rainratel = (BYTE)(at10);
+		tsen.RAIN.rainratel = BYTE(at10);
 	}
 
 	int tr10 = int((float(RainCounter) * 10.0F));
 	tsen.RAIN.raintotal1 = 0;
-	tsen.RAIN.raintotal2 = (BYTE)(tr10 / 256);
+	tsen.RAIN.raintotal2 = BYTE(tr10 / 256);
 	tr10 -= (tsen.RAIN.raintotal2 * 256);
-	tsen.RAIN.raintotal3 = (BYTE)(tr10);
+	tsen.RAIN.raintotal3 = BYTE(tr10);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.RAIN, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RAIN), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendRainRateSensor(const int NodeID, const int BatteryLevel, const float RainRate, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -440,15 +440,15 @@ void CDomoticzHardwareBase::SendRainRateSensor(const int NodeID, const int Batte
 	tsen.RAIN.id2 = NodeID & 0xFF;
 
 	int at10 = round(std::abs(RainRate * 10000.0F));
-	tsen.RAIN.rainrateh = (BYTE)(at10 / 256);
+	tsen.RAIN.rainrateh = BYTE(at10 / 256);
 	at10 -= (tsen.RAIN.rainrateh * 256);
-	tsen.RAIN.rainratel = (BYTE)(at10);
+	tsen.RAIN.rainratel = BYTE(at10);
 
 	tsen.RAIN.raintotal1 = 0;
 	tsen.RAIN.raintotal2 = 0;
 	tsen.RAIN.raintotal3 = 0;
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.RAIN, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RAIN), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 float CDomoticzHardwareBase::GetRainSensorValue(const int NodeID, bool& bExists)
@@ -472,7 +472,7 @@ float CDomoticzHardwareBase::GetRainSensorValue(const int NodeID, bool& bExists)
 		return 0.0F;
 	}
 	bExists = true;
-	return (float)atof(splitresults[1].c_str());
+	return float(atof(splitresults[1].c_str()));
 }
 
 bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, float& WindSpeed, float& WindGust, float& WindTemp, float& WindChill, bool bHaveWindTemp, bool& bExists)
@@ -500,11 +500,11 @@ bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, f
 		return 0.0F;
 	}
 	bExists = true;
-	WindDir = (int)atof(splitresults[0].c_str());
-	WindSpeed = (float)atof(splitresults[2].c_str());
-	WindGust = (float)atof(splitresults[3].c_str());
-	WindTemp = (float)atof(splitresults[4].c_str());
-	WindChill = (float)atof(splitresults[5].c_str());
+	WindDir = int(atof(splitresults[0].c_str()));
+	WindSpeed = float(atof(splitresults[2].c_str()));
+	WindGust = float(atof(splitresults[3].c_str()));
+	WindTemp = float(atof(splitresults[4].c_str()));
+	WindChill = float(atof(splitresults[5].c_str()));
 	return bExists;
 }
 
@@ -524,7 +524,7 @@ void CDomoticzHardwareBase::SendWattMeter(const uint8_t NodeID, const uint8_t Ch
 	umeter.dunit = ChildID;
 	umeter.rssi = RssiLevel;
 	umeter.fusage = musage;
-	sDecodeRXMessage(this, (const unsigned char *)&umeter, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&umeter), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 
@@ -546,10 +546,10 @@ void CDomoticzHardwareBase::SendKwhMeter(const int NodeID, const int ChildID, co
 	_tGeneralDevice gdevice;
 	gdevice.subtype = sTypeKwh;
 	gdevice.intval1 = (NodeID << 8) | ChildID;
-	gdevice.floatval1 = (float)musage;
-	gdevice.floatval2 = (float)(mtotal * 1000.0);
+	gdevice.floatval1 = float(musage);
+	gdevice.floatval2 = float(mtotal * 1000.0);
 	gdevice.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 double CDomoticzHardwareBase::GetKwhMeter(const int NodeID, const int ChildID, bool& bExists)
@@ -573,26 +573,26 @@ double CDomoticzHardwareBase::GetKwhMeter(const int NodeID, const int ChildID, b
 		return 0.0F;
 	}
 	bExists = true;
-	return (float)atof(result[0][0].c_str());
+	return float(atof(result[0][0].c_str()));
 }
 
 void CDomoticzHardwareBase::SendMeterSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float metervalue, const std::string& defaultname, const int RssiLevel /* =12 */)
 {
-	unsigned long counter = (unsigned long)(metervalue * 1000.0F);
+	uint64_t counter = uint64_t(metervalue * 1000.0F);
 	RBUF tsen;
 	memset(&tsen, 0, sizeof(RBUF));
 	tsen.RFXMETER.packetlength = sizeof(tsen.RFXMETER) - 1;
 	tsen.RFXMETER.packettype = pTypeRFXMeter;
 	tsen.RFXMETER.subtype = sTypeRFXMeterCount;
 	tsen.RFXMETER.rssi = RssiLevel;
-	tsen.RFXMETER.id1 = (BYTE)NodeID;
-	tsen.RFXMETER.id2 = (BYTE)ChildID;
+	tsen.RFXMETER.id1 = BYTE(NodeID);
+	tsen.RFXMETER.id2 = BYTE(ChildID);
 
-	tsen.RFXMETER.count1 = (BYTE)((counter & 0xFF000000) >> 24);
-	tsen.RFXMETER.count2 = (BYTE)((counter & 0x00FF0000) >> 16);
-	tsen.RFXMETER.count3 = (BYTE)((counter & 0x0000FF00) >> 8);
-	tsen.RFXMETER.count4 = (BYTE)(counter & 0x000000FF);
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXMETER, defaultname.c_str(), BatteryLevel, nullptr);
+	tsen.RFXMETER.count1 = BYTE((counter & 0xFF000000) >> 24);
+	tsen.RFXMETER.count2 = BYTE((counter & 0x00FF0000) >> 16);
+	tsen.RFXMETER.count3 = BYTE((counter & 0x0000FF00) >> 8);
+	tsen.RFXMETER.count4 = BYTE(counter & 0x000000FF);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXMETER), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendLuxSensor(const uint8_t NodeID, const uint8_t ChildID, const uint8_t BatteryLevel, const float Lux, const std::string& defaultname)
@@ -605,7 +605,7 @@ void CDomoticzHardwareBase::SendLuxSensor(const uint8_t NodeID, const uint8_t Ch
 	lmeter.dunit = ChildID;
 	lmeter.fLux = Lux;
 	lmeter.battery_level = BatteryLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&lmeter, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lmeter), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendAirQualitySensor(const uint8_t NodeID, const uint8_t ChildID, const int BatteryLevel, const int AirQuality, const std::string& defaultname)
@@ -617,17 +617,17 @@ void CDomoticzHardwareBase::SendAirQualitySensor(const uint8_t NodeID, const uin
 	meter.airquality = AirQuality;
 	meter.id1 = NodeID;
 	meter.id2 = ChildID;
-	sDecodeRXMessage(this, (const unsigned char *)&meter, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&meter), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendSwitchIfNotExists(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname,
 						  const std::string &userName)
 {
 	//make device ID
-	unsigned char ID1 = (unsigned char)((NodeID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((NodeID & 0xFF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((NodeID & 0xFF00) >> 8);
-	unsigned char ID4 = (unsigned char)NodeID & 0xFF;
+	uint8_t ID1 = uint8_t((NodeID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((NodeID & 0xFF0000) >> 16);
+	uint8_t ID3 = uint8_t((NodeID & 0xFF00) >> 8);
+	uint8_t ID4 = uint8_t(NodeID) & 0xFF;
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
@@ -644,13 +644,13 @@ void CDomoticzHardwareBase::SendSwitchUnchecked(int NodeID, uint8_t ChildID, int
 						int RssiLevel /* =12 */)
 {
 	double rlevel = (16.0 / 100.0) * Level;
-	uint8_t level = (uint8_t)(rlevel);
+	uint8_t level = uint8_t(rlevel);
 
 	//make device ID
-	unsigned char ID1 = (unsigned char)((NodeID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((NodeID & 0xFF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((NodeID & 0xFF00) >> 8);
-	unsigned char ID4 = (unsigned char)NodeID & 0xFF;
+	uint8_t ID1 = uint8_t((NodeID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((NodeID & 0xFF0000) >> 16);
+	uint8_t ID3 = uint8_t((NodeID & 0xFF00) >> 8);
+	uint8_t ID4 = uint8_t(NodeID) & 0xFF;
 
 	//Send as Lighting 2
 	tRBUF lcmd;
@@ -677,7 +677,7 @@ void CDomoticzHardwareBase::SendSwitchUnchecked(int NodeID, uint8_t ChildID, int
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char*)& lcmd.LIGHTING2, defaultname.c_str(), BatteryLevel, userName.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), BatteryLevel, userName.c_str());
 }
 
 
@@ -688,10 +688,10 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 	int level = int(rlevel);
 
 	//make device ID
-	unsigned char ID1 = (unsigned char)((NodeID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((NodeID & 0xFF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((NodeID & 0xFF00) >> 8);
-	unsigned char ID4 = (unsigned char)NodeID & 0xFF;
+	uint8_t ID1 = uint8_t((NodeID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((NodeID & 0xFF0000) >> 16);
+	uint8_t ID3 = uint8_t((NodeID & 0xFF00) >> 8);
+	uint8_t ID4 = uint8_t(NodeID) & 0xFF;
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
@@ -732,7 +732,7 @@ void CDomoticzHardwareBase::SendBlindSensor(const uint8_t NodeID, const uint8_t 
 	lcmd.BLINDS1.cmnd = Command;
 	lcmd.BLINDS1.filler = 0;
 	lcmd.BLINDS1.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char*)& lcmd.BLINDS1, defaultname.c_str(), BatteryLevel, userName.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.BLINDS1), defaultname.c_str(), BatteryLevel, userName.c_str());
 }
 
 void CDomoticzHardwareBase::SendRGBWSwitch(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const int Level, const bool bIsRGBW, const std::string &defaultname,
@@ -751,8 +751,8 @@ void CDomoticzHardwareBase::SendRGBWSwitch(const int NodeID, const uint8_t Child
 	else
 		lcmd.command = Color_LedOn;
 	lcmd.dunit = ChildID;
-	lcmd.value = (uint32_t)level;
-	sDecodeRXMessage(this, (const unsigned char*)& lcmd, defaultname.c_str(), BatteryLevel, userName.c_str());
+	lcmd.value = uint32_t(level);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd), defaultname.c_str(), BatteryLevel, userName.c_str());
 }
 
 void CDomoticzHardwareBase::SendVoltageSensor(const int NodeID, const uint32_t ChildID, const int BatteryLevel, const float Volt, const std::string& defaultname)
@@ -762,7 +762,7 @@ void CDomoticzHardwareBase::SendVoltageSensor(const int NodeID, const uint32_t C
 	gDevice.id = ChildID;
 	gDevice.intval1 = (NodeID << 8) | ChildID;
 	gDevice.floatval1 = Volt;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendCurrentSensor(const int NodeID, const int BatteryLevel, const float Current1, const float Current2, const float Current3, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -778,21 +778,21 @@ void CDomoticzHardwareBase::SendCurrentSensor(const int NodeID, const int Batter
 	tsen.CURRENT.battery_level = BatteryLevel;
 
 	int at10 = round(std::abs(Current1 * 10.0F));
-	tsen.CURRENT.ch1h = (BYTE)(at10 / 256);
+	tsen.CURRENT.ch1h = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.CURRENT.ch1l = (BYTE)(at10);
+	tsen.CURRENT.ch1l = BYTE(at10);
 
 	at10 = round(std::abs(Current2 * 10.0F));
-	tsen.CURRENT.ch2h = (BYTE)(at10 / 256);
+	tsen.CURRENT.ch2h = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.CURRENT.ch2l = (BYTE)(at10);
+	tsen.CURRENT.ch2l = BYTE(at10);
 
 	at10 = round(std::abs(Current3 * 10.0F));
-	tsen.CURRENT.ch3h = (BYTE)(at10 / 256);
+	tsen.CURRENT.ch3h = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.CURRENT.ch3l = (BYTE)(at10);
+	tsen.CURRENT.ch3l = BYTE(at10);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.CURRENT, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.CURRENT), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendPercentageSensor(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const float Percentage, const std::string& defaultname)
@@ -802,14 +802,14 @@ void CDomoticzHardwareBase::SendPercentageSensor(const int NodeID, const uint8_t
 	gDevice.id = ChildID;
 	gDevice.intval1 = NodeID;
 	gDevice.floatval1 = Percentage;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 bool CDomoticzHardwareBase::CheckPercentageSensorExists(const int NodeID, const int /*ChildID*/)
 {
 	std::vector<std::vector<std::string> > result;
 	char szTmp[30];
-	sprintf(szTmp, "%08X", (unsigned int)NodeID);
+	sprintf(szTmp, "%08X", uint32_t(NodeID));
 	result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
 		m_HwdID, szTmp, int(pTypeGeneral), int(sTypePercentage));
 	return (!result.empty());
@@ -822,7 +822,7 @@ void CDomoticzHardwareBase::SendWaterflowSensor(const int NodeID, const uint8_t 
 	gDevice.id = ChildID;
 	gDevice.intval1 = (NodeID << 8) | ChildID;
 	gDevice.floatval1 = LPM;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendVisibilitySensor(const int NodeID, const int ChildID, const int BatteryLevel, const float Visibility, const std::string& defaultname)
@@ -832,7 +832,7 @@ void CDomoticzHardwareBase::SendVisibilitySensor(const int NodeID, const int Chi
 	gDevice.id = ChildID;
 	gDevice.intval1 = (NodeID << 8) | ChildID;
 	gDevice.floatval1 = Visibility;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendCustomSensor(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const float CustomValue, const std::string& defaultname, const std::string& defaultLabel, const int RssiLevel /* =12 */)
@@ -854,10 +854,10 @@ void CDomoticzHardwareBase::SendCustomSensor(const int NodeID, const uint8_t Chi
 	bool bDoesExists = !result.empty();
 
 	if (bDoesExists)
-		sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 	else
 	{
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char*)& gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 		//Set the Label
 		std::string soptions = "1;" + defaultLabel;
 		m_sql.safe_query("UPDATE DeviceStatus SET Options='%q' WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
@@ -886,19 +886,19 @@ void CDomoticzHardwareBase::SendWind(const int NodeID, const int BatteryLevel, c
 	tsen.WIND.id2 = NodeID & 0xFF;
 
 	int aw = WindDir;
-	tsen.WIND.directionh = (BYTE)(aw / 256);
+	tsen.WIND.directionh = BYTE(aw / 256);
 	aw -= (tsen.WIND.directionh * 256);
-	tsen.WIND.directionl = (BYTE)(aw);
+	tsen.WIND.directionl = BYTE(aw);
 
 	int sw = round(WindSpeed * 10.0F);
-	tsen.WIND.av_speedh = (BYTE)(sw / 256);
+	tsen.WIND.av_speedh = BYTE(sw / 256);
 	sw -= (tsen.WIND.av_speedh * 256);
-	tsen.WIND.av_speedl = (BYTE)(sw);
+	tsen.WIND.av_speedl = BYTE(sw);
 
 	int gw = round(WindGust * 10.0F);
-	tsen.WIND.gusth = (BYTE)(gw / 256);
+	tsen.WIND.gusth = BYTE(gw / 256);
 	gw -= (tsen.WIND.gusth * 256);
-	tsen.WIND.gustl = (BYTE)(gw);
+	tsen.WIND.gustl = BYTE(gw);
 
 	if (!bHaveWindTemp)
 	{
@@ -906,29 +906,29 @@ void CDomoticzHardwareBase::SendWind(const int NodeID, const int BatteryLevel, c
 		tsen.WIND.tempsign = (WindChill >= 0) ? 0 : 1;
 		tsen.WIND.chillsign = (WindChill >= 0) ? 0 : 1;
 		int at10 = round(std::abs(WindChill * 10.0F));
-		tsen.WIND.temperatureh = (BYTE)(at10 / 256);
-		tsen.WIND.chillh = (BYTE)(at10 / 256);
+		tsen.WIND.temperatureh = BYTE(at10 / 256);
+		tsen.WIND.chillh = BYTE(at10 / 256);
 		at10 -= (tsen.WIND.chillh * 256);
-		tsen.WIND.temperaturel = (BYTE)(at10);
-		tsen.WIND.chilll = (BYTE)(at10);
+		tsen.WIND.temperaturel = BYTE(at10);
+		tsen.WIND.chilll = BYTE(at10);
 	}
 	else
 	{
 		//temp+chill
 		tsen.WIND.tempsign = (WindTemp >= 0) ? 0 : 1;
 		int at10 = round(std::abs(WindTemp * 10.0F));
-		tsen.WIND.temperatureh = (BYTE)(at10 / 256);
+		tsen.WIND.temperatureh = BYTE(at10 / 256);
 		at10 -= (tsen.WIND.temperatureh * 256);
-		tsen.WIND.temperaturel = (BYTE)(at10);
+		tsen.WIND.temperaturel = BYTE(at10);
 
 		tsen.WIND.chillsign = (WindChill >= 0) ? 0 : 1;
 		at10 = round(std::abs(WindChill * 10.0F));
-		tsen.WIND.chillh = (BYTE)(at10 / 256);
+		tsen.WIND.chillh = BYTE(at10 / 256);
 		at10 -= (tsen.WIND.chillh * 256);
-		tsen.WIND.chilll = (BYTE)(at10);
+		tsen.WIND.chilll = BYTE(at10);
 	}
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.WIND, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.WIND), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendPressureSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float pressure, const std::string& defaultname)
@@ -937,7 +937,7 @@ void CDomoticzHardwareBase::SendPressureSensor(const int NodeID, const int Child
 	gdevice.subtype = sTypePressure;
 	gdevice.intval1 = (NodeID << 8) | ChildID;
 	gdevice.floatval1 = pressure;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendSolarRadiationSensor(const unsigned char NodeID, const int BatteryLevel, const float radiation, const std::string& defaultname)
@@ -946,7 +946,7 @@ void CDomoticzHardwareBase::SendSolarRadiationSensor(const unsigned char NodeID,
 	gdevice.subtype = sTypeSolarRadiation;
 	gdevice.id = NodeID;
 	gdevice.floatval1 = radiation;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendSoundSensor(const int NodeID, const int BatteryLevel, const int sLevel, const std::string& defaultname)
@@ -956,17 +956,17 @@ void CDomoticzHardwareBase::SendSoundSensor(const int NodeID, const int BatteryL
 	gDevice.id = 1;
 	gDevice.intval1 = NodeID;
 	gDevice.intval2 = sLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendAlertSensor(const int NodeID, const int BatteryLevel, const int alertLevel, const std::string& message, const std::string& defaultname)
 {
 	_tGeneralDevice gDevice;
 	gDevice.subtype = sTypeAlert;
-	gDevice.id = (unsigned char)NodeID;
+	gDevice.id = uint8_t(NodeID);
 	gDevice.intval1 = alertLevel;
 	sprintf(gDevice.text, "%.63s", message.c_str());
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendGeneralSwitch(const int NodeID, const int ChildID, const int BatteryLevel, const uint8_t SwitchState, const uint8_t Level, const std::string &defaultname,
@@ -977,8 +977,8 @@ void CDomoticzHardwareBase::SendGeneralSwitch(const int NodeID, const int ChildI
 	gSwitch.unitcode = ChildID;
 	gSwitch.cmnd = SwitchState;
 	gSwitch.level = Level;
-	gSwitch.rssi = (uint8_t)RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char*)& gSwitch, defaultname.c_str(), BatteryLevel, userName.c_str());
+	gSwitch.rssi = uint8_t(RssiLevel);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gSwitch), defaultname.c_str(), BatteryLevel, userName.c_str());
 }
 
 void CDomoticzHardwareBase::SendMoistureSensor(const int NodeID, const int BatteryLevel, const int mLevel, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -989,7 +989,7 @@ void CDomoticzHardwareBase::SendMoistureSensor(const int NodeID, const int Batte
 	gDevice.intval1 = NodeID;
 	gDevice.intval2 = mLevel;
 	gDevice.rssi = RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendUVSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float UVI, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -1001,18 +1001,18 @@ void CDomoticzHardwareBase::SendUVSensor(const int NodeID, const int ChildID, co
 	tsen.UV.subtype = sTypeUV1;
 	tsen.UV.battery_level = BatteryLevel;
 	tsen.UV.rssi = RssiLevel;
-	tsen.UV.id1 = (unsigned char)NodeID;
-	tsen.UV.id2 = (unsigned char)ChildID;
+	tsen.UV.id1 = uint8_t(NodeID);
+	tsen.UV.id2 = uint8_t(ChildID);
 
-	tsen.UV.uv = (BYTE)round(UVI * 10);
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.UV, defaultname.c_str(), BatteryLevel, nullptr);
+	tsen.UV.uv = BYTE(round(UVI * 10));
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.UV), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendZWaveAlarmSensor(const int NodeID, const uint8_t InstanceID, const int BatteryLevel, const uint8_t aType, const int aValue, const std::string& alarmLabel, const std::string& defaultname)
 {
 	uint8_t ID1 = 0;
-	uint8_t ID2 = (unsigned char)((NodeID & 0xFF00) >> 8);
-	uint8_t ID3 = (unsigned char)NodeID & 0xFF;
+	uint8_t ID2 = uint8_t((NodeID & 0xFF00) >> 8);
+	uint8_t ID3 = uint8_t(NodeID) & 0xFF;
 	uint8_t ID4 = InstanceID;
 
 	unsigned long lID = (ID1 << 24) + (ID2 << 16) + (ID3 << 8) + ID4;
@@ -1020,14 +1020,14 @@ void CDomoticzHardwareBase::SendZWaveAlarmSensor(const int NodeID, const uint8_t
 	_tGeneralDevice gDevice;
 	gDevice.subtype = sTypeZWaveAlarm;
 	gDevice.id = aType;
-	gDevice.intval1 = (int)(lID);
+	gDevice.intval1 = int(lID);
 	gDevice.intval2 = aValue;
 
 	int maxChars = (alarmLabel.size() < sizeof(_tGeneralDevice::text) - 1) ? alarmLabel.size() : sizeof(_tGeneralDevice::text) - 1;
 	strncpy(gDevice.text, alarmLabel.c_str(), maxChars);
 	gDevice.text[maxChars] = 0;
 
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendFanSensor(const int Idx, const int BatteryLevel, const int FanSpeed, const std::string& defaultname)
@@ -1037,7 +1037,7 @@ void CDomoticzHardwareBase::SendFanSensor(const int Idx, const int BatteryLevel,
 	gDevice.id = 1;
 	gDevice.intval1 = Idx;
 	gDevice.intval2 = FanSpeed;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), BatteryLevel, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), BatteryLevel, nullptr);
 }
 
 void CDomoticzHardwareBase::SendSecurity1Sensor(const int NodeID, const int DeviceSubType, const int BatteryLevel, const int Status, const std::string &defaultname, const std::string &userName,
@@ -1056,7 +1056,7 @@ void CDomoticzHardwareBase::SendSecurity1Sensor(const int NodeID, const int Devi
 	m_sec1.SECURITY1.rssi = RssiLevel;
 	m_sec1.SECURITY1.battery_level = BatteryLevel;
 
-	sDecodeRXMessage(this, (const unsigned char*)& m_sec1.SECURITY1, defaultname.c_str(), BatteryLevel, userName.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_sec1.SECURITY1), defaultname.c_str(), BatteryLevel, userName.c_str());
 }
 /**
  * SendSelectorSwitch
@@ -1095,8 +1095,8 @@ void CDomoticzHardwareBase::SendSelectorSwitch(const int NodeID, const uint8_t C
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT ID, sValue, Options FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, xcmd.unitcode);
 	bool bDoesExists = !result.empty();
-    
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd,  defaultname.c_str(), 255, userName.c_str());  // will create the base switch if not exist
+
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&xcmd), defaultname.c_str(), 255, userName.c_str()); // will create the base switch if not exist
 
 	if (!bDoesExists)//Switch is new so  we need to update it with all relevant info
 	{

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -85,7 +85,7 @@ void DomoticzTCP::OnConnect()
 	{
 		char szAuth[300];
 		snprintf(szAuth, sizeof(szAuth), "AUTH;%s;%s", m_username.c_str(), m_password.c_str());
-		WriteToHardware((const char*)&szAuth, (const unsigned char)strlen(szAuth));
+		WriteToHardware(reinterpret_cast<const char *>(&szAuth), uint8_t(strlen(szAuth)));
 	}
 	sOnConnected(this);
 }
@@ -103,7 +103,7 @@ void DomoticzTCP::OnData(const unsigned char *pData, size_t length)
 		return;
 	}
 	std::lock_guard<std::mutex> l(readQueueMutex);
-	onInternalMessage((const unsigned char *)pData, length, false); // Do not check validity, this might be non RFX-message
+	onInternalMessage(pData, length, false); // Do not check validity, this might be non RFX-message
 }
 
 void DomoticzTCP::OnError(const boost::system::error_code& error)
@@ -153,7 +153,7 @@ bool DomoticzTCP::WriteToHardware(const char *pdata, const unsigned char length)
 	}
 	else if (ASyncTCP::isConnected())
 	{
-		write(std::string((const char*)pdata, length));
+		write(std::string(pdata, length));
 		return true;
 	}
 #else

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -135,7 +135,7 @@ namespace http {
 			int sensortype = atoi(ssensortype.c_str());
 			unsigned int type = 0;
 			unsigned int subType = 0;
-			uint64_t DeviceRowIdx = (uint64_t )-1;
+			auto DeviceRowIdx = std::numeric_limits<std::uint64_t>::max();
 
 			for (const auto &sensor : mappedsensorname)
 			{
@@ -167,7 +167,7 @@ namespace http {
 
 					m_sql.m_bAcceptNewHardware = bPrevAcceptNewHardware;
 
-					if (DeviceRowIdx != (uint64_t)-1)
+					if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 					{
 						root["status"] = "OK";
 						root["title"] = "CreateVirtualSensor";
@@ -246,7 +246,7 @@ namespace http {
 
 			m_sql.m_bAcceptNewHardware = bPrevAcceptNewHardware;
 
-			if (DeviceRowIdx != (uint64_t)-1)
+			if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 			{
 				root["status"] = "OK";
 				root["title"] = "CreateSensor";

--- a/hardware/ETH8020.cpp
+++ b/hardware/ETH8020.cpp
@@ -127,7 +127,7 @@ bool CETH8020::WriteToHardware(const char *pdata, const unsigned char /*length*/
 void CETH8020::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, const bool bOn, const double Level, const std::string &defaultname)
 {
 	double rlevel = (15.0 / 100)*Level;
-	uint8_t level = (uint8_t)(rlevel);
+	uint8_t level = uint8_t(rlevel);
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", 0, 0, 0, Idx);
@@ -170,7 +170,7 @@ void CETH8020::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, cons
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 void CETH8020::GetMeterDetails()
@@ -219,7 +219,7 @@ void CETH8020::GetMeterDetails()
 			pos1 = tmpstr.find('>');
 			if (pos1 != std::string::npos)
 			{
-				Idx = (uint8_t)atoi(tmpstr.substr(0, pos1).c_str());
+				Idx = uint8_t(atoi(tmpstr.substr(0, pos1).c_str()));
 				tmpstr = tmpstr.substr(pos1+1);
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
@@ -237,18 +237,18 @@ void CETH8020::GetMeterDetails()
 			pos1 = tmpstr.find('>');
 			if (pos1 != std::string::npos)
 			{
-				Idx = (uint8_t)atoi(tmpstr.substr(0, pos1).c_str());
+				Idx = uint8_t(atoi(tmpstr.substr(0, pos1).c_str()));
 				tmpstr = tmpstr.substr(pos1 + 1);
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
 				{
 					int lValue = atoi(tmpstr.substr(0, pos1).c_str());
-					float voltage = (float)(5.0F / 1023.0F) * lValue;
+					float voltage = (5.0F / 1023.0F) * lValue;
 					if (voltage > 5.0F)
 						voltage = 5.0F;
 					std::stringstream sstr;
 					sstr << "Voltage " << Idx;
-					SendVoltageSensor(0, (uint8_t)Idx, 255, voltage, sstr.str());
+					SendVoltageSensor(0, Idx, 255, voltage, sstr.str());
 				}
 			}
 		}

--- a/hardware/Ec3kMeterTCP.cpp
+++ b/hardware/Ec3kMeterTCP.cpp
@@ -239,7 +239,7 @@ void Ec3kMeterTCP::ParseData(const unsigned char *pData, int Len)
 		std::stringstream sensorNameWMaxSS;
 		sensorNameWMaxSS << "EC3K meter " << std::hex << id << " maximum";
 		const std::string sensorNameWMax = sensorNameWMaxSS.str();
-		SendWattMeter((uint8_t)id, 2, 255, w_max, sensorNameWMax);
+		SendWattMeter(uint8_t(id), 2, 255, w_max, sensorNameWMax);
 
 		// TODO: send times + reset_count?
 	}

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -266,7 +266,7 @@ void CEcoDevices::GetMeterDetails()
 			m_status.pflow1 = m_status.flow1;
 			m_status.time1 = atime;
 			SendMeterSensor(m_HwdID, 1, 255, m_status.index1 / 1000.0F, m_status.hostname + " Counter 1");
-			SendWaterflowSensor(m_HwdID, 2, 255, (float)m_status.flow1, m_status.hostname + " Flow counter 1");
+			SendWaterflowSensor(m_HwdID, 2, 255, float(m_status.flow1), m_status.hostname + " Flow counter 1");
 		}
 
 		// Process Counter 2
@@ -277,7 +277,7 @@ void CEcoDevices::GetMeterDetails()
 			m_status.pflow2 = m_status.flow2;
 			m_status.time2 = atime;
 			SendMeterSensor(m_HwdID, 3, 255, m_status.index2 / 1000.0F, m_status.hostname + " Counter 2");
-			SendWaterflowSensor(m_HwdID, 4, 255, (float)m_status.flow2, m_status.hostname + " Flow counter 2");
+			SendWaterflowSensor(m_HwdID, 4, 255, float(m_status.flow2), m_status.hostname + " Flow counter 2");
 		}
 	}
 	else
@@ -451,7 +451,7 @@ void CEcoDevices::GetMeterRT2Details()
 
 	//Measured voltage on power supply
 	m_status.voltage = i_xpath_int(XMLdoc.RootElement(), "/response/vmesure/text()");
-	SendVoltageSensor(m_HwdID, 1, 255, (float)m_status.voltage, "EcoDevice RT2");
+	SendVoltageSensor(m_HwdID, 1, 255, float(m_status.voltage), "EcoDevice RT2");
 
 	// Teleinfo data processing
 	for (i = 0; i < 32; i++)
@@ -509,11 +509,11 @@ void CEcoDevices::GetMeterRT2Details()
 		if (splitresults[0].empty())
 			break;
 
-		fvalue1 = (float)atof(splitresults[0].c_str());
+		fvalue1 = float(atof(splitresults[0].c_str()));
 		if (fvalue1 > 0)
 			SendMeterSensor(m_HwdID, i, 255, fvalue1 / 1000, m_status.hostname + " " + label);
-		fvalue2 = (float)atof(splitresults[1].c_str());
+		fvalue2 = float(atof(splitresults[1].c_str()));
 		if (fvalue2 > 0)
-			SendWaterflowSensor(m_HwdID, (uint8_t)i, 255, fvalue2, m_status.hostname + " " + label);
+			SendWaterflowSensor(m_HwdID, uint8_t(i), 255, fvalue2, m_status.hostname + " " + label);
 	}
 }

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -340,7 +340,7 @@ const _t4BSLookup T4BSTable[] = {
 
 const char* Get_Enocean4BSType(const int Org, const int Func, const int Type)
 {
-	const _t4BSLookup* pOrgTable = (const _t4BSLookup*)&T4BSTable;
+	const _t4BSLookup *pOrgTable = reinterpret_cast<const _t4BSLookup *>(&T4BSTable);
 	while (pOrgTable->Label)
 	{
 		if (
@@ -357,7 +357,7 @@ const char* Get_Enocean4BSType(const int Org, const int Func, const int Type)
 
 const char* Get_Enocean4BSDesc(const int Org, const int Func, const int Type)
 {
-	const _t4BSLookup* pOrgTable = (const _t4BSLookup*)&T4BSTable;
+	const _t4BSLookup *pOrgTable = reinterpret_cast<const _t4BSLookup *>(&T4BSTable);
 	while (pOrgTable->Label)
 	{
 		if (
@@ -782,7 +782,7 @@ enocean_data_structure enocean_clean_data_structure() {
 	int i = 0;
 	enocean_data_structure ds;
 	for (i = 0; i < sizeof(ds); i++) {
-		BYTE* b = (BYTE*)&ds + i;
+		BYTE *b = reinterpret_cast<BYTE *>(&ds) + i;
 		*b = 0x00;
 	}
 	return ds;
@@ -831,7 +831,7 @@ unsigned char enocean_calc_checksum(const enocean_data_structure* input_data) {
 }
 
 char* enocean_gethex_internal(BYTE* in, const int framesize) {
-	char* hexstr = (char*)malloc((framesize * 2) + 1);  // because every hex-byte needs 2 characters
+	char *hexstr = static_cast<char *>(malloc((framesize * 2) + 1)); // because every hex-byte needs 2 characters
 	if (!hexstr)
 		return nullptr;
 	char* tempstr = hexstr;
@@ -852,7 +852,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 	const int framesize = sizeof(enocean_data_structure);
 	// every byte of the frame takes 2 characters in the human representation + the length of the text blocks (without trailing '\0');
 	const int stringsize = (framesize * 2) + 1 + sizeof(HR_TYPE) - 1 + sizeof(HR_RPS) - 1 + sizeof(HR_DATA) - 1 + sizeof(HR_SENDER) - 1 + sizeof(HR_STATUS) - 1;
-	char* humanString = (char*)malloc(stringsize);
+	char *humanString = static_cast<char *>(malloc(stringsize));
 	if (!humanString)
 		return nullptr;
 	char* tempstring = humanString;
@@ -901,7 +901,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 		}
 		sprintf(tempstring, HR_SENDER);
 		tempstring += sizeof(HR_SENDER) - 1;
-		temphexstring = enocean_gethex_internal((BYTE*)&(pFrame->ID_BYTE3), 4);
+		temphexstring = enocean_gethex_internal(const_cast<BYTE *>(&(pFrame->ID_BYTE3)), 4);
 		if (temphexstring)
 		{
 			strcpy(tempstring, temphexstring);
@@ -910,7 +910,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 		}
 		sprintf(tempstring, HR_DATA);
 		tempstring += sizeof(HR_DATA) - 1;
-		temphexstring = enocean_gethex_internal((BYTE*)&(pFrame->DATA_BYTE3), 4);
+		temphexstring = enocean_gethex_internal(const_cast<BYTE *>(&(pFrame->DATA_BYTE3)), 4);
 		if (temphexstring)
 		{
 			strcpy(tempstring, temphexstring);
@@ -924,7 +924,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 		tempstring += sizeof(HR_6DT) - 1;
 		sprintf(tempstring, HR_SENDER);
 		tempstring += sizeof(HR_SENDER) - 1;
-		temphexstring = enocean_gethex_internal((BYTE*)&(frame_6DT->ADDRESS1), 2);
+		temphexstring = enocean_gethex_internal(static_cast<BYTE *>(&(frame_6DT->ADDRESS1)), 2);
 		if (temphexstring)
 		{
 			strcpy(tempstring, temphexstring);
@@ -933,7 +933,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 		}
 		sprintf(tempstring, HR_DATA);
 		tempstring += sizeof(HR_DATA) - 1;
-		temphexstring = enocean_gethex_internal((BYTE*)&(frame_6DT->DATA_BYTE5), 6);
+		temphexstring = enocean_gethex_internal(static_cast<BYTE *>(&(frame_6DT->DATA_BYTE5)), 6);
 		if (temphexstring)
 		{
 			strcpy(tempstring, temphexstring);
@@ -947,7 +947,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 		tempstring += sizeof(HR_MDA) - 1;
 		sprintf(tempstring, HR_SENDER);
 		tempstring += sizeof(HR_SENDER) - 1;
-		temphexstring = enocean_gethex_internal((BYTE*)&(frame_MDA->ADDRESS1), 2);
+		temphexstring = enocean_gethex_internal(static_cast<BYTE *>(&(frame_MDA->ADDRESS1)), 2);
 		if (temphexstring)
 		{
 			strcpy(tempstring, temphexstring);
@@ -962,7 +962,7 @@ char* enocean_hexToHuman(const enocean_data_structure* pFrame)
 	}
 	sprintf(tempstring, HR_STATUS);
 	tempstring += sizeof(HR_STATUS) - 1;
-	temphexstring = enocean_gethex_internal((BYTE*)&(pFrame->STATUS), 1);
+	temphexstring = enocean_gethex_internal(const_cast<BYTE *>(&(pFrame->STATUS)), 1);
 	if (temphexstring)
 	{
 		strcpy(tempstring, temphexstring);
@@ -1046,7 +1046,7 @@ bool CEnOceanESP2::OpenSerialDevice()
 	*/
 
 	iframe = tcm120_rd_idbase();
-	write((const char*)&iframe, sizeof(enocean_data_structure));
+	write(reinterpret_cast<const char *>(&iframe), sizeof(enocean_data_structure));
 
 	return true;
 }
@@ -1090,7 +1090,7 @@ void CEnOceanESP2::readCallback(const char* data, size_t len)
 			break;
 		case ERS_CHECKSUM:
 			m_buffer[m_bufferpos++] = c;
-			if (m_buffer[m_bufferpos - 1] == enocean_calc_checksum((const enocean_data_structure*)&m_buffer))
+			if (m_buffer[m_bufferpos - 1] == enocean_calc_checksum(reinterpret_cast<const enocean_data_structure *>(&m_buffer)))
 			{
 				ParseData();
 			}
@@ -1127,10 +1127,10 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 		return false;
 	}
 
-	iframe.ID_BYTE3 = (unsigned char)((sID & 0xFF000000) >> 24);//tsen->LIGHTING2.id1;
-	iframe.ID_BYTE2 = (unsigned char)((sID & 0x00FF0000) >> 16);//tsen->LIGHTING2.id2;
-	iframe.ID_BYTE1 = (unsigned char)((sID & 0x0000FF00) >> 8);//tsen->LIGHTING2.id3;
-	iframe.ID_BYTE0 = (unsigned char)(sID & 0x0000FF);//tsen->LIGHTING2.id4;
+	iframe.ID_BYTE3 = uint8_t((sID & 0xFF000000) >> 24); // tsen->LIGHTING2.id1;
+	iframe.ID_BYTE2 = uint8_t((sID & 0x00FF0000) >> 16); // tsen->LIGHTING2.id2;
+	iframe.ID_BYTE1 = uint8_t((sID & 0x0000FF00) >> 8);  // tsen->LIGHTING2.id3;
+	iframe.ID_BYTE0 = uint8_t(sID & 0x0000FF);	     // tsen->LIGHTING2.id4;
 
 	unsigned char RockerID = 0;
 	unsigned char Pressed = 1;
@@ -1147,14 +1147,14 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 	uint8_t LastLevel = 0;
 	std::vector<std::vector<std::string> > result;
 	char szDeviceID[20];
-	sprintf(szDeviceID, "%08X", (unsigned int)sID);
+	sprintf(szDeviceID, "%08X", uint32_t(sID));
 	result = m_sql.safe_query("SELECT SwitchType,LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", m_HwdID, szDeviceID, int(tsen->LIGHTING2.unitcode));
 	if (!result.empty())
 	{
-		_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+		_eSwitchType switchtype = _eSwitchType(atoi(result[0][0].c_str()));
 		if (switchtype == STYPE_Dimmer)
 			bIsDimmer = true;
-		LastLevel = (uint8_t)atoi(result[0][1].c_str());
+		LastLevel = uint8_t(atoi(result[0][1].c_str()));
 	}
 
 	uint8_t iLevel = tsen->LIGHTING2.level;
@@ -1177,7 +1177,7 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 			float fLevel = (100.0F / 15.0F) * float(iLevel);
 			if (fLevel > 99.0F)
 				fLevel = 100.0F;
-			iLevel = (uint8_t)(fLevel);
+			iLevel = uint8_t(fLevel);
 		}
 		cmnd = light2_sSetLevel;
 	}
@@ -1193,13 +1193,13 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 
 		iframe.CHECKSUM = enocean_calc_checksum(&iframe);
 
-		Add2SendQueue((const char*)&iframe, sizeof(enocean_data_structure));
+		Add2SendQueue(reinterpret_cast<const char *>(&iframe), sizeof(enocean_data_structure));
 
 		//Next command is send a bit later (button release)
 		iframe.DATA_BYTE3 = 0;
 		iframe.STATUS = 0x20;
 		iframe.CHECKSUM = enocean_calc_checksum(&iframe);
-		Add2SendQueue((const char*)&iframe, sizeof(enocean_data_structure));
+		Add2SendQueue(reinterpret_cast<const char *>(&iframe), sizeof(enocean_data_structure));
 	}
 	else
 	{
@@ -1219,7 +1219,7 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 			iframe.DATA_BYTE0 = 0x09;//Dim On
 
 		iframe.CHECKSUM = enocean_calc_checksum(&iframe);
-		Add2SendQueue((const char*)&iframe, sizeof(enocean_data_structure));
+		Add2SendQueue(reinterpret_cast<const char *>(&iframe), sizeof(enocean_data_structure));
 	}
 	return true;
 }
@@ -1245,10 +1245,10 @@ void CEnOceanESP2::SendDimmerTeachIn(const char* pdata, const unsigned char /*le
 			return;
 		}
 
-		iframe.ID_BYTE3 = (unsigned char)((sID & 0xFF000000) >> 24);//tsen->LIGHTING2.id1;
-		iframe.ID_BYTE2 = (unsigned char)((sID & 0x00FF0000) >> 16);//tsen->LIGHTING2.id2;
-		iframe.ID_BYTE1 = (unsigned char)((sID & 0x0000FF00) >> 8);//tsen->LIGHTING2.id3;
-		iframe.ID_BYTE0 = (unsigned char)(sID & 0x0000FF);//tsen->LIGHTING2.id4;
+		iframe.ID_BYTE3 = uint8_t((sID & 0xFF000000) >> 24); // tsen->LIGHTING2.id1;
+		iframe.ID_BYTE2 = uint8_t((sID & 0x00FF0000) >> 16); // tsen->LIGHTING2.id2;
+		iframe.ID_BYTE1 = uint8_t((sID & 0x0000FF00) >> 8);  // tsen->LIGHTING2.id3;
+		iframe.ID_BYTE0 = uint8_t(sID & 0x0000FF);	     // tsen->LIGHTING2.id4;
 
 		unsigned char RockerID = 0;
 		//unsigned char UpDown = 1;
@@ -1266,7 +1266,7 @@ void CEnOceanESP2::SendDimmerTeachIn(const char* pdata, const unsigned char /*le
 		iframe.DATA_BYTE1 = 0;
 		iframe.DATA_BYTE0 = 0;
 		iframe.CHECKSUM = enocean_calc_checksum(&iframe);
-		Add2SendQueue((const char*)&iframe, sizeof(enocean_data_structure));
+		Add2SendQueue(reinterpret_cast<const char *>(&iframe), sizeof(enocean_data_structure));
 	}
 }
 
@@ -1284,14 +1284,14 @@ float CEnOceanESP2::GetValueRange(const float InValue, const float ScaleMax, con
 
 bool CEnOceanESP2::ParseData()
 {
-	enocean_data_structure* pFrame = (enocean_data_structure*)&m_buffer;
+	enocean_data_structure *pFrame = reinterpret_cast<enocean_data_structure *>(&m_buffer);
 	unsigned char Checksum = enocean_calc_checksum(pFrame);
 	if (Checksum != pFrame->CHECKSUM)
 		return false; //checksum Mismatch!
 
 	long id = (pFrame->ID_BYTE3 << 24) + (pFrame->ID_BYTE2 << 16) + (pFrame->ID_BYTE1 << 8) + pFrame->ID_BYTE0;
 	char szDeviceID[20];
-	sprintf(szDeviceID, "%08X", (unsigned int)id);
+	sprintf(szDeviceID, "%08X", uint32_t(id));
 
 	//Handle possible OK/Errors
 	bool bStopProcessing = false;
@@ -1382,10 +1382,10 @@ bool CEnOceanESP2::ParseData()
 				tsen.LIGHTING2.packettype = pTypeLighting2;
 				tsen.LIGHTING2.subtype = sTypeAC;
 				tsen.LIGHTING2.seqnbr = 0;
-				tsen.LIGHTING2.id1 = (BYTE)pFrame->ID_BYTE3;
-				tsen.LIGHTING2.id2 = (BYTE)pFrame->ID_BYTE2;
-				tsen.LIGHTING2.id3 = (BYTE)pFrame->ID_BYTE1;
-				tsen.LIGHTING2.id4 = (BYTE)pFrame->ID_BYTE0;
+				tsen.LIGHTING2.id1 = BYTE(pFrame->ID_BYTE3);
+				tsen.LIGHTING2.id2 = BYTE(pFrame->ID_BYTE2);
+				tsen.LIGHTING2.id3 = BYTE(pFrame->ID_BYTE1);
+				tsen.LIGHTING2.id4 = BYTE(pFrame->ID_BYTE0);
 				tsen.LIGHTING2.level = 0;
 				tsen.LIGHTING2.rssi = 12;
 
@@ -1401,7 +1401,7 @@ bool CEnOceanESP2::ParseData()
 					tsen.LIGHTING2.unitcode = SecondRockerID + 10;
 					tsen.LIGHTING2.cmnd = (SecondUpDown == 1) ? light2_sOn : light2_sOff;
 				}
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.LIGHTING2), nullptr, 255, m_Name.c_str());
 			}
 		}
 		break;
@@ -1471,24 +1471,24 @@ bool CEnOceanESP2::ParseData()
 				tsen.RFXMETER.rssi = 12;
 				tsen.RFXMETER.id1 = pFrame->ID_BYTE2;
 				tsen.RFXMETER.id2 = pFrame->ID_BYTE1;
-				tsen.RFXMETER.count1 = (BYTE)((cvalue & 0xFF000000) >> 24);
-				tsen.RFXMETER.count2 = (BYTE)((cvalue & 0x00FF0000) >> 16);
-				tsen.RFXMETER.count3 = (BYTE)((cvalue & 0x0000FF00) >> 8);
-				tsen.RFXMETER.count4 = (BYTE)(cvalue & 0x000000FF);
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXMETER, nullptr, 255, nullptr);
+				tsen.RFXMETER.count1 = BYTE((cvalue & 0xFF000000) >> 24);
+				tsen.RFXMETER.count2 = BYTE((cvalue & 0x00FF0000) >> 16);
+				tsen.RFXMETER.count3 = BYTE((cvalue & 0x0000FF00) >> 8);
+				tsen.RFXMETER.count4 = BYTE(cvalue & 0x000000FF);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXMETER), nullptr, 255, nullptr);
 			}
 			else if (szST == "AMR.Electricity")
 			{
 				//0xA5, 0x12, 0x01, "Electricity"
 				int cvalue = (pFrame->DATA_BYTE3 << 16) | (pFrame->DATA_BYTE2 << 8) | (pFrame->DATA_BYTE1);
 				_tUsageMeter umeter;
-				umeter.id1 = (BYTE)pFrame->ID_BYTE3;
-				umeter.id2 = (BYTE)pFrame->ID_BYTE2;
-				umeter.id3 = (BYTE)pFrame->ID_BYTE1;
-				umeter.id4 = (BYTE)pFrame->ID_BYTE0;
+				umeter.id1 = BYTE(pFrame->ID_BYTE3);
+				umeter.id2 = BYTE(pFrame->ID_BYTE2);
+				umeter.id3 = BYTE(pFrame->ID_BYTE1);
+				umeter.id4 = BYTE(pFrame->ID_BYTE0);
 				umeter.dunit = 1;
-				umeter.fusage = (float)cvalue;
-				sDecodeRXMessage(this, (const unsigned char *)&umeter, nullptr, 255, nullptr);
+				umeter.fusage = float(cvalue);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&umeter), nullptr, 255, nullptr);
 			}
 			else if (szST == "AMR.Gas")
 			{
@@ -1502,11 +1502,11 @@ bool CEnOceanESP2::ParseData()
 				tsen.RFXMETER.rssi = 12;
 				tsen.RFXMETER.id1 = pFrame->ID_BYTE2;
 				tsen.RFXMETER.id2 = pFrame->ID_BYTE1;
-				tsen.RFXMETER.count1 = (BYTE)((cvalue & 0xFF000000) >> 24);
-				tsen.RFXMETER.count2 = (BYTE)((cvalue & 0x00FF0000) >> 16);
-				tsen.RFXMETER.count3 = (BYTE)((cvalue & 0x0000FF00) >> 8);
-				tsen.RFXMETER.count4 = (BYTE)(cvalue & 0x000000FF);
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXMETER, nullptr, 255, nullptr);
+				tsen.RFXMETER.count1 = BYTE((cvalue & 0xFF000000) >> 24);
+				tsen.RFXMETER.count2 = BYTE((cvalue & 0x00FF0000) >> 16);
+				tsen.RFXMETER.count3 = BYTE((cvalue & 0x0000FF00) >> 8);
+				tsen.RFXMETER.count4 = BYTE(cvalue & 0x000000FF);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXMETER), nullptr, 255, nullptr);
 			}
 			else if (szST == "AMR.Water")
 			{
@@ -1520,11 +1520,11 @@ bool CEnOceanESP2::ParseData()
 				tsen.RFXMETER.rssi = 12;
 				tsen.RFXMETER.id1 = pFrame->ID_BYTE2;
 				tsen.RFXMETER.id2 = pFrame->ID_BYTE1;
-				tsen.RFXMETER.count1 = (BYTE)((cvalue & 0xFF000000) >> 24);
-				tsen.RFXMETER.count2 = (BYTE)((cvalue & 0x00FF0000) >> 16);
-				tsen.RFXMETER.count3 = (BYTE)((cvalue & 0x0000FF00) >> 8);
-				tsen.RFXMETER.count4 = (BYTE)(cvalue & 0x000000FF);
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXMETER, nullptr, 255, nullptr);
+				tsen.RFXMETER.count1 = BYTE((cvalue & 0xFF000000) >> 24);
+				tsen.RFXMETER.count2 = BYTE((cvalue & 0x00FF0000) >> 16);
+				tsen.RFXMETER.count3 = BYTE((cvalue & 0x0000FF00) >> 8);
+				tsen.RFXMETER.count4 = BYTE(cvalue & 0x000000FF);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXMETER), nullptr, 255, nullptr);
 			}
 			else if (szST.find("RoomOperatingPanel") == 0)
 			{
@@ -1579,10 +1579,10 @@ bool CEnOceanESP2::ParseData()
 
 					tsen.TEMP.tempsign = (temp >= 0) ? 0 : 1;
 					int at10 = round(std::abs(temp * 10.0F));
-					tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
+					tsen.TEMP.temperatureh = BYTE(at10 / 256);
 					at10 -= (tsen.TEMP.temperatureh * 256);
-					tsen.TEMP.temperaturel = (BYTE)(at10);
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP, nullptr, -1, nullptr);
+					tsen.TEMP.temperaturel = BYTE(at10);
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP), nullptr, -1, nullptr);
 				}
 			}
 			else if (szST == "LightSensor.01")
@@ -1621,18 +1621,18 @@ bool CEnOceanESP2::ParseData()
 					tsen.RFXSENSOR.id = pFrame->ID_BYTE1;
 					tsen.RFXSENSOR.filler = pFrame->ID_BYTE0 & 0x0F;
 					tsen.RFXSENSOR.rssi = (pFrame->ID_BYTE0 & 0xF0) >> 4;
-					tsen.RFXSENSOR.msg1 = (BYTE)(voltage / 256);
-					tsen.RFXSENSOR.msg2 = (BYTE)(voltage - (tsen.RFXSENSOR.msg1 * 256));
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXSENSOR, nullptr, 255, nullptr);
+					tsen.RFXSENSOR.msg1 = BYTE(voltage / 256);
+					tsen.RFXSENSOR.msg2 = BYTE(voltage - (tsen.RFXSENSOR.msg1 * 256));
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXSENSOR), nullptr, 255, nullptr);
 				}
 				_tLightMeter lmeter;
-				lmeter.id1 = (BYTE)pFrame->ID_BYTE3;
-				lmeter.id2 = (BYTE)pFrame->ID_BYTE2;
-				lmeter.id3 = (BYTE)pFrame->ID_BYTE1;
-				lmeter.id4 = (BYTE)pFrame->ID_BYTE0;
+				lmeter.id1 = BYTE(pFrame->ID_BYTE3);
+				lmeter.id2 = BYTE(pFrame->ID_BYTE2);
+				lmeter.id3 = BYTE(pFrame->ID_BYTE1);
+				lmeter.id4 = BYTE(pFrame->ID_BYTE0);
 				lmeter.dunit = 1;
 				lmeter.fLux = lux;
-				sDecodeRXMessage(this, (const unsigned char *)&lmeter, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lmeter), nullptr, 255, nullptr);
 			}
 			else if (szST.find("Temperature") == 0)
 			{
@@ -1690,10 +1690,10 @@ bool CEnOceanESP2::ParseData()
 
 				tsen.TEMP.tempsign = (temp >= 0) ? 0 : 1;
 				int at10 = round(std::abs(temp * 10.0F));
-				tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
+				tsen.TEMP.temperatureh = BYTE(at10 / 256);
 				at10 -= (tsen.TEMP.temperatureh * 256);
-				tsen.TEMP.temperaturel = (BYTE)(at10);
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP, nullptr, -1, nullptr);
+				tsen.TEMP.temperaturel = BYTE(at10);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP), nullptr, -1, nullptr);
 			}
 			else if (szST == "TempHum")
 			{
@@ -1717,12 +1717,12 @@ bool CEnOceanESP2::ParseData()
 				tsen.TEMP_HUM.battery_level = 9;
 				tsen.TEMP_HUM.tempsign = (temp >= 0) ? 0 : 1;
 				int at10 = round(std::abs(temp * 10.0F));
-				tsen.TEMP_HUM.temperatureh = (BYTE)(at10 / 256);
+				tsen.TEMP_HUM.temperatureh = BYTE(at10 / 256);
 				at10 -= (tsen.TEMP_HUM.temperatureh * 256);
-				tsen.TEMP_HUM.temperaturel = (BYTE)(at10);
-				tsen.TEMP_HUM.humidity = (BYTE)hum;
+				tsen.TEMP_HUM.temperaturel = BYTE(at10);
+				tsen.TEMP_HUM.humidity = BYTE(hum);
 				tsen.TEMP_HUM.humidity_status = Get_Humidity_Level(tsen.TEMP_HUM.humidity);
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.TEMP_HUM, nullptr, -1, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.TEMP_HUM), nullptr, -1, nullptr);
 			}
 			else if (szST == "OccupancySensor.01")
 			{
@@ -1742,9 +1742,9 @@ bool CEnOceanESP2::ParseData()
 						tsen.RFXSENSOR.id = pFrame->ID_BYTE1;
 						tsen.RFXSENSOR.filler = pFrame->ID_BYTE0 & 0x0F;
 						tsen.RFXSENSOR.rssi = (pFrame->ID_BYTE0 & 0xF0) >> 4;
-						tsen.RFXSENSOR.msg1 = (BYTE)(voltage / 256);
-						tsen.RFXSENSOR.msg2 = (BYTE)(voltage - (tsen.RFXSENSOR.msg1 * 256));
-						sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXSENSOR, nullptr, 255, nullptr);
+						tsen.RFXSENSOR.msg1 = BYTE(voltage / 256);
+						tsen.RFXSENSOR.msg2 = BYTE(voltage - (tsen.RFXSENSOR.msg1 * 256));
+						sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXSENSOR), nullptr, 255, nullptr);
 					}
 
 					bool bPIROn = (pFrame->DATA_BYTE1 > 127);
@@ -1754,15 +1754,15 @@ bool CEnOceanESP2::ParseData()
 					tsen.LIGHTING2.subtype = sTypeAC;
 					tsen.LIGHTING2.seqnbr = 0;
 
-					tsen.LIGHTING2.id1 = (BYTE)pFrame->ID_BYTE3;
-					tsen.LIGHTING2.id2 = (BYTE)pFrame->ID_BYTE2;
-					tsen.LIGHTING2.id3 = (BYTE)pFrame->ID_BYTE1;
-					tsen.LIGHTING2.id4 = (BYTE)pFrame->ID_BYTE0;
+					tsen.LIGHTING2.id1 = BYTE(pFrame->ID_BYTE3);
+					tsen.LIGHTING2.id2 = BYTE(pFrame->ID_BYTE2);
+					tsen.LIGHTING2.id3 = BYTE(pFrame->ID_BYTE1);
+					tsen.LIGHTING2.id4 = BYTE(pFrame->ID_BYTE0);
 					tsen.LIGHTING2.level = 0;
 					tsen.LIGHTING2.rssi = 12;
 					tsen.LIGHTING2.unitcode = 1;
 					tsen.LIGHTING2.cmnd = (bPIROn) ? light2_sOn : light2_sOff;
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.LIGHTING2), nullptr, 255, m_Name.c_str());
 				}
 				else {
 					//Error code
@@ -1783,9 +1783,9 @@ bool CEnOceanESP2::ParseData()
 					tsen.RFXSENSOR.id = pFrame->ID_BYTE1;
 					tsen.RFXSENSOR.filler = pFrame->ID_BYTE0 & 0x0F;
 					tsen.RFXSENSOR.rssi = (pFrame->ID_BYTE0 & 0xF0) >> 4;
-					tsen.RFXSENSOR.msg1 = (BYTE)(voltage / 256);
-					tsen.RFXSENSOR.msg2 = (BYTE)(voltage - (tsen.RFXSENSOR.msg1 * 256));
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXSENSOR, nullptr, 255, nullptr);
+					tsen.RFXSENSOR.msg1 = BYTE(voltage / 256);
+					tsen.RFXSENSOR.msg2 = BYTE(voltage - (tsen.RFXSENSOR.msg1 * 256));
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXSENSOR), nullptr, 255, nullptr);
 
 					bool bPIROn = (pFrame->DATA_BYTE0 & 0x80) != 0;
 					memset(&tsen, 0, sizeof(RBUF));
@@ -1794,15 +1794,15 @@ bool CEnOceanESP2::ParseData()
 					tsen.LIGHTING2.subtype = sTypeAC;
 					tsen.LIGHTING2.seqnbr = 0;
 
-					tsen.LIGHTING2.id1 = (BYTE)pFrame->ID_BYTE3;
-					tsen.LIGHTING2.id2 = (BYTE)pFrame->ID_BYTE2;
-					tsen.LIGHTING2.id3 = (BYTE)pFrame->ID_BYTE1;
-					tsen.LIGHTING2.id4 = (BYTE)pFrame->ID_BYTE0;
+					tsen.LIGHTING2.id1 = BYTE(pFrame->ID_BYTE3);
+					tsen.LIGHTING2.id2 = BYTE(pFrame->ID_BYTE2);
+					tsen.LIGHTING2.id3 = BYTE(pFrame->ID_BYTE1);
+					tsen.LIGHTING2.id4 = BYTE(pFrame->ID_BYTE0);
 					tsen.LIGHTING2.level = 0;
 					tsen.LIGHTING2.rssi = 12;
 					tsen.LIGHTING2.unitcode = 1;
 					tsen.LIGHTING2.cmnd = (bPIROn) ? light2_sOn : light2_sOff;
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.LIGHTING2), nullptr, 255, m_Name.c_str());
 				}
 				else {
 					//Error code
@@ -1823,21 +1823,21 @@ bool CEnOceanESP2::ParseData()
 					tsen.RFXSENSOR.id = pFrame->ID_BYTE1;
 					tsen.RFXSENSOR.filler = pFrame->ID_BYTE0 & 0x0F;
 					tsen.RFXSENSOR.rssi = (pFrame->ID_BYTE0 & 0xF0) >> 4;
-					tsen.RFXSENSOR.msg1 = (BYTE)(voltage / 256);
-					tsen.RFXSENSOR.msg2 = (BYTE)(voltage - (tsen.RFXSENSOR.msg1 * 256));
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.RFXSENSOR, nullptr, 255, nullptr);
+					tsen.RFXSENSOR.msg1 = BYTE(voltage / 256);
+					tsen.RFXSENSOR.msg2 = BYTE(voltage - (tsen.RFXSENSOR.msg1 * 256));
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RFXSENSOR), nullptr, 255, nullptr);
 
 					int lux = (pFrame->DATA_BYTE2 << 2) | (pFrame->DATA_BYTE1 >> 6);
 					if (lux > 1000)
 						lux = 1000;
 					_tLightMeter lmeter;
-					lmeter.id1 = (BYTE)pFrame->ID_BYTE3;
-					lmeter.id2 = (BYTE)pFrame->ID_BYTE2;
-					lmeter.id3 = (BYTE)pFrame->ID_BYTE1;
-					lmeter.id4 = (BYTE)pFrame->ID_BYTE0;
+					lmeter.id1 = BYTE(pFrame->ID_BYTE3);
+					lmeter.id2 = BYTE(pFrame->ID_BYTE2);
+					lmeter.id3 = BYTE(pFrame->ID_BYTE1);
+					lmeter.id4 = BYTE(pFrame->ID_BYTE0);
 					lmeter.dunit = 1;
-					lmeter.fLux = (float)lux;
-					sDecodeRXMessage(this, (const unsigned char *)&lmeter, nullptr, 255, nullptr);
+					lmeter.fLux = float(lux);
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lmeter), nullptr, 255, nullptr);
 
 					bool bPIROn = (pFrame->DATA_BYTE0 & 0x80) != 0;
 					memset(&tsen, 0, sizeof(RBUF));
@@ -1846,15 +1846,15 @@ bool CEnOceanESP2::ParseData()
 					tsen.LIGHTING2.subtype = sTypeAC;
 					tsen.LIGHTING2.seqnbr = 0;
 
-					tsen.LIGHTING2.id1 = (BYTE)pFrame->ID_BYTE3;
-					tsen.LIGHTING2.id2 = (BYTE)pFrame->ID_BYTE2;
-					tsen.LIGHTING2.id3 = (BYTE)pFrame->ID_BYTE1;
-					tsen.LIGHTING2.id4 = (BYTE)pFrame->ID_BYTE0;
+					tsen.LIGHTING2.id1 = BYTE(pFrame->ID_BYTE3);
+					tsen.LIGHTING2.id2 = BYTE(pFrame->ID_BYTE2);
+					tsen.LIGHTING2.id3 = BYTE(pFrame->ID_BYTE1);
+					tsen.LIGHTING2.id4 = BYTE(pFrame->ID_BYTE0);
 					tsen.LIGHTING2.level = 0;
 					tsen.LIGHTING2.rssi = 12;
 					tsen.LIGHTING2.unitcode = 1;
 					tsen.LIGHTING2.cmnd = (bPIROn) ? light2_sOn : light2_sOff;
-					sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
+					sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.LIGHTING2), nullptr, 255, m_Name.c_str());
 				}
 				else {
 					//Error code

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -225,7 +225,7 @@ void EnphaseAPI::parseProduction(const Json::Value& root)
 	m_p1power.powerusage1 = mtotal;
 	m_p1power.powerusage2 = 0;
 	m_p1power.usagecurrent = std::max(musage,0);
-	sDecodeRXMessage(this, (const unsigned char *)&m_p1power, "Enphase Production kWh Total", 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_p1power), "Enphase Production kWh Total", 255, nullptr);
 }
 
 void EnphaseAPI::parseConsumption(const Json::Value& root)
@@ -250,7 +250,7 @@ void EnphaseAPI::parseConsumption(const Json::Value& root)
 	m_c1power.powerusage1 = mtotal;
 	m_c1power.powerusage2 = 0;
 	m_c1power.usagecurrent = std::max(musage,0);
-	sDecodeRXMessage(this, (const unsigned char *)&m_c1power, "Enphase Consumption kWh Total", 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_c1power), "Enphase Consumption kWh Total", 255, nullptr);
 }
 
 void EnphaseAPI::parseNetConsumption(const Json::Value& root)
@@ -275,5 +275,5 @@ void EnphaseAPI::parseNetConsumption(const Json::Value& root)
 	m_c2power.powerusage1 = mtotal;
 	m_c2power.powerusage2 = 0;
 	m_c2power.usagecurrent = std::max(musage,0);
-	sDecodeRXMessage(this, (const unsigned char *)&m_c2power, "Enphase Net Consumption kWh Total", 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_c2power), "Enphase Net Consumption kWh Total", 255, nullptr);
 }

--- a/hardware/EvohomeBase.cpp
+++ b/hardware/EvohomeBase.cpp
@@ -53,7 +53,7 @@ const char* CEvohomeBase::GetWebAPIModeName(uint8_t nControllerMode)
 
 const char* CEvohomeBase::GetZoneModeName(uint8_t nZoneMode)
 {
-	return m_szZoneMode[std::min(nZoneMode, (uint8_t)6)];
+	return m_szZoneMode[std::min(nZoneMode, uint8_t(6))];
 }
 
 CEvohomeBase::CEvohomeBase()
@@ -140,11 +140,11 @@ void CEvohomeBase::InitZoneNames()
 {
 	std::lock_guard<std::mutex> l(m_mtxZoneName);
 	char szTmp[1024];
-	for(int i=0;i<(int)m_ZoneNames.size();i++)
+	for (size_t i = 0; i < m_ZoneNames.size(); i++)
 	{
 		if(m_ZoneNames[i].empty())
 		{
-			sprintf(szTmp,"Zone %d",i+1);
+			sprintf(szTmp, "Zone %zu", i + 1);
 			m_ZoneNames[i]=szTmp;
 		}
 	}
@@ -237,7 +237,7 @@ void CEvohomeBase::Log(bool bDebug, int nLogLevel, const char* format, ... )
         va_end(argList);
 
 	if(!bDebug || m_bDebug)
-		_log.Log(static_cast<_eLogLevel>(nLogLevel), "%s", cbuffer);
+		_log.Log(_eLogLevel(nLogLevel), "%s", cbuffer);
 	if(m_bDebug && m_pEvoLog)
 	{
 		LogDate();
@@ -282,7 +282,7 @@ namespace http {
 			sprintf(ID, "%lu", nid);
 
 			//get zone count
-			result = m_sql.safe_query("SELECT COUNT(*) FROM DeviceStatus WHERE (HardwareID==%d) AND (Type==%d)", HwdID, (int)iSensorType);
+			result = m_sql.safe_query("SELECT COUNT(*) FROM DeviceStatus WHERE (HardwareID==%d) AND (Type==%d)", HwdID, iSensorType);
 
 			int nDevCount = 0;
 			if (!result.empty())
@@ -311,7 +311,7 @@ namespace http {
 					root["message"] = "Maximum number of supported zones reached";
 					return;
 				}
-				m_sql.UpdateValue(HwdID, ID, (uint8_t)nDevCount + 1, pTypeEvohomeZone, sTypeEvohomeZone, 10, 255, 0, "0.0;0.0;Auto", devname);
+				m_sql.UpdateValue(HwdID, ID, uint8_t(nDevCount) + 1, pTypeEvohomeZone, sTypeEvohomeZone, 10, 255, 0, "0.0;0.0;Auto", devname);
 				bCreated = true;
 				break;
 			case pTypeEvohomeWater://DHW...should be 1 per hardware

--- a/hardware/EvohomeBase.h
+++ b/hardware/EvohomeBase.h
@@ -245,7 +245,7 @@ class CEvohomeID : public CEvohomeDataType
 		unsigned int idType;
 		unsigned int idAddr;
 		sscanf(szID.c_str(), "%u:%u", &idType, &idAddr);
-		return GetID(static_cast<unsigned char>(idType), idAddr);
+		return GetID(uint8_t(idType), idAddr);
 	}
 	static std::string GetStrID(unsigned int nID)
 	{
@@ -391,11 +391,11 @@ class CEvohomeDateTime : public CEvohomeDataType
 	{
 		unsigned int y, m, d, h, n;
 		sscanf(str, "%04u-%02u-%02uT%02u:%02u:", &y, &m, &d, &h, &n);
-		out.year = static_cast<uint16_t>(y);
-		out.month = static_cast<uint8_t>(m);
-		out.day = static_cast<uint8_t>(d);
-		out.hrs = static_cast<uint8_t>(h);
-		out.mins = static_cast<uint8_t>(n);
+		out.year = uint16_t(y);
+		out.month = uint8_t(m);
+		out.day = uint8_t(d);
+		out.hrs = uint8_t(h);
+		out.mins = uint8_t(n);
 	}
 
 	unsigned char DecodeTime(const unsigned char *msg, unsigned char nOfs)
@@ -665,7 +665,7 @@ class CEvohomeMsg
 		{
 			if (szPkt == szPacketType[i])
 			{
-				type = static_cast<packettype>(i);
+				type = packettype(i);
 				break;
 			}
 		}

--- a/hardware/EvohomeScript.cpp
+++ b/hardware/EvohomeScript.cpp
@@ -105,7 +105,8 @@ void CEvohomeScript::RunScript(const char* pdata, const unsigned char /*length*/
 		return;
 	_tEVOHOME2* tsen = (_tEVOHOME2*)pdata;
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT  HardwareID, DeviceID,Unit,Type,SubType,SwitchType,StrParam1 FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d)", m_HwdID, (int)tsen->zone, (int)tsen->type);
+	result = m_sql.safe_query("SELECT  HardwareID, DeviceID,Unit,Type,SubType,SwitchType,StrParam1 FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d) AND (Type==%d)", m_HwdID,
+				  int(tsen->zone), int(tsen->type));
 	if (!result.empty())
 	{
 		unsigned long ID;
@@ -123,11 +124,11 @@ void CEvohomeScript::RunScript(const char* pdata, const unsigned char /*length*/
 			boost::replace_all(OnAction, "{deviceid}", s_strid.str());
 			s_strid.clear();
 			s_strid.str("");
-			s_strid << (int)tsen->zone;
+			s_strid << int(tsen->zone);
 			boost::replace_all(OnAction, "{unit}", s_strid.str());
 			s_strid.clear();
 			s_strid.str("");
-			s_strid << (int)tsen->mode;
+			s_strid << int(tsen->mode);
 			boost::replace_all(OnAction, "{mode}", s_strid.str());
 			s_strid.clear();
 			s_strid.str("");
@@ -135,7 +136,7 @@ void CEvohomeScript::RunScript(const char* pdata, const unsigned char /*length*/
 			boost::replace_all(OnAction, "{setpoint}", s_strid.str());
 			s_strid.clear();
 			s_strid.str("");
-			s_strid << (int)tsen->temperature;
+			s_strid << int(tsen->temperature);
 			boost::replace_all(OnAction, "{state}", s_strid.str());
 			boost::replace_all(OnAction, "{until}", CEvohomeDateTime::GetISODate(tsen));
 			//Execute possible script

--- a/hardware/EvohomeTCP.cpp
+++ b/hardware/EvohomeTCP.cpp
@@ -82,7 +82,7 @@ void CEvohomeTCP::OnData(const unsigned char *pData, size_t length)
 	try
 	{
 		//_log.Log(LOG_NORM,"evohome: received %ld bytes",len);
-		HandleLoopData((const char *)pData, length);
+		HandleLoopData(reinterpret_cast<const char *>(pData), length);
 	}
 	catch (...)
 	{

--- a/hardware/FritzboxTCP.cpp
+++ b/hardware/FritzboxTCP.cpp
@@ -135,7 +135,7 @@ bool FritzboxTCP::WriteToHardware(const char *pdata, const unsigned char length)
 	{
 		return false;
 	}
-	write((const unsigned char*)pdata,length);
+	write(reinterpret_cast<const unsigned char *>(pdata), length);
 	return true;
 }
 
@@ -179,7 +179,7 @@ void FritzboxTCP::ParseData(const unsigned char *pData, int Len)
 void FritzboxTCP::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, const bool bOn, const double Level, const std::string &defaultname)
 {
 	double rlevel = (15.0 / 100)*Level;
-	uint8_t level = (uint8_t)(rlevel);
+	uint8_t level = uint8_t(rlevel);
 
 	char szIdx[10];
 	sprintf(szIdx, "%X%02X%02X%02X", 0, 0, 0, Idx);
@@ -222,14 +222,14 @@ void FritzboxTCP::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, c
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 void FritzboxTCP::ParseLine()
 {
 	if (m_bufferpos < 2)
 		return;
-	std::string sLine((char*)&m_buffer);
+	std::string sLine(reinterpret_cast<char *>(&m_buffer));
 
 	//_log.Log(LOG_STATUS, sLine.c_str());
 

--- a/hardware/GoodweAPI.cpp
+++ b/hardware/GoodweAPI.cpp
@@ -111,7 +111,7 @@ GoodweAPI::GoodweAPI(const int ID, const std::string &userName, const int Server
 	m_UserName(userName)
 {
 	m_HwdID=ID;
-	switch ((_eGoodweLocation)ServerLocation)
+	switch (_eGoodweLocation(ServerLocation))
 	{
 		case GOODWE_LOCATION_EUROPE:
 			m_Host = GOODWE_HOST_EU;
@@ -185,7 +185,7 @@ void GoodweAPI::SendCurrentSensor(const int NodeID, const uint8_t ChildID, const
 	gDevice.id = ChildID;
 	gDevice.intval1 = (NodeID << 8) | ChildID;
 	gDevice.floatval1 = Amp;
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), 255, nullptr);
 }
 
 int GoodweAPI::getSunRiseSunSetMinutes(const bool bGetSunRise)
@@ -237,7 +237,7 @@ uint32_t GoodweAPI::hash(const std::string &str)
 		int c = str[i++];
 		hash = ((hash << 5) + hash) + c;
 	}
-	return (uint32_t)hash;
+	return uint32_t(hash);
 }
 
 bool GoodweAPI::getValueFromJson(const Json::Value &inputValue, std::string &outputValue, const std::string &errorString)
@@ -459,8 +459,7 @@ void GoodweAPI::ParseDevice(const Json::Value &device, const std::string &sStati
 		sStationName + " " + sDeviceSerial + " error");
 	SendVoltageSensor(NodeID, ChildID + IDX_VOLT_L1, 255, fVoltagePhase1, 
 		sStationName + " " + sDeviceSerial + " Mains L1");
-	SendCurrentSensor(NodeID, (uint8_t)ChildID + IDX_CUR_L1, 255, fCurrentPhase1,
-		sStationName + " " + sDeviceSerial + " Mains L1");
+	SendCurrentSensor(NodeID, uint8_t(ChildID) + IDX_CUR_L1, 255, fCurrentPhase1, sStationName + " " + sDeviceSerial + " Mains L1");
 
 	// Send data for L2 and L3 only when we detect a voltage
 
@@ -468,21 +467,18 @@ void GoodweAPI::ParseDevice(const Json::Value &device, const std::string &sStati
 	{
 		SendVoltageSensor(NodeID, ChildID + IDX_VOLT_L2, 255, fVoltagePhase2, 
 			sStationName + " " + sDeviceSerial + " Mains L2");
-		SendCurrentSensor(NodeID, (uint8_t)ChildID + IDX_CUR_L2, 255, fCurrentPhase2,
-			sStationName + " " + sDeviceSerial + " Mains L2");
+		SendCurrentSensor(NodeID, uint8_t(ChildID) + IDX_CUR_L2, 255, fCurrentPhase2, sStationName + " " + sDeviceSerial + " Mains L2");
 	}
 	if (fVoltagePhase3 > 0.1F)
 	{
 		SendVoltageSensor(NodeID, ChildID + IDX_VOLT_L3, 255, fVoltagePhase3, 
 			sStationName + " " + sDeviceSerial + " Mains L3");
-		SendCurrentSensor(NodeID, (uint8_t)ChildID + IDX_CUR_L3, 255, fCurrentPhase3,
-			sStationName + " " + sDeviceSerial + " Mains L3");
+		SendCurrentSensor(NodeID, uint8_t(ChildID) + IDX_CUR_L3, 255, fCurrentPhase3, sStationName + " " + sDeviceSerial + " Mains L3");
 	}
 
 	SendVoltageSensor(NodeID, ChildID + IDX_VOLT_S1, 255, fVoltageString1, 
 		sStationName + " " + sDeviceSerial + "Input string 1");
-	SendCurrentSensor(NodeID, (uint8_t)ChildID + IDX_CUR_S1, 255, fCurrentString1,
-		sStationName + " " + sDeviceSerial + " Input String 1");
+	SendCurrentSensor(NodeID, uint8_t(ChildID) + IDX_CUR_S1, 255, fCurrentString1, sStationName + " " + sDeviceSerial + " Input String 1");
 
 	// Send data for string 2 only when we detect a voltage
 
@@ -490,7 +486,6 @@ void GoodweAPI::ParseDevice(const Json::Value &device, const std::string &sStati
 	{
 		SendVoltageSensor(NodeID, ChildID + IDX_VOLT_S2, 255, fVoltageString2, 
 			sStationName + " " + sDeviceSerial + "Input string 2");
-		SendCurrentSensor(NodeID, (uint8_t)ChildID + IDX_CUR_S2, 255, fCurrentString2,
-			sStationName + " " + sDeviceSerial + " Input String 2");
+		SendCurrentSensor(NodeID, uint8_t(ChildID) + IDX_CUR_S2, 255, fCurrentString2, sStationName + " " + sDeviceSerial + " Input String 2");
 	}
 }

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -31,7 +31,7 @@ void CHEOS::ParseLine()
 {
 	if (m_bufferpos < 2)
 		return;
-	std::string sLine((char*)&m_buffer);
+	std::string sLine(reinterpret_cast<char *>(&m_buffer));
 
 	try
 	{
@@ -675,7 +675,7 @@ bool CHEOS::WriteInt(const std::string &sendStr)
 	ssSend << sendStr << "\r\n";
 	sSend = ssSend.str();
 
-	write((const unsigned char*)sSend.c_str(), sSend.size());
+	write(reinterpret_cast<const unsigned char *>(sSend.c_str()), sSend.size());
 	return true;
 }
 
@@ -799,14 +799,14 @@ void CHEOS::ReloadNodes()
 	result = m_sql.safe_query("SELECT ID,DeviceID, Name, nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d)", m_HwdID);
 	if (!result.empty())
 	{
-		_log.Log(LOG_STATUS, "DENON for HEOS: %d players found.", (int)result.size());
+		_log.Log(LOG_STATUS, "DENON for HEOS: %d players found.", int(result.size()));
 		for (const auto &sd : result)
 		{
 			HEOSNode pnode;
 			pnode.ID = atoi(sd[0].c_str());
 			pnode.DevID = atoi(sd[1].c_str());
 			pnode.Name = sd[2];
-			pnode.nStatus = (_eMediaStatus)atoi(sd[3].c_str());
+			pnode.nStatus = _eMediaStatus(atoi(sd[3].c_str()));
 			pnode.sStatus = sd[4];
 			pnode.LastOK = mytime(nullptr);
 
@@ -869,9 +869,9 @@ namespace http {
 
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
+				_eSwitchType sType = _eSwitchType(atoi(result[0][0].c_str()));
 				int PlayerID = atoi(result[0][1].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][2].c_str());
+				_eHardwareTypes hType = _eHardwareTypes(atoi(result[0][2].c_str()));
 				//int HwID = atoi(result[0][3].c_str());
 				// Is the device a media Player?
 				if (sType == STYPE_Media)

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -209,8 +209,8 @@ void CHardwareMonitor::SendCurrent(const unsigned long Idx, const float Curr, co
 	gDevice.subtype = sTypeCurrent;
 	gDevice.id = 1;
 	gDevice.floatval1 = Curr;
-	gDevice.intval1 = static_cast<int>(Idx);
-	sDecodeRXMessage(this, (const unsigned char *)&gDevice, defaultname.c_str(), 255, nullptr);
+	gDevice.intval1 = int(Idx);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gDevice), defaultname.c_str(), 255, nullptr);
 }
 
 void CHardwareMonitor::GetInternalTemperature()
@@ -230,7 +230,7 @@ void CHardwareMonitor::GetInternalTemperature()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float temperature = static_cast<float>(atof(tmpline.c_str()));
+	float temperature = float(atof(tmpline.c_str()));
 	if (temperature == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -263,7 +263,7 @@ void CHardwareMonitor::GetInternalARMClockSpeed()
 
 	if (strarray.size()==2)
 	{
-		ArmClockSpeed = static_cast<float>(atof(strarray[1].c_str()))/1000000;
+		ArmClockSpeed = float(atof(strarray[1].c_str())) / 1000000;
 	}
 
 	Debug(DEBUG_NORM,"Updating sensor with value %.2f",ArmClockSpeed);
@@ -294,7 +294,7 @@ void CHardwareMonitor::GetInternalV3DClockSpeed()
 
 	if (strarray.size()==2)
 	{
-		V3DClockSpeed = static_cast<float>(atof(strarray[1].c_str()))/1000000;
+		V3DClockSpeed = float(atof(strarray[1].c_str())) / 1000000;
 	}
 
 	Debug(DEBUG_NORM,"Updating sensor with value %.2f",V3DClockSpeed);
@@ -325,7 +325,7 @@ void CHardwareMonitor::GetInternalCoreClockSpeed()
 
 	if (strarray.size()==2)
 	{
-		CoreClockSpeed = static_cast<float>(atof(strarray[1].c_str()))/1000000;
+		CoreClockSpeed = float(atof(strarray[1].c_str())) / 1000000;
 	}
 
 	Debug(DEBUG_NORM,"Updating sensor with value %.2f",CoreClockSpeed);
@@ -350,7 +350,7 @@ void CHardwareMonitor::GetInternalVoltage()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float voltage = static_cast<float>(atof(tmpline.c_str()));
+	float voltage = float(atof(tmpline.c_str()));
 	if (voltage == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -374,7 +374,7 @@ void CHardwareMonitor::GetInternalCurrent()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float current = static_cast<float>(atof(tmpline.c_str()));
+	float current = float(atof(tmpline.c_str()));
 	if (current == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -391,13 +391,13 @@ void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int di
 	if (qType == "Temperature")
 	{
 		doffset = 1000;
-		float temp = static_cast<float>(atof(devValue.c_str()));
+		float temp = float(atof(devValue.c_str()));
 		SendTempSensor(doffset + dindex, 255, temp, devName);
 	}
 	else if (qType == "Load")
 	{
 		doffset = 1100;
-		float perc = static_cast<float>(atof(devValue.c_str()));
+		float perc = float(atof(devValue.c_str()));
 		SendPercentageSensor(doffset + dindex, 0, 255, perc, devName);
 	}
 	else if (qType == "Fan")
@@ -409,19 +409,19 @@ void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int di
 	else if (qType == "Voltage")
 	{
 		doffset = 1300;
-		float volt = static_cast<float>(atof(devValue.c_str()));
-		SendVoltageSensor(0, (uint32_t)(doffset + dindex), 255, volt, devName);
+		float volt = float(atof(devValue.c_str()));
+		SendVoltageSensor(0, uint32_t(doffset + dindex), 255, volt, devName);
 	}
 	else if (qType == "Current")
 	{
 		doffset = 1400;
-		float curr = static_cast<float>(atof(devValue.c_str()));
+		float curr = float(atof(devValue.c_str()));
 		SendCurrent(doffset + dindex, curr, devName);
 	}
 	else if (qType == "Process")
 	{
 		doffset = 1500;
-		float usage = static_cast<float>(atof(devValue.c_str()));
+		float usage = float(atof(devValue.c_str()));
 		SendCustomSensor(0, doffset + dindex, 255, usage, devName, "MB");
 	}
 }
@@ -628,7 +628,7 @@ bool CHardwareMonitor::IsOHMRunning()
 		VARIANT vtProp;
 		VariantInit(&vtProp);
 		hr = pclsObj->Get(L"ProcessId", 0, &vtProp, 0, 0);
-		int procId = static_cast<int>(vtProp.iVal);
+		int procId = int(vtProp.iVal);
 		if (procId) {
 			bOHMRunning = true;
 		}
@@ -714,8 +714,7 @@ void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string &qType)
 		struct timeval tp;
 		if (gettimeofday(&tp, (struct timezone *)nullptr) == -1)
 			return 0;
-		return ((double) (tp.tv_sec)) +
-			(((double) tp.tv_usec) * 0.000001 );
+		return (double(tp.tv_sec)) + ((double(tp.tv_usec)) * 0.000001);
 	}
 
 #if defined(__linux__)

--- a/hardware/HttpPoller.cpp
+++ b/hardware/HttpPoller.cpp
@@ -26,7 +26,7 @@ m_refresh(refresh)
 	if (strextra.size() == 3 || strextra.size() == 4 || strextra.size() == 5)
 	{
 		m_script = base64_decode(strextra[0]);
-		m_method = (unsigned short)atoi(base64_decode(strextra[1]).c_str());
+		m_method = uint16_t(atoi(base64_decode(strextra[1]).c_str()));
 		m_contenttype = base64_decode(strextra[2]);
 		if (strextra.size() >= 4)
 		{

--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -149,11 +149,11 @@ namespace
 	};
 } // namespace
 
-I2C::I2C(const int ID, const _eI2CType DevType, const std::string &Address, const std::string &SerialPort, const int Mode1) :
-	m_dev_type(DevType),
-	m_i2c_addr((uint8_t)atoi(Address.c_str())),
-	m_ActI2CBus(SerialPort),
-	m_invert_data((bool)Mode1)
+I2C::I2C(const int ID, const _eI2CType DevType, const std::string &Address, const std::string &SerialPort, const int Mode1)
+	: m_dev_type(DevType)
+	, m_i2c_addr(uint8_t(atoi(Address.c_str())))
+	, m_ActI2CBus(SerialPort)
+	, m_invert_data(bool(Mode1))
 {
 	_log.Log(LOG_STATUS, "I2C  Start HW witf ID: %d Name: %s Address: %d Port: %s Invert:%d ", ID, szI2CTypeNames[m_dev_type], m_i2c_addr, m_ActI2CBus.c_str(), m_invert_data);
 	m_HwdID = ID;
@@ -419,7 +419,7 @@ void I2C::MCP23017_Init()
 				value = true;
 			}
 
-			int DeviceID = (m_i2c_addr << 8) + (unsigned char)unit; 			// DeviceID from i2c_address and pin_number
+			int DeviceID = (m_i2c_addr << 8) + uint8_t(unit);					// DeviceID from i2c_address and pin_number
 			SendSwitch(DeviceID, unit, 255, value, 0, "", m_Name); 					// create or update switch
 			//_log.Log(LOG_NORM, "SendSwitch(DeviceID: %d, unit: %d, value: %d", DeviceID, unit, value );
 		}
@@ -756,7 +756,7 @@ int I2C::HTU21D_checkCRC8(uint16_t data)
 	{
 		if (data & 0x8000)
 		{
-			data = (uint16_t)((data << 1) ^ HTU21D_CRC8_POLYNOMINAL);
+			data = uint16_t((data << 1) ^ HTU21D_CRC8_POLYNOMINAL);
 		}
 		else
 		{
@@ -789,7 +789,7 @@ int I2C::HTU21D_GetHumidity(int fd, float *Hum)
 		return -1;
 	}
 	rawHumidity ^= 0x02;
-	*Hum = -6 + 0.001907 * (float)rawHumidity;
+	*Hum = -6 + 0.001907 * float(rawHumidity);
 	return 0;
 #endif
 }
@@ -819,7 +819,7 @@ int I2C::HTU21D_GetTemperature(int fd, float *Temp)
 		_log.Log(LOG_ERROR, "%s: Incorrect temperature checksum!...", szI2CTypeNames[m_dev_type]);
 		return -1;
 	}
-	*Temp = -46.85 + 0.002681 * (float)rawTemperature;
+	*Temp = -46.85 + 0.002681 * float(rawTemperature);
 	return 0;
 #endif
 }
@@ -1005,7 +1005,7 @@ int I2C::bmp_GetPressure(int fd, double *Pres)
 
 	//printf ("\nDelay:%i\n",(BMPx8x_minDelay+(4<<BMPx8x_OverSampling)));
 	if (ReadInt(fd, rValues, BMPx8x_Results, 3) != 0) return -1;
-	up = (((unsigned int)rValues[0] << 16) | ((unsigned int)rValues[1] << 8) | (unsigned int)rValues[2]) >> (8 - BMPx8x_OverSampling);
+	up = ((uint32_t(rValues[0]) << 16) | (uint32_t(rValues[1]) << 8) | uint32_t(rValues[2])) >> (8 - BMPx8x_OverSampling);
 
 	int x1, x2, x3, b3, b6, p;
 	unsigned int b4, b7;
@@ -1014,14 +1014,14 @@ int I2C::bmp_GetPressure(int fd, double *Pres)
 	x1 = (bmp_b2 * (b6 * b6) >> 12) >> 11;
 	x2 = (bmp_ac2 * b6) >> 11;
 	x3 = x1 + x2;
-	b3 = (((((int)bmp_ac1) * 4 + x3) << BMPx8x_OverSampling) + 2) >> 2;
+	b3 = ((((int(bmp_ac1)) * 4 + x3) << BMPx8x_OverSampling) + 2) >> 2;
 
 	x1 = (bmp_ac3 * b6) >> 13;
 	x2 = (bmp_b1 * ((b6 * b6) >> 12)) >> 16;
 	x3 = ((x1 + x2) + 2) >> 2;
-	b4 = (bmp_ac4 * (unsigned int)(x3 + 32768)) >> 15;
+	b4 = (bmp_ac4 * uint32_t(x3 + 32768)) >> 15;
 
-	b7 = ((unsigned int)(up - b3) * (50000 >> BMPx8x_OverSampling));
+	b7 = ((up - b3) * (50000 >> BMPx8x_OverSampling));
 	if (b7 < 0x80000000)
 		p = (b7 << 1) / b4;
 	else
@@ -1031,7 +1031,7 @@ int I2C::bmp_GetPressure(int fd, double *Pres)
 	x1 = (x1 * 3038) >> 16;
 	x2 = (-7357 * p) >> 16;
 	p += (x1 + x2 + 3791) >> 4;
-	*Pres = ((double)p / 100);
+	*Pres = (double(p) / 100);
 	return 0;
 #endif
 }
@@ -1055,8 +1055,8 @@ int I2C::bmp_GetTemperature(int fd, double *Temp)
 	ut = ((rValues[0] << 8) | rValues[1]);
 
 	int x1, x2;
-	x1 = (((int)ut - (int)bmp_ac6)*(int)bmp_ac5) >> 15;
-	x2 = ((int)bmp_mc << 11) / (x1 + bmp_md);
+	x1 = ((int(ut) - int(bmp_ac6)) * int(bmp_ac5)) >> 15;
+	x2 = (int(bmp_mc) << 11) / (x1 + bmp_md);
 	bmp_b5 = x1 + x2;
 
 	double result = ((bmp_b5 + 8) >> 4);
@@ -1229,7 +1229,7 @@ uint8_t I2C::CalculateForecast(const float pressure)
 				nforecast = bmpbaroforecast_rain;
 			else if (pressure >= 1029)
 				nforecast = bmpbaroforecast_sunny;
-			m_LastSendForecast = (unsigned char)nforecast;
+			m_LastSendForecast = uint8_t(nforecast);
 		}
 		break;
 		}
@@ -1284,8 +1284,8 @@ void I2C::bmp_Read_BMP_SensorDetails()
 	//this is probably not good, need to take the rising/falling of the pressure into account?
 	//any help would be welcome!
 
-	tsensor.forecast = CalculateForecast(((float)pressure) * 10.0F);
-	sDecodeRXMessage(this, (const unsigned char *)&tsensor, nullptr, 255, nullptr);
+	tsensor.forecast = CalculateForecast((float(pressure)) * 10.0F);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsensor), nullptr, 255, nullptr);
 }
 
 bool I2C::readBME280ID(const int fd, int &ChipID, int &Version)
@@ -1318,7 +1318,7 @@ int8_t getChar(uint8_t *data, int index)
 	int result = data[index];
 	if (result > 127)
 		result -= 256;
-	return (int8_t)result;
+	return int8_t(result);
 }
 
 uint8_t getUChar(uint8_t *data, int index)
@@ -1385,7 +1385,7 @@ bool I2C::readBME280All(const int fd, float &temp, float &pressure, int &humidit
 
 	// Wait in ms(Datasheet Appendix B : Measurement time and current calculation)
 	double wait_time = 1.25 + (2.3 * BMEx8x_OverSampling_Temp) + ((2.3 * BMEx8x_OverSampling_Pres) + 0.575) + ((2.3 * BMEx8x_OverSampling_Hum) + 0.575);
-	int wait_time_ms = (int)rint(wait_time) + 1;
+	int wait_time_ms = int(rint(wait_time)) + 1;
 	sleep_milliseconds(wait_time_ms);
 
 	// Read temperature/pressure/humidity
@@ -1467,7 +1467,7 @@ void I2C::bmp_Read_BME_SensorDetails()
 	}
 	close(fd);
 #endif
-	uint8_t forecast = CalculateForecast(((float)pressure) * 10.0F);
+	uint8_t forecast = CalculateForecast((pressure)*10.0F);
 	//We are using the TempHumBaro Float type now, convert the forecast
 	int nforecast = wsbaroforecast_some_clouds;
 	if (pressure <= 980)

--- a/hardware/ICYThermostat.cpp
+++ b/hardware/ICYThermostat.cpp
@@ -102,7 +102,7 @@ void CICYThermostat::SendSetPointSensor(const unsigned char Idx, const float Tem
 
 	thermos.temp=Temp;
 
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), 255, nullptr);
 }
 
 bool CICYThermostat::GetSerialAndToken()

--- a/hardware/KMTronic433.cpp
+++ b/hardware/KMTronic433.cpp
@@ -155,7 +155,7 @@ bool KMTronic433::WriteInt(const unsigned char *data, const size_t len, const bo
 	if (!isOpen())
 		return false;
 	m_bHaveReceived = false;
-	write((const char*)data, len);
+	write(reinterpret_cast<const char *>(data), len);
 	if (!bWaitForReturn)
 		return true;
 	sleep_milliseconds(100);

--- a/hardware/KMTronicBase.cpp
+++ b/hardware/KMTronicBase.cpp
@@ -65,7 +65,7 @@ bool KMTronicBase::WriteToHardware(const char *pdata, const unsigned char /*leng
 		{
 			unsigned char SendBuf[3];
 			SendBuf[0] = 0xFF;
-			SendBuf[1] = (uint8_t)node_id;
+			SendBuf[1] = uint8_t(node_id);
 			SendBuf[2] = (pCmd->LIGHTING2.cmnd == light2_sOn) ? 1 : 0;
 			WriteInt(SendBuf, 3,false);
 			return true;

--- a/hardware/KMTronicSerial.cpp
+++ b/hardware/KMTronicSerial.cpp
@@ -156,7 +156,7 @@ bool KMTronicSerial::WriteInt(const unsigned char *data, const size_t len, const
 	if (!isOpen())
 		return false;
 	m_bHaveReceived = false;
-	write((const char*)data, len);
+	write(reinterpret_cast<const char *>(data), len);
 	if (!bWaitForReturn)
 		return true;
 	sleep_milliseconds(100);
@@ -179,7 +179,7 @@ void KMTronicSerial::GetRelayStates()
 	bool bIs485 = false;
 	for (int iBoard = 0; iBoard < 6; iBoard++)
 	{
-		SendBuf[1] = (uint8_t)(0xA1 + iBoard);
+		SendBuf[1] = uint8_t(0xA1 + iBoard);
 		if (WriteInt(SendBuf, 3, true))
 		{
 			bIs485 = true;
@@ -247,7 +247,7 @@ void KMTronicSerial::GetRelayStates()
 	SendBuf[2] = 0x03;
 	for (ii = 0; ii < Max_KMTronic_Relais; ii++)
 	{
-		SendBuf[1] = (uint8_t)(ii+1);
+		SendBuf[1] = uint8_t(ii + 1);
 		if (WriteInt(SendBuf, 3,true))
 		{
 			if (m_bufferpos == 3)

--- a/hardware/KMTronicTCP.cpp
+++ b/hardware/KMTronicTCP.cpp
@@ -276,7 +276,7 @@ void KMTronicTCP::ParseTemps(const std::string &sResult)
 			pos1 = tmpstr.find("</temp>");
 			if (pos1 != std::string::npos)
 			{
-				float temp = (float)atof(tmpstr.substr(0, pos1).c_str());
+				float temp = float(atof(tmpstr.substr(0, pos1).c_str()));
 				SendTempSensor(Idx++, 255, temp, name);
 				continue;
 			}

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -170,7 +170,7 @@ CKodiNode::CKodiNode(boost::asio::io_service *pIos, const int pHwdID, const int 
 	if (result2.size() == 1)
 	{
 		m_ID = atoi(result2[0][0].c_str());
-		m_PreviousStatus.Status((_eMediaStatus)atoi(result2[0][1].c_str()));
+		m_PreviousStatus.Status(_eMediaStatus(atoi(result2[0][1].c_str())));
 		m_PreviousStatus.Status(result2[0][2]);
 	}
 	m_CurrentStatus = m_PreviousStatus;
@@ -364,8 +364,10 @@ void CKodiNode::handleMessage(std::string& pMessage)
 							{
 								m_CurrentStatus.Status(MSTAT_VIDEO);
 								if (root["result"]["item"].isMember("showtitle"))	m_CurrentStatus.ShowTitle(root["result"]["item"]["showtitle"].asCString());
-								if (root["result"]["item"].isMember("season"))		m_CurrentStatus.Season((int)root["result"]["item"]["season"].asInt());
-								if (root["result"]["item"].isMember("episode"))		m_CurrentStatus.Episode((int)root["result"]["item"]["episode"].asInt());
+								if (root["result"]["item"].isMember("season"))
+									m_CurrentStatus.Season(int(root["result"]["item"]["season"].asInt()));
+								if (root["result"]["item"].isMember("episode"))
+									m_CurrentStatus.Episode(int(root["result"]["item"]["episode"].asInt()));
 							}
 							if (m_CurrentStatus.Type() == "channel")
 							{
@@ -1420,8 +1422,8 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
+				_eSwitchType sType = _eSwitchType(atoi(result[0][0].c_str()));
+				_eHardwareTypes hType = _eHardwareTypes(atoi(result[0][1].c_str()));
 				int HwID = atoi(result[0][2].c_str());
 				// Is the device a media Player?
 				if (sType == STYPE_Media)

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -563,7 +563,7 @@ void CLogitechMediaServer::ReloadNodes()
 	result = m_sql.safe_query("SELECT ID,Name,MacAddress FROM WOLNodes WHERE (HardwareID==%d)", m_HwdID);
 	if (!result.empty())
 	{
-		_log.Log(LOG_STATUS, "Logitech Media Server: %d player-switch(es) found.", (int)result.size());
+		_log.Log(LOG_STATUS, "Logitech Media Server: %d player-switch(es) found.", int(result.size()));
 		for (const auto &sd : result)
 		{
 			LogitechMediaServerNode pnode;
@@ -581,7 +581,7 @@ void CLogitechMediaServer::ReloadNodes()
 			if (result2.size() == 1)
 			{
 				pnode.ID = atoi(result2[0][0].c_str());
-				pnode.nStatus = (_eMediaStatus)atoi(result2[0][1].c_str());
+				pnode.nStatus = _eMediaStatus(atoi(result2[0][1].c_str()));
 				pnode.sStatus = result2[0][2];
 			}
 
@@ -918,8 +918,8 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
+				_eSwitchType sType = _eSwitchType(atoi(result[0][0].c_str()));
+				_eHardwareTypes hType = _eHardwareTypes(atoi(result[0][1].c_str()));
 				int HwID = atoi(result[0][2].c_str());
 				// Is the device a media Player?
 				if (sType == STYPE_Media)

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -41,7 +41,7 @@ MQTT::MQTT(const int ID, const std::string &IPAddress, const unsigned short usIP
 	mosqdz::lib_init();
 
 	m_usIPPort = usIPPort;
-	m_publish_scheme = (_ePublishTopics)PublishScheme;
+	m_publish_scheme = _ePublishTopics(PublishScheme);
 
 	m_TopicIn = TOPIC_IN;
 	m_TopicOut = TOPIC_OUT;
@@ -167,7 +167,7 @@ void MQTT::on_connect(int rc)
 void MQTT::on_message(const struct mosquitto_message* message)
 {
 	std::string topic = message->topic;
-	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
+	std::string qMessage = std::string(static_cast<char *>(message->payload), static_cast<char *>(message->payload) + message->payloadlen);
 
 	_log.Log(LOG_NORM, "MQTT: Topic: %s, Message: %s", topic.c_str(), qMessage.c_str());
 
@@ -197,7 +197,7 @@ void MQTT::on_message(const struct mosquitto_message* message)
 		//Checks
 		if ((szCommand == "udevice") || (szCommand == "switchlight") || (szCommand == "getdeviceinfo"))
 		{
-			idx = (uint64_t)root["idx"].asInt64();
+			idx = uint64_t(root["idx"].asInt64());
 			//Get the raw device parameters
 			result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID==%" PRIu64 ")", idx);
 			if (result.empty())
@@ -208,7 +208,7 @@ void MQTT::on_message(const struct mosquitto_message* message)
 		}
 		else if ((szCommand == "switchscene") || (szCommand == "getsceneinfo"))
 		{
-			idx = (uint64_t)root["idx"].asInt64();
+			idx = uint64_t(root["idx"].asInt64());
 			result = m_sql.safe_query("SELECT Name FROM Scenes WHERE (ID==%" PRIu64 ")", idx);
 			if (result.empty())
 			{
@@ -218,7 +218,7 @@ void MQTT::on_message(const struct mosquitto_message* message)
 		}
 		else if (szCommand == "setuservariable")
 		{
-			idx = (uint64_t)root["idx"].asInt64();
+			idx = uint64_t(root["idx"].asInt64());
 			result = m_sql.safe_query("SELECT Name, ValueType FROM UserVariables WHERE (ID==%" PRIu64 ")", idx);
 			if (result.empty())
 			{
@@ -310,7 +310,7 @@ void MQTT::on_message(const struct mosquitto_message* message)
 		}
 		else if (szCommand == "setcolbrightnessvalue")
 		{
-			idx = (uint64_t)root["idx"].asInt64();
+			idx = uint64_t(root["idx"].asInt64());
 			_tColor color;
 
 			std::string hex = root["hex"].asString();
@@ -341,9 +341,9 @@ void MQTT::on_message(const struct mosquitto_message* message)
 					int r, g, b;
 					rgb2hsb(color.r, color.g, color.b, hsb);
 					hsb2rgb(hsb[0] * 360.0F, hsb[1], 1.0F, r, g, b, 255);
-					color.r = (uint8_t)r;
-					color.g = (uint8_t)g;
-					color.b = (uint8_t)b;
+					color.r = uint8_t(r);
+					color.g = uint8_t(g);
+					color.b = uint8_t(b);
 					brightnessAdj = hsb[2];
 				}
 				//_log.Debug(DEBUG_NORM, "MQTT: setcolbrightnessvalue: color: '%s', bri: '%s'", color.toString().c_str(), brightness.c_str());
@@ -360,35 +360,35 @@ void MQTT::on_message(const struct mosquitto_message* message)
 				switch (hex.length())
 				{
 				case 6: //RGB
-					r = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-					g = (uint8_t)((ihex & 0x000000FF00) >> 8);
-					b = (uint8_t)ihex & 0xFF;
+					r = uint8_t((ihex & 0x0000FF0000) >> 16);
+					g = uint8_t((ihex & 0x000000FF00) >> 8);
+					b = uint8_t(ihex) & 0xFF;
 					float hsb[3];
 					int tr, tg, tb; // tmp of 'int' type so can be passed as references to hsb2rgb
 					rgb2hsb(r, g, b, hsb);
 					// Normalize RGB to full brightness
 					hsb2rgb(hsb[0] * 360.0F, hsb[1], 1.0F, tr, tg, tb, 255);
-					r = (uint8_t)tr;
-					g = (uint8_t)tg;
-					b = (uint8_t)tb;
+					r = uint8_t(tr);
+					g = uint8_t(tg);
+					b = uint8_t(tb);
 					brightnessAdj = hsb[2];
 					// Backwards compatibility: set iswhite for unsaturated colors
 					iswhite = (hsb[1] < (20.0 / 255.0)) ? "true" : "false";
 					color = _tColor(r, g, b, cw, ww, ColorModeRGB);
 					break;
 				case 8: //RGB_WW
-					r = (uint8_t)((ihex & 0x00FF000000) >> 24);
-					g = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-					b = (uint8_t)((ihex & 0x000000FF00) >> 8);
-					ww = (uint8_t)ihex & 0xFF;
+					r = uint8_t((ihex & 0x00FF000000) >> 24);
+					g = uint8_t((ihex & 0x0000FF0000) >> 16);
+					b = uint8_t((ihex & 0x000000FF00) >> 8);
+					ww = uint8_t(ihex) & 0xFF;
 					color = _tColor(r, g, b, cw, ww, ColorModeCustom);
 					break;
 				case 10: //RGB_CW_WW
-					r = (uint8_t)((ihex & 0xFF00000000) >> 32);
-					g = (uint8_t)((ihex & 0x00FF000000) >> 24);
-					b = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-					cw = (uint8_t)((ihex & 0x000000FF00) >> 8);
-					ww = (uint8_t)ihex & 0xFF;
+					r = uint8_t((ihex & 0xFF00000000) >> 32);
+					g = uint8_t((ihex & 0x00FF000000) >> 24);
+					b = uint8_t((ihex & 0x0000FF0000) >> 16);
+					cw = uint8_t((ihex & 0x000000FF00) >> 8);
+					ww = uint8_t(ihex) & 0xFF;
 					color = _tColor(r, g, b, cw, ww, ColorModeCustom);
 					break;
 				}
@@ -405,7 +405,7 @@ void MQTT::on_message(const struct mosquitto_message* message)
 				if (!sat.empty()) iSat = float(atof(sat.c_str()));
 				hsb2rgb(iHue, iSat / 100.0F, 1.0F, r, g, b, 255);
 
-				color = _tColor((uint8_t)r, (uint8_t)g, (uint8_t)b, 0, 0, ColorModeRGB);
+				color = _tColor(uint8_t(r), uint8_t(g), uint8_t(b), 0, 0, ColorModeRGB);
 				if (iswhite == "true") color.mode = ColorModeWhite;
 				//_log.Debug(DEBUG_NORM, "MQTT: setcolbrightnessvalue2: hue: %f, rgb: %02x%02x%02x, color: '%s'", iHue, r, g, b, color.toString().c_str());
 			}
@@ -449,10 +449,10 @@ void MQTT::on_message(const struct mosquitto_message* message)
 		{
 			std::string varvalue = root["value"].asString();
 
-			idx = (uint64_t)root["idx"].asInt64();
+			idx = uint64_t(root["idx"].asInt64());
 			result = m_sql.safe_query("SELECT Name, ValueType FROM UserVariables WHERE (ID==%" PRIu64 ")", idx);
 			std::string sVarName = result[0][0];
-			_eUsrVariableType varType = (_eUsrVariableType)atoi(result[0][1].c_str());
+			_eUsrVariableType varType = _eUsrVariableType(atoi(result[0][1].c_str()));
 
 			std::string errorMessage;
 			if (!m_sql.UpdateUserVariable(root["idx"].asString(), sVarName, varType, varvalue, true, errorMessage))
@@ -744,7 +744,7 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		int dSubType = atoi(sd[iIndex++].c_str());
 		int nvalue = atoi(sd[iIndex++].c_str());
 		std::string svalue = sd[iIndex++];
-		_eSwitchType switchType = (_eSwitchType)atoi(sd[iIndex++].c_str());
+		_eSwitchType switchType = _eSwitchType(atoi(sd[iIndex++].c_str()));
 		int RSSI = atoi(sd[iIndex++].c_str());
 		int BatteryLevel = atoi(sd[iIndex++].c_str());
 		std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[iIndex++]);
@@ -759,14 +759,14 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		root["id"] = did;
 		root["unit"] = dunit;
 		root["name"] = name;
-		root["dtype"] = RFX_Type_Desc((uint8_t)dType, 1);
-		root["stype"] = RFX_Type_SubType_Desc((uint8_t)dType, (uint8_t)dSubType);
+		root["dtype"] = RFX_Type_Desc(uint8_t(dType), 1);
+		root["stype"] = RFX_Type_SubType_Desc(uint8_t(dType), uint8_t(dSubType));
 
 		if (IsLightOrSwitch(dType, dSubType) == true) {
 			root["switchType"] = Switch_Type_Desc(switchType);
 		}
 		else if ((dType == pTypeRFXMeter) || (dType == pTypeRFXSensor)) {
-			root["meterType"] = Meter_Type_Desc((_eMeterType)switchType);
+			root["meterType"] = Meter_Type_Desc(_eMeterType(switchType));
 		}
 		// Add device options
 		for (const auto &option : options)
@@ -856,8 +856,8 @@ void MQTT::SendSceneInfo(const uint64_t SceneIdx, const std::string&/*SceneName*
 	std::string sName = sd[1];
 	std::string sLastUpdate = sd[6];
 
-	unsigned char nValue = (uint8_t)atoi(sd[4].c_str());
-	unsigned char scenetype = (uint8_t)atoi(sd[5].c_str());
+	unsigned char nValue = uint8_t(atoi(sd[4].c_str()));
+	unsigned char scenetype = uint8_t(atoi(sd[5].c_str()));
 	//int iProtected = atoi(sd[7].c_str());
 
 	//std::string onaction = base64_encode((sd[8]);

--- a/hardware/Meteorologisk.cpp
+++ b/hardware/Meteorologisk.cpp
@@ -218,7 +218,7 @@ void CMeteorologisk::GetMeterDetails()
 	Json::Value selectedTimeserie = 0;
 	time_t now = time(nullptr);
 
-	for(int i = 0; i < (int)timeseries.size(); i++)
+	for (int i = 0; i < int(timeseries.size()); i++)
 	{
 		Json::Value timeserie = timeseries[i];
 		std::string stime = timeserie["time"].asString();

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -149,7 +149,7 @@ void Meteostick::readCallback(const char *data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData((const unsigned char*)data, static_cast<int>(len));
+	ParseData(reinterpret_cast<const unsigned char *>(data), int(len));
 }
 
 bool Meteostick::WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/)
@@ -213,16 +213,16 @@ void Meteostick::SendWindSensor(const unsigned char Idx, const float Temp, const
 	tsen.WIND.id2 = Idx;
 
 	int aw = round(Direction);
-	tsen.WIND.directionh = (BYTE)(aw / 256);
+	tsen.WIND.directionh = BYTE(aw / 256);
 	aw -= (tsen.WIND.directionh * 256);
-	tsen.WIND.directionl = (BYTE)(aw);
+	tsen.WIND.directionl = BYTE(aw);
 
 	tsen.WIND.av_speedh = 0;
 	tsen.WIND.av_speedl = 0;
 	int sw = round(Speed * 10.0F);
-	tsen.WIND.av_speedh = (BYTE)(sw / 256);
+	tsen.WIND.av_speedh = BYTE(sw / 256);
 	sw -= (tsen.WIND.av_speedh * 256);
-	tsen.WIND.av_speedl = (BYTE)(sw);
+	tsen.WIND.av_speedl = BYTE(sw);
 
 	tsen.WIND.gusth = 0;
 	tsen.WIND.gustl = 0;
@@ -241,11 +241,11 @@ void Meteostick::SendWindSensor(const unsigned char Idx, const float Temp, const
 	}
 	dWindChill *= 10.0F;
 	tsen.WIND.chillsign = (dWindChill >= 0) ? 0 : 1;
-	tsen.WIND.chillh = (BYTE)(dWindChill / 256);
+	tsen.WIND.chillh = BYTE(dWindChill / 256);
 	dWindChill -= (tsen.WIND.chillh * 256);
-	tsen.WIND.chilll = (BYTE)(dWindChill);
+	tsen.WIND.chilll = BYTE(dWindChill);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.WIND, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.WIND), defaultname.c_str(), 255, nullptr);
 }
 
 void Meteostick::SendLeafWetnessRainSensor(const unsigned char Idx, const unsigned char Channel, const int Wetness, const std::string &defaultname)
@@ -254,8 +254,8 @@ void Meteostick::SendLeafWetnessRainSensor(const unsigned char Idx, const unsign
 	_tGeneralDevice gdevice;
 	gdevice.subtype = sTypeLeafWetness;
 	gdevice.intval1 = Wetness;
-	gdevice.id = (uint8_t)finalID;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), 255, nullptr);
+	gdevice.id = uint8_t(finalID);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), 255, nullptr);
 }
 
 void Meteostick::SendSoilMoistureSensor(const unsigned char Idx, const unsigned char Channel, const int Moisture, const std::string &defaultname)
@@ -268,16 +268,16 @@ void Meteostick::SendSolarRadiationSensor(const unsigned char Idx, const float R
 {
 	_tGeneralDevice gdevice;
 	gdevice.subtype = sTypeSolarRadiation;
-	gdevice.id = static_cast<int>(Idx);
+	gdevice.id = int(Idx);
 	gdevice.floatval1 = Radiation;
-	sDecodeRXMessage(this, (const unsigned char *)&gdevice, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), defaultname.c_str(), 255, nullptr);
 }
 
 void Meteostick::ParseLine()
 {
 	if (m_bufferpos < 1)
 		return;
-	std::string sLine((char*)&m_buffer);
+	std::string sLine(reinterpret_cast<char *>(&m_buffer));
 
 	std::vector<std::string> results;
 	StringSplit(sLine, " ", results);
@@ -335,8 +335,8 @@ void Meteostick::ParseLine()
 		//temperature in Celsius, pressure in hPa
 		if (results.size() >= 3)
 		{
-			float temp = static_cast<float>(atof(results[1].c_str()));
-			float baro = static_cast<float>(atof(results[2].c_str()));
+			float temp = float(atof(results[1].c_str()));
+			float baro = float(atof(results[2].c_str()));
 
 			SendTempBaroSensorInt(0, temp, baro, "Meteostick Temp+Baro");
 		}
@@ -345,11 +345,11 @@ void Meteostick::ParseLine()
 		//current wind speed in m / s, wind direction in degrees
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
 			if (m_LastOutsideTemp[ID%MAX_IDS] != 12345)
 			{
-				float speed = static_cast<float>(atof(results[2].c_str()));
-				int direction = static_cast<int>(atoi(results[3].c_str()));
+				float speed = float(atof(results[2].c_str()));
+				int direction = int(atoi(results[3].c_str()));
 				SendWindSensor(ID, m_LastOutsideTemp[ID%MAX_IDS], speed, direction, "Wind");
 			}
 		}
@@ -358,9 +358,9 @@ void Meteostick::ParseLine()
 		//temperature in degree Celsius, humidity in percent
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float temp = static_cast<float>(atof(results[2].c_str()));
-			int hum = static_cast<int>(atoi(results[3].c_str()));
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			float temp = float(atof(results[2].c_str()));
+			int hum = int(atoi(results[3].c_str()));
 
 			SendTempHumSensor(ID, 255, temp, hum, "Outside Temp+Hum");
 			m_LastOutsideTemp[ID%MAX_IDS] = temp;
@@ -373,7 +373,7 @@ void Meteostick::ParseLine()
 		//it only has a small counter, so we should make the total counter ourselfses
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
 			int raincntr = atoi(results[2].c_str());
 			float Rainmm = 0;
 			if (m_LastRainValue[ID%MAX_IDS] != -1)
@@ -408,8 +408,8 @@ void Meteostick::ParseLine()
 		//solar radiation, solar radiation in W / qm
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float Radiation = static_cast<float>(atof(results[2].c_str()));
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			float Radiation = float(atof(results[2].c_str()));
 			SendSolarRadiationSensor(ID, Radiation, "Solar Radiation");
 		}
 		break;
@@ -417,8 +417,8 @@ void Meteostick::ParseLine()
 		//UV index
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float UV = static_cast<float>(atof(results[2].c_str()));
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			float UV = float(atof(results[2].c_str()));
 			CDomoticzHardwareBase::SendUVSensor(0, ID, 255, UV, "UV");
 		}
 		break;
@@ -427,9 +427,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), leaf wetness (0-15)
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			unsigned char Wetness = (unsigned char)atoi(results[3].c_str());
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			uint8_t Channel = uint8_t(atoi(results[2].c_str()));
+			uint8_t Wetness = uint8_t(atoi(results[3].c_str()));
 			SendLeafWetnessRainSensor(ID, Channel, Wetness, "Leaf Wetness");
 		}
 		break;
@@ -438,9 +438,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), Soil moisture in cbar(0 - 200)
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			unsigned char Moisture = (unsigned char)atoi(results[3].c_str());
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			uint8_t Channel = uint8_t(atoi(results[2].c_str()));
+			uint8_t Moisture = uint8_t(atoi(results[3].c_str()));
 			SendSoilMoistureSensor(ID, Channel, Moisture, "Soil Moisture");
 		}
 		break;
@@ -449,9 +449,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), soil / leaf temperature in degrees Celsius
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			float temp = static_cast<float>(atof(results[3].c_str()));
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			uint8_t Channel = uint8_t(atoi(results[2].c_str()));
+			float temp = float(atof(results[3].c_str()));
 			unsigned char finalID = (ID * 10) + Channel;
 			SendTempSensor(finalID, 255, temp, "Soil/Leaf Temp");
 		}
@@ -460,8 +460,8 @@ void Meteostick::ParseLine()
 		//solar panel power in(0 - 100)
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float Percentage = static_cast<float>(atof(results[2].c_str()));
+			uint8_t ID = uint8_t(atoi(results[1].c_str()));
+			float Percentage = float(atof(results[2].c_str()));
 			SendPercentageSensor(ID, 0, 255, Percentage, "power of solar panel");
 		}
 		break;

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -181,9 +181,9 @@ bool MochadTCP::WriteToHardware(const char *pdata, const unsigned char /*length*
 	if (pdata[1] == pTypeInterfaceControl && pdata[2] == sTypeInterfaceCommand && pdata[4] == cmdSTATUS) {
 		sprintf (s_buffer,"ST\n");
 	} else if (pdata[1] == pTypeLighting1 && pdata[2] == sTypeX10 && pdata[6] == light1_sOn) {
-		sprintf (s_buffer,"RF %c%d on\n",(char)(pdata[4]), pdata[5]);
+		sprintf(s_buffer, "RF %c%d on\n", (pdata[4]), pdata[5]);
 	} else if (pdata[1] == pTypeLighting1 && pdata[2] == sTypeX10 && pdata[6] == light1_sOff) {
-		sprintf (s_buffer,"RF %c%d off\n",(char)(pdata[4]), pdata[5]);
+		sprintf(s_buffer, "RF %c%d off\n", (pdata[4]), pdata[5]);
 	} else {
 //			case light1_sDim:
 //			case light1_sBright:
@@ -193,13 +193,13 @@ bool MochadTCP::WriteToHardware(const char *pdata, const unsigned char /*length*
 		return false;
 	}
 //	_log.Log(LOG_STATUS, "Mochad: send '%s'", s_buffer);
-	write((const unsigned char *)s_buffer, strlen(s_buffer));
+	write(reinterpret_cast<const unsigned char *>(s_buffer), strlen(s_buffer));
 	return true;
 }
 
 void MochadTCP::MatchLine()
 {
-	if ((strlen((const char*)&m_mochadbuffer)<1)||(m_mochadbuffer[0]==0x0a))
+	if ((strlen(reinterpret_cast<const char *>(&m_mochadbuffer)) < 1) || (m_mochadbuffer[0] == 0x0a))
 		return; //null value (startup)
 
 	int j,k;
@@ -217,7 +217,7 @@ void MochadTCP::MatchLine()
 		switch(t.matchtype)
 		{
 		case ID:
-			if (strncmp(t.key, (const char *)&m_mochadbuffer, strlen(t.key)) != 0)
+			if (strncmp(t.key, reinterpret_cast<const char *>(&m_mochadbuffer), strlen(t.key)) != 0)
 			{
 				continue;
 			}
@@ -225,14 +225,14 @@ void MochadTCP::MatchLine()
 			found = true;
 			break;
 		case STD:
-			if (strncmp(t.key, (const char *)&m_mochadbuffer, strlen(t.key)) != 0)
+			if (strncmp(t.key, reinterpret_cast<const char *>(&m_mochadbuffer), strlen(t.key)) != 0)
 			{
 				continue;
 			}
 			found = true;
 			break;
 		case LINE17:
-			if (strncmp(t.key, (const char *)&m_mochadbuffer, strlen(t.key)) != 0)
+			if (strncmp(t.key, reinterpret_cast<const char *>(&m_mochadbuffer), strlen(t.key)) != 0)
 			{
 				continue;
 			}
@@ -240,12 +240,13 @@ void MochadTCP::MatchLine()
 			found = true;
 			break;
 		case LINE18:
-			if((m_linecount == 18)&&(strncmp(t.key, (const char*)&m_mochadbuffer, strlen(t.key)) == 0)) {
+			if ((m_linecount == 18) && (strncmp(t.key, reinterpret_cast<const char *>(&m_mochadbuffer), strlen(t.key)) == 0))
+			{
 				found = true;
 			}
 			break;
 		case EXCLMARK:
-			if (strncmp(t.key, (const char *)&m_mochadbuffer, strlen(t.key)) != 0)
+			if (strncmp(t.key, reinterpret_cast<const char *>(&m_mochadbuffer), strlen(t.key)) != 0)
 			{
 				continue;
 			}
@@ -277,7 +278,7 @@ void MochadTCP::MatchLine()
 				return;
 			if (!('0' <= m_mochadbuffer[j] && m_mochadbuffer[j] <= '1')) goto onError;
 			m_mochad.LIGHTING1.cmnd = m_mochadbuffer[j++] - '0';
-			sDecodeRXMessage(this, (const unsigned char *)&m_mochad, nullptr, 255, m_Name.c_str());
+			sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_mochad), nullptr, 255, m_Name.c_str());
 			if (!(','==  m_mochadbuffer[j++])) return;
 		}
 		break;
@@ -313,9 +314,9 @@ checkFunc:
 		else goto onError;
 		for (k=1;k<=16;k++) {
 			if (selected[currentHouse][k] >0) {
-				m_mochad.LIGHTING1.housecode = (BYTE)(currentHouse+'A');
-				m_mochad.LIGHTING1.unitcode = (BYTE)k;
-				sDecodeRXMessage(this, (const unsigned char *)&m_mochad, nullptr, 255, m_Name.c_str());
+				m_mochad.LIGHTING1.housecode = BYTE(currentHouse + 'A');
+				m_mochad.LIGHTING1.unitcode = BYTE(k);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_mochad), nullptr, 255, m_Name.c_str());
 				selected[currentHouse][k] = 0;
 			}
 		}
@@ -325,14 +326,14 @@ checkFunc:
 		char *pchar;
 		char tempRFSECbuf[50];
 
-		if (strstr((const char*)&m_mochadbuffer[j], "DS10A"))
+		if (strstr(reinterpret_cast<const char *>(&m_mochadbuffer[j]), "DS10A"))
 		{
 			m_mochadsec.SECURITY1.subtype = sTypeSecX10;
 			setSecID(&m_mochadbuffer[t.start]);
 			m_mochadsec.SECURITY1.battery_level = 0x0f;
 
 			// parse sensor conditions, e.g. "Contact_alert_min_DS10A" or "'Contact_normal_max_low_DS10A"
-			strcpy(tempRFSECbuf, (const char *)&m_mochadbuffer[t.start + t.width + 7]);
+			strcpy(tempRFSECbuf, reinterpret_cast<const char *>(&m_mochadbuffer[t.start + t.width + 7]));
 			pchar = strtok(tempRFSECbuf, " _");
 			while (pchar != nullptr)
 			{
@@ -353,14 +354,14 @@ checkFunc:
 			}
 			m_mochadsec.SECURITY1.rssi = 12; // signal strength ?? 12 = no signal strength
 		}
-		else if (strstr((const char *)&m_mochadbuffer[j], "KR10A"))
+		else if (strstr(reinterpret_cast<const char *>(&m_mochadbuffer[j]), "KR10A"))
 		{
 			m_mochadsec.SECURITY1.subtype = sTypeSecX10R;
 			setSecID(&m_mochadbuffer[t.start]);
 			m_mochadsec.SECURITY1.battery_level = 0x0f;
 
 			// parse remote conditions, e.g. "Panic_KR10A" "Lights_On_KR10A" "Lights_Off_KR10A" "Disarm_KR10A" "Arm_KR10A"
-			strcpy(tempRFSECbuf, (const char *)&m_mochadbuffer[t.start + t.width + 7]);
+			strcpy(tempRFSECbuf, reinterpret_cast<const char *>(&m_mochadbuffer[t.start + t.width + 7]));
 			pchar = strtok(tempRFSECbuf, " _");
 			while (pchar != nullptr)
 			{
@@ -378,14 +379,14 @@ checkFunc:
 			}
 			m_mochadsec.SECURITY1.rssi = 12;
 		}
-		else if (strstr((const char *)&m_mochadbuffer[j], "MS10A"))
+		else if (strstr(reinterpret_cast<const char *>(&m_mochadbuffer[j]), "MS10A"))
 		{
 			m_mochadsec.SECURITY1.subtype = sTypeSecX10M;
 			setSecID(&m_mochadbuffer[t.start]);
 			m_mochadsec.SECURITY1.battery_level = 0x0f;
 
 			// parse remote conditions, "Motion_alert_MS10A" and "Motion_normal_MS10A"
-			strcpy(tempRFSECbuf, (const char *)&m_mochadbuffer[t.start + t.width + 7]);
+			strcpy(tempRFSECbuf, reinterpret_cast<const char *>(&m_mochadbuffer[t.start + t.width + 7]));
 			pchar = strtok(tempRFSECbuf, " _");
 			while (pchar != nullptr)
 			{
@@ -402,7 +403,7 @@ checkFunc:
 		else
 			goto onError;
 
-		sDecodeRXMessage(this, (const unsigned char *)&m_mochadsec, nullptr, 255, m_Name.c_str());
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_mochadsec), nullptr, 255, m_Name.c_str());
 		break;
 	}
 	return;
@@ -429,7 +430,8 @@ void MochadTCP::ParseData(const unsigned char *pData, int Len)
 			// discard newline, close string, parse line and clear it.
 			if(m_bufferpos > 0) m_mochadbuffer[m_bufferpos] = 0;
 			m_linecount++;
-			if (strlen((const char *)m_mochadbuffer) > 14) {
+			if (strlen(reinterpret_cast<const char *>(m_mochadbuffer)) > 14)
+			{
 				int i = 0;
 				while (m_mochadbuffer[i+15] != 0) {
 					m_mochadbuffer[i] = m_mochadbuffer[i+15];

--- a/hardware/MultiFun.cpp
+++ b/hardware/MultiFun.cpp
@@ -228,7 +228,7 @@ bool MultiFun::WriteToHardware(const char *pdata, const unsigned char /*length*/
 			cmd[11] = 0x01;
 			cmd[12] = 0x02; // number of bytes
 			cmd[13] = 0x00;
-			cmd[14] = (uint8_t)change;
+			cmd[14] = uint8_t(change);
 
 			int ret = SendCommand(cmd, 15, buffer, true);
 			if (ret == 4)
@@ -241,12 +241,12 @@ bool MultiFun::WriteToHardware(const char *pdata, const unsigned char /*length*/
 		const _tThermostat *therm = reinterpret_cast<const _tThermostat*>(pdata);
 
 		float temp = therm->temp;
-		int calculatedTemp = (int)temp;
+		int calculatedTemp = int(temp);
 
 		if ((therm->id2 == 0x1F || therm->id2 == 0x20) ||
 			((therm->id2 == 0x1C || therm->id2 == 0x1D) && m_isWeatherWork[therm->id2 - 0x1C]))
 		{
-			calculatedTemp = (int)(temp * 5);
+			calculatedTemp = int(temp * 5);
 			calculatedTemp = calculatedTemp | 0x8000;
 		}
 
@@ -266,7 +266,7 @@ bool MultiFun::WriteToHardware(const char *pdata, const unsigned char /*length*/
 		cmd[11] = 0x01;
 		cmd[12] = 0x02; // number of bytes
 		cmd[13] = 0x00;
-		cmd[14] = (uint8_t)calculatedTemp;
+		cmd[14] = uint8_t(calculatedTemp);
 
 		int ret = SendCommand(cmd, 15, buffer, true);
 		if (ret == 4)
@@ -445,7 +445,7 @@ void MultiFun::GetRegisters(bool firstTime)
 					}
 					m_LastDevices = value;
 
-					float level = (float)((value & 0xFC00) >> 10);
+					float level = float((value & 0xFC00) >> 10);
 					SendPercentageSensor(2, 1, 255, level, "BLOWER POWER");
 					break;
 				}
@@ -464,7 +464,7 @@ void MultiFun::GetRegisters(bool firstTime)
 					}
 					m_LastState = value;
 
-					float level = (float)((value & 0xFC00) >> 10);
+					float level = float((value & 0xFC00) >> 10);
 					SendPercentageSensor(3, 1, 255, level, "Fuel Level");
 					break;
 				}
@@ -475,19 +475,19 @@ void MultiFun::GetRegisters(bool firstTime)
 					char name[20];
 					sprintf(name, "C.H. %d Temperature", i - 0x1C + 1);
 
-					float temp = (float)value;
+					float temp = float(value);
 					if ((value & 0x8000) == 0x8000)
 					{
-						temp = (float)((value & 0x0FFF) * 0.2);
+						temp = float((value & 0x0FFF) * 0.2);
 					}
 					m_isWeatherWork[i - 0x1C] = (value & 0x8000) == 0x8000;
-					SendSetPointSensor((uint8_t)i, 1, 1, temp, name);
+					SendSetPointSensor(uint8_t(i), 1, 1, temp, name);
 					break;
 				}
 
 				case 0x1E:
 				{
-					SendSetPointSensor(0x1E, 1, 1, (float)value, "H.W.U. Temperature");
+					SendSetPointSensor(0x1E, 1, 1, float(value), "H.W.U. Temperature");
 					break;
 				}
 
@@ -499,8 +499,8 @@ void MultiFun::GetRegisters(bool firstTime)
 
 					if (m_isSensorExists[i - 0x1F])
 					{
-						float temp = (float)((value & 0x0FFF) * 0.2);
-						SendSetPointSensor((uint8_t)i, 1, 1, temp, name);
+						float temp = float((value & 0x0FFF) * 0.2);
+						SendSetPointSensor(uint8_t(i), 1, 1, temp, name);
 					}
 					else
 					{
@@ -550,7 +550,7 @@ int MultiFun::SendCommand(const unsigned char* cmd, const unsigned int cmdLength
 	unsigned char databuffer[BUFFER_LENGHT];
 	int ret = -1;
 
-	if (m_socket->write((char*)cmd, cmdLength) != (int)cmdLength)
+	if (m_socket->write((char *)cmd, cmdLength) != int(cmdLength))
 	{
 		_log.Log(LOG_ERROR, "MultiFun: Send command failed");
 		DestroySocket();
@@ -562,7 +562,7 @@ int MultiFun::SendCommand(const unsigned char* cmd, const unsigned int cmdLength
 	if (bIsDataReadable)
 	{
 		memset(databuffer, 0, BUFFER_LENGHT);
-		ret = m_socket->read((char*)databuffer, BUFFER_LENGHT, false);
+		ret = m_socket->read(reinterpret_cast<char *>(databuffer), BUFFER_LENGHT, false);
 	}
 
 	if ((ret <= 0) || (ret >= BUFFER_LENGHT))
@@ -584,7 +584,7 @@ int MultiFun::SendCommand(const unsigned char* cmd, const unsigned int cmdLength
 				}
 				answerLength = ret - 8; // answer = frame - prefix
 
-				if ((int)databuffer[4] * 256 + (int)databuffer[5] == (unsigned char)(answerLength + 2))
+				if (int(databuffer[4]) * 256 + int(databuffer[5]) == uint8_t(answerLength + 2))
 				{
 					if (!write)
 					{

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -275,7 +275,7 @@ void MySensorsBase::LoadDevicesFromDatabase()
 					_tMySensorChild mSensor;
 					mSensor.nodeID = ID;
 					mSensor.childID = atoi(sd2[0].c_str());
-					mSensor.presType = (_ePresentationType)atoi(sd2[1].c_str());
+					mSensor.presType = _ePresentationType(atoi(sd2[1].c_str()));
 					gID += std::count_if(mNode.m_childs.begin(), mNode.m_childs.end(),
 							     [&](const _tMySensorChild &child) { return (child.presType == mSensor.presType) && (child.groupID == gID); });
 					mSensor.groupID = gID;
@@ -785,61 +785,61 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 	case V_TRIPPED:
 		//	Tripped status of a security sensor. 1 = Tripped, 0 = Untripped
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Security Sensor", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Security Sensor", pChild->batValue);
 		break;
 	case V_ARMED:
 		//Armed status of a security sensor. 1 = Armed, 0 = Bypassed
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Security Sensor", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Security Sensor", pChild->batValue);
 		break;
 	case V_LOCK_STATUS:
 		//Lock status. 1 = Locked, 0 = Unlocked
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Lock Sensor", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID, (intValue == 1), 100, (!pChild->childName.empty()) ? pChild->childName : "Lock Sensor", pChild->batValue);
 		break;
 	case V_STATUS:
 		//	Light status. 0 = off 1 = on
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID, (intValue != 0), 100, (!pChild->childName.empty()) ? pChild->childName : "Light", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID, (intValue != 0), 100, (!pChild->childName.empty()) ? pChild->childName : "Light", pChild->batValue);
 		break;
 	case V_SCENE_ON:
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID + intValue, true, 100, (!pChild->childName.empty()) ? pChild->childName : "Scene", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID + intValue, true, 100, (!pChild->childName.empty()) ? pChild->childName : "Scene", pChild->batValue);
 		break;
 	case V_SCENE_OFF:
 		if (pChild->GetValue(vType, intValue))
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID + intValue, false, 100, (!pChild->childName.empty()) ? pChild->childName : "Scene", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID + intValue, false, 100, (!pChild->childName.empty()) ? pChild->childName : "Scene", pChild->batValue);
 		break;
 	case V_PERCENTAGE:
 		//	Dimmer value. 0 - 100 %
 		if (pChild->GetValue(vType, intValue))
 		{
 			int level = intValue;
-			UpdateSwitch(vType, (uint8_t)pChild->nodeID, pChild->childID, (level != 0), level, (!pChild->childName.empty()) ? pChild->childName : "Light", pChild->batValue);
+			UpdateSwitch(vType, uint8_t(pChild->nodeID), pChild->childID, (level != 0), level, (!pChild->childName.empty()) ? pChild->childName : "Light", pChild->batValue);
 		}
 		break;
 	case V_RGB:
 		//RRGGBB
 		if (pChild->GetValue(vType, intValue))
-			SendRGBWSwitch(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, intValue, false, (!pChild->childName.empty()) ? pChild->childName : "RGB Light", m_Name);
+			SendRGBWSwitch(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, intValue, false, (!pChild->childName.empty()) ? pChild->childName : "RGB Light", m_Name);
 		break;
 	case V_RGBW:
 		//RRGGBBWW
 		if (pChild->GetValue(vType, intValue))
-			SendRGBWSwitch(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, intValue, true, (!pChild->childName.empty()) ? pChild->childName : "RGBW Light", m_Name);
+			SendRGBWSwitch(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, intValue, true, (!pChild->childName.empty()) ? pChild->childName : "RGBW Light", m_Name);
 		break;
 	case V_UP:
 	case V_DOWN:
 	case V_STOP:
 		if (pChild->GetValue(vType, intValue))
-			SendBlindSensor((uint8_t)pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, (uint8_t)intValue, (!pChild->childName.empty()) ? pChild->childName : "Blinds/Window",
+			SendBlindSensor(uint8_t(pChild->nodeID), uint8_t(pChild->childID), pChild->batValue, uint8_t(intValue), (!pChild->childName.empty()) ? pChild->childName : "Blinds/Window",
 					m_Name);
 		break;
 	case V_LIGHT_LEVEL:
 		if (pChild->GetValue(vType, floatValue))
 		{
 			//Light level in percentage
-			SendPercentageSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Light Level");
+			SendPercentageSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Light Level");
 			//SendLuxSensor(pChild->nodeID, pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Light Level");
 		}
 		break;
@@ -849,16 +849,18 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 			if (pChild->presType == S_DUST)
 			{
 				if (pChild->GetValue(vType, floatValue))
-					SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Dust Sensor", "ug/m3");
+					SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Dust Sensor",
+							 "ug/m3");
 			}
 			else if (pChild->presType == S_AIR_QUALITY)
 			{
-				SendAirQualitySensor((uint8_t)pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, intValue, (!pChild->childName.empty()) ? pChild->childName : "Air Quality");
+				SendAirQualitySensor(uint8_t(pChild->nodeID), uint8_t(pChild->childID), pChild->batValue, intValue, (!pChild->childName.empty()) ? pChild->childName : "Air Quality");
 			}
 			else if (pChild->presType == S_LIGHT_LEVEL)
 			{
 				if (pChild->GetValue(vType, floatValue))
-					SendLuxSensor((uint8_t)pChild->nodeID, (uint8_t)pChild->childID, (uint8_t)pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Lux");
+					SendLuxSensor(uint8_t(pChild->nodeID), uint8_t(pChild->childID), uint8_t(pChild->batValue), floatValue,
+						      (!pChild->childName.empty()) ? pChild->childName : "Lux");
 			}
 			else if (pChild->presType == S_SOUND)
 			{
@@ -871,7 +873,7 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 			if (pChild->presType == S_VIBRATION)
 			{
 				if (pChild->GetValue(vType, floatValue))
-					SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Vibration", "Hz");
+					SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Vibration", "Hz");
 			}
 		}
 		break;
@@ -890,7 +892,7 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 					SendKwhMeter(pSensorKwh->nodeID, pSensorKwh->childID, pSensorKwh->batValue, floatValue, Kwh, (!pChild->childName.empty()) ? pChild->childName : "Meter");
 			}
 			else {
-				SendWattMeter((uint8_t)pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Usage");
+				SendWattMeter(uint8_t(pChild->nodeID), uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Usage");
 			}
 		}
 	}
@@ -918,9 +920,9 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 		if (pChild->GetValue(vType, floatValue))
 		{
 			if (pChild->presType == S_WATER)
-				SendWaterflowSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Flow");
+				SendWaterflowSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Flow");
 			else
-				SendWaterflowSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Gas Flow");
+				SendWaterflowSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Gas Flow");
 		}
 		break;
 	case V_VOLUME:
@@ -943,11 +945,11 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 		break;
 	case V_IMPEDANCE:
 		if (pChild->GetValue(vType, floatValue))
-			SendPercentageSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Impedance");
+			SendPercentageSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Impedance");
 		break;
 	case V_WEIGHT:
 		if (pChild->GetValue(vType, floatValue))
-			SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Weight", "g");
+			SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Weight", "g");
 		break;
 	case V_CURRENT:
 		if (pChild->GetValue(vType, floatValue))
@@ -988,11 +990,11 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 		break;
 	case V_HVAC_SETPOINT_HEAT:
 		if (pChild->GetValue(vType, floatValue))
-			SendSetPointSensor((uint8_t)pNode->nodeID, (uint8_t)pChild->childID, (unsigned char)vType, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Setpoint Heat");
+			SendSetPointSensor(uint8_t(pNode->nodeID), uint8_t(pChild->childID), uint8_t(vType), floatValue, (!pChild->childName.empty()) ? pChild->childName : "Setpoint Heat");
 		break;
 	case V_HVAC_SETPOINT_COOL:
 		if (pChild->GetValue(vType, floatValue))
-			SendSetPointSensor((uint8_t)pNode->nodeID, (uint8_t)pChild->childID, (unsigned char)vType, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Setpoint Cool");
+			SendSetPointSensor(uint8_t(pNode->nodeID), uint8_t(pChild->childID), uint8_t(vType), floatValue, (!pChild->childName.empty()) ? pChild->childName : "Setpoint Cool");
 		break;
 	case V_TEXT:
 		if (pChild->GetValue(vType, stringValue))
@@ -1009,31 +1011,32 @@ void MySensorsBase::SendSensor2Domoticz(_tMySensorNode *pNode, _tMySensorChild *
 			gswitch.unitcode = pNode->nodeID;
 			gswitch.cmnd = gswitch_sOn;
 			gswitch.level = 100;
-			gswitch.battery_level = (uint8_t)pChild->batValue;
+			gswitch.battery_level = uint8_t(pChild->batValue);
 			gswitch.rssi = 12;
 			gswitch.seqnbr = 0;
-			sDecodeRXMessage(this, (const unsigned char *)&gswitch, (!pChild->childName.empty()) ? pChild->childName.c_str() : "IR Command", pChild->batValue, m_Name.c_str());
+			sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), (!pChild->childName.empty()) ? pChild->childName.c_str() : "IR Command", pChild->batValue,
+					 m_Name.c_str());
 		}
 		break;
 	case V_PH:
 		if (pChild->GetValue(vType, floatValue))
-			SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "pH");
+			SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "pH");
 		break;
 	case V_ORP:
 		if (pChild->GetValue(vType, floatValue))
-			SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "mV");
+			SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "mV");
 		break;
 	case V_EC:
 		if (pChild->GetValue(vType, floatValue))
-			SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "S/cm");
+			SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Water Quality", "S/cm");
 		break;
 	case V_VA:
 		if (pChild->GetValue(vType, floatValue))
-			SendCustomSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Voltage Ampere", "VA");
+			SendCustomSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Voltage Ampere", "VA");
 		break;
 	case V_POWER_FACTOR:
 		if (pChild->GetValue(vType, floatValue))
-			SendPercentageSensor(pChild->nodeID, (uint8_t)pChild->childID, pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Power Factor");
+			SendPercentageSensor(pChild->nodeID, uint8_t(pChild->childID), pChild->batValue, floatValue, (!pChild->childName.empty()) ? pChild->childName : "Power Factor");
 		break;
 	}
 }
@@ -1104,7 +1107,7 @@ void MySensorsBase::UpdateRGBWSwitchLastUpdate(const int NodeID, const int Child
 	if (NodeID == 1)
 		sprintf(szIdx, "%d", 1);
 	else
-		sprintf(szIdx, "%08x", (unsigned int)NodeID);
+		sprintf(szIdx, "%08x", uint32_t(NodeID));
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", m_HwdID, szIdx, ChildID);
@@ -1166,13 +1169,11 @@ void MySensorsBase::UpdateSwitch(const _eSetType vType, const unsigned char Idx,
 	{
 		gswitch.cmnd = gswitch_sOn;
 	}
-	gswitch.level = (uint8_t)level;
-	gswitch.battery_level = (uint8_t)BatLevel;
+	gswitch.level = uint8_t(level);
+	gswitch.battery_level = uint8_t(BatLevel);
 	gswitch.rssi = 12;
 	gswitch.seqnbr = 0;
-	sDecodeRXMessage(this, (const unsigned char *)&gswitch, defaultname.c_str(), BatLevel, m_Name.c_str());
-
-
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), defaultname.c_str(), BatLevel, m_Name.c_str());
 }
 
 bool MySensorsBase::GetBlindsValue(const int NodeID, const int ChildID, int &blind_value)
@@ -1452,10 +1453,10 @@ bool MySensorsBase::WriteToHardware(const char *pdata, const unsigned char /*len
 	{
 		//RGW/RGBW command
 		const _tColorSwitch *pLed = reinterpret_cast<const _tColorSwitch*>(pdata);
-		//unsigned char ID1 = (unsigned char)((pLed->id & 0xFF000000) >> 24);
-		//unsigned char ID2 = (unsigned char)((pLed->id & 0x00FF0000) >> 16);
-		unsigned char ID3 = (unsigned char)((pLed->id & 0x0000FF00) >> 8);
-		unsigned char ID4 = (unsigned char)pLed->id & 0x000000FF;
+		// uint8_t ID1 = uint8_t((pLed->id & 0xFF000000) >> 24);
+		// uint8_t ID2 = uint8_t((pLed->id & 0x00FF0000) >> 16);
+		uint8_t ID3 = uint8_t((pLed->id & 0x0000FF00) >> 8);
+		uint8_t ID4 = uint8_t(pLed->id) & 0x000000FF;
 
 		int node_id = (ID3 << 8) | ID4;
 		int child_sensor_id = pLed->dunit;
@@ -1579,7 +1580,7 @@ bool MySensorsBase::WriteToHardware(const char *pdata, const unsigned char /*len
 
 		int node_id = pMeter->id2;
 		int child_sensor_id = pMeter->id3;
-		_eSetType vtype_id = (_eSetType)pMeter->id4;
+		_eSetType vtype_id = _eSetType(pMeter->id4);
 
 		if (_tMySensorNode *pNode = FindNode(node_id))
 		{
@@ -1658,7 +1659,7 @@ bool MySensorsBase::GetChildDBInfo(const int NodeID, const int ChildID, _ePresen
 	result = m_sql.safe_query("SELECT [Type], [Name], [UseAck] FROM MySensorsChilds WHERE (HardwareID=%d) AND (NodeID=%d) AND (ChildID=%d)", m_HwdID, NodeID, ChildID);
 	if (result.empty())
 		return false;
-	pType = (_ePresentationType)atoi(result[0][0].c_str());
+	pType = _ePresentationType(atoi(result[0][0].c_str()));
 	Name = result[0][1];
 	UseAck = (atoi(result[0][2].c_str()) != 0);
 	return true;
@@ -1676,9 +1677,9 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 	if (results.size() < 5)
 		return; //invalid data
 
-	uint8_t node_id = (uint8_t)atoi(results[0].c_str());
-	uint8_t child_sensor_id = (uint8_t)atoi(results[1].c_str());
-	_eMessageType message_type = (_eMessageType)atoi(results[2].c_str());
+	uint8_t node_id = uint8_t(atoi(results[0].c_str()));
+	uint8_t child_sensor_id = uint8_t(atoi(results[1].c_str()));
+	_eMessageType message_type = _eMessageType(atoi(results[2].c_str()));
 	int ack = atoi(results[3].c_str());
 	int sub_type = atoi(results[4].c_str());
 	std::string payload;
@@ -1842,7 +1843,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 	}
 	else if (message_type == MT_Set)
 	{
-		_eSetType vType = (_eSetType)sub_type;
+		_eSetType vType = _eSetType(sub_type);
 
 		_tMySensorNode *pNode = FindNode(node_id);
 		if (pNode == nullptr)
@@ -1889,7 +1890,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 		switch (vType)
 		{
 		case V_TEMP:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_HUM:
@@ -1897,7 +1898,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 			bHaveValue = true;
 			break;
 		case V_PRESSURE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_VAR1: //Custom value
@@ -1962,41 +1963,41 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 			break;
 		case V_LEVEL:
 			pChild->SetValue(vType, atoi(payload.c_str()));
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_RAIN:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_WATT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_KWH:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_DISTANCE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_FLOW:
 			//Flow of water in meter
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_VOLUME:
 			//Water Volume
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_WIND:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_GUST:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_DIRECTION:
@@ -2004,7 +2005,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 			bHaveValue = true;
 			break;
 		case V_LIGHT_LEVEL:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_FORECAST:
@@ -2026,28 +2027,28 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 			bHaveValue = true;
 			break;
 		case V_VOLTAGE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_UV:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_IMPEDANCE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_WEIGHT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_CURRENT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_HVAC_SETPOINT_HEAT:
 		case V_HVAC_SETPOINT_COOL:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		case V_TEXT:
@@ -2087,7 +2088,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 		case V_VAR:
 		case V_VA:
 		case V_POWER_FACTOR:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, float(atof(payload.c_str())));
 			bHaveValue = true;
 			break;
 		default:
@@ -2114,7 +2115,7 @@ void MySensorsBase::ParseLine(const std::string &sLine)
 
 		bool bDoAdd = false;
 
-		_ePresentationType pType = (_ePresentationType)sub_type;
+		_ePresentationType pType = _ePresentationType(sub_type);
 		_eSetType vType = V_UNKNOWN;
 
 		switch (pType)
@@ -2463,7 +2464,7 @@ namespace http {
 			{
 				int ChildID = atoi(sd2[0].c_str());
 				root["result"][ii]["child_id"] = ChildID;
-				root["result"][ii]["type"] = MySensorsBase::GetMySensorsPresentationTypeStr((MySensorsBase::_ePresentationType)atoi(sd2[1].c_str()));
+				root["result"][ii]["type"] = MySensorsBase::GetMySensorsPresentationTypeStr(MySensorsBase::_ePresentationType(atoi(sd2[1].c_str())));
 				root["result"][ii]["name"] = sd2[2];
 				root["result"][ii]["use_ack"] = (sd2[3] != "0") ? "true" : "false";
 				root["result"][ii]["ack_timeout"] = atoi(sd2[4].c_str());

--- a/hardware/MySensorsMQTT.cpp
+++ b/hardware/MySensorsMQTT.cpp
@@ -13,7 +13,7 @@
 
 MySensorsMQTT::MySensorsMQTT(const int ID, const std::string &Name, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password,
 			     const std::string &CAfilenameExtra, const int TLS_Version, const int PublishScheme, const bool PreventLoop)
-	: MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilenameExtra, TLS_Version, (int)MQTT::PT_out, std::string("Domoticz-MySensors") + std::string(GenerateUUID()), PreventLoop)
+	: MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilenameExtra, TLS_Version, int(MQTT::PT_out), std::string("Domoticz-MySensors") + std::string(GenerateUUID()), PreventLoop)
 	, MyTopicIn(TOPIC_IN)
 	, MyTopicOut(TOPIC_OUT)
 {
@@ -103,7 +103,7 @@ bool MySensorsMQTT::StopHardware()
 void MySensorsMQTT::on_message(const struct mosquitto_message *message)
 {
 	std::string topic = message->topic;
-	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
+	std::string qMessage = std::string(static_cast<char *>(message->payload), static_cast<char *>(message->payload) + message->payloadlen);
 
 	_log.Log(LOG_NORM, "MySensorsMQTT: Topic: %s, Message: %s", topic.c_str(), qMessage.c_str());
 

--- a/hardware/MySensorsSerial.cpp
+++ b/hardware/MySensorsSerial.cpp
@@ -196,7 +196,7 @@ void MySensorsSerial::readCallback(const char *data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData((const unsigned char*)data, static_cast<int>(len));
+	ParseData(reinterpret_cast<const unsigned char *>(data), int(len));
 }
 
 void MySensorsSerial::WriteInt(const std::string &sendStr)

--- a/hardware/MySensorsTCP.cpp
+++ b/hardware/MySensorsTCP.cpp
@@ -128,6 +128,6 @@ void MySensorsTCP::WriteInt(const std::string &sendStr)
 	{
 		return;
 	}
-	write((const unsigned char*)sendStr.c_str(), sendStr.size());
+	write(reinterpret_cast<const unsigned char *>(sendStr.c_str()), sendStr.size());
 }
 

--- a/hardware/NefitEasy.cpp
+++ b/hardware/NefitEasy.cpp
@@ -403,7 +403,7 @@ bool CNefitEasy::GetStatusDetails()
 		tmpstr = root2["TSP"].asString();
 		if (tmpstr != "null")
 		{
-			float temp = static_cast<float>(atof(tmpstr.c_str()));
+			float temp = float(atof(tmpstr.c_str()));
 			SendSetPointSensor(1, 1, 1, temp, "Setpoint");
 		}
 	}
@@ -412,7 +412,7 @@ bool CNefitEasy::GetStatusDetails()
 		tmpstr = root2["IHT"].asString();
 		if (tmpstr != "null")
 		{
-			float temp = static_cast<float>(atof(tmpstr.c_str()));
+			float temp = float(atof(tmpstr.c_str()));
 			SendTempSensor(1, -1, temp, "Room Temperature");
 		}
 	}
@@ -757,13 +757,13 @@ bool CNefitEasy::GetGasUsage()
 	float yeargas = root["value"].asFloat();
 	//convert from kWh to m3
 	yeargas *= (0.12307692F * 1000.0F);
-	uint32_t gusage = (uint32_t)yeargas;
+	uint32_t gusage = uint32_t(yeargas);
 	if (gusage < m_lastgasusage)
 	{
 
 	}
 	m_p1gas.gasusage = gusage;
-	sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_p1gas), "Gas", 255, nullptr);
 	return true;
 }
 

--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -130,7 +130,7 @@ void CNest::SendSetPointSensor(const unsigned char Idx, const float Temp, const 
 	thermos.dunit=0;
 	thermos.temp=Temp;
 
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), 255, nullptr);
 }
 
 
@@ -174,10 +174,10 @@ void CNest::UpdateSwitch(const unsigned char Idx, const bool bOn, const std::str
 		level = 15;
 		lcmd.LIGHTING2.cmnd = light2_sOn;
 	}
-	lcmd.LIGHTING2.level = (BYTE)level;
+	lcmd.LIGHTING2.level = BYTE(level);
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 bool CNest::Login()
@@ -268,13 +268,13 @@ bool CNest::WriteToHardware(const char *pdata, const unsigned char /*length*/)
 	if (node_id % 3 == 0)
 	{
 		//Away
-		return SetAway((uint8_t)node_id, bIsOn);
+		return SetAway(uint8_t(node_id), bIsOn);
 	}
 
 	if (node_id % 4 == 0)
 	{
 		//Manual Eco Mode
-		return SetManualEcoMode((uint8_t)node_id, bIsOn);
+		return SetManualEcoMode(uint8_t(node_id), bIsOn);
 	}
 
 	return false;
@@ -337,13 +337,13 @@ void CNest::UpdateSmokeSensor(const unsigned char Idx, const bool bOn, const std
 		level = 15;
 		lcmd.LIGHTING2.cmnd = light2_sOn;
 	}
-	lcmd.LIGHTING2.level = (uint8_t)level;
+	lcmd.LIGHTING2.level = uint8_t(level);
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
 
 	if (!bDeviceExits)
 	{
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 		//Assign default name for device
 		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q' WHERE (HardwareID==%d) AND (DeviceID=='%q')", defaultname.c_str(), m_HwdID, szIdx);
 		result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, szIdx);
@@ -353,7 +353,7 @@ void CNest::UpdateSmokeSensor(const unsigned char Idx, const bool bOn, const std
 		}
 	}
 	else
-		sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 
@@ -524,7 +524,7 @@ void CNest::GetMeterDetails()
 				if (!bBool)
 					bIAlarm = true;
 			}
-			UpdateSmokeSensor((uint8_t)SwitchIndex, bIAlarm, devName);
+			UpdateSmokeSensor(uint8_t(SwitchIndex), bIAlarm, devName);
 			SwitchIndex++;
 		}
 	}
@@ -602,7 +602,7 @@ void CNest::GetMeterDetails()
 			if (!nshared["target_temperature"].empty())
 			{
 				float currentSetpoint = nshared["target_temperature"].asFloat();
-				SendSetPointSensor((const unsigned char)(iThermostat * 3) + 1, currentSetpoint, Name + " Setpoint");
+				SendSetPointSensor(uint8_t(iThermostat * 3) + 1, currentSetpoint, Name + " Setpoint");
 			}
 			//Room Temperature/Humidity
 			if (!nshared["current_temperature"].empty())
@@ -616,14 +616,14 @@ void CNest::GetMeterDetails()
 			if (nshared["can_heat"].asBool() && !nshared["hvac_heater_state"].empty())
 			{
 				bool bIsHeating = nshared["hvac_heater_state"].asBool();
-				UpdateSwitch((unsigned char)(113 + (iThermostat * 3)), bIsHeating, Name + " HeatingOn");
+				UpdateSwitch(uint8_t(113 + (iThermostat * 3)), bIsHeating, Name + " HeatingOn");
 			}
 
 			// Check if thermostat is currently Cooling
 			if (nshared["can_cool"].asBool() && !nshared["hvac_ac_state"].empty())
 			{
 				bool bIsCooling = nshared["hvac_ac_state"].asBool();
-				UpdateSwitch((unsigned char)(114 + (iThermostat * 3)), bIsCooling, Name + " CoolingOn");
+				UpdateSwitch(uint8_t(114 + (iThermostat * 3)), bIsCooling, Name + " CoolingOn");
 			}
 
 			//Away
@@ -672,7 +672,7 @@ void CNest::SetSetpoint(const int idx, const float temp)
 	unsigned char tSign = m_sql.m_tempsign[0];
 	if (tSign == 'F')
 	{
-		tempDest = static_cast<float>(ConvertToCelsius(tempDest));
+		tempDest = float(ConvertToCelsius(tempDest));
 	}
 
 	Json::Value root;
@@ -716,7 +716,7 @@ bool CNest::SetAway(const unsigned char Idx, const bool bIsAway)
 
 	Json::Value root;
 	root["away"] = bIsAway;
-	root["away_timestamp"] = (int)mytime(nullptr);
+	root["away_timestamp"] = int(mytime(nullptr));
 	root["away_setter"] = 0;
 
 	std::string sResult;

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -136,10 +136,10 @@ void OTGWBase::UpdateSwitch(const unsigned char Idx, const bool bOn, const std::
 		level=15;
 		lcmd.LIGHTING2.cmnd=light2_sOn;
 	}
-	lcmd.LIGHTING2.level= (uint8_t)level;
+	lcmd.LIGHTING2.level = uint8_t(level);
 	lcmd.LIGHTING2.filler=0;
 	lcmd.LIGHTING2.rssi=12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 void OTGWBase::UpdateSetPointSensor(const unsigned char Idx, const float Temp, const std::string &defaultname)
@@ -153,7 +153,7 @@ void OTGWBase::UpdateSetPointSensor(const unsigned char Idx, const float Temp, c
 	thermos.dunit=0;
 	thermos.temp=Temp;
 
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), 255, nullptr);
 }
 
 bool OTGWBase::GetOutsideTemperatureFromDomoticz(float &tvalue)
@@ -215,7 +215,7 @@ bool OTGWBase::SwitchLight(const int idx, const std::string &LCmd, const int /*s
 			Log(LOG_ERROR, "Invalid switch command received!");
 			return false;
 		}
-		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+		WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 	}
 	return true;
 }
@@ -264,20 +264,20 @@ void OTGWBase::GetVersion()
 {
 	char szCmd[30];
 	strcpy(szCmd, "PR=A\r\n");
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 }
 
 void OTGWBase::GetGatewayDetails()
 {
 	char szCmd[30];
 	strcpy(szCmd, "PR=G\r\n");
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 	strcpy(szCmd, "PR=I\r\n");
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 	strcpy(szCmd, "PR=O\r\n");
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 	strcpy(szCmd, "PS=1\r\n");
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 }
 
 void OTGWBase::SendTime()
@@ -294,7 +294,7 @@ void OTGWBase::SendTime()
 
 	char szCmd[20];
 	sprintf(szCmd, "SC=%d:%02d/%d\r\n", ltime.tm_hour, ltime.tm_min, lday);
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 }
 
 void OTGWBase::SendOutsideTemperature()
@@ -304,7 +304,7 @@ void OTGWBase::SendOutsideTemperature()
 		return;
 	char szCmd[30];
 	sprintf(szCmd, "OT=%.1f\r\n", temp);
-	WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+	WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 }
 
 void OTGWBase::SetSetpoint(const int idx, const float temp)
@@ -315,7 +315,7 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 		//Control Set Point (MsgID=1)
 		Log(LOG_STATUS, "Setting Control SetPoint to: %.1f", temp);
 		sprintf(szCmd, "CS=%.1f\r\n", temp);
-		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
+		WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
 	}
 	else if (idx == 5)
 	{
@@ -323,24 +323,24 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 		//Make this a temporarily Set Point, this will be overridden when the thermostat changes/applying it's program
 		Log(LOG_STATUS, "Setting Room SetPoint to: %.1f", temp);
 		sprintf(szCmd, "TT=%.1f\r\n", temp);
-		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
-		UpdateSetPointSensor((uint8_t)idx, temp, "Room Setpoint");
+		WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
+		UpdateSetPointSensor(uint8_t(idx), temp, "Room Setpoint");
 	}
 	else if (idx == 15)
 	{
 		//DHW setpoint (MsgID=56)
 		Log(LOG_STATUS, "Setting Heating SetPoint to: %.1f", temp);
 		sprintf(szCmd, "SW=%.1f\r\n", temp);
-		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
-		UpdateSetPointSensor((uint8_t)idx, temp, "DHW Setpoint");
+		WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
+		UpdateSetPointSensor(uint8_t(idx), temp, "DHW Setpoint");
 	}
 	else if (idx == 16)
 	{
 		//Max CH water setpoint (MsgID=57)
 		Log(LOG_STATUS, "Setting Max CH water SetPoint to: %.1f", temp);
 		sprintf(szCmd, "SH=%.1f\r\n", temp);
-		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
-		UpdateSetPointSensor((uint8_t)idx, temp, "Max_CH Water Setpoint");
+		WriteInt(reinterpret_cast<const unsigned char *>(&szCmd), uint8_t(strlen(szCmd)));
+		UpdateSetPointSensor(uint8_t(idx), temp, "Max_CH Water Setpoint");
 	}
 	GetGatewayDetails();
 }
@@ -349,7 +349,7 @@ void OTGWBase::ParseLine()
 {
 	if (m_bufferpos<2)
 		return;
-	std::string sLine((char*)&m_buffer);
+	std::string sLine(reinterpret_cast<char *>(&m_buffer));
 
 	std::vector<std::string> results;
 	StringSplit(sLine,",",results);
@@ -413,43 +413,50 @@ void OTGWBase::ParseLine()
 			bool bDiagnosticEvent=(_status.MsgID[9+1]=='1');												UpdateSwitch(116,bDiagnosticEvent,"DiagnosticEvent");
 		}
 
-		_status.Control_setpoint = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
+		_status.Control_setpoint = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
 		_status.Remote_parameter_flags=results[idx++];
 		if(bIsFirmware5)
 		{
 			idx+=2;
 		}
-		_status.Maximum_relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Maximum_relative_modulation_level = float(atof(results[idx++].c_str()));
 		bool bExists = CheckPercentageSensorExists(MsgID14, 1);
 		if ((_status.Maximum_relative_modulation_level != 0) || (bExists))
 		{
 			SendPercentageSensor(MsgID14, 1, 255, _status.Maximum_relative_modulation_level, "Maximum Relative Modulation Level");
 		}
 		_status.Boiler_capacity_and_modulation_limits=results[idx++];
-		_status.Room_Setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Room_Setpoint = float(atof(results[idx++].c_str()));
 		UpdateSetPointSensor((uint8_t)MsgID16, ((m_OverrideTemperature != 0.0F) ? m_OverrideTemperature : _status.Room_Setpoint), "Room Setpoint");
-		_status.Relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Relative_modulation_level = float(atof(results[idx++].c_str()));
 		bExists = CheckPercentageSensorExists(MsgID17, 1);
 		if ((_status.Relative_modulation_level != 0) || (bExists))
 		{
 			SendPercentageSensor(MsgID17, 1, 255, _status.Relative_modulation_level, "Relative modulation level");
 		}
-		_status.CH_water_pressure = static_cast<float>(atof(results[idx++].c_str()));
+		_status.CH_water_pressure = float(atof(results[idx++].c_str()));
 		if (_status.CH_water_pressure != 0)
 		{
 			SendPressureSensor(0, MsgID18, 255, _status.CH_water_pressure, "CH Water Pressure");
 		}
 		if(bIsFirmware5)
 		{
-			_status.DHW_flow_rate = static_cast<float>(atof(results[idx++].c_str()));						SendWaterflowSensor(MsgID19, 1, 255, _status.DHW_flow_rate, "DHW Flow Rate");
+			_status.DHW_flow_rate = float(atof(results[idx++].c_str()));
+			SendWaterflowSensor(MsgID19, 1, 255, _status.DHW_flow_rate, "DHW Flow Rate");
 			//CH2 room setpoint (MsgID=23)
 			idx+=1;
 		}
-		_status.Room_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID24, 255, _status.Room_temperature, "Room Temperature");
-		_status.Boiler_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID25, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
-		_status.DHW_temperature = static_cast<float>(atof(results[idx++].c_str()));							SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
-		_status.Outside_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
-		_status.Return_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
+		_status.Room_temperature = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID24, 255, _status.Room_temperature, "Room Temperature");
+		_status.Boiler_water_temperature = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID25, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
+		_status.DHW_temperature = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
+		_status.Outside_temperature = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
+		_status.Return_water_temperature = float(atof(results[idx++].c_str()));
+		SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
 		if(bIsFirmware5)
 		{
 			//CH2 flow temperature(MsgID = 31)
@@ -458,22 +465,15 @@ void OTGWBase::ParseLine()
 		}
 		_status.DHW_setpoint_boundaries=results[idx++];
 		_status.Max_CH_setpoint_boundaries=results[idx++];
-		_status.DHW_setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.DHW_setpoint = float(atof(results[idx++].c_str()));
 		if (_status.DHW_setpoint != 0.0F)
 		{
-			UpdateSetPointSensor((uint8_t)MsgID56, _status.DHW_setpoint, "DHW Setpoint");
+			UpdateSetPointSensor(uint8_t(MsgID56), _status.DHW_setpoint, "DHW Setpoint");
 		}
-		_status.Max_CH_water_setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Max_CH_water_setpoint = float(atof(results[idx++].c_str()));
 		if (_status.Max_CH_water_setpoint != 0.0F)
 		{
-			UpdateSetPointSensor((uint8_t)MsgID57, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
-		}
-		if(bIsFirmware5)
-		{
-			//V/H master status(MsgID = 70)
-			//V/H control setpoint(MsgID = 71)
-			//Relative ventilation(MsgID = 77)
-			idx+=3;
+			UpdateSetPointSensor(uint8_t(idx) - 1, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
 		}
 		_status.Burner_starts=atol(results[idx++].c_str());
 		_status.CH_pump_starts=atol(results[idx++].c_str());
@@ -493,7 +493,7 @@ void OTGWBase::ParseLine()
 	else if (sLine.find("PR: G") != std::string::npos)
 	{
 		_tOTGWGPIO _GPIO;
-		_GPIO.A = static_cast<int>(sLine[6] - '0');
+		_GPIO.A = int(sLine[6] - '0');
 		//		if (_GPIO.A==0 || _GPIO.A==1)
 		//		{
 		UpdateSwitch(96, (_GPIO.A == 1), "GPIOAPulledToGround");
@@ -502,7 +502,7 @@ void OTGWBase::ParseLine()
 		//		{
 		// Remove device (how?)
 		//		}
-		_GPIO.B = static_cast<int>(sLine[7] - '0');
+		_GPIO.B = int(sLine[7] - '0');
 		//		if (_GPIO.B==0 || _GPIO.B==1)
 		//		{
 		UpdateSwitch(97, (_GPIO.B == 1), "GPIOBPulledToGround");
@@ -515,9 +515,9 @@ void OTGWBase::ParseLine()
 	else if (sLine.find("PR: I") != std::string::npos)
 	{
 		_tOTGWGPIO _GPIO;
-		_GPIO.A = static_cast<int>(sLine[6] - '0');
+		_GPIO.A = int(sLine[6] - '0');
 		UpdateSwitch(98, (_GPIO.A == 1), "GPIOAStatusIsHigh");
-		_GPIO.B = static_cast<int>(sLine[7] - '0');
+		_GPIO.B = int(sLine[7] - '0');
 		UpdateSwitch(99, (_GPIO.B == 1), "GPIOBStatusIsHigh");
 	}
 	else if (sLine.find("PR: O") != std::string::npos)
@@ -528,7 +528,7 @@ void OTGWBase::ParseLine()
 		if (status == 'c' || status == 't')
 		{
 			// Get override setpoint value
-			m_OverrideTemperature = static_cast<float>(atof(sLine.substr(7).c_str()));
+			m_OverrideTemperature = float(atof(sLine.substr(7).c_str()));
 		}
 	}
 	else if (sLine.find("PR: A") != std::string::npos)
@@ -619,7 +619,7 @@ namespace http {
 
 			cmnd += "\r\n";
 
-			pOTGW->WriteInt((const unsigned char*)cmnd.c_str(), (const unsigned char)cmnd.size());
+			pOTGW->WriteInt(reinterpret_cast<const unsigned char *>(cmnd.c_str()), uint8_t(cmnd.size()));
 			root["status"] = "OK";
 			root["title"] = "SendOpenThermCommand";
 		}

--- a/hardware/OTGWSerial.cpp
+++ b/hardware/OTGWSerial.cpp
@@ -62,7 +62,7 @@ void OTGWSerial::readCallback(const char *data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData((const unsigned char*)data, static_cast<int>(len));
+	ParseData(reinterpret_cast<const unsigned char *>(data), int(len));
 }
 
 bool OTGWSerial::OpenSerialDevice()
@@ -154,6 +154,6 @@ bool OTGWSerial::WriteInt(const unsigned char *pData, const unsigned char Len)
 {
 	if (!isOpen())
 		return false;
-	write((const char*)pData, Len);
+	write(reinterpret_cast<const char *>(pData), Len);
 	return true;
 }

--- a/hardware/OctoPrintMQTT.cpp
+++ b/hardware/OctoPrintMQTT.cpp
@@ -326,7 +326,7 @@ void COctoPrintMQTT::on_message(const struct mosquitto_message *message)
 		return; //not interested in the last will
 	std::string topic = message->topic;
 
-	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
+	std::string qMessage = std::string(static_cast<char *>(message->payload), static_cast<char *>(message->payload) + message->payloadlen);
 
 #ifdef DEBUG_OCTO_W
 	SaveString2Disk(qMessage, "E:\\OCTO_mqtt.json");
@@ -388,7 +388,7 @@ void COctoPrintMQTT::on_message(const struct mosquitto_message *message)
 						return; //do not update faster then 30 seconds
 				}
 				m_LastSendTemp[szSensorName] = atime;
-				int crcID = Crc32(0, (const unsigned char*)szSensorName.c_str(), szSensorName.length());
+				int crcID = Crc32(0, reinterpret_cast<const unsigned char *>(szSensorName.c_str()), szSensorName.length());
 				SendTempSensor(crcID, 255, std::stof(root["actual"].asString()), szSensorName);
 			}
 			else if (szMsgType == "progress")

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -361,7 +361,7 @@ std::string COpenWeatherMap::GetHourFromUTCtimestamp(const uint8_t hournr, const
 {
 	std::string sHour = "Unknown";
 
-	time_t t = (time_t)strtol(UTCtimestamp.c_str(), nullptr, 10);
+	time_t t = time_t(strtol(UTCtimestamp.c_str(), nullptr, 10));
 	std::string sDate = ctime(&t);
 
 	std::vector<std::string> strarray;
@@ -393,7 +393,7 @@ std::string COpenWeatherMap::GetDayFromUTCtimestamp(const uint8_t daynr, const s
 {
 	std::string sDay = "Unknown";
 
-	time_t t = (time_t)strtol(UTCtimestamp.c_str(), nullptr, 10);
+	time_t t = time_t(strtol(UTCtimestamp.c_str(), nullptr, 10));
 	std::string sDate = ctime(&t);
 
 	std::vector<std::string> strarray;
@@ -445,7 +445,7 @@ bool COpenWeatherMap::ProcessForecast(Json::Value &forecast, const std::string &
 			float windspeed_ms = forecast["wind_speed"].asFloat();
 			int wind_degrees = forecast["wind_deg"].asInt();
 			float barometric = forecast["pressure"].asFloat();
-			uint8_t humidity = (uint8_t) forecast["humidity"].asUInt();
+			uint8_t humidity = uint8_t(forecast["humidity"].asUInt());
 			std::string wdesc = forecast["weather"][0]["description"].asString();
 			std::string wicon = forecast["weather"][0]["icon"].asString();
 
@@ -761,7 +761,7 @@ void COpenWeatherMap::GetMeterDetails()
 	//Visibility
 	if (!current["visibility"].empty() && current["visibility"].isInt())
 	{
-		float visibility = ((float)current["visibility"].asInt()) / 1000.0F;
+		float visibility = (float(current["visibility"].asInt())) / 1000.0F;
 		if (visibility >= 0)
 		{
 			SendVisibilitySensor(6, 1, 255, visibility, "Visibility");

--- a/hardware/OpenWebNetTCP.cpp
+++ b/hardware/OpenWebNetTCP.cpp
@@ -188,7 +188,7 @@ bool COpenWebNetTCP::ownWrite(csocket *connectionSocket, const char* pdata, size
 	int bytesWritten = connectionSocket->write(pdata, size);
 	if (bytesWritten != size) 
 	{
-		_log.Log(LOG_ERROR, "COpenWebNetTCP: partial write: %u/%u", bytesWritten, (unsigned int)size);
+		_log.Log(LOG_ERROR, "COpenWebNetTCP: partial write: %u/%u", bytesWritten, int(size));
 		return (false);
 	}
 	return (true);
@@ -210,11 +210,11 @@ int COpenWebNetTCP::ownRead(csocket *connectionSocket, char* pdata, size_t size)
 uint32_t COpenWebNetTCP::ownCalcPass(const std::string &password, const std::string &nonce)
 {
 	uint32_t msr = 0x7FFFFFFF;
-	uint32_t m_1 = (uint32_t)0xFFFFFFFF;
-	uint32_t m_8 = (uint32_t)0xFFFFFFF8;
-	uint32_t m_16 = (uint32_t)0xFFFFFFF0;
-	uint32_t m_128 = (uint32_t)0xFFFFFF80;
-	uint32_t m_16777216 = (uint32_t)0xFF000000;
+	uint32_t m_1 = uint32_t(0xFFFFFFFF);
+	uint32_t m_8 = uint32_t(0xFFFFFFF8);
+	uint32_t m_16 = uint32_t(0xFFFFFFF0);
+	uint32_t m_128 = uint32_t(0xFFFFFF80);
+	uint32_t m_16777216 = uint32_t(0xFF000000);
 	bool flag = true;
 	uint32_t num1 = 0;
 	uint32_t num2 = 0;
@@ -229,7 +229,7 @@ uint32_t COpenWebNetTCP::ownCalcPass(const std::string &password, const std::str
 		{
 			if (flag)
 			{
-				num2 = (uint32_t)atoi(password.c_str());
+				num2 = uint32_t(atoi(password.c_str()));
 				flag = false;
 			}
 		}
@@ -699,7 +699,7 @@ bool COpenWebNetTCP::GetValueMeter(const int NodeID, const int ChildID, double *
 		std::string sup, sValue = result[0][0];
 
 		if (usage)
-			*usage = (float)atof(sValue.c_str());
+			*usage = float(atof(sValue.c_str()));
 
 		if (energy)
 		{
@@ -707,7 +707,7 @@ bool COpenWebNetTCP::GetValueMeter(const int NodeID, const int ChildID, double *
 			if (pos >= 0)
 			{
 				sup = sValue.substr(pos + 1);
-				*energy = (float)atof(sup.c_str());
+				*energy = float(atof(sup.c_str()));
 			}
 		}
 
@@ -797,8 +797,8 @@ void COpenWebNetTCP::SendGeneralSwitch(const int NodeID, const uint8_t ChildID, 
 	gSwitch.unitcode = ChildID;
 	gSwitch.cmnd = cmd;
 	gSwitch.level = level;
-	gSwitch.rssi = (uint8_t)RssiLevel;
-	sDecodeRXMessage(this, (const unsigned char*)& gSwitch, defaultname.c_str(), BatteryLevel, m_Name.c_str());
+	gSwitch.rssi = uint8_t(RssiLevel);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gSwitch), defaultname.c_str(), BatteryLevel, m_Name.c_str());
 }
 
 /**
@@ -808,7 +808,7 @@ void COpenWebNetTCP::UpdateBlinds(const int who, const int where, const int Comm
 {
 	//NOTE: interface id (bus identifier) go in 'Unit' field
 	//make device ID
-	int NodeID = (((int)who << 16) & 0xFFFF0000) | (((int)where) & 0x0000FFFF);
+	int NodeID = ((who << 16) & 0xFFFF0000) | ((where)&0x0000FFFF);
 
 	/* insert switch type */
 	char szIdx[10];
@@ -885,7 +885,7 @@ void COpenWebNetTCP::UpdateCenPlus(const int who, const int where, const int Com
 {
 	//NOTE: interface id (bus identifier) go in 'Unit' field
 	//make device ID
-	int NodeID = (int)((((int)who << 16) & 0xFFFF0000) | (((int)(where + (iAppValue * 2) + (what * 3))) & 0x0000FFFF));
+	int NodeID = int(((who << 16) & 0xFFFF0000) | (((where + (iAppValue * 2) + (what * 3))) & 0x0000FFFF));
 	char szIdx[10];
 	sprintf(szIdx, "%08X", NodeID);
 	std::vector<std::vector<std::string> > result;
@@ -904,7 +904,7 @@ void COpenWebNetTCP::UpdateCenPlus(const int who, const int where, const int Com
 	}
 
 	//check if we have a change, if not do not update it
-	bool bOn = (bool)Command;
+	bool bOn = bool(Command);
 	if ((!bOn) && (nvalue == gswitch_sOff)) return;
 	if ((bOn && (nvalue == gswitch_sOn))) return;
 
@@ -920,7 +920,7 @@ void COpenWebNetTCP::UpdateSoundDiffusion(const int who, const int where, const 
 {
 	//NOTE: interface id (bus identifier) go in 'Unit' field
 	//make device ID
-	int NodeID = (((int)who << 16) & 0xFFFF0000) | (((int)where) & 0x0000FFFF);
+	int NodeID = ((who << 16) & 0xFFFF0000) | ((where)&0x0000FFFF);
 
 	/* insert switch type */
 	char szIdx[10];
@@ -942,7 +942,7 @@ void COpenWebNetTCP::UpdateSwitch(const int who, const int where, const int what
 {
 	//NOTE: interface id (bus identifier) go in 'Unit' field
 	//make device ID
-	int NodeID = (((int)who << 16) & 0xFFFF0000) | (((int)where) & 0x0000FFFF);
+	int NodeID = ((who << 16) & 0xFFFF0000) | ((where)&0x0000FFFF);
 
 	/* insert switch type */
 	char szIdx[10];
@@ -975,7 +975,7 @@ void COpenWebNetTCP::UpdateSwitch(const int who, const int where, const int what
 	int level = (what > 1) ? (what * 10) : 0;
 
 	//check if we have a change, if not do not update it
-	bool bOn = (bool)what;
+	bool bOn = bool(what);
 	if ((!bOn) && (nvalue == gswitch_sOff)) return;
 	if ((bOn && (nvalue != gswitch_sOff)))
 	{
@@ -1170,7 +1170,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		switch (atoi(dimension.c_str()))
 		{
 		case TEMPERATURE_CONTROL_DIMENSION_TEMPERATURE:
-			UpdateTemp(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateTemp(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), float(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), 255, devname.c_str());
 			break;
 		case TEMPERATURE_CONTROL_DIMENSION_VALVES_STATUS:
 			devname += " Valves";
@@ -1182,7 +1182,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			break;
 		case TEMPERATURE_CONTROL_DIMENSION_COMPLETE_PROBE_STATUS:
 			devname += " Setpoint";
-			UpdateSetPoint(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), devname.c_str());
+			UpdateSetPoint(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), float(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), devname.c_str());
 			break;
 		default:
 			_log.Log(LOG_STATUS, "COpenWebNetTCP: who=%s, where=%s, dimension=%s not yet supported", who.c_str(), where.c_str(), dimension.c_str());
@@ -1405,10 +1405,10 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		switch (atoi(dimension.c_str()))
 		{
 		case ENERGY_MANAGEMENT_DIMENSION_ACTIVE_POWER:
-			UpdatePower(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), static_cast<float>(atof(value.c_str())), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdatePower(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), float(atof(value.c_str())), atoi(sInterface.c_str()), 255, devname.c_str());
 			break;
 		case ENERGY_MANAGEMENT_DIMENSION_ENERGY_TOTALIZER:
-			UpdateEnergy(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 1000.), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateEnergy(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), float(atof(value.c_str()) / 1000.), atoi(sInterface.c_str()), 255, devname.c_str());
 			break;
 		case ENERGY_MANAGEMENT_DIMENSION_END_AUTOMATIC_UPDATE:			
 			if (atoi(value.c_str()))
@@ -1540,7 +1540,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 					ltime.tm_isdst = lnowtime.tm_isdst;
 					rcv_tm = mktime(&ltime);
 
-					delta = static_cast<int>(now - rcv_tm);
+					delta = int(now - rcv_tm);
 
 					if ((delta < -60) || (delta > 60))	// delta +-1min
 					{
@@ -1884,7 +1884,7 @@ bool COpenWebNetTCP::SetSetpoint(const int idx, const float temp)
 	//int who = (idx >> 16) & 0xff;  fixed to 'WHO_TEMPERATURE_CONTROL'
 	int iInterface = (idx >> 8) & 0xff;
 	int where = idx & 0xff;
-	int _temp = (int)(temp * 10);
+	int _temp = int(temp * 10);
 
 	std::vector<bt_openwebnet> responses;
 	bt_openwebnet request;

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -88,7 +88,7 @@ bool COpenWebNetUSB::WriteToHardware(const char *pdata, const unsigned char leng
 		case sSwitchBlindsT1:
 		case sSwitchLightT1:
 			//Bus command
-			whereStr << (int)(pCmd->id & 0xFFFF);
+			whereStr << (pCmd->id & 0xFFFF);
 			break;
 		case sSwitchBlindsT2:
 		case sSwitchLightT2:
@@ -234,10 +234,10 @@ bool COpenWebNetUSB::FindDevice(int deviceID, int deviceUnit, int subType, int* 
 	std::vector<std::vector<std::string> > result;
 
 	//make device ID
-	unsigned char ID1 = (unsigned char)((deviceID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((deviceID & 0xFF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((deviceID & 0xFF00) >> 8);
-	unsigned char ID4 = (unsigned char)(deviceID & 0xFF);
+	uint8_t ID1 = uint8_t((deviceID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((deviceID & 0xFF0000) >> 16);
+	uint8_t ID3 = uint8_t((deviceID & 0xFF00) >> 8);
+	uint8_t ID4 = uint8_t(deviceID & 0xFF);
 
 	char szIdx[10];
 	sprintf(szIdx, "%02X%02X%02X%02X", ID1, ID2, ID3, ID4);
@@ -335,7 +335,7 @@ bool COpenWebNetUSB::sendCommand(bt_openwebnet& command, std::vector<bt_openwebn
 		return false;
 	}
 
-	std::string responseStr((const char*)m_readBuffer, m_readBufferSize);
+	std::string responseStr(reinterpret_cast<const char *>(m_readBuffer), m_readBufferSize);
 	bt_openwebnet responseSession(responseStr);
 	_log.Log(LOG_STATUS, "COpenWebNet : sent=%s received=%s", OPENWEBNET_COMMAND_SESSION, responseStr.c_str());
 
@@ -356,7 +356,8 @@ bool COpenWebNetUSB::sendCommand(bt_openwebnet& command, std::vector<bt_openwebn
 		_log.Log(LOG_STATUS, "COpenWebNet : sent=%s received=%s", command.m_frameOpen.c_str(), m_readBuffer);
 	}
 
-	if (!ParseData((char*)m_readBuffer, m_readBufferSize, response)) {
+	if (!ParseData(reinterpret_cast<char *>(m_readBuffer), m_readBufferSize, response))
+	{
 		if (!silent) {
 			_log.Log(LOG_ERROR, "COpenWebNet : Cannot parse answer : %s", m_readBuffer);
 		}

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -403,7 +403,7 @@ uint8_t COpenZWave::GetInstanceFromValueID(const OpenZWave::ValueID& vID)
 		//}
 	}
 
-	return (uint8_t)instance;
+	return uint8_t(instance);
 }
 
 //-----------------------------------------------------------------------------
@@ -412,7 +412,7 @@ uint8_t COpenZWave::GetInstanceFromValueID(const OpenZWave::ValueID& vID)
 //-----------------------------------------------------------------------------
 void OnNotification(OpenZWave::Notification const* _notification, void* _context)
 {
-	COpenZWave* pClass = static_cast<COpenZWave*>(_context);
+	auto pClass = static_cast<COpenZWave *>(_context);
 	try
 	{
 		pClass->OnZWaveNotification(_notification);
@@ -729,7 +729,7 @@ void COpenZWave::OnZWaveNotification(OpenZWave::Notification const* _notificatio
 		if (NodeInfo * nodeInfo = GetNodeInfo(_homeID, _nodeID))
 		{
 			nodeInfo->eState = NSTATE_AWAKE;
-			UpdateNodeEvent(vID, static_cast<int>(_notification->GetEvent()));
+			UpdateNodeEvent(vID, int(_notification->GetEvent()));
 			nodeInfo->Instances[instance][commandClass].m_LastSeen = m_updateTime;
 			nodeInfo->LastSeen = m_updateTime;
 		}
@@ -1246,18 +1246,18 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 		}
 
 		OpenZWave::ValueID vID(0, 0, OpenZWave::ValueID::ValueGenre_Basic, 0, 0, 0, OpenZWave::ValueID::ValueType_Bool);
-		uint8_t svalue = (uint8_t)value;
+		uint8_t svalue = uint8_t(value);
 
 		if ((pDevice->devType == ZWaveBase::ZDTYPE_SWITCH_NORMAL) || (bHandleAsBinary))
 		{
 			//On/Off device
-			bool bFound = (GetValueByCommandClass(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_SWITCH_BINARY, vID) == true);
+			bool bFound = (GetValueByCommandClass(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_SWITCH_BINARY, vID) == true);
 			if (!bFound)
-				bFound = (GetValueByCommandClass(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_DOOR_LOCK, vID) == true);
+				bFound = (GetValueByCommandClass(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_DOOR_LOCK, vID) == true);
 			if (!bFound)
-				bFound = (GetValueByCommandClassIndex(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_SWITCH_MULTILEVEL, ValueID_Index_SwitchMultiLevel::Level, vID) == true);
+				bFound = (GetValueByCommandClassIndex(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_SWITCH_MULTILEVEL, ValueID_Index_SwitchMultiLevel::Level, vID) == true);
 			if (!bFound)
-				bFound = (GetValueByCommandClass(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_SOUND_SWITCH, vID) == true);
+				bFound = (GetValueByCommandClass(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_SOUND_SWITCH, vID) == true);
 			if (bFound)
 			{
 				OpenZWave::ValueID::ValueType vType = vID.GetType();
@@ -1279,12 +1279,12 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 				{
 					if (svalue == 0) {
 						//Off
-						m_pManager->SetValue(vID, (uint8_t)0);
+						m_pManager->SetValue(vID, uint8_t(0));
 						pDevice->intvalue = 0;
 					}
 					else {
 						//On
-						m_pManager->SetValue(vID, (uint8_t)255);
+						m_pManager->SetValue(vID, uint8_t(255));
 						pDevice->intvalue = 255;
 					}
 				}
@@ -1335,7 +1335,7 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 			//dimmable/color light  device
 			if ((svalue > 99) && (svalue != 255))
 				svalue = 99;
-			if (GetValueByCommandClassIndex(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_SWITCH_MULTILEVEL, ValueID_Index_SwitchMultiLevel::Level, vID) == true)
+			if (GetValueByCommandClassIndex(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_SWITCH_MULTILEVEL, ValueID_Index_SwitchMultiLevel::Level, vID) == true)
 			{
 				std::string vLabel = m_pManager->GetValueLabel(vID);
 
@@ -1344,7 +1344,7 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 
 				if (vID.GetType() == OpenZWave::ValueID::ValueType_Byte)
 				{
-					if (!m_pManager->SetValue(vID, (uint8_t)svalue))
+					if (!m_pManager->SetValue(vID, svalue))
 					{
 						_log.Log(LOG_ERROR, "OpenZWave: Error setting Switch Value! NodeID: %d (0x%02x)", pDevice->nodeID, pDevice->nodeID);
 					}
@@ -1372,7 +1372,7 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 				}
 
 			}
-			else if (GetValueByCommandClassIndex(pDevice->nodeID, (uint8_t)instanceID, COMMAND_CLASS_PROPRIETARY, ValueID_Index_SwitchMultiLevel::Level, vID) == true)
+			else if (GetValueByCommandClassIndex(pDevice->nodeID, uint8_t(instanceID), COMMAND_CLASS_PROPRIETARY, ValueID_Index_SwitchMultiLevel::Level, vID) == true)
 			{
 				if (
 					(pNode->Manufacturer_id == 0x010F)
@@ -1387,7 +1387,7 @@ bool COpenZWave::SwitchLight(_tZWaveDevice* pDevice, const int instanceID, const
 
 					if (vID.GetType() == OpenZWave::ValueID::ValueType_Byte)
 					{
-						if (!m_pManager->SetValue(vID, (uint8_t)svalue))
+						if (!m_pManager->SetValue(vID, svalue))
 						{
 							_log.Log(LOG_ERROR, "OpenZWave: Error setting Slat/Tilt Value! NodeID: %d (0x%02x)", pDevice->nodeID, pDevice->nodeID);
 						}
@@ -1563,7 +1563,7 @@ void COpenZWave::SetThermostatSetPoint(const uint8_t nodeID, const uint8_t insta
 		if (vUnits == "F")
 		{
 			//Convert to Fahrenheit
-			temp = (float)ConvertToFahrenheit(temp);
+			temp = float(ConvertToFahrenheit(temp));
 		}
 		try
 		{
@@ -1600,7 +1600,8 @@ void COpenZWave::DebugValue(const OpenZWave::ValueID& vID, const int Line)
 	//std::string vLabel = m_pManager->GetValueLabel(vID);
 	uint8_t commandclass = vID.GetCommandClassId();
 
-	_log.Log(LOG_STATUS, "OpenZWave: Debug Value: Node: %d (0x%02x), CommandClass: %s, Instance: %d, Index: %d, Id: 0x%llX, Line: %d", static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vInstance, vIndex, vID.GetId(), Line);
+	_log.Log(LOG_STATUS, "OpenZWave: Debug Value: Node: %d (0x%02x), CommandClass: %s, Instance: %d, Index: %d, Id: 0x%llX, Line: %d", int(NodeID), int(NodeID), cclassStr(commandclass), vInstance,
+		 vIndex, vID.GetId(), Line);
 }
 
 
@@ -1639,15 +1640,18 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 	std::string vUnits = m_pManager->GetValueUnits(vID);
 
 	if (vLabel == "Unknown") {
-		_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Warning: OpenZWave returned ValueLabel \"Unknown\" on Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d", static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex);
+		_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Warning: OpenZWave returned ValueLabel \"Unknown\" on Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d",
+			 int(NodeID), int(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex);
 	}
 
 	if (commandclass == COMMAND_CLASS_CONFIGURATION)
 	{
 #ifdef _DEBUG
-		_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d, Id: 0x%llX", static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex, vID.GetId());
+		_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d, Id: 0x%llX", int(NodeID), int(NodeID), cclassStr(commandclass),
+			 vLabel.c_str(), vOrgInstance, vOrgIndex, vID.GetId());
 #else
-		_log.Debug(DEBUG_HARDWARE, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d, Id: 0x%llX", static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vLabel.c_str(), vInstance, vIndex, vID.GetId());
+		_log.Debug(DEBUG_HARDWARE, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d, Id: 0x%llX", int(NodeID), int(NodeID),
+			   cclassStr(commandclass), vLabel.c_str(), vInstance, vIndex, vID.GetId());
 #endif
 		return;
 	}
@@ -1661,7 +1665,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 				std::string strValue;
 				if (m_pManager->GetValueAsString(vID, &strValue) == true)
 				{
-					pNode->Application_version = (int)(atof(strValue.c_str()) * 100);
+					pNode->Application_version = int(atoi(strValue.c_str()) * 100);
 				}
 			}
 			else
@@ -1678,7 +1682,8 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 
 	uint8_t instance = GetInstanceFromValueID(vID);
 
-	_log.Log(LOG_NORM, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d", static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex);
+	_log.Log(LOG_NORM, "OpenZWave: Value_Added: Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d", int(NodeID), int(NodeID), cclassStr(commandclass), vLabel.c_str(),
+		 vOrgInstance, vOrgIndex);
 
 	if ((instance == 0) && (NodeID == m_controllerID))
 		return;// We skip instance 0 if there are more, since it should be mapped to other instances or their superposition
@@ -1846,7 +1851,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 		int newInstance = GetIndexFromAlarm(vLabel);
 		if (newInstance == 0)
 			newInstance = vOrgIndex;
-		_device.instanceID = (uint8_t)newInstance;
+		_device.instanceID = uint8_t(newInstance);
 		_device.devType = ZDTYPE_SWITCH_NORMAL;
 		_device.intvalue = (alarm_value == 0) ? 0 : 255;
 		InsertDevice(_device);
@@ -2090,7 +2095,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 			|| (vOrgIndex == ValueID_Index_SensorMultiLevel::Z_Axis_Acceleration)
 			)
 		{
-			_device.instanceID = (uint8_t)vOrgIndex;
+			_device.instanceID = uint8_t(vOrgIndex);
 			_device.custom_label = "m/s2";
 			_device.devType = ZDTYPE_SENSOR_CUSTOM;
 		}
@@ -2101,7 +2106,8 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 		}
 		else
 		{
-			_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Unhandled Label: %s, Unit: %s, Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d", vLabel.c_str(), vUnits.c_str(), static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex);
+			_log.Log(LOG_STATUS, "OpenZWave: Value_Added: Unhandled Label: %s, Unit: %s, Node: %d (0x%02x), CommandClass: %s, Label: %s, Instance: %d, Index: %d", vLabel.c_str(),
+				 vUnits.c_str(), int(NodeID), int(NodeID), cclassStr(commandclass), vLabel.c_str(), vOrgInstance, vOrgIndex);
 			return;
 		}
 		_device.floatValue = fValue * _device.scaleMultiply;
@@ -2345,7 +2351,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 			//if (lValue != 1)
 				//return; //only accept CentralSceneMask_KeyPressed1time
 
-			_device.instanceID = (uint8_t)vIndex;
+			_device.instanceID = uint8_t(vIndex);
 			_device.devType = ZDTYPE_CENTRAL_SCENE;
 			_device.intvalue = lValue;
 			InsertDevice(_device);
@@ -2463,7 +2469,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 			{
 				if (m_pManager->GetValueAsByte(vID, &byteValue) == true)
 				{
-					_device.instanceID = (uint8_t)vOrgIndex;
+					_device.instanceID = uint8_t(vOrgIndex);
 					_device.devType = ZDTYPE_SWITCH_DIMMER;
 					_device.intvalue = byteValue;
 					InsertDevice(_device);
@@ -2507,7 +2513,7 @@ void COpenZWave::UpdateNodeEvent(const OpenZWave::ValueID& vID, int EventID)
 	if (instance == 0)
 		return;
 	uint16_t index = vID.GetIndex();
-	instance = (uint8_t)index;
+	instance = uint8_t(index);
 
 	uint8_t commandclass = vID.GetCommandClassId();
 
@@ -2523,7 +2529,7 @@ void COpenZWave::UpdateNodeEvent(const OpenZWave::ValueID& vID, int EventID)
 		}
 		instance = GetIndexFromAlarm(vLabel);
 		if (instance == 0)
-			instance = (uint8_t)index;
+			instance = uint8_t(index);
 	}
 
 	_tZWaveDevice* pDevice = FindDevice(NodeID, instance, COMMAND_CLASS_SENSOR_BINARY, ZDTYPE_SWITCH_NORMAL);
@@ -2534,7 +2540,7 @@ void COpenZWave::UpdateNodeEvent(const OpenZWave::ValueID& vID, int EventID)
 		if (pDevice == nullptr)
 		{
 			// absolute last try
-			instance = (uint8_t)vID.GetIndex();
+			instance = uint8_t(vID.GetIndex());
 			pDevice = FindDevice(NodeID, -1, COMMAND_CLASS_SENSOR_MULTILEVEL, ZDTYPE_SWITCH_NORMAL);
 			if (pDevice == nullptr)
 			{
@@ -2674,7 +2680,7 @@ void COpenZWave::UpdateValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 	{
 		instance = GetIndexFromAlarm(vLabel);
 		if (instance == 0)
-			instance = (uint8_t)vOrgIndex;
+			instance = uint8_t(vOrgIndex);
 	}
 
 	std::stringstream sstr;
@@ -2998,7 +3004,7 @@ void COpenZWave::UpdateValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 					char szDeviceName[50];
 					sprintf(szDeviceName, "Alarm Type: 0x%02X", m_LastAlarmTypeReceived);
 					std::string tmpstr = szDeviceName;
-					SendSwitch(NodeID, (uint8_t)m_LastAlarmTypeReceived, pDevice->batValue, (intValue != 0) ? true : false, 0, tmpstr, m_Name);
+					SendSwitch(NodeID, uint8_t(m_LastAlarmTypeReceived), pDevice->batValue, (intValue != 0) ? true : false, 0, tmpstr, m_Name);
 					m_LastAlarmTypeReceived = -1;
 				}
 			}
@@ -3008,7 +3014,7 @@ void COpenZWave::UpdateValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 				{
 					char szTmp[100];
 					sprintf(szTmp, "Alarm Type: %s %d (0x%02X)", vLabel.c_str(), vOrgIndex, vOrgIndex);
-					SendZWaveAlarmSensor(pDevice->nodeID, pDevice->instanceID, pDevice->batValue, (uint8_t)vOrgIndex, intListValue, szListValue, szTmp);
+					SendZWaveAlarmSensor(pDevice->nodeID, pDevice->instanceID, pDevice->batValue, uint8_t(vOrgIndex), intListValue, szListValue, szTmp);
 				}
 
 				if (vOrgIndex == ValueID_Index_Alarm::Type_Access_Control)
@@ -3335,8 +3341,8 @@ void COpenZWave::UpdateValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 		if (fValue < -1000000)
 		{
 			//NeoCoolcam reports values of -21474762
-			_log.Log(LOG_ERROR, "OpenZWave: Invalid counter value received!: (%f) Node: %d (0x%02x), CommandClass: %s, Instance: %d, Index: %d, Id: 0x%llX", fValue,
-					static_cast<int>(NodeID), static_cast<int>(NodeID), cclassStr(commandclass), pDevice->orgInstanceID, pDevice->orgIndexID, vID.GetId());
+			_log.Log(LOG_ERROR, "OpenZWave: Invalid counter value received!: (%f) Node: %d (0x%02x), CommandClass: %s, Instance: %d, Index: %d, Id: 0x%llX", fValue, int(NodeID),
+				 int(NodeID), cclassStr(commandclass), pDevice->orgInstanceID, pDevice->orgIndexID, vID.GetId());
 			return; //counter should not be negative
 		}
 		pDevice->floatValue = fValue * pDevice->scaleMultiply;
@@ -3749,12 +3755,12 @@ bool COpenZWave::NetworkInfo(const int hwID, std::vector< std::vector< int > >& 
 	int rowCnt = 0;
 	for (const auto &sd : result)
 	{
-		unsigned int _homeID = static_cast<unsigned int>(std::stoul(sd[0]));
+		uint32_t _homeID = uint32_t(std::stoul(sd[0]));
 
 		if (_homeID != m_controllerID)
 			continue;
 
-		uint8_t _nodeID = (uint8_t)atoi(sd[1].c_str());
+		uint8_t _nodeID = uint8_t(atoi(sd[1].c_str()));
 		if (COpenZWave::NodeInfo * nodeInfo = GetNodeInfo(_homeID, _nodeID))
 		{
 			std::vector<int> row;
@@ -4035,7 +4041,7 @@ void COpenZWave::GetConfigFile(std::string& filePath, std::string& fileContent)
 
 void COpenZWave::OnZWaveDeviceStatusUpdate(int _cs, int _err)
 {
-	OpenZWave::Driver::ControllerState cs = (OpenZWave::Driver::ControllerState)_cs;
+	auto cs = OpenZWave::Driver::ControllerState(_cs);
 	//OpenZWave::Driver::ControllerError err = (OpenZWave::Driver::ControllerError)_err;
 
 	std::string szLog;
@@ -4381,8 +4387,8 @@ void COpenZWave::SetClock(const uint8_t nodeID, const uint8_t /*instanceID*/, co
 	try
 	{
 		m_pManager->SetValueListSelection(vDay, ZWave_Clock_Days(day));
-		m_pManager->SetValue(vHour, (const uint8)hour);
-		m_pManager->SetValue(vMinute, (const uint8)minute);
+		m_pManager->SetValue(vHour, uint8_t(hour));
+		m_pManager->SetValue(vMinute, uint8_t(minute));
 	}
 	catch (OpenZWave::OZWException& ex)
 	{
@@ -4407,7 +4413,7 @@ void COpenZWave::SetThermostatMode(const uint8_t nodeID, const uint8_t instanceI
 			COpenZWave::NodeInfo* pNode = GetNodeInfo(homeID, vnodeID);
 			if (pNode)
 			{
-				if (tMode < (int)pNode->tModes.size())
+				if (tMode < int(pNode->tModes.size()))
 				{
 					m_pManager->SetValueListSelection(vID, pNode->tModes[tMode]);
 				}
@@ -4449,20 +4455,20 @@ std::vector<std::string> COpenZWave::GetSupportedThermostatModes(const unsigned 
 {
 	std::lock_guard<std::mutex> l(m_NotificationMutex);
 	std::vector<std::string> ret;
-	uint8_t ID1 = (uint8_t)((ID & 0xFF000000) >> 24);
-	uint8_t ID2 = (uint8_t)((ID & 0x00FF0000) >> 16);
-	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
-	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
+	uint8_t ID1 = uint8_t((ID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((ID & 0x00FF0000) >> 16);
+	uint8_t ID3 = uint8_t((ID & 0x0000FF00) >> 8);
+	uint8_t ID4 = uint8_t((ID & 0x000000FF));
 
 	int nodeID = (ID2 << 8) | ID3;
 	uint8_t instanceID = ID4;
 	int indexID = ID1;
 
-	const _tZWaveDevice *pDevice = FindDevice((uint8_t)nodeID, instanceID, COMMAND_CLASS_THERMOSTAT_MODE, ZDTYPE_SENSOR_THERMOSTAT_MODE);
+	const _tZWaveDevice *pDevice = FindDevice(uint8_t(nodeID), instanceID, COMMAND_CLASS_THERMOSTAT_MODE, ZDTYPE_SENSOR_THERMOSTAT_MODE);
 	if (pDevice)
 	{
 		OpenZWave::ValueID vID(0, 0, OpenZWave::ValueID::ValueGenre_Basic, 0, 0, 0, OpenZWave::ValueID::ValueType_Bool);
-		if (GetValueByCommandClass((uint8_t)nodeID, instanceID, COMMAND_CLASS_THERMOSTAT_MODE, vID) == true)
+		if (GetValueByCommandClass(uint8_t(nodeID), instanceID, COMMAND_CLASS_THERMOSTAT_MODE, vID) == true)
 		{
 			unsigned int homeID = vID.GetHomeId();
 			uint8_t vnodeID = vID.GetNodeId();
@@ -4480,20 +4486,20 @@ std::string COpenZWave::GetSupportedThermostatFanModes(const unsigned long ID)
 {
 	std::lock_guard<std::mutex> l(m_NotificationMutex);
 	std::string retstr;
-	uint8_t ID1 = (uint8_t)((ID & 0xFF000000) >> 24);
-	uint8_t ID2 = (uint8_t)((ID & 0x00FF0000) >> 16);
-	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
-	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
+	uint8_t ID1 = uint8_t((ID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((ID & 0x00FF0000) >> 16);
+	uint8_t ID3 = uint8_t((ID & 0x0000FF00) >> 8);
+	uint8_t ID4 = uint8_t((ID & 0x000000FF));
 
 	int nodeID = (ID2 << 8) | ID3;
 	uint8_t instanceID = ID4;
 	int indexID = ID1;
 
-	const _tZWaveDevice *pDevice = FindDevice((uint8_t)nodeID, instanceID, COMMAND_CLASS_THERMOSTAT_FAN_MODE, ZDTYPE_SENSOR_THERMOSTAT_FAN_MODE);
+	const _tZWaveDevice *pDevice = FindDevice(uint8_t(nodeID), instanceID, COMMAND_CLASS_THERMOSTAT_FAN_MODE, ZDTYPE_SENSOR_THERMOSTAT_FAN_MODE);
 	if (pDevice)
 	{
 		OpenZWave::ValueID vID(0, 0, OpenZWave::ValueID::ValueGenre_Basic, 0, 0, 0, OpenZWave::ValueID::ValueType_Bool);
-		if (GetValueByCommandClass((uint8_t)nodeID, instanceID, COMMAND_CLASS_THERMOSTAT_FAN_MODE, vID) == true)
+		if (GetValueByCommandClass(uint8_t(nodeID), instanceID, COMMAND_CLASS_THERMOSTAT_FAN_MODE, vID) == true)
 		{
 			unsigned int homeID = vID.GetHomeId();
 			uint8_t vnodeID = vID.GetNodeId();
@@ -4885,7 +4891,7 @@ void COpenZWave::GetNodeValuesJson(const unsigned int homeID, const uint8_t node
 						{
 							std::vector<std::string> strs;
 							m_pManager->GetValueListItems(ittValue, &strs);
-							root["result"][index]["config"][ivalue]["list_items"] = static_cast<int>(strs.size());
+							root["result"][index]["config"][ivalue]["list_items"] = int(strs.size());
 							int vcounter = 0;
 							for (const auto &str : strs)
 								root["result"][index]["config"][ivalue]["listitem"][vcounter++] = str;
@@ -5149,15 +5155,15 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Byte)
 						{
-							bRet = m_pManager->SetValue(vID, (uint8)atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, uint8_t(atoi(ValueVal.c_str())));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Short)
 						{
-							bRet = m_pManager->SetValue(vID, (int16)atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, int16_t(atoi(ValueVal.c_str())));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Decimal)
 						{
-							bRet = m_pManager->SetValue(vID, (float)atof(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, float_t(atof(ValueVal.c_str())));
 						}
 						else
 						{
@@ -5262,7 +5268,7 @@ bool COpenZWave::RemoveUserCode(const unsigned int homeID, const uint8_t nodeID,
 	for (const auto &value : pNode->Instances[1][COMMAND_CLASS_USER_CODE].Values)
 	{
 		if (value.GetIndex() == ValueID_Index_UserCode::RemoveCode)
-			m_pManager->SetValue(value, (uint16_t)codeIndex);
+			m_pManager->SetValue(value, uint16_t(codeIndex));
 		/*
 				if ((vNodeValue.GetGenre() == OpenZWave::ValueID::ValueGenre_User) && (vNodeValue.GetInstance() == 1) && (vNodeValue.GetType() == OpenZWave::ValueID::ValueType_String))
 				{
@@ -5358,7 +5364,7 @@ bool COpenZWave::GetBatteryLevels(Json::Value& root)
 	std::map<uint16_t, std::string> _NodeNames;
 	for (const auto &r : result)
 	{
-		uint16_t nodeID = (uint16_t)atoi(r[0].c_str());
+		uint16_t nodeID = uint16_t(atoi(r[0].c_str()));
 		_NodeNames[nodeID] = r[1];
 	}
 
@@ -5467,10 +5473,10 @@ namespace http {
 				int ii = 0;
 				for (const auto &sd : result)
 				{
-					unsigned int homeID = static_cast<unsigned int>(std::stoul(sd[1]));
+					uint32_t homeID = uint32_t(std::stoul(sd[1]));
 					if (homeID != pOZWHardware->GetControllerID())
 						continue;
-					uint8 nodeID = (uint8)atoi(sd[2].c_str());
+					uint8 nodeID = uint8_t(atoi(sd[2].c_str()));
 					//if (nodeID>1) //Don't include the controller
 					{
 						COpenZWave::NodeInfo* pNode = pOZWHardware->GetNodeInfo(homeID, nodeID);
@@ -5529,8 +5535,8 @@ namespace http {
 			root["title"] = "UpdateZWaveNode";
 
 			int hwid = atoi(result[0][0].c_str());
-			unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-			uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+			uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+			uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(hwid);
 			if (pHardware == nullptr)
 				return; //not found!?
@@ -5559,8 +5565,8 @@ namespace http {
 			if (result.empty())
 				return;
 			int hwid = atoi(result[0][0].c_str());
-			//unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-			uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+			// uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+			uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 			if (pHardware == nullptr)
 				return;
@@ -5689,7 +5695,7 @@ namespace http {
 				root["node_id"] = pOZWHardware->m_LastIncludedNode;
 				root["node_type"] = pOZWHardware->m_LastIncludedNodeType;
 				std::string productName("Unknown");
-				COpenZWave::NodeInfo* pNode = pOZWHardware->GetNodeInfo(pOZWHardware->GetControllerID(), (uint8_t)pOZWHardware->m_LastIncludedNode);
+				COpenZWave::NodeInfo *pNode = pOZWHardware->GetNodeInfo(pOZWHardware->GetControllerID(), uint8_t(pOZWHardware->m_LastIncludedNode));
 				if (pNode)
 				{
 					productName = pNode->Product_name;
@@ -5822,7 +5828,7 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "ZWaveHealNode";
 			COpenZWave *pOZWHardware = (COpenZWave *)pHardware;
-			pOZWHardware->HealNode((uint8_t)atoi(node.c_str()));
+			pOZWHardware->HealNode(uint8_t(atoi(node.c_str())));
 		}
 
 		void CWebServer::Cmd_ZWaveNetworkInfo(WebEmSession& session, const request& req, Json::Value& root)
@@ -5916,7 +5922,7 @@ namespace http {
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				int nodeId = 0, instance = 0;
 				sscanf(removenode.c_str(), "%d.%d", &nodeId, &instance);
-				pOZWHardware->RemoveNodeFromGroup((uint8_t)atoi(node.c_str()), (uint8_t)atoi(group.c_str()), (uint8_t)nodeId, (uint8_t)instance);
+				pOZWHardware->RemoveNodeFromGroup(uint8_t(atoi(node.c_str())), uint8_t(atoi(group.c_str())), uint8_t(nodeId), uint8_t(instance));
 				root["status"] = "OK";
 				root["title"] = "ZWaveRemoveGroupNode";
 			}
@@ -5950,7 +5956,7 @@ namespace http {
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				int nodeId = 0, instance = 0;
 				sscanf(addnode.c_str(), "%d.%d", &nodeId, &instance);
-				pOZWHardware->AddNodeToGroup((uint8_t)atoi(node.c_str()), (uint8_t)atoi(group.c_str()), (uint8_t)nodeId, (uint8_t)instance);
+				pOZWHardware->AddNodeToGroup(uint8_t(atoi(node.c_str())), uint8_t(atoi(group.c_str())), uint8_t(nodeId), uint8_t(instance));
 				root["status"] = "OK";
 				root["title"] = "ZWaveAddGroupNode";
 			}
@@ -5981,8 +5987,8 @@ namespace http {
 
 					for (const auto &sd : result)
 					{
-						unsigned int homeID = static_cast<unsigned int>(std::stoul(sd[1]));
-						uint8_t nodeID = (uint8_t)atoi(sd[2].c_str());
+						uint32_t homeID = uint32_t(std::stoul(sd[1]));
+						uint8_t nodeID = uint8_t(atoi(sd[2].c_str()));
 						COpenZWave::NodeInfo* pNode = pOZWHardware->GetNodeInfo(homeID, nodeID);
 						if (pNode == nullptr)
 							continue;
@@ -5999,10 +6005,10 @@ namespace http {
 							for (int iGroup = 0; iGroup < numGroups; iGroup++)
 							{
 								root["result"]["nodes"][ii]["groups"][iGroup]["id"] = iGroup + 1;
-								root["result"]["nodes"][ii]["groups"][iGroup]["groupName"] = pOZWHardware->GetGroupName(nodeID, (uint8_t)iGroup + 1);
+								root["result"]["nodes"][ii]["groups"][iGroup]["groupName"] = pOZWHardware->GetGroupName(nodeID, uint8_t(iGroup) + 1);
 
 								std::vector< std::string > nodesingroup;
-								int numNodesInGroup = pOZWHardware->ListAssociatedNodesinGroup(nodeID, (uint8_t)iGroup + 1, nodesingroup);
+								int numNodesInGroup = pOZWHardware->ListAssociatedNodesinGroup(nodeID, uint8_t(iGroup) + 1, nodesingroup);
 								if (numNodesInGroup > 0) {
 									std::stringstream list;
 									std::copy(nodesingroup.begin(), nodesingroup.end(), std::ostream_iterator<std::string>(list, ","));
@@ -6056,8 +6062,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6082,8 +6088,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6107,8 +6113,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6132,8 +6138,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6157,8 +6163,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6556,8 +6562,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6583,8 +6589,8 @@ namespace http {
 			if (!result.empty())
 			{
 				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				uint32_t homeID = uint32_t(std::stoul(result[0][1]));
+				uint8_t nodeID = uint8_t(atoi(result[0][2].c_str()));
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{

--- a/hardware/P1MeterSerial.cpp
+++ b/hardware/P1MeterSerial.cpp
@@ -148,7 +148,7 @@ bool P1MeterSerial::StartHardware()
 	sOnConnected(this);
 
 #ifdef DEBUG_P1_R
-	ParseP1Data((const uint8_t*)szP1Test, static_cast<int>(strlen(szP1Test)), m_bDisableCRC, m_ratelimit);
+	ParseP1Data((const uint8_t *)szP1Test, int(strlen(szP1Test)), m_bDisableCRC, m_ratelimit);
 #endif
 
 	return true;
@@ -171,7 +171,7 @@ void P1MeterSerial::readCallback(const char *data, size_t len)
 {
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
-	ParseP1Data((const unsigned char*)data, static_cast<int>(len), m_bDisableCRC, m_ratelimit);
+	ParseP1Data(reinterpret_cast<const unsigned char *>(data), int(len), m_bDisableCRC, m_ratelimit);
 }
 
 bool P1MeterSerial::WriteToHardware(const char *pdata, const unsigned char length)

--- a/hardware/P1MeterTCP.cpp
+++ b/hardware/P1MeterTCP.cpp
@@ -92,7 +92,7 @@ void P1MeterTCP::OnDisconnect()
 
 void P1MeterTCP::OnData(const unsigned char *pData, size_t length)
 {
-	ParseP1Data((const unsigned char*)pData, length, m_bDisableCRC, m_ratelimit);
+	ParseP1Data(pData, length, m_bDisableCRC, m_ratelimit);
 }
 
 

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -266,7 +266,7 @@ CPanasonicNode::CPanasonicNode(const int pHwdID, const int PollIntervalsec, cons
 	if (result2.size() == 1)
 	{
 		m_ID = atoi(result2[0][0].c_str());
-		m_PreviousStatus.Status((_eMediaStatus)atoi(result2[0][1].c_str()));
+		m_PreviousStatus.Status(_eMediaStatus(atoi(result2[0][1].c_str())));
 		m_PreviousStatus.Status(result2[0][2]);
 	}
 	m_CurrentStatus = m_PreviousStatus;
@@ -1334,8 +1334,8 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
+				_eSwitchType sType = _eSwitchType(atoi(result[0][0].c_str()));
+				_eHardwareTypes hType = _eHardwareTypes(atoi(result[0][1].c_str()));
 				int HwID = atoi(result[0][2].c_str());
 				// Is the device a media Player?
 				if (sType == STYPE_Media)

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -151,7 +151,7 @@ bool CPhilipsHue::WriteToHardware(const char *pdata, const unsigned char /*lengt
 	{
 		const _tGeneralSwitch *pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pSen);
 		//light command
-		nodeID = static_cast<int>(pSwitch->id);
+		nodeID = int(pSwitch->id);
 		if ((pSwitch->cmnd == gswitch_sOff) || (pSwitch->cmnd == gswitch_sGroupOff))
 		{
 			LCmd = "Off";
@@ -177,7 +177,7 @@ bool CPhilipsHue::WriteToHardware(const char *pdata, const unsigned char /*lengt
 	else if (packettype == pTypeColorSwitch)
 	{
 		const _tColorSwitch *pLed = reinterpret_cast<const _tColorSwitch*>(pSen);
-		nodeID = static_cast<int>(pLed->id);
+		nodeID = int(pLed->id);
 
 		if (pLed->command == Color_LedOff)
 		{
@@ -478,7 +478,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		if (NodeID==1)
 			sprintf(szID, "%d", NodeID);
 		else
-			sprintf(szID, "%08X", (unsigned int)NodeID);
+			sprintf(szID, "%08X", uint32_t(NodeID));
 		sprintf(szSValue, "%d;%d", tstate.sat, tstate.hue);
 		unsigned char unitcode = 1;
 		int cmd = (tstate.on ? Color_LedOn : Color_LedOff);
@@ -528,7 +528,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 			if (sTypeOld != sType)
 			{
 				_log.Log(LOG_STATUS, "Philips Hue: Updating SubType of light '%s' from %u to %u", szID, sTypeOld, sType);
-				m_sql.UpdateDeviceValue("SubType", (int)sType, sID);
+				m_sql.UpdateDeviceValue("SubType", int(sType), sID);
 			}
 		}
 
@@ -572,7 +572,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		lcmd.value = tstate.level;
 		lcmd.color = color;
 		lcmd.subtype = sType;
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd, Name.c_str(), 255, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&lcmd), Name.c_str(), 255, m_Name.c_str());
 
 		if (result.empty())
 		{
@@ -584,7 +584,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 	else if (LType == HLTYPE_SCENE)
 	{
 		char szID[10];
-		sprintf(szID, "%08X", (unsigned int)NodeID);
+		sprintf(szID, "%08X", uint32_t(NodeID));
 		unsigned char unitcode = 1;
 		int cmd = (tstate.on ? Color_LedOn : Color_LedOff);
 
@@ -623,7 +623,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		lcmd.command = cmd;
 		lcmd.value = 0;
 		//lcmd.subtype = sType; // TODO: set type also for groups?
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd, Name.c_str(), 255, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&lcmd), Name.c_str(), 255, m_Name.c_str());
 
 		if (result.empty())
 		{
@@ -636,7 +636,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 	{
 		//Send as GeneralSwitch
 		char szID[10];
-		sprintf(szID, "%08X", (unsigned int)NodeID);
+		sprintf(szID, "%08X", uint32_t(NodeID));
 		unsigned char unitcode = 1;
 		int cmd = (tstate.on ? gswitch_sOn : gswitch_sOff);
 
@@ -686,7 +686,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		lcmd.cmnd = cmd;
 		lcmd.level = tstate.level;
 		lcmd.seqnbr = 1;
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&lcmd, Name.c_str(), 255, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&lcmd), Name.c_str(), 255, m_Name.c_str());
 
 		if (result.empty())
 		{
@@ -1153,7 +1153,7 @@ bool CPhilipsHue::GetSensors(const Json::Value &root)
 						float convertedLightLevel = float((current_sensor.m_state.m_lightlevel - 1) / 10000.00F);
 						lux = pow(10, convertedLightLevel);
 					}
-					SendLuxSensor(sID, 0, current_sensor.m_config.m_battery, (const float)lux, current_sensor.m_type + " Lux " + current_sensor.m_name);
+					SendLuxSensor(sID, 0, current_sensor.m_config.m_battery, float(lux), current_sensor.m_type + " Lux " + current_sensor.m_name);
 				}
 			}
 			else
@@ -1181,7 +1181,7 @@ bool CPhilipsHue::InsertUpdateSelectorSwitch(const int NodeID, const uint8_t Uni
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, xcmd.unitcode);
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, Name.c_str(), BatteryLevel, m_Name.c_str());
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&xcmd), Name.c_str(), BatteryLevel, m_Name.c_str());
 	if (result.empty())
 	{
 		//_log.Log(LOG_STATUS, "Philips Hue Switch: New Device Found (%s)", Name.c_str());
@@ -1209,7 +1209,7 @@ void CPhilipsHue::InsertUpdateSwitch(const int NodeID, const uint8_t Unitcode, c
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, xcmd.unitcode);
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&xcmd, Name.c_str(), BatteryLevel, m_Name.c_str());
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&xcmd), Name.c_str(), BatteryLevel, m_Name.c_str());
 	if (result.empty())
 	{
 		//_log.Log(LOG_STATUS, "Philips Hue Switch: New Device Found (%s)", Name.c_str());
@@ -1247,7 +1247,7 @@ namespace http {
 			if ((sipaddress.empty()) || (sport.empty()))
 				return;
 
-			std::string sresult = CPhilipsHue::RegisterUser(sipaddress, (unsigned short)atoi(sport.c_str()), susername);
+			std::string sresult = CPhilipsHue::RegisterUser(sipaddress, uint16_t(atoi(sport.c_str())), susername);
 			std::vector<std::string> strarray;
 			StringSplit(sresult, ";", strarray);
 			if (strarray.size() != 2)

--- a/hardware/PhilipsHue/PhilipsHueHelper.cpp
+++ b/hardware/PhilipsHue/PhilipsHueHelper.cpp
@@ -251,8 +251,8 @@ bool CPhilipsHue::StatesSimilar(const _tHueLightState &s1, const _tHueLightState
 				break;
 			case HLMODE_HS:
 			{
-				uint16_t h1 = (uint16_t) s1.hue;
-				uint16_t h2 = (uint16_t) s2.hue;
+				uint16_t h1 = uint16_t(s1.hue);
+				uint16_t h2 = uint16_t(s2.hue);
 				res = abs(int16_t(h1-h2)) < 655 && // 655 is 1% of 65535, the range of hue
 					  abs(s1.sat - s2.sat) <= 3;   // 3 is 1% of 255, the range of sat
 				  break;

--- a/hardware/PiFace.h
+++ b/hardware/PiFace.h
@@ -26,32 +26,32 @@ class CIOCount
 	CIOCount();
 	~CIOCount() = default;
 
-	int Update(unsigned long Counts);
-	unsigned long GetTotal() const
+	int Update(uint32_t Counts);
+	uint32_t GetTotal() const
 	{
 		return Total;
 	};
-	unsigned long GetLastTotal() const
+	uint32_t GetLastTotal() const
 	{
 		return LastTotal;
 	};
-	unsigned long GetRateLimit() const
+	uint32_t GetRateLimit() const
 	{
 		return Minimum_Pulse_Period_ms;
 	};
-	unsigned long GetDivider() const
+	uint32_t GetDivider() const
 	{
 		return Divider;
 	};
-	void SetTotal(unsigned long NewTotalValue)
+	void SetTotal(uint32_t NewTotalValue)
 	{
 		Total = NewTotalValue;
 	};
-	void SetLastTotal(unsigned long NewTotalValue)
+	void SetLastTotal(uint32_t NewTotalValue)
 	{
 		LastTotal = NewTotalValue;
 	};
-	void SetRateLimit(unsigned long NewRateLimit)
+	void SetRateLimit(uint32_t NewRateLimit)
 	{
 		Minimum_Pulse_Period_ms = NewRateLimit;
 	};
@@ -60,21 +60,21 @@ class CIOCount
 		Total = 0;
 		LastTotal = 0;
 	};
-	bool ProcessUpdateInterval(unsigned long PassedTime_ms);
-	void SetUpdateInterval(unsigned long NewValue_ms);
-	void SetUpdateIntervalPerc(unsigned long NewValue)
+	bool ProcessUpdateInterval(uint32_t PassedTime_ms);
+	void SetUpdateInterval(uint32_t NewValue_ms);
+	void SetUpdateIntervalPerc(uint32_t NewValue)
 	{
 		UpdateIntervalPerc = NewValue;
 	};
-	void SetDivider(unsigned long NewValue)
+	void SetDivider(uint32_t NewValue)
 	{
 		Divider = NewValue;
 	};
-	unsigned long GetUpdateInterval()
+	uint32_t GetUpdateInterval()
 	{
 		return UpdateInterval_ms;
 	};
-	unsigned long GetUpdateIntervalPerc()
+	uint32_t GetUpdateIntervalPerc()
 	{
 		return UpdateIntervalPerc;
 	};
@@ -83,13 +83,13 @@ class CIOCount
 	int Type;
 
       private:
-	unsigned long Total;
-	unsigned long LastTotal;
-	unsigned long UpdateInterval_ms;
-	unsigned long UpdateDownCount_ms;
-	unsigned long UpdateIntervalPerc;
-	unsigned long Minimum_Pulse_Period_ms;
-	unsigned long Divider;
+	uint32_t Total;
+	uint32_t LastTotal;
+	uint32_t UpdateInterval_ms;
+	uint32_t UpdateDownCount_ms;
+	uint32_t UpdateIntervalPerc;
+	uint32_t Minimum_Pulse_Period_ms;
+	uint32_t Divider;
 	boost::posix_time::ptime Last_Pulse;
 	boost::posix_time::ptime Cur_Pulse;
 	boost::posix_time::ptime Last_Callback;

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -142,9 +142,9 @@ private:
 	static unsigned short get_identifier()
 	{
 #if defined(BOOST_WINDOWS)
-		return static_cast<unsigned short>(::GetCurrentProcessId());
+		return uint16_t(::GetCurrentProcessId());
 #else
-		return static_cast<unsigned short>(::getpid());
+		return uint16_t(::getpid());
 #endif
 	}
 	boost::asio::ip::icmp::resolver resolver_;

--- a/hardware/RAVEn.cpp
+++ b/hardware/RAVEn.cpp
@@ -72,8 +72,8 @@ void RAVEn::readCallback(const char *indata, size_t inlen)
     }
     if(data == (indata+inlen))
     {
-        _log.Log(LOG_ERROR, "RAVEn::readCallback only got NULLs (%d of them)", (int)inlen);
-        return;
+	    _log.Log(LOG_ERROR, "RAVEn::readCallback only got NULLs (%d of them)", int(inlen));
+	    return;
     }
     size_t len = (indata+inlen) - data;
 #ifdef _DEBUG

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -237,7 +237,7 @@ void CRFLinkBase::ParseData(const char *data, size_t len)
 		{
 			// discard newline, close string, parse line and clear it.
 			m_rfbuffer[m_rfbufferpos] = '\0';
-			std::string sLine((char*)&m_rfbuffer);
+			std::string sLine(reinterpret_cast<char *>(&m_rfbuffer));
 			ParseLine(sLine);
 			m_rfbufferpos = 0;
 		}
@@ -392,7 +392,7 @@ bool CRFLinkBase::WriteToHardware(const char *pdata, const unsigned char length)
 			if (pLed->color.mode == ColorModeWhite)
 			{
 				// brightness (0-100) converted to 0x00-0xff
-				int brightness = (unsigned char)pLed->value;
+				int brightness = uint8_t(pLed->value);
 				brightness = (brightness * 255) / 100;
 				brightness = brightness & 0xff;
 				colorbright &= 0xff00;
@@ -404,7 +404,7 @@ bool CRFLinkBase::WriteToHardware(const char *pdata, const unsigned char length)
 			else if (pLed->color.mode == ColorModeRGB)
 			{
 				// brightness (0-100) converted to 0x00-0xff
-				int brightness = (unsigned char)pLed->value;
+				int brightness = uint8_t(pLed->value);
 				brightness = (brightness * 255) / 100;
 				brightness = brightness & 0xff;
 				// Convert RGB to HSV
@@ -412,7 +412,7 @@ bool CRFLinkBase::WriteToHardware(const char *pdata, const unsigned char length)
 				rgb2hsb(pLed->color.r, pLed->color.g, pLed->color.b, hsb);
 				int iHue = int(hsb[0] * 255.0F);
 				iHue = (iHue + 0x20) & 0xFF; // Milight color offset correction
-				colorbright = (((unsigned char)iHue) << 8) | brightness;
+				colorbright = (uint8_t(iHue) << 8) | brightness;
 				switchcmnd = "COLOR";
 				switchcmnd2 = "BRIGHT";
 				bSendOn = true;
@@ -441,11 +441,11 @@ bool CRFLinkBase::WriteToHardware(const char *pdata, const unsigned char length)
 			break;
 		case Color_SetBrightnessLevel: {
 			// brightness (0-100) converted to 0x00-0xff
-			int brightness = (unsigned char)pLed->value;
+			int brightness = uint8_t(pLed->value);
 			brightness = (brightness * 255) / 100;
 			brightness = brightness & 0xff;
 			colorbright = colorbright & 0xff00;
-			colorbright = colorbright + (unsigned char)brightness;
+			colorbright = colorbright + uint8_t(brightness);
 			switchcmnd = "BRIGHT";
 			bSendOn = true;
 		}
@@ -600,7 +600,7 @@ bool CRFLinkBase::SendSwitchInt(const int ID, const int switchunit, const int Ba
 	gswitch.battery_level = BatteryLevel;
 	gswitch.rssi = 12;
 	gswitch.seqnbr = 0;
-	sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, BatteryLevel, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), nullptr, BatteryLevel, m_Name.c_str());
 
 	return true;
 }

--- a/hardware/RFLinkTCP.cpp
+++ b/hardware/RFLinkTCP.cpp
@@ -104,7 +104,7 @@ void CRFLinkTCP::Do_Work()
 
 void CRFLinkTCP::OnData(const unsigned char *pData, size_t length)
 {
-	ParseData((const char*)pData,length);
+	ParseData(reinterpret_cast<const char *>(pData), length);
 }
 
 void CRFLinkTCP::OnError(const boost::system::error_code& error)

--- a/hardware/RFXBase.cpp
+++ b/hardware/RFXBase.cpp
@@ -36,8 +36,8 @@ bool CRFXBase::onInternalMessage(const unsigned char *pBuffer, const size_t Len,
 		}
 		if (m_rxbufferpos > m_rxbuffer[0])
 		{
-			if (!checkValid || CheckValidRFXData((uint8_t*)&m_rxbuffer))
-				sDecodeRXMessage(this, (const uint8_t *)&m_rxbuffer, nullptr, -1, m_Name.c_str());
+			if (!checkValid || CheckValidRFXData(reinterpret_cast<uint8_t *>(&m_rxbuffer)))
+				sDecodeRXMessage(this, reinterpret_cast<const uint8_t *>(&m_rxbuffer), nullptr, -1, m_Name.c_str());
 			else
 				Log(LOG_ERROR, "Invalid data received!....");
 
@@ -237,7 +237,7 @@ void CRFXBase::Set_Async_Parameters(const _eRFXAsyncType AsyncType)
 	cmd.ASYNCPORT.filler1 = 0;
 	cmd.ASYNCPORT.filler2 = 0;
 
-	WriteToHardware((const char*)&cmd, sizeof(cmd.ASYNCPORT));
+	WriteToHardware(reinterpret_cast<const char *>(&cmd), sizeof(cmd.ASYNCPORT));
 }
 
 void CRFXBase::Parse_Async_Data(const uint8_t *pData, const int Len)
@@ -273,7 +273,7 @@ void CRFXBase::SendCommand(const unsigned char Cmd)
 	cmd.ICMND.msg7 = 0;
 	cmd.ICMND.msg8 = 0;
 	cmd.ICMND.msg9 = 0;
-	WriteToHardware((const char*)&cmd, sizeof(cmd.ICMND));
+	WriteToHardware(reinterpret_cast<const char *>(&cmd), sizeof(cmd.ICMND));
 }
 
 bool CRFXBase::SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned char Mode2, const unsigned char Mode3, const unsigned char Mode4, const unsigned char Mode5, const unsigned char Mode6)
@@ -290,9 +290,9 @@ bool CRFXBase::SetRFXCOMHardwaremodes(const unsigned char Mode1, const unsigned 
 	Response.ICMND.msg4 = Mode4;
 	Response.ICMND.msg5 = Mode5;
 	Response.ICMND.msg6 = Mode6;
-	if (!WriteToHardware((const char*)&Response, sizeof(Response.ICMND)))
+	if (!WriteToHardware(reinterpret_cast<const char *>(&Response), sizeof(Response.ICMND)))
 		return false;
-	m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&Response, nullptr, -1, m_Name.c_str());
+	m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&Response), nullptr, -1, m_Name.c_str());
 	//Save it also
 	SendCommand(cmdSAVE);
 

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -331,7 +331,7 @@ bool RFXComSerial::UpgradeFirmware()
 			bcmd[1] = 1;
 			bcmd[2] = Address & 0xFF;
 			bcmd[3] = (Address & 0xFF00) >> 8;
-			bcmd[4] = (unsigned char)((Address & 0xFF0000) >> 16);
+			bcmd[4] = uint8_t((Address & 0xFF0000) >> 16);
 			memcpy(bcmd + 5, firmware.second.c_str(), firmware.second.size());
 			bool ret = Write_TX_PKT(bcmd, 5 + firmware.second.size(), 20);
 			if (!ret)
@@ -507,7 +507,7 @@ bool RFXComSerial::Read_Firmware_File(const char *szFilename, std::map<unsigned 
 			int iByte = 0;
 			sstr << std::hex << szHex;
 			sstr >> iByte;
-			rawLineBuf[raw_length++] = (unsigned char)iByte;
+			rawLineBuf[raw_length++] = uint8_t(iByte);
 			if (!sLine.empty())
 				chksum += iByte;
 			if (raw_length > sizeof(rawLineBuf) - 1)
@@ -536,7 +536,7 @@ bool RFXComSerial::Read_Firmware_File(const char *szFilename, std::map<unsigned 
 		{
 		case 0:
 			//Data record
-			dstring += std::string((const char*)&rawLineBuf + 4, (const char*)rawLineBuf + 4 + byte_count);
+			dstring += std::string(reinterpret_cast<const char *>(&rawLineBuf) + 4, reinterpret_cast<const char *>(rawLineBuf) + 4 + byte_count);
 			if (dstring.size() == PKT_writeblock)
 			{
 				dest_address = (((((addrh << 16) | (faddress + byte_count)) - PKT_writeblock)) / PKT_bytesperaddr);
@@ -676,7 +676,7 @@ bool RFXComSerial::Write_TX_PKT(const unsigned char *pdata, size_t length, int m
 	{
 		try
 		{
-			size_t twrite = m_serial.write((const uint8_t *)&output_buffer, tot_bytes);
+			size_t twrite = m_serial.write(reinterpret_cast<const uint8_t *>(&output_buffer), tot_bytes);
 			sleep_milliseconds(RFX_WRITE_DELAY);
 			if (twrite == tot_bytes)
 			{
@@ -712,7 +712,7 @@ bool RFXComSerial::Read_TX_PKT()
 	m_rx_tot_bytes = 0;
 	while (m_rx_tot_bytes < sizeof(m_rx_input_buffer))
 	{
-		size_t tot_read = m_serial.read((uint8_t*)&sbuffer, sizeof(sbuffer));
+		size_t tot_read = m_serial.read(reinterpret_cast<uint8_t *>(&sbuffer), sizeof(sbuffer));
 		if (tot_read <= 0)
 			return false;
 		int ii = 0;
@@ -830,7 +830,7 @@ void RFXComSerial::readCallback(const char *data, size_t len)
 	{
 		if (!m_bInBootloaderMode)
 		{
-			bool bRet = onInternalMessage((const unsigned char *)data, len);
+			bool bRet = onInternalMessage(reinterpret_cast<const unsigned char *>(data), len);
 			if (bRet == false)
 			{
 				//close serial connection, and restart
@@ -945,7 +945,7 @@ namespace http {
 			unsigned char Mode5 = atoi(result[0][4].c_str());
 			unsigned char Mode6 = atoi(result[0][5].c_str());
 
-			_eHardwareTypes HWType = (_eHardwareTypes)atoi(result[0][6].c_str());
+			_eHardwareTypes HWType = _eHardwareTypes(atoi(result[0][6].c_str()));
 
 			tRBUF Response;
 			Response.ICMND.freqsel = Mode1;
@@ -996,7 +996,7 @@ namespace http {
 						if (AsyncMode.empty())
 							AsyncMode = "0";
 						result = m_sql.safe_query("UPDATE Hardware SET Extra='%q' WHERE (ID='%q')", AsyncMode.c_str(), idx.c_str());
-						pBase->SetAsyncType((CRFXBase::_eRFXAsyncType)atoi(AsyncMode.c_str()));
+						pBase->SetAsyncType(CRFXBase::_eRFXAsyncType(atoi(AsyncMode.c_str())));
 					}
 				}
 			}

--- a/hardware/RFXComTCP.cpp
+++ b/hardware/RFXComTCP.cpp
@@ -107,6 +107,6 @@ bool RFXComTCP::WriteToHardware(const char *pdata, const unsigned char length)
 {
 	if (!isConnected())
 		return false;
-	write((const unsigned char*)pdata, length);
+	write(reinterpret_cast<const unsigned char *>(pdata), length);
 	return true;
 }

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -247,7 +247,7 @@ void CRego6XXSerial::Do_Work()
 					for (int i = 2; i < 8; i++)
 						cmd.data.crc ^= cmd.raw[i];
 
-					WriteToHardware((char *)cmd.raw, sizeof(cmd.raw));
+					WriteToHardware(reinterpret_cast<char *>(cmd.raw), sizeof(cmd.raw));
 				}
 				else
 				{
@@ -371,14 +371,14 @@ bool CRego6XXSerial::ParseData()
 		if (g_allRegisters[m_pollcntr].type == REGO_TYPE_TEMP)
 		{
 			strcpy(m_Rego6XXTemp.ID, g_allRegisters[m_pollcntr].name);
-			m_Rego6XXTemp.temperature = (float)(data * 0.1);
+			m_Rego6XXTemp.temperature = float(data * 0.1);
 			if ((m_Rego6XXTemp.temperature >= -48.2) && // -48.3 means no sensor.
 			    ((std::fabs(m_Rego6XXTemp.temperature - g_allRegisters[m_pollcntr].lastTemp) > 0.09) || // Only send changes.
 			     (difftime(atime, g_allRegisters[m_pollcntr].lastSent) >= 300))) // Send at least every 5 minutes
 			{
 				g_allRegisters[m_pollcntr].lastSent = atime;
 				g_allRegisters[m_pollcntr].lastTemp = m_Rego6XXTemp.temperature;
-				sDecodeRXMessage(this, (const unsigned char *)&m_Rego6XXTemp, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_Rego6XXTemp), nullptr, 255, nullptr);
 			}
 		}
 		else if (g_allRegisters[m_pollcntr].type == REGO_TYPE_STATUS)
@@ -391,7 +391,7 @@ bool CRego6XXSerial::ParseData()
 			{
 				g_allRegisters[m_pollcntr].lastSent = atime;
 				g_allRegisters[m_pollcntr].lastValue = m_Rego6XXValue.value;
-				sDecodeRXMessage(this, (const unsigned char *)&m_Rego6XXValue, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_Rego6XXValue), nullptr, 255, nullptr);
 			}
 		}
 		else if (g_allRegisters[m_pollcntr].type == REGO_TYPE_COUNTER)
@@ -404,7 +404,7 @@ bool CRego6XXSerial::ParseData()
 			{
 				g_allRegisters[m_pollcntr].lastSent = atime;
 				g_allRegisters[m_pollcntr].lastValue = m_Rego6XXValue.value;
-				sDecodeRXMessage(this, (const unsigned char *)&m_Rego6XXValue, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_Rego6XXValue), nullptr, 255, nullptr);
 			}
 		}
 

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -373,11 +373,11 @@ void RelayNet::TcpGetSetRelay(int RelayNumber, bool SetRelay, bool State)
 		sndbuf[0] = 'R'; 		//	Get relay status
 	}
 
-	sndbuf[1] = 0x30 + (char) RelayNumber;
+	sndbuf[1] = 0x30 + char(RelayNumber);
 	sndbuf[2] = '\r';
 	sndbuf[3] = '\n';
 
-	write((const unsigned char*)&sndbuf[0], (size_t) sizeof(sndbuf));
+	write(reinterpret_cast<const unsigned char *>(&sndbuf[0]), size_t(sizeof(sndbuf)));
 }
 
 void RelayNet::SetRelayState(int RelayNumber, bool State)
@@ -467,11 +467,11 @@ void RelayNet::UpdateDomoticzInput(int InputNumber, bool State)
 			m_Packet.LIGHTING2.cmnd = light2_sOff;
 			m_Packet.LIGHTING2.level = 0;
 		}
-		m_Packet.LIGHTING2.unitcode = 100 + (char) InputNumber;
+		m_Packet.LIGHTING2.unitcode = 100 + char(InputNumber);
 		m_Packet.LIGHTING2.seqnbr++;
 
 		/* send packet to Domoticz */
-		sDecodeRXMessage(this, (const unsigned char *)&m_Packet.LIGHTING2, "Input", 255, m_Name.c_str());
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_Packet.LIGHTING2), "Input", 255, m_Name.c_str());
 	}
 }
 
@@ -519,11 +519,11 @@ void RelayNet::UpdateDomoticzRelay(int RelayNumber, bool State)
 			m_Packet.LIGHTING2.cmnd = light2_sOff;
 			m_Packet.LIGHTING2.level = 0;
 		}
-		m_Packet.LIGHTING2.unitcode = (char) RelayNumber;
+		m_Packet.LIGHTING2.unitcode = char(RelayNumber);
 		m_Packet.LIGHTING2.seqnbr++;
 
 		/* send packet to Domoticz */
-		sDecodeRXMessage(this, (const unsigned char *)&m_Packet.LIGHTING2, "Relay", 255, m_Name.c_str());
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_Packet.LIGHTING2), "Relay", 255, m_Name.c_str());
 	}
 }
 

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -182,7 +182,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "temperature_C"))
 	{
-		tempC = (float)atof(data["temperature_C"].c_str());
+		tempC = float(atof(data["temperature_C"].c_str()));
 		haveTemp = true;
 	}
 	if (FindField(data, "humidity"))
@@ -205,37 +205,37 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "pressure_hPa"))
 	{
-		pressure = (float)atof(data["pressure_hPa"].c_str());
+		pressure = float(atof(data["pressure_hPa"].c_str()));
 		havePressure = true;
 	}
 	if (FindField(data, "pressure_PSI"))
 	{
-		pressure_PSI = (float)atof(data["pressure_PSI"].c_str());
+		pressure_PSI = float(atof(data["pressure_PSI"].c_str()));
 		havePressure_PSI = true;
 	}
 	if (FindField(data, "pressure_kPa"))
 	{
-		pressure = 10.0F * (float)atof(data["pressure_kPa"].c_str()); // convert to hPA
+		pressure = 10.0F * float(atof(data["pressure_kPa"].c_str())); // convert to hPA
 		havePressure = true;
 	}
 	if (FindField(data, "rain_mm"))
 	{
-		rain = (float)atof(data["rain_mm"].c_str());
+		rain = float(atof(data["rain_mm"].c_str()));
 		haveRain = true;
 	}
 	if (FindField(data, "depth_cm"))
 	{
-		depth = (float)atof(data["depth_cm"].c_str());
+		depth = float(atof(data["depth_cm"].c_str()));
 		haveDepth = true;
 	}
 	if (FindField(data, "wind_avg_km_h")) // wind speed average (converting into m/s note that internal storage if 10.0f*m/s) 
 	{
-		wind_speed = ((float)atof(data["wind_avg_km_h"].c_str())) / 3.6F;
+		wind_speed = (float(atof(data["wind_avg_km_h"].c_str()))) / 3.6F;
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_avg_m_s")) // wind speed average
 	{
-		wind_speed = (float)atof(data["wind_avg_m_s"].c_str());
+		wind_speed = float(atof(data["wind_avg_m_s"].c_str()));
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_dir_deg"))
@@ -245,12 +245,12 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "wind_max_km_h")) // idem, converting to m/s
 	{
-		wind_gust = ((float)atof(data["wind_max_km_h"].c_str())) / 3.6F;
+		wind_gust = (float(atof(data["wind_max_km_h"].c_str()))) / 3.6F;
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "wind_max_m_s"))
 	{
-		wind_gust = (float)atof(data["wind_max_m_s"].c_str());
+		wind_gust = float(atof(data["wind_max_m_s"].c_str()));
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "moisture"))
@@ -260,12 +260,12 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "power_W")) // -- power_W,energy_kWh,radio_clock,sequence,
 	{
-		power = (float)atof(data["power_W"].c_str());
+		power = float(atof(data["power_W"].c_str()));
 		havePower = true;
 	}
 	if (FindField(data, "energy_kWh")) // sensor type general subtype electric counter
 	{
-		energy = (float)atof(data["energy_kWh"].c_str());
+		energy = float(atof(data["energy_kWh"].c_str()));
 		haveEnergy = true;
 	}
 	if (FindField(data, "sequence")) // please do not remove : to be added in future PR for data in sensor (for fiability reporting)
@@ -275,7 +275,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "uv"))
 	{
-		uvi = (float)atof(data["uv"].c_str());
+		uvi = float(atof(data["uv"].c_str()));
 		haveUV = true;
 	}
 	if (FindField(data, "snr"))
@@ -286,7 +286,8 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		*/
 		snr = std::stoi(data["snr"]) - 4;
 
-		if (snr > 5) snr -= (int)(snr - 5) / 2;
+		if (snr > 5)
+			snr -= (snr - 5) / 2;
 		if (snr > 11) snr = 11; // Domoticz RSSI field can only be 0-11, 12 is used for non-RF received devices
 		if (snr < 0) snr = 0; // In case snr actually was below 4 dB
 	}
@@ -307,11 +308,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		else if (FindField(data, "command"))
 			bOn = data["command"] == "On";
 		unsigned int switchidx = (id & 0xfffffff) | ((channel & 0xf) << 28);
-		SendSwitch(switchidx,
-			(const uint8_t)unit,
-			batterylevel,
-			bOn,
-			0, model, m_Name, snr);
+		SendSwitch(switchidx, uint8_t(unit), batterylevel, bOn, 0, model, m_Name, snr);
 		bDone = true;
 	}
 	if (FindField(data, "switch1") && FindField(data, "id"))
@@ -328,11 +325,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 			{
 				bool bOn = (data[szSwitch] == "CLOSED");
 				unsigned int switchidx = ((idx & 0xffffff) << 8) | (iSwitch + 1);
-				SendSwitch(switchidx,
-					(const uint8_t)unit,
-					batterylevel,
-					bOn,
-					0, model, m_Name, snr);
+				SendSwitch(switchidx, uint8_t(unit), batterylevel, bOn, 0, model, m_Name, snr);
 			}
 			bDone = true;
 		}
@@ -395,18 +388,18 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	if (haveMoisture)
 	{
 		//moisture is in percentage
-		SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, static_cast<float>(moisture), model, "%", snr);
+		SendCustomSensor(uint8_t(sensoridx), uint8_t(unit), batterylevel, float(moisture), model, "%", snr);
 		//SendMoistureSensor(sensoridx, batterylevel, moisture, model, snr);
 		bHandled = true;
 	}
 	if (havePower)
 	{
-		SendWattMeter((uint8_t)sensoridx, (uint8_t)unit, batterylevel, power, model, snr);
+		SendWattMeter(uint8_t(sensoridx), uint8_t(unit), batterylevel, power, model, snr);
 		bHandled = true;
 	}
 	if (havePressure_PSI)
 	{
-		SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, pressure_PSI, model, "PSI", snr);
+		SendCustomSensor(uint8_t(sensoridx), uint8_t(unit), batterylevel, pressure_PSI, model, "PSI", snr);
 		bHandled = true;
 	}
 	if (haveEnergy && havePower)
@@ -419,7 +412,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (haveUV)
 	{
-		SendUVSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, uvi, model, snr);
+		SendUVSensor(uint8_t(sensoridx), uint8_t(unit), batterylevel, uvi, model, snr);
 		bHandled = true;
 	}
 

--- a/hardware/S0MeterBase.h
+++ b/hardware/S0MeterBase.h
@@ -10,8 +10,8 @@ class S0MeterBase : public CDomoticzHardwareBase
 		double m_counter_start;
 		double m_current_counter;
 		double m_pulse_per_unit;
-		unsigned long first_total_pulses_received;
-		unsigned long total_pulses;
+		uint32_t first_total_pulses_received;
+		uint32_t total_pulses;
 		int m_value_buffer_total;
 		int m_value_buffer_write_pos;
 		double m_last_values[5];

--- a/hardware/S0MeterSerial.cpp
+++ b/hardware/S0MeterSerial.cpp
@@ -122,7 +122,7 @@ void S0MeterSerial::readCallback(const char *data, size_t len)
 	if (!m_bEnableReceive)
 		return; //receiving not enabled
 
-	ParseData((const unsigned char*)data, static_cast<int>(len));
+	ParseData(reinterpret_cast<const unsigned char *>(data), int(len));
 }
 
 bool S0MeterSerial::WriteToHardware(const char *pdata, const unsigned char length)

--- a/hardware/S0MeterTCP.cpp
+++ b/hardware/S0MeterTCP.cpp
@@ -83,7 +83,7 @@ bool S0MeterTCP::WriteToHardware(const char *pdata, const unsigned char length)
 
 void S0MeterTCP::OnData(const unsigned char *pData, size_t length)
 {
-	ParseData((const unsigned char*)pData,length);
+	ParseData(pData, length);
 }
 
 void S0MeterTCP::OnError(const boost::system::error_code& error)

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -172,29 +172,29 @@ void CSBFSpot::SendMeter(const unsigned char ID1,const unsigned char ID2, const 
 
 	tsen.ENERGY.battery_level=9;
 
-	unsigned long long instant=(unsigned long long)(musage*1000.0);
-	tsen.ENERGY.instant1=(unsigned char)(instant/0x1000000);
+	uint64_t instant = uint64_t(musage * 1000.0);
+	tsen.ENERGY.instant1 = uint8_t(instant / 0x1000000);
 	instant-=tsen.ENERGY.instant1*0x1000000;
-	tsen.ENERGY.instant2=(unsigned char)(instant/0x10000);
+	tsen.ENERGY.instant2 = uint8_t(instant / 0x10000);
 	instant-=tsen.ENERGY.instant2*0x10000;
-	tsen.ENERGY.instant3=(unsigned char)(instant/0x100);
+	tsen.ENERGY.instant3 = uint8_t(instant / 0x100);
 	instant-=tsen.ENERGY.instant3*0x100;
-	tsen.ENERGY.instant4=(unsigned char)(instant);
+	tsen.ENERGY.instant4 = uint8_t(instant);
 
 	double total=(mtotal*1000.0)*223.666;
-	tsen.ENERGY.total1=(unsigned char)(total/0x10000000000ULL);
+	tsen.ENERGY.total1 = uint8_t(total / 0x10000000000ULL);
 	total-=tsen.ENERGY.total1*0x10000000000ULL;
-	tsen.ENERGY.total2=(unsigned char)(total/0x100000000ULL);
+	tsen.ENERGY.total2 = uint8_t(total / 0x100000000ULL);
 	total-=tsen.ENERGY.total2*0x100000000ULL;
-	tsen.ENERGY.total3=(unsigned char)(total/0x1000000);
+	tsen.ENERGY.total3 = uint8_t(total / 0x1000000);
 	total-=tsen.ENERGY.total3*0x1000000;
-	tsen.ENERGY.total4=(unsigned char)(total/0x10000);
+	tsen.ENERGY.total4 = uint8_t(total / 0x10000);
 	total-=tsen.ENERGY.total4*0x10000;
-	tsen.ENERGY.total5=(unsigned char)(total/0x100);
+	tsen.ENERGY.total5 = uint8_t(total / 0x100);
 	total-=tsen.ENERGY.total5*0x100;
-	tsen.ENERGY.total6=(unsigned char)(total);
+	tsen.ENERGY.total6 = uint8_t(total);
 
-	sDecodeRXMessage(this, (const unsigned char *)&tsen.ENERGY, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.ENERGY), defaultname.c_str(), 255, nullptr);
 }
 
 bool CSBFSpot::GetMeter(const unsigned char ID1,const unsigned char ID2, double &musage, double &mtotal)
@@ -310,7 +310,7 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 					szKwhCounter = "0," + szKwhCounter;
 				stdreplace(szKwhCounter, ",", ".");
 				double kWhCounter = atof(szKwhCounter.c_str()) * 1000;
-				unsigned long long ulCounter = (unsigned long long)kWhCounter;
+				uint64_t ulCounter = uint64_t(kWhCounter);
 
 				//check if this day record does not exists in the database, and insert it
 				std::vector<std::vector<std::string> > result;
@@ -376,7 +376,7 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 						std::string szKwhCounter = results[iInvOff + 1];
 						stdreplace(szKwhCounter, ",", ".");
 						double kWhCounter = atof(szKwhCounter.c_str()) * 1000;
-						unsigned long long ulCounter = (unsigned long long)kWhCounter;
+						uint64_t ulCounter = uint64_t(kWhCounter);
 
 						//check if this day record does not exists in the database, and insert it
 						std::vector<std::vector<std::string> > result;
@@ -571,17 +571,17 @@ void CSBFSpot::GetMeterDetails()
 		float voltage;
 		tmpString = results[16];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = float(atof(tmpString.c_str()));
 		SendVoltageSensor(0, (InvIdx * 10) + 1, 255, voltage, "Volt uac1");
 		tmpString = results[17];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = float(atof(tmpString.c_str()));
 		if (voltage != 0) {
 			SendVoltageSensor(0, (InvIdx * 10) + 2, 255, voltage, "Volt uac2");
 		}
 		tmpString = results[18];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = float(atof(tmpString.c_str()));
 		if (voltage != 0) {
 			SendVoltageSensor(0, (InvIdx * 10) + 3, 255, voltage, "Volt uac3");
 		}
@@ -589,22 +589,22 @@ void CSBFSpot::GetMeterDetails()
 		float percentage;
 		tmpString = results[21];
 		stdreplace(tmpString, ",", ".");
-		percentage = static_cast<float>(atof(tmpString.c_str()));
+		percentage = float(atof(tmpString.c_str()));
 		SendPercentageSensor((InvIdx * 10) + 1, 0, 255, percentage, "Efficiency");
 		tmpString = results[24];
 		stdreplace(tmpString, ",", ".");
-		percentage = static_cast<float>(atof(tmpString.c_str()));
+		percentage = float(atof(tmpString.c_str()));
 		SendPercentageSensor((InvIdx * 10) + 2, 0, 255, percentage, "Hz");
 		tmpString = results[27];
 		stdreplace(tmpString, ",", ".");
-		percentage = static_cast<float>(atof(tmpString.c_str()));
+		percentage = float(atof(tmpString.c_str()));
 		SendPercentageSensor((InvIdx * 10) + 3, 0, 255, percentage, "BT_Signal");
 
 		if (results.size() >= 31)
 		{
 			tmpString = results[30];
 			stdreplace(tmpString, ",", ".");
-			float temperature = static_cast<float>(atof(tmpString.c_str()));
+			float temperature = float(atof(tmpString.c_str()));
 			SendTempSensor((InvIdx * 10) + 1, 255, temperature, "Temperature");
 		}
 		InvIdx++;
@@ -616,7 +616,7 @@ void CSBFSpot::GetMeterDetails()
 		double LastTotal = 0;
 		if (GetMeter(0, 1, LastUsage, LastTotal))
 		{
-			if (kWhCounter < (int)(LastTotal * 100) / 100)
+			if (kWhCounter < int(LastTotal * 100) / 100)
 			{
 				_log.Log(LOG_ERROR, "SBFSpot: Actual KwH counter (%f) less then last Counter (%f)!", kWhCounter, LastTotal);
 				return;

--- a/hardware/SatelIntegra.h
+++ b/hardware/SatelIntegra.h
@@ -81,7 +81,7 @@ class SatelIntegra : public CDomoticzHardwareBase
 	unsigned char m_newData[7];
 
 	// password to Integra
-	unsigned char m_userCode[8];
+	std::array<unsigned char, 8> m_userCode;
 
 	// TODO maybe create dynamic array ?
 	bool m_zonesLastState[256];

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -246,7 +246,7 @@ void SolarEdgeAPI::GetMeterDetails()
 	m_totalActivePower = 0;
 	m_totalEnergy = 0;
 
-	for (int iInverter = 0; iInverter < (int)m_inverters.size(); iInverter++)
+	for (int iInverter = 0; iInverter < int(m_inverters.size()); iInverter++)
 	{
 		GetInverterDetails(&m_inverters[iInverter], iInverter);
 	}

--- a/hardware/Sterbox.cpp
+++ b/hardware/Sterbox.cpp
@@ -175,7 +175,7 @@ void CSterbox::UpdateSwitch(const unsigned char Idx, const int SubUnit, const bo
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 void CSterbox::GetMeterDetails()
@@ -328,7 +328,7 @@ void CSterbox::GetMeterDetails()
 					tmpinp = analog[jj];
 					tmpstr2 = tmpstr2.substr(1, 10);
 
-					float lValue = (float)atof(tmpstr2.c_str());
+					float lValue = float(atof(tmpstr2.c_str()));
 					std::stringstream sstr;
 					sstr << "Analog " << jj;
 					pos1 = tmpinp.find('t');
@@ -339,12 +339,12 @@ void CSterbox::GetMeterDetails()
 					pos1 = tmpinp.find('v');
 					if (pos1 != std::string::npos)
 					{
-						SendVoltageSensor(0, (uint8_t)jj, 255, lValue, sstr.str());
+						SendVoltageSensor(0, uint8_t(jj), 255, lValue, sstr.str());
 					}
 					pos1 = tmpinp.find('l');
 					if (pos1 != std::string::npos)
 					{
-						SendLuxSensor(0, (uint8_t)jj, 255,lValue, sstr.str());
+						SendLuxSensor(0, uint8_t(jj), 255, lValue, sstr.str());
 					}
 					pos1 = tmpinp.find('h');
 					if (pos1 != std::string::npos)

--- a/hardware/TCPProxy/tcpproxy_server.cpp
+++ b/hardware/TCPProxy/tcpproxy_server.cpp
@@ -50,9 +50,7 @@ namespace tcp_proxy
 		boost::asio::ip::tcp::resolver::iterator i = resolver.resolve(query);
 		if (i == boost::asio::ip::tcp::resolver::iterator())
 		{
-			end=boost::asio::ip::tcp::endpoint(
-				boost::asio::ip::address::from_string(upstream_host),
-				(unsigned short)atoi(upstream_port.c_str()));
+			end = boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(upstream_host), uint16_t(atoi(upstream_port.c_str())));
 		}
 		else
 			end=*i;
@@ -90,7 +88,7 @@ namespace tcp_proxy
 		if (!error)
 		{
 			//std::unique_lock<std::mutex> lock(mutex_);
-			sDownstreamData(reinterpret_cast<unsigned char*>(&downstream_data_[0]),static_cast<size_t>(bytes_transferred));
+			sDownstreamData(reinterpret_cast<unsigned char *>(&downstream_data_[0]), size_t(bytes_transferred));
 			async_write(upstream_socket_, boost::asio::buffer(downstream_data_, bytes_transferred),
 				    [p = shared_from_this()](auto &&err, auto bytes) { p->handle_downstream_read(err, bytes); });
 		}
@@ -115,7 +113,7 @@ namespace tcp_proxy
 		if (!error)
 		{
 			//std::unique_lock<std::mutex> lock(mutex_);
-			sUpstreamData(reinterpret_cast<unsigned char*>(&upstream_data_[0]),static_cast<size_t>(bytes_transferred));
+			sUpstreamData(reinterpret_cast<unsigned char *>(&upstream_data_[0]), size_t(bytes_transferred));
 
 			async_write(downstream_socket_, boost::asio::buffer(upstream_data_, bytes_transferred), [p = shared_from_this()](auto &&err, auto) { p->handle_downstream_write(err); });
 		}

--- a/hardware/TE923.cpp
+++ b/hardware/TE923.cpp
@@ -194,27 +194,27 @@ void CTE923::GetSensorDetails()
 
 		float winddir = float(data.wDir) * 22.5F;
 		int aw=round(winddir);
-		tsen.WIND.directionh=(BYTE)(aw/256);
+		tsen.WIND.directionh = BYTE(aw / 256);
 		aw-=(tsen.WIND.directionh*256);
-		tsen.WIND.directionl=(BYTE)(aw);
+		tsen.WIND.directionl = BYTE(aw);
 
 		tsen.WIND.av_speedh=0;
 		tsen.WIND.av_speedl=0;
 		if (data._wSpeed==0)
 		{
 			int sw = round(data.wSpeed * 10.0F);
-			tsen.WIND.av_speedh=(BYTE)(sw/256);
+			tsen.WIND.av_speedh = BYTE(sw / 256);
 			sw-=(tsen.WIND.av_speedh*256);
-			tsen.WIND.av_speedl=(BYTE)(sw);
+			tsen.WIND.av_speedl = BYTE(sw);
 		}
 		tsen.WIND.gusth=0;
 		tsen.WIND.gustl=0;
 		if (data._wGust==0)
 		{
 			int gw = round(data.wGust * 10.0F);
-			tsen.WIND.gusth=(BYTE)(gw/256);
+			tsen.WIND.gusth = BYTE(gw / 256);
 			gw-=(tsen.WIND.gusth*256);
-			tsen.WIND.gustl=(BYTE)(gw);
+			tsen.WIND.gustl = BYTE(gw);
 		}
 
 		//this is not correct, why no wind temperature? and only chill?
@@ -227,14 +227,14 @@ void CTE923::GetSensorDetails()
 			tsen.WIND.tempsign=(data.wChill>=0)?0:1;
 			tsen.WIND.chillsign=(data.wChill>=0)?0:1;
 			int at10 = round(std::abs(data.wChill * 10.0F));
-			tsen.WIND.temperatureh=(BYTE)(at10/256);
-			tsen.WIND.chillh=(BYTE)(at10/256);
+			tsen.WIND.temperatureh = BYTE(at10 / 256);
+			tsen.WIND.chillh = BYTE(at10 / 256);
 			at10-=(tsen.WIND.chillh*256);
-			tsen.WIND.temperaturel=(BYTE)(at10);
-			tsen.WIND.chilll=(BYTE)(at10);
+			tsen.WIND.temperaturel = BYTE(at10);
+			tsen.WIND.chilll = BYTE(at10);
 		}
 
-		sDecodeRXMessage(this, (const unsigned char *)&tsen.WIND, nullptr, -1, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.WIND), nullptr, -1, nullptr);
 	}
 
 	//Rain

--- a/hardware/TE923Tool.cpp
+++ b/hardware/TE923Tool.cpp
@@ -111,7 +111,7 @@ void CTE923Tool::CloseDevice()
 }
 
 int bcd2int( char bcd ) {
-	return (( int )(( bcd & 0xF0 ) >> 4 ) * 10 + ( int )( bcd & 0x0F ) );
+	return (((bcd & 0xF0) >> 4) * 10 + (bcd & 0x0F));
 }
 
 int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data ) 
@@ -133,7 +133,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 			data->_t[i] = -2;
 		}
 		if ( data->_t[i] == 0 ) {
-			data->t[i] = (float)(( bcd2int( buf[0+offset] ) / 10.0 ) + ( bcd2int( buf[1+offset] & 0x0F ) * 10.0 ));
+			data->t[i] = float((bcd2int(buf[0 + offset]) / 10.0) + (bcd2int(buf[1 + offset] & 0x0F) * 10.0));
 			if (( buf[1+offset] & 0x20 ) == 0x20 )
 				data->t[i] += 0.05F;
 			if (( buf[1+offset] & 0x80 ) != 0x80 )
@@ -163,7 +163,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 	}
 
 	else {
-		data->uv = (float)(bcd2int( buf[18] & 0x0F ) / 10.0 + bcd2int( buf[18] & 0xF0 ) + bcd2int( buf[19] & 0x0F ) * 10.0);
+		data->uv = float(bcd2int(buf[18] & 0x0F) / 10.0 + bcd2int(buf[18] & 0xF0) + bcd2int(buf[19] & 0x0F) * 10.0);
 		data->_uv = 0;
 	}
 
@@ -172,7 +172,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 		data->press = 0;
 		data->_press = -1;
 	} else {
-		data->press = (float)(( int )( buf[21] * 0x100 + buf[20] ) * 0.0625);
+		data->press = float((buf[21] * 0x100 + buf[20]) * 0.0625);
 		data->_press = 0;
 	}
 
@@ -190,7 +190,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 		else
 			data->storm = 0;
 
-		data->forecast = ( int )( buf[22] & 0x07 );
+		data->forecast = (buf[22] & 0x07);
 	}
 
 	//decode wind chill
@@ -234,7 +234,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 		int offset = 0;
 		if (( buf[26] & 0x10 ) == 0x10 )
 			offset = 100;
-		data->wGust = (float)((( bcd2int( buf[25] ) / 10.0 ) + ( bcd2int( buf[26] & 0x0F ) * 10.0 ) + offset ) / 2.23694);
+		data->wGust = float(((bcd2int(buf[25]) / 10.0) + (bcd2int(buf[26] & 0x0F) * 10.0) + offset) / 2.23694);
 	} else
 		data->wGust = 0;
 
@@ -255,7 +255,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 		int offset = 0;
 		if (( buf[28] & 0x10 ) == 0x10 )
 			offset = 100;
-		data->wSpeed = (float)((( bcd2int( buf[27] ) / 10.0 ) + ( bcd2int( buf[28] & 0x0F ) * 10.0 ) + offset ) / 2.23694);
+		data->wSpeed = float(((bcd2int(buf[27]) / 10.0) + (bcd2int(buf[28] & 0x0F) * 10.0) + offset) / 2.23694);
 	} else
 		data->wSpeed = 0;
 
@@ -264,7 +264,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 		data->_wDir = -3;
 		data->wDir = 0;
 	} else {
-		data->wDir = ( int )buf[29] & 0x0F;
+		data->wDir = int(buf[29]) & 0x0F;
 		data->_wDir = 0;
 	}
 
@@ -272,7 +272,7 @@ int CTE923Tool::decode_te923_data( unsigned char buf[], Te923DataSet_t *data )
 	//don't know to find out it sensor link missing, but is no problem, because the counter is inside
 	//the station, not in the sensor.
 	data->_RainCount = 0;
-	data->RainCount = ( int )(( buf[31] * 0x100 + buf[30] )/2);
+	data->RainCount = ((buf[31] * 0x100 + buf[30]) / 2);
 	return 0;
 }
 
@@ -287,14 +287,14 @@ int CTE923Tool::read_from_te923( int adr, unsigned char *rbuf )
 	buf[3] = ( adr - ( buf[4] * 0x10000 ) ) / 0x100;
 	buf[2] = adr - ( buf[4] * 0x10000 ) - ( buf[3] * 0x100 );
 	buf[5] = ( buf[1] ^ buf[2] ^ buf[3] ^ buf[4] );
-	ret = usb_control_msg( m_device_handle, 0x21, 0x09, 0x0200, 0x0000, (char*)&buf, 0x08, timeout );
+	ret = usb_control_msg(m_device_handle, 0x21, 0x09, 0x0200, 0x0000, reinterpret_cast<char *>(&buf), 0x08, timeout);
 	if ( ret < 0 )
 		return -1;
 	usleep(300000);
-	while ( usb_interrupt_read( m_device_handle, 0x01, (char*)&buf, 0x8, timeout ) > 0 ) 
+	while (usb_interrupt_read(m_device_handle, 0x01, reinterpret_cast<char *>(&buf), 0x8, timeout) > 0)
 	{
 		usleep(150000);
-		int bytes = ( int )buf[0];
+		int bytes = int(buf[0]);
 		if (( count + bytes ) < BUFLEN )
 			memcpy( rbuf + count, buf + 1, bytes );
 		count += bytes;
@@ -317,14 +317,14 @@ int CTE923Tool::get_te923_lifedata( Te923DataSet_t *data )
 	unsigned char readretries=0;
 	do
 	{
-		ret = read_from_te923( adr, (unsigned char*)&buf );
+		ret = read_from_te923(adr, reinterpret_cast<unsigned char *>(&buf));
 		readretries++;
 	}
 	while (( ret <= 0 )&&(readretries<MAX_LOOP_RETRY));
 	if ( buf[0] != 0x5A )
 		return -1;
 	memmove( buf, buf + 1, BUFLEN - 1 );
-	data->timestamp = (unsigned long)time(nullptr);
+	data->timestamp = uint64_t(time(nullptr));
 	decode_te923_data( buf, data );
 	return 0;
 }
@@ -336,7 +336,7 @@ int CTE923Tool::get_te923_devstate( Te923DevSet_t *dev ) {
 	unsigned char readretries=0;
 	do
 	{
-		ret = read_from_te923( adr, (unsigned char*)&buf );
+		ret = read_from_te923(adr, reinterpret_cast<unsigned char *>(&buf));
 		readretries++;
 	}
 	while (( ret <= 0 )&&(readretries<MAX_LOOP_RETRY));
@@ -351,7 +351,7 @@ int CTE923Tool::get_te923_devstate( Te923DevSet_t *dev ) {
 	readretries=0;
 	do
 	{
-		ret = read_from_te923( adr, (unsigned char*)&buf );
+		ret = read_from_te923(adr, reinterpret_cast<unsigned char *>(&buf));
 		readretries++;
 	}
 	while (( ret <= 0 )&&(readretries<MAX_LOOP_RETRY));
@@ -418,7 +418,7 @@ int CTE923Tool::get_te923_memdata( Te923DataSet_t *data )
 		if (readretries>=MAX_LOOP_RETRY)
 			return -1;
 
-		adr = (((( int )buf[3] ) * 0x100 + ( int )buf[5] ) * 0x26 ) + 0x101;
+		adr = (((int(buf[3])) * 0x100 + int(buf[5])) * 0x26) + 0x101;
 	} else
 		adr = data->__src;
 
@@ -439,7 +439,7 @@ int CTE923Tool::get_te923_memdata( Te923DataSet_t *data )
 		return -1;
 
 	int day = bcd2int( buf[2] );
-	int mon = ( int )( buf[1] & 0x0F );
+	int mon = (buf[1] & 0x0F);
 	int year = sysyear;
 	if ( mon > sysmon + 1 )
 		year--;
@@ -459,7 +459,7 @@ int CTE923Tool::get_te923_memdata( Te923DataSet_t *data )
 */
 	time_t timestamp;
 	constructTime(timestamp,newtime,year+1900,mon,day,hour,minute,0,-1);
-	data->timestamp = (unsigned long)timestamp;
+	data->timestamp = uint64_t(timestamp);
 
 	memcpy( databuf, buf + 5, 11 );
 	adr += 0x10;
@@ -516,20 +516,20 @@ void CTE923Tool::GetPrintData( Te923DataSet_t *data, char *szOutputBuffer)
 		sprintf(szTmp, "%s:", iText );
 	strcat(szOutputBuffer,szTmp);
 
-	if ( data->_forecast == 0 ) 
-		sprintf(szTmp, "%d:", (int)data->forecast );
+	if (data->_forecast == 0)
+		sprintf(szTmp, "%d:", int(data->forecast));
 	else
 		sprintf(szTmp, "%s:", iText );
 	strcat(szOutputBuffer,szTmp);
 
-	if ( data->_storm == 0 ) 
-		sprintf(szTmp, "%d:", (int)data->storm );
+	if (data->_storm == 0)
+		sprintf(szTmp, "%d:", int(data->storm));
 	else 
 		sprintf(szTmp, "%s:", iText );
 	strcat(szOutputBuffer,szTmp);
 
-	if ( data->_wDir == 0 ) 
-		sprintf(szTmp, "%d:", (int)data->wDir );
+	if (data->_wDir == 0)
+		sprintf(szTmp, "%d:", int(data->wDir));
 	else 
 		sprintf(szTmp, "%s:", iText );
 	strcat(szOutputBuffer,szTmp);

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -324,7 +324,7 @@ bool CTado::GetZoneState(const int HomeIndex, const int ZoneIndex, const _tTadoH
 		if (_jsRoot["sensorDataPoints"]["humidity"]["percentage"].isNumeric())
 			fCurrentHumPct = _jsRoot["sensorDataPoints"]["humidity"]["percentage"].asFloat();
 		if (_fCurrentTempC > 0) {
-			SendTempHumSensor(ZoneIndex * 100 + 3, 255, _fCurrentTempC, (int)fCurrentHumPct, home.Name + " " + zone.Name + " TempHum");
+			SendTempHumSensor(ZoneIndex * 100 + 3, 255, _fCurrentTempC, int(fCurrentHumPct), home.Name + " " + zone.Name + " TempHum");
 		}
 
 		// Manual override of zone setpoint
@@ -353,7 +353,7 @@ bool CTado::GetZoneState(const int HomeIndex, const int ZoneIndex, const _tTadoH
 			_bHeatingOn = _sHeatingPowerPercentage > 0;
 			UpdateSwitch(ZoneIndex * 100 + 6, _bHeatingOn, home.Name + " " + zone.Name + " Heating On");
 
-			SendPercentageSensor(ZoneIndex * 100 + 7, 0, 255, (float)_sHeatingPowerPercentage, home.Name + " " + zone.Name + " Heating Power");
+			SendPercentageSensor(ZoneIndex * 100 + 7, 0, 255, float(_sHeatingPowerPercentage), home.Name + " " + zone.Name + " Heating Power");
 		}
 
 		// Open Window Detected
@@ -428,7 +428,7 @@ void CTado::SendSetPointSensor(const int Idx, const float Temp, const std::strin
 
 	thermos.temp = Temp;
 
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, defaultname.c_str(), 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), defaultname.c_str(), 255, nullptr);
 }
 
 // Creates or updates on/off switches.
@@ -480,7 +480,7 @@ void CTado::UpdateSwitch(const int Idx, const bool bOn, const std::string &defau
 	lcmd.LIGHTING2.level = level;
 	lcmd.LIGHTING2.filler = 0;
 	lcmd.LIGHTING2.rssi = 12;
-	sDecodeRXMessage(this, (const unsigned char *)&lcmd.LIGHTING2, defaultname.c_str(), 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&lcmd.LIGHTING2), defaultname.c_str(), 255, m_Name.c_str());
 }
 
 // Removes any active overlay from a specific zone.
@@ -599,7 +599,8 @@ void CTado::Do_Work()
 			else iTokenCycleCount++;
 
 			// Iterate through the discovered homes and zones. Get some state information.
-			for (int HomeIndex = 0; HomeIndex < (int)m_TadoHomes.size(); HomeIndex++) {
+			for (size_t HomeIndex = 0; HomeIndex < m_TadoHomes.size(); HomeIndex++)
+			{
 
 				if (!GetHomeState(HomeIndex, m_TadoHomes[HomeIndex]))
 				{
@@ -608,7 +609,7 @@ void CTado::Do_Work()
 					continue;
 				}
 
-				for (int ZoneIndex = 0; ZoneIndex < (int)m_TadoHomes[HomeIndex].Zones.size(); ZoneIndex++)
+				for (int ZoneIndex = 0; ZoneIndex < int(m_TadoHomes[HomeIndex].Zones.size()); ZoneIndex++)
 				{
 					if (!GetZoneState(HomeIndex, ZoneIndex, m_TadoHomes[HomeIndex], m_TadoHomes[HomeIndex].Zones[ZoneIndex]))
 					{
@@ -634,9 +635,9 @@ std::vector<std::string> CTado::StringSplitEx(const std::string &inputString, co
 
 	// Else we're building a new vector with all the overflowing elements merged into the last element.
 	std::vector<std::string> cappedArray;
-	for (int i = 0; (unsigned int)i < array.size(); i++)
+	for (size_t i = 0; i < array.size(); i++)
 	{
-		if (i <= maxelements-1)
+		if (int(i) <= maxelements - 1)
 		{
 			cappedArray.push_back(array[i]);
 		}

--- a/hardware/TeleinfoSerial.cpp
+++ b/hardware/TeleinfoSerial.cpp
@@ -134,5 +134,5 @@ void CTeleinfoSerial::readCallback(const char *data, size_t len)
 		_log.Log(LOG_ERROR, "(%s) Receiving is not enabled", m_Name.c_str());
 		return;
 	}
-	ParseTeleinfoData(data, static_cast<int>(len));
+	ParseTeleinfoData(data, int(len));
 }

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -66,14 +66,14 @@ void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *mod
     switch (dataType)
     {
     case TELLSTICK_TEMPERATURE:
-        SendTempSensor(deviceId, 255, static_cast<float>(atof(value)), "Temp");
-        break;
+	    SendTempSensor(deviceId, 255, float(atof(value)), "Temp");
+	    break;
     case TELLSTICK_HUMIDITY:
         SendHumiditySensor(deviceId, 255, atoi(value), "Humidity");
         break;
     case TELLSTICK_RAINRATE:
-        SendRainSensor(deviceId, 255, static_cast<float>(atof(value)), "Rain");
-        break;
+	    SendRainSensor(deviceId, 255, float(atof(value)), "Rain");
+	    break;
     case TELLSTICK_RAINTOTAL:
     case TELLSTICK_WINDDIRECTION:
     case TELLSTICK_WINDAVERAGE:
@@ -97,16 +97,16 @@ void CTellstick::deviceEvent(int deviceId, int method, const char *data)
     {
     case TELLSTICK_TURNON:
         gswitch.cmnd = gswitch_sOn;
-	    sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), nullptr, 255, m_Name.c_str());
 	break;
     case TELLSTICK_TURNOFF:
         gswitch.cmnd = gswitch_sOff;
-	    sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), nullptr, 255, m_Name.c_str());
 	break;
     case TELLSTICK_DIM:
         gswitch.cmnd = gswitch_sSetLevel;
         gswitch.level = atoi(data)*99/255;
-	    sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, 255, m_Name.c_str());
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gswitch), nullptr, 255, m_Name.c_str());
 	break;
     default:
         _log.Log(LOG_NORM, "Unknown event from device %i\n", deviceId);
@@ -157,7 +157,7 @@ void CTellstick::rawDeviceEvent(int controllerId, const char *data)
 	pos = message.find(';', pos + 1);
     }
     if (!deviceId.empty() && !winddirection.empty() && ! windaverage.empty() && ! windgust.empty()) {
-        SendWind(atoi(deviceId.c_str()), 255, atoi(winddirection.c_str()), static_cast<float>(atof(windaverage.c_str())), static_cast<float>(atof(windgust.c_str())), 0, 0, false, false, "Wind");
+	    SendWind(atoi(deviceId.c_str()), 255, atoi(winddirection.c_str()), float(atof(windaverage.c_str())), float(atof(windgust.c_str())), 0, 0, false, false, "Wind");
     }
 }
 

--- a/hardware/Thermosmart.cpp
+++ b/hardware/Thermosmart.cpp
@@ -170,7 +170,7 @@ void CThermosmart::SendSetPointSensor(const unsigned char Idx, const float Temp,
 	thermos.id4=Idx;
 	thermos.dunit=0;
 	thermos.temp=Temp;
-	sDecodeRXMessage(this, (const unsigned char *)&thermos, "Setpoint", 255, nullptr);
+	sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&thermos), "Setpoint", 255, nullptr);
 }
 
 bool CThermosmart::Login()
@@ -368,15 +368,15 @@ void CThermosmart::GetMeterDetails()
 	}
 
 	float temperature;
-	temperature = (float)root["target_temperature"].asFloat();
+	temperature = root["target_temperature"].asFloat();
 	SendSetPointSensor(1, temperature, "target temperature");
 
-	temperature = (float)root["room_temperature"].asFloat();
+	temperature = root["room_temperature"].asFloat();
 	SendTempSensor(2, 255, temperature, "room temperature");
 
 	if (!root["outside_temperature"].empty())
 	{
-		temperature = (float)root["outside_temperature"].asFloat();
+		temperature = root["outside_temperature"].asFloat();
 		SendTempSensor(3, 255, temperature, "outside temperature");
 	}
 	if (!root["source"].empty())

--- a/hardware/ToonThermostat.h
+++ b/hardware/ToonThermostat.h
@@ -53,23 +53,23 @@ class CToonThermostat : public CDomoticzHardwareBase
 	std::string m_ClientIDChecksum;
 	std::shared_ptr<std::thread> m_thread;
 
-	unsigned long m_LastUsage1;
-	unsigned long m_LastUsage2;
-	unsigned long m_OffsetUsage1;
-	unsigned long m_OffsetUsage2;
-	unsigned long m_LastDeliv1;
-	unsigned long m_LastDeliv2;
-	unsigned long m_OffsetDeliv1;
-	unsigned long m_OffsetDeliv2;
+	uint32_t m_LastUsage1;
+	uint32_t m_LastUsage2;
+	uint32_t m_OffsetUsage1;
+	uint32_t m_OffsetUsage2;
+	uint32_t m_LastDeliv1;
+	uint32_t m_LastDeliv2;
+	uint32_t m_OffsetDeliv1;
+	uint32_t m_OffsetDeliv2;
 
 	bool m_bDoLogin;
 	P1Power m_p1power;
 	P1Gas m_p1gas;
 	time_t m_lastSharedSendElectra;
 	time_t m_lastSharedSendGas;
-	unsigned long m_lastgasusage;
-	unsigned long m_lastelectrausage;
-	unsigned long m_lastelectradeliv;
+	uint32_t m_lastgasusage;
+	uint32_t m_lastelectrausage;
+	uint32_t m_lastelectradeliv;
 
 	int m_poll_counter;
 	int m_retry_counter;

--- a/hardware/USBtin.cpp
+++ b/hardware/USBtin.cpp
@@ -237,7 +237,7 @@ void USBtin::readCallback(const char *data, size_t len)
 		_log.Log(LOG_ERROR,"USBtin: Warning Error buffer size reaches/ maybe Can is overrun...");
 		return;
 	}
-	ParseData(data, static_cast<int>(len));
+	ParseData(data, int(len));
 }
 
 void USBtin::ParseData(const char *pData, int Len)
@@ -267,29 +267,29 @@ void USBtin::ParseData(const char *pData, int Len)
 		{
 			m_USBtinBelErrorCount = 0;
 			if( m_USBtinBuffer[0] == USBTIN_HARDWARE_VERSION ){
-				strncpy(value, (char*)&(m_USBtinBuffer[1]), 4);
+				strncpy(value, &(m_USBtinBuffer[1]), 4);
 				_log.Log(LOG_STATUS,"USBtin: Hardware Version: %s", value);
 
 			}
 			else if( m_USBtinBuffer[0] == USBTIN_FIRMWARE_VERSION ){
-				strncpy(value, (char*)&(m_USBtinBuffer[1]), 4);
+				strncpy(value, &(m_USBtinBuffer[1]), 4);
 				_log.Log(LOG_STATUS,"USBtin: Firware Version: %s", value);
 			}
 			else if( m_USBtinBuffer[0] == USBTIN_SERIAL_NUMBER ){
-				strncpy(value, (char*)&(m_USBtinBuffer[1]), 4);
+				strncpy(value, &(m_USBtinBuffer[1]), 4);
 				_log.Log(LOG_STATUS,"USBtin: Serial Number: %s", value);
 			}
 			else if( m_USBtinBuffer[0] == USBTIN_CR ){
 				_log.Log(LOG_STATUS,"USBtin: return OK :-)");
 			}
 			else if( m_USBtinBuffer[0] == USBTIN_EXT_TRAME_RECEIVE ){ // Receive Extended Frame :
-				strncpy(value, (char*)&(m_USBtinBuffer[1]), 8); //take the "Extended ID" CAN parts and paste it in the char table
+				strncpy(value, &(m_USBtinBuffer[1]), 8);	  // take the "Extended ID" CAN parts and paste it in the char table
 				int IDhexNumber;
 				sscanf(value, "%x", &IDhexNumber); //IDhexNumber now contains the the digital value of the Ext ID
 
 				memset(&value[0], 0, sizeof(value));
 
-				strncpy(value, (char*)&(m_USBtinBuffer[9]), 1); //read the DLC (lenght of message)
+				strncpy(value, &(m_USBtinBuffer[9]), 1); // read the DLC (lenght of message)
 				int DLChexNumber;
 				sscanf(value, "%x", &DLChexNumber);
 
@@ -304,7 +304,7 @@ void USBtin::ParseData(const char *pData, int Len)
 					{
 						ValData = 0;
 
-						strncpy(value, (char*)&(m_USBtinBuffer[10+(2*i)]), 2); //to fill the Buffer of 8 bytes
+						strncpy(value, &(m_USBtinBuffer[10 + (2 * i)]), 2); // to fill the Buffer of 8 bytes
 						sscanf(value, "%x", &ValData);
 
 						Buffer_Octets[i]=ValData;
@@ -347,7 +347,7 @@ void USBtin::ParseData(const char *pData, int Len)
 
 bool USBtin::writeFrame(const std::string & data)
 {
-	char length = (uint8_t)data.size();
+	char length = uint8_t(data.size());
 	if (!isOpen()){
 		return false;
 	}

--- a/hardware/VolcraftCO20.cpp
+++ b/hardware/VolcraftCO20.cpp
@@ -149,8 +149,7 @@ static int read_one_sensor (struct usb_device *dev, uint16_t &value)
 	}
 
 	/* Prepare value from first read.  */
-	value = ((unsigned char *)usb_io_buf)[3] << 8
-		| ((unsigned char *)usb_io_buf)[2] << 0;
+	value = (reinterpret_cast<unsigned char *>(usb_io_buf))[3] << 8 | (reinterpret_cast<unsigned char *>(usb_io_buf))[2] << 0;
 
 	/* Dummy read.  */
 	usb_interrupt_read(devh, 0x0081/*endpoint*/,

--- a/hardware/WOL.cpp
+++ b/hardware/WOL.cpp
@@ -76,7 +76,7 @@ bool GenerateWOLPacket(unsigned char *pPacket, const std::string &MACAddress)
 		std::stringstream SS(results[ii]);
 		unsigned int c;
 		SS >> std::hex >> c;
-		mac[ii] = (unsigned char)c;
+		mac[ii] = uint8_t(c);
 	}
 
 	/** first 6 bytes of 255 **/
@@ -99,7 +99,7 @@ bool CWOL::SendWOLPacket(const unsigned char *pPacket)
 
 	// this call is what allows broadcast packets to be sent:
 	int broadcast = 1;
-	if (setsockopt(udpSocket, SOL_SOCKET, SO_BROADCAST, (const char*)&broadcast, sizeof(broadcast)) == -1)
+	if (setsockopt(udpSocket, SOL_SOCKET, SO_BROADCAST, reinterpret_cast<const char *>(&broadcast), sizeof(broadcast)) == -1)
 	{
 		closesocket(udpSocket);
 		return false;
@@ -108,7 +108,7 @@ bool CWOL::SendWOLPacket(const unsigned char *pPacket)
 	udpClient.sin_addr.s_addr = INADDR_ANY;
 	udpClient.sin_port = 0;
 
-	bind(udpSocket, (struct sockaddr*)&udpClient, sizeof(udpClient));
+	bind(udpSocket, reinterpret_cast<struct sockaddr *>(&udpClient), sizeof(udpClient));
 
 	/** make the packet as shown above **/
 
@@ -118,7 +118,7 @@ bool CWOL::SendWOLPacket(const unsigned char *pPacket)
 	udpServer.sin_port = htons(m_wol_port);
 
 	/** send the packet **/
-	sendto(udpSocket, (const char*)pPacket, 102, 0, (struct sockaddr*)&udpServer, sizeof(udpServer));
+	sendto(udpSocket, reinterpret_cast<const char *>(pPacket), 102, 0, reinterpret_cast<struct sockaddr *>(&udpServer), sizeof(udpServer));
 
 	closesocket(udpSocket);
 

--- a/hardware/Winddelen.cpp
+++ b/hardware/Winddelen.cpp
@@ -207,37 +207,37 @@ void CWinddelen::GetMeterDetails()
 			int windDir = 0;
 			std::string szWD = root["windDirection"].asString();
 			if (szWD == "N")
-				windDir = static_cast<int>(std::rint(0 * 22.5F));
+				windDir = int(std::rint(0 * 22.5F));
 			else if ((szWD == "NNE") || (szWD == "NNO"))
-				windDir = static_cast<int>(std::rint(1 * 22.5F));
+				windDir = int(std::rint(1 * 22.5F));
 			else if ((szWD == "NE") || (szWD == "NO"))
-				windDir = static_cast<int>(std::rint(2 * 22.5F));
+				windDir = int(std::rint(2 * 22.5F));
 			else if ((szWD == "ENE") || (szWD == "ONO"))
-				windDir = static_cast<int>(std::rint(3 * 22.5F));
+				windDir = int(std::rint(3 * 22.5F));
 			else if ((szWD == "E") || (szWD == "O"))
-				windDir = static_cast<int>(std::rint(4 * 22.5F));
+				windDir = int(std::rint(4 * 22.5F));
 			else if ((szWD == "ESE") || (szWD == "OZO"))
-				windDir = static_cast<int>(std::rint(5 * 22.5F));
+				windDir = int(std::rint(5 * 22.5F));
 			else if ((szWD == "SE") || (szWD == "ZO"))
-				windDir = static_cast<int>(std::rint(6 * 22.5F));
+				windDir = int(std::rint(6 * 22.5F));
 			else if ((szWD == "SSE") || (szWD == "ZZO"))
-				windDir = static_cast<int>(std::rint(7 * 22.5F));
+				windDir = int(std::rint(7 * 22.5F));
 			else if ((szWD == "S") || (szWD == "Z"))
-				windDir = static_cast<int>(std::rint(8 * 22.5F));
+				windDir = int(std::rint(8 * 22.5F));
 			else if ((szWD == "SSW") || (szWD == "ZZW"))
-				windDir = static_cast<int>(std::rint(9 * 22.5F));
+				windDir = int(std::rint(9 * 22.5F));
 			else if ((szWD == "SW") || (szWD == "ZW"))
-				windDir = static_cast<int>(std::rint(10 * 22.5F));
+				windDir = int(std::rint(10 * 22.5F));
 			else if ((szWD == "WSW") || (szWD == "WZW"))
-				windDir = static_cast<int>(std::rint(11 * 22.5F));
+				windDir = int(std::rint(11 * 22.5F));
 			else if ((szWD == "SSW") || (szWD == "ZZW"))
-				windDir = static_cast<int>(std::rint(12 * 22.5F));
+				windDir = int(std::rint(12 * 22.5F));
 			else if (szWD == "WNW")
-				windDir = static_cast<int>(std::rint(13 * 22.5F));
+				windDir = int(std::rint(13 * 22.5F));
 			else if (szWD == "NW")
-				windDir = static_cast<int>(std::rint(14 * 22.5F));
+				windDir = int(std::rint(14 * 22.5F));
 			else if (szWD == "NNW")
-				windDir = static_cast<int>(std::rint(15 * 22.5F));
+				windDir = int(std::rint(15 * 22.5F));
 
 			SendWind(m_usMillID, 255, windDir, windSpeed, windSpeed, 0, 0, false, false, "Wind");
 		}

--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -254,7 +254,7 @@ void CWunderground::GetMeterDetails()
 	if (!m_bFirstTime)
 	{
 		time_t tlocal = time(nullptr);
-		time_t tobserver = (time_t)root["epoch"].asInt();
+		time_t tobserver = time_t(root["epoch"].asInt());
 		if (difftime(tlocal, tobserver) >= 1800)
 		{
 			//When we don't get any valid data in 30 minutes, we also stop using the values
@@ -292,7 +292,7 @@ void CWunderground::GetMeterDetails()
 	if (barometric!=0)
 	{
 		//Add temp+hum+baro device
-		SendTempHumBaroSensor(1, 255, temp, humidity, static_cast<float>(barometric), barometric_forcast, "THB");
+		SendTempHumBaroSensor(1, 255, temp, humidity, float(barometric), barometric_forcast, "THB");
 	}
 	else if (humidity!=0)
 	{
@@ -322,21 +322,21 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["metric_si"]["windSpeed"] != "N/A") && (root["metric_si"]["windSpeed"] != "--"))
 		{
-			windspeed_ms = static_cast<float>(atof(root["metric_si"]["windSpeed"].asString().c_str()));
+			windspeed_ms = float(atof(root["metric_si"]["windSpeed"].asString().c_str()));
 		}
 	}
 	if (root["metric_si"]["windGust"].empty()==false)
 	{
 		if ((root["metric_si"]["windGust"] != "N/A") && (root["metric_si"]["windGust"] != "--"))
 		{
-			windgust_ms = static_cast<float>(atof(root["metric_si"]["windGust"].asString().c_str()));
+			windgust_ms = float(atof(root["metric_si"]["windGust"].asString().c_str()));
 		}
 	}
 	if (root["metric_si"]["windChill"].empty()==false)
 	{
 		if ((root["metric_si"]["windChill"] != "N/A") && (root["metric_si"]["windChill"] != "--"))
 		{
-			wind_chill = static_cast<float>(atof(root["metric_si"]["windChill"].asString().c_str()));
+			wind_chill = float(atof(root["metric_si"]["windChill"].asString().c_str()));
 		}
 	}
 	if (wind_degrees!=-1)
@@ -353,23 +353,23 @@ void CWunderground::GetMeterDetails()
 
 		float winddir=float(wind_degrees);
 		int aw=round(winddir);
-		tsen.WIND.directionh=(BYTE)(aw/256);
+		tsen.WIND.directionh = BYTE(aw / 256);
 		aw-=(tsen.WIND.directionh*256);
-		tsen.WIND.directionl=(BYTE)(aw);
+		tsen.WIND.directionl = BYTE(aw);
 
 		tsen.WIND.av_speedh=0;
 		tsen.WIND.av_speedl=0;
 		int sw = round(windspeed_ms * 10.0F);
-		tsen.WIND.av_speedh=(BYTE)(sw/256);
+		tsen.WIND.av_speedh = BYTE(sw / 256);
 		sw-=(tsen.WIND.av_speedh*256);
-		tsen.WIND.av_speedl=(BYTE)(sw);
+		tsen.WIND.av_speedl = BYTE(sw);
 
 		tsen.WIND.gusth=0;
 		tsen.WIND.gustl=0;
 		int gw = round(windgust_ms * 10.0F);
-		tsen.WIND.gusth=(BYTE)(gw/256);
+		tsen.WIND.gusth = BYTE(gw / 256);
 		gw-=(tsen.WIND.gusth*256);
-		tsen.WIND.gustl=(BYTE)(gw);
+		tsen.WIND.gustl = BYTE(gw);
 
 		//this is not correct, why no wind temperature? and only chill?
 		tsen.WIND.chillh=0;
@@ -379,17 +379,17 @@ void CWunderground::GetMeterDetails()
 
 		tsen.WIND.tempsign=(wind_temp>=0)?0:1;
 		int at10 = round(std::abs(wind_temp * 10.0F));
-		tsen.WIND.temperatureh=(BYTE)(at10/256);
+		tsen.WIND.temperatureh = BYTE(at10 / 256);
 		at10-=(tsen.WIND.temperatureh*256);
-		tsen.WIND.temperaturel=(BYTE)(at10);
+		tsen.WIND.temperaturel = BYTE(at10);
 
 		tsen.WIND.chillsign=(wind_chill>=0)?0:1;
 		at10 = round(std::abs(wind_chill * 10.0F));
-		tsen.WIND.chillh=(BYTE)(at10/256);
+		tsen.WIND.chillh = BYTE(at10 / 256);
 		at10-=(tsen.WIND.chillh*256);
-		tsen.WIND.chilll=(BYTE)(at10);
+		tsen.WIND.chilll = BYTE(at10);
 
-		sDecodeRXMessage(this, (const unsigned char *)&tsen.WIND, nullptr, 255, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.WIND), nullptr, 255, nullptr);
 	}
 
 	//UV
@@ -397,7 +397,7 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["uv"] != "N/A") && (root["uv"] != "--"))
 		{
-			float UV = static_cast<float>(atof(root["uv"].asString().c_str()));
+			float UV = float(atof(root["uv"].asString().c_str()));
 			if ((UV < 16) && (UV >= 0))
 			{
 				SendUVSensor(0, 1, 255, UV, "UV");
@@ -410,7 +410,7 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["metric_si"]["precipTotal"] != "N/A") && (root["metric_si"]["precipTotal"] != "--"))
 		{
-			float RainCount = static_cast<float>(atof(root["metric_si"]["precipTotal"].asString().c_str()));
+			float RainCount = float(atof(root["metric_si"]["precipTotal"].asString().c_str()));
 			if ((RainCount != -9999.00F) && (RainCount >= 0.00F))
 			{
 				RBUF tsen;
@@ -430,24 +430,24 @@ void CWunderground::GetMeterDetails()
 				{
 					if ((root["metric_si"]["precipRate"] != "N/A") && (root["metric_si"]["precipRate"] != "--"))
 					{
-						float rainrateph = static_cast<float>(atof(root["metric_si"]["precipRate"].asString().c_str()));
+						float rainrateph = float(atof(root["metric_si"]["precipRate"].asString().c_str()));
 						if (rainrateph != -9999.00F)
 						{
 							int at10 = round(std::abs(rainrateph * 100.0F));
-							tsen.RAIN.rainrateh = (BYTE)(at10 / 256);
+							tsen.RAIN.rainrateh = BYTE(at10 / 256);
 							at10 -= (tsen.RAIN.rainrateh * 256);
-							tsen.RAIN.rainratel = (BYTE)(at10);
+							tsen.RAIN.rainratel = BYTE(at10);
 						}
 					}
 				}
 
 				int tr10 = int((float(RainCount) * 10.0F));
 				tsen.RAIN.raintotal1 = 0;
-				tsen.RAIN.raintotal2 = (BYTE)(tr10 / 256);
+				tsen.RAIN.raintotal2 = BYTE(tr10 / 256);
 				tr10 -= (tsen.RAIN.raintotal2 * 256);
-				tsen.RAIN.raintotal3 = (BYTE)(tr10);
+				tsen.RAIN.raintotal3 = BYTE(tr10);
 
-				sDecodeRXMessage(this, (const unsigned char *)&tsen.RAIN, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&tsen.RAIN), nullptr, 255, nullptr);
 			}
 		}
 	}
@@ -457,13 +457,13 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["visibility"] != "N/A") && (root["visibility"] != "--"))
 		{
-			float visibility = static_cast<float>(atof(root["visibility"].asString().c_str()));
+			float visibility = float(atof(root["visibility"].asString().c_str()));
 			if (visibility >= 0)
 			{
 				_tGeneralDevice gdevice;
 				gdevice.subtype = sTypeVisibility;
 				gdevice.floatval1 = visibility;
-				sDecodeRXMessage(this, (const unsigned char *)&gdevice, nullptr, 255, nullptr);
+				sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), nullptr, 255, nullptr);
 			}
 		}
 	}
@@ -471,13 +471,13 @@ void CWunderground::GetMeterDetails()
 	//Solar Radiation
 	if (root["solarRadiation"].empty() == false)
 	{
-		float radiation = static_cast<float>(atof(root["solarRadiation"].asString().c_str()));
+		float radiation = float(atof(root["solarRadiation"].asString().c_str()));
 		if (radiation >= 0.0F)
 		{
 			_tGeneralDevice gdevice;
 			gdevice.subtype = sTypeSolarRadiation;
 			gdevice.floatval1 = radiation;
-			sDecodeRXMessage(this, (const unsigned char *)&gdevice, nullptr, 255, nullptr);
+			sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&gdevice), nullptr, 255, nullptr);
 		}
 	}
 }

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -129,12 +129,12 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 		_log.Log(LOG_STATUS, "YeeLight: Invalid location received! (No IP Address)");
 		return;
 	}
-	uint32_t sID = (uint32_t)(atoi(ipaddress[0].c_str()) << 24) | (uint32_t)(atoi(ipaddress[1].c_str()) << 16) | (atoi(ipaddress[2].c_str()) << 8) | atoi(ipaddress[3].c_str());
+	uint32_t sID = uint32_t(atoi(ipaddress[0].c_str()) << 24) | uint32_t(atoi(ipaddress[1].c_str()) << 16) | (atoi(ipaddress[2].c_str()) << 8) | atoi(ipaddress[3].c_str());
 	char szDeviceID[20];
 	if (sID == 1)
 		sprintf(szDeviceID, "%d", 1);
 	else
-		sprintf(szDeviceID, "%08X", (unsigned int)sID);
+		sprintf(szDeviceID, "%08X", uint32_t(sID));
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT nValue, LastLevel, SubType, ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d)", m_HwdID, szDeviceID, pTypeColorSwitch);
@@ -159,7 +159,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 		ycmd.value = value;
 		ycmd.command = cmd;
 		// TODO: Update color
-		m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&ycmd, nullptr, -1, m_Name.c_str());
+		m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&ycmd), nullptr, -1, m_Name.c_str());
 		m_sql.safe_query("UPDATE DeviceStatus SET Name='%q', SwitchType=%d, LastLevel=%d WHERE(HardwareID == %d) AND (DeviceID == '%q')", lightName.c_str(), (STYPE_Dimmer), value, m_HwdID, szDeviceID);
 	}
 	else {
@@ -169,7 +169,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 		if (sTypeOld != YeeType)
 		{
 			_log.Log(LOG_STATUS, "YeeLight: Updating SubType of light (%s/%s) from %u to %u", Location.c_str(), lightName.c_str(), sTypeOld, YeeType);
-			m_sql.UpdateDeviceValue("SubType", (int)YeeType, sIdx);
+			m_sql.UpdateDeviceValue("SubType", YeeType, sIdx);
 		}
 
 		int nvalue = atoi(result[0][0].c_str());
@@ -192,7 +192,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 			ycmd.value = value;
 			ycmd.command = cmd;
 			// TODO: Update color
-			m_mainworker.PushAndWaitRxMessage(this, (const unsigned char *)&ycmd, nullptr, -1, m_Name.c_str());
+			m_mainworker.PushAndWaitRxMessage(this, reinterpret_cast<const unsigned char *>(&ycmd), nullptr, -1, m_Name.c_str());
 		}
 	}
 }
@@ -211,17 +211,17 @@ bool Yeelight::WriteToHardware(const char *pdata, const unsigned char length)
 	if (pLed->id == 1)
 		sprintf(szTmp, "%d", 1);
 	else
-		sprintf(szTmp, "%08X", (unsigned int)pLed->id);
+		sprintf(szTmp, "%08X", uint32_t(pLed->id));
 	std::string ID = szTmp;
 
 	std::stringstream s_strid;
 	s_strid << std::hex << ID;
 	s_strid >> lID;
 
-	unsigned char ID1 = (unsigned char)((lID & 0xFF000000) >> 24);
-	unsigned char ID2 = (unsigned char)((lID & 0x00FF0000) >> 16);
-	unsigned char ID3 = (unsigned char)((lID & 0x0000FF00) >> 8);
-	unsigned char ID4 = (unsigned char)((lID & 0x000000FF));
+	uint8_t ID1 = uint8_t((lID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((lID & 0x00FF0000) >> 16);
+	uint8_t ID3 = uint8_t((lID & 0x0000FF00) >> 8);
+	uint8_t ID4 = uint8_t((lID & 0x000000FF));
 
 	//IP Address
 	sprintf(szTmp, "%d.%d.%d.%d", ID1, ID2, ID3, ID4);

--- a/hardware/YouLess.cpp
+++ b/hardware/YouLess.cpp
@@ -130,10 +130,10 @@ bool CYouLess::GetP1Details()
 	{
 		int Pwr = root["pwr"].asInt();
 
-		m_p1power.powerusage1 = (unsigned long)(root["p1"].asDouble() * 1000);
-		m_p1power.powerusage2 = (unsigned long)(root["p2"].asDouble() * 1000);
-		m_p1power.powerdeliv1 = (unsigned long)(root["n1"].asDouble() * 1000);
-		m_p1power.powerdeliv2 = (unsigned long)(root["n2"].asDouble() * 1000);
+		m_p1power.powerusage1 = uint32_t(root["p1"].asDouble() * 1000);
+		m_p1power.powerusage2 = uint32_t(root["p2"].asDouble() * 1000);
+		m_p1power.powerdeliv1 = uint32_t(root["n1"].asDouble() * 1000);
+		m_p1power.powerdeliv2 = uint32_t(root["n2"].asDouble() * 1000);
 
 		if (Pwr >= 0)
 		{
@@ -145,9 +145,9 @@ bool CYouLess::GetP1Details()
 			m_p1power.delivcurrent = -Pwr;
 			m_p1power.usagecurrent = 0;
 		}
-		sDecodeRXMessage(this, (const unsigned char *)&m_p1power, "Power", 255, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_p1power), "Power", 255, nullptr);
 
-		m_p1gas.gasusage = (unsigned long)(root["gas"].asDouble() * 1000);
+		m_p1gas.gasusage = uint32_t(root["gas"].asDouble() * 1000);
 		time_t atime = mytime(nullptr);
 		if (
 			(m_p1gas.gasusage != m_lastgasusage) ||
@@ -156,7 +156,7 @@ bool CYouLess::GetP1Details()
 		{
 			m_lastgasusage = m_p1gas.gasusage;
 			m_lastSharedSendGas = atime;
-			sDecodeRXMessage(this, (const unsigned char *)&m_p1gas, "Gas", 255, nullptr);
+			sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_p1gas), "Gas", 255, nullptr);
 		}
 		m_bHaveP1OrS0 = true;
 	}
@@ -222,6 +222,6 @@ void CYouLess::GetMeterDetails()
 	{
 		m_meter.powerusage = lpusage;
 		m_meter.usagecurrent = lpcurrent;
-		sDecodeRXMessage(this, (const unsigned char *)&m_meter, nullptr, 255, nullptr);
+		sDecodeRXMessage(this, reinterpret_cast<const unsigned char *>(&m_meter), nullptr, 255, nullptr);
 	}
 }

--- a/hardware/YouLess.h
+++ b/hardware/YouLess.h
@@ -38,6 +38,6 @@ class CYouLess : public CDomoticzHardwareBase
 	bool m_bHaveP1OrS0;
 	P1Power m_p1power;
 	P1Gas m_p1gas;
-	unsigned long m_lastgasusage;
+	uint32_t m_lastgasusage;
 	time_t m_lastSharedSendGas;
 };

--- a/hardware/ZiBlueSerial.cpp
+++ b/hardware/ZiBlueSerial.cpp
@@ -156,6 +156,6 @@ bool CZiBlueSerial::WriteInt(const uint8_t *pData, const size_t length)
 {
 	if (!isOpen())
 		return false;
-	write((const char*)pData,length);
+	write(reinterpret_cast<const char *>(pData), length);
 	return true;
 }

--- a/hardware/ZiBlueTCP.cpp
+++ b/hardware/ZiBlueTCP.cpp
@@ -76,7 +76,7 @@ void CZiBlueTCP::Do_Work()
 
 void CZiBlueTCP::OnData(const unsigned char *pData, size_t length)
 {
-	ParseData((const char*)pData,length);
+	ParseData(reinterpret_cast<const char *>(pData), length);
 }
 
 void CZiBlueTCP::OnError(const boost::system::error_code& error)

--- a/hardware/cayenne_lpp/CayenneLPP_Dec.cpp
+++ b/hardware/cayenne_lpp/CayenneLPP_Dec.cpp
@@ -229,7 +229,7 @@ bool CayenneLPPDec::ParseLPP(const uint8_t *pBuffer, size_t Len, Json::Value &ro
 			root[iIndex]["channel"] = channel;
 			root[iIndex]["type"] = "gps";
 
-			int32_t tvalue = (int32_t)(pBuffer[2] << 16) | (pBuffer[3] << 8) | pBuffer[4];
+			int32_t tvalue = int32_t(pBuffer[2] << 16) | (pBuffer[3] << 8) | pBuffer[4];
 			if ((pBuffer[2]&0xF0) == 0xF0)
 				tvalue |= 0xFF000000;
 			float value = float(tvalue) / 10000.0F;
@@ -239,7 +239,7 @@ bool CayenneLPPDec::ParseLPP(const uint8_t *pBuffer, size_t Len, Json::Value &ro
 				tvalue |= 0xFF000000;
 			value = float(tvalue) / 10000.0F;
 			root[iIndex]["lon"] = value;
-			tvalue = (int32_t)((pBuffer[8] << 16) | (pBuffer[9] << 8) | pBuffer[10]);
+			tvalue = int32_t((pBuffer[8] << 16) | (pBuffer[9] << 8) | pBuffer[10]);
 			if ((pBuffer[8] & 0xF0) == 0xF0)
 				tvalue |= 0xFF000000;
 			value = float(tvalue) / 100.0F;

--- a/hardware/eHouse/EhouseEvents.cpp
+++ b/hardware/eHouse/EhouseEvents.cpp
@@ -42,7 +42,7 @@ signed int eHouseTCP::GetIndexOfEvent(unsigned char *TempEvent)
 	unsigned int i;
 	for (i = 0; i < EVENT_QUEUE_MAX; i++)
 	{
-		if (memcmp(TempEvent, (struct EventQueueT *) &m_EvQ[i]->LocalEventsToRun, EVENT_SIZE) == 0)
+		if (memcmp(TempEvent, reinterpret_cast<struct EventQueueT *>(&m_EvQ[i]->LocalEventsToRun), EVENT_SIZE) == 0)
 			return i;	//Exist on Event Queue
 	}
 	return -1;
@@ -182,10 +182,9 @@ void eHouseTCP::AddTextEvents(unsigned char *ev, int size)
 	while (offset < size - 1)
 	{
 		int tmp = hex2bin(ev, offset);			// decode Text Hex Coded Event
-		if (tmp >= 0)						// valid hex char
-			evnt[i] = (unsigned char)tmp;	// construct binary
-		else
+		if (tmp < 0)					// valid hex char
 			return;		//ignore if wrong data (non hex digit)
+		evnt[i] = uint8_t(tmp); // construct binary
 		i++;
 		if (i == 10)		//only if valid eHouse text event 10 binary = 20 hex char event
 		{
@@ -212,7 +211,7 @@ signed int eHouseTCP::AddToLocalEvent(unsigned char *Even, unsigned char offset)
 	signed int i;
 	//signed int k;
 	unsigned char Event[EVENT_SIZE + 1];
-	memcpy(Event, (unsigned char *)&Even[offset], EVENT_SIZE); //copy event from selected offset
+	memcpy(Event, &Even[offset], EVENT_SIZE); // copy event from selected offset
 	if (Event[2] == 0)  return 0;
 	if (Event[2] == 0xff)  return 0;
 	i = GetIndexOfEvent(Event);

--- a/hardware/eHouse/EhouseUdpListener.cpp
+++ b/hardware/eHouse/EhouseUdpListener.cpp
@@ -46,7 +46,7 @@ void eHouseTCP::eCMaloc(int eHEIndex, int devaddrh, int devaddrl)
 	if (m_ECMn == nullptr)
 	{
 		LOG(LOG_STATUS, "Allocating CommManager LAN Controller (192.168.%d.%d)", devaddrh, devaddrl);
-		m_ECMn = (struct CommManagerNamesT *) malloc(sizeof(struct CommManagerNamesT));
+		m_ECMn = static_cast<struct CommManagerNamesT *>(malloc(sizeof(struct CommManagerNamesT)));
 		if (m_ECMn == nullptr)
 		{
 			LOG(LOG_ERROR, "CAN'T Allocate ECM Names Memory");
@@ -55,8 +55,8 @@ void eHouseTCP::eCMaloc(int eHEIndex, int devaddrh, int devaddrl)
 		m_ECMn->INITIALIZED = 'a';	//first byte of structure for detection of allocated memory
 		m_ECMn->AddrH = devaddrh;
 		m_ECMn->AddrL = devaddrl;
-		m_ECM = (union CMStatusT *) malloc(sizeof(union CMStatusT));
-		m_ECMPrv = (union CMStatusT *) malloc(sizeof(union CMStatusT));
+		m_ECM = static_cast<union CMStatusT *>(malloc(sizeof(union CMStatusT)));
+		m_ECMPrv = static_cast<union CMStatusT *>(malloc(sizeof(union CMStatusT)));
 		if (m_ECM == nullptr)
 			LOG(LOG_ERROR, "CAN'T Allocate ECM Memory");
 		if (m_ECMPrv == nullptr)
@@ -72,7 +72,7 @@ void eHouseTCP::eHPROaloc(int eHEIndex, int devaddrh, int devaddrl)
 	if (m_eHouseProN == nullptr)
 	{
 		LOG(LOG_STATUS, "Allocating eHouse PRO Controller (192.168.%d.%d)", devaddrh, devaddrl);
-		m_eHouseProN = (struct eHouseProNamesT *) malloc(sizeof(struct eHouseProNamesT)); //Giz: ?? why use mallocs ?
+		m_eHouseProN = static_cast<struct eHouseProNamesT *>(malloc(sizeof(struct eHouseProNamesT))); // Giz: ?? why use mallocs ?
 		if (m_eHouseProN == nullptr)
 		{
 			LOG(LOG_ERROR, "CAN'T Allocate PRO Names Memory");
@@ -81,8 +81,8 @@ void eHouseTCP::eHPROaloc(int eHEIndex, int devaddrh, int devaddrl)
 		m_eHouseProN->INITIALIZED = 'a';	//first byte of structure for detection of allocated memory
 		m_eHouseProN->AddrH[0] = devaddrh;
 		m_eHouseProN->AddrL[0] = devaddrl;
-		m_eHouseProStatus = (union eHouseProStatusUT *)  malloc(sizeof(union eHouseProStatusUT));
-		m_eHouseProStatusPrv = (union eHouseProStatusUT *) malloc(sizeof(union eHouseProStatusUT));
+		m_eHouseProStatus = static_cast<union eHouseProStatusUT *>(malloc(sizeof(union eHouseProStatusUT)));
+		m_eHouseProStatusPrv = static_cast<union eHouseProStatusUT *>(malloc(sizeof(union eHouseProStatusUT)));
 		if (m_eHouseProStatus == nullptr)
 			LOG(LOG_ERROR, "CAN'T Allocate PRO Stat Memory");
 		if (m_eHouseProStatusPrv == nullptr)
@@ -103,7 +103,7 @@ void eHouseTCP::eAURAaloc(int eHEIndex, int devaddrh, int devaddrl)
 		if (m_AuraN[i] == nullptr)
 		{
 			LOG(LOG_STATUS, "Allocating Aura Thermostat (%d.%d)", devaddrh, i + 1);
-			m_AuraN[i] = (struct AuraNamesT *) malloc(sizeof(struct AuraNamesT));
+			m_AuraN[i] = static_cast<struct AuraNamesT *>(malloc(sizeof(struct AuraNamesT)));
 			if (m_AuraN[i] == nullptr)
 			{
 				LOG(LOG_ERROR, "CAN'T Allocate AURA Names Memory");
@@ -112,9 +112,9 @@ void eHouseTCP::eAURAaloc(int eHEIndex, int devaddrh, int devaddrl)
 			m_AuraN[i]->INITIALIZED = 'a';	//first byte of structure for detection of allocated memory
 			m_AuraN[i]->AddrH = devaddrh;
 			m_AuraN[i]->AddrL = i + 1;
-			m_AuraDev[i] = (struct AURAT *) malloc(sizeof(struct AURAT));
-			m_AuraDevPrv[i] = (struct AURAT *) malloc(sizeof(struct AURAT));
-			m_adcs[i] = (struct CtrlADCT *) malloc(sizeof(struct CtrlADCT));
+			m_AuraDev[i] = static_cast<struct AURAT *>(malloc(sizeof(struct AURAT)));
+			m_AuraDevPrv[i] = static_cast<struct AURAT *>(malloc(sizeof(struct AURAT)));
+			m_adcs[i] = static_cast<struct CtrlADCT *>(malloc(sizeof(struct CtrlADCT)));
 			if (m_adcs[i] == nullptr)
 				LOG(LOG_ERROR, "CAN'T Allocate ADCs Memory");
 			if (m_AuraDev[i] == nullptr)
@@ -144,7 +144,7 @@ void eHouseTCP::eHEaloc(int eHEIndex, int devaddrh, int devaddrl)
 		if (m_eHEn[i] == nullptr)
 		{
 			LOG(LOG_STATUS, "Allocating eHouse LAN controller (192.168.%d.%d)", devaddrh, i + m_INITIAL_ADDRESS_LAN);
-			m_eHEn[i] = (struct EtherneteHouseNamesT *) malloc(sizeof(struct EtherneteHouseNamesT));
+			m_eHEn[i] = static_cast<struct EtherneteHouseNamesT *>(malloc(sizeof(struct EtherneteHouseNamesT)));
 			if (m_eHEn[i] == nullptr)
 			{
 				LOG(LOG_ERROR, "CAN'T Allocate LAN Names Memory");
@@ -153,8 +153,8 @@ void eHouseTCP::eHEaloc(int eHEIndex, int devaddrh, int devaddrl)
 			m_eHEn[i]->INITIALIZED = 'a';	//first byte of structure for detection of allocated memory
 			m_eHEn[i]->AddrH = devaddrh;
 			m_eHEn[i]->AddrL = i + m_INITIAL_ADDRESS_LAN;
-			m_eHERMs[i] = (union ERMFullStatT *) malloc(sizeof(union ERMFullStatT));
-			m_eHERMPrev[i] = (union ERMFullStatT *) malloc(sizeof(union ERMFullStatT));
+			m_eHERMs[i] = static_cast<union ERMFullStatT *>(malloc(sizeof(union ERMFullStatT)));
+			m_eHERMPrev[i] = static_cast<union ERMFullStatT *>(malloc(sizeof(union ERMFullStatT)));
 			if (m_eHERMs[i] == nullptr)
 				LOG(LOG_ERROR, "CAN'T Allocate LAN Stat Memory");
 			if (m_eHERMPrev[i] == nullptr)
@@ -180,7 +180,7 @@ void eHouseTCP::eHaloc(int eHEIndex, int devaddrh, int devaddrl)
 		//		if (strlen((char *) &eHn[i]) < 1)
 		if (m_eHn[i] == nullptr)
 		{
-			m_eHn[i] = (struct eHouse1NamesT *) malloc(sizeof(struct eHouse1NamesT));
+			m_eHn[i] = static_cast<struct eHouse1NamesT *>(malloc(sizeof(struct eHouse1NamesT)));
 			if (m_eHn[i] == nullptr)
 			{
 				LOG(LOG_ERROR, "CAN'T Allocate RS-485 Names Memory");
@@ -204,8 +204,8 @@ void eHouseTCP::eHaloc(int eHEIndex, int devaddrh, int devaddrl)
 					m_eHn[i]->AddrL = i;
 				}
 			LOG(LOG_STATUS, "Allocating eHouse RS-485 Controller (%d,%d)", m_eHn[i]->AddrH, m_eHn[i]->AddrL);
-			m_eHRMs[i] = (union ERMFullStatT *) malloc(sizeof(union ERMFullStatT));
-			m_eHRMPrev[i] = (union ERMFullStatT *) malloc(sizeof(union ERMFullStatT));
+			m_eHRMs[i] = static_cast<union ERMFullStatT *>(malloc(sizeof(union ERMFullStatT)));
+			m_eHRMPrev[i] = static_cast<union ERMFullStatT *>(malloc(sizeof(union ERMFullStatT)));
 			if (m_eHRMs[i] == nullptr)
 				LOG(LOG_ERROR, "CANT Allocate RS-485 Stat Memory");
 			if (m_eHRMPrev[i] == nullptr)
@@ -232,7 +232,7 @@ void eHouseTCP::eHWIFIaloc(int eHEIndex, int devaddrh, int devaddrl)
 		if (m_eHWIFIn[i] == nullptr)
 		{
 			LOG(LOG_STATUS, "Allocating eHouse WiFi Controller (192.168.%d.%d)", devaddrh, m_INITIAL_ADDRESS_WIFI + i);
-			m_eHWIFIn[i] = (struct WiFieHouseNamesT *) malloc(sizeof(struct WiFieHouseNamesT));
+			m_eHWIFIn[i] = static_cast<struct WiFieHouseNamesT *>(malloc(sizeof(struct WiFieHouseNamesT)));
 			if (m_eHWIFIn[i] == nullptr)
 			{
 				LOG(LOG_ERROR, "CAN'T Allocate WiFi Names Memory");
@@ -241,9 +241,9 @@ void eHouseTCP::eHWIFIaloc(int eHEIndex, int devaddrh, int devaddrl)
 			m_eHWIFIn[i]->INITIALIZED = 'a';	//first byte of structure for detection of allocated memory
 			m_eHWIFIn[i]->AddrH = devaddrh;
 			m_eHWIFIn[i]->AddrL = devaddrl;
-			m_eHWiFi[i] = (union WiFiStatusT *) malloc(sizeof(union WiFiStatusT));
-			m_eHWIFIs[i] = (union WIFIFullStatT *) malloc(sizeof(union WIFIFullStatT));
-			m_eHWIFIPrev[i] = (union WIFIFullStatT *) malloc(sizeof(union WIFIFullStatT));
+			m_eHWiFi[i] = static_cast<union WiFiStatusT *>(malloc(sizeof(union WiFiStatusT)));
+			m_eHWIFIs[i] = static_cast<union WIFIFullStatT *>(malloc(sizeof(union WIFIFullStatT)));
+			m_eHWIFIPrev[i] = static_cast<union WIFIFullStatT *>(malloc(sizeof(union WIFIFullStatT)));
 			if (m_eHWIFIs[i] == nullptr)
 				LOG(LOG_ERROR, "CAN'T Allocate WiFi Stat Memory");
 			if (m_eHWIFIPrev[i] == nullptr)
@@ -297,31 +297,33 @@ void eHouseTCP::UpdateAuraToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 		return;
 	}
 	size = 4;
-	acurr = (float)(m_AuraDev[index]->TempSet);
-	aprev = (float)(m_AuraDevPrv[index]->TempSet);
+	acurr = float(m_AuraDev[index]->TempSet);
+	aprev = float(m_AuraDevPrv[index]->TempSet);
 	//printf("\r\n!!!!!Aura [%s]  TempSet =%f, Temp=%f\r\n", Auras[index],acurr, AuraDev[index].Temp);
 	if ((acurr != aprev) || (m_AuraDevPrv[index]->Addr == 0))
 	{
-		if (m_CHANGED_DEBUG) _log.Log(LOG_STATUS, "Temp Preset #%d changed to: %d", (int)index, (int)acurr);
+		if (m_CHANGED_DEBUG)
+			_log.Log(LOG_STATUS, "Temp Preset #%d changed to: %d", int(index), int(acurr));
 		sprintf(sval, "%.1f", (m_AuraDev[index]->TempSet));
 		AddrH = 0x81;
 		AddrL = m_AuraDev[index]->Addr;
 		//printf("[AURA] %x,%x\r\n", AddrH, AddrL);
-		UpdateSQLStatus(AddrH, AddrL, EH_AURA, VISUAL_AURA_PRESET, 1, m_AuraDev[index]->RSSI, (int)round(m_AuraDev[index]->TempSet * 10), sval, (int)round(m_AuraDev[index]->volt));
+		UpdateSQLStatus(AddrH, AddrL, EH_AURA, VISUAL_AURA_PRESET, 1, m_AuraDev[index]->RSSI, int(round(m_AuraDev[index]->TempSet * 10)), sval, int(round(m_AuraDev[index]->volt)));
 	}
 
 	//ADCs
 	//for (i = 0; i < size; i++)
 	{
-		acurr = (float)(m_AuraDev[index]->Temp);
-		aprev = (float)(m_AuraDevPrv[index]->Temp);
+		acurr = float(m_AuraDev[index]->Temp);
+		aprev = float(m_AuraDevPrv[index]->Temp);
 		if ((acurr != aprev) || (m_AuraDevPrv[index]->Addr == 0))
 		{
-			sprintf(sval, "%.1f", ((float)acurr));
+			sprintf(sval, "%.1f", (acurr));
 			AddrH = 0x81;
 			AddrL = m_AuraDev[index]->Addr;
-			UpdateSQLStatus(AddrH, AddrL, EH_AURA, VISUAL_AURA_IN, 1, m_AuraDev[index]->RSSI, (int)round(acurr * 10), sval, (int)round(m_AuraDev[index]->volt));
-			if (m_CHANGED_DEBUG) _log.Log(LOG_STATUS, "Temp #%d changed to: %f", (int)index, acurr);
+			UpdateSQLStatus(AddrH, AddrL, EH_AURA, VISUAL_AURA_IN, 1, m_AuraDev[index]->RSSI, int(round(acurr * 10)), sval, int(round(m_AuraDev[index]->volt)));
+			if (m_CHANGED_DEBUG)
+				_log.Log(LOG_STATUS, "Temp #%d changed to: %f", int(index), acurr);
 		}
 	}
 	memcpy(&m_AuraDevPrv[index]->Addr, &m_AuraDev[index]->Addr, sizeof(struct AURAT));
@@ -342,7 +344,9 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 		prev = (m_ECMPrv->CMB.outs[i / 8] >> (i % 8)) & 0x1;
 		if ((curr != prev) || (m_ECMPrv->data[1] == 0))
 		{
-			if (m_CHANGED_DEBUG) if (m_ECMPrv->data[1]) _log.Log(LOG_STATUS, "[CM 192.168.%d.%d] Out #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+			if (m_CHANGED_DEBUG)
+				if (m_ECMPrv->data[1])
+					_log.Log(LOG_STATUS, "[CM 192.168.%d.%d] Out #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 			UpdateSQLStatus(AddrH, AddrL, EH_LAN, 0x21, i, 100, curr, "", 100);
 		}
 	}
@@ -357,7 +361,9 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 			prev = (m_ECMPrv->CMB.inputs[i / 8] >> (i % 8)) & 0x1;
 			if ((curr != prev) || (m_ECMPrv->data[1] == 0))
 			{
-				if (m_CHANGED_DEBUG) if (m_ECMPrv->data[1]) _log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+				if (m_CHANGED_DEBUG)
+					if (m_ECMPrv->data[1])
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_INPUT_IN, i, 100, curr, "", 100);
 			}
 		}
@@ -365,7 +371,8 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 		{
 			curr = m_ECM->CMB.CURRENT_ADC_PROGRAM;
 			if (m_CHANGED_DEBUG)
-				if (m_ECMPrv->data[1]) _log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ADC Program #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+				if (m_ECMPrv->data[1])
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ADC Program #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 		/* if (ECM.CMB.CURRENT_PROFILE!=ECMPrv.CMB.CURRENT_PROFILE)
 			{
@@ -377,7 +384,8 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 		{
 			curr = m_ECM->CMB.CURRENT_PROGRAM;
 			if (m_CHANGED_DEBUG)
-				if (m_ECMPrv->data[1]) _log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Program #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+				if (m_ECMPrv->data[1])
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Program #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 
 		size = 3;
@@ -390,7 +398,8 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 			if ((curr != prev) || (m_ECMPrv->data[1] == 0))
 			{
 				if (m_CHANGED_DEBUG)
-					if (m_ECMPrv->data[1]) _log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Dimmer #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					if (m_ECMPrv->data[1])
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Dimmer #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_DIMMER_OUT, i, 100, (curr * 100) / 255, "", 100);
 			}
 		}
@@ -425,7 +434,7 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 			curr = m_ECM->CMB.CURRENT_ZONE;
 			if (m_CHANGED_DEBUG)
 				if (m_ECMPrv->data[1])
-					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ZONE #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ZONE #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 		size = 48;
 		//Outputs signals
@@ -439,7 +448,7 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_ECMPrv->data[1])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Outs #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Outs #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 			}
 		}
 
@@ -454,7 +463,7 @@ void eHouseTCP::UpdateCMToSQL(unsigned char AddrH, unsigned char AddrL, unsigned
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_ECMPrv->data[1])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				//UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_INPUT_IN, i, 100,curr, "", 100);
 			}
 		}
@@ -527,7 +536,8 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 		if ((curr != prev) || (m_eHERMPrev[index]->data[0] == 0))
 		{
 			if (m_CHANGED_DEBUG)
-				if (m_eHERMPrev[index]->data[0]) _log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Out #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+				if (m_eHERMPrev[index]->data[0])
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Out #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 			UpdateSQLStatus(AddrH, AddrL, EH_LAN, 0x21, i, 100, curr, "", 100);
 		}
 	}
@@ -542,7 +552,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Input #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_INPUT_IN, i, 100, curr, "", 100);
 			}
 		}
@@ -552,7 +562,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			curr = m_eHERMs[index]->eHERM.CURRENT_ADC_PROGRAM;
 			if (m_CHANGED_DEBUG)
 				if (m_eHERMPrev[index]->data[0])
-					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ADC Program #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current ADC Program #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 
 		if (m_eHERMs[index]->eHERM.CURRENT_PROFILE != m_eHERMPrev[index]->eHERM.CURRENT_PROFILE)
@@ -560,7 +570,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			curr = m_eHERMs[index]->eHERM.CURRENT_PROFILE;
 			if (m_CHANGED_DEBUG)
 				if (m_eHERMPrev[index]->data[0])
-					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Profile #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Profile #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 
 		if (m_eHERMs[index]->eHERM.CURRENT_PROGRAM != m_eHERMPrev[index]->eHERM.CURRENT_PROGRAM)
@@ -568,7 +578,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			curr = m_eHERMs[index]->eHERM.CURRENT_PROGRAM;
 			if (m_CHANGED_DEBUG)
 				if (m_eHERMPrev[index]->data[0])
-					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Program #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Current Program #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 
 		size = 3;
@@ -581,7 +591,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Dimmer #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Dimmer #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_DIMMER_OUT, i, 100, (curr * 100) / 255, "", 100);
 			}
 		}
@@ -596,7 +606,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] ADC H Preset #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)acurr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] ADC H Preset #%d changed to: %d", int(AddrH), int(AddrL), int(i), acurr);
 			}
 		}
 		//ADCs L Preset
@@ -608,7 +618,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] ADC Low Preset #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)acurr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] ADC Low Preset #%d changed to: %d", int(AddrH), int(AddrL), int(i), acurr);
 			}
 		}
 		//ADCs
@@ -632,7 +642,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] TEMP Low Preset #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)acurr);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] TEMP Low Preset #%d changed to: %d", int(AddrH), int(AddrL), int(i), acurr);
 			}
 		}
 
@@ -647,8 +657,8 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHERMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Temp H Preset #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)acurr);
-				sprintf(sval, "%.1f", ((float)(m_eHERMs[index]->eHERM.TempH[i] + m_eHERMs[index]->eHERM.TempL[i])) / 20);
+						_log.Log(LOG_STATUS, "[LAN 192.168.%d.%d] Temp H Preset #%d changed to: %d", int(AddrH), int(AddrL), int(i), acurr);
+				sprintf(sval, "%.1f", (float(m_eHERMs[index]->eHERM.TempH[i] + m_eHERMs[index]->eHERM.TempL[i])) / 20);
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_MCP9700_PRESET, i, 100, midpoint, sval, 100);
 			}
 		}
@@ -660,7 +670,7 @@ void eHouseTCP::UpdateLanToSQL(unsigned char AddrH, unsigned char AddrL, unsigne
 			aprev = (m_eHERMPrev[index]->eHERM.Temp[i]);
 			if ((acurr != aprev) || (m_eHERMPrev[index]->data[0] == 0))
 			{
-				sprintf(sval, "%.1f", ((float)acurr) / 10);
+				sprintf(sval, "%.1f", (float(acurr)) / 10);
 				UpdateSQLStatus(AddrH, AddrL, EH_LAN, VISUAL_MCP9700_IN, i, 100, acurr, sval, 100);
 			}
 		}
@@ -685,7 +695,7 @@ void eHouseTCP::UpdatePROToSQL(unsigned char AddrH, unsigned char AddrL)
 		{
 			if (m_CHANGED_DEBUG)
 				if (m_eHouseProStatusPrv->data[0])
-					_log.Log(LOG_STATUS, "[PRO 192.168.%d.%d] OUT #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[PRO 192.168.%d.%d] OUT #%d changed to: %d", int(AddrH), int(AddrL), i, int(curr));
 			UpdateSQLStatus(AddrH, AddrL, EH_PRO, 0x21, i, 100, curr, "", 100);
 		}
 	}
@@ -817,7 +827,9 @@ void eHouseTCP::UpdateWiFiToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 		prev = (m_eHWIFIPrev[index]->eHWIFI.Outs[i / 8] >> (i % 8)) & 0x1;
 		if ((curr != prev) || (m_eHWIFIPrev[index]->data[0] == 0))
 		{
-			if (m_CHANGED_DEBUG) if (m_eHWIFIPrev[index]->data[0]) _log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Out #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+			if (m_CHANGED_DEBUG)
+				if (m_eHWIFIPrev[index]->data[0])
+					_log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Out #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 			UpdateSQLStatus(AddrH, AddrL, EH_WIFI, 0x21, i + 1, 100, curr, "", 100);
 		}
 	}
@@ -832,7 +844,7 @@ void eHouseTCP::UpdateWiFiToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHWIFIPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Input #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Input #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_WIFI, VISUAL_INPUT_IN, i + 1, 100, curr, "", 100);
 			}
 		}
@@ -862,7 +874,7 @@ void eHouseTCP::UpdateWiFiToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHWIFIPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Dimmer #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[WIFI 192.168.%d.%d] Dimmer #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_WIFI, VISUAL_DIMMER_OUT, i + 1, 100, (curr), "", 100);
 			}
 		}
@@ -922,7 +934,7 @@ void eHouseTCP::UpdateWiFiToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 			if ((acurr != aprev) || (m_eHWIFIPrev[index]->data[0] == 0))
 			{
 				//if (eHWIFIPrev[[index].data[0]) printf("[WIFI 192.168.%d.%d] Temp H Preset #%d changed to: %d\r\n", (int) AddrH, (int) AddrL, (int) i, (int)acurr);
-				sprintf(sval, "%.1f", ((float)(m_eHWIFIs[index]->eHWIFI.TempH[i] + m_eHWIFIs[index]->eHWIFI.TempL[i])) / 20);
+				sprintf(sval, "%.1f", (float(m_eHWIFIs[index]->eHWIFI.TempH[i] + m_eHWIFIs[index]->eHWIFI.TempL[i])) / 20);
 				UpdateSQLStatus(AddrH, AddrL, EH_WIFI, VISUAL_MCP9700_PRESET, i + 1, 100, midpoint, sval, 100);
 			}
 		}
@@ -934,7 +946,7 @@ void eHouseTCP::UpdateWiFiToSQL(unsigned char AddrH, unsigned char AddrL, unsign
 			aprev = (m_eHWIFIPrev[index]->eHWIFI.Temp[i]);
 			if ((acurr != aprev) || (m_eHWIFIPrev[index]->data[0] == 0))
 			{
-				sprintf(sval, "%.1f", ((float)acurr) / 10);
+				sprintf(sval, "%.1f", (float(acurr)) / 10);
 				UpdateSQLStatus(AddrH, AddrL, EH_WIFI, VISUAL_MCP9700_IN, i + 1, 100, acurr, sval, 100);
 				//if (eHWIFIPrev[[index].data[0]) printf("[WIFI 192.168.%d.%d] Temp #%d changed to: %d", (int) AddrH, (int) AddrL, (int) i, (int) curr);
 			}
@@ -969,7 +981,9 @@ void eHouseTCP::UpdateRS485ToSQL(unsigned char AddrH, unsigned char AddrL, unsig
 		prev = (m_eHRMPrev[index]->eHERM.Outs[i / 8] >> (i % 8)) & 0x1;
 		if ((curr != prev) || (m_eHRMPrev[index]->data[0] == 0))
 		{
-			if (m_CHANGED_DEBUG) if (m_eHRMPrev[index]->data[0]) printf("[RS485 (%d,%d)] Out #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+			if (m_CHANGED_DEBUG)
+				if (m_eHRMPrev[index]->data[0])
+					printf("[RS485 (%d,%d)] Out #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 			UpdateSQLStatus(AddrH, AddrL, EH_RS485, 0x21, i + 1, 100, curr, "", 100);
 		}
 	}
@@ -987,7 +1001,7 @@ void eHouseTCP::UpdateRS485ToSQL(unsigned char AddrH, unsigned char AddrL, unsig
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHRMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Input #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Input #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_RS485, VISUAL_INPUT_IN, i + 1, 100, curr, "", 100);
 			}
 		}
@@ -996,12 +1010,14 @@ void eHouseTCP::UpdateRS485ToSQL(unsigned char AddrH, unsigned char AddrL, unsig
 			curr = m_eHRMs[index]->eHERM.CURRENT_PROFILE;
 			if (m_CHANGED_DEBUG)
 				if (m_eHRMPrev[index]->data[0])
-					_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Current Profile #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+					_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Current Profile #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 		if (m_eHRMs[index]->eHERM.CURRENT_PROGRAM != m_eHRMPrev[index]->eHERM.CURRENT_PROGRAM)
 		{
 			curr = m_eHRMs[index]->eHERM.CURRENT_PROGRAM;
-			if (m_CHANGED_DEBUG) if (m_eHRMPrev[index]->data[0]) _log.Log(LOG_STATUS, "[RS485 (%d,%d) Current Program #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+			if (m_CHANGED_DEBUG)
+				if (m_eHRMPrev[index]->data[0])
+					_log.Log(LOG_STATUS, "[RS485 (%d,%d) Current Program #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 		}
 
 		size = 3;
@@ -1014,7 +1030,7 @@ void eHouseTCP::UpdateRS485ToSQL(unsigned char AddrH, unsigned char AddrL, unsig
 			{
 				if (m_CHANGED_DEBUG)
 					if (m_eHRMPrev[index]->data[0])
-						_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Dimmer #%d changed to: %d", (int)AddrH, (int)AddrL, (int)i, (int)curr);
+						_log.Log(LOG_STATUS, "[RS485 (%d,%d)] Dimmer #%d changed to: %d", int(AddrH), int(AddrL), int(i), int(curr));
 				UpdateSQLStatus(AddrH, AddrL, EH_RS485, VISUAL_DIMMER_OUT, i + 1, 100, (curr * 100) / 255, "", 100);
 			}
 		}
@@ -1042,15 +1058,15 @@ void eHouseTCP::UpdateRS485ToSQL(unsigned char AddrH, unsigned char AddrL, unsig
 			aprev = (m_eHRMPrev[index]->eHERM.Temp[i]);
 			if ((acurr != aprev) || (m_eHRMPrev[index]->data[0] == 0))
 			{
-				sprintf(sval, "%.1f", ((float)acurr) / 10);
+				sprintf(sval, "%.1f", (float(acurr)) / 10);
 				if (i > 0)
 				{
-					sprintf(sval, "%.1f", ((float)acurr) / 10);
+					sprintf(sval, "%.1f", (float(acurr)) / 10);
 					UpdateSQLStatus(AddrH, AddrL, EH_RS485, VISUAL_LM335_IN, i + 1, 100, acurr, sval, 100);
 				}
 				else
 				{
-					sprintf(sval, "%.1f", ((float)acurr) / 10);
+					sprintf(sval, "%.1f", (float(acurr)) / 10);
 					UpdateSQLStatus(AddrH, AddrL, EH_RS485, VISUAL_INVERTED_PERCENT_IN, i, 100, acurr, sval, 100);
 				}
 				//printf("[LAN 192.168.%d.%d] Temp #%d changed to: %d\r\n", (int) AddrH, (int) AddrL, (int) i, (int) curr);
@@ -1209,14 +1225,14 @@ float eHouseTCP::getAdcVolt2(int index)
 
 
 	//val+=eHERMs[index].eHERM.ADC[3].LSB;
-	float vae = (float)val;
+	float vae = float(val);
 	float temp;
-	m_VccRef = (float)((2500.0 * 1023.0) / vae);
+	m_VccRef = float((2500.0 * 1023.0) / vae);
 	m_VccRef /= 10;
-	temp = (float)(3300.0 / 2500.0);
+	temp = float(3300.0 / 2500.0);
 	temp *= vae;
-	m_AdcRefMax = (int)temp;
-	m_CalcCalibration = (float)(1 / ((val * (3300.0 / 2500.0)) / 1024));
+	m_AdcRefMax = int(temp);
+	m_CalcCalibration = float(1 / ((val * (3300.0 / 2500.0)) / 1024));
 	return m_VccRef;
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -1255,67 +1271,67 @@ void eHouseTCP::CalculateAdc2(unsigned char index)
 			//temp=-273.16+(temp*5000)/(1023*10);
 		adcvalue *= CalibrationV;
 		adcvalue += OffsetV;
-		temmp = (int)round(adcvalue);
+		temmp = int(round(adcvalue));
 		m_eHEn[index]->AdcValue[field] = temmp;
 
 		temp = -273.16 + Offset + ((adcvalue * Vcc) / (10 * 1023)) * Calibration;  //LM335 10mv/1c offset -273.16
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHEn[index]->SensorTempsLM335[field] = temp / 10;
 
 		temp = Offset + ((adcvalue * Vcc) / (10 * 1023)) * Calibration;          //LM35 10mv/1c offset 0
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHEn[index]->SensorTempsLM35[field] = temp / 10;
 
 		temp = -50.0 + Offset + ((adcvalue * Vcc) / (10.0 * 1023.0)) * Calibration;  //mcp9700 10mv/c offset -50
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHEn[index]->SensorTempsMCP9700[field] = temp / 10;
 		temp = (adcvalue * 100) / 1023;
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHEn[index]->SensorPercents[field] = temp / 10;
 		m_eHEn[index]->SensorInvPercents[field] = 100 - (temp / 10);
 		if (field != 9)
 		{
 			temp = -50.0 + Offset + ((adch * Vcc) / (10.0 * 1023.0)) * 1;//Calibration;  //mcp9700 10mv/c offset -50
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHERMs[index]->eHERM.TempH[field] = (int)round(temp);
+			m_eHERMs[index]->eHERM.TempH[field] = int(round(temp));
 
 			temp = -50.0 + Offset + ((adcl*Vcc) / (10.0*1023.0)) * 1;//Calibration;  //mcp9700 10mv/c offset -50
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHERMs[index]->eHERM.TempL[field] = (int)round(temp);
-			m_eHERMs[index]->eHERM.Temp[field] = (int)round(m_eHEn[index]->SensorTempsMCP9700[field] * 10);
+			m_eHERMs[index]->eHERM.TempL[field] = int(round(temp));
+			m_eHERMs[index]->eHERM.Temp[field] = int(round(m_eHEn[index]->SensorTempsMCP9700[field] * 10));
 			m_eHERMs[index]->eHERM.Unit[field] = 'C';
 		}
 		else {
 			temp = (adch * 100) / 1023;
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHERMs[index]->eHERM.TempH[field] = (int)round((1000 - (temp)));
+			m_eHERMs[index]->eHERM.TempH[field] = int(round((1000 - (temp))));
 
 			temp = (adcl * 100) / 1023;
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHERMs[index]->eHERM.TempL[field] = (int)round((1000 - (temp)));
+			m_eHERMs[index]->eHERM.TempL[field] = int(round((1000 - (temp))));
 
-			m_eHERMs[index]->eHERM.Temp[field] = (int)round(m_eHEn[index]->SensorInvPercents[field] * 10);
+			m_eHERMs[index]->eHERM.Temp[field] = int(round(m_eHEn[index]->SensorInvPercents[field] * 10));
 			m_eHERMs[index]->eHERM.Unit[field] = '%';
 		}
 
 
 
 		temp = -20.513 + Offset + ((adcvalue * Vcc) / (19.5 * 1023)) * Calibration;  //mcp9701 19.5mv/c offset -20.513
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHEn[index]->SensorTempsMCP9701[field] = temp / 10;
 
 
 		temp = Calibration * (adcvalue * Vcc) / 1023;
-		temmp = (int)round(temp / 10);
+		temmp = int(round(temp / 10));
 		temp = temmp;
 		m_eHEn[index]->SensorVolts[field] = temp / 100;
 	}
@@ -1364,65 +1380,65 @@ void eHouseTCP::CalculateAdcWiFi(unsigned char index)
 			//temp=-273.16+(temp*5000)/(1023*10);
 		adcvalue *= CalibrationV;
 		adcvalue += OffsetV;
-		temmp = (int)round(adcvalue);
+		temmp = int(round(adcvalue));
 		m_eHWIFIn[index]->AdcValue[field] = temmp;
 
 		temp = -273.16 + Offset + ((adcvalue * Vcc) / (10 * 1023)) * Calibration;  //LM335 10mv/1c offset -273.16
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorTempsLM335[field] = temp / 10;
 
 		temp = Offset + ((adcvalue * Vcc) / (10 * 1023)) * Calibration;          //LM35 10mv/1c offset 0
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorTempsLM35[field] = temp / 10;
 
 		temp = -50.0 + Offset + ((adcvalue * Vcc) / (10.0 * 1023.0)) * Calibration;  //mcp9700 10mv/c offset -50
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorTempsMCP9700[field] = temp / 10;
 		temp = (adcvalue * 100) / 1023;
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorPercents[field] = temp / 10;
 		m_eHWIFIn[index]->SensorInvPercents[field] = 100 - (temp / 10);
 		if (field == 0)
 		{
 			temp = -50.0 + Offset + ((adch * Vcc) / (10.0 * 1023.0)) * 1;//Calibration;  //mcp9700 10mv/c offset -50
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHWIFIs[index]->eHWIFI.TempH[field] = (int)round(temp);
+			m_eHWIFIs[index]->eHWIFI.TempH[field] = int(round(temp));
 
 			temp = -50.0 + Offset + ((adcl * Vcc) / (10.0 * 1023.0)) * 1;//Calibration;  //mcp9700 10mv/c offset -50
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHWIFIs[index]->eHWIFI.TempL[field] = (int)round(temp);
-			m_eHWIFIs[index]->eHWIFI.Temp[field] = (int)round(m_eHWIFIn[index]->SensorTempsMCP9700[field] * 10);
+			m_eHWIFIs[index]->eHWIFI.TempL[field] = int(round(temp));
+			m_eHWIFIs[index]->eHWIFI.Temp[field] = int(round(m_eHWIFIn[index]->SensorTempsMCP9700[field] * 10));
 			m_eHWIFIs[index]->eHWIFI.Unit[field] = 'C';
 		}
 		else {
 			temp = (adch * 100) / 1023;
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHWIFIs[index]->eHWIFI.TempH[field] = (int)round((1000 - (temp)));
+			m_eHWIFIs[index]->eHWIFI.TempH[field] = int(round((1000 - (temp))));
 
 			temp = (adcl * 100) / 1023;
-			temmp = (int)round(temp * 10);
+			temmp = int(round(temp * 10));
 			temp = temmp;
-			m_eHWIFIs[index]->eHWIFI.TempL[field] = (int)round((1000 - (temp)));
+			m_eHWIFIs[index]->eHWIFI.TempL[field] = int(round((1000 - (temp))));
 
-			m_eHWIFIs[index]->eHWIFI.Temp[field] = (int)round(m_eHWIFIn[index]->SensorInvPercents[field] * 10);
+			m_eHWIFIs[index]->eHWIFI.Temp[field] = int(round(m_eHWIFIn[index]->SensorInvPercents[field] * 10));
 			m_eHWIFIs[index]->eHWIFI.Unit[field] = '%';
 		}
 
 
 
 		temp = -20.513 + Offset + ((adcvalue * Vcc) / (19.5 * 1023)) * Calibration;  //mcp9701 19.5mv/c offset -20.513
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorTempsMCP9701[field] = temp / 10;
 		temp = Calibration * (adcvalue * Vcc) / 1023;
-		temmp = (int)round(temp / 10);
+		temmp = int(round(temp / 10));
 		temp = temmp;
 		m_eHWIFIn[index]->SensorVolts[field] = temp / 100;
 	}
@@ -1464,26 +1480,26 @@ void eHouseTCP::CalculateAdcEH1(unsigned char index)
 
 		adcvalue *= CalibrationV;
 		adcvalue += OffsetV;
-		temmp = (int)round(adcvalue);
+		temmp = int(round(adcvalue));
 		m_eHn[index]->AdcValue[field] = temmp;
 
 		temp = Offset + ((adcvalue * Vcc) / (10 * 1023)) - 273.16;  //LM335 10mv/1c offset -273.16
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHn[index]->SensorTempsLM335[field] = temp / 10;
 
 		temp = Offset + ((adcvalue * Vcc) / (10 * 1023)) * Calibration;          //LM35 10mv/1c offset 0
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHn[index]->SensorTempsLM35[field] = temp / 10;
 
 		temp = -50.0 + Offset + ((adcvalue * Vcc) / (10.0 * 1023.0)) * Calibration;  //mcp9700 10mv/c offset -50
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHn[index]->SensorTempsMCP9700[field] = temp / 10;
 
 		temp = (adcvalue * 100) / 1023;
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHn[index]->SensorPercents[field] = temp / 10;
 		m_eHn[index]->SensorInvPercents[field] = 100 - (temp / 10);
@@ -1492,7 +1508,7 @@ void eHouseTCP::CalculateAdcEH1(unsigned char index)
 		{
 			m_eHRMs[index]->eHERM.TempH[field] = 1500;
 			m_eHRMs[index]->eHERM.TempL[field] = 0;
-			m_eHRMs[index]->eHERM.Temp[field] = (int)round(m_eHn[index]->SensorTempsLM335[field] * 10);
+			m_eHRMs[index]->eHERM.Temp[field] = int(round(m_eHn[index]->SensorTempsLM335[field] * 10));
 			m_eHRMs[index]->eHERM.Unit[field] = 'C';
 		}
 		else
@@ -1500,18 +1516,18 @@ void eHouseTCP::CalculateAdcEH1(unsigned char index)
 			m_eHRMs[index]->eHERM.TempH[field] = 1000;//(1000 - (temp));
 			m_eHRMs[index]->eHERM.TempL[field] = 0;//(1000 - (temp));
 
-			m_eHRMs[index]->eHERM.Temp[field] = (int)round(m_eHn[index]->SensorInvPercents[field] * 10);
+			m_eHRMs[index]->eHERM.Temp[field] = int(round(m_eHn[index]->SensorInvPercents[field] * 10));
 			m_eHRMs[index]->eHERM.Unit[field] = '%';
 		}
 
 
 
 		temp = -20.513 + Offset + ((adcvalue * Vcc) / (19.5 * 1023)) * Calibration;  //mcp9701 19.5mv/c offset -20.513
-		temmp = (int)round(temp * 10);
+		temmp = int(round(temp * 10));
 		temp = temmp;
 		m_eHn[index]->SensorTempsMCP9701[field] = temp / 10;
 		temp = Calibration * (adcvalue * Vcc) / 1023;
-		temmp = (int)round(temp / 10);
+		temmp = int(round(temp / 10));
 		temp = temmp;
 		m_eHn[index]->SensorVolts[field] = temp / 100;
 	}
@@ -1534,7 +1550,7 @@ void eHouseTCP::GetStr(unsigned char *GetNamesDta)
 	while ((GetNamesDta[m_GetIndex] != 13) && (m_GetIndex < m_GetSize))
 	{
 		if (strlen(m_GetLine) < sizeof(m_GetLine))
-			strncat(m_GetLine, (char *)&GetNamesDta[m_GetIndex], 1);
+			strncat(m_GetLine, reinterpret_cast<char *>(&GetNamesDta[m_GetIndex]), 1);
 		m_GetIndex++;
 
 	}
@@ -1569,24 +1585,30 @@ void eHouseTCP::GetUDPNamesRS485(unsigned char *data, int nbytes)
 	GetStr(data);			//name
 	i = 1;
 	eHaloc(nr, data[1], data[2]);
-	m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_RS485, (char *)&m_GetLine);//for Automatic RoomPlan generation for RoomManager
-	if (m_PlanID < 0) m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_RS485, (char *)&m_GetLine); //Add RoomPlan for RoomManager (RM)
+	m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_RS485, reinterpret_cast<char *>(&m_GetLine)); // for Automatic RoomPlan generation for RoomManager
+	if (m_PlanID < 0)
+		m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_RS485, reinterpret_cast<char *>(&m_GetLine)); // Add RoomPlan for RoomManager (RM)
 
-	strncpy((char *)&m_eHn[nr]->Name, (char *)&m_GetLine, sizeof(m_eHn[nr]->Name)); //RM Controller Name
-	strncpy((char *)&Name, (char *)&m_GetLine, sizeof(Name));
+	strncpy(reinterpret_cast<char *>(&m_eHn[nr]->Name), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->Name)); // RM Controller Name
+	strncpy(reinterpret_cast<char *>(&Name), reinterpret_cast<char *>(&m_GetLine), sizeof(Name));
 	GetStr(data);   //comment
 
 	for (i = 0; i < sizeof(m_eHn[nr]->ADCs) / sizeof(m_eHn[nr]->ADCs[0]); i++)          //ADC Names (measurement+regulation)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHn[nr]->ADCs[i], (char *)&m_GetLine, sizeof(m_eHn[nr]->ADCs[i]));
+		strncpy(reinterpret_cast<char *>(&m_eHn[nr]->ADCs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->ADCs[i]));
 		if (nr > 0)
 		{
-			if (i > 0) UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_LM335_IN, i + 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-			else UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_INVERTED_PERCENT_IN, i + 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+			if (i > 0)
+				UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_LM335_IN, i + 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+					       m_PlanID);
+			else
+				UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_INVERTED_PERCENT_IN, i + 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true,
+					       100, m_PlanID);
 			//        UpdateSQLState(data[1], data[2], EH_RS485, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_LM335_PRESET, i, 1, 0, "20.5", Name, (char *) &GetLine, true, 100);
 		}
-		else UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_LM335_IN, i + 1, 0, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		else
+			UpdateSQLState(data[1], data[2], EH_RS485, pTypeTEMP, sTypeTEMP5, 0, VISUAL_LM335_IN, i + 1, 0, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	/*    GetStr(data);// #ADC CFG; Not available for eHouse 1
@@ -1600,17 +1622,18 @@ void eHouseTCP::GetUDPNamesRS485(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHn[nr]->Outs) / sizeof(m_eHn[nr]->Outs[0]); i++)      //binary outputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHn[nr]->Outs[i], (char *)&m_GetLine, sizeof(m_eHn[nr]->Outs[i]));
-		UpdateSQLState(data[1], data[2], EH_RS485, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i + 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHn[nr]->Outs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->Outs[i]));
+		UpdateSQLState(data[1], data[2], EH_RS485, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i + 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	GetStr(data);
 	for (i = 0; i < sizeof(m_eHn[nr]->Inputs) / sizeof(m_eHn[nr]->Inputs[0]); i++)  //binary inputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHn[nr]->Inputs[i], (char *)&m_GetLine, sizeof(m_eHn[nr]->Inputs[i]));
-		if (nr != 0) UpdateSQLState(data[1], data[2], EH_RS485, pTypeGeneralSwitch, sSwitchGeneralSwitch,    //not HM
-			STYPE_Contact, VISUAL_INPUT_IN, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHn[nr]->Inputs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->Inputs[i]));
+		if (nr != 0)
+			UpdateSQLState(data[1], data[2], EH_RS485, pTypeGeneralSwitch, sSwitchGeneralSwitch, // not HM
+				       STYPE_Contact, VISUAL_INPUT_IN, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 
@@ -1618,8 +1641,8 @@ void eHouseTCP::GetUDPNamesRS485(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHn[nr]->Dimmers) / sizeof(m_eHn[nr]->Dimmers[0]); i++)    //dimmers names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHn[nr]->Dimmers[i], (char *)&m_GetLine, sizeof(m_eHn[nr]->Dimmers[i]));
-		UpdateSQLState(data[1], data[2], EH_RS485, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHn[nr]->Dimmers[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->Dimmers[i]));
+		UpdateSQLState(data[1], data[2], EH_RS485, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 	UpdateSQLState(data[1], data[2], EH_RS485, pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, VISUAL_DIMMER_RGB, 1, 1, 0, "", Name, "RGB", true, 100, m_PlanID);  //RGB dimmer
 	GetStr(data);	//rollers names
@@ -1627,7 +1650,9 @@ void eHouseTCP::GetUDPNamesRS485(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHn[nr]->Outs) / sizeof(m_eHn[nr]->Outs[0]); i += 2)    //Blinds Names (use twin - single outputs) out #1,#2=> blind #1
 	{
 		GetStr(data);
-		if (nr == STATUS_ARRAYS_SIZE) UpdateSQLState(data[1], data[2], EH_RS485, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		if (nr == STATUS_ARRAYS_SIZE)
+			UpdateSQLState(data[1], data[2], EH_RS485, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true,
+				       100, m_PlanID);
 	}
 
 	int k = 0;
@@ -1636,11 +1661,11 @@ void eHouseTCP::GetUDPNamesRS485(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHn[nr]->Programs) / sizeof(m_eHn[nr]->Programs[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHn[nr]->Programs[i], (char *)&m_GetLine, sizeof(m_eHn[nr]->Programs[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHn[nr]->Programs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHn[nr]->Programs[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 #ifdef UNLIMITED_PGM
 			if (k <= 10) 
 #endif
@@ -1717,20 +1742,21 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	GetStr(data);			//name
 	i = 1;
 	eHEaloc(nr, data[1], data[2]);
-	m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_LAN, (char *)&m_GetLine);//for Automatic RoomPlan generation for RoomManager
-	if (m_PlanID < 0) m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_LAN, (char *)&m_GetLine); //Add RoomPlan for RoomManager (RM)
+	m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_LAN, reinterpret_cast<char *>(&m_GetLine)); // for Automatic RoomPlan generation for RoomManager
+	if (m_PlanID < 0)
+		m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_LAN, reinterpret_cast<char *>(&m_GetLine)); // Add RoomPlan for RoomManager (RM)
 
-
-	strncpy((char *)&m_eHEn[nr]->Name, (char *)&m_GetLine, sizeof(m_eHEn[nr]->Name)); //RM Controller Name
-	strncpy((char *)&Name, (char *)&m_GetLine, sizeof(Name));
+	strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->Name), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->Name)); // RM Controller Name
+	strncpy(reinterpret_cast<char *>(&Name), reinterpret_cast<char *>(&m_GetLine), sizeof(Name));
 	GetStr(data);			//comment
 
 	for (i = 0; i < sizeof(m_eHEn[nr]->ADCs) / sizeof(m_eHEn[nr]->ADCs[0]); i++)          //ADC Names (measurement+regulation)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHEn[nr]->ADCs[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->ADCs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i, 1, 0, "20.5", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->ADCs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->ADCs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i, 1, 0, "20.5", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 	GetStr(data);// #ADC CFG;
@@ -1744,16 +1770,17 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHEn[nr]->Outs) / sizeof(m_eHEn[nr]->Outs[0]); i++)      //binary outputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHEn[nr]->Outs[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->Outs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->Outs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->Outs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	GetStr(data);
 	for (i = 0; i < sizeof(m_eHEn[nr]->Inputs) / sizeof(m_eHEn[nr]->Inputs[0]); i++)  //binary inputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHEn[nr]->Inputs[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->Inputs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->Inputs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->Inputs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 
@@ -1761,8 +1788,8 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHEn[nr]->Dimmers) / sizeof(m_eHEn[nr]->Dimmers[0]); i++)    //dimmers names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHEn[nr]->Dimmers[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->Dimmers[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->Dimmers[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->Dimmers[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 	UpdateSQLState(data[1], data[2], EH_LAN, pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, VISUAL_DIMMER_RGB, 0, 1, 0, "", Name, "RGB", true, 100, m_PlanID);  //RGB dimmer
 	GetStr(data);		//rollers names
@@ -1770,8 +1797,7 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHEn[nr]->Rollers) / sizeof(m_eHEn[nr]->Rollers[0]); i++)    //Blinds Names (use twin - single outputs) out #1,#2=> blind #1
 	{
 		GetStr(data);
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-	
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	int k = 0;
@@ -1780,11 +1806,11 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHEn[nr]->Programs) / sizeof(m_eHEn[nr]->Programs[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHEn[nr]->Programs[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->Programs[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->Programs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->Programs[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 //			if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -1807,11 +1833,11 @@ void eHouseTCP::GetUDPNamesLAN(unsigned char *data, int nbytes)
 	{
 		GetStr(data);
 		//printf("%s\r\n", (char *) &GetLine);
-		strncpy((char *)&m_eHEn[nr]->ADCPrograms[i], (char *)&m_GetLine, sizeof(m_eHEn[nr]->ADCPrograms[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHEn[nr]->ADCPrograms[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHEn[nr]->ADCPrograms[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -1868,19 +1894,21 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	GetStr(data);				//name
 	i = 1;
 	eCMaloc(0, data[1], data[2]);
-	m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_LAN, (char *)&m_GetLine);		//for Automatic RoomPlan generation for RoomManager
-	if (m_PlanID < 0) m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_LAN, (char *)&m_GetLine); //Add RoomPlan for RoomManager (RM)
+	m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_LAN, reinterpret_cast<char *>(&m_GetLine)); // for Automatic RoomPlan generation for RoomManager
+	if (m_PlanID < 0)
+		m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_LAN, reinterpret_cast<char *>(&m_GetLine)); // Add RoomPlan for RoomManager (RM)
 
-	strncpy((char *)&m_ECMn->Name, (char *)&m_GetLine, sizeof(m_ECMn->Name)); //RM Controller Name
-	strncpy((char *)&Name, (char *)&m_GetLine, sizeof(Name));
+	strncpy(reinterpret_cast<char *>(&m_ECMn->Name), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->Name)); // RM Controller Name
+	strncpy(reinterpret_cast<char *>(&Name), reinterpret_cast<char *>(&m_GetLine), sizeof(Name));
 	GetStr(data);   //comment
 
 	for (i = 0; i < sizeof(m_ECMn->ADCs) / sizeof(m_ECMn->ADCs[0]); i++)          //ADC Names (measurement+regulation)
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->ADCs[i], (char *)&m_GetLine, sizeof(m_ECMn->ADCs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i, 1, 0, "20.5", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_ECMn->ADCs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->ADCs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i, 1, 0, "20.5", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 	GetStr(data);		// #ADC CFG;
@@ -1894,16 +1922,17 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_ECMn->Outs) / sizeof(m_ECMn->Outs[0]); i++)      //binary outputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->Outs[i], (char *)&m_GetLine, sizeof(m_ECMn->Outs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_ECMn->Outs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->Outs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	GetStr(data);
 	for (i = 0; i < sizeof(m_ECMn->Inputs) / sizeof(m_ECMn->Inputs[0]); i++)  //binary inputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->Inputs[i], (char *)&m_GetLine, sizeof(m_ECMn->Inputs[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_ECMn->Inputs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->Inputs[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 
@@ -1911,8 +1940,8 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_ECMn->Dimmers) / sizeof(m_ECMn->Dimmers[0]); i++)    //dimmers names
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->Dimmers[i], (char *)&m_GetLine, sizeof(m_ECMn->Dimmers[i]));
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_ECMn->Dimmers[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->Dimmers[i]));
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 	UpdateSQLState(data[1], data[2], EH_LAN, pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, VISUAL_DIMMER_RGB, 0, 1, 0, "", Name, "RGB", true, 100, m_PlanID);  //RGB dimmer
 	GetStr(data);//rolers names
@@ -1920,7 +1949,7 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_ECMn->Rollers) / sizeof(m_ECMn->Rollers[0]); i++)    //Blinds Names (use twin - single outputs) out #1,#2=> blind #1
 	{
 		GetStr(data);
-		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_LAN, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	int k = 0;
@@ -1929,11 +1958,11 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_ECMn->Programs) / sizeof(m_ECMn->Programs[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->Programs[i], (char *)&m_GetLine, sizeof(m_ECMn->Programs[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_ECMn->Programs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->Programs[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -1954,11 +1983,11 @@ void eHouseTCP::GetUDPNamesCM(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_ECMn->ADCPrograms) / sizeof(m_ECMn->ADCPrograms[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_ECMn->ADCPrograms[i], (char *)&m_GetLine, sizeof(m_ECMn->ADCPrograms[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_ECMn->ADCPrograms[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_ECMn->ADCPrograms[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -2014,23 +2043,25 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 	GetStr(data);				//name
 	i = 1;
 	//eHPROaloc(0, data[1], data[2]);
-	m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_PRO, (char *)&m_GetLine);//for Automatic RoomPlan generation for RoomManager
-	if (m_PlanID < 0) m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_PRO, (char *)&m_GetLine); //Add RoomPlan for RoomManager (RM)
+	m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_PRO, reinterpret_cast<char *>(&m_GetLine)); // for Automatic RoomPlan generation for RoomManager
+	if (m_PlanID < 0)
+		m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_PRO, reinterpret_cast<char *>(&m_GetLine)); // Add RoomPlan for RoomManager (RM)
 
-	strncpy((char *)&m_eHouseProN->Name, (char *)&m_GetLine, sizeof(m_eHouseProN->Name));	//RM Controller Name
-	strncpy((char *)&Name, (char *)&m_GetLine, sizeof(Name));
+	strncpy(reinterpret_cast<char *>(&m_eHouseProN->Name), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Name)); // RM Controller Name
+	strncpy(reinterpret_cast<char *>(&Name), reinterpret_cast<char *>(&m_GetLine), sizeof(Name));
 	GetStr(data);		//comment
 
 	for (i = 0; i < sizeof(m_eHouseProN->ADCs) / sizeof(m_eHouseProN->ADCs[0]); i++)          //ADC Names (measurement+regulation)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->ADCs[i], (char *)&m_GetLine, sizeof(m_eHouseProN->ADCs[i]));
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->ADCs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->ADCs[i]));
 		if (i < MAX_AURA_DEVS)
 		{
 			//eAURAaloc(i, 0x81, i + 1);
-			UpdateSQLState(0x81, i + 1, EH_AURA, pTypeTEMP, sTypeTEMP5, 0, VISUAL_AURA_IN, 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-			UpdateSQLState(0x81, i + 1, EH_AURA, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_AURA_PRESET, 1, 1, 0, "20.5", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-			if (strlen((char *)&m_AuraN[i]) > 0)
+			UpdateSQLState(0x81, i + 1, EH_AURA, pTypeTEMP, sTypeTEMP5, 0, VISUAL_AURA_IN, 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
+			UpdateSQLState(0x81, i + 1, EH_AURA, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_AURA_PRESET, 1, 1, 0, "20.5", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+				       m_PlanID);
+			if (strlen(reinterpret_cast<char *>(&m_AuraN[i])) > 0)
 			{
 				m_AuraDevPrv[i]->Addr = 0;
 				m_AuraN[i]->BinaryStatus[0] = 0;
@@ -2044,23 +2075,24 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 		GetStr(data);
 		//eHouseProN.ADCType[i] =GetLine[0]-'0';
 		if (i < MAX_AURA_DEVS)
-			strncpy((char *)&m_eHouseProN->ADCType[i], (char *)&m_GetLine, sizeof(m_eHouseProN->ADCType[i]));//[0]-'0';
+			strncpy(reinterpret_cast<char *>(&m_eHouseProN->ADCType[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->ADCType[i])); //[0]-'0';
 	}
 
 	GetStr(data);// #Outs;
 	for (i = 0; i < sizeof(m_eHouseProN->Outs) / sizeof(m_eHouseProN->Outs[0]); i++)      //binary outputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->Outs[i], (char *)&m_GetLine, sizeof(m_eHouseProN->Outs[i]));
-		UpdateSQLState(data[1], data[2], EH_PRO, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->Outs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Outs[i]));
+		UpdateSQLState(data[1], data[2], EH_PRO, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	GetStr(data);
 	for (i = 0; i < sizeof(m_eHouseProN->Inputs) / sizeof(m_eHouseProN->Inputs[0]); i++)  //binary inputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->Inputs[i], (char *)&m_GetLine, sizeof(m_eHouseProN->Inputs[i]));
-		UpdateSQLState(data[1], data[2], EH_PRO, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->Inputs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Inputs[i]));
+		UpdateSQLState(data[1], data[2], EH_PRO, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 
@@ -2068,7 +2100,7 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHouseProN->Dimmers) / sizeof(m_eHouseProN->Dimmers[0]); i++)    //dimmers names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->Dimmers[i], (char *)&m_GetLine, sizeof(m_eHouseProN->Dimmers[i]));
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->Dimmers[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Dimmers[i]));
 		//    UpdateSQLState(data[1], data[2], EH_PRO, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i, 1, 0, "", Name, (char *) &GetLine, true, 100);
 	}
 	//UpdateSQLState(data[1], data[2], EH_LAN, pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, VISUAL_DIMMER_RGB, 0, 1, 0, "", Name, "RGB", true, 100);  //RGB dimmer
@@ -2077,7 +2109,7 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHouseProN->Rollers) / sizeof(m_eHouseProN->Rollers[0]); i++)    //Blinds Names (use twin - single outputs) out #1,#2=> blind #1
 	{
 		GetStr(data);
-		UpdateSQLState(data[1], data[2], EH_PRO, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_PRO, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	int k = 0;
@@ -2086,11 +2118,11 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHouseProN->Programs) / sizeof(m_eHouseProN->Programs[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->Programs[i], (char *)&m_GetLine, sizeof(m_eHouseProN->Programs[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->Programs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Programs[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -2116,11 +2148,11 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHouseProN->ADCPrograms) / sizeof(m_eHouseProN->ADCPrograms[0]); i++)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->ADCPrograms[i], (char *)&m_GetLine, sizeof(m_eHouseProN->ADCPrograms[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->ADCPrograms[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->ADCPrograms[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -2148,11 +2180,11 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 		//strcat(Name,"\r\n");
 		//if (i > 9) break;
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->SecuPrograms[i], (char *)&m_GetLine, sizeof(m_eHouseProN->SecuPrograms[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->SecuPrograms[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->SecuPrograms[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -2180,11 +2212,11 @@ void eHouseTCP::GetUDPNamesPRO(unsigned char *data, int nbytes)
 		//strcat(Name,"\r\n");
 		//if (i > 9) break;
 		GetStr(data);
-		strncpy((char *)&m_eHouseProN->Zones[i], (char *)&m_GetLine, sizeof(m_eHouseProN->Zones[i]));
-		if ((strlen((char *)&m_GetLine) > 1) && (strstr((char *)&m_GetLine, "@") == nullptr))
+		strncpy(reinterpret_cast<char *>(&m_eHouseProN->Zones[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHouseProN->Zones[i]));
+		if ((strlen(reinterpret_cast<char *>(&m_GetLine)) > 1) && (strstr(reinterpret_cast<char *>(&m_GetLine), "@") == nullptr))
 		{
 			k++;
-			sprintf(tmp, "%s (%d)|", (char *)&m_GetLine, i + 1);
+			sprintf(tmp, "%s (%d)|", reinterpret_cast<char *>(&m_GetLine), i + 1);
 			//if (k <= 10) strncat(PGMs, tmp, strlen(tmp));
 #ifdef UNLIMITED_PGM
 			if (k <= 10)
@@ -2232,19 +2264,21 @@ void eHouseTCP::GetUDPNamesWiFi(unsigned char *data, int nbytes)
 	GetStr(data);				//name
 	i = 1;
 	eHWIFIaloc(nr, data[1], data[2]);
-	m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_WIFI, (char *)&m_GetLine);					//for Automatic RoomPlan generation for RoomManager
-	if (m_PlanID < 0) m_PlanID = UpdateSQLPlan((int)data[1], (int)data[2], EH_WIFI, (char *)&m_GetLine);	//Add RoomPlan for RoomManager (RM)
+	m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_WIFI, reinterpret_cast<char *>(&m_GetLine)); // for Automatic RoomPlan generation for RoomManager
+	if (m_PlanID < 0)
+		m_PlanID = UpdateSQLPlan(int(data[1]), int(data[2]), EH_WIFI, reinterpret_cast<char *>(&m_GetLine)); // Add RoomPlan for RoomManager (RM)
 
-	strncpy((char *)&m_eHWIFIn[nr]->Name, (char *)&m_GetLine, sizeof(m_eHWIFIn[nr]->Name));				//RM Controller Name
-	strncpy((char *)&Name, (char *)&m_GetLine, sizeof(Name));
+	strncpy(reinterpret_cast<char *>(&m_eHWIFIn[nr]->Name), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHWIFIn[nr]->Name)); // RM Controller Name
+	strncpy(reinterpret_cast<char *>(&Name), reinterpret_cast<char *>(&m_GetLine), sizeof(Name));
 	GetStr(data);   //comment
 
 	for (i = 0; i < sizeof(m_eHWIFIn[nr]->ADCs) / sizeof(m_eHWIFIn[nr]->ADCs[0]); i++)          //ADC Names (measurement+regulation)
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHWIFIn[nr]->ADCs[i], (char *)&m_GetLine, sizeof(m_eHWIFIn[nr]->ADCs[i]));
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i + 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i + 1, 1, 0, "20.5", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHWIFIn[nr]->ADCs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHWIFIn[nr]->ADCs[i]));
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeTEMP, sTypeTEMP5, 0, VISUAL_MCP9700_IN, i + 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeThermostat, sTypeThermSetpoint, 0, VISUAL_MCP9700_PRESET, i + 1, 1, 0, "20.5", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 	GetStr(data);		// #ADC CFG;
@@ -2258,16 +2292,17 @@ void eHouseTCP::GetUDPNamesWiFi(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHWIFIn[nr]->Outs) / sizeof(m_eHWIFIn[nr]->Outs[0]); i++)			//binary outputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHWIFIn[nr]->Outs[i], (char *)&m_GetLine, sizeof(m_eHWIFIn[nr]->Outs[i]));
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i + 1, 1, 0, "0", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHWIFIn[nr]->Outs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHWIFIn[nr]->Outs[i]));
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeGeneralSwitch, sSwitchTypeAC, STYPE_OnOff, 0x21, i + 1, 1, 0, "0", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 
 	GetStr(data);
 	for (i = 0; i < sizeof(m_eHWIFIn[nr]->Inputs) / sizeof(m_eHWIFIn[nr]->Inputs[0]); i++)  //binary inputs names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHWIFIn[nr]->Inputs[i], (char *)&m_GetLine, sizeof(m_eHWIFIn[nr]->Inputs[i]));
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHWIFIn[nr]->Inputs[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHWIFIn[nr]->Inputs[i]));
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeGeneralSwitch, sSwitchGeneralSwitch, STYPE_Contact, VISUAL_INPUT_IN, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true,
+			       100, m_PlanID);
 	}
 
 
@@ -2275,8 +2310,8 @@ void eHouseTCP::GetUDPNamesWiFi(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHWIFIn[nr]->Dimmers) / sizeof(m_eHWIFIn[nr]->Dimmers[0]); i++)    //dimmers names
 	{
 		GetStr(data);
-		strncpy((char *)&m_eHWIFIn[nr]->Dimmers[i], (char *)&m_GetLine, sizeof(m_eHWIFIn[nr]->Dimmers[i]));
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		strncpy(reinterpret_cast<char *>(&m_eHWIFIn[nr]->Dimmers[i]), reinterpret_cast<char *>(&m_GetLine), sizeof(m_eHWIFIn[nr]->Dimmers[i]));
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeLighting2, sTypeAC, STYPE_Dimmer, VISUAL_DIMMER_OUT, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100, m_PlanID);
 	}
 	UpdateSQLState(data[1], data[2], EH_WIFI, pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, VISUAL_DIMMER_RGB, 1, 1, 0, "", Name, "RGB", true, 100, m_PlanID);  //RGB dimmer
 	GetStr(data);//rollers names
@@ -2284,7 +2319,8 @@ void eHouseTCP::GetUDPNamesWiFi(unsigned char *data, int nbytes)
 	for (i = 0; i < sizeof(m_eHWIFIn[nr]->Rollers) / sizeof(m_eHWIFIn[nr]->Rollers[0]); i++)    //Blinds Names (use twin - single outputs) out #1,#2=> blind #1
 	{
 		GetStr(data);
-		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i + 1, 1, 0, "", Name, (char *)&m_GetLine, true, 100, m_PlanID);
+		UpdateSQLState(data[1], data[2], EH_WIFI, pTypeLighting2, sTypeAC, STYPE_BlindsPercentage, VISUAL_BLINDS, i + 1, 1, 0, "", Name, reinterpret_cast<char *>(&m_GetLine), true, 100,
+			       m_PlanID);
 	}
 
 	int k = 0;
@@ -2462,8 +2498,10 @@ void eHouseTCP::Do_Work()
 		saddr.sin_port = htons(m_UDP_PORT);
 		m_eHouseUDPSocket = socket(AF_INET, SOCK_DGRAM, 0);	//socket creation
 
-		opt = 1; setsockopt(m_eHouseUDPSocket, SOL_SOCKET, SO_REUSEADDR, (char *)&opt, sizeof(opt));
-		opt = 1; setsockopt(m_eHouseUDPSocket, SOL_SOCKET, SO_KEEPALIVE, (char *)&opt, sizeof(opt));
+		opt = 1;
+		setsockopt(m_eHouseUDPSocket, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<char *>(&opt), sizeof(opt));
+		opt = 1;
+		setsockopt(m_eHouseUDPSocket, SOL_SOCKET, SO_KEEPALIVE, reinterpret_cast<char *>(&opt), sizeof(opt));
 
 		//opt = 0;	setsockopt(eHouseUDPSocket, SOL_SOCKET, SO_LINGER, &opt, sizeof(int));
 #ifndef WIN32
@@ -2482,7 +2520,7 @@ void eHouseTCP::Do_Work()
 
 #endif
 
-		ressock = bind(m_eHouseUDPSocket, (struct sockaddr *) &saddr, sizeof(saddr));  //bind socket
+		ressock = bind(m_eHouseUDPSocket, reinterpret_cast<struct sockaddr *>(&saddr), sizeof(saddr)); // bind socket
 	}
 	int SecIter = 0;
 	unsigned char ou = 0;
@@ -2537,19 +2575,19 @@ void eHouseTCP::Do_Work()
 		size = sizeof(caddr);
 		memset(udp_status, 0, sizeof(udp_status));
 		if (!m_ViaTCP)
-			nbytes = recvfrom(m_eHouseUDPSocket, (char *)&udp_status, MAXMSG, 0, (struct sockaddr *) & caddr, &size);	//Standard UDP Operation (LAN)
+			nbytes = recvfrom(m_eHouseUDPSocket, reinterpret_cast<char *>(&udp_status), MAXMSG, 0, reinterpret_cast<struct sockaddr *>(&caddr), &size); // Standard UDP Operation (LAN)
 		else
 		{
 			if (m_NoDetectTCPPack != 0)
 			{
-				nbytes = recv(m_TCPSocket, (char *)&udp_status, MAXMSG, 0);				//TCP Operation Based on Timeout - may loose combined statuses
+				nbytes = recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status), MAXMSG, 0); // TCP Operation Based on Timeout - may loose combined statuses
 				if (eH1(udp_status[1], udp_status[2]))
 					eh1 = 1;
 			}
 			else	//recover multiple packets for Slow links (eg. Internet)
 			{
 				int len = 0;
-				nbytes = recv(m_TCPSocket, (char *)&udp_status, 4, 0);
+				nbytes = recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status), 4, 0);
 				/*				if (udp_status[2] == 202)
 									{
 									len ++;
@@ -2566,7 +2604,7 @@ void eHouseTCP::Do_Work()
 					if (nbytes > 0)
 					{
 						LOG(LOG_STATUS, "Problem receive data<3");
-						recv(m_TCPSocket, (char *)&udp_status, MAXMSG, 0);
+						recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status), MAXMSG, 0);
 						continue;
 					}
 					else
@@ -2597,7 +2635,7 @@ void eHouseTCP::Do_Work()
 				if ((udp_status[0] == 0) || (udp_status[2] == 0) || (nbytes == 0))
 				{
 					LOG(LOG_STATUS, "[eHouse TCP] Data Is Zero");
-					recv(m_TCPSocket, (char *)&udp_status, MAXMSG, 0);
+					recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status), MAXMSG, 0);
 					continue;
 				}
 				if (eH1(udp_status[1], udp_status[2]))					///Check if via eHouse PRO Gateway (eHouse RS-485, CAN, RF, Thermostat, etc)
@@ -2608,12 +2646,12 @@ void eHouseTCP::Do_Work()
 				}
 				if ((udp_status[0] < 255) && (udp_status[4] != 'n'))	//not eHouse PRO
 				{
-					nbytes += recv(m_TCPSocket, (char *)&udp_status[4], len, 0);
+					nbytes += recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status[4]), len, 0);
 				}
 				else
 				{									//eHouse PRO
 					if (m_ProSize == 0) m_ProSize = MAXMSG;
-					nbytes += recv(m_TCPSocket, (char *)&udp_status[4], m_ProSize, 0);
+					nbytes += recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status[4]), m_ProSize, 0);
 				}
 			}
 		}
@@ -2649,7 +2687,7 @@ void eHouseTCP::Do_Work()
 		}
 		else
 		{
-			m_ipaddrh = (unsigned char)(((caddr.sin_addr.s_addr & 0x00ff0000) >> 16) & 0xff);
+			m_ipaddrh = uint8_t(((caddr.sin_addr.s_addr & 0x00ff0000) >> 16) & 0xff);
 			m_ipaddrl = (caddr.sin_addr.s_addr >> 24) & 0xff;
 		}
 
@@ -2678,7 +2716,7 @@ void eHouseTCP::Do_Work()
 			else
 			{   //eHouse PRO  status
 				sum = 0;
-				sum2 = ((unsigned int)udp_status[nbytes - 2]) << 8;   //get sent checksum
+				sum2 = uint32_t(udp_status[nbytes - 2]) << 8; // get sent checksum
 				sum2 += udp_status[nbytes - 1];
 				unsigned int iii;
 				for (iii = 0; iii < nbytes - 2U; iii++) // calculate local checksum
@@ -2723,12 +2761,12 @@ void eHouseTCP::Do_Work()
 		//received status
 		{										//size more than 0
 			sum = 0;
-			sum2 = ((unsigned int)udp_status[nbytes - 2]);
+			sum2 = uint32_t(udp_status[nbytes - 2]);
 			sum2 = sum2 << 8;							//get sent checksum
 			sum2 += udp_status[nbytes - 1];
 			for (i = 0; i < nbytes - 2; i++)               //calculate local checksum
 			{
-				sum += (unsigned int)udp_status[i];
+				sum += uint32_t(udp_status[i]);
 			}
 			devaddrh = udp_status[1];
 			devaddrl = udp_status[2];
@@ -2756,13 +2794,13 @@ void eHouseTCP::Do_Work()
 					//if    (udp_status[3] == 'l')
 					if (nbytes > 6)
 					{
-						strncpy((char *)&log, (char *)&udp_status[4], nbytes - 6);
+						strncpy(reinterpret_cast<char *>(&log), reinterpret_cast<char *>(&udp_status[4]), nbytes - 6);
 						LOG(LOG_STATUS, "[%s Log] (%-3d,%-3d) - %s", LogPrefix, devaddrh, devaddrl, log);
 						if (m_IRPerform)
 						{
-							if (strstr((char *)&log, "[IR]"))
+							if (strstr(reinterpret_cast<char *>(&log), "[IR]"))
 							{
-								sprintf((char *)&dir, "%02x_%02x", devaddrh, devaddrl);
+								sprintf(reinterpret_cast<char *>(&dir), "%02x_%02x", devaddrh, devaddrl);
 								/*                                                mf("IR", dir,"captured", &log[6], 0);
 																				mf("IR", dir,"events", &log[6], 1);*/
 							}
@@ -2957,7 +2995,8 @@ void eHouseTCP::Do_Work()
 									m_AuraDev[aindex]->ID |= m_AuraN[aindex]->BinaryStatus[i++];
 									m_AuraDev[aindex]->ID = m_AuraDev[aindex]->ID << 8;
 									m_AuraDev[aindex]->ID |= m_AuraN[aindex]->BinaryStatus[i++];
-									if (m_DEBUG_AURA) LOG(LOG_STATUS, "[Aura UDP %d] ID: %lx\t", aindex + 1, (long int)m_AuraDev[aindex]->ID);
+									if (m_DEBUG_AURA)
+										LOG(LOG_STATUS, "[Aura UDP %d] ID: %lx\t", aindex + 1, long(m_AuraDev[aindex]->ID));
 									m_AuraDev[aindex]->DType = m_AuraN[aindex]->BinaryStatus[i++];            //device type
 									if (m_DEBUG_AURA) LOG(LOG_STATUS, " DevType: %d\t", m_AuraDev[index]->DType);
 									i++;//params count
@@ -3011,7 +3050,7 @@ void eHouseTCP::Do_Work()
 												}
 												//for (i = 0; i<AuraDev[auraindex].ParamsCount; i++)
 												{
-													m_AuraN[aindex]->ParamPreset[0] = (unsigned int)(m_AuraDev[aindex]->TempSet * 10);
+													m_AuraN[aindex]->ParamPreset[0] = uint32_t(m_AuraDev[aindex]->TempSet * 10);
 
 													//eHPROaloc(0, SrvAddrH, SrvAddrL);
 
@@ -3131,7 +3170,8 @@ void eHouseTCP::Do_Work()
 									time += m_AuraN[aindex]->BinaryStatus[i++];
 									m_AuraDev[aindex]->ServerTempSet = time;
 									m_AuraDev[aindex]->ServerTempSet /= 10;
-									if (m_DEBUG_AURA) LOG(LOG_STATUS, "FlagsB: %lx\t", (long unsigned int) m_adcs[aindex]->flagsb);
+									if (m_DEBUG_AURA)
+										LOG(LOG_STATUS, "FlagsB: %lx\t", m_adcs[aindex]->flagsb);
 									m_AuraDev[aindex]->LQI = m_AuraN[aindex]->BinaryStatus[i++];
 									if (m_DEBUG_AURA) LOG(LOG_STATUS, "LQI: %d\t", m_AuraDev[aindex]->LQI);
 									m_AuraN[aindex]->BinaryStatusLength = m_AuraN[aindex]->BinaryStatus[0];//nbytes;
@@ -3149,7 +3189,7 @@ void eHouseTCP::Do_Work()
 				LOG(LOG_STATUS, "[%s] St:  (%03d,%03d) Invalid Check Sum {%d!=%d} (%dB)", LogPrefix, devaddrh, devaddrl, sum, sum2, nbytes);
 				if (m_ViaTCP)
 				{
-					nbytes = recv(m_TCPSocket, (char *)&udp_status, MAXMSG, 0);
+					nbytes = recv(m_TCPSocket, reinterpret_cast<char *>(&udp_status), MAXMSG, 0);
 					continue;
 				}
 				//if (ViaTCP) LOG(LOG_STATUS, "[TCP n=%d] #%d (%d,%d) Data=%c", nbytes, udp_status[0], udp_status[1], udp_status[2], udp_status[4]);
@@ -3209,7 +3249,7 @@ void eHouseTCP::Do_Work()
 	}
 	else
 		ressock = shutdown(m_eHouseUDPSocket, SHUT_RDWR);
-	LOG(LOG_STATUS, "[%s] Shut %d/ERROR CODE: %d", LogPrefix, (unsigned int)ressock, errno);
+	LOG(LOG_STATUS, "[%s] Shut %d/ERROR CODE: %d", LogPrefix, uint32_t(ressock), errno);
 	switch (errno)
 	{
 	case EBADF:

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -251,7 +251,7 @@ void CMercApi::GetChargeData(Json::Value& jsondata, CVehicleApi::tChargeData& da
 					if(!iter2["value"].empty())
 					{
 						_log.Debug(DEBUG_NORM, "MercApi: SoC has value %s", iter2["value"].asString().c_str());
-						data.battery_level = static_cast<float>(atof(iter2["value"].asString().c_str()));
+						data.battery_level = float(atof(iter2["value"].asString().c_str()));
 					}
 				}
 				if (id == "rangeelectric")
@@ -373,7 +373,7 @@ bool CMercApi::GetCustomData(tCustomData& data)
 
 		if(m_fieldcnt < 0)
 		{
-			m_fieldcnt = static_cast<int16_t>(strarray.size());
+			m_fieldcnt = int16_t(strarray.size());
 			_log.Debug(DEBUG_NORM, "MercApi: Reset Customfield count to %d", m_fieldcnt);
 		}
 		else
@@ -455,7 +455,7 @@ void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
 					if(!iter2["value"].empty())
 					{
 						_log.Debug(DEBUG_NORM, "MercApi: Odo has value %s", iter2["value"].asString().c_str());
-						data.odo = static_cast<float>(atof(iter2["value"].asString().c_str()));
+						data.odo = float(atof(iter2["value"].asString().c_str()));
 					}
 				}
 			}
@@ -588,7 +588,7 @@ bool CMercApi::ProcessAvailableResources(Json::Value& jsondata)
 
 			m_fields = ss.str();
 			StringSplit(m_fields, ",", strarray);
-			m_fieldcnt = static_cast<int16_t>(strarray.size());
+			m_fieldcnt = int16_t(strarray.size());
 
 			_log.Log(LOG_STATUS, "Found %d resource fields: %s", m_fieldcnt, m_fields.c_str());
 
@@ -941,9 +941,9 @@ uint16_t CMercApi::ExtractHTTPResultCode(const std::string& sResponseHeaderLine0
 		{
 			if (sResponseHeaderLine0.find_first_of(' ') != std::string::npos)
 			{
-				iHttpCodeStartPos = (uint8_t)sResponseHeaderLine0.find_first_of(' ') + 1;	// So look for a SPACE as the seperator (RFC2616)
+				iHttpCodeStartPos = uint8_t(sResponseHeaderLine0.find_first_of(' ')) + 1; // So look for a SPACE as the seperator (RFC2616)
 
-				iHttpCode = (uint16_t)std::stoi(sResponseHeaderLine0.substr(iHttpCodeStartPos, 3));
+				iHttpCode = uint16_t(std::stoi(sResponseHeaderLine0.substr(iHttpCodeStartPos, 3)));
 				if (iHttpCode < 100 || iHttpCode > 599)		// Check valid resultcode range
 				{
 					_log.Log(LOG_STATUS, "Found non-standard resultcode (%d) in HTTP response statusline: %s", iHttpCode, sResponseHeaderLine0.c_str());

--- a/hardware/eVehicles/TeslaApi.cpp
+++ b/hardware/eVehicles/TeslaApi.cpp
@@ -226,7 +226,7 @@ void CTeslaApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
 {
 	data.odo = (jsondata["odometer"].asFloat());
 	if (!m_config.unit_miles)
-		data.odo = data.odo * (float)1.60934;
+		data.odo = data.odo * float(1.60934);
 
 	if (jsondata["df"].asBool() ||
 		jsondata["pf"].asBool() ||

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -197,7 +197,7 @@ void CeVehicle::SendPercentage(int percType, float value)
 {
 	if ((percType == VEHICLE_LEVEL_BATTERY) && m_api->m_capabilities.has_battery_level)
 	{
-		int iBattLevel = static_cast<int>(value);
+		int iBattLevel = int(value);
 		float fBattLevel = value;
 		if (fBattLevel < 0.0F || fBattLevel > 100.0F)	// Filter out wrong readings
 		{
@@ -886,7 +886,7 @@ void CeVehicle::UpdateCustomVehicleData(CVehicleApi::tCustomData& data)
 
 						if (is_number(sValue))
 						{
-							float fValue = static_cast<float>(std::atof(sValue.c_str()));
+							float fValue = float(std::atof(sValue.c_str()));
 							SendCustom(VEHICLE_CUSTOM, iChildID, fValue, sLabel);
 						}
 						else if (isBool)

--- a/hardware/openwebnet/bt_openwebnet.cpp
+++ b/hardware/openwebnet/bt_openwebnet.cpp
@@ -12,7 +12,7 @@ std::string bt_openwebnet::FirstToken(const std::string& myText, const std::stri
 {
 	std::istringstream iss(myText);
 	std::string token;
-	if (std::getline(iss, token, (char)delimiters.at(0)))
+	if (std::getline(iss, token, char(delimiters.at(0))))
 	{
 		return token;
 	}

--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -305,7 +305,7 @@ void MyNode::updateGroup(uint8 node, uint8 grp, char* glist)
 	while (p != nullptr && *p && n < (*it)->max)
 	{
 		np = strsep(&p, ",");
-		v[n++] = (uint8)strtol(np, nullptr, 10);
+		v[n++] = uint8_t(strtol(np, nullptr, 10));
 	}
 	/* Look for nodes in the passed-in argument list, if not present add them */
 	std::vector<uint8>::iterator nit;
@@ -420,7 +420,7 @@ MyValue *MyNode::lookup(const std::string &data)
 	size_t pos1, pos2;
 	std::string str;
 
-	node = (uint8)strtol(data.c_str(), nullptr, 10);
+	node = uint8_t(strtol(data.c_str(), nullptr, 10));
 	if (node == 0)
 		return nullptr;
 	pos1 = data.find('-', 0);
@@ -450,10 +450,10 @@ MyValue *MyNode::lookup(const std::string &data)
 	if (pos2 == std::string::npos)
 		return nullptr;
 	str = data.substr(pos1, pos2 - pos1);
-	inst = (uint8)strtol(str.c_str(), nullptr, 10);
+	inst = uint8_t(strtol(str.c_str(), nullptr, 10));
 	pos1 = pos2 + 1;
 	str = data.substr(pos1);
-	ind = (uint8)strtol(str.c_str(), nullptr, 10);
+	ind = uint8_t(strtol(str.c_str(), nullptr, 10));
 	OpenZWave::ValueID id(homeId, node, vg, cls, inst, ind, typ);
 	MyNode* n = nodes[node];
 	if (n == nullptr)
@@ -877,7 +877,7 @@ COpenZWaveControlPanel::COpenZWaveControlPanel() :
 
 void web_controller_update(OpenZWave::Driver::ControllerState cs, OpenZWave::Driver::ControllerError err, void* ct)
 {
-	COpenZWaveControlPanel* cp = (COpenZWaveControlPanel*)ct;
+	auto cp = static_cast<COpenZWaveControlPanel *>(ct);
 	std::string s;
 	bool more = true;
 
@@ -1178,7 +1178,7 @@ std::string COpenZWaveControlPanel::SendPollResponse()
 					nodeElement->SetAttribute("beam", OpenZWave::Manager::Get()->IsNodeBeamingDevice(homeId, i) ? "true" : "false");
 					nodeElement->SetAttribute("routing", OpenZWave::Manager::Get()->IsNodeRoutingDevice(homeId, i) ? "true" : "false");
 					nodeElement->SetAttribute("security", OpenZWave::Manager::Get()->IsNodeSecurityDevice(homeId, i) ? "true" : "false");
-					nodeElement->SetAttribute("time", (int)nodes[i]->getTime());
+					nodeElement->SetAttribute("time", int(nodes[i]->getTime()));
 #ifdef OZW_WRITE_LOG
 					Log::Write(LogLevel_Info, "i=%d failed=%d\n", i, OpenZWave::Manager::Get()->IsNodeFailed(homeId, i));
 					Log::Write(LogLevel_Info, "i=%d awake=%d\n", i, OpenZWave::Manager::Get()->IsNodeAwake(homeId, i));

--- a/hardware/openzwave/control_panel/zwavelib.cpp
+++ b/hardware/openzwave/control_panel/zwavelib.cpp
@@ -59,16 +59,16 @@ OpenZWave::ValueID::ValueGenre valueGenreNum (char const *str)
 {
   if (strcmp(str, "basic") == 0)
     return OpenZWave::ValueID::ValueGenre_Basic;
-  else if (strcmp(str, "user") == 0)
-    return OpenZWave::ValueID::ValueGenre_User;
-  else if (strcmp(str, "config") == 0)
-    return OpenZWave::ValueID::ValueGenre_Config;
-  else if (strcmp(str, "system") == 0)
-    return OpenZWave::ValueID::ValueGenre_System;
-  else if (strcmp(str, "count") == 0)
-    return OpenZWave::ValueID::ValueGenre_Count;
-  else
-    return (OpenZWave::ValueID::ValueGenre)255;
+  if (strcmp(str, "user") == 0)
+	  return OpenZWave::ValueID::ValueGenre_User;
+  if (strcmp(str, "config") == 0)
+	  return OpenZWave::ValueID::ValueGenre_Config;
+  if (strcmp(str, "system") == 0)
+	  return OpenZWave::ValueID::ValueGenre_System;
+  if (strcmp(str, "count") == 0)
+	  return OpenZWave::ValueID::ValueGenre_Count;
+
+  return OpenZWave::ValueID::ValueGenre(255);
 }
 
 const char *valueTypeStr (OpenZWave::ValueID::ValueType vt)
@@ -102,26 +102,26 @@ OpenZWave::ValueID::ValueType valueTypeNum (char const *str)
 {
   if (strcmp(str, "bool") == 0)
     return OpenZWave::ValueID::ValueType_Bool;
-  else if (strcmp(str, "byte") == 0)
-    return OpenZWave::ValueID::ValueType_Byte;
-  else if (strcmp(str, "decimal") == 0)
-    return OpenZWave::ValueID::ValueType_Decimal;
-  else if (strcmp(str, "int") == 0)
-    return OpenZWave::ValueID::ValueType_Int;
-  else if (strcmp(str, "list") == 0)
-    return OpenZWave::ValueID::ValueType_List;
-  else if (strcmp(str, "schedule") == 0)
-    return OpenZWave::ValueID::ValueType_Schedule;
-  else if (strcmp(str, "short") == 0)
-    return OpenZWave::ValueID::ValueType_Short;
-  else if (strcmp(str, "string") == 0)
-    return OpenZWave::ValueID::ValueType_String;
-  else if (strcmp(str, "button") == 0)
-    return OpenZWave::ValueID::ValueType_Button;
-  else if (strcmp(str, "raw") == 0)
-    return OpenZWave::ValueID::ValueType_Raw;
-  else
-    return (OpenZWave::ValueID::ValueType)255;
+  if (strcmp(str, "byte") == 0)
+	  return OpenZWave::ValueID::ValueType_Byte;
+  if (strcmp(str, "decimal") == 0)
+	  return OpenZWave::ValueID::ValueType_Decimal;
+  if (strcmp(str, "int") == 0)
+	  return OpenZWave::ValueID::ValueType_Int;
+  if (strcmp(str, "list") == 0)
+	  return OpenZWave::ValueID::ValueType_List;
+  if (strcmp(str, "schedule") == 0)
+	  return OpenZWave::ValueID::ValueType_Schedule;
+  if (strcmp(str, "short") == 0)
+	  return OpenZWave::ValueID::ValueType_Short;
+  if (strcmp(str, "string") == 0)
+	  return OpenZWave::ValueID::ValueType_String;
+  if (strcmp(str, "button") == 0)
+	  return OpenZWave::ValueID::ValueType_Button;
+  if (strcmp(str, "raw") == 0)
+	  return OpenZWave::ValueID::ValueType_Raw;
+
+  return OpenZWave::ValueID::ValueType(255);
 }
 
 const char *nodeBasicStr (uint8 basic)

--- a/hardware/pinger/icmp_header.h
+++ b/hardware/pinger/icmp_header.h
@@ -64,8 +64,8 @@ private:
 
   void encode(int a, int b, unsigned short n)
   {
-    rep_[a] = static_cast<unsigned char>(n >> 8);
-    rep_[b] = static_cast<unsigned char>(n & 0xFF);
+	  rep_[a] = uint8_t(n >> 8);
+	  rep_[b] = uint8_t(n & 0xFF);
   }
 
   unsigned char rep_[8];
@@ -81,14 +81,14 @@ void compute_checksum(icmp_header& header,
   Iterator body_iter = body_begin;
   while (body_iter != body_end)
   {
-    sum += (static_cast<unsigned char>(*body_iter++) << 8);
-    if (body_iter != body_end)
-      sum += static_cast<unsigned char>(*body_iter++);
+	  sum += (uint8_t(*body_iter++) << 8);
+	  if (body_iter != body_end)
+		  sum += uint8_t(*body_iter++);
   }
 
   sum = (sum >> 16) + (sum & 0xFFFF);
   sum += (sum >> 16);
-  header.checksum(static_cast<unsigned short>(~sum));
+  header.checksum(uint16_t(~sum));
 }
 
 #endif // ICMP_HEADER_HPP

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -180,7 +180,7 @@ namespace Plugins {
 		if (Py_LoadLibrary() && m_InitialPythonThread)
 		{
 			if (Py_IsInitialized()) {
-				PyEval_RestoreThread((PyThreadState*)m_InitialPythonThread);
+				PyEval_RestoreThread(static_cast<PyThreadState *>(m_InitialPythonThread));
 				Py_Finalize();
 			}
 		}
@@ -369,7 +369,7 @@ namespace Plugins {
 				if (Message)
 				{
 					std::lock_guard<std::mutex> l(PythonMutex); // Take mutex to guard access to CPluginTransport::m_pConnection inside the message
-					CPlugin* pPlugin = (CPlugin*)Message->Plugin();
+					CPlugin *pPlugin = const_cast<CPlugin *>(Message->Plugin());
 					pPlugin->RestoreThread();
 					delete Message;
 					pPlugin->ReleaseThread();

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -60,16 +60,16 @@ namespace Plugins
 		if (pPlugin)
 			Name = pPlugin->m_Name;
 
-		PyErr_Fetch(&pExcept, &pValue, (PyObject **)&pTraceback);
+		PyErr_Fetch(&pExcept, &pValue, reinterpret_cast<PyObject **>(&pTraceback));
 
 		if (pExcept)
 		{
-			TypeName = (PyTypeObject *)pExcept;
+			TypeName = reinterpret_cast<PyTypeObject *>(pExcept);
 			pTypeText = TypeName->tp_name;
 		}
 		if (pValue)
 		{
-			pErrBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pValue);
+			pErrBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pValue));
 		}
 		if (pTypeText && pErrBytes)
 		{
@@ -111,8 +111,8 @@ namespace Plugins
 			{
 				int lineno = PyFrame_GetLineNumber(frame);
 				PyCodeObject *pCode = frame->f_code;
-				PyBytesObject *pFileBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_filename);
-				PyBytesObject *pFuncBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_name);
+				PyBytesObject *pFileBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_filename));
+				PyBytesObject *pFuncBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_name));
 				if (pPlugin)
 					pPlugin->Log(LOG_ERROR, "(%s) ----> Line %d in %s, function %s", Name.c_str(), lineno, pFileBytes->ob_sval, pFuncBytes->ob_sval);
 				else
@@ -141,7 +141,7 @@ namespace Plugins
 
 	int PyDomoticz_ProfileFunc(PyObject *self, PyFrameObject *frame, int what, PyObject *arg)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", __func__);
@@ -157,14 +157,14 @@ namespace Plugins
 			PyCodeObject *pCode = frame->f_code;
 			if (pCode && pCode->co_filename)
 			{
-				PyBytesObject *pFileBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_filename);
+				PyBytesObject *pFileBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_filename));
 				sFuncName = pFileBytes->ob_sval;
 			}
 			if (pCode && pCode->co_name)
 			{
 				if (!sFuncName.empty())
 					sFuncName += "\\";
-				PyBytesObject *pFuncBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_name);
+				PyBytesObject *pFuncBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_name));
 				sFuncName = pFuncBytes->ob_sval;
 			}
 
@@ -187,7 +187,7 @@ namespace Plugins
 
 	int PyDomoticz_TraceFunc(PyObject *self, PyFrameObject *frame, int what, PyObject *arg)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", __func__);
@@ -203,14 +203,14 @@ namespace Plugins
 			PyCodeObject *pCode = frame->f_code;
 			if (pCode && pCode->co_filename)
 			{
-				PyBytesObject *pFileBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_filename);
+				PyBytesObject *pFileBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_filename));
 				sFuncName = pFileBytes->ob_sval;
 			}
 			if (pCode && pCode->co_name)
 			{
 				if (!sFuncName.empty())
 					sFuncName += "\\";
-				PyBytesObject *pFuncBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_name);
+				PyBytesObject *pFuncBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_name));
 				sFuncName = pFuncBytes->ob_sval;
 			}
 
@@ -233,7 +233,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Debug(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:PyDomoticz_Debug, unable to obtain module state.");
@@ -256,7 +256,7 @@ namespace Plugins
 				else
 				{
 					std::string message = "(" + pModState->pPlugin->m_Name + ") " + msg;
-					pModState->pPlugin->Log((_eLogLevel)LOG_NORM, message);
+					pModState->pPlugin->Log(LOG_NORM, message);
 				}
 			}
 		}
@@ -267,7 +267,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Log(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:PyDomoticz_Log, unable to obtain module state.");
@@ -287,7 +287,7 @@ namespace Plugins
 			else
 			{
 				std::string message = "(" + pModState->pPlugin->m_Name + ") " + msg;
-				pModState->pPlugin->Log((_eLogLevel)LOG_NORM, message);
+				pModState->pPlugin->Log(LOG_NORM, message);
 			}
 		}
 
@@ -297,7 +297,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Status(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", std::string(__func__).c_str());
@@ -317,7 +317,7 @@ namespace Plugins
 			else
 			{
 				std::string message = "(" + pModState->pPlugin->m_Name + ") " + msg;
-				pModState->pPlugin->Log((_eLogLevel)LOG_STATUS, message);
+				pModState->pPlugin->Log(LOG_STATUS, message);
 			}
 		}
 
@@ -327,7 +327,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Error(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:PyDomoticz_Error, unable to obtain module state.");
@@ -348,7 +348,7 @@ namespace Plugins
 			else
 			{
 				std::string message = "(" + pModState->pPlugin->m_Name + ") " + msg;
-				pModState->pPlugin->Log((_eLogLevel)LOG_ERROR, message);
+				pModState->pPlugin->Log(LOG_ERROR, message);
 			}
 		}
 
@@ -358,7 +358,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Debugging(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:PyDomoticz_Debugging, unable to obtain module state.");
@@ -381,7 +381,7 @@ namespace Plugins
 				if (type == 1)
 					type = PDM_ALL;
 
-				pModState->pPlugin->m_bDebug = (PluginDebugMask)type;
+				pModState->pPlugin->m_bDebug = PluginDebugMask(type);
 				pModState->pPlugin->Log(LOG_NORM, "(%s) Debug logging mask set to: %s%s%s%s%s%s%s%s%s", pModState->pPlugin->m_Name.c_str(), (type == PDM_NONE ? "NONE" : ""),
 					 (type & PDM_PYTHON ? "PYTHON " : ""), (type & PDM_PLUGIN ? "PLUGIN " : ""), (type & PDM_QUEUE ? "QUEUE " : ""), (type & PDM_IMAGE ? "IMAGE " : ""),
 					 (type & PDM_DEVICE ? "DEVICE " : ""), (type & PDM_CONNECTION ? "CONNECTION " : ""), (type & PDM_MESSAGE ? "MESSAGE " : ""), (type == PDM_ALL ? "ALL" : ""));
@@ -394,7 +394,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Heartbeat(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:PyDomoticz_Heartbeat, unable to obtain module state.");
@@ -424,7 +424,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Notifier(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", __func__);
@@ -463,7 +463,7 @@ namespace Plugins
 
 	static PyObject *PyDomoticz_Trace(PyObject *self, PyObject *args)
 	{
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", __func__);
@@ -482,7 +482,7 @@ namespace Plugins
 			}
 			else
 			{
-				pModState->pPlugin->m_bTracing = (bool)bTrace;
+				pModState->pPlugin->m_bTracing = bool(bTrace);
 				pModState->pPlugin->Log(LOG_NORM, "(%s) Low level Python tracing %s.", pModState->pPlugin->m_Name.c_str(), (pModState->pPlugin->m_bTracing ? "ENABLED" : "DISABLED"));
 
 				if (pModState->pPlugin->m_bTracing)
@@ -510,7 +510,7 @@ namespace Plugins
 
 		Py_INCREF(Py_None);
 
-		module_state *pModState = ((struct module_state *)PyModule_GetState(self));
+		module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(self)));
 		if (!pModState)
 		{
 			_log.Log(LOG_ERROR, "CPlugin:%s, unable to obtain module state.", __func__);
@@ -567,7 +567,8 @@ namespace Plugins
 						 { "Heartbeat", PyDomoticz_Heartbeat, METH_VARARGS, "Set the heartbeat interval, default 10 seconds." },
 						 { "Notifier", PyDomoticz_Notifier, METH_VARARGS, "Enable notification handling with supplied name." },
 						 { "Trace", PyDomoticz_Trace, METH_VARARGS, "Enable/Disable line level Python tracing." },
-						 { "Configuration", (PyCFunction)PyDomoticz_Configuration, METH_VARARGS | METH_KEYWORDS, "Retrieve and Store structured plugin configuration." },
+						 { "Configuration", reinterpret_cast<PyCFunction>(PyDomoticz_Configuration), METH_VARARGS | METH_KEYWORDS,
+						   "Retrieve and Store structured plugin configuration." },
 						 { nullptr, nullptr, 0, nullptr } };
 
 	static int DomoticzTraverse(PyObject *m, visitproc visit, void *arg)
@@ -648,24 +649,24 @@ namespace Plugins
 		PyTypeObject *TypeName;
 		PyBytesObject *pErrBytes = nullptr;
 
-		PyErr_Fetch(&pExcept, &pValue, (PyObject **)&pTraceback);
+		PyErr_Fetch(&pExcept, &pValue, reinterpret_cast<PyObject **>(&pTraceback));
 
 		if (pExcept)
 		{
-			TypeName = (PyTypeObject *)pExcept;
+			TypeName = reinterpret_cast<PyTypeObject *>(pExcept);
 			Log(LOG_ERROR, "(%s) Module Import failed, exception: '%s'", m_Name.c_str(), TypeName->tp_name);
 		}
 		if (pValue)
 		{
 			std::string sError;
-			pErrBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pValue); // Won't normally return text for Import related errors
+			pErrBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pValue)); // Won't normally return text for Import related errors
 			if (!pErrBytes)
 			{
 				// ImportError has name and path attributes
 				if (PyObject_HasAttrString(pValue, "path"))
 				{
 					PyObject *pString = PyObject_GetAttrString(pValue, "path");
-					PyBytesObject *pBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pString);
+					PyBytesObject *pBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pString));
 					if (pBytes)
 					{
 						sError += "Path: ";
@@ -677,7 +678,7 @@ namespace Plugins
 				if (PyObject_HasAttrString(pValue, "name"))
 				{
 					PyObject *pString = PyObject_GetAttrString(pValue, "name");
-					PyBytesObject *pBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pString);
+					PyBytesObject *pBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pString));
 					if (pBytes)
 					{
 						sError += " Name: ";
@@ -696,7 +697,7 @@ namespace Plugins
 				if (PyObject_HasAttrString(pValue, "filename"))
 				{
 					PyObject *pString = PyObject_GetAttrString(pValue, "filename");
-					PyBytesObject *pBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pString);
+					PyBytesObject *pBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pString));
 					sError += "File: ";
 					sError += pBytes->ob_sval;
 					Py_XDECREF(pString);
@@ -775,16 +776,16 @@ namespace Plugins
 		PyBytesObject *pErrBytes = nullptr;
 		const char *pTypeText = nullptr;
 
-		PyErr_Fetch(&pExcept, &pValue, (PyObject **)&pTraceback);
+		PyErr_Fetch(&pExcept, &pValue, reinterpret_cast<PyObject **>(&pTraceback));
 
 		if (pExcept)
 		{
-			TypeName = (PyTypeObject *)pExcept;
+			TypeName = reinterpret_cast<PyTypeObject *>(pExcept);
 			pTypeText = TypeName->tp_name;
 		}
 		if (pValue)
 		{
-			pErrBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pValue);
+			pErrBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pValue));
 		}
 		if (pTypeText && pErrBytes)
 		{
@@ -816,14 +817,14 @@ namespace Plugins
 				std::string FileName;
 				if (pCode->co_filename)
 				{
-					PyBytesObject *pFileBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_filename);
+					PyBytesObject *pFileBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_filename));
 					FileName = pFileBytes->ob_sval;
 					Py_XDECREF(pFileBytes);
 				}
 				std::string FuncName = "Unknown";
 				if (pCode->co_name)
 				{
-					PyBytesObject *pFuncBytes = (PyBytesObject *)PyUnicode_AsASCIIString(pCode->co_name);
+					PyBytesObject *pFuncBytes = reinterpret_cast<PyBytesObject *>(PyUnicode_AsASCIIString(pCode->co_name));
 					FuncName = pFuncBytes->ob_sval;
 					Py_XDECREF(pFuncBytes);
 				}
@@ -1046,7 +1047,7 @@ namespace Plugins
 
 		try
 		{
-			PyEval_RestoreThread((PyThreadState *)m_mainworker.m_pluginsystem.PythonThread());
+			PyEval_RestoreThread(static_cast<PyThreadState *>(m_mainworker.m_pluginsystem.PythonThread()));
 			m_PyInterpreter = Py_NewInterpreter();
 			if (!m_PyInterpreter)
 			{
@@ -1092,7 +1093,7 @@ namespace Plugins
 				}
 				else
 				{
-					PyObject *pFunc = PyObject_GetAttrString((PyObject *)pSiteModule, "getsitepackages");
+					PyObject *pFunc = PyObject_GetAttrString(static_cast<PyObject *>(pSiteModule), "getsitepackages");
 					if (pFunc && PyCallable_Check(pFunc))
 					{
 						PyObject *pSites = PyObject_CallObject(pFunc, nullptr);
@@ -1122,7 +1123,7 @@ namespace Plugins
 			}
 
 			// Update the path itself
-			PySys_SetPath((wchar_t *)sPath.c_str());
+			PySys_SetPath(const_cast<wchar_t *>(sPath.c_str()));
 
 			try
 			{
@@ -1136,7 +1137,7 @@ namespace Plugins
 				}
 				else
 				{
-					PyObject *pFunc = PyObject_GetAttrString((PyObject *)pFaultModule, "enable");
+					PyObject *pFunc = PyObject_GetAttrString(static_cast<PyObject *>(pFaultModule), "enable");
 					if (pFunc && PyCallable_Check(pFunc))
 					{
 						PyObject_CallObject(pFunc, nullptr);
@@ -1172,7 +1173,7 @@ namespace Plugins
 				Log(LOG_ERROR, "(%s) start up failed, Domoticz module not found in interpreter.", m_PluginKey.c_str());
 				goto Error;
 			}
-			module_state *pModState = ((struct module_state *)PyModule_GetState(pMod));
+			module_state *pModState = (static_cast<struct module_state *>(PyModule_GetState(pMod)));
 			pModState->pPlugin = this;
 
 			// Start worker thread
@@ -1244,7 +1245,7 @@ namespace Plugins
 	{
 		try
 		{
-			PyObject *pModuleDict = PyModule_GetDict((PyObject *)m_PyModule); // returns a borrowed referece to the __dict__ object for the module
+			PyObject *pModuleDict = PyModule_GetDict(static_cast<PyObject *>(m_PyModule)); // returns a borrowed referece to the __dict__ object for the module
 			PyObject *pParamsDict = PyDict_New();
 			if (PyDict_SetItemString(pModuleDict, "Parameters", pParamsDict) == -1)
 			{
@@ -1299,7 +1300,7 @@ namespace Plugins
 			}
 
 			m_DeviceDict = PyDict_New();
-			if (PyDict_SetItemString(pModuleDict, "Devices", (PyObject *)m_DeviceDict) == -1)
+			if (PyDict_SetItemString(pModuleDict, "Devices", static_cast<PyObject *>(m_DeviceDict)) == -1)
 			{
 				Log(LOG_ERROR, "(%s) failed to add Device dictionary.", m_PluginKey.c_str());
 				goto Error;
@@ -1313,10 +1314,10 @@ namespace Plugins
 				// Add device objects into the device dictionary with Unit as the key
 				for (const auto &sd : result)
 				{
-					CDevice *pDevice = (CDevice *)CDevice_new(&CDeviceType, (PyObject *)nullptr, (PyObject *)nullptr);
+					CDevice *pDevice = reinterpret_cast<CDevice *>(CDevice_new(&CDeviceType, (PyObject *)nullptr, (PyObject *)nullptr));
 
 					PyObject *pKey = PyLong_FromLong(atoi(sd[0].c_str()));
-					if (PyDict_SetItem((PyObject *)m_DeviceDict, pKey, (PyObject *)pDevice) == -1)
+					if (PyDict_SetItem(static_cast<PyObject *>(m_DeviceDict), pKey, reinterpret_cast<PyObject *>(pDevice)) == -1)
 					{
 						Log(LOG_ERROR, "(%s) failed to add unit '%s' to device dictionary.", m_PluginKey.c_str(), sd[0].c_str());
 						goto Error;
@@ -1332,7 +1333,7 @@ namespace Plugins
 			}
 
 			m_ImageDict = PyDict_New();
-			if (PyDict_SetItemString(pModuleDict, "Images", (PyObject *)m_ImageDict) == -1)
+			if (PyDict_SetItemString(pModuleDict, "Images", static_cast<PyObject *>(m_ImageDict)) == -1)
 			{
 				Log(LOG_ERROR, "(%s) failed to add Image dictionary.", m_PluginKey.c_str());
 				goto Error;
@@ -1346,10 +1347,10 @@ namespace Plugins
 				// Add image objects into the image dictionary with ID as the key
 				for (const auto &sd : result)
 				{
-					CImage *pImage = (CImage *)CImage_new(&CImageType, (PyObject *)nullptr, (PyObject *)nullptr);
+					CImage *pImage = reinterpret_cast<CImage *>(CImage_new(&CImageType, (PyObject *)nullptr, (PyObject *)nullptr));
 
 					PyObject *pKey = PyUnicode_FromString(sd[1].c_str());
-					if (PyDict_SetItem((PyObject *)m_ImageDict, pKey, (PyObject *)pImage) == -1)
+					if (PyDict_SetItem(static_cast<PyObject *>(m_ImageDict), pKey, reinterpret_cast<PyObject *>(pImage)) == -1)
 					{
 						Log(LOG_ERROR, "(%s) failed to add ID '%s' to image dictionary.", m_PluginKey.c_str(), sd[0].c_str());
 						goto Error;
@@ -1382,7 +1383,7 @@ namespace Plugins
 	void CPlugin::ConnectionProtocol(CDirectiveBase *pMess)
 	{
 		ProtocolDirective *pMessage = (ProtocolDirective *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 		if (m_Notifier)
 		{
 			delete pConnection->pProtocol;
@@ -1397,7 +1398,7 @@ namespace Plugins
 	void CPlugin::ConnectionConnect(CDirectiveBase *pMess)
 	{
 		ConnectDirective *pMessage = (ConnectDirective *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 
 		if (pConnection->pTransport && pConnection->pTransport->IsConnected())
 		{
@@ -1428,9 +1429,9 @@ namespace Plugins
 				return;
 			}
 			if ((sTransport == "TLS/IP") || pConnection->pProtocol->Secure())
-				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCPSecure(m_HwdID, (PyObject *)pConnection, sAddress, sPort);
+				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCPSecure(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, sPort);
 			else
-				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCP(m_HwdID, (PyObject *)pConnection, sAddress, sPort);
+				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCP(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, sPort);
 		}
 		else if (sTransport == "Serial")
 		{
@@ -1438,7 +1439,7 @@ namespace Plugins
 				Log(LOG_ERROR, "(%s) Transport '%s' does not support secure connections.", m_Name.c_str(), sTransport.c_str());
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "(%s) Transport set to: '%s', '%s', %d.", m_Name.c_str(), sTransport.c_str(), sAddress.c_str(), pConnection->Baud);
-			pConnection->pTransport = (CPluginTransport *)new CPluginTransportSerial(m_HwdID, (PyObject *)pConnection, sAddress, pConnection->Baud);
+			pConnection->pTransport = (CPluginTransport *)new CPluginTransportSerial(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, pConnection->Baud);
 		}
 		else
 		{
@@ -1464,7 +1465,7 @@ namespace Plugins
 	void CPlugin::ConnectionListen(CDirectiveBase *pMess)
 	{
 		ListenDirective *pMessage = (ListenDirective *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 
 		if (pConnection->pTransport && pConnection->pTransport->IsConnected())
 		{
@@ -1490,9 +1491,9 @@ namespace Plugins
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "(%s) Transport set to: '%s', %s:%s.", m_Name.c_str(), sTransport.c_str(), sAddress.c_str(), sPort.c_str());
 			if (!pConnection->pProtocol->Secure())
-				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCP(m_HwdID, (PyObject *)pConnection, "", sPort);
+				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCP(m_HwdID, reinterpret_cast<PyObject *>(pConnection), "", sPort);
 			else
-				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCPSecure(m_HwdID, (PyObject *)pConnection, "", sPort);
+				pConnection->pTransport = (CPluginTransport *)new CPluginTransportTCPSecure(m_HwdID, reinterpret_cast<PyObject *>(pConnection), "", sPort);
 		}
 		else if (sTransport == "UDP/IP")
 		{
@@ -1501,7 +1502,7 @@ namespace Plugins
 				Log(LOG_ERROR, "(%s) Transport '%s' does not support secure connections.", m_Name.c_str(), sTransport.c_str());
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "(%s) Transport set to: '%s', %s:%s.", m_Name.c_str(), sTransport.c_str(), sAddress.c_str(), sPort.c_str());
-			pConnection->pTransport = (CPluginTransport *)new CPluginTransportUDP(m_HwdID, (PyObject *)pConnection, sAddress, sPort);
+			pConnection->pTransport = (CPluginTransport *)new CPluginTransportUDP(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, sPort);
 		}
 		else if (sTransport == "ICMP/IP")
 		{
@@ -1510,7 +1511,7 @@ namespace Plugins
 				Log(LOG_ERROR, "(%s) Transport '%s' does not support secure connections.", m_Name.c_str(), sTransport.c_str());
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "(%s) Transport set to: '%s', %s.", m_Name.c_str(), sTransport.c_str(), sAddress.c_str());
-			pConnection->pTransport = (CPluginTransport *)new CPluginTransportICMP(m_HwdID, (PyObject *)pConnection, sAddress, sPort);
+			pConnection->pTransport = (CPluginTransport *)new CPluginTransportICMP(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, sPort);
 		}
 		else
 		{
@@ -1536,7 +1537,7 @@ namespace Plugins
 	void CPlugin::ConnectionRead(CPluginMessageBase *pMess)
 	{
 		ReadEvent *pMessage = (ReadEvent *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 
 		pConnection->pProtocol->ProcessInbound(pMessage);
 	}
@@ -1544,7 +1545,7 @@ namespace Plugins
 	void CPlugin::ConnectionWrite(CDirectiveBase *pMess)
 	{
 		WriteDirective *pMessage = (WriteDirective *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 		std::string sTransport = PyUnicode_AsUTF8(pConnection->Transport);
 		std::string sConnection = PyUnicode_AsUTF8(pConnection->Name);
 		if (pConnection->pTransport)
@@ -1577,7 +1578,7 @@ namespace Plugins
 					else
 						Log(LOG_NORM, "(%s) Transport set to: '%s', %s for '%s'.", m_Name.c_str(), sTransport.c_str(), sAddress.c_str(), sConnection.c_str());
 				}
-				pConnection->pTransport = (CPluginTransport *)new CPluginTransportUDP(m_HwdID, (PyObject *)pConnection, sAddress, sPort);
+				pConnection->pTransport = (CPluginTransport *)new CPluginTransportUDP(m_HwdID, reinterpret_cast<PyObject *>(pConnection), sAddress, sPort);
 			}
 			else
 			{
@@ -1608,12 +1609,12 @@ namespace Plugins
 	void CPlugin::ConnectionDisconnect(CDirectiveBase *pMess)
 	{
 		DisconnectDirective *pMessage = (DisconnectDirective *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 
 		// Return any partial data to plugin
 		if (pConnection->pProtocol)
 		{
-			pConnection->pProtocol->Flush(pMessage->m_pPlugin, (PyObject *)pConnection);
+			pConnection->pProtocol->Flush(pMessage->m_pPlugin, reinterpret_cast<PyObject *>(pConnection));
 		}
 
 		if (pConnection->pTransport)
@@ -1652,10 +1653,10 @@ namespace Plugins
 
 	void CPlugin::onDeviceAdded(int Unit)
 	{
-		CDevice *pDevice = (CDevice *)CDevice_new(&CDeviceType, (PyObject *)nullptr, (PyObject *)nullptr);
+		CDevice *pDevice = reinterpret_cast<CDevice *>(CDevice_new(&CDeviceType, (PyObject *)nullptr, (PyObject *)nullptr));
 
 		PyObject *pKey = PyLong_FromLong(Unit);
-		if (PyDict_SetItem((PyObject *)m_DeviceDict, pKey, (PyObject *)pDevice) == -1)
+		if (PyDict_SetItem(static_cast<PyObject *>(m_DeviceDict), pKey, reinterpret_cast<PyObject *>(pDevice)) == -1)
 		{
 			Log(LOG_ERROR, "(%s) failed to add unit '%d' to device dictionary.", m_PluginKey.c_str(), Unit);
 			return;
@@ -1673,7 +1674,7 @@ namespace Plugins
 	{
 		PyObject *pKey = PyLong_FromLong(Unit);
 
-		CDevice *pDevice = (CDevice *)PyDict_GetItem((PyObject *)m_DeviceDict, pKey);
+		CDevice *pDevice = reinterpret_cast<CDevice *>(PyDict_GetItem(static_cast<PyObject *>(m_DeviceDict), pKey));
 
 		if (!pDevice)
 		{
@@ -1687,7 +1688,7 @@ namespace Plugins
 	void CPlugin::onDeviceRemoved(int Unit)
 	{
 		PyObject *pKey = PyLong_FromLong(Unit);
-		if (PyDict_DelItem((PyObject *)m_DeviceDict, pKey) == -1)
+		if (PyDict_DelItem(static_cast<PyObject *>(m_DeviceDict), pKey) == -1)
 		{
 			Log(LOG_ERROR, "(%s) failed to remove unit '%u' from device dictionary.", m_PluginKey.c_str(), Unit);
 		}
@@ -1726,12 +1727,12 @@ namespace Plugins
 	void CPlugin::DisconnectEvent(CEventBase *pMess)
 	{
 		DisconnectedEvent *pMessage = (DisconnectedEvent *)pMess;
-		CConnection *pConnection = (CConnection *)pMessage->m_pConnection;
+		CConnection *pConnection = reinterpret_cast<CConnection *>(pMessage->m_pConnection);
 
 		// Return any partial data to plugin
 		if (pConnection->pProtocol)
 		{
-			pConnection->pProtocol->Flush(pMessage->m_pPlugin, (PyObject *)pConnection);
+			pConnection->pProtocol->Flush(pMessage->m_pPlugin, reinterpret_cast<PyObject *>(pConnection));
 		}
 
 		if (pConnection->pTransport)
@@ -1754,7 +1755,7 @@ namespace Plugins
 			// inform the plugin if transport is connection based
 			if (pMessage->bNotifyPlugin)
 			{
-				MessagePlugin(new onDisconnectCallback(this, (PyObject *)pConnection));
+				MessagePlugin(new onDisconnectCallback(this, reinterpret_cast<PyObject *>(pConnection)));
 			}
 
 			// Plugin exiting and all connections have disconnect messages queued
@@ -1768,7 +1769,7 @@ namespace Plugins
 	void CPlugin::RestoreThread()
 	{
 		if (m_PyInterpreter)
-			PyEval_RestoreThread((PyThreadState *)m_PyInterpreter);
+			PyEval_RestoreThread(static_cast<PyThreadState *>(m_PyInterpreter));
 	}
 
 	void CPlugin::ReleaseThread()
@@ -1784,14 +1785,14 @@ namespace Plugins
 			// Callbacks MUST already have taken the PythonMutex lock otherwise bad things will happen
 			if (m_PyModule && !sHandler.empty())
 			{
-				PyObject *pFunc = PyObject_GetAttrString((PyObject *)m_PyModule, sHandler.c_str());
+				PyObject *pFunc = PyObject_GetAttrString(static_cast<PyObject *>(m_PyModule), sHandler.c_str());
 				if (pFunc && PyCallable_Check(pFunc))
 				{
 					if (m_bDebug & PDM_QUEUE)
 						Log(LOG_NORM, "(%s) Calling message handler '%s'.", m_Name.c_str(), sHandler.c_str());
 
 					PyErr_Clear();
-					PyObject *pReturnValue = PyObject_CallObject(pFunc, (PyObject *)pParams);
+					PyObject *pReturnValue = PyObject_CallObject(pFunc, static_cast<PyObject *>(pParams));
 					if (!pReturnValue)
 					{
 						LogPythonException(sHandler);
@@ -1830,11 +1831,11 @@ namespace Plugins
 			if (m_SettingsDict)
 				Py_XDECREF(m_SettingsDict);
 			if (m_PyInterpreter)
-				Py_EndInterpreter((PyThreadState *)m_PyInterpreter);
+				Py_EndInterpreter(static_cast<PyThreadState *>(m_PyInterpreter));
 			// To release the GIL there must be a valid thread state so use
 			// the one created during start up of the plugin system because it will always exist
 			CPluginSystem pManager;
-			PyThreadState_Swap((PyThreadState *)pManager.PythonThread());
+			PyThreadState_Swap(static_cast<PyThreadState *>(pManager.PythonThread()));
 			PyEval_ReleaseLock();
 		}
 		catch (std::exception *e)
@@ -1856,11 +1857,11 @@ namespace Plugins
 
 	bool CPlugin::LoadSettings()
 	{
-		PyObject *pModuleDict = PyModule_GetDict((PyObject *)m_PyModule); // returns a borrowed referece to the __dict__ object for the module
+		PyObject *pModuleDict = PyModule_GetDict(static_cast<PyObject *>(m_PyModule)); // returns a borrowed referece to the __dict__ object for the module
 		if (m_SettingsDict)
 			Py_XDECREF(m_SettingsDict);
 		m_SettingsDict = PyDict_New();
-		if (PyDict_SetItemString(pModuleDict, "Settings", (PyObject *)m_SettingsDict) == -1)
+		if (PyDict_SetItemString(pModuleDict, "Settings", static_cast<PyObject *>(m_SettingsDict)) == -1)
 		{
 			Log(LOG_ERROR, "(%s) failed to add Settings dictionary.", m_PluginKey.c_str());
 			return false;
@@ -1885,7 +1886,7 @@ namespace Plugins
 				{
 					pValue = PyUnicode_FromString(sd[1].c_str());
 				}
-				if (PyDict_SetItem((PyObject *)m_SettingsDict, pKey, pValue))
+				if (PyDict_SetItem(static_cast<PyObject *>(m_SettingsDict), pKey, pValue))
 				{
 					Log(LOG_ERROR, "(%s) failed to add setting '%s' to settings dictionary.", m_PluginKey.c_str(), sd[0].c_str());
 					return false;
@@ -1904,26 +1905,26 @@ namespace Plugins
 		if (m_bDebug & (PDM_CONNECTION | PDM_MESSAGE))
 		{
 			if (Incoming)
-				Log(LOG_NORM, "(%s) Received %d bytes of data", m_Name.c_str(), (int)Buffer.size());
+				Log(LOG_NORM, "(%s) Received %d bytes of data", m_Name.c_str(), int(Buffer.size()));
 			else
-				Log(LOG_NORM, "(%s) Sending %d bytes of data", m_Name.c_str(), (int)Buffer.size());
+				Log(LOG_NORM, "(%s) Sending %d bytes of data", m_Name.c_str(), int(Buffer.size()));
 		}
 
 		if (m_bDebug & PDM_MESSAGE)
 		{
-			for (int i = 0; i < (int)Buffer.size(); i = i + DZ_BYTES_PER_LINE)
+			for (size_t i = 0; i < Buffer.size(); i = i + DZ_BYTES_PER_LINE)
 			{
 				std::stringstream ssHex;
 				std::string sChars;
-				for (int j = 0; j < DZ_BYTES_PER_LINE; j++)
+				for (size_t j = 0; j < DZ_BYTES_PER_LINE; j++)
 				{
-					if (i + j < (int)Buffer.size())
+					if (i + j < Buffer.size())
 					{
 						if (Buffer[i + j] < 16)
-							ssHex << '0' << std::hex << (int)Buffer[i + j] << " ";
+							ssHex << '0' << std::hex << int(Buffer[i + j]) << " ";
 						else
-							ssHex << std::hex << (int)Buffer[i + j] << " ";
-						if ((int)Buffer[i + j] > 32)
+							ssHex << std::hex << int(Buffer[i + j]) << " ";
+						if (Buffer[i + j] > 32)
 							sChars += Buffer[i + j];
 						else
 							sChars += ".";
@@ -1961,7 +1962,7 @@ namespace Plugins
 
 		PyObject *key, *value;
 		Py_ssize_t pos = 0;
-		while (PyDict_Next((PyObject *)m_DeviceDict, &pos, &key, &value))
+		while (PyDict_Next(static_cast<PyObject *>(m_DeviceDict), &pos, &key, &value))
 		{
 			long iKey = PyLong_AsLong(key);
 			if (iKey == -1 && PyErr_Occurred())
@@ -1972,7 +1973,7 @@ namespace Plugins
 
 			if (iKey == Unit)
 			{
-				CDevice *pDevice = (CDevice *)value;
+				CDevice *pDevice = reinterpret_cast<CDevice *>(value);
 				return (pDevice->TimedOut != 0);
 			}
 		}
@@ -2051,7 +2052,7 @@ namespace Plugins
 #endif
 
 		std::string szStatus = "Off";
-		int posStatus = (int)ExtraData.find("|Status=");
+		int posStatus = int(ExtraData.find("|Status="));
 		if (posStatus >= 0)
 		{
 			posStatus += 8;
@@ -2061,7 +2062,7 @@ namespace Plugins
 		}
 
 		// Use image is specified
-		int posImage = (int)ExtraData.find("|Image=");
+		int posImage = int(ExtraData.find("|Image="));
 		if (posImage >= 0)
 		{
 			posImage += 7;
@@ -2073,7 +2074,7 @@ namespace Plugins
 		}
 
 		// Use uploaded and custom images
-		int posCustom = (int)ExtraData.find("|CustomImage=");
+		int posCustom = int(ExtraData.find("|CustomImage="));
 		if (posCustom >= 0)
 		{
 			posCustom += 13;
@@ -2100,13 +2101,13 @@ namespace Plugins
 		}
 
 		// if a switch type was supplied try and work out the image
-		int posType = (int)ExtraData.find("|SwitchType=");
+		int posType = int(ExtraData.find("|SwitchType="));
 		if (posType >= 0)
 		{
 			posType += 12;
 			std::string szType = ExtraData.substr(posType, ExtraData.find('|', posType) - posType);
 			std::string szTypeImage;
-			_eSwitchType switchtype = (_eSwitchType)atoi(szType.c_str());
+			_eSwitchType switchtype = _eSwitchType(atoi(szType.c_str()));
 			switch (switchtype)
 			{
 				case STYPE_OnOff:
@@ -2213,7 +2214,7 @@ namespace Plugins
 
 		std::string sIconFile = GetIconFile(ExtraData);
 		std::string sName = "Unknown";
-		int posName = (int)ExtraData.find("|Name=");
+		int posName = int(ExtraData.find("|Name="));
 		if (posName >= 0)
 		{
 			posName += 6;
@@ -2221,7 +2222,7 @@ namespace Plugins
 		}
 
 		std::string sStatus = "Unknown";
-		int posStatus = (int)ExtraData.find("|Status=");
+		int posStatus = int(ExtraData.find("|Status="));
 		if (posStatus >= 0)
 		{
 			posStatus += 8;

--- a/hardware/plugins/icmp_header.hpp
+++ b/hardware/plugins/icmp_header.hpp
@@ -64,8 +64,8 @@ private:
 
   void encode(int a, int b, unsigned short n)
   {
-    rep_[a] = static_cast<unsigned char>(n >> 8);
-    rep_[b] = static_cast<unsigned char>(n & 0xFF);
+	  rep_[a] = uint8_t(n >> 8);
+	  rep_[b] = uint8_t(n & 0xFF);
   }
 
   unsigned char rep_[8];
@@ -81,14 +81,14 @@ void compute_checksum(icmp_header& header,
   Iterator body_iter = body_begin;
   while (body_iter != body_end)
   {
-    sum += (static_cast<unsigned char>(*body_iter++) << 8);
-    if (body_iter != body_end)
-      sum += static_cast<unsigned char>(*body_iter++);
+	  sum += (uint8_t(*body_iter++) << 8);
+	  if (body_iter != body_end)
+		  sum += uint8_t(*body_iter++);
   }
 
   sum = (sum >> 16) + (sum & 0xFFFF);
   sum += (sum >> 16);
-  header.checksum(static_cast<unsigned short>(~sum));
+  header.checksum(uint16_t(~sum));
 }
 
 #endif // ICMP_HEADER_HPP

--- a/hardware/serial/impl/unix.cpp
+++ b/hardware/serial/impl/unix.cpp
@@ -60,9 +60,9 @@ MillisecondTimer::MillisecondTimer (const uint32_t millis)
 {
   int64_t tv_nsec = expiry.tv_nsec + (millis * 1e6);
   if (tv_nsec >= 1e9) {
-    int64_t sec_diff = tv_nsec / static_cast<int> (1e9);
-    expiry.tv_nsec = tv_nsec - static_cast<int> (1e9 * sec_diff);
-    expiry.tv_sec += sec_diff;
+	  int64_t sec_diff = tv_nsec / int(1e9);
+	  expiry.tv_nsec = tv_nsec - int(1e9 * sec_diff);
+	  expiry.tv_sec += sec_diff;
   } else {
     expiry.tv_nsec = tv_nsec;
   }
@@ -170,17 +170,16 @@ Serial::SerialImpl::reconfigurePort ()
   }
 
   // set up raw mode / no echo / binary
-  options.c_cflag |= (tcflag_t)  (CLOCAL | CREAD);
-  options.c_lflag &= (tcflag_t) ~(ICANON | ECHO | ECHOE | ECHOK | ECHONL |
-                                       ISIG | IEXTEN); //|ECHOPRT
+  options.c_cflag |= tcflag_t(CLOCAL | CREAD);
+  options.c_lflag &= tcflag_t(~(ICANON | ECHO | ECHOE | ECHOK | ECHONL | ISIG | IEXTEN)); //|ECHOPRT
 
-  options.c_oflag &= (tcflag_t) ~(OPOST);
-  options.c_iflag &= (tcflag_t) ~(INLCR | IGNCR | ICRNL | IGNBRK);
+  options.c_oflag &= tcflag_t(~(OPOST));
+  options.c_iflag &= tcflag_t(~(INLCR | IGNCR | ICRNL | IGNBRK));
 #ifdef IUCLC
-  options.c_iflag &= (tcflag_t) ~IUCLC;
+  options.c_iflag &= tcflag_t(~IUCLC);
 #endif
 #ifdef PARMRK
-  options.c_iflag &= (tcflag_t) ~PARMRK;
+  options.c_iflag &= tcflag_t(~PARMRK);
 #endif
 
   // setup baud rate
@@ -306,7 +305,7 @@ Serial::SerialImpl::reconfigurePort ()
     // other than those specified by POSIX. The driver for the underlying serial hardware
     // ultimately determines which baud rates can be used. This ioctl sets both the input
     // and output speed.
-    speed_t new_baud = static_cast<speed_t> (baudrate_);
+    speed_t new_baud = speed_t(baudrate_);
     if (-1 == ioctl (fd_, IOSSIOSPEED, &new_baud, 1)) {
       THROW (IOException, errno);
     }
@@ -319,7 +318,7 @@ Serial::SerialImpl::reconfigurePort ()
     }
 
     // set custom divisor
-    ser.custom_divisor = ser.baud_base / static_cast<int> (baudrate_);
+    ser.custom_divisor = ser.baud_base / int(baudrate_);
     // update flags
     ser.flags &= ~ASYNC_SPD_MASK;
     ser.flags |= ASYNC_SPD_CUST;
@@ -341,7 +340,7 @@ Serial::SerialImpl::reconfigurePort ()
   }
 
   // setup char len
-  options.c_cflag &= (tcflag_t) ~CSIZE;
+  options.c_cflag &= tcflag_t(~CSIZE);
   if (bytesize_ == eightbits)
     options.c_cflag |= CS8;
   else if (bytesize_ == sevenbits)
@@ -354,7 +353,7 @@ Serial::SerialImpl::reconfigurePort ()
     throw invalid_argument ("invalid char len");
   // setup stopbits
   if (stopbits_ == stopbits_one)
-    options.c_cflag &= (tcflag_t) ~(CSTOPB);
+	  options.c_cflag &= tcflag_t(~(CSTOPB));
   else if (stopbits_ == stopbits_one_point_five)
     // ONE POINT FIVE same as TWO.. there is no POSIX support for 1.5
     options.c_cflag |=  (CSTOPB);
@@ -363,12 +362,12 @@ Serial::SerialImpl::reconfigurePort ()
   else
     throw invalid_argument ("invalid stop bit");
   // setup parity
-  options.c_iflag &= (tcflag_t) ~(INPCK | ISTRIP);
+  options.c_iflag &= tcflag_t(~(INPCK | ISTRIP));
   if (parity_ == parity_none) {
-    options.c_cflag &= (tcflag_t) ~(PARENB | PARODD);
+	  options.c_cflag &= tcflag_t(~(PARENB | PARODD));
   } else if (parity_ == parity_even) {
-    options.c_cflag &= (tcflag_t) ~(PARODD);
-    options.c_cflag |=  (PARENB);
+	  options.c_cflag &= tcflag_t(~(PARODD));
+	  options.c_cflag |= (PARENB);
   } else if (parity_ == parity_odd) {
     options.c_cflag |=  (PARENB | PARODD);
   }
@@ -378,7 +377,7 @@ Serial::SerialImpl::reconfigurePort ()
   }
   else if (parity_ == parity_space) {
     options.c_cflag |=  (PARENB | CMSPAR);
-    options.c_cflag &= (tcflag_t) ~(PARODD);
+    options.c_cflag &= tcflag_t(~(PARODD));
   }
 #else
   // CMSPAR is not defined on OSX. So do not support mark or space parity.
@@ -407,24 +406,24 @@ Serial::SerialImpl::reconfigurePort ()
   if (xonxoff_)
     options.c_iflag |=  (IXON | IXOFF); //|IXANY)
   else
-    options.c_iflag &= (tcflag_t) ~(IXON | IXOFF | IXANY);
+	  options.c_iflag &= tcflag_t(~(IXON | IXOFF | IXANY));
 #else
   if (xonxoff_)
     options.c_iflag |=  (IXON | IXOFF);
   else
-    options.c_iflag &= (tcflag_t) ~(IXON | IXOFF);
+	  options.c_iflag &= tcflag_t(~(IXON | IXOFF));
 #endif
   // rtscts
 #ifdef CRTSCTS
   if (rtscts_)
     options.c_cflag |=  (CRTSCTS);
   else
-    options.c_cflag &= (unsigned long) ~(CRTSCTS);
+	  options.c_cflag &= uint64_t(~(CRTSCTS));
 #elif defined CNEW_RTSCTS
   if (rtscts_)
     options.c_cflag |=  (CNEW_RTSCTS);
   else
-    options.c_cflag &= (unsigned long) ~(CNEW_RTSCTS);
+	  options.c_cflag &= uint64_t(~(CNEW_RTSCTS));
 #else
 #error "OS Support seems wrong."
 #endif
@@ -483,7 +482,7 @@ Serial::SerialImpl::available ()
   if (-1 == ioctl (fd_, TIOCINQ, &count)) {
       THROW (IOException, errno);
   }
-  return static_cast<size_t>(count);
+  return size_t(count);
 }
 
 bool
@@ -520,8 +519,8 @@ Serial::SerialImpl::waitReadable (uint32_t timeout)
 void
 Serial::SerialImpl::waitByteTimes (size_t count)
 {
-  timespec wait_time = { 0, static_cast<long>(byte_time_ns_ * count)};
-  pselect(0, nullptr, nullptr, nullptr, &wait_time, nullptr);
+	timespec wait_time = { 0, long(byte_time_ns_ * count) };
+	pselect(0, nullptr, nullptr, nullptr, &wait_time, nullptr);
 }
 
 size_t
@@ -535,7 +534,7 @@ Serial::SerialImpl::read (uint8_t *buf, size_t size)
 
   // Calculate total timeout in milliseconds t_c + (t_m * N)
   long total_timeout_ms = timeout_.read_timeout_constant;
-  total_timeout_ms += timeout_.read_timeout_multiplier * static_cast<long> (size);
+  total_timeout_ms += timeout_.read_timeout_multiplier * long(size);
   MillisecondTimer total_timeout(total_timeout_ms);
 
   // Pre-fill buffer with available bytes
@@ -554,8 +553,7 @@ Serial::SerialImpl::read (uint8_t *buf, size_t size)
     }
     // Timeout for the next select is whichever is less of the remaining
     // total read timeout and the inter-byte timeout.
-    uint32_t timeout = std::min(static_cast<uint32_t> (timeout_remaining_ms),
-                                timeout_.inter_byte_timeout);
+    uint32_t timeout = std::min(uint32_t(timeout_remaining_ms), timeout_.inter_byte_timeout);
     // Wait for the device to be readable, and then attempt to read.
     if (waitReadable(timeout)) {
       // If it's a fixed-length multi-byte read, insert a wait here so that
@@ -581,7 +579,7 @@ Serial::SerialImpl::read (uint8_t *buf, size_t size)
                                "returned no data (device disconnected?)");
       }
       // Update bytes_read
-      bytes_read += static_cast<size_t> (bytes_read_now);
+      bytes_read += size_t(bytes_read_now);
       // If bytes_read == size then we have read everything we need
       if (bytes_read == size) {
         break;
@@ -612,7 +610,7 @@ Serial::SerialImpl::write (const uint8_t *data, size_t length)
 
   // Calculate total timeout in milliseconds t_c + (t_m * N)
   long total_timeout_ms = timeout_.write_timeout_constant;
-  total_timeout_ms += timeout_.write_timeout_multiplier * static_cast<long> (length);
+  total_timeout_ms += timeout_.write_timeout_multiplier * long(length);
   MillisecondTimer total_timeout(total_timeout_ms);
 
   while (bytes_written < length) {
@@ -660,21 +658,24 @@ Serial::SerialImpl::write (const uint8_t *data, size_t length)
                                  "returned no data (device disconnected?)");
         }
         // Update bytes_written
-        bytes_written += static_cast<size_t> (bytes_written_now);
-        // If bytes_written == size then we have written everything we need to
-        if (bytes_written == length) {
-          break;
-        }
-        // If bytes_written < size then we have more to write
-        if (bytes_written < length) {
-          continue;
-        }
-        // If bytes_written > size then we have over written, which shouldn't happen
-        if (bytes_written > length) {
-          throw SerialException ("write over wrote, too many bytes where "
-                                 "written, this shouldn't happen, might be "
-                                 "a logical error!");
-        }
+	bytes_written += size_t(bytes_written_now);
+	// If bytes_written == size then we have written everything we need to
+	if (bytes_written == length)
+	{
+		break;
+	}
+	// If bytes_written < size then we have more to write
+	if (bytes_written < length)
+	{
+		continue;
+	}
+	// If bytes_written > size then we have over written, which shouldn't happen
+	if (bytes_written > length)
+	{
+		throw SerialException("write over wrote, too many bytes where "
+				      "written, this shouldn't happen, might be "
+				      "a logical error!");
+	}
       }
       // This shouldn't happen, if r > 0 our fd has to be in the list!
       THROW (IOException, "select reports ready to write, but our fd isn't"
@@ -811,7 +812,7 @@ Serial::SerialImpl::sendBreak (int duration)
   if (is_open_ == false) {
     throw PortNotOpenedException ("Serial::sendBreak");
   }
-  tcsendbreak (fd_, static_cast<int> (duration / 4));
+  tcsendbreak(fd_, int(duration / 4));
 }
 
 void

--- a/hardware/serial/impl/win.cpp
+++ b/hardware/serial/impl/win.cpp
@@ -386,7 +386,7 @@ size_t Serial::SerialImpl::available()
 		ss << "Error while checking status of the serial port: " << GetLastError();
 		THROW(IOException, ss.str().c_str());
 	}
-	return static_cast<size_t>(cs.cbInQue);
+	return size_t(cs.cbInQue);
 }
 
 bool Serial::SerialImpl::waitReadable(uint32_t timeout)
@@ -407,7 +407,7 @@ size_t Serial::SerialImpl::read(uint8_t *buf, size_t size)
 		throw PortNotOpenedException("Serial::read");
 	}
 	DWORD bytes_read;
-	if (!ReadFile(fd_, buf, static_cast<DWORD>(size), &bytes_read, nullptr))
+	if (!ReadFile(fd_, buf, DWORD(size), &bytes_read, nullptr))
 	{
 		stringstream ss;
 		ss << "Error while reading from the serial port: " << GetLastError();
@@ -423,7 +423,7 @@ size_t Serial::SerialImpl::write(const uint8_t *data, size_t length)
 		throw PortNotOpenedException("Serial::write");
 	}
 	DWORD bytes_written;
-	if (!WriteFile(fd_, data, static_cast<DWORD>(length), &bytes_written, nullptr))
+	if (!WriteFile(fd_, data, DWORD(length), &bytes_written, nullptr))
 	{
 		stringstream ss;
 		ss << "Error while writing to the serial port: " << GetLastError();

--- a/httpclient/HTTPClient.cpp
+++ b/httpclient/HTTPClient.cpp
@@ -30,35 +30,35 @@ std::string	HTTPClient::m_sUserAgent = "domoticz/1.0";
 size_t write_curl_headerdata(void *contents, size_t size, size_t nmemb, void *userp) // called once for each header
 {
 	size_t realsize = size * nmemb;
-	std::vector<std::string>* pvHeaderData = (std::vector<std::string>*)userp;
-	pvHeaderData->push_back(std::string((unsigned char*)contents, (std::find((unsigned char*)contents, (unsigned char*)contents + realsize, '\r'))));
+	auto pvHeaderData = static_cast<std::vector<std::string> *>(userp);
+	pvHeaderData->push_back(std::string(static_cast<unsigned char *>(contents), (std::find(static_cast<unsigned char *>(contents), static_cast<unsigned char *>(contents) + realsize, '\r'))));
 	return realsize;
 }
 
 size_t write_curl_data(void *contents, size_t size, size_t nmemb, void *userp)
 {
 	size_t realsize = size * nmemb;
-	std::vector<unsigned char>* pvHTTPResponse = (std::vector<unsigned char>*)userp;
-	pvHTTPResponse->insert(pvHTTPResponse->end(), (unsigned char*)contents, (unsigned char*)contents + realsize);
+	std::vector<unsigned char> *pvHTTPResponse = static_cast<std::vector<unsigned char> *>(userp);
+	pvHTTPResponse->insert(pvHTTPResponse->end(), static_cast<unsigned char *>(contents), static_cast<unsigned char *>(contents) + realsize);
 	return realsize;
 }
 
 size_t write_curl_data_file(void *contents, size_t size, size_t nmemb, void *userp)
 {
 	size_t realsize = size * nmemb;
-	std::ofstream *outfile = (std::ofstream*)userp;
-	outfile->write((const char*)contents, realsize);
+	std::ofstream *outfile = static_cast<std::ofstream *>(userp);
+	outfile->write(static_cast<const char *>(contents), realsize);
 	return realsize;
 }
 
 size_t write_curl_data_single_line(void *contents, size_t size, size_t nmemb, void *userp)
 {
 	size_t realsize = size * nmemb;
-	std::vector<unsigned char>* pvHTTPResponse = (std::vector<unsigned char>*)userp;
+	std::vector<unsigned char> *pvHTTPResponse = static_cast<std::vector<unsigned char> *>(userp);
 	size_t ii=0;
 	while (ii< realsize)
 	{
-		unsigned char *pData = (unsigned char*)contents + ii;
+		unsigned char *pData = static_cast<unsigned char *>(contents) + ii;
 		if ((pData[0] == '\n') || (pData[0] == '\r'))
 			return 0;
 		pvHTTPResponse->push_back(pData[0]);
@@ -96,7 +96,7 @@ void HTTPClient::Cleanup()
 
 void HTTPClient::SetGlobalOptions(void *curlobj)
 {
-	CURL *curl=(CURL *)curlobj;
+	CURL *curl = static_cast<CURL *>(curlobj);
 	curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC | CURLAUTH_DIGEST);
 	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_data);
 	curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
@@ -180,7 +180,7 @@ const _tHTTPErrors HTTPCodes[] = {
 
 void HTTPClient::LogError(const long response_code)
 {
-	const _tHTTPErrors* pCodes = (const _tHTTPErrors*)&HTTPCodes;
+	const _tHTTPErrors *pCodes = reinterpret_cast<const _tHTTPErrors *>(&HTTPCodes);
 
 	while (pCodes[0].http_code != 0)
 	{

--- a/httpclient/UrlEncode.cpp
+++ b/httpclient/UrlEncode.cpp
@@ -27,7 +27,7 @@ std::string CURLEncode::decToHex(char num, int radix)
 {
 	std::string csTmp;
 	int num_char;
-	num_char = (int) num;
+	num_char = int(num);
 
 	// ISO-8859-1 
 	// IF THE IF LOOP IS COMMENTED, THE CODE WILL FAIL TO GENERATE A 
@@ -38,7 +38,7 @@ std::string CURLEncode::decToHex(char num, int radix)
 	while (num_char >= radix)
 	{
 		int temp = num_char % radix;
-		num_char = (int)std::floor((float)num_char / radix);
+		num_char = int(std::floor(float(num_char) / radix));
 		csTmp = hexVals[temp];
 	}
 	csTmp += hexVals[num_char%16];
@@ -74,7 +74,7 @@ bool CURLEncode::isUnsafe(char compareChar)
 	}
 	int char_ascii_value = 0;
 	//char_ascii_value = __toascii(compareChar);
-	char_ascii_value = (int) compareChar;
+	char_ascii_value = int(compareChar);
 
 	// found no unsafe chars, return false
 	return !(bcharfound == false && char_ascii_value > 32 && char_ascii_value < 123);
@@ -126,7 +126,7 @@ std::string CURLEncode::URLDecode(const std::string &SRC)
 			int iret=sscanf(SRC.substr(i+1,2).c_str(), "%x", &ii);
 			if (iret < 1)
 				return "";
-			ch=static_cast<char>(ii);
+			ch = char(ii);
 			ret+=ch;
 			i=i+2;
 		} else {

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -44,7 +44,7 @@ void CCameraHandler::ReloadCameras()
 			citem.Username = base64_decode(sd[4]);
 			citem.Password = base64_decode(sd[5]);
 			citem.ImageURL = sd[6];
-			citem.Protocol = (eCameraProtocol)atoi(sd[7].c_str());
+			citem.Protocol = eCameraProtocol(atoi(sd[7].c_str()));
 			m_cameradevices.push_back(citem);
 			_AddedCameras.push_back(sd[0]);
 		}
@@ -71,7 +71,7 @@ void CCameraHandler::ReloadCameraActiveDevices(const std::string &CamID)
 		{
 			cameraActiveDevice aDevice;
 			aDevice.ID = std::stoull(sd[0]);
-			aDevice.DevSceneType = (unsigned char)atoi(sd[1].c_str());
+			aDevice.DevSceneType = uint8_t(atoi(sd[1].c_str()));
 			aDevice.DevSceneRowID = std::stoull(sd[2]);
 			pCamera->mActiveDevices.push_back(aDevice);
 		}
@@ -173,7 +173,7 @@ bool CCameraHandler::TakeRaspberrySnapshot(std::vector<unsigned char> &camimage)
 			{
 				char buf[512];
 				while (is.read(buf, sizeof(buf)).gcount() > 0)
-					camimage.insert(camimage.end(), buf, buf + (unsigned int)is.gcount());
+					camimage.insert(camimage.end(), buf, buf + uint32_t(is.gcount()));
 				is.close();
 				std::remove(OutputFileName.c_str());
 				return true;
@@ -217,7 +217,7 @@ bool CCameraHandler::TakeUVCSnapshot(const std::string &device, std::vector<unsi
 			{
 				char buf[512];
 				while (is.read(buf, sizeof(buf)).gcount() > 0)
-					camimage.insert(camimage.end(), buf, buf + (unsigned int)is.gcount());
+					camimage.insert(camimage.end(), buf, buf + uint32_t(is.gcount()));
 				is.close();
 				std::remove(OutputFileName.c_str());
 				return true;

--- a/main/CmdLine.cpp
+++ b/main/CmdLine.cpp
@@ -101,7 +101,7 @@ int CCmdLine::SplitLine(int argc, char **argv)
 		}
 	}
 
-	return static_cast<int>(size());
+	return int(size());
 }
 
 /*------------------------------------------------------
@@ -218,14 +218,14 @@ std::string CCmdLine::GetArgument(const char *pSwitch, int iIdx)
 		CCmdLine::iterator theIterator = find(pSwitch);
 		if (theIterator != end())
 		{
-			if (static_cast<int>((*theIterator).second.m_strings.size()) > iIdx)
+			if (int(theIterator->second.m_strings.size()) > iIdx)
 			{
-				return (*theIterator).second.m_strings[iIdx];
+				return theIterator->second.m_strings[iIdx];
 			}
 		}
 	}
 
-	throw (int)0;
+	throw 0;
 
 	return "";
 }
@@ -248,7 +248,7 @@ int CCmdLine::GetArgumentCount(const char *pSwitch)
 		CCmdLine::iterator theIterator = find(pSwitch);
 		if (theIterator != end())
 		{
-			iArgumentCount = static_cast<int>((*theIterator).second.m_strings.size());
+			iArgumentCount = int(theIterator->second.m_strings.size());
 		}
 	}
 

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -408,7 +408,7 @@ void CEventSystem::UpdateJsonMap(_tDeviceStatus &item, const uint64_t ulDevID)
 					item.JsonMapString[index] = l_JsonValueString.assign(value);
 					break;
 				case JTYPE_FLOAT:
-					item.JsonMapFloat[index] = (float)atof(value.c_str());
+					item.JsonMapFloat[index] = float(atof(value.c_str()));
 					break;
 				case JTYPE_INT:
 					item.JsonMapInt[index] = atoi(value.c_str());
@@ -489,7 +489,7 @@ void CEventSystem::GetCurrentStates()
 			sitem.sValue = l_sValue.assign(sd[4]);
 
 			sitem.switchtype = atoi(sd[7].c_str());
-			_eSwitchType switchtype = (_eSwitchType)sitem.switchtype;
+			_eSwitchType switchtype = _eSwitchType(sitem.switchtype);
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[10]);
 			sitem.nValueWording = l_nValueWording.assign(nValueToWording(sitem.devType, sitem.subType, switchtype, sitem.nValue, sitem.sValue, options));
 			sitem.lastUpdate = l_lastUpdate.assign(sd[8]);
@@ -658,7 +658,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP:
 			if (!splitresults.empty())
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				isTemp = true;
 			}
 			break;
@@ -667,7 +667,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					isTemp = true;
 				}
 			}
@@ -675,7 +675,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = float(atof(splitresults[0].c_str()));
 					isUtility = true;
 				}
 			}
@@ -683,7 +683,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeThermostat1:
 			if (!splitresults.empty())
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				isTemp = true;
 			}
 			break;
@@ -694,9 +694,9 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP_HUM:
 			if (splitresults.size() > 1)
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				humidity = atoi(splitresults[1].c_str());
-				dewpoint = (float)CalculateDewPoint(temp, humidity);
+				dewpoint = float(CalculateDewPoint(temp, humidity));
 				isTemp = true;
 				isHum = true;
 				isDew = true;
@@ -707,10 +707,10 @@ void CEventSystem::GetCurrentMeasurementStates()
 				_log.Log(LOG_ERROR, "EventSystem: TEMP_HUM_BARO missing values : ID=%" PRIu64 ", sValue=%s", sitem.ID, sitem.sValue.c_str());
 				continue;
 			}
-			temp = static_cast<float>(atof(splitresults[0].c_str()));
+			temp = float(atof(splitresults[0].c_str()));
 			humidity = atoi(splitresults[1].c_str());
-			barometer = static_cast<float>(atof(splitresults[3].c_str()));
-			dewpoint = (float)CalculateDewPoint(temp, humidity);
+			barometer = float(atof(splitresults[3].c_str()));
+			dewpoint = float(CalculateDewPoint(temp, humidity));
 			isTemp = true;
 			isHum = true;
 			isBaro = true;
@@ -719,34 +719,34 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP_BARO:
 			if (splitresults.size() > 1)
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
-				barometer = static_cast<float>(atof(splitresults[1].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
+				barometer = float(atof(splitresults[1].c_str()));
 				isTemp = true;
 				isBaro = true;
 			}
 			break;
 		case pTypeBARO:
-			barometer = static_cast<float>(atof(splitresults[0].c_str()));
+			barometer = float(atof(splitresults[0].c_str()));
 			isBaro = true;
 			break;
 		case pTypeRadiator1:
 			if (sitem.subType == sTypeSmartwares)
 			{
-				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
+				utilityval = float(atof(sitem.sValue.c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypeUV:
 			if (splitresults.size() == 2)
 			{
-				uv = static_cast<float>(atof(splitresults[0].c_str()));
+				uv = float(atof(splitresults[0].c_str()));
 				isUV = true;
 				weatherval = uv;
 				isWeather = true;
 
 				if (sitem.subType == sTypeUV3)
 				{
-					temp = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = float(atof(splitresults[1].c_str()));
 					isTemp = true;
 				}
 			}
@@ -754,7 +754,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeWIND:
 			if (splitresults.size() == 6)
 			{
-				winddir = static_cast<float>(atof(splitresults[0].c_str()));
+				winddir = float(atof(splitresults[0].c_str()));
 				isWindDir = true;
 
 				if (sitem.subType != sTypeWIND5)
@@ -779,8 +779,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 				}
 				if ((sitem.subType == sTypeWIND4) || (sitem.subType == sTypeWINDNoTemp))
 				{
-					temp = static_cast<float>(atof(splitresults[4].c_str()));
-					//chill = static_cast<float>(atof(splitresults[5].c_str()));
+					temp = float(atof(splitresults[4].c_str()));
+					// chill = float(atof(splitresults[5].c_str()));
 					isTemp = true;
 				}
 			}
@@ -790,55 +790,55 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					isTemp = true;
 				}
 			}
 			else if ((sitem.subType == sTypeRFXSensorVolt) || (sitem.subType == sTypeRFXSensorAD))
 			{
-				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
+				utilityval = float(atof(sitem.sValue.c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypeAirQuality:
-			utilityval = (float)(sitem.nValue);
+			utilityval = float(sitem.nValue);
 			isUtility = true;
 			break;
 		case pTypeENERGY:
 			if (!splitresults.empty())
 			{
 				if (splitresults.size() == 2)
-					utilityval = static_cast<float>(atof(splitresults[1].c_str()));
+					utilityval = float(atof(splitresults[1].c_str()));
 				else
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = float(atof(splitresults[0].c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypePOWER:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = float(atof(splitresults[0].c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypeUsage:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = float(atof(splitresults[0].c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypeP1Power:
 			if (splitresults.size() == 6)
 			{
-				utilityval = static_cast<float>(atof(splitresults[4].c_str()));
+				utilityval = float(atof(splitresults[4].c_str()));
 				isUtility = true;
 			}
 			break;
 		case pTypeLux:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = float(atof(splitresults[0].c_str()));
 				isUtility = true;
 			}
 			break;
@@ -848,14 +848,14 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if ((sitem.subType == sTypeVisibility) || (sitem.subType == sTypeSolarRadiation))
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = float(atof(splitresults[0].c_str()));
 					isUtility = true;
 					weatherval = utilityval;
 					isWeather = true;
 				}
 				else if (sitem.subType == sTypeBaro)
 				{
-					barometer = static_cast<float>(atof(splitresults[0].c_str()));
+					barometer = float(atof(splitresults[0].c_str()));
 					isBaro = true;
 				}
 				else if ((sitem.subType == sTypeAlert)
@@ -870,7 +870,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 					|| (sitem.subType == sTypeSoundLevel)
 					)
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = float(atof(splitresults[0].c_str()));
 					isUtility = true;
 				}
 			}
@@ -883,7 +883,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 				}
 				else if (sitem.subType == sTypeCounterIncremental)
 				{
-					const _eMeterType metertype = (const _eMeterType)sitem.switchtype;
+					const auto metertype = _eMeterType(sitem.switchtype);
 
 					float divider = m_sql.GetCounterDivider(int(metertype), int(sitem.devType), float(sitem.AddjValue2));
 
@@ -908,7 +908,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 				}
 				else if (sitem.subType == sTypeManagedCounter)
 				{
-					const _eMeterType metertype = (const _eMeterType)sitem.switchtype;
+					const auto metertype = _eMeterType(sitem.switchtype);
 
 					float divider = m_sql.GetCounterDivider(int(metertype), int(sitem.devType), float(sitem.AddjValue2));
 
@@ -929,7 +929,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			if (splitresults.size() == 2)
 			{
 				rainmm = 0;
-				rainmmlasthour = static_cast<float>(atof(splitresults[0].c_str())) / 100.0F;
+				rainmmlasthour = float(atof(splitresults[0].c_str())) / 100.0F;
 				isRain = true;
 				weatherval = rainmmlasthour;
 				isWeather = true;
@@ -961,8 +961,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 					}
 					else
 					{
-						float total_min = static_cast<float>(atof(sd2[0].c_str()));
-						float total_max = static_cast<float>(atof(splitresults[1].c_str()));
+						float total_min = float(atof(sd2[0].c_str()));
+						float total_max = float(atof(splitresults[1].c_str()));
 						total_real = total_max - total_min;
 					}
 					rainmm = float(total_real);
@@ -995,7 +995,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeRFXMeter:
 			if (sitem.subType == sTypeRFXMeterCount)
 			{
-				const _eMeterType metertype = (const _eMeterType)sitem.switchtype;
+				const auto metertype = _eMeterType(sitem.switchtype);
 				float divider = m_sql.GetCounterDivider(int(metertype), int(sitem.devType), float(sitem.AddjValue2));
 
 				//get value of today
@@ -1171,9 +1171,9 @@ bool CEventSystem::Update(const Notification::_eType type, const Notification::_
 		return false;
 	_tEventQueue item;
 	item.reason = REASON_NOTIFICATION;
-	item.nValue = static_cast<int>(type);
+	item.nValue = int(type);
 	item.sValue = eventdata;
-	item.lastLevel = static_cast<uint8_t>(status);
+	item.lastLevel = uint8_t(status);
 	if (type != Notification::DZ_STOP)
 		m_eventqueue.push(item);
 	else // blocking call on application shutdown
@@ -1217,7 +1217,7 @@ void CEventSystem::SetEventTrigger(const uint64_t ulDevID, const _eReason reason
 	boost::unique_lock<boost::shared_mutex> eventtriggerMutexLock(m_eventtriggerMutex);
 	if (!m_eventtrigger.empty())
 	{
-		time_t atime = mytime(nullptr) + static_cast<int>(fDelayTime);
+		time_t atime = mytime(nullptr) + int(fDelayTime);
 		for (auto itt = m_eventtrigger.begin(); itt != m_eventtrigger.end();)
 		{
 			if (itt->ID == ulDevID && itt->reason == reason && itt->timestamp >= atime) // cancel later or equal queued items
@@ -1229,7 +1229,7 @@ void CEventSystem::SetEventTrigger(const uint64_t ulDevID, const _eReason reason
 	_tEventTrigger item;
 	item.ID = ulDevID;
 	item.reason = reason;
-	item.timestamp = mytime(nullptr) + static_cast<int>(fDelayTime);
+	item.timestamp = mytime(nullptr) + int(fDelayTime);
 	m_eventtrigger.push_back(item);
 }
 
@@ -1458,9 +1458,9 @@ void CEventSystem::ProcessDevice(
 
 	std::vector<std::string> sd = result[0];
 
-	_eSwitchType switchType = (_eSwitchType)std::stoi(sd[0]);
+	_eSwitchType switchType = _eSwitchType(std::stoi(sd[0]));
 	std::string lastUpdate = sd[1];
-	uint8_t lastLevel = (uint8_t)std::stoi(sd[2]);
+	uint8_t lastLevel = uint8_t(std::stoi(sd[2]));
 	std::string dev_options = sd[3];
 	std::string devname = sd[4];
 
@@ -1682,8 +1682,8 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	lua_setglobal(lua_state, "print");
 
 	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
-	
-	CLuaTable luaTable(lua_state, "device", (int)m_devicestates.size(), 0);
+
+	CLuaTable luaTable(lua_state, "device", int(m_devicestates.size()), 0);
 
 	for (const auto &state : m_devicestates)
 	{
@@ -1694,8 +1694,8 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	devicestatesMutexLock.unlock();
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
-	
-	luaTable.InitTable(lua_state, "variable", (int)m_uservariables.size(), 0);
+
+	luaTable.InitTable(lua_state, "variable", int(m_uservariables.size()), 0);
 
 	for (const auto &variable : m_uservariables)
 	{
@@ -1721,14 +1721,14 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 
 	if (!m_tempValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "temperaturedevice", (int)m_tempValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "temperaturedevice", int(m_tempValuesByID.size()), 0);
 		for (const auto &temp : m_tempValuesByID)
 			luaTable.AddNumber(temp.first, temp.second);
 		luaTable.Publish();
 	}
 	if (!m_dewValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "dewpointdevice", (int)m_dewValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "dewpointdevice", int(m_dewValuesByID.size()), 0);
 		for (const auto &dew : m_dewValuesByID)
 		{
 			luaTable.AddNumber(dew.first, dew.second);
@@ -1737,7 +1737,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_humValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "humiditydevice", (int)m_humValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "humiditydevice", int(m_humValuesByID.size()), 0);
 		for (const auto &hum : m_humValuesByID)
 		{
 			luaTable.AddNumber(hum.first, hum.second);
@@ -1746,7 +1746,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_baroValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "barometerdevice", (int)m_baroValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "barometerdevice", int(m_baroValuesByID.size()), 0);
 		for (const auto &baro : m_baroValuesByID)
 		{
 			luaTable.AddNumber(baro.first, baro.second);
@@ -1755,7 +1755,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_utilityValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "utilitydevice", (int)m_utilityValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "utilitydevice", int(m_utilityValuesByID.size()), 0);
 		for (const auto &utility : m_utilityValuesByID)
 		{
 			luaTable.AddNumber(utility.first, utility.second);
@@ -1764,7 +1764,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_weatherValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "weatherdevice", (int)m_weatherValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "weatherdevice", int(m_weatherValuesByID.size()), 0);
 		for (const auto &weather : m_weatherValuesByID)
 		{
 			luaTable.AddNumber(weather.first, weather.second);
@@ -1773,7 +1773,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_rainValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "raindevice", (int)m_rainValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "raindevice", int(m_rainValuesByID.size()), 0);
 		for (const auto &rain : m_rainValuesByID)
 		{
 			luaTable.AddNumber(rain.first, rain.second);
@@ -1782,7 +1782,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_rainLastHourValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "rainlasthourdevice", (int)m_rainLastHourValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "rainlasthourdevice", int(m_rainLastHourValuesByID.size()), 0);
 		for (const auto &rainlh : m_rainLastHourValuesByID)
 		{
 			luaTable.AddNumber(rainlh.first, rainlh.second);
@@ -1791,7 +1791,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_uvValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "uvdevice", (int)m_uvValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "uvdevice", int(m_uvValuesByID.size()), 0);
 		for (const auto &uv : m_uvValuesByID)
 		{
 			luaTable.AddNumber(uv.first, uv.second);
@@ -1800,7 +1800,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_winddirValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "winddirdevice", (int)m_winddirValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "winddirdevice", int(m_winddirValuesByID.size()), 0);
 		for (const auto &winddir : m_winddirValuesByID)
 		{
 			luaTable.AddNumber(winddir.first, winddir.second);
@@ -1809,7 +1809,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_windspeedValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "windspeeddevice", (int)m_windspeedValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "windspeeddevice", int(m_windspeedValuesByID.size()), 0);
 		for (const auto &windspeed : m_windspeedValuesByID)
 		{
 			luaTable.AddNumber(windspeed.first, windspeed.second);
@@ -1818,7 +1818,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_windgustValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "windgustdevice", (int)m_windgustValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "windgustdevice", int(m_windgustValuesByID.size()), 0);
 		for (const auto &windgust : m_windgustValuesByID)
 		{
 			luaTable.AddNumber(windgust.first, windgust.second);
@@ -1827,7 +1827,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	}
 	if (!m_zwaveAlarmValuesByID.empty())
 	{
-		luaTable.InitTable(lua_state, "zwavealarms", (int)m_zwaveAlarmValuesByID.size(), 0);
+		luaTable.InitTable(lua_state, "zwavealarms", int(m_zwaveAlarmValuesByID.size()), 0);
 		for (const auto &alarm : m_zwaveAlarmValuesByID)
 		{
 			luaTable.AddNumber(alarm.first, alarm.second);
@@ -1835,7 +1835,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 		luaTable.Publish();
 	}
 
-	lua_pushnumber(lua_state, (lua_Number)m_SecStatus);
+	lua_pushnumber(lua_state, lua_Number(m_SecStatus));
 	lua_setglobal(lua_state, "securitystatus");
 
 	return lua_state;
@@ -2106,7 +2106,7 @@ std::string CEventSystem::ProcessVariableArgument(const std::string &Argument)
 		if (itt != m_zwaveAlarmValuesByID.end())
 		{
 			std::stringstream sstr;
-			sstr << (int)itt->second;
+			sstr << int(itt->second);
 			return sstr.str();
 		}
 	}
@@ -2235,14 +2235,14 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 				{
 					std::vector<std::string> sd = result[0];
 					std::string errorMessage;
-					if (!m_sql.UpdateUserVariable(variableNo, sd[0], (const _eUsrVariableType)atoi(sd[1].c_str()), doWhat, false, errorMessage))
+					if (!m_sql.UpdateUserVariable(variableNo, sd[0], _eUsrVariableType(atoi(sd[1].c_str())), doWhat, false, errorMessage))
 					{
 						_log.Log(LOG_ERROR, "EventSystem: Error updating variable %s: %s", sd[0].c_str(), errorMessage.c_str());
 					}
 				}
 			}
 			else
-				m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, (const uint64_t)atol(variableNo.c_str()), doWhat, false));
+				m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, uint64_t(atol(variableNo.c_str())), doWhat, false));
 
 			actionsDone = true;
 			continue;
@@ -2515,19 +2515,19 @@ void CEventSystem::ParseActionString(const std::string &oAction_, _tActionParseR
 				oResults_.sCommand.append(sToken);
 				break;
 			case 1:
-				oResults_.fForSec = 60.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fForSec = 60.F * float(atof(sToken.c_str()));
 				break;
 			case 2:
-				oResults_.fAfterSec = 1.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fAfterSec = 1.F * float(atof(sToken.c_str()));
 				break;
 			case 3:
-				oResults_.fRandomSec = 60.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fRandomSec = 60.F * float(atof(sToken.c_str()));
 				break;
 			case 4:
 				oResults_.iRepeat = atoi(sToken.c_str());
 				break;
 			case 5:
-				oResults_.fRepeatSec = 1.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fRepeatSec = 1.F * float(atof(sToken.c_str()));
 				break;
 			}
 		}
@@ -2628,7 +2628,7 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQu
 {
 	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 
-	CLuaTable luaTable(lua_state, "otherdevices", (int)m_devicestates.size(), 0);
+	CLuaTable luaTable(lua_state, "otherdevices", int(m_devicestates.size()), 0);
 	for (const auto &state : m_devicestates)
 	{
 		luaTable.AddString(state.second.deviceName, (state.first == item.id && item.reason == REASON_DEVICE)
@@ -2637,7 +2637,7 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQu
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "otherdevices_lastupdate", (int)m_devicestates.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_lastupdate", int(m_devicestates.size()), 0);
 	for (const auto &state : m_devicestates)
 	{
 		luaTable.AddString(state.second.deviceName,
@@ -2645,7 +2645,7 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQu
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "otherdevices_svalues", (int)m_devicestates.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_svalues", int(m_devicestates.size()), 0);
 	for (const auto &state : m_devicestates)
 	{
 		luaTable.AddString(state.second.deviceName,
@@ -2653,14 +2653,14 @@ void CEventSystem::ExportDeviceStatesToLua(lua_State *lua_state, const _tEventQu
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "otherdevices_idx", (int)m_devicestates.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_idx", int(m_devicestates.size()), 0);
 	for (const auto &state : m_devicestates)
 	{
 		luaTable.AddInteger(state.second.deviceName, state.second.ID);
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "otherdevices_lastlevel", (int)m_devicestates.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_lastlevel", int(m_devicestates.size()), 0);
 	for (const auto &state : m_devicestates)
 	{
 		luaTable.AddNumber(state.second.deviceName,
@@ -2696,7 +2696,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 
 		if (!m_tempValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_temperature", (int)m_tempValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_temperature", int(m_tempValuesByName.size()), 0);
 			for (const auto &temp : m_tempValuesByName)
 			{
 				luaTable.AddNumber(temp.first, temp.second);
@@ -2709,7 +2709,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_dewValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_dewpoint", (int)m_dewValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_dewpoint", int(m_dewValuesByName.size()), 0);
 			for (const auto &dew : m_dewValuesByName)
 			{
 				luaTable.AddNumber(dew.first, dew.second);
@@ -2722,7 +2722,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_humValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_humidity", (int)m_humValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_humidity", int(m_humValuesByName.size()), 0);
 			for (const auto &hum : m_humValuesByName)
 			{
 				luaTable.AddNumber(hum.first, hum.second);
@@ -2735,20 +2735,20 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_baroValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_barometer", (int)m_baroValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_barometer", int(m_baroValuesByName.size()), 0);
 			for (const auto &baro : m_baroValuesByName)
 			{
 				luaTable.AddNumber(baro.first, baro.second);
 				if (baro.first == item.devname)
 				{
-					thisDeviceBaro = (float)baro.second;
+					thisDeviceBaro = float(baro.second);
 				}
 			}
 			luaTable.Publish();
 		}
 		if (!m_utilityValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_utility", (int)m_utilityValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_utility", int(m_utilityValuesByName.size()), 0);
 			for (const auto &utility : m_utilityValuesByName)
 			{
 				luaTable.AddNumber(utility.first, utility.second);
@@ -2761,7 +2761,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_rainValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_rain", (int)m_rainValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_rain", int(m_rainValuesByName.size()), 0);
 			for (const auto &rain : m_rainValuesByName)
 			{
 				luaTable.AddNumber(rain.first, rain.second);
@@ -2774,7 +2774,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_rainLastHourValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_rain_lasthour", (int)m_rainLastHourValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_rain_lasthour", int(m_rainLastHourValuesByName.size()), 0);
 			for (const auto &rainlh : m_rainLastHourValuesByName)
 			{
 				luaTable.AddNumber(rainlh.first, rainlh.second);
@@ -2787,7 +2787,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_uvValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_uv", (int)m_uvValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_uv", int(m_uvValuesByName.size()), 0);
 			for (const auto &uv : m_uvValuesByName)
 			{
 				luaTable.AddNumber(uv.first, uv.second);
@@ -2800,7 +2800,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_winddirValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_winddir", (int)m_winddirValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_winddir", int(m_winddirValuesByName.size()), 0);
 			for (const auto &winddir : m_winddirValuesByName)
 			{
 				luaTable.AddNumber(winddir.first, winddir.second);
@@ -2812,7 +2812,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_windspeedValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_windspeed", (int)m_windspeedValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_windspeed", int(m_windspeedValuesByName.size()), 0);
 			for (const auto &windspeed : m_windspeedValuesByName)
 			{
 				luaTable.AddNumber(windspeed.first, windspeed.second);
@@ -2824,7 +2824,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_windgustValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_windgust", (int)m_windgustValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_windgust", int(m_windgustValuesByName.size()), 0);
 			for (const auto &windgust : m_windgustValuesByName)
 			{
 				luaTable.AddNumber(windgust.first, windgust.second);
@@ -2836,7 +2836,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_weatherValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_weather", (int)m_weatherValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_weather", int(m_weatherValuesByName.size()), 0);
 			for (const auto &weather : m_weatherValuesByName)
 			{
 				luaTable.AddNumber(weather.first, weather.second);
@@ -2849,7 +2849,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 		}
 		if (!m_zwaveAlarmValuesByName.empty())
 		{
-			CLuaTable luaTable(lua_state, "otherdevices_zwavealarms", (int)m_zwaveAlarmValuesByName.size(), 0);
+			CLuaTable luaTable(lua_state, "otherdevices_zwavealarms", int(m_zwaveAlarmValuesByName.size()), 0);
 			for (const auto &alarm : m_zwaveAlarmValuesByName)
 			{
 				luaTable.AddNumber(alarm.first, alarm.second);
@@ -2941,7 +2941,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 
-	CLuaTable luaTable(lua_state, "uservariables", (int)m_uservariables.size(), 0);
+	CLuaTable luaTable(lua_state, "uservariables", int(m_uservariables.size()), 0);
 
 	for (const auto &uservar : m_uservariables)
 	{
@@ -2961,7 +2961,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "uservariables_lastupdate", (int)m_uservariables.size(), 0);
+	luaTable.InitTable(lua_state, "uservariables_lastupdate", int(m_uservariables.size()), 0);
 
 	for (const auto &uservar : m_uservariables)
 	{
@@ -2986,7 +2986,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	uservariablesMutexLock.unlock();
 
 	boost::shared_lock<boost::shared_mutex> scenesgroupsMutexLock(m_scenesgroupsMutex);
-	luaTable.InitTable(lua_state, "otherdevices_scenesgroups", (int)m_scenesgroups.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_scenesgroups", int(m_scenesgroups.size()), 0);
 	for (const auto &group : m_scenesgroups)
 	{
 		_tScenesGroups sgitem = group.second;
@@ -2994,7 +2994,7 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	}
 	luaTable.Publish();
 
-	luaTable.InitTable(lua_state, "otherdevices_scenesgroups_idx", (int)m_scenesgroups.size(), 0);
+	luaTable.InitTable(lua_state, "otherdevices_scenesgroups_idx", int(m_scenesgroups.size()), 0);
 	for (const auto &group : m_scenesgroups)
 	{
 		_tScenesGroups sgitem = group.second;
@@ -3389,7 +3389,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			if (parseResult.fAfterSec < (1. / timer_resolution_hz / 2))
 			{
 				std::string errorMessage;
-				if (!m_sql.UpdateUserVariable(sd[0], variableName, (const _eUsrVariableType)atoi(sd[1].c_str()), variableValue, false, errorMessage))
+				if (!m_sql.UpdateUserVariable(sd[0], variableName, _eUsrVariableType(atoi(sd[1].c_str())), variableValue, false, errorMessage))
 				{
 					_log.Log(LOG_ERROR, "EventSystem: Error updating variable %s: %s", variableName.c_str(), errorMessage.c_str());
 				}
@@ -3672,7 +3672,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 		}
 
 		std::vector<std::string> sd = result[0];
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[0].c_str());
+		_eSwitchType switchtype = _eSwitchType(atoi(sd[0].c_str()));
 		int iOnDelay = atoi(sd[1].c_str());
 
 		bool bIsOn = IsLightSwitchOn(oParseResults.sCommand);
@@ -3688,7 +3688,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 
 		float fRandomTime = 0;
 		if (oParseResults.fRandomSec > (1. / timer_resolution_hz / 2))
-			fRandomTime = static_cast<float>(GenerateRandomNumber(static_cast<int>(oParseResults.fRandomSec)));
+			fRandomTime = float(GenerateRandomNumber(int(oParseResults.fRandomSec)));
 
 		float fDelayTime = oParseResults.fAfterSec + fPreviousRandomTime + fRandomTime + iDeviceDelay + (iIndex * oParseResults.fForSec) + (iIndex * oParseResults.fRepeatSec);
 		fPreviousRandomTime = fRandomTime;
@@ -3882,7 +3882,7 @@ std::string CEventSystem::nValueToWording(const uint8_t dType, const uint8_t dSu
 	}
 	else if (switchtype == STYPE_Media)
 	{
-		lstatus = Media_Player_States((const _eMediaStatus)nValue);
+		lstatus = Media_Player_States(_eMediaStatus(nValue));
 	}
 	else if (lstatus.empty())
 	{
@@ -4004,7 +4004,7 @@ int CEventSystem::calculateDimLevel(int deviceID, int percentageLevel)
 
 		unsigned char dType = atoi(sd[0].c_str());
 		unsigned char dSubType = atoi(sd[1].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[2].c_str());
+		_eSwitchType switchtype = _eSwitchType(atoi(sd[2].c_str()));
 		std::string lstatus;
 		int llevel = 0;
 		bool bHaveDimmer = false;
@@ -4141,7 +4141,7 @@ namespace http {
 
 					if (interpreter == "Blockly") {
 						const Json::Value array = jsonRoot["eventlogic"];
-						for (int index = 0; index < (int)array.size(); ++index)
+						for (int index = 0; index < int(array.size()); ++index)
 						{
 							std::string conditions = array[index].get("conditions", "").asString();
 							std::string actions = array[index].get("actions", "").asString();
@@ -4387,7 +4387,7 @@ namespace http {
 
 						if (interpreter == "Blockly") {
 							const Json::Value array = jsonRoot["eventlogic"];
-							for (int index = 0; index < (int)array.size(); ++index)
+							for (int index = 0; index < int(array.size()); ++index)
 							{
 								std::string conditions = array[index].get("conditions", "").asString();
 								std::string actions = array[index].get("actions", "").asString();
@@ -4433,7 +4433,7 @@ namespace http {
 				for (const auto &state : devStates)
 				{
 					root["title"] = "Current States";
-					root["result"][ii]["id"] = (Json::Value::UInt64)state.ID;
+					root["result"][ii]["id"] = Json::Value::UInt64(state.ID);
 					root["result"][ii]["name"] = state.deviceName;
 					root["result"][ii]["value"] = state.nValueWording;
 					std::stringstream sstr;

--- a/main/EventsPythonDevice.cpp
+++ b/main/EventsPythonDevice.cpp
@@ -14,7 +14,7 @@
           Py_XDECREF(self->n_value_string);
           Py_XDECREF(self->s_value);
           Py_XDECREF(self->last_update_string);
-          Py_TYPE(self)->tp_free((PyObject*)self);
+	  Py_TYPE(self)->tp_free(reinterpret_cast<PyObject *>(self));
       }
 
       PyObject *
@@ -22,7 +22,7 @@
       {
           PDevice *self;
 
-          self = (PDevice *)type->tp_alloc(type, 0);
+	  self = reinterpret_cast<PDevice *>(type->tp_alloc(type, 0));
 	  if (self != nullptr)
 	  {
 		  self->name = PyUnicode_FromString("");
@@ -60,7 +60,7 @@
 		  self->switch_type = 0;
 	  }
 
-	  return (PyObject *)self;
+	  return reinterpret_cast<PyObject *>(self);
       }
 
       int

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -132,7 +132,7 @@ std::vector<char> HexToBytes(const std::string& hex) {
 
 	for (unsigned int i = 0; i < hex.length(); i += 2) {
 		std::string byteString = hex.substr(i, 2);
-		char byte = (char)strtol(byteString.c_str(), nullptr, 16);
+		char byte = char(strtol(byteString.c_str(), nullptr, 16));
 		bytes.push_back(byte);
 	}
 
@@ -227,7 +227,7 @@ std::vector<std::string> GetSerialPorts(bool &bUseDirectPath)
 			std::vector<ULONG> intPorts;
 			intPorts.resize(255);
 			ULONG nPortNumbersFound = 0;
-			const ULONG nReturn = pGetCommPorts(&(intPorts[0]), static_cast<ULONG>(intPorts.size()), &nPortNumbersFound);
+			const ULONG nReturn = pGetCommPorts(&(intPorts[0]), ULONG(intPorts.size()), &nPortNumbersFound);
 			if (nReturn == ERROR_SUCCESS)
 			{
 				for (ULONG i = 0; i < nPortNumbersFound; i++)
@@ -486,8 +486,7 @@ float pressureToAltitude(float seaLevel, float atmospheric, float temp)
 	/* P0 = sea-level pressure (in hPa) */
 	/* P = atmospheric pressure (in hPa) */
 	/* T = temperature (in °C) */
-	return (((float)pow((seaLevel / atmospheric), 0.190223F) - 1.0F)
-		* (temp + 273.15F)) / 0.0065F;
+	return ((pow((seaLevel / atmospheric), 0.190223F) - 1.0F) * (temp + 273.15F)) / 0.0065F;
 }
 
 /**************************************************************************/
@@ -512,8 +511,7 @@ float pressureSeaLevelFromAltitude(float altitude, float atmospheric, float temp
 	/* P = atmospheric pressure (in hPa) */
 	/* h = altitude (in meters) */
 	/* T = Temperature (in °C) */
-	return atmospheric * (float)pow((1.0F - (0.0065F * altitude) /
-		(temp + 0.0065F * altitude + 273.15F)), -5.257F);
+	return atmospheric * pow((1.0F - (0.0065F * altitude) / (temp + 0.0065F * altitude + 273.15F)), -5.257F);
 }
 
 //Haversine formula to calculate distance between two points
@@ -713,8 +711,8 @@ double ConvertToFahrenheit(const double Celsius)
 
 double RoundDouble(const long double invalue, const short numberOfPrecisions)
 {
-	long long p = (long long) pow(10.0L, numberOfPrecisions);
-	double ret= (long long)(invalue * p + 0.5L) / (double)p;
+	int64_t p = int64_t(pow(10.0L, numberOfPrecisions));
+	double ret = int64_t(invalue * p + 0.5L) / double(p);
 	return ret;
 }
 
@@ -809,7 +807,7 @@ std::string TimeToString(const time_t *ltime, const _eTimeFormat format)
 	}
 
 	if (format > TF_DateTime && ltime == nullptr)
-		sstr << "." << std::setw(3) << std::setfill('0') << ((int)tv.tv_usec / 1000);
+		sstr << "." << std::setw(3) << std::setfill('0') << (int(tv.tv_usec) / 1000);
 
 	return sstr.str();
 }
@@ -819,11 +817,11 @@ std::string GenerateMD5Hash(const std::string &InputString, const std::string &S
 	std::string cstring = InputString + Salt;
 	unsigned char digest[MD5_DIGEST_LENGTH + 1];
 	digest[MD5_DIGEST_LENGTH] = 0;
-	MD5((const unsigned char*)cstring.c_str(), cstring.size(), (unsigned char*)&digest);
+	MD5(reinterpret_cast<const unsigned char *>(cstring.c_str()), cstring.size(), reinterpret_cast<unsigned char *>(&digest));
 	char mdString[(MD5_DIGEST_LENGTH * 2) + 1];
 	mdString[MD5_DIGEST_LENGTH * 2] = 0;
 	for (int i = 0; i < 16; i++)
-		sprintf(&mdString[i * 2], "%02x", (unsigned int)digest[i]);
+		sprintf(&mdString[i * 2], "%02x", uint32_t(digest[i]));
 	return mdString;
 }
 
@@ -840,7 +838,7 @@ void hsb2rgb(const float hue, const float saturation, const float vlue, int &out
 	hh = hue;
 	if (hh >= 360.0) hh = 0.0;
 	hh /= 60.0;
-	i = (long)hh;
+	i = long(hh);
 	ff = hh - i;
 	p = vlue * (1.0 - saturation);
 	q = vlue * (1.0 - (saturation * ff));
@@ -892,17 +890,17 @@ void rgb2hsb(const int r, const int g, const int b, float hsbvals[3])
 	int cmin = (r < g) ? r : g;
 	if (b < cmin) cmin = b;
 
-	brightness = ((float)cmax) / 255.0F;
+	brightness = (float(cmax)) / 255.0F;
 	if (cmax != 0)
-		saturation = ((float)(cmax - cmin)) / ((float)cmax);
+		saturation = (float(cmax - cmin)) / (float(cmax));
 	else
 		saturation = 0;
 	if (saturation == 0)
 		hue = 0;
 	else {
-		float redc = ((float)(cmax - r)) / ((float)(cmax - cmin));
-		float greenc = ((float)(cmax - g)) / ((float)(cmax - cmin));
-		float bluec = ((float)(cmax - b)) / ((float)(cmax - cmin));
+		float redc = (float(cmax - r)) / (float(cmax - cmin));
+		float greenc = (float(cmax - g)) / (float(cmax - cmin));
+		float bluec = (float(cmax - b)) / (float(cmax - cmin));
 		if (r == cmax)
 			hue = bluec - greenc;
 		else if (g == cmax)
@@ -1169,7 +1167,7 @@ bool IsArgumentSecure(const std::string &arg)
 uint32_t SystemUptime()
 {
 #if defined(WIN32)
-	return static_cast<uint32_t>(GetTickCount64() / 1000u);
+	return uint32_t(GetTickCount64() / 1000u);
 #elif defined(__linux__) || defined(__linux) || defined(linux)
 	struct sysinfo info;
 	if (sysinfo(&info) != 0)
@@ -1199,14 +1197,14 @@ static struct
 	time_t t;
 	clock_t c;
 	int counter;
-} entropy = { 0, (time_t) 0, (clock_t) 0, 0 };
+} entropy = { 0, time_t(0), clock_t(0), 0 };
 
-static unsigned char * p = (unsigned char *) (&entropy + 1);
+static unsigned char *p = reinterpret_cast<unsigned char *>(&entropy + 1);
 static int accSeed = 0;
 
 int GenerateRandomNumber(const int range)
 {
-	if (p == ((unsigned char *) (&entropy + 1)))
+	if (p == (reinterpret_cast<unsigned char *>(&entropy + 1)))
 	{
 		switch (entropy.which)
 		{
@@ -1222,9 +1220,9 @@ int GenerateRandomNumber(const int range)
 				break;
 		}
 		entropy.which = (entropy.which + 1) % 3;
-		p = (unsigned char *) &entropy.t;
+		p = reinterpret_cast<unsigned char *>(&entropy.t);
 	}
-	accSeed = ((accSeed * (UCHAR_MAX + 2U)) | 1) + (int) *p;
+	accSeed = ((accSeed * (UCHAR_MAX + 2U)) | 1) + int(*p);
 	p++;
 	srand (accSeed);
 	return (rand() / (RAND_MAX / range));
@@ -1274,7 +1272,7 @@ typedef struct tagTHREADNAME_INFO
 } THREADNAME_INFO;
 #pragma pack(pop)
 int SetThreadName(const std::thread::native_handle_type &thread, const char* threadName) {
-	DWORD dwThreadID = ::GetThreadId( static_cast<HANDLE>( thread ) );
+	DWORD dwThreadID = ::GetThreadId(HANDLE(thread));
 	THREADNAME_INFO info;
 	info.dwType = 0x1000;
 	info.szName = threadName;

--- a/main/LuaCommon.cpp
+++ b/main/LuaCommon.cpp
@@ -157,12 +157,12 @@ int CLuaCommon::l_domoticz_applyJsonPath(lua_State* lua_state)
 					}
 					if (node.isInt())
 					{
-						lua_pushnumber(lua_state, (double)node.asInt());
+						lua_pushnumber(lua_state, double(node.asInt()));
 						return 1;
 					}
 					if (node.isInt64())
 					{
-						lua_pushnumber(lua_state, (double)node.asInt64());
+						lua_pushnumber(lua_state, double(node.asInt64()));
 						return 1;
 					}
 					if (node.isString())

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -31,7 +31,7 @@ int CLuaHandler::l_domoticz_updateDevice(lua_State* lua_state)
 		if (lua_isnumber(lua_state, 1) && (lua_isstring(lua_state, 2) || lua_isnumber(lua_state, 2)) && lua_isstring(lua_state, 3))
 		{
 			// Extract the parameters from the lua 'updateDevice' function
-			int ideviceId = (int)lua_tointeger(lua_state, 1);
+			int ideviceId = int(lua_tointeger(lua_state, 1));
 			std::string nvalue = lua_tostring(lua_state, 2);
 			std::string svalue = lua_tostring(lua_state, 3);
 			if (((lua_isstring(lua_state, 3) && nvalue.empty()) && svalue.empty()))
@@ -45,12 +45,12 @@ int CLuaHandler::l_domoticz_updateDevice(lua_State* lua_state)
 			int signallevel = 12;
 			if (nargs >= 4 && lua_isnumber(lua_state, 4))
 			{
-				signallevel = (int)lua_tointeger(lua_state, 4);
+				signallevel = int(lua_tointeger(lua_state, 4));
 			}
 			int batterylevel = 255;
 			if (nargs == 5 && lua_isnumber(lua_state, 5))
 			{
-				batterylevel = (int)lua_tointeger(lua_state, 5);
+				batterylevel = int(lua_tointeger(lua_state, 5));
 			}
 			_log.Log(LOG_NORM, "CLuaHandler (updateDevice from LUA) : idx=%d nvalue=%s svalue=%s invalue=%d signallevel=%d batterylevel=%d", ideviceId, nvalue.c_str(), svalue.c_str(), invalue, signallevel, batterylevel);
 
@@ -167,7 +167,7 @@ bool CLuaHandler::executeLuaScript(const std::string &script, const std::string 
 
 	// Push all url parameters as a map indexed by the parameter name
 	// Each entry will be uri[<param name>] = <param value>
-	int totParameters = (int)allParameters.size();
+	int totParameters = int(allParameters.size());
 	lua_createtable(lua_state, totParameters, 0);
 	for (int i = 0; i < totParameters; i++)
 	{

--- a/main/LuaTable.cpp
+++ b/main/LuaTable.cpp
@@ -153,7 +153,7 @@ void CLuaTable::CloseSubTableEntry()
 void CLuaTable::PushRow(std::vector<_tEntry>::iterator itt)
 {
 	if (itt->label_type == TYPE_VALUE_INDEX)
-		lua_pushinteger(m_lua_state, (lua_Integer)itt->index);
+		lua_pushinteger(m_lua_state, lua_Integer(itt->index));
 	else
 		lua_pushstring(m_lua_state, itt->label.c_str());
 
@@ -163,10 +163,10 @@ void CLuaTable::PushRow(std::vector<_tEntry>::iterator itt)
 		lua_pushboolean(m_lua_state, itt->bValue);
 		break;
 	case TYPE_INTEGER:
-		lua_pushinteger(m_lua_state, (lua_Integer)itt->iValue);
+		lua_pushinteger(m_lua_state, lua_Integer(itt->iValue));
 		break;
 	case TYPE_NUMBER:
-		lua_pushnumber(m_lua_state, (lua_Number)itt->dValue);
+		lua_pushnumber(m_lua_state, lua_Number(itt->dValue));
 		break;
 	case TYPE_STRING:
 		lua_pushstring(m_lua_state, itt->sValue.c_str());
@@ -193,7 +193,7 @@ void CLuaTable::Publish()
 				lua_createtable(m_lua_state, itt->nrCols, itt->nrRows);
 				break;
 			case TYPE_SUBTABLE_OPEN_INDEX:
-				lua_pushinteger(m_lua_state, (lua_Integer)itt->index);
+				lua_pushinteger(m_lua_state, lua_Integer(itt->index));
 				lua_createtable(m_lua_state, itt->nrCols, itt->nrRows);
 				break;
 			case TYPE_SUBTABLE_CLOSE:

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1136,7 +1136,7 @@ void GetLightStatus(
 
 		if (switchtype != STYPE_Media) {
 			// Calculate % that the light is currently on, taking the maxdimlevel into account.
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int(float((100.0F / float(maxDimLevel)) * atof(sValue.c_str())));
 		}
 
 		// Fill in other parameters
@@ -1205,7 +1205,7 @@ void GetLightStatus(
 			bHaveGroupCmd = true;
 			bHaveDimmer = true;
 			maxDimLevel = 32;
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int(float((100.0F / float(maxDimLevel)) * atof(sValue.c_str())));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1393,7 +1393,7 @@ void GetLightStatus(
 			break;
 		case sTypeIT:
 			maxDimLevel = 9;
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int(float((100.0F / float(maxDimLevel)) * atof(sValue.c_str())));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1468,7 +1468,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		llevel = int(float((100.0F / float(maxDimLevel)) * atof(sValue.c_str())));
 
 		// Fill in other parameters
 		switch (dSubType)
@@ -1577,7 +1577,7 @@ void GetLightStatus(
 			lstatus = "Set Level";
 			bHaveDimmer = true;
 			llevel = nValue - fs20_sDimlevel_1 + 1;
-			llevel = (int)float((100.0F / float(maxDimLevel)) * llevel);
+			llevel = int(float((100.0F / float(maxDimLevel)) * llevel));
 			break;
 		case fs20_sOn_100:
 			lstatus = "On";
@@ -1622,7 +1622,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		llevel = int(float((100.0F / float(maxDimLevel)) * atof(sValue.c_str())));
 
 		switch (nValue)
 		{
@@ -4024,7 +4024,7 @@ void ConvertToGeneralSwitchType(std::string& devid, int& dtype, int& subtype)
 		s_strid << std::hex << strtoul(devid.c_str(), nullptr, 16);
 		unsigned long deviceid = 0;
 		s_strid >> deviceid;
-		deviceid = (unsigned long)((deviceid & 0xffffff00) >> 8);
+		deviceid = ((deviceid & 0xffffff00) >> 8);
 		char szTmp[20];
 		sprintf(szTmp, "%08lX", deviceid);
 		//_log.Log(LOG_ERROR, "RFLink: deviceid: %x", deviceid);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -1387,8 +1387,8 @@ bool CSQLHelper::OpenDatabase()
 				for (const auto &sd : result)
 				{
 					int hwId = atoi(sd[0].c_str());
-					_eHardwareTypes hwtype = (_eHardwareTypes)atoi(sd[1].c_str());
-					size_t Port = (size_t)atoi(sd[2].c_str());
+					_eHardwareTypes hwtype = _eHardwareTypes(atoi(sd[1].c_str()));
+					size_t Port = size_t(atoi(sd[2].c_str()));
 
 					if (IsSerialDevice(hwtype))
 					{
@@ -1409,7 +1409,7 @@ bool CSQLHelper::OpenDatabase()
 						}
 						else
 						{
-							sprintf(szSerialPort, "/dev/ttyUSB%d", (int)Port);
+							sprintf(szSerialPort, "/dev/ttyUSB%d", int(Port));
 						}
 #endif
 						safe_query("UPDATE Hardware SET Port=0, SerialPort='%q' WHERE (ID=%d)",
@@ -1810,7 +1810,7 @@ bool CSQLHelper::OpenDatabase()
 						for (const auto &sd : result1)
 						{
 							uint64_t devidx = atoi(sd[0].c_str());
-							_eMeterType switchType = (_eMeterType)atoi(sd[2].c_str());
+							_eMeterType switchType = _eMeterType(atoi(sd[2].c_str()));
 
 							if (switchType == MTYPE_COUNTER)
 							{
@@ -2238,7 +2238,7 @@ bool CSQLHelper::OpenDatabase()
 				{
 					szQuery2.clear();
 					szQuery2.str("");
-					szQuery2 << "SELECT ID FROM DeviceStatus WHERE ([Type]=" << (int)pTypeGeneral << ") AND (SubType=" << (int)sTypeSolarRadiation << ") AND (HardwareID=" << sd[0] << ")";
+					szQuery2 << "SELECT ID FROM DeviceStatus WHERE ([Type]=" << pTypeGeneral << ") AND (SubType=" << sTypeSolarRadiation << ") AND (HardwareID=" << sd[0] << ")";
 					result2 = query(szQuery2.str());
 
 					for (const auto &sd : result2)
@@ -2246,7 +2246,7 @@ bool CSQLHelper::OpenDatabase()
 						//Change device type
 						szQuery2.clear();
 						szQuery2.str("");
-						szQuery2 << "UPDATE DeviceStatus SET SubType=" << (int)sTypeCustom << ", DeviceID='00000100', Options='1;DU' WHERE (ID=" << sd[0] << ")";
+						szQuery2 << "UPDATE DeviceStatus SET SubType=" << sTypeCustom << ", DeviceID='00000100', Options='1;DU' WHERE (ID=" << sd[0] << ")";
 						query(szQuery2.str());
 
 						//change log
@@ -2259,7 +2259,7 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << (float)atof(sd3[0].c_str()) / 10.0F << ", '"
+							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << float(atof(sd3[0].c_str())) / 10.0F << ", '"
 								 << sd3[1] << "')";
 							query(szQuery2.str());
 						}
@@ -2277,9 +2277,9 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							float percentage_min = (float)atof(sd3[0].c_str()) / 10.0F;
-							float percentage_max = (float)atof(sd3[1].c_str()) / 10.0F;
-							float percentage_avg = (float)atof(sd3[2].c_str()) / 10.0F;
+							float percentage_min = float(atof(sd3[0].c_str())) / 10.0F;
+							float percentage_max = float(atof(sd3[1].c_str())) / 10.0F;
+							float percentage_avg = float(atof(sd3[2].c_str())) / 10.0F;
 							szQuery2 << "INSERT INTO Percentage_Calendar (DeviceRowID, Percentage_Min, Percentage_Max, Percentage_Avg, Date) VALUES (" << sd[0] << ", " << percentage_min << ", " << percentage_max << ", " << percentage_avg << ", '" << sd3[3] << "')";
 							query(szQuery2.str());
 						}
@@ -2352,7 +2352,7 @@ bool CSQLHelper::OpenDatabase()
 				{
 					szQuery2.clear();
 					szQuery2.str("");
-					szQuery2 << "SELECT ID FROM DeviceStatus WHERE ([Type]=" << (int)pTypeColorSwitch << ") AND (SubType=" << (int)sTypeColor_RGB_W << ") AND (HardwareID=" << sd[0] << ")";
+					szQuery2 << "SELECT ID FROM DeviceStatus WHERE ([Type]=" << pTypeColorSwitch << ") AND (SubType=" << sTypeColor_RGB_W << ") AND (HardwareID=" << sd[0] << ")";
 					result2 = query(szQuery2.str());
 
 					for (const auto &sd : result2)
@@ -2360,7 +2360,7 @@ bool CSQLHelper::OpenDatabase()
 						//Change device type
 						szQuery2.clear();
 						szQuery2.str("");
-						szQuery2 << "UPDATE DeviceStatus SET SubType=" << (int)sTypeColor_RGB_W_Z << " WHERE (ID=" << sd[0] << ")";
+						szQuery2 << "UPDATE DeviceStatus SET SubType=" << sTypeColor_RGB_W_Z << " WHERE (ID=" << sd[0] << ")";
 						query(szQuery2.str());
 					}
 				}
@@ -3006,29 +3006,27 @@ bool CSQLHelper::OpenDatabase()
 	}
 	if (!GetPreferencesVar("WindUnit", nValue))
 	{
-		UpdatePreferencesVar("WindUnit", (int)WINDUNIT_MS);
+		UpdatePreferencesVar("WindUnit", int(WINDUNIT_MS));
 	}
 	else
 	{
-		m_windunit = (_eWindUnit)nValue;
+		m_windunit = _eWindUnit(nValue);
 	}
 	if (!GetPreferencesVar("TempUnit", nValue))
 	{
-		UpdatePreferencesVar("TempUnit", (int)TEMPUNIT_C);
+		UpdatePreferencesVar("TempUnit", int(TEMPUNIT_C));
 	}
 	else
 	{
-		m_tempunit = (_eTempUnit)nValue;
-
+		m_tempunit = _eTempUnit(nValue);
 	}
 	if (!GetPreferencesVar("WeightUnit", nValue))
 	{
-		UpdatePreferencesVar("WeightUnit", (int)WEIGHTUNIT_KG);
+		UpdatePreferencesVar("WeightUnit", int(WEIGHTUNIT_KG));
 	}
 	else
 	{
-		m_weightunit = (_eWeightUnit)nValue;
-
+		m_weightunit = _eWeightUnit(nValue);
 	}
 	SetUnitsAndScale();
 
@@ -3590,7 +3588,7 @@ void CSQLHelper::PerformThreadedAction(const _tTaskItem tItem)
 		std::string response;
 		std::vector<std::string> headerData;
 
-		HTTPClient::_eHTTPmethod tmethod = static_cast<HTTPClient::_eHTTPmethod>(method);
+		HTTPClient::_eHTTPmethod tmethod = HTTPClient::_eHTTPmethod(method);
 
 		bool ret = false;
 		if (tmethod == HTTPClient::HTTP_METHOD_GET)
@@ -3690,7 +3688,7 @@ void CSQLHelper::Do_Work()
 
 		if (m_bAcceptHardwareTimerActive)
 		{
-			m_iAcceptHardwareTimerCounter -= static_cast<float>(1. / timer_resolution_hz);
+			m_iAcceptHardwareTimerCounter -= float(1. / timer_resolution_hz);
 			if (m_iAcceptHardwareTimerCounter <= (1.0F / timer_resolution_hz / 2))
 			{
 				m_bAcceptHardwareTimerActive = false;
@@ -4130,7 +4128,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 {
 	m_mainworker.m_szLastSwitchUser = userName;
 
-	uint64_t DeviceRowIdx = (uint64_t)-1;
+	auto DeviceRowIdx = std::numeric_limits<std::uint64_t>::max();
 	char ID[20];
 	sprintf(ID, "%lu", nid);
 
@@ -4141,7 +4139,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 		if (!result.empty())
 		{
 			std::vector<std::string> sd = result[0];
-			_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[0].c_str());
+			_eHardwareTypes Type = _eHardwareTypes(atoi(sd[0].c_str()));
 			if (Type == HTYPE_PythonPlugin)
 			{
 				// Not allowed to add device to plugin HW (plugin framework does not use key column "ID" but instead uses column "unit" as key)
@@ -4197,10 +4195,10 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 		break;
 	case pTypeThermostat: //Thermostat Setpoint
 	{
-		unsigned char ID1 = (unsigned char)((nid & 0xFF000000) >> 24);
-		unsigned char ID2 = (unsigned char)((nid & 0x00FF0000) >> 16);
-		unsigned char ID3 = (unsigned char)((nid & 0x0000FF00) >> 8);
-		unsigned char ID4 = (unsigned char)((nid & 0x000000FF));
+		uint8_t ID1 = uint8_t((nid & 0xFF000000) >> 24);
+		uint8_t ID2 = uint8_t((nid & 0x00FF0000) >> 16);
+		uint8_t ID3 = uint8_t((nid & 0x0000FF00) >> 8);
+		uint8_t ID4 = uint8_t((nid & 0x000000FF));
 		sprintf(ID, "%X%02X%02X%02X", ID1, ID2, ID3, ID4);
 
 		DeviceRowIdx = UpdateValue(HardwareID, ID, 1, SensorType, SensorSubType, 12, 255, 0, "20.5", devname);
@@ -4309,7 +4307,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 				std::string rID = std::string(ID);
 				padLeft(rID, 8, '0');
 				DeviceRowIdx = UpdateValue(HardwareID, rID.c_str(), 1, SensorType, SensorSubType, 12, 255, 0, "0.0", devname);
-				if (DeviceRowIdx != (uint64_t)-1)
+				if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 				{
 					//Set the Label
 					m_sql.safe_query("UPDATE DeviceStatus SET Options='%q' WHERE (ID==%" PRIu64 ")", soptions.c_str(), DeviceRowIdx);
@@ -4345,13 +4343,13 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 		break;
 		case sSwitchTypeSelector:		//Selector Switch
 		{
-			unsigned char ID1 = (unsigned char)((nid & 0xFF000000) >> 24);
-			unsigned char ID2 = (unsigned char)((nid & 0x00FF0000) >> 16);
-			unsigned char ID3 = (unsigned char)((nid & 0x0000FF00) >> 8);
-			unsigned char ID4 = (unsigned char)((nid & 0x000000FF));
+			uint8_t ID1 = uint8_t((nid & 0xFF000000) >> 24);
+			uint8_t ID2 = uint8_t((nid & 0x00FF0000) >> 16);
+			uint8_t ID3 = uint8_t((nid & 0x0000FF00) >> 8);
+			uint8_t ID4 = uint8_t((nid & 0x000000FF));
 			sprintf(ID, "%02X%02X%02X%02X", ID1, ID2, ID3, ID4);
 			DeviceRowIdx = UpdateValue(HardwareID, ID, 1, SensorType, SensorSubType, 12, 255, 0, "0", devname);
-			if (DeviceRowIdx != (uint64_t)-1)
+			if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 			{
 				//Set switch type to selector
 				m_sql.safe_query("UPDATE DeviceStatus SET SwitchType=%d WHERE (ID==%" PRIu64 ")", STYPE_Selector, DeviceRowIdx);
@@ -4379,7 +4377,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 			std::string rID = std::string(ID);
 			padLeft(rID, 8, '0');
 			DeviceRowIdx = UpdateValue(HardwareID, rID.c_str(), 1, SensorType, SensorSubType, 12, 255, 1, devname);
-			if (DeviceRowIdx != (uint64_t)-1)
+			if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 			{
 				//Set switch type to dimmer
 				m_sql.safe_query("UPDATE DeviceStatus SET SwitchType=%d WHERE (ID==%" PRIu64 ")", STYPE_Dimmer, DeviceRowIdx);
@@ -4391,7 +4389,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 	}
 	}
 
-	if (DeviceRowIdx != (uint64_t)-1)
+	if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 	{
 		m_sql.safe_query("UPDATE DeviceStatus SET Used=1 WHERE (ID==%" PRIu64 ")", DeviceRowIdx);
 		m_mainworker.m_eventsystem.GetCurrentStates();
@@ -4413,8 +4411,8 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, const char* ID, const uns
 uint64_t CSQLHelper::UpdateValue(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string& devname, const bool bUseOnOffAction)
 {
 	uint64_t devRowID = UpdateValueInt(HardwareID, ID, unit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction);
-	if (devRowID == (uint64_t)-1)
-		return -1;
+	if (devRowID == std::numeric_limits<std::uint64_t>::max())
+		return std::numeric_limits<std::uint64_t>::max();
 
 	if (!IsLightOrSwitch(devType, subType))
 	{
@@ -4451,12 +4449,12 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, const char* ID, const uns
 			);
 
 			//Call the EventSystem for the main switch
-			uint64_t ParentID = (uint64_t)atoll(sd[0].c_str());
+			uint64_t ParentID = uint64_t(atoll(sd[0].c_str()));
 			std::string ParentName = sd[1];
 			int ParentHardwareID = atoi(sd[2].c_str());
-			unsigned char ParentType = (unsigned char)atoi(sd[3].c_str());
-			unsigned char ParentSubType = (unsigned char)atoi(sd[4].c_str());
-			unsigned char ParentUnit = (unsigned char)atoi(sd[5].c_str());
+			uint8_t ParentType = (uint8_t)atoi(sd[3].c_str());
+			uint8_t ParentSubType = (uint8_t)atoi(sd[4].c_str());
+			uint8_t ParentUnit = (uint8_t)atoi(sd[5].c_str());
 			m_mainworker.m_eventsystem.ProcessDevice(ParentHardwareID, ParentID, ParentUnit, ParentType, ParentSubType, signallevel, batterylevel, nValue, sValue);
 
 			m_mainworker.sOnDeviceUpdate(std::stoi(sd[2]), std::stoll(sd[0]));
@@ -4651,7 +4649,7 @@ uint64_t CSQLHelper::InsertDevice(const int HardwareID, const char* ID, const un
 	if (!m_bAcceptNewHardware)
 	{
 		_log.Debug(DEBUG_NORM, "Device creation failed, Domoticz settings prevent accepting new devices.");
-		return -1; //We do not allow new devices
+		return std::numeric_limits<std::uint64_t>::max(); // We do not allow new devices
 	}
 
 	if (devname.empty())
@@ -4674,7 +4672,7 @@ uint64_t CSQLHelper::InsertDevice(const int HardwareID, const char* ID, const un
 	if (result.empty())
 	{
 		_log.Log(LOG_ERROR, "Serious database error, problem getting ID from DeviceStatus!");
-		return -1;
+		return std::numeric_limits<std::uint64_t>::max();
 	}
 	ulID = std::stoull(result[0][0]);
 
@@ -4685,7 +4683,7 @@ uint64_t CSQLHelper::GetDeviceIndex(const int HardwareID, const std::string& ID,
 	std::vector<std::vector<std::string> > result;
 	result = safe_query("SELECT ID, Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", HardwareID, ID.c_str(), unit, devType, subType);
 	if (result.empty())
-		return -1;
+		return std::numeric_limits<std::uint64_t>::max();
 	devname = result[0].at(1);
 	return std::stoull(result[0].at(0));
 }
@@ -4693,7 +4691,7 @@ uint64_t CSQLHelper::GetDeviceIndex(const int HardwareID, const std::string& ID,
 uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const unsigned char unit, const unsigned char devType, const unsigned char subType, const unsigned char signallevel, const unsigned char batterylevel, const int nValue, const char* sValue, std::string& devname, const bool bUseOnOffAction)
 {
 	if (!m_dbase)
-		return -1;
+		return std::numeric_limits<std::uint64_t>::max();
 
 	uint64_t ulID = 0;
 	bool bDeviceUsed = false;
@@ -4709,9 +4707,9 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 		//Insert
 		ulID = InsertDevice(HardwareID, ID, unit, devType, subType, 0, nValue, sValue, devname, signallevel, batterylevel);
 
-		if (ulID == (uint64_t)-1)
+		if (ulID == std::numeric_limits<std::uint64_t>::max())
 		{
-			return -1;
+			return std::numeric_limits<std::uint64_t>::max();
 		}
 
 #ifdef ENABLE_PYTHON
@@ -4733,7 +4731,7 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 		auto options = BuildDeviceOptions(sOption);
 		devname = result[0][1];
 		bDeviceUsed = atoi(result[0][2].c_str()) != 0;
-		stype = (_eSwitchType)atoi(result[0][3].c_str());
+		stype = _eSwitchType(atoi(result[0][3].c_str()));
 		old_nValue = atoi(result[0][4].c_str());
 		old_sValue = result[0][5];
 		time_t now = time(nullptr);
@@ -4754,8 +4752,7 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 
 			interval = difftime(now, lutime);
 			StringSplit(result[0][5], ";", parts);
-			nEnergy = static_cast<float>(strtof(parts[0].c_str(), nullptr) * interval / 3600
-							 + strtof(parts[1].c_str(), nullptr)); // Rob: whats happening here... strtof ?
+			nEnergy = float(strtof(parts[0].c_str(), nullptr) * interval / 3600 + strtof(parts[1].c_str(), nullptr)); // Rob: whats happening here... strtof ?
 			StringSplit(sValue, ";", parts);
 			sprintf(sCompValue, "%s;%.1f", parts[0].c_str(), nEnergy);
 			sValue = sCompValue;
@@ -4953,8 +4950,8 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 			bool bHaveDimmer = false;
 			std::vector<std::string> sd = result[0];
 			std::string Name = sd[0];
-			_eSwitchType switchtype = (_eSwitchType)atoi(sd[1].c_str());
-			float AddjValue = static_cast<float>(atof(sd[2].c_str()));
+			_eSwitchType switchtype = _eSwitchType(atoi(sd[1].c_str()));
+			float AddjValue = float(atof(sd[2].c_str()));
 			GetLightStatus(devType, subType, switchtype, nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 
 			bool bIsLightSwitchOn = IsLightSwitchOn(lstatus);
@@ -5029,7 +5026,7 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 						for (const auto &sd : result)
 						{
 							std::string camidx = sd[0];
-							float delay = static_cast<float>(atof(sd[1].c_str()));
+							float delay = float(atof(sd[1].c_str()));
 							std::string subject = Name + " Status: " + lstatus;
 							AddTaskItem(_tTaskItem::EmailCameraSnapshot(delay + 1, camidx, subject));
 						}
@@ -5075,7 +5072,7 @@ uint64_t CSQLHelper::UpdateValueInt(const int HardwareID, const char* ID, const 
 			}
 			if (bIsLightSwitchOn)
 			{
-				if ((int)AddjValue != 0) //Off Delay
+				if (int(AddjValue) != 0) // Off Delay
 				{
 					bool bAdd2DelayQueue = false;
 					int cmd = 0;
@@ -5208,7 +5205,7 @@ bool CSQLHelper::GetLastValue(const int HardwareID, const char* DeviceID, const 
 
 	if (!sqlresult.empty())
 	{
-		nValue = (int)atoi(sqlresult[0][0].c_str());
+		nValue = atoi(sqlresult[0][0].c_str());
 		sValue = sqlresult[0][1];
 		sLastUpdate = sqlresult[0][2];
 
@@ -5231,8 +5228,8 @@ void CSQLHelper::GetAddjustment(const int HardwareID, const char* ID, const unsi
 		HardwareID, ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		AddjValue = static_cast<float>(atof(result[0][0].c_str()));
-		AddjMulti = static_cast<float>(atof(result[0][1].c_str()));
+		AddjValue = float(atof(result[0][0].c_str()));
+		AddjMulti = float(atof(result[0][1].c_str()));
 	}
 }
 
@@ -5259,8 +5256,8 @@ void CSQLHelper::GetAddjustment2(const int HardwareID, const char* ID, const uns
 		HardwareID, ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		AddjValue = static_cast<float>(atof(result[0][0].c_str()));
-		AddjMulti = static_cast<float>(atof(result[0][1].c_str()));
+		AddjValue = float(atof(result[0][0].c_str()));
+		AddjMulti = float(atof(result[0][1].c_str()));
 	}
 }
 
@@ -5602,31 +5599,31 @@ void CSQLHelper::UpdateTemperatureLog()
 			case pTypeRego6XXTemp:
 			case pTypeTEMP:
 			case pTypeThermostat:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				break;
 			case pTypeThermostat1:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				break;
 			case pTypeRadiator1:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				break;
 			case pTypeEvohomeWater:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					if (splitresults[1] == "On")
 						setpoint = 60;
 					else if (splitresults[1] == "Off")
 						setpoint = 0;
 					else
-						setpoint = static_cast<float>(atof(splitresults[1].c_str()));
+						setpoint = float(atof(splitresults[1].c_str()));
 				}
 				break;
 			case pTypeEvohomeZone:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
-					setpoint = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
+					setpoint = float(atof(splitresults[1].c_str()));
 				}
 				break;
 			case pTypeHUM:
@@ -5635,27 +5632,27 @@ void CSQLHelper::UpdateTemperatureLog()
 			case pTypeTEMP_HUM:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					humidity = atoi(splitresults[1].c_str());
-					dewpoint = (float)CalculateDewPoint(temp, humidity);
+					dewpoint = float(CalculateDewPoint(temp, humidity));
 				}
 				break;
 			case pTypeTEMP_HUM_BARO:
 				if (splitresults.size() == 5)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					humidity = atoi(splitresults[1].c_str());
 					if (dSubType == sTypeTHBFloat)
 						barometer = int(atof(splitresults[3].c_str()) * 10.0F);
 					else
 						barometer = atoi(splitresults[3].c_str());
-					dewpoint = (float)CalculateDewPoint(temp, humidity);
+					dewpoint = float(CalculateDewPoint(temp, humidity));
 				}
 				break;
 			case pTypeTEMP_BARO:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 					barometer = int(atof(splitresults[1].c_str()) * 10.0F);
 				}
 				break;
@@ -5664,7 +5661,7 @@ void CSQLHelper::UpdateTemperatureLog()
 					continue;
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = float(atof(splitresults[1].c_str()));
 				}
 				break;
 			case pTypeWIND:
@@ -5674,20 +5671,20 @@ void CSQLHelper::UpdateTemperatureLog()
 				{
 					if (dSubType != sTypeWINDNoTemp)
 					{
-						temp = static_cast<float>(atof(splitresults[4].c_str()));
+						temp = float(atof(splitresults[4].c_str()));
 					}
-					chill = static_cast<float>(atof(splitresults[5].c_str()));
+					chill = float(atof(splitresults[5].c_str()));
 				}
 				break;
 			case pTypeRFXSensor:
 				if (dSubType != sTypeRFXSensorTemp)
 					continue;
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = float(atof(splitresults[0].c_str()));
 				break;
 			case pTypeGeneral:
 				if (dSubType == sTypeSystemTemp)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = float(atof(splitresults[0].c_str()));
 				}
 				else if (dSubType == sTypeBaro)
 				{
@@ -5751,7 +5748,7 @@ void CSQLHelper::UpdateRainLog()
 				continue; //impossible
 
 			int rate = atoi(splitresults[0].c_str());
-			float total = static_cast<float>(atof(splitresults[1].c_str()));
+			float total = float(atof(splitresults[1].c_str()));
 
 			//insert record
 			safe_query(
@@ -5807,7 +5804,7 @@ void CSQLHelper::UpdateWindLog()
 			if (splitresults.size() < 4)
 				continue; //impossible
 
-			float direction = static_cast<float>(atof(splitresults[0].c_str()));
+			float direction = float(atof(splitresults[0].c_str()));
 
 			int speed = atoi(splitresults[2].c_str());
 			int gust = atoi(splitresults[3].c_str());
@@ -5876,7 +5873,7 @@ void CSQLHelper::UpdateUVLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			float level = static_cast<float>(atof(splitresults[0].c_str()));
+			float level = float(atof(splitresults[0].c_str()));
 
 			//insert record
 			safe_query(
@@ -6215,7 +6212,7 @@ void CSQLHelper::UpdateMeter()
 			{
 				sprintf(szTmp, "%d", nValue);
 				sValue = szTmp;
-				m_notifications.CheckAndHandleNotification(ID, hardwareID, DeviceID, devname, Unit, dType, dSubType, (int)nValue);
+				m_notifications.CheckAndHandleNotification(ID, hardwareID, DeviceID, devname, Unit, dType, dSubType, nValue);
 			}
 			else if ((dType == pTypeGeneral) && ((dSubType == sTypeSoilMoisture) || (dSubType == sTypeLeafWetness)))
 			{
@@ -6426,19 +6423,19 @@ void CSQLHelper::UpdateMultiMeter()
 				if (splitresults.size() != 3)
 					continue; //impossible
 
-				value1 = (unsigned long)(atof(splitresults[0].c_str()) * 10.0F);
-				value2 = (unsigned long)(atof(splitresults[1].c_str()) * 10.0F);
-				value3 = (unsigned long)(atof(splitresults[2].c_str()) * 10.0F);
+				value1 = uint64_t(atof(splitresults[0].c_str()) * 10.0F);
+				value2 = uint64_t(atof(splitresults[1].c_str()) * 10.0F);
+				value3 = uint64_t(atof(splitresults[2].c_str()) * 10.0F);
 			}
 			else if ((dType == pTypeCURRENTENERGY) && (dSubType == sTypeELEC4))
 			{
 				if (splitresults.size() != 4)
 					continue; //impossible
 
-				value1 = (unsigned long)(atof(splitresults[0].c_str()) * 10.0F);
-				value2 = (unsigned long)(atof(splitresults[1].c_str()) * 10.0F);
-				value3 = (unsigned long)(atof(splitresults[2].c_str()) * 10.0F);
-				value4 = (unsigned long long)(atof(splitresults[3].c_str()) * 1000.0F);
+				value1 = uint64_t(atof(splitresults[0].c_str()) * 10.0F);
+				value2 = uint64_t(atof(splitresults[1].c_str()) * 10.0F);
+				value3 = uint64_t(atof(splitresults[2].c_str()) * 10.0F);
+				value4 = uint64_t(atof(splitresults[3].c_str()) * 1000.0F);
 			}
 			else
 				continue;//don't know you (yet)
@@ -6501,7 +6498,7 @@ void CSQLHelper::UpdatePercentageLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			float percentage = static_cast<float>(atof(sValue.c_str()));
+			float percentage = float(atof(sValue.c_str()));
 
 			//insert record
 			safe_query(
@@ -6554,7 +6551,7 @@ void CSQLHelper::UpdateFanLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			int speed = (int)atoi(sValue.c_str());
+			int speed = atoi(sValue.c_str());
 
 			//insert record
 			safe_query(
@@ -6603,17 +6600,17 @@ void CSQLHelper::AddCalendarTemperature()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float temp_min = static_cast<float>(atof(sd[0].c_str()));
-			float temp_max = static_cast<float>(atof(sd[1].c_str()));
-			float temp_avg = static_cast<float>(atof(sd[2].c_str()));
-			float chill_min = static_cast<float>(atof(sd[3].c_str()));
-			float chill_max = static_cast<float>(atof(sd[4].c_str()));
+			float temp_min = float(atof(sd[0].c_str()));
+			float temp_max = float(atof(sd[1].c_str()));
+			float temp_avg = float(atof(sd[2].c_str()));
+			float chill_min = float(atof(sd[3].c_str()));
+			float chill_max = float(atof(sd[4].c_str()));
 			int humidity = atoi(sd[5].c_str());
 			int barometer = atoi(sd[6].c_str());
-			float dewpoint = static_cast<float>(atof(sd[7].c_str()));
-			float setpoint_min = static_cast<float>(atof(sd[8].c_str()));
-			float setpoint_max = static_cast<float>(atof(sd[9].c_str()));
-			float setpoint_avg = static_cast<float>(atof(sd[10].c_str()));
+			float dewpoint = float(atof(sd[7].c_str()));
+			float setpoint_min = float(atof(sd[8].c_str()));
+			float setpoint_max = float(atof(sd[9].c_str()));
+			float setpoint_avg = float(atof(sd[10].c_str()));
 			result = safe_query(
 				"INSERT INTO Temperature_Calendar (DeviceRowID, Temp_Min, Temp_Max, Temp_Avg, Chill_Min, Chill_Max, Humidity, Barometer, DewPoint, SetPoint_Min, SetPoint_Max, SetPoint_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%.2f', '%.2f', '%.2f', '%.2f', '%.2f', '%d', '%d', '%.2f', '%.2f', '%.2f', '%.2f', '%q')",
@@ -6691,8 +6688,8 @@ void CSQLHelper::AddCalendarUpdateRain()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float total_min = static_cast<float>(atof(sd[0].c_str()));
-			float total_max = static_cast<float>(atof(sd[1].c_str()));
+			float total_min = float(atof(sd[0].c_str()));
+			float total_max = float(atof(sd[1].c_str()));
 			int rate = atoi(sd[2].c_str());
 
 			float total_real = 0;
@@ -6784,8 +6781,8 @@ void CSQLHelper::AddCalendarUpdateMeter()
 		//unsigned char Unit = atoi(sd[3].c_str());
 		unsigned char devType = atoi(sd[4].c_str());
 		unsigned char subType = atoi(sd[5].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[6].c_str());
-		_eMeterType metertype = (_eMeterType)switchtype;
+		_eSwitchType switchtype = _eSwitchType(atoi(sd[6].c_str()));
+		_eMeterType metertype = _eMeterType(switchtype);
 
 		float tGasDivider = GasDivider;
 
@@ -6813,9 +6810,9 @@ void CSQLHelper::AddCalendarUpdateMeter()
 		{
 			std::vector<std::string> sd = result[0];
 
-			double total_min = (double)atof(sd[0].c_str());
-			double total_max = (double)atof(sd[1].c_str());
-			double avg_value = (double)atof(sd[2].c_str());
+			double total_min = atof(sd[0].c_str());
+			double total_max = atof(sd[1].c_str());
+			double avg_value = atof(sd[2].c_str());
 
 			// if kwh counter => total_min = first value of the day, and total_max = last value of the day
 			// because last value can be lower than first value when consumed energy is negative (e.g. photovoltaic produces more than building usage)
@@ -6825,7 +6822,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
-					total_min = (double)atof(sd[0].c_str());
+					total_min = atof(sd[0].c_str());
 					total_max = total_min;
 				}
 				result = safe_query("SELECT Value FROM Meter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00') ORDER BY Date DESC LIMIT 1",
@@ -6833,7 +6830,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
-					total_max = (double)atof(sd[0].c_str());
+					total_max = atof(sd[0].c_str());
 				}
 			}
 
@@ -7022,20 +7019,20 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 			{
 				for (int ii = 0; ii < 6; ii++)
 				{
-					float total_min = static_cast<float>(atof(sd[(ii * 2) + 0].c_str()));
-					float total_max = static_cast<float>(atof(sd[(ii * 2) + 1].c_str()));
+					float total_min = float(atof(sd[(ii * 2) + 0].c_str()));
+					float total_max = float(atof(sd[(ii * 2) + 1].c_str()));
 					total_real[ii] = total_max - total_min;
 				}
-				counter1 = static_cast<float>(atof(sd[1].c_str()));
-				counter2 = static_cast<float>(atof(sd[3].c_str()));
-				counter3 = static_cast<float>(atof(sd[9].c_str()));
-				counter4 = static_cast<float>(atof(sd[11].c_str()));
+				counter1 = float(atof(sd[1].c_str()));
+				counter2 = float(atof(sd[3].c_str()));
+				counter3 = float(atof(sd[9].c_str()));
+				counter4 = float(atof(sd[11].c_str()));
 			}
 			else
 			{
 				for (int ii = 0; ii < 6; ii++)
 				{
-					float fvalue = static_cast<float>(atof(sd[ii].c_str()));
+					float fvalue = float(atof(sd[ii].c_str()));
 					total_real[ii] = fvalue;
 				}
 			}
@@ -7119,7 +7116,7 @@ void CSQLHelper::AddCalendarUpdateWind()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float Direction = static_cast<float>(atof(sd[0].c_str()));
+			float Direction = float(atof(sd[0].c_str()));
 			int speed_min = atoi(sd[1].c_str());
 			int speed_max = atoi(sd[2].c_str());
 			int gust_min = atoi(sd[3].c_str());
@@ -7176,7 +7173,7 @@ void CSQLHelper::AddCalendarUpdateUV()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float level = static_cast<float>(atof(sd[0].c_str()));
+			float level = float(atof(sd[0].c_str()));
 
 			result = safe_query(
 				"INSERT INTO UV_Calendar (DeviceRowID, Level, Date) "
@@ -7225,9 +7222,9 @@ void CSQLHelper::AddCalendarUpdatePercentage()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float percentage_min = static_cast<float>(atof(sd[0].c_str()));
-			float percentage_max = static_cast<float>(atof(sd[1].c_str()));
-			float percentage_avg = static_cast<float>(atof(sd[2].c_str()));
+			float percentage_min = float(atof(sd[0].c_str()));
+			float percentage_max = float(atof(sd[1].c_str()));
+			float percentage_avg = float(atof(sd[2].c_str()));
 			result = safe_query(
 				"INSERT INTO Percentage_Calendar (DeviceRowID, Percentage_Min, Percentage_Max, Percentage_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%g', '%g', '%g','%q')",
@@ -7277,9 +7274,9 @@ void CSQLHelper::AddCalendarUpdateFan()
 		{
 			std::vector<std::string> sd = result[0];
 
-			int speed_min = (int)atoi(sd[0].c_str());
-			int speed_max = (int)atoi(sd[1].c_str());
-			int speed_avg = (int)atoi(sd[2].c_str());
+			int speed_min = atoi(sd[0].c_str());
+			int speed_max = atoi(sd[1].c_str());
+			int speed_avg = atoi(sd[2].c_str());
 			result = safe_query(
 				"INSERT INTO Fan_Calendar (DeviceRowID, Speed_Min, Speed_Max, Speed_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%d', '%d', '%d','%q')",
@@ -7739,8 +7736,8 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 	if (result.empty())
 		return; //not found
 
-	unsigned char orgValue = (unsigned char)atoi(result[0][0].c_str());
-	unsigned char newValue = orgValue;
+	uint8_t orgValue = uint8_t(atoi(result[0][0].c_str()));
+	uint8_t newValue = orgValue;
 
 	result = safe_query("SELECT a.ID, a.DeviceID, a.Unit, a.Type, a.SubType, a.SwitchType, a.nValue, a.sValue FROM DeviceStatus AS a, SceneDevices as b WHERE (a.ID == b.DeviceRowID) AND (b.SceneRowID == %" PRIu64 ")",
 		Idx);
@@ -7756,7 +7753,7 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 		//unsigned char Unit=atoi(sd[2].c_str());
 		unsigned char dType = atoi(sd[3].c_str());
 		unsigned char dSubType = atoi(sd[4].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+		_eSwitchType switchtype = _eSwitchType(atoi(sd[5].c_str()));
 
 		std::string lstatus;
 		int llevel = 0;
@@ -8055,7 +8052,7 @@ uint64_t CSQLHelper::UpdateValueLighting2GroupCmd(const int HardwareID, const ch
 	// We only have to update all others units within the ID group. If the current unit does not have the same value,
 	// it will be updated too. The reason we choose the UpdateValue is the propagation of the change to all units involved, including LogUpdate.
 
-	uint64_t devRowIndex = -1;
+	uint64_t devRowIndex = std::numeric_limits<std::uint64_t>::max();
 	typedef std::vector<std::vector<std::string> > VectorVectorString;
 
 	VectorVectorString result = safe_query("SELECT Unit FROM DeviceStatus WHERE ((DeviceID=='%q') AND (Type==%d) AND (SubType==%d) AND (nValue!=%d))",
@@ -8098,7 +8095,7 @@ uint64_t CSQLHelper::UpdateValueHomeConfortGroupCmd(const int HardwareID, const 
 	// We only have to update all others units within the ID group. If the current unit does not have the same value,
 	// it will be updated too. The reason we choose the UpdateValue is the propagation of the change to all units involved, including LogUpdate.
 
-	uint64_t devRowIndex = -1;
+	uint64_t devRowIndex = std::numeric_limits<std::uint64_t>::max();
 	typedef std::vector<std::vector<std::string> > VectorVectorString;
 
 	VectorVectorString result = safe_query("SELECT Unit FROM DeviceStatus WHERE ((DeviceID=='%q') AND (Type==%d) AND (SubType==%d) AND (nValue!=%d))",
@@ -8965,7 +8962,7 @@ bool CSQLHelper::InsertCustomIconFromZipFile(const std::string& szZipFile, std::
 				rpath = fpath.substr(0, ipos);
 
 			uLong fsize;
-			unsigned char* pFBuf = (unsigned char*)(pos).Extract(fsize, 1);
+			unsigned char *pFBuf = static_cast<unsigned char *>((pos).Extract(fsize, 1));
 			if (pFBuf == nullptr)
 			{
 				ErrorMessage = "Could not extract icons.txt";
@@ -9086,7 +9083,7 @@ bool CSQLHelper::InsertCustomIconFromZipFile(const std::string& szZipFile, std::
 						}
 						// SQLITE_STATIC because the statement is finalized
 						// before the buffer is freed:
-						pFBuf = (unsigned char*)in.find(IconFile).Extract(fsize);
+						pFBuf = static_cast<unsigned char *>(in.find(IconFile).Extract(fsize));
 						if (pFBuf == nullptr)
 						{
 							ErrorMessage = "Could not extract File: " + IconFile16;

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -25,7 +25,7 @@ CScheduler::CScheduler()
 	m_tNautTwEnd = 0;
 	m_tAstTwStart = 0;
 	m_tAstTwEnd = 0;
-	srand((int)mytime(nullptr));
+	srand(int(mytime(nullptr)));
 }
 
 void CScheduler::StartScheduler()
@@ -83,15 +83,15 @@ void CScheduler::ReloadSchedules()
 				titem.bIsScene = false;
 				titem.bIsThermostat = false;
 
-				_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
+				_eTimerType timerType = _eTimerType(atoi(sd[2].c_str()));
 				titem.RowID = std::stoull(sd[0]);
 				titem.TimerID= std::stoull(sd[14]);
-				titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-				titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+				titem.startHour = uint8_t(atoi(sd[1].substr(0, 2).c_str()));
+				titem.startMin = uint8_t(atoi(sd[1].substr(3, 2).c_str()));
 				titem.startTime = 0;
 				titem.timerType = timerType;
-				titem.timerCmd = (_eTimerCommand)atoi(sd[3].c_str());
-				titem.Level = (unsigned char)atoi(sd[4].c_str());
+				titem.timerCmd = _eTimerCommand(atoi(sd[3].c_str()));
+				titem.Level = uint8_t(atoi(sd[4].c_str()));
 				titem.bUseRandomness = (atoi(sd[8].c_str()) != 0);
 				titem.Color = _tColor(sd[9]);
 				titem.MDay = 0;
@@ -103,9 +103,9 @@ void CScheduler::ReloadSchedules()
 					std::string sdate = sd[10];
 					if (sdate.size() != 10)
 						continue; //invalid
-					titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-					titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-					titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+					titem.startYear = uint16_t(atoi(sdate.substr(0, 4).c_str()));
+					titem.startMonth = uint8_t(atoi(sdate.substr(5, 2).c_str()));
+					titem.startDay = uint8_t(atoi(sdate.substr(8, 2).c_str()));
 				}
 				else if (timerType == TTYPE_MONTHLY)
 				{
@@ -186,16 +186,16 @@ void CScheduler::ReloadSchedules()
 				std::stringstream s_str(sd[12]);
 				s_str >> titem.TimerID; }
 
-			_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
+			_eTimerType timerType = _eTimerType(atoi(sd[2].c_str()));
 
 			if (timerType == TTYPE_FIXEDDATETIME)
 			{
 				std::string sdate = sd[8];
 				if (sdate.size() != 10)
 					continue; //invalid
-				titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-				titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-				titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+				titem.startYear = uint16_t(atoi(sdate.substr(0, 4).c_str()));
+				titem.startMonth = uint8_t(atoi(sdate.substr(5, 2).c_str()));
+				titem.startDay = uint8_t(atoi(sdate.substr(8, 2).c_str()));
 			}
 			else if (timerType == TTYPE_MONTHLY)
 			{
@@ -230,12 +230,12 @@ void CScheduler::ReloadSchedules()
 				titem.Occurence = atoi(socc.c_str());
 			}
 
-			titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-			titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+			titem.startHour = uint8_t(atoi(sd[1].substr(0, 2).c_str()));
+			titem.startMin = uint8_t(atoi(sd[1].substr(3, 2).c_str()));
 			titem.startTime = 0;
 			titem.timerType = timerType;
-			titem.timerCmd = (_eTimerCommand)atoi(sd[3].c_str());
-			titem.Level = (unsigned char)atoi(sd[4].c_str());
+			titem.timerCmd = _eTimerCommand(atoi(sd[3].c_str()));
+			titem.Level = uint8_t(atoi(sd[4].c_str()));
 			titem.bUseRandomness = (atoi(sd[7].c_str()) != 0);
 			if ((titem.timerCmd == TCMD_ON) && (titem.Level == 0))
 			{
@@ -276,16 +276,16 @@ void CScheduler::ReloadSchedules()
 				std::stringstream s_str(sd[10]);
 				s_str >> titem.TimerID; }
 
-			_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
+			_eTimerType timerType = _eTimerType(atoi(sd[2].c_str()));
 
 			if (timerType == TTYPE_FIXEDDATETIME)
 			{
 				std::string sdate = sd[6];
 				if (sdate.size() != 10)
 					continue; //invalid
-				titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-				titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-				titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+				titem.startYear = uint16_t(atoi(sdate.substr(0, 4).c_str()));
+				titem.startMonth = uint8_t(atoi(sdate.substr(5, 2).c_str()));
+				titem.startDay = uint8_t(atoi(sdate.substr(8, 2).c_str()));
 			}
 			else if (timerType == TTYPE_MONTHLY)
 			{
@@ -320,12 +320,12 @@ void CScheduler::ReloadSchedules()
 				titem.Occurence = atoi(socc.c_str());
 			}
 
-			titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-			titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+			titem.startHour = uint8_t(atoi(sd[1].substr(0, 2).c_str()));
+			titem.startMin = uint8_t(atoi(sd[1].substr(3, 2).c_str()));
 			titem.startTime = 0;
 			titem.timerType = timerType;
 			titem.timerCmd = TCMD_ON;
-			titem.Temperature = static_cast<float>(atof(sd[3].c_str()));
+			titem.Temperature = float(atof(sd[3].c_str()));
 			titem.Level = 100;
 			titem.bUseRandomness = false;
 			titem.Days = atoi(sd[4].c_str());
@@ -567,12 +567,12 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	{
 		//pItem->Days: mon=1 .. sat=32, sun=64
 		//convert to : sun=0, mon=1 .. sat=6
-		int daynum = (int)log2(pItem->Days) + 1;
+		int daynum = int(log2(pItem->Days)) + 1;
 		if (daynum == 7) daynum = 0;
 
-		boost::gregorian::nth_day_of_the_week_in_month::week_num Occurence = static_cast<boost::gregorian::nth_day_of_the_week_in_month::week_num>(pItem->Occurence);
-		boost::gregorian::greg_weekday::weekday_enum Day = static_cast<boost::gregorian::greg_weekday::weekday_enum>(daynum);
-		boost::gregorian::months_of_year Month = static_cast<boost::gregorian::months_of_year>(ltime.tm_mon + 1);
+		boost::gregorian::nth_day_of_the_week_in_month::week_num Occurence = boost::gregorian::nth_day_of_the_week_in_month::week_num(pItem->Occurence);
+		boost::gregorian::greg_weekday::weekday_enum Day = boost::gregorian::greg_weekday::weekday_enum(daynum);
+		boost::gregorian::months_of_year Month = boost::gregorian::months_of_year(ltime.tm_mon + 1);
 
 		typedef boost::gregorian::nth_day_of_the_week_in_month nth_dow;
 		nth_dow ndm(Occurence, Day, Month);
@@ -589,7 +589,7 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 				ltime.tm_mon = 0;
 				ltime.tm_year++;
 			}
-			Month = static_cast<boost::gregorian::months_of_year>(ltime.tm_mon + 1);
+			Month = boost::gregorian::months_of_year(ltime.tm_mon + 1);
 			nth_dow ndm(Occurence, Day, Month);
 			boost::gregorian::date d = ndm.get_date(ltime.tm_year + 1900);
 
@@ -619,12 +619,12 @@ bool CScheduler::AdjustScheduleItem(tScheduleItem *pItem, bool bForceAddDay)
 	{
 		//pItem->Days: mon=1 .. sat=32, sun=64
 		//convert to : sun=0, mon=1 .. sat=6
-		int daynum = (int)log2(pItem->Days) + 1;
+		int daynum = int(log2(pItem->Days)) + 1;
 		if (daynum == 7) daynum = 0;
 
-		boost::gregorian::nth_day_of_the_week_in_month::week_num Occurence = static_cast<boost::gregorian::nth_day_of_the_week_in_month::week_num>(pItem->Occurence);
-		boost::gregorian::greg_weekday::weekday_enum Day = static_cast<boost::gregorian::greg_weekday::weekday_enum>(daynum);
-		boost::gregorian::months_of_year Month = static_cast<boost::gregorian::months_of_year>(ltime.tm_mon + 1);
+		boost::gregorian::nth_day_of_the_week_in_month::week_num Occurence = boost::gregorian::nth_day_of_the_week_in_month::week_num(pItem->Occurence);
+		boost::gregorian::greg_weekday::weekday_enum Day = boost::gregorian::greg_weekday::weekday_enum(daynum);
+		boost::gregorian::months_of_year Month = boost::gregorian::months_of_year(ltime.tm_mon + 1);
 
 		typedef boost::gregorian::nth_day_of_the_week_in_month nth_dow;
 		nth_dow ndm(Occurence, Day, Month);
@@ -857,7 +857,7 @@ void CScheduler::CheckSchedules()
 
 							unsigned char dType = atoi(sd[0].c_str());
 							unsigned char dSubType = atoi(sd[1].c_str());
-							_eSwitchType switchtype = (_eSwitchType)atoi(sd[2].c_str());
+							_eSwitchType switchtype = _eSwitchType(atoi(sd[2].c_str()));
 							std::string lstatus;
 							int llevel = 0;
 							bool bHaveDimmer = false;
@@ -1598,7 +1598,7 @@ namespace http {
 			unsigned char hour = atoi(shour.c_str());
 			unsigned char min = atoi(smin.c_str());
 			int days = atoi(sdays.c_str());
-			float temperature = static_cast<float>(atof(stvalue.c_str()));
+			float temperature = float(atof(stvalue.c_str()));
 			int mday = atoi(smday.c_str());
 			int month = atoi(smonth.c_str());
 			int occurence = atoi(soccurence.c_str());
@@ -1690,7 +1690,7 @@ namespace http {
 			unsigned char hour = atoi(shour.c_str());
 			unsigned char min = atoi(smin.c_str());
 			int days = atoi(sdays.c_str());
-			float tempvalue = static_cast<float>(atof(stvalue.c_str()));
+			float tempvalue = float(atof(stvalue.c_str()));
 			int mday = atoi(smday.c_str());
 			int month = atoi(smonth.c_str());
 			int occurence = atoi(soccurence.c_str());

--- a/main/SignalHandler.cpp
+++ b/main/SignalHandler.cpp
@@ -41,7 +41,7 @@ extern time_t m_LastHeartbeat;
 static void printRegInfo(siginfo_t * info, ucontext_t * ucontext)
 {
 #if defined(REG_RIP) //x86_64
-	_log.Log(LOG_ERROR, "siginfo address=%p, address=%p", info->si_addr, (void*)((ucontext_t *)ucontext)->uc_mcontext.gregs[REG_RIP]);
+	_log.Log(LOG_ERROR, "siginfo address=%p, address=%p", info->si_addr, (void *)(ucontext)->uc_mcontext.gregs[REG_RIP]);
 #elif defined(REG_EIP) //x86
 	_log.Log(LOG_ERROR, "siginfo address=%p, address=%p", info->si_addr, (void*)((ucontext_t *)ucontext)->uc_mcontext.gregs[REG_EIP]);
 #elif defined(__aarch64__) //arm64 (aarch64 according to gnu)
@@ -439,7 +439,7 @@ void signal_handler(int sig_num
 				, "-");
 #endif
 #if defined(__linux__)
-			printRegInfo(info, ((ucontext_t *)ucontext));
+			printRegInfo(info, (static_cast<ucontext_t *>(ucontext)));
 #endif
 #ifndef WIN32
 			if (!pthread_equal(fatal_handling_thread, pthread_self()))
@@ -466,7 +466,7 @@ void signal_handler(int sig_num
 			, "-");
 #endif
 #if defined(__linux__)
-		printRegInfo(info, ((ucontext_t *)ucontext));
+		printRegInfo(info, (static_cast<ucontext_t *>(ucontext)));
 #endif
 		dumpstack(info, ucontext);
 		// re-raise signal to enforce core dump

--- a/main/SunRiseSet.cpp
+++ b/main/SunRiseSet.cpp
@@ -106,7 +106,7 @@ double get_utc_offset() {
 	ptm->tm_isdst = -1;
 	gmt = mktime(ptm);
 
-	double utc_offset = (double)difftime(rawtime, gmt) / 3600.0;
+	double utc_offset = difftime(rawtime, gmt) / 3600.0;
 
 	return utc_offset;
 }
@@ -157,8 +157,8 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 
 
 	double _tmpH;
-	result.DaylengthMins = static_cast<int>(round(modf(daylen, &_tmpH) * 60));
-	result.DaylengthHours = static_cast<int>(_tmpH);
+	result.DaylengthMins = int(round(modf(daylen, &_tmpH) * 60));
+	result.DaylengthHours = int(_tmpH);
 	//fix a possible rounding issue above
 	SunRiseSet::fixRoundIssue(&result.DaylengthHours, &result.DaylengthMins);
 
@@ -169,15 +169,15 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 
 	rise = UtcToLocal(rise, timezone);
 	set = UtcToLocal(set, timezone);
-	result.SunAtSouthMin = static_cast<int>(round(modf((rise + set) / 2.0, &_tmpH) * 60));
-	result.SunAtSouthHour = static_cast<int>(_tmpH);
+	result.SunAtSouthMin = int(round(modf((rise + set) / 2.0, &_tmpH) * 60));
+	result.SunAtSouthHour = int(_tmpH);
 
 	switch (rs) {
 	case 0:
-		result.SunRiseMin = static_cast<int>(round(modf(rise, &_tmpH) * 60));
-		result.SunRiseHour = static_cast<int>(_tmpH);
-		result.SunSetMin = static_cast<int>(round(modf(set, &_tmpH) * 60));
-		result.SunSetHour = static_cast<int>(_tmpH);
+		result.SunRiseMin = int(round(modf(rise, &_tmpH) * 60));
+		result.SunRiseHour = int(_tmpH);
+		result.SunSetMin = int(round(modf(set, &_tmpH) * 60));
+		result.SunSetHour = int(_tmpH);
 		//fix a possible rounding issue above
 		SunRiseSet::fixRoundIssue(&result.SunRiseHour, &result.SunRiseMin);
 		SunRiseSet::fixRoundIssue(&result.SunSetHour, &result.SunSetMin);
@@ -196,10 +196,10 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 	case 0:
 		civ_start = UtcToLocal(civ_start, timezone);
 		civ_end = UtcToLocal(civ_end, timezone);
-		result.CivilTwilightStartMin = static_cast<int>(round(modf(civ_start, &_tmpH) * 60));
-		result.CivilTwilightStartHour = static_cast<int>(_tmpH);
-		result.CivilTwilightEndMin = static_cast<int>(round(modf(civ_end, &_tmpH) * 60));
-		result.CivilTwilightEndHour = static_cast<int>(_tmpH);
+		result.CivilTwilightStartMin = int(round(modf(civ_start, &_tmpH) * 60));
+		result.CivilTwilightStartHour = int(_tmpH);
+		result.CivilTwilightEndMin = int(round(modf(civ_end, &_tmpH) * 60));
+		result.CivilTwilightEndHour = int(_tmpH);
 		//fix a possible rounding issue above
 		SunRiseSet::fixRoundIssue(&result.CivilTwilightStartHour, &result.CivilTwilightStartMin);
 		SunRiseSet::fixRoundIssue(&result.CivilTwilightEndHour, &result.CivilTwilightEndMin);
@@ -218,10 +218,10 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 	case 0:
 		naut_start = UtcToLocal(naut_start, timezone);
 		naut_end = UtcToLocal(naut_end, timezone);
-		result.NauticalTwilightStartMin = static_cast<int>(round(modf(naut_start, &_tmpH) * 60));
-		result.NauticalTwilightStartHour = static_cast<int>(_tmpH);
-		result.NauticalTwilightEndMin = static_cast<int>(round(modf(naut_end, &_tmpH) * 60));
-		result.NauticalTwilightEndHour = static_cast<int>(_tmpH);
+		result.NauticalTwilightStartMin = int(round(modf(naut_start, &_tmpH) * 60));
+		result.NauticalTwilightStartHour = int(_tmpH);
+		result.NauticalTwilightEndMin = int(round(modf(naut_end, &_tmpH) * 60));
+		result.NauticalTwilightEndHour = int(_tmpH);
 		//fix a possible rounding issue above
 		SunRiseSet::fixRoundIssue(&result.NauticalTwilightStartHour, &result.NauticalTwilightStartMin);
 		SunRiseSet::fixRoundIssue(&result.NauticalTwilightEndHour, &result.NauticalTwilightEndMin);
@@ -240,10 +240,10 @@ bool SunRiseSet::GetSunRiseSet(const double latit, const double longit, const in
 	case 0:
 		astr_start = UtcToLocal(astr_start, timezone);
 		astr_end = UtcToLocal(astr_end, timezone);
-		result.AstronomicalTwilightStartMin = static_cast<int>(round(modf(astr_start, &_tmpH) * 60));
-		result.AstronomicalTwilightStartHour = static_cast<int>(_tmpH);
-		result.AstronomicalTwilightEndMin = static_cast<int>(round(modf(astr_end, &_tmpH) * 60));
-		result.AstronomicalTwilightEndHour = static_cast<int>(_tmpH);
+		result.AstronomicalTwilightStartMin = int(round(modf(astr_start, &_tmpH) * 60));
+		result.AstronomicalTwilightStartHour = int(_tmpH);
+		result.AstronomicalTwilightEndMin = int(round(modf(astr_end, &_tmpH) * 60));
+		result.AstronomicalTwilightEndHour = int(_tmpH);
 		//fix a possible rounding issue above
 		SunRiseSet::fixRoundIssue(&result.AstronomicalTwilightStartHour, &result.AstronomicalTwilightStartMin);
 		SunRiseSet::fixRoundIssue(&result.AstronomicalTwilightEndHour, &result.AstronomicalTwilightEndMin);

--- a/main/TrendCalculator.cpp
+++ b/main/TrendCalculator.cpp
@@ -28,7 +28,7 @@ _tTrendCalculator::_eTendencyType _tTrendCalculator::AddValueAndReturnTendency(c
 	else
 	{
 		time_t atime = time(nullptr);
-		int AvarageMinutes = (int)TendType;
+		int AvarageMinutes = int(TendType);
 		if (atime - m_timeLastAvarage >= (AvarageMinutes * 60))
 		{
 			//Calculate Mean (M)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1066,7 +1066,7 @@ namespace http {
 				(shtype.empty())
 				)
 				return;
-			_eHardwareTypes htype = (_eHardwareTypes)atoi(shtype.c_str());
+			_eHardwareTypes htype = _eHardwareTypes(atoi(shtype.c_str()));
 
 			int iDataTimeout = atoi(sdatatimeout.c_str());
 			int mode1 = 0;
@@ -1076,7 +1076,7 @@ namespace http {
 			int mode5 = 0;
 			int mode6 = 0;
 			int port = atoi(sport.c_str());
-			uint32_t iLogLevelEnabled = (uint32_t)atoi(loglevel.c_str());
+			uint32_t iLogLevelEnabled = uint32_t(atoi(loglevel.c_str()));
 			std::string mode1Str = request::findValue(&req, "Mode1");
 			if (!mode1Str.empty()) {
 				mode1 = atoi(mode1Str.c_str());
@@ -1508,11 +1508,11 @@ namespace http {
 
 			bool bEnabled = (senabled == "true") ? true : false;
 
-			_eHardwareTypes htype = (_eHardwareTypes)atoi(shtype.c_str());
+			_eHardwareTypes htype = _eHardwareTypes(atoi(shtype.c_str()));
 			int iDataTimeout = atoi(sdatatimeout.c_str());
 
 			int port = atoi(sport.c_str());
-			uint32_t iLogLevelEnabled = (uint32_t)atoi(loglevel.c_str());
+			uint32_t iLogLevelEnabled = uint32_t(atoi(loglevel.c_str()));
 
 			bool bIsSerial = false;
 
@@ -1964,7 +1964,7 @@ namespace http {
 			}
 
 			std::string errorMessage;
-			if (!m_sql.AddUserVariable(variablename, (const _eUsrVariableType)atoi(variabletype.c_str()), variablevalue, errorMessage))
+			if (!m_sql.AddUserVariable(variablename, _eUsrVariableType(atoi(variabletype.c_str())), variablevalue, errorMessage))
 			{
 				root["message"] = errorMessage;
 			}
@@ -2065,7 +2065,7 @@ namespace http {
 				bTypeNameChanged = true; //new type
 
 			std::string errorMessage;
-			if (!m_sql.UpdateUserVariable(idx, variablename, (const _eUsrVariableType)atoi(variabletype.c_str()), variablevalue, !bTypeNameChanged, errorMessage))
+			if (!m_sql.UpdateUserVariable(idx, variablename, _eUsrVariableType(atoi(variabletype.c_str())), variablevalue, !bTypeNameChanged, errorMessage))
 			{
 				root["message"] = errorMessage;
 			}
@@ -2184,7 +2184,7 @@ namespace http {
 			std::string sloglevel = request::findValue(&req, "loglevel");
 			if (!sloglevel.empty())
 			{
-				lLevel = (_eLogLevel)atoi(sloglevel.c_str());
+				lLevel = _eLogLevel(atoi(sloglevel.c_str()));
 			}
 
 			std::list<CLogger::_tLogLineStruct> logmessages = _log.GetLog(lLevel);
@@ -2196,7 +2196,7 @@ namespace http {
 					std::stringstream szLogTime;
 					szLogTime << msg.logtime;
 					root["LastLogTime"] = szLogTime.str();
-					root["result"][ii]["level"] = static_cast<int>(msg.level);
+					root["result"][ii]["level"] = int(msg.level);
 					root["result"][ii]["message"] = msg.logmessage;
 					ii++;
 				}
@@ -2640,13 +2640,13 @@ namespace http {
 			//round to 5 seconds (nicer in about page)
 			tuptime = ((tuptime / 5) * 5) + 5;
 			int days, hours, minutes, seconds;
-			days = (int)(tuptime / 86400);
+			days = int(tuptime / 86400);
 			tuptime -= (days * 86400);
-			hours = (int)(tuptime / 3600);
+			hours = int(tuptime / 3600);
 			tuptime -= (hours * 3600);
-			minutes = (int)(tuptime / 60);
+			minutes = int(tuptime / 60);
 			tuptime -= (minutes * 60);
-			seconds = (int)tuptime;
+			seconds = int(tuptime);
 			root["status"] = "OK";
 			root["title"] = "GetUptime";
 			root["days"] = days;
@@ -2749,7 +2749,7 @@ namespace http {
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
 				{
-					//urights = static_cast<int>(m_users[iUser].userrights);
+					// urights = int(m_users[iUser].userrights);
 					UserID = m_users[iUser].ID;
 				}
 			}
@@ -3221,7 +3221,7 @@ namespace http {
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
 				{
-					urights = static_cast<int>(m_users[iUser].userrights);
+					urights = int(m_users[iUser].userrights);
 					_log.Log(LOG_STATUS, "User: %s initiated a Thermostat State change command", m_users[iUser].Username.c_str());
 				}
 			}
@@ -3440,7 +3440,7 @@ namespace http {
 			{
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
-					urights = static_cast<int>(m_users[iUser].userrights);
+					urights = int(m_users[iUser].userrights);
 			}
 			root["statuscode"] = urights;
 
@@ -3512,7 +3512,7 @@ namespace http {
 				return false; //viewer
 			//User
 			int iUser = FindUser(pSession->username.c_str());
-			if ((iUser < 0) || (iUser >= (int)m_users.size()))
+			if ((iUser < 0) || (iUser >= int(m_users.size())))
 				return false;
 
 			if (m_users[iUser].TotSensors == 0)
@@ -3636,7 +3636,7 @@ namespace http {
 				{
 					int dType = atoi(result[0][3].c_str());
 					int sType = atoi(result[0][4].c_str());
-					_eSwitchType switchtype = (_eSwitchType)atoi(result[0][5].c_str());
+					_eSwitchType switchtype = _eSwitchType(atoi(result[0][5].c_str()));
 					std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][6]);
 					GetLightCommand(dType, sType, switchtype, scommand, command, options);
 				}
@@ -3738,7 +3738,7 @@ namespace http {
 				{
 					int dType = atoi(result[0][3].c_str());
 					int sType = atoi(result[0][4].c_str());
-					_eSwitchType switchtype = (_eSwitchType)atoi(result[0][5].c_str());
+					_eSwitchType switchtype = _eSwitchType(atoi(result[0][5].c_str()));
 					std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][6]);
 					GetLightCommand(dType, sType, switchtype, scommand, command, options);
 				}
@@ -3820,7 +3820,7 @@ namespace http {
 						root["result"][ii]["OnDelay"] = atoi(sd[12].c_str());
 						root["result"][ii]["OffDelay"] = atoi(sd[13].c_str());
 
-						_eSwitchType switchtype = (_eSwitchType)atoi(sd[14].c_str());
+						_eSwitchType switchtype = _eSwitchType(atoi(sd[14].c_str()));
 
 						unsigned char devType = atoi(sd[3].c_str());
 
@@ -3933,7 +3933,7 @@ namespace http {
 					{
 						int ID = atoi(sd[0].c_str());
 						std::string Name = sd[1];
-						_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[2].c_str());
+						_eHardwareTypes Type = _eHardwareTypes(atoi(sd[2].c_str()));
 
 						if (
 							(Type == HTYPE_RFXLAN) ||
@@ -4037,7 +4037,7 @@ namespace http {
 						int Type = atoi(sd[2].c_str());
 						int SubType = atoi(sd[3].c_str());
 						int used = atoi(sd[4].c_str());
-						_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+						_eSwitchType switchtype = _eSwitchType(atoi(sd[5].c_str()));
 						std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[6]);
 						bool bdoAdd = false;
 						switch (Type)
@@ -4107,7 +4107,8 @@ namespace http {
 										std::map<std::string, std::string> selectorStatuses;
 										GetSelectorSwitchStatuses(options, selectorStatuses);
 										bool levelOffHidden = (options["LevelOffHidden"] == "true");
-										for (int i = 0; i < (int)selectorStatuses.size(); i++) {
+										for (int i = 0; i < int(selectorStatuses.size()); i++)
+										{
 											if (levelOffHidden && (i == 0)) {
 												continue;
 											}
@@ -4135,7 +4136,7 @@ namespace http {
 											{
 												ss << ",";
 											}
-											ss << (int)float((100.0F / float(maxDimLevel)) * i);
+											ss << int(float(100.0F / float(maxDimLevel)) * i);
 										}
 									}
 									dimmerLevels = ss.str();
@@ -4408,7 +4409,7 @@ namespace http {
 					(slighttype.empty())
 					)
 					return;
-				_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
+				_eSwitchType switchtype = _eSwitchType(atoi(sswitchtype.c_str()));
 				int lighttype = atoi(slighttype.c_str());
 				int dtype;
 				int subtype = 0;
@@ -5073,7 +5074,7 @@ namespace http {
 					(name.empty())
 					)
 					return;
-				_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
+				_eSwitchType switchtype = _eSwitchType(atoi(sswitchtype.c_str()));
 				int lighttype = atoi(slighttype.c_str());
 				int dtype = 0;
 				int subtype = 0;
@@ -5088,7 +5089,7 @@ namespace http {
 					if (!result.empty())
 					{
 						std::vector<std::string> sd = result[0];
-						_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[0].c_str());
+						_eHardwareTypes Type = _eHardwareTypes(atoi(sd[0].c_str()));
 						if (Type == HTYPE_PythonPlugin)
 						{
 							// Not allowed to add device to plugin HW (plugin framework does not use key column "ID" but instead uses column "unit" as key)
@@ -6294,7 +6295,7 @@ namespace http {
 				if ((stype.empty()) || (swhen.empty()) || (svalue.empty()) || (spriority.empty()) || (ssendalways.empty()) || (srecovery.empty()))
 					return;
 
-				_eNotificationTypes ntype = (_eNotificationTypes)atoi(stype.c_str());
+				_eNotificationTypes ntype = _eNotificationTypes(atoi(stype.c_str()));
 				std::string ttype = Notification_Type_Desc(ntype, 1);
 				if (
 					(ntype == NTYPE_SWITCH_ON) ||
@@ -6370,7 +6371,7 @@ namespace http {
 				//delete old record
 				m_notifications.RemoveNotification(idx);
 
-				_eNotificationTypes ntype = (_eNotificationTypes)atoi(stype.c_str());
+				_eNotificationTypes ntype = _eNotificationTypes(atoi(stype.c_str()));
 				std::string ttype = Notification_Type_Desc(ntype, 1);
 				if (
 					(ntype == NTYPE_SWITCH_ON) ||
@@ -6945,7 +6946,7 @@ namespace http {
 					iUser = FindUser(session.username.c_str());
 					if (iUser != -1)
 					{
-						urights = (int)m_users[iUser].userrights;
+						urights = int(m_users[iUser].userrights);
 						_log.Log(LOG_STATUS, "User: %s initiated a modal command", m_users[iUser].Username.c_str());
 					}
 				}
@@ -7268,9 +7269,9 @@ namespace http {
 					switch (hex.length())
 					{
 						case 6: //RGB
-							r = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-							g = (uint8_t)((ihex & 0x000000FF00) >> 8);
-							b = (uint8_t)ihex & 0xFF;
+							r = uint8_t((ihex & 0x0000FF0000) >> 16);
+							g = uint8_t((ihex & 0x000000FF00) >> 8);
+							b = uint8_t(ihex) & 0xFF;
 							float hsb[3];
 							int tr, tg, tb; // tmp of 'int' type so can be passed as references to hsb2rgb
 							rgb2hsb(r, g, b, hsb);
@@ -7285,18 +7286,18 @@ namespace http {
 							color = _tColor(r, g, b, cw, ww, ColorModeRGB);
 							break;
 						case 8: //RGB_WW
-							r = (uint8_t)((ihex & 0x00FF000000) >> 24);
-							g = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-							b = (uint8_t)((ihex & 0x000000FF00) >> 8);
-							ww = (uint8_t)ihex & 0xFF;
+							r = uint8_t((ihex & 0x00FF000000) >> 24);
+							g = uint8_t((ihex & 0x0000FF0000) >> 16);
+							b = uint8_t((ihex & 0x000000FF00) >> 8);
+							ww = uint8_t(ihex) & 0xFF;
 							color = _tColor(r, g, b, cw, ww, ColorModeCustom);
 							break;
 						case 10: //RGB_CW_WW
-							r = (uint8_t)((ihex & 0xFF00000000) >> 32);
-							g = (uint8_t)((ihex & 0x00FF000000) >> 24);
-							b = (uint8_t)((ihex & 0x0000FF0000) >> 16);
-							cw = (uint8_t)((ihex & 0x000000FF00) >> 8);
-							ww = (uint8_t)ihex & 0xFF;
+							r = uint8_t((ihex & 0xFF00000000) >> 32);
+							g = uint8_t((ihex & 0x00FF000000) >> 24);
+							b = uint8_t((ihex & 0x0000FF0000) >> 16);
+							cw = uint8_t((ihex & 0x000000FF00) >> 8);
+							ww = uint8_t(ihex) & 0xFF;
 							color = _tColor(r, g, b, cw, ww, ColorModeCustom);
 							break;
 					}
@@ -7331,7 +7332,7 @@ namespace http {
 
 				_log.Log(LOG_STATUS, "setcolbrightnessvalue: ID: %" PRIx64 ", bri: %d, color: '%s'", ID, ival, color.toString().c_str());
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
-				m_mainworker.SwitchLight(ID, "Set Color", (unsigned char)ival, color, false, 0, szSwitchUser);
+				m_mainworker.SwitchLight(ID, "Set Color", uint8_t(ival), color, false, 0, szSwitchUser);
 
 				root["status"] = "OK";
 				root["title"] = "SetColBrightnessValue";
@@ -8037,7 +8038,7 @@ namespace http {
 
 			for (int ii = 0; ii < STYPE_END; ii++)
 			{
-				_switchtypes[Switch_Type_Desc((_eSwitchType)ii)] = ii;
+				_switchtypes[Switch_Type_Desc(_eSwitchType(ii))] = ii;
 			}
 			//return a sorted list
 			for (const auto &type : _switchtypes)
@@ -8052,7 +8053,7 @@ namespace http {
 			char szTmp[200];
 			for (int ii = 0; ii < MTYPE_END; ii++)
 			{
-				sprintf(szTmp, "<option value=\"%d\">%s</option>\n", ii, Meter_Type_Desc((_eMeterType)ii));
+				sprintf(szTmp, "<option value=\"%d\">%s</option>\n", ii, Meter_Type_Desc(_eMeterType(ii)));
 				content_part += szTmp;
 			}
 		}
@@ -8104,15 +8105,14 @@ namespace http {
 						{
 							for (const auto &sd : result)
 							{
-								int bIsActive = static_cast<int>(atoi(sd[1].c_str()));
-								if (bIsActive)
+								if (std::stoi(sd[1]))
 								{
-									unsigned long ID = (unsigned long)atol(sd[0].c_str());
+									auto ID = uint32_t(atol(sd[0].c_str()));
 
 									std::string username = base64_decode(sd[2]);
 									std::string password = sd[3];
 
-									_eUserRights rights = (_eUserRights)atoi(sd[4].c_str());
+									_eUserRights rights = _eUserRights(atoi(sd[4].c_str()));
 									int activetabs = atoi(sd[5].c_str());
 
 									AddUser(ID, username, password, rights, activetabs);
@@ -8135,12 +8135,12 @@ namespace http {
 			wtmp.ID = ID;
 			wtmp.Username = username;
 			wtmp.Password = password;
-			wtmp.userrights = (_eUserRights)userrights;
+			wtmp.userrights = _eUserRights(userrights);
 			wtmp.ActiveTabs = activetabs;
 			wtmp.TotSensors = atoi(result[0][0].c_str());
 			m_users.push_back(wtmp);
 
-			m_pWebEm->AddUserPassword(ID, username, password, (_eUserRights)userrights, activetabs);
+			m_pWebEm->AddUserPassword(ID, username, password, _eUserRights(userrights), activetabs);
 		}
 
 		void CWebServer::ClearUserPasswords()
@@ -8191,22 +8191,21 @@ namespace http {
 
 			int nUnit = atoi(request::findValue(&req, "WindUnit").c_str());
 			m_sql.UpdatePreferencesVar("WindUnit", nUnit);
-			m_sql.m_windunit = (_eWindUnit)nUnit;
+			m_sql.m_windunit = _eWindUnit(nUnit);
 
 			nUnit = atoi(request::findValue(&req, "TempUnit").c_str());
 			m_sql.UpdatePreferencesVar("TempUnit", nUnit);
-			m_sql.m_tempunit = (_eTempUnit)nUnit;
+			m_sql.m_tempunit = _eTempUnit(nUnit);
 
 			nUnit = atoi(request::findValue(&req, "WeightUnit").c_str());
 			m_sql.UpdatePreferencesVar("WeightUnit", nUnit);
-			m_sql.m_weightunit = (_eWeightUnit)nUnit;
-
+			m_sql.m_weightunit = _eWeightUnit(nUnit);
 
 			m_sql.SetUnitsAndScale();
 
 			std::string AuthenticationMethod = request::findValue(&req, "AuthenticationMethod");
-			_eAuthenticationMethod amethod = (_eAuthenticationMethod)atoi(AuthenticationMethod.c_str());
-			m_sql.UpdatePreferencesVar("AuthenticationMethod", static_cast<int>(amethod));
+			_eAuthenticationMethod amethod = _eAuthenticationMethod(atoi(AuthenticationMethod.c_str()));
+			m_sql.UpdatePreferencesVar("AuthenticationMethod", int(amethod));
 			m_pWebEm->SetAuthenticationMethod(amethod);
 
 			std::string ReleaseChannel = request::findValue(&req, "ReleaseChannel");
@@ -8333,12 +8332,12 @@ namespace http {
 			std::string senableautobackup = request::findValue(&req, "enableautobackup");
 			m_sql.UpdatePreferencesVar("UseAutoBackup", (senableautobackup == "on" ? 1 : 0));
 
-			float CostEnergy = static_cast<float>(atof(request::findValue(&req, "CostEnergy").c_str()));
-			float CostEnergyT2 = static_cast<float>(atof(request::findValue(&req, "CostEnergyT2").c_str()));
-			float CostEnergyR1 = static_cast<float>(atof(request::findValue(&req, "CostEnergyR1").c_str()));
-			float CostEnergyR2 = static_cast<float>(atof(request::findValue(&req, "CostEnergyR2").c_str()));
-			float CostGas = static_cast<float>(atof(request::findValue(&req, "CostGas").c_str()));
-			float CostWater = static_cast<float>(atof(request::findValue(&req, "CostWater").c_str()));
+			float CostEnergy = float(atof(request::findValue(&req, "CostEnergy").c_str()));
+			float CostEnergyT2 = float(atof(request::findValue(&req, "CostEnergyT2").c_str()));
+			float CostEnergyR1 = float(atof(request::findValue(&req, "CostEnergyR1").c_str()));
+			float CostEnergyR2 = float(atof(request::findValue(&req, "CostEnergyR2").c_str()));
+			float CostGas = float(atof(request::findValue(&req, "CostGas").c_str()));
+			float CostWater = float(atof(request::findValue(&req, "CostWater").c_str()));
 			m_sql.UpdatePreferencesVar("CostEnergy", int(CostEnergy * 10000.0F));
 			m_sql.UpdatePreferencesVar("CostEnergyT2", int(CostEnergyT2 * 10000.0F));
 			m_sql.UpdatePreferencesVar("CostEnergyR1", int(CostEnergyR1 * 10000.0F));
@@ -8437,7 +8436,7 @@ namespace http {
 			}
 			std::string EnableEventSystemFullURLLog = request::findValue(&req, "EventSystemLogFullURL");
 			m_sql.m_bEnableEventSystemFullURLLog = EnableEventSystemFullURLLog == "on" ? true : false;
-			m_sql.UpdatePreferencesVar("EventSystemLogFullURL", (int)m_sql.m_bEnableEventSystemFullURLLog);
+			m_sql.UpdatePreferencesVar("EventSystemLogFullURL", int(m_sql.m_bEnableEventSystemFullURLLog));
 
 			rnOldvalue = 0;
 			m_sql.GetPreferencesVar("DisableDzVentsSystem", rnOldvalue);
@@ -8664,7 +8663,7 @@ namespace http {
 				}
 			}
 
-			root["ActTime"] = static_cast<int>(now);
+			root["ActTime"] = int(now);
 
 			char szTmp[300];
 
@@ -8725,7 +8724,7 @@ namespace http {
 						result = m_sql.safe_query("SELECT COUNT(*) FROM SharedDevices WHERE (SharedUserID == %lu)", m_users[iUser].ID);
 						if (!result.empty())
 						{
-							totUserDevices = (unsigned int)std::stoi(result[0][0]);
+							totUserDevices = uint32_t(std::stoi(result[0][0]));
 						}
 						bShowScenes = (m_users[iUser].ActiveTabs&(1 << 1)) != 0;
 					}
@@ -9142,8 +9141,8 @@ namespace http {
 							continue;
 					}
 
-					_eSwitchType switchtype = (_eSwitchType)atoi(sd[13].c_str());
-					_eMeterType metertype = (_eMeterType)switchtype;
+					_eSwitchType switchtype = _eSwitchType(atoi(sd[13].c_str()));
+					_eMeterType metertype = _eMeterType(switchtype);
 					double AddjValue = atof(sd[15].c_str());
 					double AddjMulti = atof(sd[16].c_str());
 					double AddjValue2 = atof(sd[17].c_str());
@@ -9425,7 +9424,7 @@ namespace http {
 					}
 					else
 					{
-						sprintf(szData, "%04X", (unsigned int)atoi(sd[1].c_str()));
+						sprintf(szData, "%04X", uint32_t(atoi(sd[1].c_str())));
 						if (
 							(dType == pTypeTEMP) ||
 							(dType == pTypeTEMP_BARO) ||
@@ -9728,7 +9727,7 @@ namespace http {
 								root["result"][ii]["TypeImg"] = "LogitechMediaServer";
 							else
 								root["result"][ii]["TypeImg"] = "Media";
-							root["result"][ii]["Status"] = Media_Player_States((_eMediaStatus)nValue);
+							root["result"][ii]["Status"] = Media_Player_States(_eMediaStatus(nValue));
 							lstatus = sValue;
 						}
 						else if (
@@ -9963,12 +9962,12 @@ namespace http {
 						root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
 						_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-						uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+						uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 						if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 						{
 							tstate = m_mainworker.m_trend_calculator[tID].m_state;
 						}
-						root["result"][ii]["trend"] = (int)tstate;
+						root["result"][ii]["trend"] = int(tstate);
 					}
 					else if (dType == pTypeThermostat1)
 					{
@@ -9992,12 +9991,12 @@ namespace http {
 						root["result"][ii]["TypeImg"] = "temperature";
 						root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-						uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+						uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 						if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 						{
 							tstate = m_mainworker.m_trend_calculator[tID].m_state;
 						}
-						root["result"][ii]["trend"] = (int)tstate;
+						root["result"][ii]["trend"] = int(tstate);
 					}
 					else if (dType == pTypeHUM)
 					{
@@ -10030,12 +10029,12 @@ namespace http {
 							root["result"][ii]["DewPoint"] = szTmp;
 
 							_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-							uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+							uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 							if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 							{
 								tstate = m_mainworker.m_trend_calculator[tID].m_state;
 							}
-							root["result"][ii]["trend"] = (int)tstate;
+							root["result"][ii]["trend"] = int(tstate);
 						}
 					}
 					else if (dType == pTypeTEMP_HUM_BARO)
@@ -10088,12 +10087,12 @@ namespace http {
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
 							_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-							uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+							uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 							if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 							{
 								tstate = m_mainworker.m_trend_calculator[tID].m_state;
 							}
-							root["result"][ii]["trend"] = (int)tstate;
+							root["result"][ii]["trend"] = int(tstate);
 						}
 					}
 					else if (dType == pTypeTEMP_BARO)
@@ -10118,12 +10117,12 @@ namespace http {
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
 							_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-							uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+							uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 							if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 							{
 								tstate = m_mainworker.m_trend_calculator[tID].m_state;
 							}
-							root["result"][ii]["trend"] = (int)tstate;
+							root["result"][ii]["trend"] = int(tstate);
 						}
 					}
 					else if (dType == pTypeUV)
@@ -10132,7 +10131,7 @@ namespace http {
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 2)
 						{
-							float UVI = static_cast<float>(atof(strarray[0].c_str()));
+							float UVI = float(atof(strarray[0].c_str()));
 							root["result"][ii]["UVI"] = strarray[0];
 							if (dSubType == sTypeUV3)
 							{
@@ -10142,12 +10141,12 @@ namespace http {
 								sprintf(szData, "%.1f UVI, %.1f&deg; %c", UVI, tvalue, tempsign);
 
 								_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-								uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+								uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 								if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 								{
 									tstate = m_mainworker.m_trend_calculator[tID].m_state;
 								}
-								root["result"][ii]["trend"] = (int)tstate;
+								root["result"][ii]["trend"] = int(tstate);
 							}
 							else
 							{
@@ -10206,12 +10205,12 @@ namespace http {
 								root["result"][ii]["Chill"] = tvalue;
 
 								_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-								uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+								uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 								if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 								{
 									tstate = m_mainworker.m_trend_calculator[tID].m_state;
 								}
-								root["result"][ii]["trend"] = (int)tstate;
+								root["result"][ii]["trend"] = int(tstate);
 							}
 							root["result"][ii]["Data"] = sValue;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -10263,11 +10262,11 @@ namespace http {
 								total_real *= AddjMulti;
 								if (dSubType == sTypeRAINByRate)
 								{
-									rate = static_cast<float>(atof(sd2[1].c_str()) / 10000.0F);
+									rate = float(atof(sd2[1].c_str()) / 10000.0F);
 								}
 								else
 								{
-									rate = (static_cast<float>(atof(strarray[0].c_str())) / 100.0F) * float(AddjMulti);
+									rate = (float(atof(strarray[0].c_str())) / 100.0F) * float(AddjMulti);
 								}
 
 								sprintf(szTmp, "%.1f", total_real);
@@ -10359,7 +10358,7 @@ namespace http {
 						double meteroffset = AddjValue;
 						float divider = m_sql.GetCounterDivider(int(metertype), int(dType), float(AddjValue2));
 
-						double dvalue = static_cast<double>(atof(sValue.c_str()));
+						double dvalue = double(atof(sValue.c_str()));
 
 						switch (metertype)
 						{
@@ -10461,7 +10460,7 @@ namespace http {
 						root["result"][ii]["TypeImg"] = "counter";
 						root["result"][ii]["ValueQuantity"] = "";
 						root["result"][ii]["ValueUnits"] = "";
-						double dvalue = static_cast<double>(atof(sValue.c_str()));
+						double dvalue = double(atof(sValue.c_str()));
 						double meteroffset = AddjValue;
 
 						switch (metertype)
@@ -10513,12 +10512,12 @@ namespace http {
 						StringSplit(sValue, ";", splitresults);
 						double dvalue;
 						if (splitresults.size() < 2) {
-							dvalue = static_cast<double>(atof(sValue.c_str()));
+							dvalue = double(atof(sValue.c_str()));
 						}
 						else {
-							dvalue = static_cast<double>(atof(splitresults[1].c_str()));
+							dvalue = double(atof(splitresults[1].c_str()));
 							if (dvalue < 0.0) {
-								dvalue = static_cast<double>(atof(splitresults[0].c_str()));
+								dvalue = double(atof(splitresults[0].c_str()));
 							}
 						}
 						root["result"][ii]["Data"] = root["result"][ii]["Counter"];
@@ -11050,7 +11049,7 @@ namespace http {
 					{
 						if (dSubType == sTypeVisibility)
 						{
-							float vis = static_cast<float>(atof(sValue.c_str()));
+							float vis = float(atof(sValue.c_str()));
 							if (metertype == 0)
 							{
 								//km
@@ -11069,7 +11068,7 @@ namespace http {
 						}
 						else if (dSubType == sTypeDistance)
 						{
-							float vis = static_cast<float>(atof(sValue.c_str()));
+							float vis = float(atof(sValue.c_str()));
 							if (metertype == 0)
 							{
 								//Metric
@@ -11087,7 +11086,7 @@ namespace http {
 						}
 						else if (dSubType == sTypeSolarRadiation)
 						{
-							float radiation = static_cast<float>(atof(sValue.c_str()));
+							float radiation = float(atof(sValue.c_str()));
 							sprintf(szTmp, "%.1f Watt/m2", radiation);
 							root["result"][ii]["Data"] = szTmp;
 							root["result"][ii]["Radiation"] = atof(sValue.c_str());
@@ -11123,12 +11122,12 @@ namespace http {
 							root["result"][ii]["TypeImg"] = "temperature";
 							root["result"][ii]["Type"] = "temperature";
 							_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
-							uint64_t tID = ((uint64_t)(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
+							uint64_t tID = (uint64_t(hardwareID & 0x7FFFFFFF) << 32) | (devIdx & 0x7FFFFFFF);
 							if (m_mainworker.m_trend_calculator.find(tID) != m_mainworker.m_trend_calculator.end())
 							{
 								tstate = m_mainworker.m_trend_calculator[tID].m_state;
 							}
-							root["result"][ii]["trend"] = (int)tstate;
+							root["result"][ii]["trend"] = int(tstate);
 						}
 						else if (dSubType == sTypePercentage)
 						{
@@ -11304,7 +11303,7 @@ namespace http {
 
 									if (!vmodes.empty())
 									{
-										if (nValue < (int)vmodes.size())
+										if (nValue < int(vmodes.size()))
 										{
 											sprintf(szData, "%s", vmodes[nValue].c_str());
 										}
@@ -11450,7 +11449,7 @@ namespace http {
 							root["result"][ii]["StrParam2"] = strParam2;
 							root["result"][ii]["Protected"] = (iProtected != 0);
 
-							if (CustomImage < static_cast<int>(m_custom_light_icons.size()))
+							if (CustomImage < int(m_custom_light_icons.size()))
 								root["result"][ii]["Image"] = m_custom_light_icons[CustomImage].RootFile;
 							else
 								root["result"][ii]["Image"] = "Light";
@@ -11798,7 +11797,7 @@ namespace http {
 							sd[0].c_str());
 						if (!result2.empty())
 						{
-							totDevices = (unsigned int)atoi(result2[0][0].c_str());
+							totDevices = uint32_t(atoi(result2[0][0].c_str()));
 						}
 						root["result"][ii]["Devices"] = totDevices;
 
@@ -11881,7 +11880,7 @@ namespace http {
 					result3 = m_sql.safe_query("SELECT COUNT(*) FROM Plans WHERE (FloorplanID=='%q')", sd[0].c_str());
 					if (!result3.empty())
 					{
-						totPlans = (unsigned int)atoi(result3[0][0].c_str());
+						totPlans = uint32_t(atoi(result3[0][0].c_str()));
 					}
 					root["result"][ii]["Plans"] = totPlans;
 
@@ -11917,7 +11916,7 @@ namespace http {
 			struct tm tLastUpdate;
 			localtime_r(&now, &tLastUpdate);
 
-			root["ActTime"] = static_cast<int>(now);
+			root["ActTime"] = int(now);
 
 			std::vector<std::vector<std::string> > result, result2;
 			std::string szQuery = "SELECT ID, Name, Activators, Favorite, nValue, SceneType, LastUpdate, Protected, OnAction, OffAction, Description FROM Scenes";
@@ -12026,7 +12025,7 @@ namespace http {
 				int ii = 0;
 				for (const auto &sd : result)
 				{
-					_eHardwareTypes hType = (_eHardwareTypes)atoi(sd[3].c_str());
+					_eHardwareTypes hType = _eHardwareTypes(atoi(sd[3].c_str()));
 					if (hType == HTYPE_DomoticzInternal)
 						continue;
 					root["result"][ii]["idx"] = sd[0];
@@ -12154,7 +12153,7 @@ namespace http {
 			{
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
-					urights = static_cast<int>(m_users[iUser].userrights);
+					urights = int(m_users[iUser].userrights);
 			}
 			if (urights < 2)
 				return;
@@ -12189,7 +12188,7 @@ namespace http {
 			{
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
-					urights = static_cast<int>(m_users[iUser].userrights);
+					urights = int(m_users[iUser].userrights);
 			}
 			if (urights < 2)
 				return;
@@ -12225,7 +12224,7 @@ namespace http {
 				iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
 				{
-					urights = static_cast<int>(m_users[iUser].userrights);
+					urights = int(m_users[iUser].userrights);
 				}
 			}
 			if (urights < 1)
@@ -12244,7 +12243,7 @@ namespace http {
 			{
 				_log.Log(LOG_STATUS, "User: %s initiated a SetPoint command", m_users[iUser].Username.c_str());
 			}
-			m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setpoint.c_str())));
+			m_mainworker.SetSetPoint(idx, float(atof(setpoint.c_str())));
 		}
 
 		void CWebServer::Cmd_GetSceneActivations(WebEmSession & session, const request& req, Json::Value &root)
@@ -12294,9 +12293,9 @@ namespace http {
 						std::string lstatus = "-";
 						if ((SceneType == 0) && (arrayCode.size() == 2))
 						{
-							unsigned char devType = (unsigned char)atoi(sd[1].c_str());
-							unsigned char subType = (unsigned char)atoi(sd[2].c_str());
-							_eSwitchType switchtype = (_eSwitchType)atoi(sd[3].c_str());
+							unsigned char devType = static_cast<unsigned char>(atoi(sd[1].c_str()));
+							unsigned char subType = static_cast<unsigned char>(atoi(sd[2].c_str()));
+							_eSwitchType switchtype = static_cast<_eSwitchType>(atoi(sd[3].c_str()));
 							int nValue = sCode;
 							std::string sValue;
 							int llevel = 0;
@@ -13069,10 +13068,10 @@ namespace http {
 			//First delete all devices for this user, then add the (new) onces
 			m_sql.safe_query("DELETE FROM SharedDevices WHERE (SharedUserID == '%q')", idx.c_str());
 
-			int nDevices = static_cast<int>(strarray.size());
-			for (int ii = 0; ii < nDevices; ii++)
+			int nDevices = int(strarray.size());
+			for (const auto &device : strarray)
 			{
-				m_sql.safe_query("INSERT INTO SharedDevices (SharedUserID,DeviceRowID) VALUES ('%q','%q')", idx.c_str(), strarray[ii].c_str());
+				m_sql.safe_query("INSERT INTO SharedDevices (SharedUserID,DeviceRowID) VALUES ('%q','%q')", idx.c_str(), device.c_str());
 			}
 			LoadUsers();
 		}
@@ -13207,7 +13206,7 @@ namespace http {
 					int iUser = FindUser(session.username.c_str());
 					if (iUser != -1)
 					{
-						urights = static_cast<int>(m_users[iUser].userrights);
+						urights = int(m_users[iUser].userrights);
 						_log.Log(LOG_STATUS, "User: %s initiated a SetPoint command", m_users[iUser].Username.c_str());
 					}
 				}
@@ -13216,9 +13215,9 @@ namespace http {
 				if (dType == pTypeEvohomeWater)
 					m_mainworker.SetSetPoint(idx, (state == "On") ? 1.0F : 0.0F, mode, until); // FIXME float not guaranteed precise?
 				else if (dType == pTypeEvohomeZone)
-					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())), mode, until);
+					m_mainworker.SetSetPoint(idx, float(atof(setPoint.c_str())), mode, until);
 				else
-					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())));
+					m_mainworker.SetSetPoint(idx, float(atof(setPoint.c_str())));
 			}
 			else if (!clock.empty())
 			{
@@ -13228,7 +13227,7 @@ namespace http {
 					int iUser = FindUser(session.username.c_str());
 					if (iUser != -1)
 					{
-						urights = static_cast<int>(m_users[iUser].userrights);
+						urights = int(m_users[iUser].userrights);
 						_log.Log(LOG_STATUS, "User: %s initiated a SetClock command", m_users[iUser].Username.c_str());
 					}
 				}
@@ -13244,7 +13243,7 @@ namespace http {
 					int iUser = FindUser(session.username.c_str());
 					if (iUser != -1)
 					{
-						urights = static_cast<int>(m_users[iUser].userrights);
+						urights = int(m_users[iUser].userrights);
 						_log.Log(LOG_STATUS, "User: %s initiated a Thermostat Mode command", m_users[iUser].Username.c_str());
 					}
 				}
@@ -13260,7 +13259,7 @@ namespace http {
 					int iUser = FindUser(session.username.c_str());
 					if (iUser != -1)
 					{
-						urights = static_cast<int>(m_users[iUser].userrights);
+						urights = int(m_users[iUser].userrights);
 						_log.Log(LOG_STATUS, "User: %s initiated a Thermostat Fan Mode command", m_users[iUser].Username.c_str());
 					}
 				}
@@ -13279,7 +13278,7 @@ namespace http {
 				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
-					_eHardwareTypes Type = (_eHardwareTypes)dType;
+					_eHardwareTypes Type = _eHardwareTypes(atoi(sd[0].c_str()));
 					if (Type == HTYPE_PythonPlugin)
 					{
 						bUpdateUnit = false;
@@ -13529,32 +13528,32 @@ namespace http {
 				}
 				else if (Key == "CostEnergy")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostEnergy"] = szTmp;
 				}
 				else if (Key == "CostEnergyT2")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostEnergyT2"] = szTmp;
 				}
 				else if (Key == "CostEnergyR1")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostEnergyR1"] = szTmp;
 				}
 				else if (Key == "CostEnergyR2")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostEnergyR2"] = szTmp;
 				}
 				else if (Key == "CostGas")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostGas"] = szTmp;
 				}
 				else if (Key == "CostWater")
 				{
-					sprintf(szTmp, "%.4f", (float)(nValue) / 10000.0F);
+					sprintf(szTmp, "%.4f", static_cast<float>(nValue) / 10000.0F);
 					root["CostWater"] = szTmp;
 				}
 				else if (Key == "ActiveTimerPlan")
@@ -13793,7 +13792,7 @@ namespace http {
 
 			unsigned char dType = atoi(result[0][0].c_str());
 			unsigned char dSubType = atoi(result[0][1].c_str());
-			_eSwitchType switchtype = (_eSwitchType)atoi(result[0][2].c_str());
+			_eSwitchType switchtype = static_cast<_eSwitchType>(atoi(result[0][2].c_str()));
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][3]);
 
 			if (
@@ -14021,7 +14020,7 @@ namespace http {
 
 			unsigned char dType = atoi(result[0][0].c_str());
 			unsigned char dSubType = atoi(result[0][1].c_str());
-			_eMeterType metertype = (_eMeterType)atoi(result[0][2].c_str());
+			_eMeterType metertype = static_cast<_eMeterType>(atoi(result[0][2].c_str()));
 			if (
 				(dType == pTypeP1Power) ||
 				(dType == pTypeENERGY) ||
@@ -14291,10 +14290,10 @@ namespace http {
 
 									if (bHaveFirstValue)
 									{
-										long curUsage1 = (long)(actUsage1 - lastUsage1);
-										long curUsage2 = (long)(actUsage2 - lastUsage2);
-										long curDeliv1 = (long)(actDeliv1 - lastDeliv1);
-										long curDeliv2 = (long)(actDeliv2 - lastDeliv2);
+										long curUsage1 = static_cast<long>(actUsage1 - lastUsage1);
+										long curUsage2 = static_cast<long>(actUsage2 - lastUsage2);
+										long curDeliv1 = static_cast<long>(actDeliv1 - lastDeliv1);
+										long curDeliv2 = static_cast<long>(actDeliv2 - lastDeliv2);
 
 										if ((curUsage1 < 0) || (curUsage1 > 100000))
 											curUsage1 = 0;
@@ -14305,7 +14304,7 @@ namespace http {
 										if ((curDeliv2 < 0) || (curDeliv2 > 100000))
 											curDeliv2 = 0;
 
-										float tdiff = static_cast<float>(difftime(atime, lastTime));
+										float tdiff = float(difftime(atime, lastTime));
 										if (tdiff == 0)
 											tdiff = 1;
 										float tlaps = 3600.0F / tdiff;
@@ -14328,15 +14327,15 @@ namespace http {
 										sprintf(szTmp, "%ld", curDeliv2);
 										root["result"][ii]["r2"] = szTmp;
 
-										long pUsage1 = (long)(actUsage1 - firstUsage1);
-										long pUsage2 = (long)(actUsage2 - firstUsage2);
+										long pUsage1 = static_cast<long>(actUsage1 - firstUsage1);
+										long pUsage2 = static_cast<long>(actUsage2 - firstUsage2);
 
 										sprintf(szTmp, "%ld", pUsage1 + pUsage2);
 										root["result"][ii]["eu"] = szTmp;
 										if (bHaveDeliverd)
 										{
-											long pDeliv1 = (long)(actDeliv1 - firstDeliv1);
-											long pDeliv2 = (long)(actDeliv2 - firstDeliv2);
+											long pDeliv1 = static_cast<long>(actDeliv1 - firstDeliv1);
+											long pDeliv2 = static_cast<long>(actDeliv2 - firstDeliv2);
 											sprintf(szTmp, "%ld", pDeliv1 + pDeliv2);
 											root["result"][ii]["eg"] = szTmp;
 										}
@@ -14569,9 +14568,9 @@ namespace http {
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
+								float fval1 = float(atof(sd[0].c_str()) / 10.0F);
+								float fval2 = float(atof(sd[1].c_str()) / 10.0F);
+								float fval3 = float(atof(sd[2].c_str()) / 10.0F);
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -14641,9 +14640,9 @@ namespace http {
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
+								float fval1 = float(atof(sd[0].c_str()) / 10.0F);
+								float fval2 = float(atof(sd[1].c_str()) / 10.0F);
+								float fval3 = float(atof(sd[2].c_str()) / 10.0F);
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -14956,7 +14955,7 @@ namespace http {
 									{
 										long long curValue = actValue - ulLastValue;
 
-										float tdiff = static_cast<float>(difftime(atime, lastTime));
+										float tdiff = float(difftime(atime, lastTime));
 										if (tdiff == 0)
 											tdiff = 1;
 										float tlaps = 3600.0F / tdiff;
@@ -15068,7 +15067,7 @@ namespace http {
 						int ii = 0;
 						for (const auto &sd : result)
 						{
-							float ActTotal = static_cast<float>(atof(sd[0].c_str()));
+							float ActTotal = float(atof(sd[0].c_str()));
 							int Hour = atoi(sd[1].substr(11, 2).c_str());
 							if (Hour != LastHour)
 							{
@@ -15222,12 +15221,12 @@ namespace http {
 
 						for (const auto &sd : result)
 						{
-							float fdirection = static_cast<float>(atof(sd[0].c_str()));
+							float fdirection = float(atof(sd[0].c_str()));
 							if (fdirection >= 360)
 								fdirection = 0;
 							int direction = int(fdirection);
-							float speedOrg = static_cast<float>(atof(sd[1].c_str()));
-							float gustOrg = static_cast<float>(atof(sd[2].c_str()));
+							float speedOrg = float(atof(sd[1].c_str()));
+							float gustOrg = float(atof(sd[2].c_str()));
 							if ((gustOrg == 0) && (speedOrg != 0))
 								gustOrg = speedOrg;
 							if (gustOrg == 0)
@@ -15418,8 +15417,8 @@ namespace http {
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
+						float total_min = float(atof(sd[0].c_str()));
+						float total_max = float(atof(sd[1].c_str()));
 						//int rate = atoi(sd[2].c_str());
 
 						double total_real = 0;
@@ -15470,10 +15469,10 @@ namespace http {
 								std::string szValueUsage2 = sd[2];
 								std::string szValueDeliv2 = sd[3];
 
-								float fUsage1 = (float)(atof(szValueUsage1.c_str()));
-								float fUsage2 = (float)(atof(szValueUsage2.c_str()));
-								float fDeliv1 = (float)(atof(szValueDeliv1.c_str()));
-								float fDeliv2 = (float)(atof(szValueDeliv2.c_str()));
+								float fUsage1 = static_cast<float>(atof(szValueUsage1.c_str()));
+								float fUsage2 = static_cast<float>(atof(szValueUsage2.c_str()));
+								float fDeliv1 = static_cast<float>(atof(szValueDeliv1.c_str()));
+								float fDeliv2 = static_cast<float>(atof(szValueDeliv2.c_str()));
 
 								fDeliv1 = (fDeliv1 < 10) ? 0 : fDeliv1;
 								fDeliv2 = (fDeliv2 < 10) ? 0 : fDeliv2;
@@ -16111,8 +16110,8 @@ namespace http {
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
+						float total_min = float(atof(sd[0].c_str()));
+						float total_max = float(atof(sd[1].c_str()));
 						//int rate = atoi(sd[2].c_str());
 
 						double total_real = 0;
@@ -16493,12 +16492,12 @@ namespace http {
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
-								float fval4 = static_cast<float>(atof(sd[3].c_str()) / 10.0F);
-								float fval5 = static_cast<float>(atof(sd[4].c_str()) / 10.0F);
-								float fval6 = static_cast<float>(atof(sd[5].c_str()) / 10.0F);
+								float fval1 = float(atof(sd[0].c_str()) / 10.0F);
+								float fval2 = float(atof(sd[1].c_str()) / 10.0F);
+								float fval3 = float(atof(sd[2].c_str()) / 10.0F);
+								float fval4 = float(atof(sd[3].c_str()) / 10.0F);
+								float fval5 = float(atof(sd[4].c_str()) / 10.0F);
+								float fval6 = float(atof(sd[5].c_str()) / 10.0F);
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -16577,12 +16576,12 @@ namespace http {
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
-								float fval4 = static_cast<float>(atof(sd[3].c_str()) / 10.0F);
-								float fval5 = static_cast<float>(atof(sd[4].c_str()) / 10.0F);
-								float fval6 = static_cast<float>(atof(sd[5].c_str()) / 10.0F);
+								float fval1 = float(atof(sd[0].c_str()) / 10.0F);
+								float fval2 = float(atof(sd[1].c_str()) / 10.0F);
+								float fval3 = float(atof(sd[2].c_str()) / 10.0F);
+								float fval4 = float(atof(sd[3].c_str()) / 10.0F);
+								float fval5 = float(atof(sd[4].c_str()) / 10.0F);
+								float fval6 = float(atof(sd[5].c_str()) / 10.0F);
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -16654,7 +16653,7 @@ namespace http {
 							size_t spos = sValue.find(';');
 							if (spos != std::string::npos)
 							{
-								float fvalue = static_cast<float>(atof(sValue.substr(spos + 1).c_str()));
+								float fvalue = float(atof(sValue.substr(spos + 1).c_str()));
 								sprintf(szTmp, "%.3f", fvalue / (divider / 100.0F));
 								root["counter"] = szTmp;
 							}
@@ -16664,7 +16663,7 @@ namespace http {
 							size_t spos = sValue.find(';');
 							if (spos != std::string::npos)
 							{
-								float fvalue = static_cast<float>(atof(sValue.substr(spos + 1).c_str()));
+								float fvalue = float(atof(sValue.substr(spos + 1).c_str()));
 								sprintf(szTmp, "%.3f", fvalue / divider);
 								root["counter"] = szTmp;
 							}
@@ -16672,7 +16671,7 @@ namespace http {
 						else if (dType == pTypeRFXMeter)
 						{
 							//Add last counter value
-							float fvalue = static_cast<float>(atof(sValue.c_str()));
+							float fvalue = float(atof(sValue.c_str()));
 							switch (metertype)
 							{
 							case MTYPE_ENERGY:
@@ -16698,7 +16697,7 @@ namespace http {
 							if (results.size() == 2)
 							{
 								//Add last counter value
-								float fvalue = static_cast<float>(atof(results[0].c_str()));
+								float fvalue = float(atof(results[0].c_str()));
 								switch (metertype)
 								{
 								case MTYPE_ENERGY:
@@ -16878,26 +16877,26 @@ namespace http {
 
 							root["result"][ii]["d"] = szDateEnd;
 
-							sprintf(szTmp, "%.3f", (float)(total_real_usage_1 / divider));
+							sprintf(szTmp, "%.3f", (total_real_usage_1 / divider));
 							root["result"][ii]["v"] = szTmp;
-							sprintf(szTmp, "%.3f", (float)(total_real_usage_2 / divider));
+							sprintf(szTmp, "%.3f", (total_real_usage_2 / divider));
 							root["result"][ii]["v2"] = szTmp;
 
-							sprintf(szTmp, "%.3f", (float)(total_real_deliv_1 / divider));
+							sprintf(szTmp, "%.3f", (total_real_deliv_1 / divider));
 							root["result"][ii]["r1"] = szTmp;
-							sprintf(szTmp, "%.3f", (float)(total_real_deliv_2 / divider));
+							sprintf(szTmp, "%.3f", (total_real_deliv_2 / divider));
 							root["result"][ii]["r2"] = szTmp;
 
-							sprintf(szTmp, "%.3f", (float)(total_min_usage_1 / divider));
+							sprintf(szTmp, "%.3f", (total_min_usage_1 / divider));
 							root["result"][ii]["c1"] = szTmp;
-							sprintf(szTmp, "%.3f", (float)(total_min_usage_2 / divider));
+							sprintf(szTmp, "%.3f", (total_min_usage_2 / divider));
 							root["result"][ii]["c3"] = szTmp;
 
 							if (total_max_deliv_2 != 0)
 							{
-								sprintf(szTmp, "%.3f", (float)(total_min_deliv_1 / divider));
+								sprintf(szTmp, "%.3f", (total_min_deliv_1 / divider));
 								root["result"][ii]["c2"] = szTmp;
-								sprintf(szTmp, "%.3f", (float)(total_min_deliv_2 / divider));
+								sprintf(szTmp, "%.3f", (total_min_deliv_2 / divider));
 								root["result"][ii]["c4"] = szTmp;
 							}
 							else
@@ -17590,8 +17589,8 @@ namespace http {
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
+						float total_min = float(atof(sd[0].c_str()));
+						float total_max = float(atof(sd[1].c_str()));
 						//int rate = atoi(sd[2].c_str());
 
 						float total_real = 0;
@@ -17635,8 +17634,8 @@ namespace http {
 								std::string szUsage2 = sd[2];
 								std::string szDeliv2 = sd[3];
 
-								float fUsage = (float)(atof(szUsage1.c_str()) + atof(szUsage2.c_str()));
-								float fDeliv = (float)(atof(szDeliv1.c_str()) + atof(szDeliv2.c_str()));
+								float fUsage = static_cast<float>(atof(szUsage1.c_str()) + atof(szUsage2.c_str()));
+								float fDeliv = static_cast<float>(atof(szDeliv1.c_str()) + atof(szDeliv2.c_str()));
 
 								if (fDeliv != 0)
 									bHaveDeliverd = true;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -708,7 +708,7 @@ int main(int argc, char**argv)
 	{
 #if !defined WIN32
 		char szStartupPath[255];
-		getExecutablePathName((char*)&szStartupPath,255);
+		getExecutablePathName(reinterpret_cast<char *>(&szStartupPath), 255);
 		szStartupFolder=szStartupPath;
 		if (szStartupFolder.find_last_of('/')!=std::string::npos)
 			szStartupFolder=szStartupFolder.substr(0,szStartupFolder.find_last_of('/')+1);
@@ -735,7 +735,7 @@ int main(int argc, char**argv)
 	}
 
 	/* call srand once for the entire app */
-	std::srand((unsigned int)std::time(nullptr));
+	std::srand(uint32_t(std::time(nullptr)));
 	szRandomUUID = GenerateUUID();    
 
 	GetAppVersion();
@@ -803,7 +803,7 @@ int main(int argc, char**argv)
 				return 1;
 			}
 			std::string wwwport = cmdLine.GetSafeArgument("-www", 0, "");
-			int iPort = (int)atoi(wwwport.c_str());
+			int iPort = atoi(wwwport.c_str());
 			if ((iPort < 0) || (iPort > 32767))
 			{
 				_log.Log(LOG_ERROR, "Please specify a valid www port");
@@ -844,7 +844,7 @@ int main(int argc, char**argv)
 				return 1;
 			}
 			std::string wwwport = cmdLine.GetSafeArgument("-sslwww", 0, "");
-			int iPort = (int)atoi(wwwport.c_str());
+			int iPort = atoi(wwwport.c_str());
 			if ((iPort < 0) || (iPort > 32767))
 			{
 				_log.Log(LOG_ERROR, "Please specify a valid sslwww port");

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -273,7 +273,7 @@ void CdzVents::ProcessHttpResponse(lua_State* lua_state, const std::vector<CEven
 		if (item.reason == m_mainworker.m_eventsystem.REASON_URL)
 		{
 			luaTable.OpenSubTableEntry(index, 0, 0);
-			luaTable.OpenSubTableEntry("headers", (int)item.vData.size() + 2, 0); // status is split into 3 parts
+			luaTable.OpenSubTableEntry("headers", int(item.vData.size()) + 2, 0); // status is split into 3 parts
 			if (!item.vData.empty())
 			{
 				for (const auto &header : item.vData)
@@ -340,7 +340,7 @@ bool CdzVents::ExecuteShellCommand(lua_State *lua_state, const std::vector<_tLua
 		else if (value.type == TYPE_INTEGER)
 		{
 			if (value.name == "_random")
-				delayTime = static_cast<float>(GenerateRandomNumber(value.iValue));
+				delayTime = float(GenerateRandomNumber(value.iValue));
 			if (value.name == "timeout")
 			{
 				timeout = value.iValue;
@@ -383,7 +383,7 @@ bool CdzVents::OpenURL(lua_State *lua_state, const std::vector<_tLuaTableValues>
 				extraHeaders = value.sValue;
 		}
 		else if ((value.type == TYPE_INTEGER) && (value.name == "_random"))
-			delayTime = static_cast<float>(GenerateRandomNumber(value.iValue));
+			delayTime = float(GenerateRandomNumber(value.iValue));
 		else if ((value.type == TYPE_FLOAT) && (value.name == "_after"))
 			delayTime = value.fValue;
 	}
@@ -450,7 +450,7 @@ bool CdzVents::TriggerCustomEvent(lua_State* lua_state, const std::vector<_tLuaT
 		else if ((item.type == TYPE_STRING) && (item.name == "data"))
 			sValue = item.sValue;
 		else if ((item.type == TYPE_INTEGER) && (item.name == "_random"))
-			delayTime = static_cast<float>(GenerateRandomNumber(item.iValue));
+			delayTime = float(GenerateRandomNumber(item.iValue));
 		else if ((item.type == TYPE_FLOAT) && (item.name == "_after"))
 			delayTime = item.fValue;
 	}
@@ -481,7 +481,7 @@ bool CdzVents::UpdateDevice(lua_State *lua_state, const std::vector<_tLuaTableVa
 			else if (item.name == "protected")
 				Protected = item.iValue;
 			else if (item.name == "_random")
-				delayTime = static_cast<float>(GenerateRandomNumber(item.iValue));
+				delayTime = float(GenerateRandomNumber(item.iValue));
 		}
 
 		else if ((item.type == TYPE_FLOAT) && (item.name == "_after"))
@@ -516,7 +516,7 @@ bool CdzVents::TriggerIFTTT(lua_State *lua_state, const std::vector<_tLuaTableVa
 		if (item.type == TYPE_INTEGER)
 		{
 			if (item.name == "_random")
-				delayTime = static_cast<float>(GenerateRandomNumber(item.iValue));
+				delayTime = float(GenerateRandomNumber(item.iValue));
 			else if (item.name == "sID")
 				sID = std::to_string(item.iValue);
 			else if (item.name == "sValue1")
@@ -560,7 +560,7 @@ bool CdzVents::UpdateVariable(lua_State *lua_state, const std::vector<_tLuaTable
 			if (item.name == "idx")
 				idx = item.iValue;
 			else if (item.name == "_random")
-				delayTime = static_cast<float>(GenerateRandomNumber(item.iValue));
+				delayTime = float(GenerateRandomNumber(item.iValue));
 		}
 
 		else if ((item.type == TYPE_FLOAT) && (item.name == "_after"))
@@ -662,7 +662,7 @@ void CdzVents::IterateTable(lua_State *lua_state, const int tIndex, std::vector<
 			else if (std::string(luaL_typename(lua_state, -2)) == "number")
 			{
 				item.type = TYPE_INTEGER;
-				item.iValue = static_cast<int>(lua_tonumber(lua_state, -2));
+				item.iValue = int(lua_tonumber(lua_state, -2));
 			}
 			else
 			{
@@ -687,12 +687,12 @@ void CdzVents::IterateTable(lua_State *lua_state, const int tIndex, std::vector<
 			if (item.name == "_after")
 			{
 				item.type = TYPE_FLOAT;
-				item.fValue = static_cast<float>(lua_tonumber(lua_state, -1));
+				item.fValue = float(lua_tonumber(lua_state, -1));
 			}
 			else
 			{
 				item.type = TYPE_INTEGER;
-				item.iValue = static_cast<int>(lua_tonumber(lua_state, -1));
+				item.iValue = int(lua_tonumber(lua_state, -1));
 			}
 		}
 		else if (std::string(luaL_typename(lua_state, -1)) == "boolean")
@@ -882,7 +882,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 			luaTable.AddString("baseType","device");
 			luaTable.AddString("deviceType", dev_type);
 			luaTable.AddString("subType", sub_type);
-			luaTable.AddString("switchType", Switch_Type_Desc((_eSwitchType)sitem.switchtype));
+			luaTable.AddString("switchType", Switch_Type_Desc(_eSwitchType(sitem.switchtype)));
 			luaTable.AddInteger("switchTypeValue", sitem.switchtype);
 			luaTable.AddString("lastUpdate", sitem.lastUpdate);
 			luaTable.AddInteger("lastLevel", sitem.lastLevel);
@@ -985,7 +985,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		luaTable.AddInteger("id", sgitem.ID);
 		luaTable.AddString("description", sgitem.description);
 		luaTable.AddString("baseType", (sgitem.scenesgroupType == 0) ? "scene" : "group");
-		luaTable.AddBool("protected", (lua_Number)sgitem.protection == 1);
+		luaTable.AddBool("protected", lua_Number(sgitem.protection) == 1);
 		luaTable.AddString("lastUpdate", sgitem.lastUpdate);
 		luaTable.AddBool("changed", triggerScene);
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -274,10 +274,10 @@ void MainWorker::AddAllDomoticzHardware()
 			std::string Name = sd[1];
 			std::string sEnabled = sd[2];
 			bool Enabled = (sEnabled == "1") ? true : false;
-			_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[3].c_str());
-			uint32_t LogLevelEnabled = (uint32_t)atoi(sd[4].c_str());
+			auto Type = _eHardwareTypes(atoi(sd[3].c_str()));
+			uint32_t LogLevelEnabled = uint32_t(atoi(sd[4].c_str()));
 			std::string Address = sd[5];
-			uint16_t Port = (uint16_t)atoi(sd[6].c_str());
+			uint16_t Port = uint16_t(atoi(sd[6].c_str()));
 			std::string SerialPort = sd[7];
 			std::string Username = sd[8];
 			std::string Password = sd[9];
@@ -620,10 +620,10 @@ bool MainWorker::RestartHardware(const std::string& idx)
 	std::vector<std::string> sd = result[0];
 	std::string Name = sd[0];
 	std::string senabled = (sd[1] == "1") ? "true" : "false";
-	_eHardwareTypes htype = (_eHardwareTypes)atoi(sd[2].c_str());
-	uint32_t LogLevelEnabled = (uint32_t)atoi(sd[3].c_str());
+	_eHardwareTypes htype = _eHardwareTypes(atoi(sd[2].c_str()));
+	uint32_t LogLevelEnabled = uint32_t(atoi(sd[3].c_str()));
 	std::string address = sd[4];
-	uint16_t port = (uint16_t)atoi(sd[5].c_str());
+	uint16_t port = uint16_t(atoi(sd[5].c_str()));
 	std::string serialport = sd[6];
 	std::string username = sd[7];
 	std::string password = sd[8];
@@ -670,10 +670,10 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RFXtrx315:
 	case HTYPE_RFXtrx433:
 	case HTYPE_RFXtrx868:
-		pHardware = new RFXComSerial(ID, SerialPort, 38400, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
+		pHardware = new RFXComSerial(ID, SerialPort, 38400, CRFXBase::_eRFXAsyncType(atoi(Extra.c_str())));
 		break;
 	case HTYPE_RFXLAN:
-		pHardware = new RFXComTCP(ID, Address, Port, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
+		pHardware = new RFXComTCP(ID, Address, Port, CRFXBase::_eRFXAsyncType(atoi(Extra.c_str())));
 		break;
 	case HTYPE_P1SmartMeter:
 		pHardware = new P1MeterSerial(ID, SerialPort, (Mode1 == 1) ? 115200 : 9600, (Mode2 != 0), Mode3, Password);
@@ -1165,7 +1165,7 @@ bool MainWorker::Start()
 	int nValue = 0;
 	if (m_sql.GetPreferencesVar("AuthenticationMethod", nValue))
 	{
-		m_webservers.SetAuthenticationMethod((http::server::_eAuthenticationMethod)nValue);
+		m_webservers.SetAuthenticationMethod(http::server::_eAuthenticationMethod(nValue));
 	}
 	std::string sValue;
 	if (m_sql.GetPreferencesVar("WebTheme", sValue))
@@ -1954,7 +1954,7 @@ uint64_t MainWorker::PerformRealActionFromDomoticzClient(const uint8_t* pRXComma
 				if (pHardware->HwdType != HTYPE_Domoticz)
 				{
 					*pOriginalHardware = pHardware;
-					pHardware->WriteToHardware((const char*)pRXCommand, pRXCommand[0] + 1);
+					pHardware->WriteToHardware(reinterpret_cast<const char *>(pRXCommand), pRXCommand[0] + 1);
 					std::stringstream s_strid;
 					s_strid << std::dec << sd[1];
 					uint64_t ullID;
@@ -2186,7 +2186,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase *pHardware, const 
 
 	const_cast<CDomoticzHardwareBase*>(pHardware)->SetHeartbeatReceived();
 
-	uint64_t DeviceRowIdx = (uint64_t)-1;
+	auto DeviceRowIdx = std::numeric_limits<std::uint64_t>::max();
 	std::string DeviceName;
 	tcp::server::CTCPClient *pClient2Ignore = nullptr;
 
@@ -2226,12 +2226,12 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase *pHardware, const 
 					// we received a control message from a domoticz client,
 					// and should actually perform this command ourself switch
 					DeviceRowIdx = PerformRealActionFromDomoticzClient(pRXCommand, &pOrgHardware);
-					if (DeviceRowIdx != (uint64_t)-1)
+					if (DeviceRowIdx != std::numeric_limits<std::uint64_t>::max())
 					{
 						if (pOrgHardware != nullptr)
 						{
 							DeviceRowIdx = -1;
-							pClient2Ignore = (tcp::server::CTCPClient *)pHardware->m_pUserData;
+							pClient2Ignore = static_cast<tcp::server::CTCPClient *>(pHardware->m_pUserData);
 							pHardware = pOrgHardware;
 						}
 						WriteMessage("Control Command, ", (pOrgHardware == nullptr));
@@ -2246,7 +2246,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase *pHardware, const 
 	procResult.DeviceName = "";
 	procResult.DeviceRowIdx = -1;
 	procResult.bProcessBatteryValue = true;
-	if (DeviceRowIdx == (uint64_t)-1)
+	if (DeviceRowIdx == std::numeric_limits<std::uint64_t>::max())
 	{
 		switch (pRXCommand[1])
 		{
@@ -2463,7 +2463,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase *pHardware, const 
 		DeviceName = procResult.DeviceName;
 	}
 
-	if (DeviceRowIdx == (uint64_t)-1)
+	if (DeviceRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if ((BatteryLevel != -1) && (procResult.bProcessBatteryValue))
@@ -2496,7 +2496,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase *pHardware, const 
 	//TODO: Notify plugin?
 
 	//Send to connected Sharing Users
-	m_sharedserver.SendToAll(pHardware->m_HwdID, DeviceRowIdx, (const char*)pRXCommand, pRXCommand[0] + 1, pClient2Ignore);
+	m_sharedserver.SendToAll(pHardware->m_HwdID, DeviceRowIdx, reinterpret_cast<const char *>(pRXCommand), pRXCommand[0] + 1, pClient2Ignore);
 
 	sOnDeviceReceived(pHardware->m_HwdID, DeviceRowIdx, DeviceName, pRXCommand);
 }
@@ -2625,15 +2625,15 @@ void MainWorker::decode_InterfaceMessage(const CDomoticzHardwareBase* pHardware,
 					break;
 				case FWtypePro1:
 					strcpy(szTmp, "Pro1");
-					NoiseLevel = static_cast<int>(pResponse->IRESPONSE.msg11);
+					NoiseLevel = int(pResponse->IRESPONSE.msg11);
 					break;
 				case FWtypePro2:
 					strcpy(szTmp, "Pro2");
-					NoiseLevel = static_cast<int>(pResponse->IRESPONSE.msg11);
+					NoiseLevel = int(pResponse->IRESPONSE.msg11);
 					break;
 				case FWtypeProXL1:
 					strcpy(szTmp, "Pro XL1");
-					NoiseLevel = static_cast<int>(pResponse->IRESPONSE.msg11);
+					NoiseLevel = int(pResponse->IRESPONSE.msg11);
 					break;
 				default:
 					strcpy(szTmp, "?");
@@ -3094,16 +3094,16 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 				for (const auto &sd : result)
 				{
-					float rate = (float)atof(sd[0].c_str()) / 10000.0F;
+					float rate = float(atof(sd[0].c_str())) / 10000.0F;
 					std::string date = sd[1];
 
 					time_t rowtime;
 					struct tm rowTimetm;
 					ParseSQLdatetime(rowtime, rowTimetm, date);
 
-					int pastSeconds = (int)(rowtime - countTime);
+					int pastSeconds = int(rowtime - countTime);
 
-					float rateAdd = (rate / (float)3600 * (float)pastSeconds);
+					float rateAdd = (rate / float(3600) * float(pastSeconds));
 					TotalRain += rateAdd;
 
 					countTime = rowtime;
@@ -3136,7 +3136,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 				ulID, ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);
 			if (result.size() == 1)
 			{
-				float totalRainFallLastHour = TotalRain - static_cast<float>(atof(result[0][0].c_str()));
+				float totalRainFallLastHour = TotalRain - float(atof(result[0][0].c_str()));
 				Rainrate = round(totalRainFallLastHour * 100.0F);
 			}
 		}
@@ -3144,7 +3144,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 	sprintf(szTmp, "%d;%.1f", Rainrate, TotalRain);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -3233,7 +3233,7 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, pResponse->WIND.subtype == sTypeWIND3, pResponse->WIND.battery_level & 0x0F);
 
 	double dDirection;
-	dDirection = (double)(pResponse->WIND.directionh * 256) + pResponse->WIND.directionl;
+	dDirection = double(pResponse->WIND.directionh * 256) + pResponse->WIND.directionl;
 	dDirection = m_wind_calculator[windID].AddValueAndReturnAvarage(dDirection);
 
 	std::string strDirection;
@@ -3350,13 +3350,13 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 	sprintf(szTmp, "%.2f;%s;%d;%d;%.1f;%.1f", dDirection, strDirection.c_str(), intSpeed, intGust, temp, chill);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(chill), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(chill), _tTrendCalculator::TAVERAGE_TEMP);
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
 	{
@@ -3487,11 +3487,11 @@ void MainWorker::decode_Temp(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 	sprintf(szTmp, "%.1f", temp);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	bool bHandledNotification = false;
 	uint8_t humidity = 0;
@@ -3627,7 +3627,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 
 	sprintf(szTmp, "%d", pResponse->HUM.humidity_status);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, humidity, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	bool bHandledNotification = false;
@@ -3643,7 +3643,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 			pHardware->m_HwdID, ID.c_str(), 0, pTypeTEMP, sTypeTEMP5);
 		if (result.size() == 1)
 		{
-			temp = static_cast<float>(atof(result[0][0].c_str()));
+			temp = float(atof(result[0][0].c_str()));
 			float AddjValue = 0.0F;
 			float AddjMulti = 1.0F;
 			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, AddjValue, AddjMulti);
@@ -3655,7 +3655,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 		}
 	}
 	if (!bHandledNotification)
-		m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, (const int)humidity);
+		m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, int(humidity));
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
 	{
@@ -3778,7 +3778,7 @@ void MainWorker::decode_TempHum(const CDomoticzHardwareBase* pHardware, const tR
 	m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
 	temp += AddjValue;
 
-	int Humidity = (int)pResponse->TEMP_HUM.humidity;
+	int Humidity = int(pResponse->TEMP_HUM.humidity);
 	uint8_t HumidityStatus = pResponse->TEMP_HUM.humidity_status;
 
 	if (Humidity > 100)
@@ -3798,11 +3798,11 @@ void MainWorker::decode_TempHum(const CDomoticzHardwareBase* pHardware, const tR
 	*/
 	sprintf(szTmp, "%.1f;%d;%d", temp, Humidity, HumidityStatus);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
 
@@ -3982,7 +3982,7 @@ void MainWorker::decode_TempHumBaro(const CDomoticzHardwareBase* pHardware, cons
 	int barometer = (pResponse->TEMP_HUM_BARO.baroh * 256) + pResponse->TEMP_HUM_BARO.barol;
 
 	int forcast = pResponse->TEMP_HUM_BARO.forecast;
-	float fbarometer = (float)barometer;
+	float fbarometer = float(barometer);
 
 	m_sql.GetAddjustment2(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, AddjValue, AddjMulti);
 	barometer += int(AddjValue);
@@ -4008,11 +4008,11 @@ void MainWorker::decode_TempHumBaro(const CDomoticzHardwareBase* pHardware, cons
 		sprintf(szTmp, "%.1f;%d;%d;%d;%d", temp, Humidity, HumidityStatus, barometer, forcast);
 	}
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	//calculate Altitude
 	//float seaLevelPressure=101325.0f;
@@ -4144,11 +4144,11 @@ void MainWorker::decode_TempBaro(const CDomoticzHardwareBase* pHardware, const t
 
 	sprintf(szTmp, "%.1f;%.1f;%d;%.2f", temp, fbarometer, forcast, pTempBaro->altitude);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
 
@@ -4248,11 +4248,11 @@ void MainWorker::decode_TempRain(const CDomoticzHardwareBase* pHardware, const t
 
 	sprintf(szTmp, "%.1f;%.1f", temp, TotalRain);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	uint64_t tID = ((uint64_t)(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
-	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+	uint64_t tID = (uint64_t(pHardware->m_HwdID & 0x7FFFFFFF) << 32) | (DevRowIdx & 0x7FFFFFFF);
+	m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	sprintf(szTmp, "%.1f", temp);
 	uint64_t DevRowIdxTemp = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeTEMP, sTypeTEMP3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
@@ -4341,7 +4341,7 @@ void MainWorker::decode_UV(const CDomoticzHardwareBase* pHardware, const tRBUF* 
 
 	sprintf(szTmp, "%.1f;%.1f", Level, temp);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -4419,7 +4419,7 @@ void MainWorker::decode_FS20(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t SignalLevel = pResponse->FS20.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -4687,7 +4687,7 @@ void MainWorker::decode_Lighting1(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t SignalLevel = pResponse->LIGHTING1.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -4899,7 +4899,8 @@ void MainWorker::decode_Lighting2(const CDomoticzHardwareBase* pHardware, const 
 		m_sql.Lighting2GroupCmd(ID, subType, single_cmnd);
 	}
 
-	if (DevRowIdx == (uint64_t)-1) {
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
+	{
 		// not found nothing to do
 		return;
 	}
@@ -5035,7 +5036,7 @@ void MainWorker::decode_Lighting4(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t SignalLevel = pResponse->LIGHTING4.rssi;
 	sprintf(szTmp, "%d", (pResponse->LIGHTING4.pulseHigh * 256) + pResponse->LIGHTING4.pulseLow);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -5231,7 +5232,7 @@ void MainWorker::decode_Lighting5(const CDomoticzHardwareBase* pHardware, const 
 	{
 		sprintf(szTmp, "%d", pResponse->LIGHTING5.level);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 		CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 	}
@@ -5698,7 +5699,7 @@ void MainWorker::decode_Lighting6(const CDomoticzHardwareBase* pHardware, const 
 
 	sprintf(szTmp, "%d", rfu);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -5765,7 +5766,7 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	uint8_t SignalLevel = pResponse->FAN.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -5910,7 +5911,7 @@ void MainWorker::decode_HomeConfort(const CDomoticzHardwareBase* pHardware, cons
 		m_sql.HomeConfortGroupCmd(ID, subType, single_cmnd);
 	}
 
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -5970,7 +5971,7 @@ void MainWorker::decode_ColorSwitch(const CDomoticzHardwareBase* pHardware, cons
 	if (pLed->id == 1)
 		sprintf(szTmp, "%d", 1);
 	else
-		sprintf(szTmp, "%08X", (unsigned int)pLed->id);
+		sprintf(szTmp, "%08X", uint32_t(pLed->id));
 	std::string ID = szTmp;
 	uint8_t Unit = pLed->dunit;
 	uint8_t cmnd = pLed->command;
@@ -5981,7 +5982,7 @@ void MainWorker::decode_ColorSwitch(const CDomoticzHardwareBase* pHardware, cons
 	sprintf(szValueTmp, "%u", value);
 	std::string sValue = szValueTmp;
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, 12, -1, cmnd, sValue.c_str(), procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -6044,7 +6045,7 @@ void MainWorker::decode_Chime(const CDomoticzHardwareBase* pHardware, const tRBU
 	uint8_t SignalLevel = pResponse->CHIME.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -6237,7 +6238,7 @@ void MainWorker::decode_UNDECODED(const CDomoticzHardwareBase* pHardware, const 
 		break;
 	}
 	std::stringstream sHexDump;
-	uint8_t* pRXBytes = (uint8_t*)&pResponse->UNDECODED.msg1;
+	uint8_t *pRXBytes = const_cast<uint8_t *>(&pResponse->UNDECODED.msg1);
 	for (int i = 0; i < pResponse->UNDECODED.packetlength - 3; i++)
 		sHexDump << HEX(pRXBytes[i]);
 	WriteMessage(sHexDump.str().c_str());
@@ -6301,7 +6302,7 @@ void MainWorker::decode_Curtain(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t SignalLevel = 9;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -6364,7 +6365,7 @@ void MainWorker::decode_BLINDS1(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t SignalLevel = pResponse->BLINDS1.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -6518,7 +6519,7 @@ void MainWorker::decode_RFY(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	uint8_t SignalLevel = pResponse->RFY.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
@@ -6646,9 +6647,9 @@ void MainWorker::decode_evohome1(const CDomoticzHardwareBase* pHardware, const t
 	uint8_t subType = pEvo->subtype;
 	std::stringstream szID;
 	if (pHardware->HwdType == HTYPE_EVOHOME_SERIAL || pHardware->HwdType == HTYPE_EVOHOME_TCP)
-		szID << std::hex << (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
+		szID << std::hex << RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
 	else //GB3: web based evohome uses decimal device ID's
-		szID << std::dec << (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
+		szID << std::dec << RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
 	std::string ID(szID.str());
 	uint8_t Unit = 0;
 	uint8_t cmnd = pEvo->status;
@@ -6685,7 +6686,7 @@ void MainWorker::decode_evohome1(const CDomoticzHardwareBase* pHardware, const t
 	}
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szUntilDate.c_str(), procResult.DeviceName, pEvo->action != 0);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	if (bNewDev)
 	{
@@ -6712,9 +6713,9 @@ void MainWorker::decode_evohome1(const CDomoticzHardwareBase* pHardware, const t
 		if (pHardware->HwdType == HTYPE_EVOHOME_SERIAL || pHardware->HwdType == HTYPE_EVOHOME_TCP)
 			sprintf(szTmp, "id            = %02X:%02X:%02X", pEvo->id1, pEvo->id2, pEvo->id3);
 		else //GB3: web based evohome uses decimal device ID's
-			sprintf(szTmp, "id            = %u", (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3));
+			sprintf(szTmp, "id            = %u", RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3));
 		WriteMessage(szTmp);
-		sprintf(szTmp, "action        = %d", (int)pEvo->action);
+		sprintf(szTmp, "action        = %d", int(pEvo->action));
 		WriteMessage(szTmp);
 		WriteMessage("status        = ");
 		WriteMessage(pEvoHW->GetControllerModeName(pEvo->status));
@@ -6736,24 +6737,21 @@ void MainWorker::decode_evohome2(const CDomoticzHardwareBase* pHardware, const t
 	std::vector<std::vector<std::string> > result;
 	if (pEvo->type == pTypeEvohomeZone && pEvo->zone > 12) //Allow for additional Zone Temp devices which require DeviceID
 	{
-		result = m_sql.safe_query(
-			"SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
-			"FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%x') AND (Type==%d)",
-			pHardware->m_HwdID, (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3), (int)pEvo->type);
+		result = m_sql.safe_query("SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
+					  "FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%x') AND (Type==%d)",
+					  pHardware->m_HwdID, RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3), int(pEvo->type));
 	}
 	else if (pEvo->zone)//if unit number is available the id3 will be the controller device id
 	{
-		result = m_sql.safe_query(
-			"SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
-			"FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit == %d) AND (Type==%d)",
-			pHardware->m_HwdID, (int)pEvo->zone, (int)pEvo->type);
+		result = m_sql.safe_query("SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
+					  "FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit == %d) AND (Type==%d)",
+					  pHardware->m_HwdID, int(pEvo->zone), int(pEvo->type));
 	}
 	else//unit number not available then id3 should be the zone device id
 	{
-		result = m_sql.safe_query(
-			"SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
-			"FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%x') AND (Type==%d)",
-			pHardware->m_HwdID, (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3), (int)pEvo->type);
+		result = m_sql.safe_query("SELECT HardwareID, DeviceID,Unit,Type,SubType,sValue,BatteryLevel "
+					  "FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%x') AND (Type==%d)",
+					  pHardware->m_HwdID, RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3), int(pEvo->type));
 	}
 	if (result.empty() && !pEvo->zone)
 		return;
@@ -6783,7 +6781,7 @@ void MainWorker::decode_evohome2(const CDomoticzHardwareBase* pHardware, const t
 		dType = pEvo->type;
 		dSubType = pEvo->subtype;
 
-		szID << std::hex << (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
+		szID << std::hex << RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
 		szDevID = szID.str();
 
 		if (!pEvoHW)
@@ -6862,7 +6860,7 @@ void MainWorker::decode_evohome2(const CDomoticzHardwareBase* pHardware, const t
 		}
 	}
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, szDevID.c_str(), Unit, dType, dSubType, SignalLevel, BatteryLevel, cmnd, szUpdateStat.c_str(), procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	if (bNewDev)
 	{
@@ -6880,7 +6878,7 @@ void MainWorker::decode_evohome3(const CDomoticzHardwareBase* pHardware, const t
 	uint8_t devType = pTypeEvohomeRelay;
 	uint8_t subType = pEvo->subtype;
 	std::stringstream szID;
-	int nDevID = (int)RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
+	int nDevID = RFX_GETID3(pEvo->id1, pEvo->id2, pEvo->id3);
 	szID << std::hex << nDevID;
 	std::string ID(szID.str());
 	uint8_t Unit = pEvo->devno;
@@ -6901,10 +6899,9 @@ void MainWorker::decode_evohome3(const CDomoticzHardwareBase* pHardware, const t
 			"FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%q')",
 			pHardware->m_HwdID, ID.c_str());
 	else
-		result = m_sql.safe_query(
-			"SELECT HardwareID,DeviceID,Unit,Type,SubType,nValue,sValue,BatteryLevel "
-			"FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit == '%d') AND (Type==%d) AND (DeviceID == '%q')",
-			pHardware->m_HwdID, (int)Unit, (int)pEvo->type, ID.c_str());
+		result = m_sql.safe_query("SELECT HardwareID,DeviceID,Unit,Type,SubType,nValue,sValue,BatteryLevel "
+					  "FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit == '%d') AND (Type==%d) AND (DeviceID == '%q')",
+					  pHardware->m_HwdID, int(Unit), int(pEvo->type), ID.c_str());
 	if (!result.empty())
 	{
 		if (pEvo->demand == 0xFF)//we sometimes get a 0418 message after the initial device creation but it will mess up the logging as we don't have a demand
@@ -6942,7 +6939,7 @@ void MainWorker::decode_evohome3(const CDomoticzHardwareBase* pHardware, const t
 	}
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szDemand.c_str(), procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (bNewDev && (Unit == 0xF9 || Unit == 0xFA || Unit == 0xFC || Unit <= 12))
@@ -6994,7 +6991,7 @@ void MainWorker::decode_Security1(const CDomoticzHardwareBase* pHardware, const 
 	}
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -7171,7 +7168,7 @@ void MainWorker::decode_Security2(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, false, pResponse->SECURITY2.battery_level & 0x0F);
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -7303,7 +7300,7 @@ void MainWorker::decode_Remote(const CDomoticzHardwareBase* pHardware, const tRB
 	uint8_t SignalLevel = pResponse->REMOTE.rssi;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -8395,7 +8392,7 @@ void MainWorker::decode_Thermostat1(const CDomoticzHardwareBase* pHardware, cons
 
 	sprintf(szTmp, "%d;%d;%d;%d", temp, set_point, mode, status);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -8469,7 +8466,7 @@ void MainWorker::decode_Thermostat2(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t BatteryLevel = 255;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -8530,7 +8527,7 @@ void MainWorker::decode_Thermostat3(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t BatteryLevel = 255;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
 
@@ -8627,7 +8624,7 @@ void MainWorker::decode_Thermostat4(const CDomoticzHardwareBase* pHardware, cons
 	);
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -8723,7 +8720,7 @@ void MainWorker::decode_Radiator1(const CDomoticzHardwareBase* pHardware, const 
 
 	sprintf(szTmp, "%d.%d", pResponse->RADIATOR1.temperature, pResponse->RADIATOR1.tempPoint5);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -8868,7 +8865,7 @@ void MainWorker::decode_Current(const CDomoticzHardwareBase* pHardware, const tR
 	float CurrentChannel3 = float((pResponse->CURRENT.ch3h * 256) + pResponse->CURRENT.ch3l) / 10.0F;
 	sprintf(szTmp, "%.1f;%.1f;%.1f", CurrentChannel1, CurrentChannel2, CurrentChannel3);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -8959,8 +8956,8 @@ void MainWorker::decode_Energy(const CDomoticzHardwareBase* pHardware, const tRB
 	_tGeneralDevice gdevice;
 	gdevice.intval1 = (pResponse->ENERGY.id1 * 256) + pResponse->ENERGY.id2;
 	gdevice.subtype = sTypeKwh;
-	gdevice.floatval1 = (float)instant;
-	gdevice.floatval2 = (float)total;
+	gdevice.floatval1 = float(instant);
+	gdevice.floatval2 = float(total);
 	gdevice.rssi = SignalLevel;
 	gdevice.battery_level = BatteryLevel;
 
@@ -8973,7 +8970,7 @@ void MainWorker::decode_Energy(const CDomoticzHardwareBase* pHardware, const tRB
 		gdevice.floatval2 *= mval;
 	}
 
-	decode_General(pHardware, (const tRBUF*)&gdevice, procResult);
+	decode_General(pHardware, reinterpret_cast<const tRBUF *>(&gdevice), procResult);
 	procResult.bProcessBatteryValue = false;
 }
 
@@ -8990,16 +8987,16 @@ void MainWorker::decode_Power(const CDomoticzHardwareBase* pHardware, const tRBU
 	uint8_t SignalLevel = pResponse->POWER.rssi;
 	uint8_t BatteryLevel = 255;
 
-	float Voltage = (float)pResponse->POWER.voltage;
+	float Voltage = float(pResponse->POWER.voltage);
 	double current = ((pResponse->POWER.currentH * 256) + pResponse->POWER.currentL) / 100.0;
 	double instant = ((pResponse->POWER.powerH * 256) + pResponse->POWER.powerL) / 10.0;// Watt
 	double usage = ((pResponse->POWER.energyH * 256) + pResponse->POWER.energyL) / 100.0; //kWh
 	double powerfactor = pResponse->POWER.pf / 100.0;
-	float frequency = (float)pResponse->POWER.freq; //Hz
+	float frequency = float(pResponse->POWER.freq); // Hz
 
 	sprintf(szTmp, "%ld;%.2f", long(round(instant)), usage * 1000.0);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
 
@@ -9007,21 +9004,21 @@ void MainWorker::decode_Power(const CDomoticzHardwareBase* pHardware, const tRBU
 	sprintf(szTmp, "%.3f", Voltage);
 	std::string tmpDevName;
 	uint64_t DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, pTypeGeneral, sTypeVoltage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName);
-	if (DevRowIdxAlt == (uint64_t)-1)
+	if (DevRowIdxAlt == std::numeric_limits<std::uint64_t>::max())
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 1, pTypeGeneral, sTypeVoltage, Voltage);
 
 	//Powerfactor
-	sprintf(szTmp, "%.2f", (float)powerfactor);
+	sprintf(szTmp, "%.2f", float(powerfactor));
 	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 2, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName);
-	if (DevRowIdxAlt == (uint64_t)-1)
+	if (DevRowIdxAlt == std::numeric_limits<std::uint64_t>::max())
 		return;
-	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 2, pTypeGeneral, sTypePercentage, (float)powerfactor);
+	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 2, pTypeGeneral, sTypePercentage, float(powerfactor));
 
 	//Frequency
-	sprintf(szTmp, "%.2f", (float)frequency);
+	sprintf(szTmp, "%.2f", frequency);
 	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 3, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName);
-	if (DevRowIdxAlt == (uint64_t)-1)
+	if (DevRowIdxAlt == std::numeric_limits<std::uint64_t>::max())
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 3, pTypeGeneral, sTypePercentage, frequency);
 
@@ -9131,12 +9128,12 @@ void MainWorker::decode_Current_Energy(const CDomoticzHardwareBase* pHardware, c
 		int voltage = 230;
 		m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
-		sprintf(szTmp, "%ld;%.2f", (long)round((CurrentChannel1 + CurrentChannel2 + CurrentChannel3) * voltage), usage);
+		sprintf(szTmp, "%ld;%.2f", long(round((CurrentChannel1 + CurrentChannel2 + CurrentChannel3) * voltage)), usage);
 		m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeENERGY, sTypeELEC3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 	}
 	sprintf(szTmp, "%.1f;%.1f;%.1f;%.3f", CurrentChannel1, CurrentChannel2, CurrentChannel3, usage);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -9236,7 +9233,7 @@ void MainWorker::decode_Weight(const CDomoticzHardwareBase* pHardware, const tRB
 
 	sprintf(szTmp, "%.1f", weight);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, weight);
@@ -9326,7 +9323,7 @@ void MainWorker::decode_RFXSensor(const CDomoticzHardwareBase* pHardware, const 
 	break;
 	}
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	switch (pResponse->RFXSENSOR.subtype)
@@ -9336,7 +9333,7 @@ void MainWorker::decode_RFXSensor(const CDomoticzHardwareBase* pHardware, const 
 		break;
 	case sTypeRFXSensorAD:
 	case sTypeRFXSensorVolt:
-		m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, (float)volt);
+		m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, float(volt));
 		break;
 	}
 
@@ -9450,7 +9447,7 @@ void MainWorker::decode_RFXMeter(const CDomoticzHardwareBase* pHardware, const t
 
 		sprintf(szTmp, "%lu", counter);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 
@@ -9687,7 +9684,7 @@ void MainWorker::decode_P1MeterPower(const CDomoticzHardwareBase* pHardware, con
 		p1Power->delivcurrent
 	);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -9744,7 +9741,7 @@ void MainWorker::decode_P1MeterGas(const CDomoticzHardwareBase* pHardware, const
 
 	sprintf(szTmp, "%u", p1Gas->gasusage);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -9786,7 +9783,7 @@ void MainWorker::decode_YouLessMeter(const CDomoticzHardwareBase* pHardware, con
 		pMeter->usagecurrent
 	);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -9830,7 +9827,7 @@ void MainWorker::decode_Rego6XXTemp(const CDomoticzHardwareBase* pHardware, cons
 		pRego->temperature
 	);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, pRego->temperature);
 
@@ -9863,7 +9860,7 @@ void MainWorker::decode_Rego6XXValue(const CDomoticzHardwareBase* pHardware, con
 	);
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, numValue, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -9901,10 +9898,10 @@ void MainWorker::decode_AirQuality(const CDomoticzHardwareBase* pHardware, const
 	uint8_t BatteryLevel = 255;
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, pMeter->airquality, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
-	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, (const int)pMeter->airquality);
+	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, int(pMeter->airquality));
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
 	{
@@ -9954,7 +9951,7 @@ void MainWorker::decode_Usage(const CDomoticzHardwareBase* pHardware, const tRBU
 	sprintf(szTmp, "%.1f", pMeter->fusage);
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, pMeter->fusage);
@@ -9996,7 +9993,7 @@ void MainWorker::decode_Lux(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	sprintf(szTmp, "%.0f", pMeter->fLux);
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, pMeter->fLux);
@@ -10047,7 +10044,7 @@ void MainWorker::decode_Thermostat(const CDomoticzHardwareBase* pHardware, const
 	}
 
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, pMeter->temp);
@@ -10103,7 +10100,7 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 		(subType == sTypeZWaveAlarm)
 		)
 	{
-		sprintf(szTmp, "%08X", (unsigned int)pMeter->intval1);
+		sprintf(szTmp, "%08X", uint32_t(pMeter->intval1));
 	}
 	else
 	{
@@ -10121,91 +10118,91 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeDistance)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeSolarRadiation)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeSoilMoisture)
 	{
 		cmnd = pMeter->intval2;
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeLeafWetness)
 	{
 		cmnd = pMeter->intval1;
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeVoltage)
 	{
 		sprintf(szTmp, "%.3f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeCurrent)
 	{
 		sprintf(szTmp, "%.3f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeBaro)
 	{
 		sprintf(szTmp, "%.02f;%d", pMeter->floatval1, pMeter->intval2);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypePressure)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypePercentage)
 	{
 		sprintf(szTmp, "%.2f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeWaterflow)
 	{
 		sprintf(szTmp, "%.2f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeFan)
 	{
 		sprintf(szTmp, "%d", pMeter->intval2);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeSoundLevel)
 	{
 		sprintf(szTmp, "%d", pMeter->intval2);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeZWaveClock)
@@ -10219,7 +10216,7 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 	}
 	else if ((subType == sTypeZWaveThermostatMode) || (subType == sTypeZWaveThermostatFanMode) || (subType == sTypeZWaveThermostatOperatingState))
 	{
-		cmnd = (uint8_t)pMeter->intval2;
+		cmnd = uint8_t(pMeter->intval2);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
 	}
 	else if (subType == sTypeKwh)
@@ -10235,14 +10232,14 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 			sprintf(szTmp, "%d", pMeter->intval1);
 		cmnd = pMeter->intval1;
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeCustom)
 	{
 		sprintf(szTmp, "%.4f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeZWaveAlarm)
@@ -10251,7 +10248,7 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 		cmnd = pMeter->intval2;
 		strcpy(szTmp, pMeter->text);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 	}
 	else if (subType == sTypeTextStatus)
@@ -10411,7 +10408,7 @@ void MainWorker::decode_GeneralSwitch(const CDomoticzHardwareBase* pHardware, co
 
 	sprintf(szTmp, "%d", level);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	uint8_t check_cmnd = cmnd;
 	if ((cmnd == gswitch_sGroupOff) || (cmnd == gswitch_sGroupOn))
@@ -10457,7 +10454,7 @@ void MainWorker::decode_BBQ(const CDomoticzHardwareBase* pHardware, const tRBUF*
 
 	sprintf(szTmp, "%.0f;%.0f", temp1, temp2);
 	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
 	{
@@ -10508,26 +10505,26 @@ void MainWorker::decode_BBQ(const CDomoticzHardwareBase* pHardware, const tRBUF*
 
 	tsen.TEMP.tempsign = (temp1 >= 0) ? 0 : 1;
 	int at10 = round(std::abs(temp1 * 10.0F));
-	tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.TEMP.temperaturel = (BYTE)(at10);
+	tsen.TEMP.temperaturel = BYTE(at10);
 	_tRxMessageProcessingResult tmpProcResult1;
 	tmpProcResult1.DeviceName = "";
 	tmpProcResult1.DeviceRowIdx = -1;
-	decode_Temp(pHardware, (const tRBUF*)&tsen.TEMP, tmpProcResult1);
+	decode_Temp(pHardware, reinterpret_cast<const tRBUF *>(&tsen.TEMP), tmpProcResult1);
 
 	tsen.TEMP.id1 = 0;
 	tsen.TEMP.id2 = 2;
 
 	tsen.TEMP.tempsign = (temp2 >= 0) ? 0 : 1;
 	at10 = round(std::abs(temp2 * 10.0F));
-	tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
+	tsen.TEMP.temperatureh = BYTE(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
-	tsen.TEMP.temperaturel = (BYTE)(at10);
+	tsen.TEMP.temperaturel = BYTE(at10);
 	_tRxMessageProcessingResult tmpProcResult2;
 	tmpProcResult2.DeviceName = "";
 	tmpProcResult2.DeviceRowIdx = -1;
-	decode_Temp(pHardware, (const tRBUF*)&tsen.TEMP, tmpProcResult2);
+	decode_Temp(pHardware, reinterpret_cast<const tRBUF *>(&tsen.TEMP), tmpProcResult2);
 
 	procResult.DeviceRowIdx = DevRowIdx;
 }
@@ -10537,7 +10534,8 @@ void MainWorker::decode_Cartelectronic(const CDomoticzHardwareBase* pHardware, c
 	char szTmp[100];
 	std::string ID;
 
-	sprintf(szTmp, "%llu", ((unsigned long long)(pResponse->TIC.id1) << 32) + (pResponse->TIC.id2 << 24) + (pResponse->TIC.id3 << 16) + (pResponse->TIC.id4 << 8) + (pResponse->TIC.id5));
+	sprintf(szTmp, "%llu",
+		(static_cast<unsigned long long>(pResponse->TIC.id1) << 32) + (pResponse->TIC.id2 << 24) + (pResponse->TIC.id3 << 16) + (pResponse->TIC.id4 << 8) + (pResponse->TIC.id5));
 	ID = szTmp;
 	//uint8_t Unit = 0;
 	//uint8_t cmnd = 0;
@@ -10779,20 +10777,17 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 	if ((pResponse->TIC.state & 0x04) == 0)
 	{
 		// Id of the counter
-		uint64_t uint64ID = ((uint64_t)pResponse->TIC.id1 << 32) +
-			((uint64_t)pResponse->TIC.id2 << 24) +
-			((uint64_t)pResponse->TIC.id3 << 16) +
-			((uint64_t)pResponse->TIC.id4 << 8) +
-			(uint64_t)(pResponse->TIC.id5);
+		auto uint64ID = (uint64_t(pResponse->TIC.id1) << 32) + (uint64_t(pResponse->TIC.id2) << 24) + (uint64_t(pResponse->TIC.id3) << 16) + (uint64_t(pResponse->TIC.id4) << 8) +
+				uint64_t(pResponse->TIC.id5);
 
 		sprintf(szTmp, "%.12" PRIu64, uint64ID);
 		ID = szTmp;
 
 		// Contract Type
-		Contract contractType = (Contract)(pResponse->TIC.contract_type >> 4);
+		Contract contractType = Contract(pResponse->TIC.contract_type >> 4);
 
 		// Period
-		PeriodTime period = (PeriodTime)(pResponse->TIC.contract_type & 0x0f);
+		PeriodTime period = PeriodTime(pResponse->TIC.contract_type & 0x0f);
 
 		// Apparent Power
 		if ((pResponse->TIC.state & 0x02) != 0) // Only if this one is present
@@ -10802,10 +10797,10 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			sprintf(szTmp, "%u", apparentPower);
 			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, pTypeUsage, sTypeElectric, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 
-			if (DevRowIdx == (uint64_t)-1)
+			if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 				return;
 
-			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, pTypeUsage, sTypeElectric, NTYPE_ENERGYINSTANT, (const float)apparentPower);
+			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, pTypeUsage, sTypeElectric, NTYPE_ENERGYINSTANT, float(apparentPower));
 		}
 
 		switch (contractType)
@@ -10840,10 +10835,10 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 
 			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 
-			if (DevRowIdx == (uint64_t)-1)
+			if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 				return;
 
-			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, (float)counter2);
+			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, float(counter2));
 			//----------------------------
 		}
 		break;
@@ -10858,10 +10853,10 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			sprintf(szTmp, "%u;%d", counter2ApparentPower, counter2);
 			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 
-			if (DevRowIdx == (uint64_t)-1)
+			if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 				return;
 
-			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, (float)counter2);
+			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, float(counter2));
 			//----------------------------
 		}
 		break;
@@ -10918,10 +10913,10 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			sprintf(szTmp, "%u;%d", counter2ApparentPower, counter2);
 			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), unitCounter2, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 
-			if (DevRowIdx == (uint64_t)-1)
+			if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 				return;
 
-			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, (float)counter2);
+			m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, float(counter2));
 			//----------------------------
 		}
 		break;
@@ -10935,10 +10930,10 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 		sprintf(szTmp, "%u;%d", counter1ApparentPower, counter1);
 		uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), unitCounter1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
 
-		if (DevRowIdx == (uint64_t)-1)
+		if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 			return;
 
-		m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, (float)counter1);
+		m_notifications.CheckAndHandleNotification(DevRowIdx, procResult.DeviceName, devType, subType, NTYPE_TODAYENERGY, float(counter1));
 		//----------------------------
 	}
 	else
@@ -10965,7 +10960,7 @@ void MainWorker::decode_CartelectronicEncoder(const CDomoticzHardwareBase* pHard
 	uint8_t BatteryLevel = (pResponse->CEENCODER.battery_level + 1) * 10;
 
 	// Id of the module
-	sprintf(szTmp, "%d", ((uint32_t)(pResponse->CEENCODER.id1 << 24) + (pResponse->CEENCODER.id2 << 16) + (pResponse->CEENCODER.id3 << 8) + pResponse->CEENCODER.id4));
+	sprintf(szTmp, "%d", (uint32_t(pResponse->CEENCODER.id1 << 24) + (pResponse->CEENCODER.id2 << 16) + (pResponse->CEENCODER.id3 << 8) + pResponse->CEENCODER.id4));
 	ID = szTmp;
 
 	// Counter 1
@@ -10973,18 +10968,18 @@ void MainWorker::decode_CartelectronicEncoder(const CDomoticzHardwareBase* pHard
 
 	sprintf(szTmp, "%d", counter1);
 	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
-	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, (float)counter1);
+	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, float(counter1));
 
 	// Counter 2
 	counter2 = (pResponse->CEENCODER.counter2_0 << 24) + (pResponse->CEENCODER.counter2_1 << 16) + (pResponse->CEENCODER.counter2_2 << 8) + (pResponse->CEENCODER.counter2_3);
 
 	sprintf(szTmp, "%d", counter2);
 	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
-	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, 1, devType, subType, (float)counter2);
+	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, 1, devType, subType, float(counter2));
 }
 
 void MainWorker::decode_Weather(const CDomoticzHardwareBase* pHardware, const tRBUF* pResponse, _tRxMessageProcessingResult& procResult)
@@ -11042,7 +11037,7 @@ void MainWorker::decode_Weather(const CDomoticzHardwareBase* pHardware, const tR
 
 	if (subType == sTypeWEATHER2)
 	{
-		int Humidity = (int)pResponse->WEATHER.humidity;
+		int Humidity = int(pResponse->WEATHER.humidity);
 		//uint8_t HumidityStatus = pResponse->WEATHER.humidity_status;
 
 		//MySensorsBase *pMySensorDevice = reinterpret_cast<MySensorsBase*>(pHardware);
@@ -11069,15 +11064,15 @@ void MainWorker::decode_Weather(const CDomoticzHardwareBase* pHardware, const tR
 	//UV
 	if (subType == sTypeWEATHER2)
 	{
-		float UV = (float)pResponse->WEATHER.uv;
+		float UV = float(pResponse->WEATHER.uv);
 		pRFXDevice->SendUVSensor(windID, 1, BatteryLevel, UV, procResult.DeviceName, SignalLevel);
 	}
 
 	//Solar
 	if (subType == sTypeWEATHER2)
 	{
-		float radiation = (float)((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow);
-		pRFXDevice->SendSolarRadiationSensor((const uint8_t)windID, BatteryLevel, radiation, procResult.DeviceName);
+		float radiation = float((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow);
+		pRFXDevice->SendSolarRadiationSensor(uint8_t(windID), BatteryLevel, radiation, procResult.DeviceName);
 	}
 }
 
@@ -11089,7 +11084,7 @@ void MainWorker::decode_Solar(const CDomoticzHardwareBase* pHardware, const tRBU
 	_tGeneralDevice gdevice;
 	gdevice.subtype = sTypeSolarRadiation;
 	gdevice.intval1 = (pResponse->SOLAR.id1 * 256) + pResponse->SOLAR.id2;
-	gdevice.id = (uint8_t)gdevice.intval1;
+	gdevice.id = uint8_t(gdevice.intval1);
 	gdevice.floatval1 = float((pResponse->SOLAR.solarhigh * 256) + float(pResponse->SOLAR.solarlow)) / 100.F;
 	gdevice.rssi = SignalLevel;
 	gdevice.battery_level = BatteryLevel;
@@ -11114,7 +11109,7 @@ void MainWorker::decode_Hunter(const CDomoticzHardwareBase* pHardware, const tRB
 	ID = szTmp;
 
 	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName);
-	if (DevRowIdx == (uint64_t)-1)
+	if (DevRowIdx == std::numeric_limits<std::uint64_t>::max())
 		return;
 
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -11180,7 +11175,7 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 	int subType = atoi(sd[1].c_str());
 	nValue = atoi(sd[2].c_str());
 	sValue = sd[3];
-	_eMeterType metertype = (_eMeterType)atoi(sd[4].c_str());
+	_eMeterType metertype = _eMeterType(atoi(sd[4].c_str()));
 
 	//Special cases
 	if ((devType == pTypeP1Power) && (subType == sTypeP1Power))
@@ -11328,10 +11323,10 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 	std::stringstream s_strid;
 	s_strid << std::hex << sd[1];
 	s_strid >> ID;
-	uint8_t ID1 = (uint8_t)((ID & 0xFF000000) >> 24);
-	uint8_t ID2 = (uint8_t)((ID & 0x00FF0000) >> 16);
-	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
-	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
+	uint8_t ID1 = uint8_t((ID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((ID & 0x00FF0000) >> 16);
+	uint8_t ID3 = uint8_t((ID & 0x0000FF00) >> 8);
+	uint8_t ID4 = uint8_t((ID & 0x000000FF));
 
 	int HardwareID = atoi(sd[0].c_str());
 
@@ -11372,7 +11367,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 	uint8_t Unit = atoi(sd[2].c_str());
 	uint8_t dType = atoi(sd[3].c_str());
 	uint8_t dSubType = atoi(sd[4].c_str());
-	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	_eSwitchType switchtype = _eSwitchType(atoi(sd[5].c_str()));
 	std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[10]);
 
 	//when asking for Toggle, just switch to the opposite value
@@ -11458,11 +11453,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 				lcmd.LIGHTING1.cmnd = light1_sOn;
 		}
 
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING1)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING1)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11519,30 +11514,30 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		else
 			level = (level > 15) ? 15 : level;
 
-		lcmd.LIGHTING2.level = (uint8_t)level;
+		lcmd.LIGHTING2.level = uint8_t(level);
 		//Special Teach-In for EnOcean Dimmers
 		if ((pHardware->HwdType == HTYPE_EnOceanESP2) && (IsTesting) && (switchtype == STYPE_Dimmer))
 		{
 			CEnOceanESP2* pEnocean = reinterpret_cast<CEnOceanESP2*>(pHardware);
-			pEnocean->SendDimmerTeachIn((const char*)&lcmd, sizeof(lcmd.LIGHTING1));
+			pEnocean->SendDimmerTeachIn(reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING1));
 		}
 		else if ((pHardware->HwdType == HTYPE_EnOceanESP3) && (IsTesting) && (switchtype == STYPE_Dimmer))
 		{
 			CEnOceanESP3* pEnocean = reinterpret_cast<CEnOceanESP3*>(pHardware);
-			pEnocean->SendDimmerTeachIn((const char*)&lcmd, sizeof(lcmd.LIGHTING1));
+			pEnocean->SendDimmerTeachIn(reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING1));
 		}
 		else
 		{
 			if (switchtype != STYPE_Motion) //dont send actual motion off command
 			{
-				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING2)))
+				if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING2)))
 					return false;
 			}
 		}
 
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11573,11 +11568,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			int pulsetimeing = atoi(result[0][0].c_str());
 			lcmd.LIGHTING4.pulseHigh = pulsetimeing / 256;
 			lcmd.LIGHTING4.pulseLow = pulsetimeing & 0xFF;
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING4)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING4)))
 				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
-				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+				PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 			}
 			return true;
 		}
@@ -11616,7 +11611,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		}
 		if (level > 31)
 			level = 31;
-		lcmd.LIGHTING5.level = (uint8_t)level;
+		lcmd.LIGHTING5.level = uint8_t(level);
 		if (dSubType == sTypeLivolo)
 		{
 			if ((switchcmd == "Set Level") && (level == 0))
@@ -11629,7 +11624,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 				//Special Case, turn off first
 				uint8_t oldCmd = lcmd.LIGHTING5.cmnd;
 				lcmd.LIGHTING5.cmnd = light5_sLivoloAllOff;
-				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+				if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 					return false;
 				lcmd.LIGHTING5.cmnd = oldCmd;
 			}
@@ -11637,12 +11632,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			{
 				//dim value we have to send multiple times
 				for (int iDim = 0; iDim < level; iDim++)
-					if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+					if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 						return false;
 			}
-			else
-				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-					return false;
+			else if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
+				return false;
 		}
 		else if ((dSubType == sTypeTRC02) || (dSubType == sTypeTRC02_2))
 		{
@@ -11660,7 +11654,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			{
 				uint8_t oldCmd = lcmd.LIGHTING5.cmnd;
 				lcmd.LIGHTING5.cmnd = light5_sRGBoff;
-				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+				if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 					return false;
 				lcmd.LIGHTING5.cmnd = oldCmd;
 				sleep_milliseconds(100);
@@ -11669,7 +11663,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			{
 				//turn on
 				lcmd.LIGHTING5.cmnd = light5_sRGBon;
-				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+				if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 					return false;
 				sleep_milliseconds(100);
 
@@ -11683,7 +11677,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 						float dval = 126.0F * hsb[0]; // Color Range is 0x06..0x84
 						lcmd.LIGHTING5.cmnd = light5_sRGBcolormin + 1 + round(dval);
-						if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+						if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 							return false;
 					}
 				}
@@ -11691,12 +11685,12 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		}
 		else
 		{
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING5)))
 				return false;
 		}
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11719,11 +11713,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.LIGHTING6.cmnd, options))
 			return false;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING6)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.LIGHTING6)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11752,13 +11746,13 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 		if (switchtype != STYPE_Motion) //dont send actual motion off command
 		{
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.FS20)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.FS20)))
 				return false;
 		}
 
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11780,11 +11774,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.HOMECONFORT.cmnd, options))
 			return false;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.HOMECONFORT)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.HOMECONFORT)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11804,11 +11798,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.FAN.cmnd, options))
 			return false;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.FAN)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.FAN)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11834,11 +11828,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		}
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.command, options))
 			return false;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(_tColorSwitch)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(_tColorSwitch)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11863,14 +11857,14 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.SECURITY1.status, options))
 				return false;
 			//send it twice
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.SECURITY1)))
 				return false;
 			sleep_milliseconds(500);
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.SECURITY1)))
 				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
-				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+				PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 			}
 		}
 		break;
@@ -11881,11 +11875,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		{
 			if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.SECURITY1.status, options))
 				return false;
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.SECURITY1)))
 				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
-				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+				PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 			}
 		}
 		break;
@@ -11907,8 +11901,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			int iHex = 0;
 			s_strid << std::hex << sHex;
 			s_strid >> iHex;
-			kCodes[ii] = (BYTE)iHex;
-
+			kCodes[ii] = BYTE(iHex);
 		}
 		tRBUF lcmd;
 		lcmd.SECURITY2.packetlength = sizeof(lcmd.SECURITY2) - 1;
@@ -11928,11 +11921,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		lcmd.SECURITY2.battery_level = 9;
 		lcmd.SECURITY2.rssi = 12;
 
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY2)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.SECURITY2)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11951,7 +11944,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			int iHex = 0;
 			s_strid << std::hex << sHex;
 			s_strid >> iHex;
-			kCodes[ii] = (BYTE)iHex;
+			kCodes[ii] = BYTE(iHex);
 		}
 		tRBUF lcmd;
 		lcmd.HUNTER.packetlength = sizeof(lcmd.HUNTER) - 1;
@@ -11968,11 +11961,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			return false;
 		lcmd.HUNTER.rssi = 12;
 
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY2)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.SECURITY2)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -11990,11 +11983,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			return false;
 		lcmd.CURTAIN1.filler = 0;
 
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.CURTAIN1)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.CURTAIN1)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12040,11 +12033,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		level = 15;
 		lcmd.BLINDS1.filler = 0;
 		lcmd.BLINDS1.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.BLINDS1)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.BLINDS1)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12084,11 +12077,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		level = 15;
 		lcmd.RFY.filler = 0;
 		lcmd.RFY.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RFY)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.RFY)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12115,11 +12108,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		}
 		lcmd.CHIME.filler = 0;
 		lcmd.CHIME.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.CHIME)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.CHIME)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12139,11 +12132,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 
 		lcmd.THERMOSTAT2.filler = 0;
 		lcmd.THERMOSTAT2.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.THERMOSTAT2)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.THERMOSTAT2)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12163,11 +12156,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		level = 15;
 		lcmd.THERMOSTAT3.filler = 0;
 		lcmd.THERMOSTAT3.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.THERMOSTAT3)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.THERMOSTAT3)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12211,11 +12204,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		lcmd.REMOTE.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
 		lcmd.REMOTE.toggle = 0;
 		lcmd.REMOTE.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.REMOTE)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.REMOTE)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12234,11 +12227,11 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		else
 			lcmd.demand = level;
 
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(_tEVOHOME3)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(_tEVOHOME3)))
 			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	}
@@ -12262,13 +12255,13 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 		lcmd.RADIATOR1.tempPoint5 = 0;
 		lcmd.RADIATOR1.filler = 0;
 		lcmd.RADIATOR1.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.RADIATOR1)))
 			return false;
 
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			lcmd.RADIATOR1.subtype = sTypeSmartwaresSwitchRadiator;
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, User.c_str());
 		}
 		return true;
 	case pTypeGeneralSwitch:
@@ -12340,16 +12333,16 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 			}
 		}
 
-		gswitch.level = (uint8_t)level;
+		gswitch.level = uint8_t(level);
 		gswitch.rssi = 12;
 		if (switchtype != STYPE_Motion) //dont send actual motion off command
 		{
-			if (!WriteToHardware(HardwareID, (const char*)&gswitch, sizeof(_tGeneralSwitch)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&gswitch), sizeof(_tGeneralSwitch)))
 				return false;
 		}
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&gswitch, nullptr, -1, User.c_str());
+			PushAndWaitRxMessage(m_hardwaredevices[hindex], reinterpret_cast<const uint8_t *>(&gswitch), nullptr, -1, User.c_str());
 		}
 	}
 	return true;
@@ -12424,10 +12417,10 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 	tsen.mode = until.empty() ? CEvohomeBase::cmPerm : CEvohomeBase::cmTmp;
 	if (tsen.mode == CEvohomeBase::cmTmp)
 		CEvohomeDateTime::DecodeISODate(tsen, until.c_str());
-	WriteToHardware(HardwareID, (const char*)&tsen, sizeof(_tEVOHOME1));
+	WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tsen), sizeof(_tEVOHOME1));
 
 	//the latency on the scripted solution is quite bad so it's good to see the update happening...ideally this would go to an 'updating' status (also useful to update database if we ever use this as a pure virtual device)
-	PushRxMessage(pHardware, (const uint8_t *)&tsen, nullptr, 255, nullptr);
+	PushRxMessage(pHardware, reinterpret_cast<const uint8_t *>(&tsen), nullptr, 255, nullptr);
 	return true;
 }
 
@@ -12456,7 +12449,7 @@ bool MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, c
 
 	//uint8_t dType = atoi(sd[3].c_str());
 	//uint8_t dSubType = atoi(sd[4].c_str());
-	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	_eSwitchType switchtype = _eSwitchType(atoi(sd[5].c_str()));
 	int iOnDelay = atoi(sd[6].c_str());
 	int nValue = atoi(sd[7].c_str());
 	std::string sValue = sd[8];
@@ -12482,7 +12475,7 @@ bool MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, c
 		{
 			_log.Log(LOG_NORM, "Delaying switch [%s] action (%s) for %d seconds", devName.c_str(), switchcmd.c_str(), iOnDelay + ExtraDelay);
 		}
-		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(static_cast<float>(iOnDelay + ExtraDelay), idx, switchcmd, level, color, "Switch with Delay", User));
+		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(float(iOnDelay + ExtraDelay), idx, switchcmd, level, color, "Switch with Delay", User));
 		return true;
 	}
 	return SwitchLightInt(sd, switchcmd, level, color, false, User);
@@ -12543,11 +12536,11 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue, cons
 		RFX_SETID3(ID, tsen.id1, tsen.id2, tsen.id3)
 			tsen.zone = Unit;//controller is 0 so let our zones start from 1...
 		tsen.updatetype = CEvohomeBase::updSetPoint;//setpoint
-		tsen.temperature = static_cast<int16_t>((dType == pTypeEvohomeWater) ? TempValue : TempValue * 100.0F);
+		tsen.temperature = int16_t((dType == pTypeEvohomeWater) ? TempValue : TempValue * 100.0F);
 		tsen.mode = nEvoMode;
 		if (nEvoMode == CEvohomeBase::zmTmp)
 			CEvohomeDateTime::DecodeISODate(tsen, until.c_str());
-		WriteToHardware(HardwareID, (const char*)&tsen, sizeof(_tEVOHOME2));
+		WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tsen), sizeof(_tEVOHOME2));
 
 		//Pass across the current controller mode if we're going to update as per the hw device
 		result = m_sql.safe_query(
@@ -12559,7 +12552,7 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue, cons
 			tsen.controllermode = atoi(sd[2].c_str());
 		}
 		//the latency on the scripted solution is quite bad so it's good to see the update happening...ideally this would go to an 'updating' status (also useful to update database if we ever use this as a pure virtual device)
-		PushAndWaitRxMessage(pHardware, (const uint8_t *)&tsen, nullptr, -1, nullptr);
+		PushAndWaitRxMessage(pHardware, reinterpret_cast<const uint8_t *>(&tsen), nullptr, -1, nullptr);
 	}
 	return true;
 }
@@ -12589,10 +12582,10 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	std::stringstream s_strid;
 	s_strid << std::hex << sd[1];
 	s_strid >> ID;
-	uint8_t ID1 = (uint8_t)((ID & 0xFF000000) >> 24);
-	uint8_t ID2 = (uint8_t)((ID & 0x00FF0000) >> 16);
-	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
-	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
+	uint8_t ID1 = uint8_t((ID & 0xFF000000) >> 24);
+	uint8_t ID2 = uint8_t((ID & 0x00FF0000) >> 16);
+	uint8_t ID3 = uint8_t((ID & 0x0000FF00) >> 8);
+	uint8_t ID4 = uint8_t((ID & 0x000000FF));
 
 	uint8_t Unit = atoi(sd[2].c_str());
 	uint8_t dType = atoi(sd[3].c_str());
@@ -12730,11 +12723,11 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 			sprintf(szTemp, "%.1f", TempValue);
 			std::vector<std::string> strarray;
 			StringSplit(szTemp, ".", strarray);
-			lcmd.RADIATOR1.temperature = (uint8_t)atoi(strarray[0].c_str());
-			lcmd.RADIATOR1.tempPoint5 = (uint8_t)atoi(strarray[1].c_str());
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
+			lcmd.RADIATOR1.temperature = uint8_t(atoi(strarray[0].c_str()));
+			lcmd.RADIATOR1.tempPoint5 = uint8_t(atoi(strarray[1].c_str()));
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&lcmd), sizeof(lcmd.RADIATOR1)))
 				return false;
-			PushAndWaitRxMessage(pHardware, (const uint8_t *)&lcmd, nullptr, -1, nullptr);
+			PushAndWaitRxMessage(pHardware, reinterpret_cast<const uint8_t *>(&lcmd), nullptr, -1, nullptr);
 		}
 		else
 		{
@@ -12743,7 +12736,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 			if (tSign == 'F')
 			{
 				//Convert to Celsius
-				tempDest = static_cast<float>(ConvertToCelsius(tempDest));
+				tempDest = float(ConvertToCelsius(tempDest));
 			}
 
 			_tThermostat tmeter;
@@ -12754,12 +12747,12 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 			tmeter.id4 = ID4;
 			tmeter.dunit = 1;
 			tmeter.temp = tempDest;
-			if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tThermostat)))
+			if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tmeter), sizeof(_tThermostat)))
 				return false;
 			if (pHardware->HwdType == HTYPE_Dummy)
 			{
 				//Also put it in the database, as this devices does not send updates
-				PushAndWaitRxMessage(pHardware, (const uint8_t *)&tmeter, nullptr, -1, nullptr);
+				PushAndWaitRxMessage(pHardware, reinterpret_cast<const uint8_t *>(&tmeter), nullptr, -1, nullptr);
 			}
 		}
 	}
@@ -12795,7 +12788,7 @@ bool MainWorker::SetClockInt(const std::vector<std::string>& sd, const std::stri
 		tmeter.subtype = sTypeZWaveClock;
 		tmeter.intval1 = ID;
 		tmeter.intval2 = (day * (24 * 60)) + (hour * 60) + minute;
-		if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tGeneralDevice)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tmeter), sizeof(_tGeneralDevice)))
 			return false;
 	}
 #endif
@@ -12837,7 +12830,7 @@ bool MainWorker::SetZWaveThermostatModeInt(const std::vector<std::string>& sd, c
 		tmeter.subtype = sTypeZWaveThermostatMode;
 		tmeter.intval1 = ID;
 		tmeter.intval2 = tMode;
-		if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tGeneralDevice)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tmeter), sizeof(_tGeneralDevice)))
 			return false;
 	}
 #endif
@@ -12865,7 +12858,7 @@ bool MainWorker::SetZWaveThermostatFanModeInt(const std::vector<std::string>& sd
 		tmeter.subtype = sTypeZWaveThermostatFanMode;
 		tmeter.intval1 = ID;
 		tmeter.intval2 = fMode;
-		if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tGeneralDevice)))
+		if (!WriteToHardware(HardwareID, reinterpret_cast<const char *>(&tmeter), sizeof(_tGeneralDevice)))
 			return false;
 	}
 #endif
@@ -13036,7 +13029,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 	{
 		std::vector<std::string> sds = result[0];
 		Name = sds[0];
-		scenetype = (_eSceneGroupType)atoi(sds[1].c_str());
+		scenetype = _eSceneGroupType(atoi(sds[1].c_str()));
 		onaction = sds[2];
 		offaction = sds[3];
 		status = sds[4];
@@ -13091,7 +13084,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 						subject = Name + " Activated";
 					else
 						subject = Name + " Status: " + switchcmd;
-					m_sql.AddTaskItem(_tTaskItem::EmailCameraSnapshot(static_cast<float>(delay + 1), camidx, subject));
+					m_sql.AddTaskItem(_tTaskItem::EmailCameraSnapshot(float(delay + 1), camidx, subject));
 				}
 			}
 		}
@@ -13131,7 +13124,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 			uint8_t dType = atoi(sd2[3].c_str());
 			uint8_t dSubType = atoi(sd2[4].c_str());
 			std::string DeviceName = sd2[8];
-			_eSwitchType switchtype = (_eSwitchType)atoi(sd2[5].c_str());
+			_eSwitchType switchtype = _eSwitchType(atoi(sd2[5].c_str()));
 
 			//Check if this device will not activate a scene
 			uint64_t dID = std::strtoull(sd[0].c_str(), nullptr, 10);
@@ -13189,7 +13182,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 			{
 				int delay = (lstatus == "Off") ? offdelay : ondelay;
 				if (m_sql.m_bEnableEventSystem && !bEventTrigger)
-					m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, static_cast<float>(delay));
+					m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, float(delay));
 				SwitchLight(idx, lstatus, ilevel, color, false, delay, User);
 				if (scenetype == SGTYPE_SCENE)
 				{
@@ -13197,7 +13190,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 					{
 						//switch with on delay, and off delay
 						if (m_sql.m_bEnableEventSystem && !bEventTrigger)
-							m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, static_cast<float>(ondelay + offdelay));
+							m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, float(ondelay + offdelay));
 						SwitchLight(idx, "Off", ilevel, color, false, ondelay + offdelay, User);
 					}
 				}
@@ -13205,7 +13198,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 			else
 			{
 				if (m_sql.m_bEnableEventSystem && !bEventTrigger)
-					m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, static_cast<float>(ondelay));
+					m_eventsystem.SetEventTrigger(idx, m_eventsystem.REASON_DEVICE, float(ondelay));
 				SwitchLight(idx, "On", ilevel, color, false, ondelay, User);
 			}
 			sleep_milliseconds(50);
@@ -13332,7 +13325,7 @@ void MainWorker::SetInternalSecStatus()
 	}
 
 	CDomoticzHardwareBase* pHardware = GetHardwareByType(HTYPE_DomoticzInternal);
-	PushAndWaitRxMessage(pHardware, (const uint8_t*)&tsen, "Domoticz Security Panel", -1, nullptr);
+	PushAndWaitRxMessage(pHardware, reinterpret_cast<const uint8_t *>(&tsen), "Domoticz Security Panel", -1, nullptr);
 }
 
 void MainWorker::UpdateDomoticzSecurityStatus(const int iSecStatus)
@@ -13482,7 +13475,7 @@ void MainWorker::HeartbeatCheck()
 						|| (pHardware->HwdType == HTYPE_RFXtrx868)
 						)
 					{
-						const CRFXBase* pRFXBase = static_cast<CRFXBase*>(pHardware);
+						auto pRFXBase = static_cast<CRFXBase *>(pHardware);
 						if (pRFXBase->m_LastP1Received != 0)
 						{
 							diff = difftime(now, pRFXBase->m_LastP1Received);
@@ -13558,7 +13551,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	// Prevent hazardous modification of DB from JSON calls
 	std::string devname = "Unknown";
 	uint64_t devidx = m_sql.GetDeviceIndex(HardwareID, DeviceID, unit, devType, subType, devname);
-	if (devidx == (uint64_t)-1)
+	if (devidx == std::numeric_limits<std::uint64_t>::max())
 		return false;
 	std::stringstream sidx;
 	sidx << devidx;
@@ -13571,7 +13564,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 		)
 	{
 		_log.Log(LOG_NORM, "Sending SetPoint to device....");
-		SetSetPoint(sidx.str(), static_cast<float>(atof(sValue.c_str())));
+		SetSetPoint(sidx.str(), float(atof(sValue.c_str())));
 #ifdef ENABLE_PYTHON
 		// notify plugin
 		m_pluginsystem.DeviceModified(devidx);
@@ -13602,10 +13595,10 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 			std::stringstream s_strid;
 			s_strid << std::hex << DeviceID;
 			s_strid >> ID;
-			uint8_t ID1 = (uint8_t)((ID & 0xFF000000) >> 24);
-			uint8_t ID2 = (uint8_t)((ID & 0x00FF0000) >> 16);
-			uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
-			uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
+			uint8_t ID1 = uint8_t((ID & 0xFF000000) >> 24);
+			uint8_t ID2 = uint8_t((ID & 0x00FF0000) >> 16);
+			uint8_t ID3 = uint8_t((ID & 0x0000FF00) >> 8);
+			uint8_t ID4 = uint8_t((ID & 0x000000FF));
 
 			tRBUF lcmd;
 			memset(&lcmd, 0, sizeof(RBUF));
@@ -13616,12 +13609,12 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 			lcmd.LIGHTING2.id2 = ID2;
 			lcmd.LIGHTING2.id3 = ID3;
 			lcmd.LIGHTING2.id4 = ID4;
-			lcmd.LIGHTING2.unitcode = (uint8_t)unit;
-			lcmd.LIGHTING2.cmnd = (uint8_t)nValue;
-			lcmd.LIGHTING2.level = (uint8_t)atoi(sValue.c_str());
+			lcmd.LIGHTING2.unitcode = uint8_t(unit);
+			lcmd.LIGHTING2.cmnd = uint8_t(nValue);
+			lcmd.LIGHTING2.level = uint8_t(atoi(sValue.c_str()));
 			lcmd.LIGHTING2.filler = 0;
 			lcmd.LIGHTING2.rssi = signallevel;
-			DecodeRXMessage(pHardware, (const uint8_t *)&lcmd.LIGHTING2, nullptr, batterylevel, userName.c_str());
+			DecodeRXMessage(pHardware, reinterpret_cast<const uint8_t *>(&lcmd.LIGHTING2), nullptr, batterylevel, userName.c_str());
 			g_bUseEventTrigger = true;
 			return true;
 		}
@@ -13643,7 +13636,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 
 			if (devType == pTypeTEMP)
 			{
-				temp = static_cast<float>(atof(sValue.c_str()));
+				temp = float(atof(sValue.c_str()));
 				temp += AddjValue;
 				sprintf(szTmp, "%.2f", temp);
 				sValue = szTmp;
@@ -13653,7 +13646,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 				StringSplit(sValue, ";", strarray);
 				if (strarray.size() == 3)
 				{
-					temp = static_cast<float>(atof(strarray[0].c_str()));
+					temp = float(atof(strarray[0].c_str()));
 					temp += AddjValue;
 					sprintf(szTmp, "%.2f;%s;%s", temp, strarray[1].c_str(), strarray[2].c_str());
 					sValue = szTmp;
@@ -13664,8 +13657,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 				StringSplit(sValue, ";", strarray);
 				if (strarray.size() == 5)
 				{
-					temp = static_cast<float>(atof(strarray[0].c_str()));
-					float fbarometer = static_cast<float>(atof(strarray[3].c_str()));
+					temp = float(atof(strarray[0].c_str()));
+					float fbarometer = float(atof(strarray[3].c_str()));
 					temp += AddjValue;
 
 					AddjValue = 0.0F;
@@ -13679,7 +13672,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 					}
 					else
 					{
-						sprintf(szTmp, "%.2f;%s;%s;%d;%s", temp, strarray[1].c_str(), strarray[2].c_str(), (int)rint(fbarometer), strarray[4].c_str());
+						sprintf(szTmp, "%.2f;%s;%s;%d;%s", temp, strarray[1].c_str(), strarray[2].c_str(), int(rint(fbarometer)), strarray[4].c_str());
 					}
 					sValue = szTmp;
 				}
@@ -13687,20 +13680,11 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 		}
 	}
 
-	devidx = m_sql.UpdateValue(
-		HardwareID,
-		DeviceID.c_str(),
-		(const uint8_t)unit,
-		(const uint8_t)devType,
-		(const uint8_t)subType,
-		signallevel,//signal level,
-		batterylevel,//battery level
-		nValue,
-		sValue.c_str(),
-		devname,
-		false
-	);
-	if (devidx == (uint64_t)-1)
+	devidx = m_sql.UpdateValue(HardwareID, DeviceID.c_str(), uint8_t(unit), uint8_t(devType), uint8_t(subType),
+				   signallevel,	 // signal level,
+				   batterylevel, // battery level
+				   nValue, sValue.c_str(), devname, false);
+	if (devidx == std::numeric_limits<std::uint64_t>::max())
 	{
 		g_bUseEventTrigger = true;
 		return false;
@@ -13718,8 +13702,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 			std::stringstream s_strid;
 			s_strid << std::hex << DeviceID;
 			s_strid >> ID;
-			uint8_t NodeID = (uint8_t)((ID & 0x0000FF00) >> 8);
-			uint8_t ChildID = (uint8_t)((ID & 0x000000FF));
+			uint8_t NodeID = uint8_t((ID & 0x0000FF00) >> 8);
+			uint8_t ChildID = uint8_t((ID & 0x000000FF));
 
 			MySensorsBase* pMySensorDevice = reinterpret_cast<MySensorsBase*>(pHardware);
 			pMySensorDevice->SendTextSensorValue(NodeID, ChildID, sValue);
@@ -13729,8 +13713,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const std::string &DeviceID,
 	//Calculate temperature trend
 	if (temp != 12345.0F)
 	{
-		uint64_t tID = ((uint64_t)(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
-		m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+		uint64_t tID = (uint64_t(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
+		m_trend_calculator[tID].AddValueAndReturnTendency(double(temp), _tTrendCalculator::TAVERAGE_TEMP);
 	}
 
 #ifdef ENABLE_PYTHON

--- a/main/mosquitto_helper.cpp
+++ b/main/mosquitto_helper.cpp
@@ -11,7 +11,7 @@ namespace mosqdz {
 
 static void on_connect_wrapper(struct mosquitto *mosq, void *userdata, int rc)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 
 	UNUSED(mosq);
 
@@ -20,42 +20,42 @@ static void on_connect_wrapper(struct mosquitto *mosq, void *userdata, int rc)
 
 static void on_connect_with_flags_wrapper(struct mosquitto *mosq, void *userdata, int rc, int flags)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_connect_with_flags(rc, flags);
 }
 
 static void on_disconnect_wrapper(struct mosquitto *mosq, void *userdata, int rc)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_disconnect(rc);
 }
 
 static void on_publish_wrapper(struct mosquitto *mosq, void *userdata, int mid)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_publish(mid);
 }
 
 static void on_message_wrapper(struct mosquitto *mosq, void *userdata, const struct mosquitto_message *message)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_message(message);
 }
 
 static void on_subscribe_wrapper(struct mosquitto *mosq, void *userdata, int mid, int qos_count, const int *granted_qos)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_subscribe(mid, qos_count, granted_qos);
 }
 
 static void on_unsubscribe_wrapper(struct mosquitto *mosq, void *userdata, int mid)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_unsubscribe(mid);
 }
@@ -63,7 +63,7 @@ static void on_unsubscribe_wrapper(struct mosquitto *mosq, void *userdata, int m
 
 static void on_log_wrapper(struct mosquitto *mosq, void *userdata, int level, const char *str)
 {
-	class mosquittodz *m = (class mosquittodz *)userdata;
+	class mosquittodz *m = static_cast<class mosquittodz *>(userdata);
 	UNUSED(mosq);
 	m->on_log(level, str);
 }

--- a/main/unzip_stream.h
+++ b/main/unzip_stream.h
@@ -72,12 +72,12 @@ namespace clx {
 		{
 			if (this->gptr() == this->egptr())
 			{
-				int_type n = static_cast<int_type>(this->gptr() - this->eback());
+				int_type n = int_type(this->gptr() - this->eback());
 				if (n > npback)
 					n = npback;
 				std::memcpy(&buffer_.at(npback - n), this->gptr() - n, n);
 
-				int_type byte = static_cast<int_type>((buffer_.size() - npback) * sizeof(char_type));
+				int_type byte = int_type((buffer_.size() - npback) * sizeof(char_type));
 				int l = unzReadCurrentFile(handler_, reinterpret_cast<char *>(&buffer_.at(npback)), byte - 1);
 				if (l <= 0)
 					return traits::eof();

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -221,11 +221,11 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const std::string &sValue) {
-	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, 0, sValue, static_cast<float>(atof(sValue.c_str())));
+	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, 0, sValue, float(atof(sValue.c_str())));
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const int nValue, const std::string &sValue) {
-	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, nValue, sValue, static_cast<float>(atof(sValue.c_str())));
+	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, nValue, sValue, float(atof(sValue.c_str())));
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const int nValue, const std::string &sValue, const float fValue) {
@@ -248,7 +248,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeP1Power:
 			nexpected = 5;
 			if (nsize >= nexpected) {
-				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)atof(strarray[4].c_str()));
+				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, static_cast<float>(atof(strarray[4].c_str())));
 			}
 			break;
 		case pTypeRFXSensor:
@@ -277,9 +277,9 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeTEMP_HUM:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
+				float Temp = static_cast<float>(atof(strarray[0].c_str()));
 				int Hum = atoi(strarray[1].c_str());
-				float dewpoint = (float)CalculateDewPoint(Temp, Hum);
+				float dewpoint = static_cast<float>(CalculateDewPoint(Temp, Hum));
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, Hum, true, true);
 				r2 = CheckAndHandleDewPointNotification(DevRowIdx, sName, Temp, dewpoint);
 				return r1 && r2;
@@ -288,27 +288,27 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeTEMP_HUM_BARO:
 			nexpected = 4;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
+				float Temp = static_cast<float>(atof(strarray[0].c_str()));
 				int Hum = atoi(strarray[1].c_str());
-				float dewpoint = (float)CalculateDewPoint(Temp, Hum);
+				float dewpoint = static_cast<float>(CalculateDewPoint(Temp, Hum));
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, Hum, true, true);
 				r2 = CheckAndHandleDewPointNotification(DevRowIdx, sName, Temp, dewpoint);
-				r3 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, (float)atof(strarray[3].c_str()));
+				r3 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, static_cast<float>(atof(strarray[3].c_str())));
 				return r1 && r2 && r3;
 			}
 			break;
 		case pTypeRAIN:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				fValue2 = (float)atof(strarray[1].c_str());
+				fValue2 = static_cast<float>(atof(strarray[1].c_str()));
 				return CheckAndHandleRainNotification(DevRowIdx, sName, cType, cSubType, NTYPE_RAIN, fValue2);
 			}
 			break;
 		case pTypeTEMP_BARO:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
-				float Baro = (float)atof(strarray[1].c_str());
+				float Temp = static_cast<float>(atof(strarray[0].c_str()));
+				float Baro = static_cast<float>(atof(strarray[1].c_str()));
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, 0, true, false);
 				r2 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, Baro);
 				return r1 && r2;
@@ -317,8 +317,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeUV:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Level = (float)atof(strarray[0].c_str());
-				float Temp = (float)atof(strarray[1].c_str());
+				float Level = static_cast<float>(atof(strarray[0].c_str()));
+				float Temp = static_cast<float>(atof(strarray[1].c_str()));
 				if (cSubType == sTypeUV3)
 				{
 					r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, 0, true, false);
@@ -332,26 +332,26 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeCURRENT:
 			nexpected = 3;
 			if (nsize >= nexpected) {
-				float CurrentChannel1 = (float)atof(strarray[0].c_str());
-				float CurrentChannel2 = (float)atof(strarray[1].c_str());
-				float CurrentChannel3 = (float)atof(strarray[2].c_str());
+				float CurrentChannel1 = static_cast<float>(atof(strarray[0].c_str()));
+				float CurrentChannel2 = static_cast<float>(atof(strarray[1].c_str()));
+				float CurrentChannel3 = static_cast<float>(atof(strarray[2].c_str()));
 				return CheckAndHandleAmpere123Notification(DevRowIdx, sName, CurrentChannel1, CurrentChannel2, CurrentChannel3);
 			}
 			break;
 		case pTypeCURRENTENERGY:
 			nexpected = 3;
 			if (nsize >= nexpected) {
-				float CurrentChannel1 = (float)atof(strarray[0].c_str());
-				float CurrentChannel2 = (float)atof(strarray[1].c_str());
-				float CurrentChannel3 = (float)atof(strarray[2].c_str());
+				float CurrentChannel1 = static_cast<float>(atof(strarray[0].c_str()));
+				float CurrentChannel2 = static_cast<float>(atof(strarray[1].c_str()));
+				float CurrentChannel3 = static_cast<float>(atof(strarray[2].c_str()));
 				return CheckAndHandleAmpere123Notification(DevRowIdx, sName, CurrentChannel1, CurrentChannel2, CurrentChannel3);
 			}
 			break;
 		case pTypeWIND:
 			nexpected = 5;
 			if (nsize >= nexpected) {
-				float wspeedms = (float)(atof(strarray[2].c_str()) / 10.0F);
-				float temp = (float)atof(strarray[4].c_str());
+				float wspeedms = static_cast<float>(atof(strarray[2].c_str()) / 10.0F);
+				float temp = static_cast<float>(atof(strarray[4].c_str()));
 				r1 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_WIND, wspeedms);
 				r2 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, temp, 0, true, false);
 				return r1 && r2;
@@ -360,12 +360,12 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeYouLess:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float usagecurrent = (float)atof(strarray[1].c_str());
+				float usagecurrent = static_cast<float>(atof(strarray[1].c_str()));
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, usagecurrent);
 			}
 			break;
 		case pTypeAirQuality:
-			return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)nValue);
+			return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, static_cast<float>(nValue));
 		case pTypeWEIGHT:
 		case pTypeLux:
 			return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue);
@@ -374,7 +374,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypePOWER:
 			nexpected = 1;
 			if (nsize >= nexpected) {
-				fValue2 = (float)atof(strarray[0].c_str());
+				fValue2 = static_cast<float>(atof(strarray[0].c_str()));
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 			}
 			break;
@@ -414,7 +414,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				case sTypeKwh:
 					nexpected = 1;
 					if (nsize >= nexpected) {
-						fValue2 = (float)atof(strarray[0].c_str());
+						fValue2 = static_cast<float>(atof(strarray[0].c_str()));
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 					}
 					break;
@@ -425,7 +425,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				case sTypeSoilMoisture:
 				case sTypeLeafWetness:
 				case sTypeAlert:
-					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)nValue);
+					return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, static_cast<float>(nValue));
 				case sTypeFan:
 				case sTypeSoundLevel:
 				case sTypeSolarRadiation:
@@ -519,7 +519,7 @@ bool CNotificationHelper::CheckAndHandleTempHumidityNotification(
 				continue; //impossible
 			std::string ntype = splitresults[0];
 			std::string custommsg;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = float(atof(splitresults[2].c_str()));
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
 			bCustomMessage = CustomRecoveryMessage(n.ID, custommsg, false);
@@ -530,7 +530,7 @@ bool CNotificationHelper::CheckAndHandleTempHumidityNotification(
 				if (m_sql.m_tempunit == TEMPUNIT_F)
 				{
 					//Convert to Celsius
-					svalue = static_cast<float>(ConvertToCelsius(svalue));
+					svalue = float(ConvertToCelsius(svalue));
 				}
 
 				if (temp > 30.0) szExtraData += "Image=temp-gt-30|";
@@ -690,7 +690,7 @@ bool CNotificationHelper::CheckAndHandleValueNotification(
 			if (splitresults.size() < 2)
 				continue; //impossible
 			std::string ntype = splitresults[0];
-			int svalue = static_cast<int>(atoi(splitresults[1].c_str()));
+			int svalue = int(atoi(splitresults[1].c_str()));
 
 			if (ntype == signvalue)
 			{
@@ -759,7 +759,7 @@ bool CNotificationHelper::CheckAndHandleAmpere123Notification(
 			std::string ntype = splitresults[0];
 			std::string custommsg;
 			std::string ltype;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = float(atof(splitresults[2].c_str()));
 			float ampere = 0.0F;
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
@@ -920,7 +920,7 @@ bool CNotificationHelper::CheckAndHandleNotification(
 				continue; //impossible
 			std::string ntype = splitresults[0];
 			std::string custommsg;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = float(atof(splitresults[2].c_str()));
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
 			bCustomMessage = CustomRecoveryMessage(n.ID, custommsg, false);
@@ -976,7 +976,7 @@ bool CNotificationHelper::CheckAndHandleSwitchNotification(
 		Idx);
 	if (result.empty())
 		return false;
-	_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+	_eSwitchType switchtype = static_cast<_eSwitchType>(atoi(result[0][0].c_str()));
 	std::string szExtraData = "|Name=" + devicename + "|SwitchType=" + result[0][0] + "|CustomImage=" + result[0][1] + "|";
 
 	std::string msg;
@@ -1088,7 +1088,7 @@ bool CNotificationHelper::CheckAndHandleSwitchNotification(
 		Idx);
 	if (result.empty())
 		return false;
-	_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+	_eSwitchType switchtype = static_cast<_eSwitchType>(atoi(result[0][0].c_str()));
 	std::string szExtraData = "|Name=" + devicename + "|SwitchType=" + result[0][0] + "|CustomImage=" + result[0][1] + "|";
 	std::string sOptions = result[0][2];
 
@@ -1204,7 +1204,7 @@ bool CNotificationHelper::CheckAndHandleRainNotification(
 		//value is already total rain
 		double total_real = mvalue;
 		total_real *= AddjMulti;
-		CheckAndHandleNotification(Idx, devicename, devType, subType, NTYPE_RAIN, (float)total_real);
+		CheckAndHandleNotification(Idx, devicename, devType, subType, NTYPE_RAIN, static_cast<float>(total_real));
 	}
 	else
 	{
@@ -1214,11 +1214,11 @@ bool CNotificationHelper::CheckAndHandleRainNotification(
 		{
 			std::vector<std::string> sd = result[0];
 
-			float total_min = static_cast<float>(atof(sd[0].c_str()));
+			float total_min = float(atof(sd[0].c_str()));
 			float total_max = mvalue;
 			double total_real = total_max - total_min;
 			total_real *= AddjMulti;
-			CheckAndHandleNotification(Idx, devicename, devType, subType, NTYPE_RAIN, (float)total_real);
+			CheckAndHandleNotification(Idx, devicename, devType, subType, NTYPE_RAIN, static_cast<float>(total_real));
 		}
 	}
 	return false;
@@ -1258,8 +1258,8 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 					std::string szExtraData;
 					std::string custommsg;
 					uint64_t Idx = n.first;
-					uint32_t SensorTimeOut = static_cast<uint32_t>(atoi(splitresults[2].c_str()));  // minutes
-					uint32_t diff = static_cast<uint32_t>(round(difftime(btime, n2.LastUpdate)));
+					uint32_t SensorTimeOut = uint32_t(atoi(splitresults[2].c_str())); // minutes
+					uint32_t diff = uint32_t(round(difftime(btime, n2.LastUpdate)));
 					bool bStartTime = (difftime(btime, m_StartTime) < SensorTimeOut * 60);
 					bool bSendNotification = ApplyRule(splitresults[1], (diff == SensorTimeOut * 60), (diff < SensorTimeOut * 60));
 					bool bCustomMessage = false;

--- a/notifications/NotificationKodi.cpp
+++ b/notifications/NotificationKodi.cpp
@@ -76,10 +76,10 @@ std::string CNotificationKodi::GetIconFile(const std::string &ExtraData)
 {
 	std::string	szImageFile;
 
-	int	posImage = (int)ExtraData.find("|Image=");
-	int	posStatus = (int)ExtraData.find("|Status=");
-	int	posCustom = (int)ExtraData.find("|CustomImage=");
-	int	posType = (int)ExtraData.find("|SwitchType=");
+	int posImage = static_cast<int>(ExtraData.find("|Image="));
+	int posStatus = static_cast<int>(ExtraData.find("|Status="));
+	int posCustom = static_cast<int>(ExtraData.find("|CustomImage="));
+	int posType = static_cast<int>(ExtraData.find("|SwitchType="));
 
 	if (posImage >= 0)
 	{
@@ -111,7 +111,7 @@ std::string CNotificationKodi::GetIconFile(const std::string &ExtraData)
 		posType+=12;
 		std::string szType = ExtraData.substr(posType, ExtraData.find('|', posType) - posType);
 		std::string	szTypeImage;
-		_eSwitchType switchtype=(_eSwitchType)atoi(szType.c_str());
+		_eSwitchType switchtype = static_cast<_eSwitchType>(atoi(szType.c_str()));
 		switch (switchtype)
 		{
 			case STYPE_OnOff:
@@ -285,9 +285,9 @@ bool CNotificationKodi::SendMessageImplementation(
 		_Sock = -1;
 		if (bMulticast) {
 			_Sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-			setsockopt(_Sock, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&_TTL, sizeof(_TTL));
+			setsockopt(_Sock, IPPROTO_IP, IP_MULTICAST_TTL, reinterpret_cast<const char *>(&_TTL), sizeof(_TTL));
 			u_char loop = 1;
-			setsockopt(_Sock, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*) &loop, sizeof(loop));
+			setsockopt(_Sock, IPPROTO_IP, IP_MULTICAST_LOOP, reinterpret_cast<const char *>(&loop), sizeof(loop));
 		}
 		else {
 			_Sock = socket(AF_INET, SOCK_DGRAM, 0);

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -396,7 +396,7 @@ unsigned long CBasePush::get_tzoffset()
 {
 	// Compute tz
 	boost::posix_time::time_duration uoffset = get_utc_offset();
-	unsigned long tzoffset = (int)((double)(uoffset.ticks() / 3600000000LL) * 3600);
+	unsigned long tzoffset = static_cast<int>(static_cast<double>(uoffset.ticks() / 3600000000LL) * 3600);
 	return tzoffset;
 }
 
@@ -448,7 +448,7 @@ std::string CBasePush::DropdownOptionsValue(const int devType, const int devSubT
 {
 	std::vector<std::string> tmpV;
 	StringSplit(RFX_Type_SubType_Values(devType, devSubType), ",", tmpV);
-	if (pos > 0 && pos <= (int)tmpV.size())
+	if (pos > 0 && pos <= static_cast<int>(tmpV.size()))
 		return tmpV[pos - 1];
 	return "???";
 }
@@ -465,8 +465,8 @@ std::string CBasePush::ProcessSendValue(const uint64_t DeviceRowIdx, const std::
 			return ""; // unhandled type
 
 		unsigned char tempsign = m_sql.m_tempsign[0];
-		_eMeterType metertype = (_eMeterType)metertypein;
-		
+		_eMeterType metertype = static_cast<_eMeterType>(metertypein);
+
 		if ((vType == "Temperature") || (vType == "Temperature 1") || (vType == "Temperature 2") || (vType == "Set point"))
 		{
 			sprintf(szData, "%g", ConvertTemperature(std::stod(rawsendValue), tempsign));
@@ -592,12 +592,12 @@ std::string CBasePush::ProcessSendValue(const uint64_t DeviceRowIdx, const std::
 			bool bHaveDimmer = false;
 			bool bHaveGroupCmd = false;
 			int maxDimLevel = 0;
-			GetLightStatus(devType, devSubType, static_cast<_eSwitchType>(metertypein), 1, rawsendValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
+			GetLightStatus(devType, devSubType, _eSwitchType(metertypein), 1, rawsendValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 
 			int level = atoi(rawsendValue.c_str());
 
 			if (maxDimLevel != 0)
-				level = (int) float((100.0F / float(maxDimLevel)) * level);
+				level = int(float((100.0F / float(maxDimLevel)) * level));
 
 			if (lstatus.find("Off") != std::string::npos)
 				level = 0;
@@ -718,7 +718,7 @@ std::string CBasePush::getUnit(const int devType, const int devSubType, const in
 		return ""; // No unit, unhandled
 
 	unsigned char tempsign = m_sql.m_tempsign[0];
-	_eMeterType metertype = (_eMeterType)metertypein;
+	_eMeterType metertype = static_cast<_eMeterType>(metertypein);
 	char szData[100];
 	szData[0] = 0;
 

--- a/push/FibaroPush.cpp
+++ b/push/FibaroPush.cpp
@@ -102,7 +102,7 @@ void CFibaroPush::DoFibaroPush(const uint64_t DeviceRowIdx)
 				bool bHaveDimmer = false;
 				bool bHaveGroupCmd = false;
 				int maxDimLevel = 0;
-				GetLightStatus(dType, dSubType, (_eSwitchType)metertype, nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
+				GetLightStatus(dType, dSubType, static_cast<_eSwitchType>(metertype), nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 				sendValue = lstatus;
 			}
 			else if (delpos > 0) {

--- a/smtpclient/SMTPClient.cpp
+++ b/smtpclient/SMTPClient.cpp
@@ -20,7 +20,7 @@ struct smtp_upload_status {
 
 static size_t smtp_payload_reader(void* ptr, size_t size, size_t nmemb, void* userp)
 {
-	struct smtp_upload_status* upload_ctx = (struct smtp_upload_status*)userp;
+	struct smtp_upload_status *upload_ctx = static_cast<struct smtp_upload_status *>(userp);
 
 	if ((size == 0) || (nmemb == 0) || ((size * nmemb) < 1)) {
 		return 0;

--- a/tcpserver/TCPClient.cpp
+++ b/tcpserver/TCPClient.cpp
@@ -68,7 +68,7 @@ void CTCPClient::handleRead(const boost::system::error_code& e,
 			}
 			else
 			{
-				pConnectionManager->DoDecodeMessage(this,(const unsigned char *)buffer_.data());
+				pConnectionManager->DoDecodeMessage(this, reinterpret_cast<const unsigned char *>(buffer_.data()));
 			}
 		}
 

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -171,7 +171,7 @@ unsigned int CTCPServerIntBase::GetUserDevicesCount(const std::string &username)
 	_tRemoteShareUser *pUser=FindUser(username);
 	if (pUser == nullptr)
 		return 0;
-	return (unsigned int) pUser->Devices.size();
+	return static_cast<unsigned int>(pUser->Devices.size());
 }
 
 void CTCPServerIntBase::SendToAll(const int /*HardwareID*/, const uint64_t DeviceRowID, const char *pData, size_t Length, const CTCPClientBase* pClient2Ignore)

--- a/webserver/Base64.cpp
+++ b/webserver/Base64.cpp
@@ -99,7 +99,7 @@ std::string base64_encode(unsigned char const* bytes_to_encode, unsigned int in_
 }
 
 std::string base64_encode(std::string const& s) {
-	return base64_encode((unsigned char const*)s.c_str(), (unsigned int)s.size());
+	return base64_encode(reinterpret_cast<unsigned char const *>(s.c_str()), static_cast<unsigned int>(s.size()));
 }
 
 std::string base64_decode(std::string const& encoded_string) {
@@ -113,7 +113,7 @@ std::string base64_decode(std::string const& encoded_string) {
     char_array_4[i++] = encoded_string[in_]; in_++;
     if (i ==4) {
       for (i = 0; i <4; i++)
-        char_array_4[i] = (unsigned char)base64_chars.find(char_array_4[i]);
+	      char_array_4[i] = static_cast<unsigned char>(base64_chars.find(char_array_4[i]));
 
       char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
       char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
@@ -131,7 +131,7 @@ std::string base64_decode(std::string const& encoded_string) {
 		char_array_4[j] = 0;
 
     for (j = 0; j <4; j++)
-      char_array_4[j] = (unsigned char)base64_chars.find(char_array_4[j]);
+	    char_array_4[j] = static_cast<unsigned char>(base64_chars.find(char_array_4[j]));
 
     char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
     char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);

--- a/webserver/GZipHelper.h
+++ b/webserver/GZipHelper.h
@@ -93,7 +93,7 @@ class CA2GZIPT
 	  }
 	if(len==-1)
     {
-		len = static_cast<int>(strlen(lpsz));
+	    len = int(strlen(lpsz));
     }
 	m_CurrentBufferSize=t_nBufferLength;
 	pgzip=m_buffer;
@@ -154,7 +154,7 @@ class CA2GZIPT
 	   {
 		   int nTimes = (Length + count) / t_nBufferLength + 1;
 		   LPGZIP pTemp = pgzip;
-		   pgzip = static_cast<LPGZIP>(malloc(nTimes * t_nBufferLength));
+		   pgzip = LPGZIP(malloc(nTimes * t_nBufferLength));
 		   if (!pgzip)
 			   return 0;
 		   m_CurrentBufferSize = nTimes * t_nBufferLength;
@@ -398,7 +398,7 @@ class CGZIP2AT
 	    m_zstream.total_in  += (uLong)len;
 	    m_zstream.total_out += (uLong)len;
         if (len == 0) m_z_eof = 1;
-		return static_cast<int>(len);
+	return int(len);
 	}
     if (m_zstream.avail_in == 0 && !m_z_eof)
 	{
@@ -436,7 +436,7 @@ class CGZIP2AT
 	if (m_z_err != Z_OK || m_z_eof) break;
     }
     m_crc = crc32(m_crc, start, (uInt)(m_zstream.next_out - start));
-	return static_cast<int>((len - m_zstream.avail_out));
+    return int(len - m_zstream.avail_out);
  }
  uLong getLong()
  {

--- a/webserver/WebsocketHandler.cpp
+++ b/webserver/WebsocketHandler.cpp
@@ -43,7 +43,7 @@ namespace http {
 					// todo: Add the username and rights from the original connection
 					if (outbound)
 					{
-						time_t nowAnd1Day = ((time_t)mytime(nullptr)) + WEBSOCKET_SESSION_TIMEOUT;
+						time_t nowAnd1Day = (mytime(nullptr)) + WEBSOCKET_SESSION_TIMEOUT;
 						session.timeout = nowAnd1Day;
 						session.expires = nowAnd1Day;
 						session.isnew = false;

--- a/webserver/Websockets.cpp
+++ b/webserver/Websockets.cpp
@@ -28,7 +28,7 @@ namespace http {
 			std::string result;
 			result.resize(payloadlen);
 			for (size_t i = 0; i < payloadlen; i++) {
-				result[i] = (uint8_t)(bytes[i] ^ mask[i % 4]);
+				result[i] = static_cast<uint8_t>(bytes[i] ^ mask[i % 4]);
 			}
 			return result;
 		}
@@ -38,25 +38,25 @@ namespace http {
 			size_t_t payloadlen = payload.length();
 			std::string res;
 			// byte 0
-			res += ((uint8_t)opcode | FIN_MASK);
+			res += (static_cast<uint8_t>(opcode) | FIN_MASK);
 			if (payloadlen < 126) {
-				res += (uint8_t)payloadlen | (domasking ? MASKING_MASK : 0);
+				res += static_cast<uint8_t>(payloadlen) | (domasking ? MASKING_MASK : 0);
 			}
 			else {
 				if (payloadlen <= 0xffff) {
-					res += (uint8_t)126 | (domasking ? MASKING_MASK : 0);
+					res += static_cast<uint8_t>(126) | (domasking ? MASKING_MASK : 0);
 					int bits = 16;
 					while (bits) {
 						bits -= 8;
-						res += (uint8_t)((payloadlen >> bits) & 0xff);
+						res += static_cast<uint8_t>((payloadlen >> bits) & 0xff);
 					}
 				}
 				else {
-					res += (uint8_t)127 | (domasking ? MASKING_MASK : 0);
+					res += static_cast<uint8_t>(127) | (domasking ? MASKING_MASK : 0);
 					int bits = 64;
 					while (bits) {
 						bits -= 8;
-						uint8_t ch = (uint8_t)((size_t)(payloadlen >> bits) & 0xff);
+						uint8_t ch = static_cast<uint8_t>(static_cast<size_t>(payloadlen >> bits) & 0xff);
 						res += ch;
 					}
 				}
@@ -69,7 +69,7 @@ namespace http {
 					i = rand();
 					res += i;
 				}
-				res += unmask(masking_key, (const uint8_t *)payload.c_str(), (size_t)payloadlen);
+				res += unmask(masking_key, reinterpret_cast<const uint8_t *>(payload.c_str()), static_cast<size_t>(payloadlen));
 			}
 			else {
 				res += payload;
@@ -88,7 +88,7 @@ namespace http {
 			rsvi1 = (bytes[0] & RSVI1_MASK) > 0;
 			rsvi2 = (bytes[0] & RSVI2_MASK) > 0;
 			rsvi3 = (bytes[0] & RSVI3_MASK) > 0;
-			opcode = (opcodes)(bytes[0] & OPCODE_MASK);
+			opcode = static_cast<opcodes>(bytes[0] & OPCODE_MASK);
 			masking = (bytes[1] & MASKING_MASK) > 0;
 			payloadlen = (bytes[1] & PAYLOADLEN_MASK);
 			remaining -= 2;
@@ -101,7 +101,7 @@ namespace http {
 				int bits = 16;
 				for (uint8_t i = 0; i < 2; i++) {
 					bits -= 8;
-					payloadlen += (size_t)bytes[ptr++] << bits;
+					payloadlen += static_cast<size_t>(bytes[ptr++]) << bits;
 					remaining--;
 				}
 			}
@@ -113,7 +113,7 @@ namespace http {
 				int bits = 64;
 				for (uint8_t i = 0; i < 8; i++) {
 					bits -= 8;
-					payloadlen += (size_t)bytes[ptr++] << bits;
+					payloadlen += static_cast<size_t>(bytes[ptr++]) << bits;
 					remaining--;
 				}
 			}

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -974,7 +974,7 @@ namespace http {
 				uint8_t wPos = 0;
 				int wptr = 0;
 				std::string szNetwork;
-				while (wPos < (uint8_t)results.size())
+				while (wPos < static_cast<uint8_t>(results.size()))
 				{
 					bool bIsMask = (results[wPos] == "*");
 					ipnetwork.Mask[wptr++] = (!bIsMask) ? 255 : 0;
@@ -1046,20 +1046,20 @@ namespace http {
 					struct addrinfo* addr = nullptr;
 					if (getaddrinfo(network.c_str(), "0", nullptr, &addr) == 0)
 					{
-						struct sockaddr_in* saddr = (((struct sockaddr_in*)addr->ai_addr));
+						struct sockaddr_in *saddr = ((reinterpret_cast<struct sockaddr_in *>(addr->ai_addr)));
 						uint8_t* pAddress = nullptr;
 						if (saddr->sin_family == AF_INET)
 						{
 							ipnetwork.bIsIPv6 = false;
 							iASize = 4;
-							pAddress = (uint8_t*)&saddr->sin_addr;
+							pAddress = reinterpret_cast<uint8_t *>(&saddr->sin_addr);
 						}
 						else if (saddr->sin_family == AF_INET6)
 						{
 							ipnetwork.bIsIPv6 = true;
 							iASize = 16;
-							struct sockaddr_in6* saddr6 = (((struct sockaddr_in6*)addr->ai_addr));
-							pAddress = (uint8_t*)&saddr6->sin6_addr;
+							struct sockaddr_in6 *saddr6 = ((reinterpret_cast<struct sockaddr_in6 *>(addr->ai_addr)));
+							pAddress = reinterpret_cast<uint8_t *>(&saddr6->sin6_addr);
 						}
 						else
 							return;
@@ -1165,7 +1165,7 @@ namespace http {
 		int cWebem::CountSessions()
 		{
 			std::unique_lock<std::mutex> lock(m_sessionsMutex);
-			return (int)m_sessions.size();
+			return static_cast<int>(m_sessions.size());
 		}
 
 		std::vector<std::string> cWebem::GetExpiredSessions()
@@ -1505,12 +1505,12 @@ namespace http {
 				bool bHaveGZipSupport = (strstr(encoding_header, "gzip") != nullptr);
 				if (bHaveGZipSupport)
 				{
-					CA2GZIP gzip((char*)rep.content.c_str(), (int)rep.content.size());
-					if ((gzip.Length > 0) && (gzip.Length < (int)rep.content.size()))
+					CA2GZIP gzip(const_cast<char *>(rep.content.c_str()), static_cast<int>(rep.content.size()));
+					if ((gzip.Length > 0) && (gzip.Length < static_cast<int>(rep.content.size())))
 					{
 						rep.bIsGZIP = true; // flag for later
 						rep.content.clear();
-						rep.content.append((char*)gzip.pgzip, gzip.Length);
+						rep.content.append(reinterpret_cast<char *>(gzip.pgzip), gzip.Length);
 						//Set new content length
 						reply::add_header(&rep, "Content-Length", std::to_string(rep.content.size()));
 						//Add gzip header
@@ -2115,7 +2115,7 @@ namespace http {
 
 					if (session.reply_status != reply::ok) // forbidden
 					{
-						rep = reply::stock_reply(static_cast<reply::status_type>(session.reply_status));
+						rep = reply::stock_reply(reply::status_type(session.reply_status));
 						return;
 					}
 
@@ -2129,7 +2129,7 @@ namespace http {
 					modify_info mInfo;
 					if (session.reply_status != reply::ok)
 					{
-						rep = reply::stock_reply(static_cast<reply::status_type>(session.reply_status));
+						rep = reply::stock_reply(reply::status_type(session.reply_status));
 						return;
 					}
 					if (rep.status != reply::ok) // bad request

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -267,7 +267,7 @@ namespace http {
 #define FILE_SEND_BUFFER_SIZE 16*1024
 				if (!send_buffer_)
 					send_buffer_ = new uint8_t[FILE_SEND_BUFFER_SIZE];
-				size_t bread = static_cast<size_t>(sendfile_.read((char*)send_buffer_, FILE_SEND_BUFFER_SIZE).gcount());
+				size_t bread = size_t(sendfile_.read(reinterpret_cast<char *>(send_buffer_), FILE_SEND_BUFFER_SIZE).gcount());
 				if (bread <= 0)
 				{
 					//Error reading file!
@@ -463,7 +463,7 @@ namespace http {
 				case ConnectionType::connection_websocket:
 				case ConnectionType::connection_websocket_closing:
 					begin = boost::asio::buffer_cast<const char*>(_buf.data());
-					result = websocket_parser.parse((const unsigned char*)begin, _buf.size(), bytes_consumed, keepalive_);
+					result = websocket_parser.parse(reinterpret_cast<const unsigned char *>(begin), _buf.size(), bytes_consumed, keepalive_);
 					_buf.consume(bytes_consumed);
 					if (result) {
 						// we received a complete packet (that was handled already)

--- a/webserver/fastcgi.cpp
+++ b/webserver/fastcgi.cpp
@@ -403,7 +403,7 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 				if (tpos == std::string::npos)
 					continue;
 				std::string errcode = theader.substr(0, tpos);
-				rep = reply::stock_reply((reply::status_type)atoi(errcode.c_str()));
+				rep = reply::stock_reply(static_cast<reply::status_type>(atoi(errcode.c_str())));
 				return true;
 			}
 

--- a/webserver/proxyclient.cpp
+++ b/webserver/proxyclient.cpp
@@ -307,7 +307,7 @@ namespace http {
 		{
 			/* data from master to slave */
 			bool success;
-			success = m_pDomServ->OnIncomingData(pdu->m_token, (const unsigned char *)pdu->m_data.c_str(), pdu->m_data.length());
+			success = m_pDomServ->OnIncomingData(pdu->m_token, reinterpret_cast<const unsigned char *>(pdu->m_data.c_str()), pdu->m_data.length());
 			if (!success) {
 				SendServDisconnect(pdu->m_token, 1);
 			}
@@ -323,7 +323,7 @@ namespace http {
 
 			DomoticzTCP *slave = sharedData.findSlaveConnection(pdu->m_tokenparam);
 			if (slave && slave->isConnected()) {
-				slave->FromProxy((const unsigned char *)pdu->m_data.c_str(), pdu->m_data.length());
+				slave->FromProxy(reinterpret_cast<const unsigned char *>(pdu->m_data.c_str()), pdu->m_data.length());
 			}
 		}
 
@@ -403,7 +403,7 @@ namespace http {
 
 		void CProxyClient::OnData(const unsigned char *pData, size_t length)
 		{
-			readbuf.append((const char *)pData, length);
+			readbuf.append(reinterpret_cast<const char *>(pData), length);
 			switch (connection_status) {
 			case status_httpmode:
 				if (parse_response(readbuf.c_str(), readbuf.size())) {
@@ -414,7 +414,8 @@ namespace http {
 				break;
 			case status_connected:
 				CWebsocketFrame frame;
-				if (frame.Parse((const uint8_t *)readbuf.c_str(), readbuf.size())) {
+				if (frame.Parse(reinterpret_cast<const uint8_t *>(readbuf.c_str()), readbuf.size()))
+				{
 					readbuf.clear();
 					switch (frame.Opcode()) {
 					case opcodes::opcode_ping:

--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -440,24 +440,16 @@ bool request_handler::url_decode(const std::string& in, std::string& out)
   {
     if (in[i] == '%')
     {
-      if (i + 3 <= in.size())
-      {
-        int value;
-        std::istringstream is(in.substr(i + 1, 2));
-        if (is >> std::hex >> value)
-        {
-          out += static_cast<char>(value);
-          i += 2;
-        }
-        else
-        {
-          return false;
-        }
-      }
-      else
-      {
-        return false;
-      }
+	    if (i + 3 > in.size())
+		    return false;
+
+	    int value;
+	    std::istringstream is(in.substr(i + 1, 2));
+	    if (!(is >> std::hex >> value))
+		    return false;
+
+	    out += char(value);
+	    i += 2;
     }
     else if (in[i] == '+')
     {


### PR DESCRIPTION
static_cast is verbose for no reason. Just replace with normal cast.

Signed-off-by: Rosen Penev <rosenp@gmail.com>