### PR TITLE
Preserve whitespace for help texts

### DIFF
--- a/www/app/hardware/setup/ZWave.js
+++ b/www/app/hardware/setup/ZWave.js
@@ -845,6 +845,16 @@ define(['app'], function (app) {
 			});
 		};
 
+		HtmlFormatString = function(s) {
+			s = s.trim();
+			s = s.replace(/'\r/g, '');
+			s = s.replace(/\. *\n[ \t]*([^0-9 \t•\*-])/g, '. $1');
+			s = s.replace(/\n[\t ]+([0-9•\*-][^\n]*)/g, '<div>$1</div>');
+			s = s.replace(/<\/div>\n/g, '</div>');
+			s = s.replace(/\n/g, '<br/>');
+			return s;
+		}
+
 		RefreshOpenZWaveNodeTable = function () {
 			$('#modal').show();
 
@@ -1041,8 +1051,8 @@ define(['app'], function (app) {
 									szConfig += " (" + $.t("actual") + ": " + item.value + ")";
 								}
 								szConfig += "<br /><br />";
-								if (item.help !== "") {
-									szConfig += '<span class="zwave_help">' + item.help + '</span><br>';
+								if (item.help.trim() !== "") {
+									szConfig += '<span class="zwave_help">' + HtmlFormatString(item.help) + '</span><br>';
 								}
 /*								
 								if (item.LastUpdate.length > 1) {

--- a/www/css/legacy.css
+++ b/www/css/legacy.css
@@ -1025,6 +1025,9 @@ div.item.statusEvoSetPointMin td#name{
 	font-style: normal;
 	color: #bbd;
 }
+.zwave_help div {
+	padding-left: 2em;
+}
 .zwave_last_update {
 	font-style: italic;
 	font-size: smaller;


### PR DESCRIPTION
Since OpenZWave/open-zwave@29f59e0f68b74b926e20c6e853e1b35a2cf857fc has been merged, the Z-Wave XML database contains whitespace formatting. This PR formats this whitespace such that Z-Wave hardware device help text are much more readable.

Example, before:
```
This parameter allows to enable different additional functions of the device. 1) Enable open window 
detector (normal) 2) Enable open window detector (rapid) 4) Increase receiver sensitivity (shortens 
battery life) 8) Enable LED indications when controlling remotely 16) Protect from setting Full ON and 
Full OFF mode by turning the knob manually 32) Device mounted in vertical position (firmware 4.7+) 64) 
Moderate regulator behaviour (instead of rapid, firmware 4.7+)) 128) Inverted knob operation (firmware 
4.7+) 256) Heating medium demand reports (firmware 4.7+) 512) Detecting heating system failures 
(firmware 4.7+) NOTE: Parameter values may be combined, e.g. 1+8=9 means than open window detector 
and LED indications when controlling remotely are enabled.
```

After:
```
This parameter allows to enable different additional functions of the device.
    1) Enable open window detector (normal)
    2) Enable open window detector (rapid)
    4) Increase receiver sensitivity (shortens battery life)
    8) Enable LED indications when controlling remotely
    16) Protect from setting Full ON and Full OFF mode by turning the knob manually
    32) Device mounted in vertical position (firmware 4.7+)
    64) Moderate regulator behaviour (instead of rapid, firmware 4.7+))
    128) Inverted knob operation (firmware 4.7+)
    256) Heating medium demand reports (firmware 4.7+)
    512) Detecting heating system failures (firmware 4.7+)
NOTE: Parameter values may be combined, e.g. 1+8=9 means than open window detector and LED indications when controlling remotely are enabled.
```