### PR TITLE
Query the OT Bridge parameters

### DIFF
--- a/hardware/EvohomeBase.cpp
+++ b/hardware/EvohomeBase.cpp
@@ -197,6 +197,20 @@ void CEvohomeBase::SetGatewayID(unsigned int nID)
 }
 
 
+unsigned int CEvohomeBase::GetOpenThermBridgeID()
+{
+	std::lock_guard<std::mutex> l(m_mtxOpenThermBridgeID);
+	return m_nOtbID;
+}
+
+
+void CEvohomeBase::SetOpenThermBridgeID(unsigned int nID)
+{
+	std::lock_guard<std::mutex> l(m_mtxOpenThermBridgeID);
+	m_nOtbID=nID;
+}
+
+
 void CEvohomeBase::LogDate()
 {
         char szTmp[256];

--- a/hardware/EvohomeBase.h
+++ b/hardware/EvohomeBase.h
@@ -764,6 +764,8 @@ class CEvohomeBase : public CDomoticzHardwareBase
 
 	unsigned int GetControllerID();
 	unsigned int GetGatewayID();
+	unsigned int GetOpenThermBridgeID();
+
 	uint8_t GetZoneCount();
 	uint8_t GetControllerMode();
 	std::string GetControllerName();
@@ -784,6 +786,7 @@ class CEvohomeBase : public CDomoticzHardwareBase
       private:
 	void SetControllerID(unsigned int nID);
 	void SetGatewayID(unsigned int nID);
+	void SetOpenThermBridgeID(unsigned int nID);
 
 	bool SetMaxZoneCount(uint8_t nZoneCount);
 	bool SetZoneCount(uint8_t nZoneCount);
@@ -818,6 +821,9 @@ class CEvohomeBase : public CDomoticzHardwareBase
 
 	unsigned int m_nMyID; // gateway ID
 	std::mutex m_mtxGatewayID;
+
+	unsigned int m_nOtbID; // OpenTherm Bridge ID
+	std::mutex m_mtxOpenThermBridgeID;
 
 	unsigned int m_nBindID;	     // device ID of bound device
 	unsigned char m_nBindIDType; // what type of device to bind

--- a/hardware/EvohomeRadio.h
+++ b/hardware/EvohomeRadio.h
@@ -69,6 +69,7 @@ class CEvohomeRadio : public CEvohomeBase
 	void RequestDHWState();
 	void RequestDHWTemp();
 	void RequestDHWSettings();
+	void RequestOpenThermBridge();
 	void RequestZoneInfo(uint8_t nZone);
 	void RequestZoneTemp(uint8_t nZone);
 	void RequestZoneName(uint8_t nZone);


### PR DESCRIPTION
The latest version of the Evohome firmware has stopped the controller querying the OT parameters from the OT Bridge. So now none of the OT devices get updated. This PR returns that functionality by making the Gateway request the OT parameters instead. Anyone with a previous firmware should stay unaffected, but the devices will get updated twice as often as the Controller and the Gateway will both request the same information. 