### PR TITLE
Prevent crash on exit when tearing down python interpreter. Fixes #4487.

### DIFF
--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -160,6 +160,7 @@
 			if (Plugins::Py_IsInitialized())
 				Py_EndInterpreter((PyThreadState *)m_PyInterpreter);
 			m_PyInterpreter = nullptr;
+			PyThreadState_Swap((PyThreadState *)m_mainworker.m_pluginsystem.PythonThread());
 			PyEval_ReleaseLock();
 			_log.Log(LOG_STATUS, "EventSystem - Python stopped...");
 			return true;


### PR DESCRIPTION
The python interpreter API is a royal mess, huh. This restores the thread state with the same thread state (pluginsystem) used to create the events sub-interpreter. 