### PR TITLE
fix some lambdas

### DIFF
--- a/hardware/ASyncSerial.cpp
+++ b/hardware/ASyncSerial.cpp
@@ -123,7 +123,7 @@ void AsyncSerial::open(const std::string& devname, unsigned int baud_rate,
 	// This gives some work to the io_service before it is started
 	pimpl->io.post([this] { return doRead(); });
 
-	boost::thread t([this] { pimpl->io.run(); });
+	boost::thread t([p = &pimpl->io] { p->run(); });
 	pimpl->backgroundThread.swap(t);
 	setErrorStatus(false); // If we get here, no error
 	pimpl->open = true;    // Port is now open
@@ -155,7 +155,7 @@ void AsyncSerial::openOnlyBaud(const std::string& devname, unsigned int baud_rat
 	//This gives some work to the io_service before it is started
 	pimpl->io.post([this] { return doRead(); });
 
-	boost::thread t([this] { pimpl->io.run(); });
+	boost::thread t([p = &pimpl->io] { p->run(); });
 	pimpl->backgroundThread.swap(t);
 	setErrorStatus(false);//If we get here, no error
 	pimpl->open=true; //Port is now open

--- a/hardware/ASyncTCP.cpp
+++ b/hardware/ASyncTCP.cpp
@@ -62,7 +62,7 @@ void ASyncTCP::connect(const std::string& ip, uint16_t port)
 	// RK: After the reset, we need to provide it work anew
 	mTcpwork = std::make_shared<boost::asio::io_service::work>(mIos);
 	if (!mTcpthread)
-		mTcpthread = std::make_shared<std::thread>([this] { mIos.run(); });
+		mTcpthread = std::make_shared<std::thread>([p = &mIos] { p->run(); });
 
 	mIp = ip;
 	mPort = port;

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -596,7 +596,7 @@ void CKodiNode::handleConnect()
 					m_CurrentStatus.Status(MSTAT_ON);
 					UpdateStatus();
 				}
-				m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this, self = shared_from_this()](auto err, auto bytes) { handleRead(err, bytes); });
+				m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [p = shared_from_this()](auto err, auto bytes) { p->handleRead(err, bytes); });
 				handleWrite(std::string(R"({"jsonrpc":"2.0","method":"System.GetProperties","params":{"properties":["canhibernate","cansuspend","canshutdown"]},"id":1007})"));
 			}
 			else
@@ -657,7 +657,7 @@ void CKodiNode::handleRead(const boost::system::error_code& e, std::size_t bytes
 		//ready for next read
 		if (!IsStopRequested(0) && m_Socket)
 		{
-			m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [this, self = shared_from_this()](auto &&err, auto &&bytes) { handleRead(err, bytes); });
+			m_Socket->async_read_some(boost::asio::buffer(m_Buffer, sizeof m_Buffer), [p = shared_from_this()](auto &&err, auto &&bytes) { p->handleRead(err, bytes); });
 		}
 	}
 	else
@@ -987,7 +987,7 @@ void CKodi::Do_Work()
 				// Note that this is the only thread that handles async i/o so we don't
 				// need to worry about locking or concurrency issues when processing messages
 				_log.Log(LOG_NORM, "Kodi: Restarting I/O service thread.");
-				boost::thread bt([this] { m_ios.run(); });
+				boost::thread bt([p = &m_ios] { p->run(); });
 				SetThreadName(bt.native_handle(), "KodiIO");
 			}
 		}
@@ -1161,7 +1161,7 @@ void CKodi::ReloadNodes()
 		}
 		sleep_milliseconds(100);
 		_log.Log(LOG_NORM, "Kodi: Starting I/O service thread.");
-		boost::thread bt([this] { m_ios.run(); });
+		boost::thread bt([p = &m_ios] { p->run(); });
 		SetThreadName(bt.native_handle(), "KodiIO");
 	}
 }

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -945,7 +945,7 @@ void XiaomiGateway::Do_Work()
 	XiaomiGateway::xiaomi_udp_server udp_server(io_service, m_HwdID, m_GatewayIp, m_LocalIp, m_ListenPort9898, m_OutputMessage, m_IncludeVoltage, this);
 	boost::thread bt;
 	if (m_ListenPort9898) {
-		bt = boost::thread([&io_service] { io_service.run(); });
+		bt = boost::thread([p = &io_service] { p->run(); });
 		SetThreadName(bt.native_handle(), "XiaomiGatewayIO");
 	}
 

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -213,7 +213,7 @@ namespace Plugins {
 			}
 
 			pTcpTransport->m_Socket->async_read_some(boost::asio::buffer(pTcpTransport->m_Buffer, sizeof pTcpTransport->m_Buffer),
-								 [this](const auto &err, auto bytes) { handleRead(err, bytes); });
+								 [pTcpTransport](auto &&err, auto bytes) { pTcpTransport->handleRead(err, bytes); });
 
 			// Requeue listener
 			if (m_Acceptor)

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -53,7 +53,7 @@ namespace http {
 		{
 			// associate handler to timer and schedule the first iteration
 			m_session_clean_timer.async_wait([this](auto &&) { CleanSessions(); });
-			m_io_service_thread = std::make_shared<std::thread>([this] { m_io_service.run(); });
+			m_io_service_thread = std::make_shared<std::thread>([p = &m_io_service] { p->run(); });
 			SetThreadName(m_io_service_thread->native_handle(), "Webem_ssncleaner");
 		}
 


### PR DESCRIPTION
modernize-avoid-bind requires C++14 to run. Unfortunately, manually
editing the lambdas to be compatible with C++11 was not a smart thing
to do. Specifically, it resulted in quite significant deviations from
the clang-tidy transformations.

Just in case, make the lambdas more similar to the ones generated by
clang-tidy.

Also fix bad lambda in tcpproxy_server.cpp . handle_downstream_write
was switched with the read variant somehow...

Signed-off-by: Rosen Penev <rosenp@gmail.com>