### PR TITLE
Fix for #4643 Timeplan duplication copies none existing Hue field

### DIFF
--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -2252,11 +2252,11 @@ namespace http {
 				std::string nID = result[0][0];
 
 				//Normal Timers
-				result = m_sql.safe_query("SELECT Active, DeviceRowID, Time, Type, Cmd, Level, Days, UseRandomness, Hue, [Date], MDay, Month, Occurence, Color FROM Timers WHERE (TimerPlan==%q) ORDER BY ID", idx.c_str());
+				result = m_sql.safe_query("SELECT Active, DeviceRowID, Time, Type, Cmd, Level, Days, UseRandomness, [Date], MDay, Month, Occurence, Color FROM Timers WHERE (TimerPlan==%q) ORDER BY ID", idx.c_str());
 				for (const auto &sd : result)
 				{
 					m_sql.safe_query(
-						"INSERT INTO Timers (Active, DeviceRowID, Time, Type, Cmd, Level, Days, UseRandomness, Hue, [Date], MDay, Month, Occurence, Color, TimerPlan) VALUES (%q, %q, '%q', %q, %q, %q, %q, %q, %q, '%q', %q, %q, %q, '%q', %q)",
+						"INSERT INTO Timers (Active, DeviceRowID, Time, Type, Cmd, Level, Days, UseRandomness, [Date], MDay, Month, Occurence, Color, TimerPlan) VALUES (%q, %q, '%q', %q, %q, %q, %q, %q, '%q', %q, %q, %q, '%q', %q)",
 						sd[0].c_str(),
 						sd[1].c_str(),
 						sd[2].c_str(),
@@ -2270,16 +2270,15 @@ namespace http {
 						sd[10].c_str(),
 						sd[11].c_str(),
 						sd[12].c_str(),
-						sd[13].c_str(),
 						nID.c_str()
 					);
 				}
 				//Scene Timers
-				result = m_sql.safe_query("SELECT Active, SceneRowID, Time, Type, Cmd, Level, Days, UseRandomness, Hue, [Date], Month, MDay, Occurence FROM SceneTimers WHERE (TimerPlan==%q) ORDER BY ID", idx.c_str());
+				result = m_sql.safe_query("SELECT Active, SceneRowID, Time, Type, Cmd, Level, Days, UseRandomness, [Date], Month, MDay, Occurence FROM SceneTimers WHERE (TimerPlan==%q) ORDER BY ID", idx.c_str());
 				for (const auto &sd : result)
 				{
 					m_sql.safe_query(
-						"INSERT INTO SceneTimers (Active, SceneRowID, Time, Type, Cmd, Level, Days, UseRandomness, Hue, [Date], Month, MDay, Occurence, TimerPlan) VALUES (%q, %q, '%q', %q, %q, %q, %q, %q, %q, '%q', %q, %q, %q, %q)",
+						"INSERT INTO SceneTimers (Active, SceneRowID, Time, Type, Cmd, Level, Days, UseRandomness, [Date], Month, MDay, Occurence, TimerPlan) VALUES (%q, %q, '%q', %q, %q, %q, %q, %q, '%q', %q, %q, %q, %q)",
 						sd[0].c_str(),
 						sd[1].c_str(),
 						sd[2].c_str(),


### PR DESCRIPTION
Hue field was transferred to Color in database version 124 but left
behind in Scheduler.cpp code.
Because field stil exists in databases where it was created once, the
issue only surface on installations with new or recently created
databases.