### PR TITLE
Updated github action, added artifact upload and excluded some actions for forked repos

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -74,9 +74,18 @@ jobs:
           shasum -a 256 package/domoticz_linux_x86_64.tgz > package/domoticz_linux_x86_64.tgz.sha256sum
           cp appversion.h.txt package/version_linux_x86_64.h
           cp History.txt package/history_linux_x86_64.txt
-
+      
+      # Artifact upload
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: domoticz_linux_x86_64-${{ github.sha }}
+          path: package/domoticz_linux_x86_64.tgz
+          retention-days: 7
+ 
       # Deploy
       - name: FTP Deployment
+        if: github.repository_owner == 'domoticz'
         uses: SamKirkland/FTP-Deploy-Action@4.0.0
         with:
           server: ${{ secrets.FTP_SERVER }}
@@ -89,6 +98,7 @@ jobs:
 
       # Trigger Docker build
       - name: Docker Stage
+        if: github.repository_owner == 'domoticz'
         uses: fjogeleit/http-request-action@master
         with:
           url: 'https://hub.docker.com/api/build/v1/source/778e5561-87f9-47e3-a431-f493328d1b6f/trigger/4cbd5d3b-5113-4d9f-b826-af620f2319a3/call/'


### PR DESCRIPTION
Small PR to update the Github actions so when using a GitHub fork of **domoticz/domoticz**, the Github action workflow for the development branch within the fork does not fail all the time (as it cannot upload certain artifacts as this is private to the main domoticz repo).

Also, the create package is now also made available as a Github artifact with a 7 day retenion instead of the default 90, but that seems way to long because of the update frequency of the development branch. As there would be a huge amount of Artifacts created, one for each update that triggers the workflow.