### PR TITLE
dzVents update to 3.1.5

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -6,6 +6,7 @@ Version 2020.xxxx (xxxx)
 - Implemented: Allow custom icons for thermostat setpoints on floorplan
 - Implemented: Allow custom icons for utility sensors
 - Implemented: Build systems for linux based on github actions
+- Implemented: Build system for docker
 - Implemented: Counter meter type now supports a divider
 - Implemented: Custom icons for RGB/W
 - Implemented: Hardware Monitor, Add clock speeds for Raspberry Pi
@@ -27,19 +28,22 @@ Version 2020.xxxx (xxxx)
 - Implemented: Websocket notification for secondary/sub devices
 - Implemented: ZWave, Legend and tooltips in Neighbor�s overview
 - Updated: Blebox; use of the latest SwitchBox API
-- Updated: dzVents; version 3.1.4 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting )
+- Updated: dzVents; version 3.1.5 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting )
 - Updated: eVehicles; added ODO meter, unlock/open alert, max charge level to Tesla module
+- Updated: eVehicles; added option to manual set API key
 - Updated: EvoHome; decode, display and store hotwater setpoint
 - Updated: Lay-out of notifications tab
 - Updated: MQTT; added option to choose notification subsystem
 - Updated: MQTT; added publish schemes: device index, device name and implemented custom topics for in- and outbound messages
 - Updated: OpenZWave; configuration files
 - Updated: Openweathermap; use latest API and overal improvements
+- Updated: OTGW; ready for firmware 5.0 and added domestic hot water flow rate
 - Updated: Plugwise; update of scene selector and added a migration process
 - Updated: SolarEdge; add support for 3 Phase inverter
 - Updated: Tado; add support for per-zone Open Window Detection
 - Updated: TTNMQTT; Better GPS/Locations handling, distance calculation (Geofencing)
 - Updated: TTNMQTT; Improved calculation and storage of signal-levels
+- Updated: Xiaomi; added new devicetypes
 - Changed: During a database backup we now 'sleep' when the status != OK
 - Changed: Differentiate kWh, kVah, kVar and kVarh
 - Changed: Energy devices allow negative values
@@ -55,11 +59,13 @@ Version 2020.xxxx (xxxx)
 - Fixed: Font in events editor on MacOS
 - Fixed: Motherboard Sensors for big partitions
 - Fixed: Possible crash in CEventSystem::SetEventTrigger
+- Fixed: Preserve custom icon and description when switching device from used -> unused -> used
 - Fixed: Prevent duplicate keys in preferences table
 - Fixed: Pushtype selection mechanism
 - Fixed: Sound device was incorrectly displayed on the Floorplan
 - Fixed: Tado Zone/Home limit, setpoint mix-up
 - Fixed: User field in device logging for switches, -text-devices and for groups/scenes
+- Fixed: Windows installation respects configured log parameters
 - Fixed: Zwave various issues
 - For a full overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits for details
 

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -256,16 +256,20 @@ A list of  one or more system triggers.
 `dailyBackupFinished`,
 `hourlyBackupFinished`,
 `monthlyBackupFinished`,
