### PR TITLE
OTGW: Fix to handle the new v5 firmware

### DIFF
--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -214,7 +214,7 @@ bool OTGWBase::SwitchLight(const int idx, const std::string &LCmd, const int /*s
 		}
 		else
 		{
-			Log(LOG_ERROR, "OTGW: Invalid switch command received!");
+			Log(LOG_ERROR, "Invalid switch command received!");
 			return false;
 		}
 		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
@@ -257,7 +257,7 @@ bool OTGWBase::WriteToHardware(const char *pdata, const unsigned char /*length*/
 	}
 	else
 	{
-		Log(LOG_STATUS, "OTGW: Skipping writing to Hardware for type: %02X, subType: %02X", packettype, subtype);
+		Log(LOG_STATUS, "Skipping writing to Hardware for type: %02X, subType: %02X", packettype, subtype);
 	}
 	return true;
 }
@@ -315,7 +315,7 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 	if (idx == 1)
 	{
 		//Control Set Point (MsgID=1)
-		Log(LOG_STATUS, "OTGW: Setting Control SetPoint to: %.1f", temp);
+		Log(LOG_STATUS, "Setting Control SetPoint to: %.1f", temp);
 		sprintf(szCmd, "CS=%.1f\r\n", temp);
 		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 	}
@@ -323,7 +323,7 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 	{
 		//Room Set Point
 		//Make this a temporarily Set Point, this will be overridden when the thermostat changes/applying it's program
-		Log(LOG_STATUS, "OTGW: Setting Room SetPoint to: %.1f", temp);
+		Log(LOG_STATUS, "Setting Room SetPoint to: %.1f", temp);
 		sprintf(szCmd, "TT=%.1f\r\n", temp);
 		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 		UpdateSetPointSensor((uint8_t)idx, temp, "Room Setpoint");
@@ -331,7 +331,7 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 	else if (idx == 15)
 	{
 		//DHW setpoint (MsgID=56)
-		Log(LOG_STATUS, "OTGW: Setting Heating SetPoint to: %.1f", temp);
+		Log(LOG_STATUS, "Setting Heating SetPoint to: %.1f", temp);
 		sprintf(szCmd, "SW=%.1f\r\n", temp);
 		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 		UpdateSetPointSensor((uint8_t)idx, temp, "DHW Setpoint");
@@ -339,7 +339,7 @@ void OTGWBase::SetSetpoint(const int idx, const float temp)
 	else if (idx == 16)
 	{
 		//Max CH water setpoint (MsgID=57)
-		Log(LOG_STATUS, "OTGW: Setting Max CH water SetPoint to: %.1f", temp);
+		Log(LOG_STATUS, "Setting Max CH water SetPoint to: %.1f", temp);
 		sprintf(szCmd, "SH=%.1f\r\n", temp);
 		WriteInt((const unsigned char*)&szCmd, (const unsigned char)strlen(szCmd));
 		UpdateSetPointSensor((uint8_t)idx, temp, "Max_CH Water Setpoint");
@@ -396,13 +396,11 @@ void OTGWBase::ParseLine()
 		_tOTGWStatus _status;
 		int idx=0;
 		m_bFirmware5 = (results.size()==34);
-	
-		std::string sFirmwareMsg = "pre version 5 firmware!";
-		if (m_bFirmware5)
-			sFirmwareMsg = "firmware 5 or higher!"; 
-		Log(LOG_STATUS, "Running with %s", sFirmwareMsg.c_str());
 
-		Debug(DEBUG_NORM, "Parsing the following PS=1 input line : %s", sLine.c_str());
+		std::string sFirmwareMsg = "pre version 5 firmware";
+		if (m_bFirmware5)
+			sFirmwareMsg = "firmware 5 or higher";
+		Debug(DEBUG_HARDWARE, "OTGW: Assuming %s! Parsing the following PS=1 input line : .%s.", sFirmwareMsg.c_str(), sLine.c_str());
 
 		_status.MsgID=results[idx++];
 		if (_status.MsgID.size()==17)
@@ -490,7 +488,7 @@ void OTGWBase::ParseLine()
 
 	if (sLine == "SE")
 	{
-		Log(LOG_ERROR, "OTGW: Error received!");
+		Log(LOG_ERROR, "Error received!");
 	}
 	else if (sLine.find("PR: G") != std::string::npos)
 	{
@@ -548,7 +546,7 @@ void OTGWBase::ParseLine()
 		if ((sLine.find("OT") == std::string::npos) && (sLine.find("PS") == std::string::npos) && (sLine.find("SC") == std::string::npos))
 		{
 			// Dont report OT/PS/SC feedback
-			Log(LOG_STATUS, "OTGW: %s", sLine.c_str());
+			Log(LOG_STATUS, "%s", sLine.c_str());
 		}
 	}
 }
@@ -605,7 +603,7 @@ namespace http {
 			size_t tpos = cmnd.find('=');
 			if (tpos != 2)
 			{
-				_log.Log(LOG_STATUS, "OTGW: Invalid user command!: %s", cmnd.c_str());
+				_log.Log(LOG_STATUS, "Invalid user command!: %s", cmnd.c_str());
 				return;
 			}
 			std::string rcmnd = cmnd.substr(0, 2);

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -64,7 +64,6 @@ OTGWBase::OTGWBase()
 	m_bufferpos = 0;
 	m_OverrideTemperature = 0.0F;
 	m_bRequestVersion = true;
-	m_bFirmware5 = false;
 }
 
 void OTGWBase::SetModes(const int Mode1, const int /*Mode2*/, const int /*Mode3*/, const int /*Mode4*/, const int /*Mode5*/, const int /*Mode6*/)
@@ -395,10 +394,10 @@ void OTGWBase::ParseLine()
 
 		_tOTGWStatus _status;
 		int idx=0;
-		m_bFirmware5 = (results.size()==34);
+		bool bIsFirmware5 = (results.size()==34);
 
 		std::string sFirmwareMsg = "pre version 5 firmware";
-		if (m_bFirmware5)
+		if (bIsFirmware5)
 			sFirmwareMsg = "firmware 5 or higher";
 		Debug(DEBUG_HARDWARE, "OTGW: Assuming %s! Parsing the following PS=1 input line : .%s.", sFirmwareMsg.c_str(), sLine.c_str());
 
@@ -422,7 +421,7 @@ void OTGWBase::ParseLine()
 
 		_status.Control_setpoint = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
 		_status.Remote_parameter_flags=results[idx++];
-		if(m_bFirmware5)
+		if(bIsFirmware5)
 		{
 			idx+=2;
 		}
@@ -446,7 +445,7 @@ void OTGWBase::ParseLine()
 		{
 			SendPressureSensor(0, MsgID18, 255, _status.CH_water_pressure, "CH Water Pressure");
 		}
-		if(m_bFirmware5)
+		if(bIsFirmware5)
 		{
 			idx+=2;
 		}
@@ -455,7 +454,7 @@ void OTGWBase::ParseLine()
 		_status.DHW_temperature = static_cast<float>(atof(results[idx++].c_str()));							SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
 		_status.Outside_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
 		_status.Return_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
-		if(m_bFirmware5)
+		if(bIsFirmware5)
 		{
 			idx+=2;
 		}
@@ -471,7 +470,7 @@ void OTGWBase::ParseLine()
 		{
 			UpdateSetPointSensor((uint8_t)MsgID57, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
 		}
-		if(m_bFirmware5)
+		if(bIsFirmware5)
 		{
 			idx+=3;
 		}

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -325,29 +325,29 @@ void OTGWBase::ParseLine()
 		//0    0	Status (MsgID=0) - Printed as two 8-bit bitfields
 		//1    1	Control setpoint (MsgID=1) - Printed as a floating point value
 		//2    2	Remote parameter flags (MsgID=6) - Printed as two 8-bit bitfields
-		// 	   3	Cooling control (MsgID=7) - 
-		//     4	Control setpoint 2 (MsgID=8) -  
+		// 	   3	Cooling control (MsgID=7) - Printed as a floating point value
+		//     4	Control setpoint 2 (MsgID=8) - Printed as a floating point value
 		//3    5	Maximum relative modulation level (MsgID=14) - Printed as a floating point value
 		//4    6	Boiler capacity and modulation limits (MsgID=15) - Printed as two bytes
 		//5    7	Room Setpoint (MsgID=16) - Printed as a floating point value
 		//6    8	Relative modulation level (MsgID=17) - Printed as a floating point value
 		//7    9	CH water pressure (MsgID=18) - Printed as a floating point value
-		//     10	DHW flow rate (MsgID=19) - 
-		//     11	CH2 room setpoint (MsgID=23) -  
+		//     10	DHW flow rate (MsgID=19) - Printed as a floating point value
+		//     11	CH2 room setpoint (MsgID=23) - Printed as a floating point value
 		//8    12	Room temperature (MsgID=24) - Printed as a floating point value
 		//9    13	Boiler water temperature (MsgID=25) - Printed as a floating point value
 		//10   14	DHW temperature (MsgID=26) - Printed as a floating point value
 		//11   15	Outside temperature (MsgID=27) - Printed as a floating point value
 		//12   16	Return water temperature (MsgID=28) - Printed as a floating point value
-		// 	   17	CH2 flow temperature (MsgID=31) -  
-		//     18	Boiler exhaust temperature (MsgID=33) -  
+		// 	   17	CH2 flow temperature (MsgID=31) - Printed as a floating point value
+		//     18	Boiler exhaust temperature (MsgID=33) - Printed as a signed decimal value
 		//13   19	DHW setpoint boundaries (MsgID=48) - Printed as two bytes
 		//14   20 	Max CH setpoint boundaries (MsgID=49) - Printed as two bytes
 		//15   21	DHW setpoint (MsgID=56) - Printed as a floating point value
 		//16   22	Max CH water setpoint (MsgID=57) - Printed as a floating point value
-		//     23	V/H master status (MsgID=70) -  
-		//     24	V/H control setpoint (MsgID=71) -  
-		//     25	Relative ventilation (MsgID=77) - 
+		//     23	V/H master status (MsgID=70) - Printed as two 8-bit bitfields
+		//     24	V/H control setpoint (MsgID=71) - Printed as a byte
+		//     25	Relative ventilation (MsgID=77) - Printed as a byte
 		//17   26	Burner starts (MsgID=116) - Printed as a decimal value
 		//18   27	CH pump starts (MsgID=117) - Printed as a decimal value
 		//19   28	DHW pump/valve starts (MsgID=118) - Printed as a decimal value
@@ -365,6 +365,8 @@ void OTGWBase::ParseLine()
 		if (m_bFirmware5)
 			sFirmwareMsg = "firmware 5 or higher!"; 
 		Log(LOG_STATUS, "Running with %s", sFirmwareMsg.c_str());
+
+		Debug(DEBUG_NORM, "Parsing the following PS=1 input line : %s", sLine.c_str());
 
 		_status.MsgID=results[idx++];
 		if (_status.MsgID.size()==17)

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -396,11 +396,6 @@ void OTGWBase::ParseLine()
 		int idx=0;
 		bool bIsFirmware5 = (results.size()==34);
 
-		std::string sFirmwareMsg = "pre version 5 firmware";
-		if (bIsFirmware5)
-			sFirmwareMsg = "firmware 5 or higher";
-		Debug(DEBUG_HARDWARE, "OTGW: Assuming %s! Parsing the following PS=1 input line : .%s.", sFirmwareMsg.c_str(), sLine.c_str());
-
 		_status.MsgID=results[idx++];
 		if (_status.MsgID.size()==17)
 		{

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -19,6 +19,42 @@
 
 #define round(a) ( int ) ( a + .5 )
 
+// Mapping to device idx for backwards compatibility
+#define MsgID0		101
+#define MsgID1		1
+#define MsgID6		2
+#define MsgID7		25
+#define MsgID8		26
+#define MsgID14		3
+#define MsgID15		4
+#define MsgID16		5
+#define MsgID17		6
+#define MsgID18		7
+#define MsgID19		27
+#define MsgID23		28
+#define MsgID24		8
+#define MsgID25		9
+#define MsgID26		10
+#define MsgID27		11
+#define MsgID28		12
+#define MsgID31		29
+#define MsgID33		30
+#define MsgID48		13
+#define MsgID49		14
+#define MsgID56		15
+#define MsgID57		16
+#define MsgID70		31
+#define MsgID71		32
+#define MsgID77		33
+#define MsgID116	17
+#define MsgID117	18
+#define MsgID118	19
+#define MsgID119	20
+#define MsgID120	21
+#define MsgID121	22
+#define MsgID122	23
+#define MsgID123	24
+
 extern http::server::CWebServerHelper m_webservers;
 
 OTGWBase::OTGWBase()
@@ -386,41 +422,41 @@ void OTGWBase::ParseLine()
 			bool bDiagnosticEvent=(_status.MsgID[9+1]=='1');												UpdateSwitch(116,bDiagnosticEvent,"DiagnosticEvent");
 		}
 
-		_status.Control_setpoint = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(idx - 1, 255, _status.Control_setpoint, "Control Setpoint");
+		_status.Control_setpoint = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
 		_status.Remote_parameter_flags=results[idx++];
 		if(m_bFirmware5)
 		{
 			idx+=2;
 		}
 		_status.Maximum_relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
-		bool bExists = CheckPercentageSensorExists(idx - 1, 1);
+		bool bExists = CheckPercentageSensorExists(MsgID14, 1);
 		if ((_status.Maximum_relative_modulation_level != 0) || (bExists))
 		{
-			SendPercentageSensor(idx - 1, 1, 255, _status.Maximum_relative_modulation_level, "Maximum Relative Modulation Level");
+			SendPercentageSensor(MsgID14, 1, 255, _status.Maximum_relative_modulation_level, "Maximum Relative Modulation Level");
 		}
 		_status.Boiler_capacity_and_modulation_limits=results[idx++];
 		_status.Room_Setpoint = static_cast<float>(atof(results[idx++].c_str()));
-		UpdateSetPointSensor((uint8_t)idx - 1, ((m_OverrideTemperature != 0.0F) ? m_OverrideTemperature : _status.Room_Setpoint), "Room Setpoint");
+		UpdateSetPointSensor((uint8_t)MsgID16, ((m_OverrideTemperature != 0.0F) ? m_OverrideTemperature : _status.Room_Setpoint), "Room Setpoint");
 		_status.Relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
-		bExists = CheckPercentageSensorExists(idx - 1, 1);
+		bExists = CheckPercentageSensorExists(MsgID17, 1);
 		if ((_status.Relative_modulation_level != 0) || (bExists))
 		{
-			SendPercentageSensor(idx - 1, 1, 255, _status.Relative_modulation_level, "Relative modulation level");
+			SendPercentageSensor(MsgID17, 1, 255, _status.Relative_modulation_level, "Relative modulation level");
 		}
 		_status.CH_water_pressure = static_cast<float>(atof(results[idx++].c_str()));
 		if (_status.CH_water_pressure != 0)
 		{
-			SendPressureSensor(0, idx - 1, 255, _status.CH_water_pressure, "CH Water Pressure");
+			SendPressureSensor(0, MsgID18, 255, _status.CH_water_pressure, "CH Water Pressure");
 		}
 		if(m_bFirmware5)
 		{
 			idx+=2;
 		}
-		_status.Room_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(idx - 1, 255, _status.Room_temperature, "Room Temperature");
-		_status.Boiler_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(idx - 1, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
-		_status.DHW_temperature = static_cast<float>(atof(results[idx++].c_str()));							SendTempSensor(idx - 1, 255, _status.DHW_temperature, "DHW Temperature");
-		_status.Outside_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(idx - 1, 255, _status.Outside_temperature, "Outside Temperature");
-		_status.Return_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(idx - 1, 255, _status.Return_water_temperature, "Return Water Temperature");
+		_status.Room_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID24, 255, _status.Room_temperature, "Room Temperature");
+		_status.Boiler_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID25, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
+		_status.DHW_temperature = static_cast<float>(atof(results[idx++].c_str()));							SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
+		_status.Outside_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
+		_status.Return_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
 		if(m_bFirmware5)
 		{
 			idx+=2;
@@ -430,12 +466,12 @@ void OTGWBase::ParseLine()
 		_status.DHW_setpoint = static_cast<float>(atof(results[idx++].c_str()));
 		if (_status.DHW_setpoint != 0.0F)
 		{
-			UpdateSetPointSensor((uint8_t)idx - 1, _status.DHW_setpoint, "DHW Setpoint");
+			UpdateSetPointSensor((uint8_t)MsgID56, _status.DHW_setpoint, "DHW Setpoint");
 		}
 		_status.Max_CH_water_setpoint = static_cast<float>(atof(results[idx++].c_str()));
 		if (_status.Max_CH_water_setpoint != 0.0F)
 		{
-			UpdateSetPointSensor((uint8_t)idx - 1, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
+			UpdateSetPointSensor((uint8_t)MsgID57, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
 		}
 		if(m_bFirmware5)
 		{

--- a/hardware/OTGWBase.h
+++ b/hardware/OTGWBase.h
@@ -47,7 +47,6 @@ class OTGWBase : public CDomoticzHardwareBase
 	void SetSetpoint(int idx, float temp);
 	virtual bool WriteInt(const unsigned char *pData, unsigned char Len) = 0;
 	std::string m_Version;
-	bool m_bFirmware5;
 
       protected:
 	void SetModes(int Mode1, int Mode2, int Mode3, int Mode4, int Mode5, int Mode6);

--- a/hardware/OTGWBase.h
+++ b/hardware/OTGWBase.h
@@ -47,6 +47,7 @@ class OTGWBase : public CDomoticzHardwareBase
 	void SetSetpoint(int idx, float temp);
 	virtual bool WriteInt(const unsigned char *pData, unsigned char Len) = 0;
 	std::string m_Version;
+	bool m_bFirmware5;
 
       protected:
 	void SetModes(int Mode1, int Mode2, int Mode3, int Mode4, int Mode5, int Mode6);


### PR DESCRIPTION
This PR is make the existing OTGW code handle the modified PS=1 output line from the new v5 firmware.

The v5 firmware adds new fields and also changes the order of the fields (new fields are inserted not at the end, but in between at certain places).

This PR does not do anything yet with the 9 new fields (mostly about support for a 2nd zone and ventilation support, both things that most boilers do not support/have yet), it just makes sure that the existing values are handled correctly.

See this forum thread for more info:
https://www.domoticz.com/forum/viewtopic.php?f=6&t=35384

As I don't have an OTGW I couldn't test it myself so it has been tested by forum user **TheSpanishInq** who runs an OTGW with firmware version 5.

_NOTE: I don't think this PR should be merged right now, but first also tested by someone with an OTGW that runs an older firmware version to be sure that these older versions still work properly. Not something I can test either._