### PR TITLE
Add API/JSON to delete shortlog and or calendarlog on a per idx base

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,7 @@
 Version 2020.xxxx (xxxx)
 - Implemented: Added option to set loglevel per hardware device
 - Implemented: Added optional parameter 'level' to addlogmessage JSON
+- Implemented: Added possibility to delete history on a per device base (API)
 - Implemented: AirconWithMe wifi module
 - Implemented: Allow complete IPv6 address in local network setting
 - Implemented: Allow custom icons for thermostat setpoints on floorplan
@@ -32,6 +33,7 @@ Version 2020.xxxx (xxxx)
 - Updated: eVehicles; added ODO meter, unlock/open alert, max charge level to Tesla module
 - Updated: eVehicles; added option to manual set API key
 - Updated: EvoHome; decode, display and store hotwater setpoint
+- Updated: EvoHome; Add support for day-off
 - Updated: Lay-out of notifications tab
 - Updated: MQTT; added option to choose notification subsystem
 - Updated: MQTT; added publish schemes: device index, device name and implemented custom topics for in- and outbound messages
@@ -64,6 +66,7 @@ Version 2020.xxxx (xxxx)
 - Fixed: Pushtype selection mechanism
 - Fixed: Sound device was incorrectly displayed on the Floorplan
 - Fixed: Tado Zone/Home limit, setpoint mix-up
+- Fixed: Timeplan duplication
 - Fixed: User field in device logging for switches, -text-devices and for groups/scenes
 - Fixed: Windows installation respects configured log parameters
 - Fixed: Zwave various issues

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7810,6 +7810,37 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 	}
 }
 
+void CSQLHelper::DeleteHistory(const char* ID, const std::string& HistoryType)
+{
+	std::vector<std::vector<std::string> > result;
+	result = safe_query("SELECT Name FROM DeviceStatus WHERE (ID==%q)", ID);
+	if (result.empty())
+		return false;
+
+	if (HistoryType == "calendarlog" )
+	{
+		safe_query("DELETE FROM Rain_Calendar WHERE (DeviceRowID=='%q')", ID );
+		safe_query("DELETE FROM Wind_Calendar WHERE (DeviceRowID=='%q') ", ID );
+		safe_query("DELETE FROM UV_Calendar WHERE (DeviceRowID=='%q') ", ID );
+		safe_query("DELETE FROM Temperature_Calendar WHERE (DeviceRowID=='%q') ", ID);
+		safe_query("DELETE FROM Meter_Calendar WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM MultiMeter_Calendar WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM Percentage_Calendar WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM Fan_Calendar WHERE (DeviceRowID=='%q')", ID);
+	}
+	else if (HistoryType == "shortlog")
+	{
+		safe_query("DELETE FROM Rain WHERE (DeviceRowID=='%q')", ID );
+		safe_query("DELETE FROM Wind WHERE (DeviceRowID=='%q') ", ID );
+		safe_query("DELETE FROM UV WHERE (DeviceRowID=='%q') ", ID );
+		safe_query("DELETE FROM Temperature WHERE (DeviceRowID=='%q') ", ID);
+		safe_query("DELETE FROM Meter WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM MultiMeter WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM Percentage WHERE (DeviceRowID=='%q')", ID);
+		safe_query("DELETE FROM Fan WHERE (DeviceRowID=='%q')", ID);
+	}
+}
+
 void CSQLHelper::DeleteDataPoint(const char* ID, const std::string& Date)
 {
 	std::vector<std::vector<std::string> > result;

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7815,7 +7815,7 @@ void CSQLHelper::DeleteHistory(const char* ID, const std::string& HistoryType)
 	std::vector<std::vector<std::string> > result;
 	result = safe_query("SELECT Name FROM DeviceStatus WHERE (ID==%q)", ID);
 	if (result.empty())
-		return false;
+		return;
 
 	if (HistoryType == "calendarlog" )
 	{

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -363,6 +363,7 @@ class CSQLHelper : public StoppableTask
 	void GetMeterType(int HardwareID, const char *ID, unsigned char unit, unsigned char devType, unsigned char subType, int &meterType);
 
 	void DeleteDataPoint(const char *ID, const std::string &Date);
+	void DeleteHistory(const char *ID, const std::string &HistoryType);
 
 	void UpdateRFXCOMHardwareDetails(int HardwareID, int msg1, int msg2, int msg3, int msg4, int msg5, int msg6);
 

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -194,6 +194,7 @@ private:
 	void Cmd_DownloadUpdate(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_DownloadReady(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_DeleteDatePoint(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteHistory(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SetActiveTimerPlan(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_AddTimer(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateTimer(WebEmSession & session, const request& req, Json::Value &root);


### PR DESCRIPTION

detailed history for some devices might be interresting while for other devices it will never be looked at
this API call provides the option to selectively delete the shortlog and/or calendarlog of a device without the need
to use external tools.
Like it is already available for switchtype devices and text sensors.

/json.htm?idx=<idx>&type=command&param=deletehistory&historytype=calenderlog
/json.htm?idx=<idx>&type=command&param=deletehistory&historytype=shortlog