+`resetAllDevicestatus`, <sup>3.1.5</sup>
+`resetAllEvents`, <sup>3.1.5</sup>
 
  - The name of the system-event followed by a time constraint, such as:
 	`['start']  = { 'at 15:*', 'at 22:* on sat, sun' }` The script will be executed if domoticz is  started, **and** it is either between 15:00 and 16:00 or between 22:00 and 23:00 in the weekend. See [time trigger rules](#timer_trigger_rules).
 	-   **start**  - fired when Domoticz has started.
 	-   **stop**  - fired when Domoticz is shutting down. As you probably can imagine you have only a limited amount of time - also depending on the load on your system -  to have Domoticz do stuff when your script has been completed. Some commands will probably not be executed. Just give it a try.
 	-  **Backups** - the trigger item (2nd parameter of the execute function) is a table that holds information about the newly created backup (location,  duration in seconds and type).  You could use this information to copy the file to some other location or for another purpose.
-		-	**dailyBackupFinished**	- automatic backup when set in domoticz
-		-	**hourlyBackupFinished**	 -							  " "
+		-	**dailyBackupFinished**   - automatic backup when set in domoticz
+		-	**hourlyBackupFinished**  - " "
 		-	**monthlyBackupFinished** - " "
 		-	**manualBackupFinished**  - fired when you start a backup using the Domoticz GUI or via **< domoticz IP:domoticz port >**/backupdatabase.php
+		-	**resetAllDevicestatus**  <sup>3.1.5</sup>- fired when the name, description or used / unused state of a device, variable or scene is updated.
+		-	**resetAllEvents**        <sup>3.1.5</sup>- fired when a dzVents script in the internal editor changed.
 
 #### timer = { ... }
 A list of one ore more time 'rules' like `every minute` or `at 17:*`. See [*timer* trigger rules](#timer_trigger_rules). If any or the rules matches with the current time/date then your execute function is called. E.g.: `on = { timer = { 'between 30 minutes before sunset and 30 minutes after sunrise' } }`.
@@ -1004,8 +1008,8 @@ Note that if you do not find your specific device type here you can always inspe
  - **updateHistory( date, sValues )**: *Strings* <sup>3.1.3</sup> *function* Managed counter only! Used to write values to short or long term storage.
 ```Lua
 	local mCounter = domoticz.devices('device name')
-	mCounter.updateHistory('2021-01-22', 10;1777193') -- Write to long term storage (meter_calendar table)
-	mCounter.updateHistory('2021-01-22 10:05:02', 10;1777193') -- Write to short term storage (meter table)
+	mCounter.updateHistory('2021-01-22', '10;1777193') -- Write to long term storage (meter_calendar table)
+	mCounter.updateHistory('2021-01-22 10:05:02', '10;1777193') -- Write to short term storage (meter table)
 ```
  - **incrementCounter(value)**: *Function*. (counter incremental) Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29). To update with a complete new value you will have to do some calculation and take the counter divider into account.
 ```Lua
@@ -2258,9 +2262,8 @@ return {
  - **url**: *String*.
  - **method**: *String*. Optional. Either `'GET'` (default), `'POST'`, `'PUT'`<sup>3.0.2</sup>  or `'DELETE'`<sup>3.0.2</sup> .
  - **callback**: *String*. Optional. A custom string that will be used by dzVents to trigger the callback handler script(s).
- - **headers**: *Table*. Optional. A Lua table with additions http request-headers.
- - **postData**: Optional. When doing a `POST`, `PUT` <sup>3.0.2</sup> or `DELETE`<sup>3.0.2</sup> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header `application/json` is set. So no need to do that manually.
-
+ - **headers**: *Table / String*. Optional. A Lua table or JSON string with additional http request-headers.
+ - **postData**: *Table / String*. Optional. When doing a `POST`, `PUT` <sup>3.0.2</sup> or `DELETE`<sup>3.0.2</sup> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header `application/json` is set. So no need to do that manually.
 Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 ### The response object
@@ -2602,6 +2605,11 @@ _.print(_.indexOf({2, 3, 'x', 4}, 'x'))
 Check out the documentation [here](https://htmlpreview.github.io/?https://github.com/rwaaren/lodash.lua/blob/master/doc/index.html).
 
 # History [link to changes in previous versions](https://www.domoticz.com/wiki/DzVents_version_History).
+
+## [3.1.5] ##
+- Add two new system-events triggers as option to the on = { ... } section. Scripts can now also be triggered based on these system-events:
+	 - resetAllDevicestatus ; when the name, description or used / unused state of a device, variable or scene changes
+	 - resetAllEvents ; When a dzVents script in the internal editor changed
 
 ## [3.1.4] ##
 - Fixed issue that prevented dzVents from accessing the domoticz API when using -wwwbind

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -244,7 +244,7 @@ If the security state in Domoticz changes and it matches with any of the states 
 
 A list of one or more system triggers.
 
-* <code>stop</code>, <code>start</code>, <code>manualBackupFinished</code>, <code>dailyBackupFinished</code>, <code>hourlyBackupFinished</code>, <code>monthlyBackupFinished</code>,
+* <code>stop</code>, <code>start</code>, <code>manualBackupFinished</code>, <code>dailyBackupFinished</code>, <code>hourlyBackupFinished</code>, <code>monthlyBackupFinished</code>, <code>resetAllDevicestatus</code>, <sup>3.1.5</sup> <code>resetAllEvents</code>, <sup>3.1.5</sup>
 * The name of the system-event followed by a time constraint, such as: <code>['start']  = { 'at 15:*', 'at 22:* on sat, sun' }</code> The script will be executed if domoticz is started, '''and''' it is either between 15:00 and 16:00 or between 22:00 and 23:00 in the weekend. See [[#timer_trigger_rules|time trigger rules]].
 ** '''start''' - fired when Domoticz has started.
 ** '''stop''' - fired when Domoticz is shutting down. As you probably can imagine you have only a limited amount of time - also depending on the load on your system - to have Domoticz do stuff when your script has been completed. Some commands will probably not be executed. Just give it a try.
@@ -253,6 +253,8 @@ A list of one or more system triggers.
 *** '''hourlyBackupFinished''' - &quot; &quot;
 *** '''monthlyBackupFinished''' - &quot; &quot;
 *** '''manualBackupFinished''' - fired when you start a backup using the Domoticz GUI or via '''&lt; domoticz IP:domoticz port &gt;'''/backupdatabase.php
+*** '''resetAllDevicestatus''' <sup>3.1.5</sup>- fired when the name, description or used / unused state of a device, variable or scene is updated.
+*** '''resetAllEvents''' <sup>3.1.5</sup>- fired when a dzVents script in the internal editor changed.
 
 ==== timer = { … } ====
 
@@ -953,8 +955,8 @@ Note that if you do not find your specific device type here you can always inspe
 * '''updateHistory( date, sValues )''': ''Strings'' <sup>3.1.3</sup> ''function'' Managed counter only! Used to write values to short or long term storage.
 
 <source lang="lua">    local mCounter = domoticz.devices('device name')
-    mCounter.updateHistory('2021-01-22', 10;1777193') -- Write to long term storage (meter_calendar table)
-    mCounter.updateHistory('2021-01-22 10:05:02', 10;1777193') -- Write to short term storage (meter table)</source>
+    mCounter.updateHistory('2021-01-22', '10;1777193') -- Write to long term storage (meter_calendar table)
+    mCounter.updateHistory('2021-01-22 10:05:02', '10;1777193') -- Write to short term storage (meter table)</source>
 * '''incrementCounter(value)''': ''Function''. (counter incremental) Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]]. To update with a complete new value you will have to do some calculation and take the counter divider into account.
 
 <source lang="lua">    local newValue = value
@@ -2195,10 +2197,8 @@ Of course you can combine the script that issues the request and handles the res
 * '''url''': ''String''.
 * '''method''': ''String''. Optional. Either <code>'GET'</code> (default), <code>'POST'</code>, <code>'PUT'</code><sup>3.0.2</sup> or <code>'DELETE'</code><sup>3.0.2</sup> .
 * '''callback''': ''String''. Optional. A custom string that will be used by dzVents to trigger the callback handler script(s).
-* '''headers''': ''Table''. Optional. A Lua table with additions http request-headers.
-* '''postData''': Optional. When doing a <code>POST</code>, <code>PUT</code> <sup>3.0.2</sup> or <code>DELETE</code><sup>3.0.2</sup> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header <code>application/json</code> is set. So no need to do that manually.
-
-Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''headers''': ''Table / String''. Optional. A Lua table or JSON string with additional http request-headers.
+* '''postData''': ''Table / String''. Optional. When doing a <code>POST</code>, <code>PUT</code> <sup>3.0.2</sup> or <code>DELETE</code><sup>3.0.2</sup> this data will be the payload of the request (body). If you provide a Lua table then this will automatically be converted to json and the request-header <code>application/json</code> is set. So no need to do that manually. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 === The response object ===
 
@@ -2525,6 +2525,12 @@ _.print(_.indexOf({2, 3, 'x', 4}, 'x'))</source>
 Check out the documentation [https://htmlpreview.github.io/?https://github.com/rwaaren/lodash.lua/blob/master/doc/index.html here].
 
 = History [https://www.domoticz.com/wiki/DzVents_version_History link to changes in previous versions]. =
+
+== [3.1.5] ==
+
+* Add two new system-events triggers as option to the on = { … } section. Scripts can now also be triggered based on these system-events:
+** resetAllDevicestatus ; when the name, description or used / unused state of a device, variable or scene changes
+** resetAllEvents ; When a dzVents script in the internal editor changed
 
 == [3.1.4] ==
 

--- a/dzVents/documentation/history.md
+++ b/dzVents/documentation/history.md
@@ -1,6 +1,12 @@
 ```{=mediawiki}
 __NOTOC__
 ```
+
+## [3.1.5] ##
+- Add two new wsystem-events triggers as option to the on = { ... } section. Scripts can now also be triggered based on these system-events:
+	 - resetAllDevicestatus ; when the name, description or used / unused state of a device, variable or scene changes 
+	 - resetAllEvents ; When a dzVents script in the internal editor changed 
+
 ## [3.1.4] ##
 - Fixed issue that prevented dzVents from accessing the domoticz API when using -wwwbind
 

--- a/dzVents/documentation/history.wiki
+++ b/dzVents/documentation/history.wiki
@@ -1,4 +1,10 @@
 __NOTOC__
+== [3.1.5] ==
+
+* Add two new wsystem-events triggers as option to the on = { … } section. Scripts can now also be triggered based on these system-events:
+** resetAllDevicestatus ; when the name, description or used / unused state of a device, variable or scene changes
+** resetAllEvents ; When a dzVents script in the internal editor changed
+
 == [3.1.4] ==
 
 * Fixed issue that prevented dzVents from accessing the domoticz API when using -wwwbind

--- a/dzVents/runtime/CustomEvent.lua
+++ b/dzVents/runtime/CustomEvent.lua
@@ -46,7 +46,7 @@ local function CustomEvent(domoticz, eventData)
 	evenItemIdentifier.setType(
 		self,
 		'isCustomEvent',
-		domoticz.BASE_TYPE_CUSTOM_EVENT,
+		domoticz.BASETYPE_CUSTOM_EVENT,
 		self.trigger
 	)
 

--- a/dzVents/runtime/SystemEvent.lua
+++ b/dzVents/runtime/SystemEvent.lua
@@ -7,12 +7,14 @@ local eventMapping = {
 	backupDoneHour = 'hourlyBackupFinished',
 	backupDoneMonth = 'monthlyBackupFinished',
 	start = 'start',
-	stop = 'stop'
+	stop = 'stop',
+	resetAllEvents = 'resetAllEvents',
+	resetAllDeviceStatus = 'resetAllDeviceStatus',
 }
 
 local function SystemEvent(domoticz, eventData)
 
-	-- eventData: {["message"]="", ["status"]="info", ["baseType"]="system", ["type"]="domoticzStart"}
+	-- eventData: {["message"]="", ["status"]="info", ["type"]="domoticzStart"}
 
 	local self = {}
 
@@ -30,7 +32,7 @@ local function SystemEvent(domoticz, eventData)
 	evenItemIdentifier.setType(
 		self,
 		'isSystemEvent',
-		domoticz.BASE_TYPE_SYSTEM_EVENT,
+		domoticz.BASETYPE_SYSTEM_EVENT,
 		eventMapping[eventData.type]
 	)
 

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -8,7 +8,7 @@ local self = {
 	LOG_INFO = 3,
 	LOG_WARNING = 3,
 	LOG_DEBUG = 4,
-	DZVERSION = '3.1.4',
+	DZVERSION = '3.1.5',
 }
 
 function jsonParser:unsupportedTypeEncoder(value_of_unsupported_type)

--- a/dzVents/runtime/eventItemIdentifier.lua
+++ b/dzVents/runtime/eventItemIdentifier.lua
@@ -12,7 +12,7 @@ return {
 		item.isSecurity = false
 		item.isSystem = false
 		item.isHardware = false
-	        item.isCustomEvent = false
+		item.isCustomEvent = false
 
 		item[typeName] = true
 

--- a/dzVents/runtime/integration-tests/scriptSelectorSwitch.lua
+++ b/dzVents/runtime/integration-tests/scriptSelectorSwitch.lua
@@ -1,44 +1,44 @@
-return {
-	active = true,
-	on = {
-		devices = {
+return
+{
+
+	on =
+	{
+		devices =
+		{
 			'vdSelectorSwitch',
 			'vdScriptStart',
 			'vdScriptEnd',
 		},
 	},
-	data = {
+	data =
+	{
 		switchStates = {initial = ''},
 	},
+
+	logging =
+	{
+		level = domoticz.LOG_DEBUG,
+		marker = 'Selector test',
+	},
+
 	execute = function(dz, item)
 
 		local switch = dz.devices('vdSelectorSwitch')
+		dz.log(item.name .. ' ==>> Selector state: ' .. item.state .. ' ==>> level: ' .. item.level .. ' ==>> date: ' .. dz.data.switchStates, dz.LOG_DEBUG )
 
-		if (item.name == 'vdScriptStart') then
-			switch.switchSelector(30).forSec(2)
-			dz.devices('vdScriptEnd').switchOn().afterSec(4)
-		end
-
-
-		if (item.name == 'vdScriptEnd') then
-			print(dz.data.switchStates)
-			print('----')
-
-			local ok = true
-
-			if (dz.data.switchStates ~= '3010') then
-				print('Error: ' .. dz.data.switchStates .. ' should be 3010')
-				ok = false
-			end
-
-			if ok then
+		if item.name == 'vdScriptStart' then
+			switch.switchSelector(10)
+			switch.switchSelector(30).afterSec(1).forSec(1)
+			dz.devices('vdScriptEnd').switchOn().afterSec(3)
+		elseif item.name == 'vdScriptEnd' then
+			if dz.data.switchStates ~= '103010' then
+				dz.log('Error: ' .. dz.data.switchStates .. ' should be 103010', dz.LOG_DEBUG)
+			else
 				dz.devices('vdScriptOK').switchOn()
 			end
-
-		end
-
-		if (item.name == 'vdSelectorSwitch') then
+		elseif item == switch then
 			dz.data.switchStates = dz.data.switchStates  .. item.level
+			dz.log(item.name .. ' ==>> Selector state: ' .. item.state .. ' ==>> level: ' .. item.level .. ' ==>> date: ' .. dz.data.switchStates , dz.LOG_DEBUG )
 		end
 
 	end

--- a/dzVents/runtime/integration-tests/scriptTestCustomAndSystemEventsScript.lua
+++ b/dzVents/runtime/integration-tests/scriptTestCustomAndSystemEventsScript.lua
@@ -2,7 +2,7 @@ return
 {
 	on =
 	{
-		system = { 'manualBackupFinished', 'st*' },
+		system = { 'manualBackupFinished', 'st*', 'reset*' },
 		customEvents = { [ 'myEvents*' ] = { 'at 04:00-03:45'} },
 		shellCommandResponses = { '*' },
 	},

--- a/dzVents/runtime/integration-tests/testSystemAndCustomEvents.lua
+++ b/dzVents/runtime/integration-tests/testSystemAndCustomEvents.lua
@@ -49,6 +49,13 @@ describe('System events', function()
 			assert.is_true( os.execute('cat ' .. dumpfile .. ' |  grep "type: stop"  > /dev/null' ))
 		end)
 
+		it('should log resetAllEvents ', function()
+			assert.is_true(os.execute('cat ' .. dumpfile .. ' |  grep "type: resetAllEvents"  > /dev/null ' ))
+		end)
+
+		it('should log resetAllDevicestatues ', function()
+			assert.is_true(os.execute('cat ' .. dumpfile .. ' |  grep "type: resetAllDevice"   > /dev/null ' ))
+		end)
 	end)
 
 end)

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -289,6 +289,7 @@ void CEventSystem::LoadEvents()
 			}
 		}
 	}
+	m_mainworker.m_notificationsystem.Notify(Notification::DZ_ALLEVENTRESET, Notification::STATUS_INFO);
 #ifdef _DEBUG
 	_log.Log(LOG_STATUS, "EventSystem: Events (re)loaded");
 #endif
@@ -512,6 +513,7 @@ void CEventSystem::GetCurrentStates()
 		}
 		m_devicestates = m_devicestates_temp;
 	}
+	m_mainworker.m_notificationsystem.Notify(Notification::DZ_ALLDEVICESTATUSRESET, Notification::STATUS_INFO);
 }
 
 void CEventSystem::GetCurrentUserVariables()
@@ -545,7 +547,7 @@ void CEventSystem::GetCurrentScenesGroups()
 	m_scenesgroups.clear();
 
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT ID, Name, nValue, SceneType, LastUpdate, Protected FROM Scenes");
+	result = m_sql.safe_query("SELECT ID, Name, nValue, SceneType, LastUpdate, Protected, Description FROM Scenes");
 	if (!result.empty())
 	{
 		for (const auto &sd : result)
@@ -566,6 +568,7 @@ void CEventSystem::GetCurrentScenesGroups()
 			sgitem.scenesgroupType = atoi(sd[3].c_str());
 			sgitem.lastUpdate = sd[4];
 			sgitem.protection = atoi(sd[5].c_str());
+			sgitem.description = sd[6];
 			result2 = m_sql.safe_query("SELECT DISTINCT A.DeviceRowID FROM SceneDevices AS A, DeviceStatus AS B WHERE (A.SceneRowID == %" PRIu64 ") AND (A.DeviceRowID == B.ID)", sgitem.ID);
 			if (!result2.empty())
 			{
@@ -1492,6 +1495,7 @@ void CEventSystem::ProcessDevice(
 		item.devname = devname;
 		item.nValue = nValue;
 		item.sValue = osValue;
+
 		item.nValueWording = UpdateSingleState(ulDevID, devname, nValue, osValue, devType, subType, switchType, "", 255, batterylevel, options);
 		boost::unique_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 		auto itt = m_devicestates.find(ulDevID);

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -42,14 +42,14 @@ class CEventSystem : public CLuaCommon, StoppableTask, CNotificationObserver
 public:
 	enum _eReason
 	{
-		REASON_DEVICE,			// 0
-		REASON_SCENEGROUP,		// 1
-		REASON_USERVARIABLE,		// 2
-		REASON_TIME,			// 3
-		REASON_SECURITY,		// 4
-		REASON_URL,			// 5
-		REASON_NOTIFICATION,		// 6
-		REASON_SHELLCOMMAND		// 7
+		REASON_DEVICE,       // 0
+		REASON_SCENEGROUP,   // 1
+		REASON_USERVARIABLE, // 2
+		REASON_TIME,         // 3
+		REASON_SECURITY,     // 4
+		REASON_URL,          // 5
+		REASON_NOTIFICATION, // 6
+		REASON_SHELLCOMMAND  // 7
 	};
 
 	struct _tDeviceStatus
@@ -100,6 +100,7 @@ public:
 		int scenesgroupType;
 		int protection;
 		std::string lastUpdate;
+		std::string description;
 		std::vector<uint64_t> memberID;
 	};
 

--- a/main/NotificationObserver.h
+++ b/main/NotificationObserver.h
@@ -5,15 +5,17 @@ class CNotificationObserver
 public:
 	enum _eType : uint16_t
 	{
-		DZ_START,        // 0
-		DZ_STOP,         // 1
-		DZ_BACKUP_DONE,  // 2
-		DZ_NOTIFICATION, // 3
-		HW_TIMEOUT,      // 4
-		HW_START,        // 5
-		HW_STOP,         // 6
-		HW_THREAD_ENDED, // 7
-		DZ_CUSTOM        // 8
+		DZ_START,               // 0
+		DZ_STOP,                // 1
+		DZ_BACKUP_DONE,         // 2
+		DZ_NOTIFICATION,        // 3
+		HW_TIMEOUT,             // 4
+		HW_START,               // 5
+		HW_STOP,                // 6
+		HW_THREAD_ENDED,        // 7
+		DZ_CUSTOM,              // 8
+		DZ_ALLEVENTRESET,       // 9
+		DZ_ALLDEVICESTATUSRESET // 10
 	};
 
 	enum _eStatus : uint8_t

--- a/main/NotificationSystem.cpp
+++ b/main/NotificationSystem.cpp
@@ -8,15 +8,17 @@
 
 const CNotificationSystem::_tNotificationTypeTable CNotificationSystem::typeTable[] =
 { // don't change order
-	{ Notification::DZ_START,        "start"           },
-	{ Notification::DZ_STOP,         "stop"            },
-	{ Notification::DZ_BACKUP_DONE,  "backupDone"	   },
-	{ Notification::DZ_NOTIFICATION, "notification"    },
-	{ Notification::HW_TIMEOUT,      "hardwareTimeout" },
-	{ Notification::HW_START,        "hardwareStart"   },
-	{ Notification::HW_STOP,         "hardwareStop"    },
-	{ Notification::HW_THREAD_ENDED, "threadEnded"     },
-	{ Notification::DZ_CUSTOM,       "customEvent"     },
+	{ Notification::DZ_START,                "start"                },
+	{ Notification::DZ_STOP,                 "stop"                 },
+	{ Notification::DZ_BACKUP_DONE,          "backupDone"           },
+	{ Notification::DZ_NOTIFICATION,         "notification"         },
+	{ Notification::HW_TIMEOUT,              "hardwareTimeout"      },
+	{ Notification::HW_START,                "hardwareStart"        },
+	{ Notification::HW_STOP,                 "hardwareStop"         },
+	{ Notification::HW_THREAD_ENDED,         "threadEnded"          },
+	{ Notification::DZ_CUSTOM,               "customEvent"          },
+	{ Notification::DZ_ALLEVENTRESET,        "resetAllEvents"       },
+	{ Notification::DZ_ALLDEVICESTATUSRESET, "resetAllDeviceStatus" },
 };
 
 const CNotificationSystem::_tNotificationStatusTable CNotificationSystem::statusTable[] =

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -30,7 +30,7 @@ extern http::server::ssl_server_settings secure_webserver_settings;
 CdzVents CdzVents::m_dzvents;
 
 CdzVents::CdzVents()
-	: m_version("3.1.4")
+	: m_version("3.1.5")
 {
 	m_bdzVentsExist = false;
 }
@@ -147,7 +147,9 @@ void CdzVents::ProcessNotification(lua_State* lua_state, const std::vector<CEven
 				case Notification::DZ_STOP:
 				case Notification::DZ_BACKUP_DONE:
 				case Notification::DZ_NOTIFICATION:
-					ProcessNotificationItem(luaTable, index, item);
+				case Notification::DZ_ALLDEVICESTATUSRESET:
+				case Notification::DZ_ALLEVENTRESET:
+				ProcessNotificationItem(luaTable, index, item);
 					break;
 				case Notification::DZ_CUSTOM:
 					bCustomEvent = true;
@@ -959,7 +961,6 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 	devicestatesMutexLock.unlock();
 
 	// Now do the scenes and groups.
-	const char *description = "";
 	boost::shared_lock<boost::shared_mutex> scenesgroupsMutexLock(m_mainworker.m_eventsystem.m_scenesgroupsMutex);
 
 	std::vector<std::vector<std::string> > result;
@@ -978,17 +979,11 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 			}
 		}
 
-		result = m_sql.safe_query("SELECT Description FROM Scenes WHERE (ID=='%d')", sgitem.ID);
-		if (result.empty())
-			description = "";
-		else
-			description = result[0][0].c_str();
-
 		luaTable.OpenSubTableEntry(index, 1, 7);
 
 		luaTable.AddString("name", sgitem.scenesgroupName);
 		luaTable.AddInteger("id", sgitem.ID);
-		luaTable.AddString("description", description);
+		luaTable.AddString("description", sgitem.description);
 		luaTable.AddString("baseType", (sgitem.scenesgroupType == 0) ? "scene" : "group");
 		luaTable.AddBool("protected", (lua_Number)sgitem.protection == 1);
 		luaTable.AddString("lastUpdate", sgitem.lastUpdate);


### PR DESCRIPTION


```
======== domoticz V2020.2 (12947), dzVents V3.1.5 +========================== Tests ==============================+
  time  | test-script                              | expected | tests | result  | successful |  failed  | seconds  |
===================================================+===============================================================+
00:00:02  Device                                        1        119      OK            119         0      0.2916
00:00:02  Domoticz                                      1         85      OK             85         0      0.3223
00:00:03  EventHelpers                                  1         34      OK             34         0      0.1935
00:00:03  EventHelpersStorage                           1         50      OK             50         0      0.2280
00:00:03  HTTPResponse                                  1          6      OK              6         0      0.0145
00:00:03  Lodash                                        1        100      OK            100         0      0.1541
00:00:04  ScriptdzVentsDispatching                      1          2      OK              2         0      0.0655
00:00:04  TimedCommand                                  1         46      OK             46         0      0.1042
00:00:04  Time                                          3        369      OK            369         0      0.7513
00:00:05  Utils                                         1         36      OK             36         0      0.0668
00:00:05  Variable                                      1         15      OK             15         0      0.0310
00:00:05  ContactDoorLockInvertedSwitch                 3          2      OK              2         0      3.0616
00:00:08  DelayedVariableScene                          8          2      OK              2         0      7.0625
00:00:15  EventState                                   19          2      OK              2         0     18.0740
00:00:33  Integration                                  34        222      OK            222         0     28.6318
00:01:02  SelectorSwitch                               10          2      OK              2         0      9.1850
00:01:20  SystemAndCustomEvents                         1          9      OK              9         0      0.0386


Total tests: 1101
Fri 12 Feb 2021 04:44:41 PM CET; dzVents version 3.1.5 tested without errors after 00:01:20
```

- Add two new system-events triggers as option to the on = { ... } section. Scripts can now also be triggered based on these system-events:
	 - resetAllDevicestatus ; when the name, description or used / unused state of a device, variable or scene changes 
	 - resetAllEvents ; When a dzVents script in the internal editor changed 


with thx to MrHobbes74 for the notification framework