### PR TITLE
Tesla quick fix for authorisation: added support for manual API key

### DIFF
--- a/hardware/eVehicles/TeslaApi.h
+++ b/hardware/eVehicles/TeslaApi.h
@@ -52,6 +52,7 @@ private:
 	std::string m_username;
 	std::string m_password;
 	std::string m_VIN;
+	std::string m_apikey;
 
 	std::string m_authtoken;
 	std::string m_refreshtoken;

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1136,6 +1136,18 @@
 					</ul>
 				</td>
 			</tr>
+			<tr>
+				<td align="right" style="width:110px"><label for="apikey"><span data-i18n="Manual API key"></span>:</label></td>
+				<td><input type="text" id="apikey" style="width: 500px; padding: .2em;" class="text ui-widget-content ui-corner-all"</td>
+			</tr>
+			<tr>
+				<td></td>
+				<td>
+					When user name and password do not work (e.g. Tesla changed the login API) you can provide a manual API key here<br>
+					until it is fixed. There are various tools online available that can generate an API key.<br>
+					Note that an API key has limited validity (usually one month).
+				</td>
+			</tr>
 		</table>
 	</div>
 	<div id="divmercedes">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -1046,6 +1046,7 @@ define(['app'], function (app) {
 				var username = $("#hardwarecontent #divlogin #username").val();
 				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
 				var vinnr = $("#hardwarecontent #divtesla #vinnr").val();
+				var apikey = $("#hardwarecontent #divtesla #apikey").val();
 				var activeinterval = parseInt($("#hardwarecontent #divtesla #activeinterval").val());
 				if (activeinterval < 1) {
 					activeinterval = 1;
@@ -1055,6 +1056,10 @@ define(['app'], function (app) {
 					defaultinterval = 20;
 				}
 				var allowwakeup = $("#hardwarecontent #divtesla #comboallowwakeup").val();
+				var extra = vinnr;
+				if (apikey != "") {
+					extra = extra + "|" + btoa(apikey);
+				}
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -1064,7 +1069,7 @@ define(['app'], function (app) {
 					"&enabled=" + bEnabled +
 					"&idx=" + idx +
 					"&datatimeout=" + datatimeout +
-					"&extra=" + vinnr +
+					"&extra=" + extra +
 					"&Mode1=" + defaultinterval +
 					"&Mode2=" + activeinterval + 
 					"&Mode3=" + allowwakeup,
@@ -2511,6 +2516,7 @@ define(['app'], function (app) {
 				var username = $("#hardwarecontent #divlogin #username").val();
 				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
 				var vinnr = encodeURIComponent($("#hardwarecontent #divtesla #vinnr").val());
+				var apikey = $("#hardwarecontent #divtesla #apikey").val();
 				var activeinterval = parseInt($("#hardwarecontent #divtesla #activeinterval").val());
 				if (activeinterval < 1) {
 					activeinterval = 1;
@@ -2520,6 +2526,10 @@ define(['app'], function (app) {
 					defaultinterval = 20;
 				}
 				var allowwakeup = $("#hardwarecontent #divtesla #comboallowwakeup").val();
+				var extra = vinnr;
+				if (apikey != "") {
+					extra = extra + "|" + btoa(apikey);
+				}
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -2528,7 +2538,7 @@ define(['app'], function (app) {
 					"&name=" + encodeURIComponent(name) +
 					"&enabled=" + bEnabled +
 					"&datatimeout=" + datatimeout +
-					"&extra=" + vinnr +
+					"&extra=" + extra +
 					"&Mode1=" + defaultinterval +
 					"&Mode2=" + activeinterval +
 					"&Mode3=" + allowwakeup,
@@ -4134,7 +4144,14 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamsenecotoon #agreement").val(data["Mode1"]);
 						}
 						else if (data["Type"].indexOf("Tesla") >= 0) {
-							$("#hardwarecontent #hardwareparamstesla #vinnr").val(data["Extra"]);
+							var tmp = data["Extra"];
+							var tmparray = tmp.split("|");
+							if (tmparray.length >= 1) {
+								$("#hardwarecontent #hardwareparamstesla #vinnr").val(tmparray[0]);
+								if (tmparray.length >= 2) {
+									$("#hardwarecontent #hardwareparamstesla #apikey").val(atob(tmparray[1]));
+								}
+							}
 							$("#hardwarecontent #hardwareparamstesla #defaultinterval").val(data["Mode1"]);
 							$("#hardwarecontent #hardwareparamstesla #activeinterval").val(data["Mode2"]);
 							$("#hardwarecontent #hardwareparamstesla #comboallowwakeup").val(data["Mode3"]);


### PR DESCRIPTION
The tesla authorisation has changed, hence the tesla module does not work anymore.
Implementing the new authorisation procedure is going to take a while.
To allow users to keep using the tesla module for now, I have added the option to add a generated API key (instead of retrieving it via the authorisation procedure).

