### PR TITLE
Increase buffer size for HEOS to fix failure in case of more than 6 players

### DIFF
--- a/hardware/HEOS.h
+++ b/hardware/HEOS.h
@@ -62,7 +62,7 @@ class CHEOS : public CDomoticzHardwareBase, ASyncTCP
 
 	std::string m_szIPAddress;
 	unsigned short m_usIPPort;
-	unsigned char m_buffer[1028];
+	unsigned char m_buffer[16384];
 	int m_bufferpos;
 	std::shared_ptr<std::thread> m_thread;
 };


### PR DESCRIPTION
Fix the problem that if you have more than 6 players the HEOS system gives a parse error and fails to set or update the player devices. The message that contains the list of players in the system contains about 150 characters per player and the buffer size is 1028, so if you have more than about 6 players the problem occurs. Increasing it to 16384 defers the problem to a system size of more than about 100 players per network.
