### PR TITLE
OpenWeatherMap: updated hardware settings UI incl. warning text

### DIFF
--- a/hardware/OpenWeatherMap.h
+++ b/hardware/OpenWeatherMap.h
@@ -9,7 +9,7 @@
 class COpenWeatherMap : public CDomoticzHardwareBase
 {
       public:
-	COpenWeatherMap(int ID, const std::string &APIKey, const std::string &Location, int adddayforecast, int addhourforecast);
+	COpenWeatherMap(int ID, const std::string &APIKey, const std::string &Location, int adddayforecast, int addhourforecast, int adddescdev, int owmforecastscreen);
 	~COpenWeatherMap() override = default;
 	bool WriteToHardware(const char *pdata, unsigned char length) override;
 	std::string GetForecastURL();
@@ -34,6 +34,8 @@ class COpenWeatherMap : public CDomoticzHardwareBase
 	bool m_itIsRaining = false;
 	bool m_add_dayforecast = false;
 	bool m_add_hourforecast = false;
+	bool m_add_descriptiondevices = false;
+	bool m_use_owminforecastscreen = false;
 	double m_Lat = 0;
 	double m_Lon = 0;
 	uint32_t m_CityID = 0;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2938,17 +2938,16 @@ namespace http {
 				sValue.clear();
 			}
 
-			root["Forecasthardware"] = "0";
-			if (m_sql.GetUserVariable("forecasthardware", USERVARTYPE_INTEGER, sValue))
+			root["Forecasthardware"] = 0;
+			int iValue = 0;
+			if (m_sql.GetPreferencesVar("ForecastHardwareID", iValue))
 			{
-				root["Forecasthardware"] = sValue;
-				sValue = "";
-				sValue.clear();
+				root["Forecasthardware"] = iValue;
 			}
 
-			if (root["Forecasthardware"] != "0")
+			if (root["Forecasthardware"] > 0)
 			{
-				int iHardwareID = atoi(root["Forecasthardware"].asString().c_str());
+				int iHardwareID = root["Forecasthardware"].asInt();
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 				if (pHardware != nullptr)
 				{
@@ -2980,17 +2979,17 @@ namespace http {
 					}
 					else
 					{
-						root["Forecasthardware"] = "0";	// reset to 0
+						root["Forecasthardware"] = 0;	// reset to 0
 					}
 				}
 				else
 				{
 					_log.Debug(DEBUG_WEBSERVER, "Forecastconfig: Could not find hardware (not active?) for ID %s!", root["Forecasthardware"].asString().c_str());
-					root["Forecasthardware"] = "0";	// reset to 0
+					root["Forecasthardware"] = 0;	// reset to 0
 				}
 			}
 
-			if (root["Forecasthardware"] == "0" && iSucces == 1)
+			if (root["Forecasthardware"] == 0 && iSucces == 1)
 			{
 				// No forecast device, but we have geo coords, so enough for fallback
 				iSucces++;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1025,7 +1025,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new BleBox(ID, Mode1);
 		break;
 	case HTYPE_OpenWeatherMap:
-		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2);
+		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2, Mode3, Mode4);
 		break;
 	case HTYPE_Ec3kMeterTCP:
 		pHardware = new Ec3kMeterTCP(ID, Address, Port);

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1006,14 +1006,23 @@
 				</td>
 			</tr>
 			<tr>
-				<td align="right" style="width:110px"><label for="adddayforecast"><span data-i18n="Daily forecast">Daily forecast</span>:</label></td>
-				<td><input type="checkbox" id="adddayforecast">&nbsp;<label for="adddayforecast">&nbsp;Forecast for today and coming 7 days (if available).</label></td>
+				<td align="right" style="width:110px"><label for="useowmforecast"><span data-i18n="Use in UI">Use in UI</span>:</label></td>
+				<td><input type="checkbox" id="useowmforecast">&nbsp;<label for="useowmforecast">&nbsp;Use OpenWeatherMap forecast data in UI.</label></td>
+			</tr>
+		<tr>
+				<td align="right" style="width:110px"><label for="adddayforecast"><span data-i18n="Daily forecast">Daily forecast (days)</span>:</label></td>
+				<td><input type="text" id="adddayforecast" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;<label for="adddayforecast">&nbsp;Forecast for today and coming 7 days, if available (1 to 8, 0 means no forecast).</label></td>
 			</tr>
 			<tr>
-				<td align="right" style="width:110px"><label for="addhourforecast"><span data-i18n="Hourly forecast">Hourly forecast</span>:</label></td>
-				<td><input type="checkbox" id="addhourforecast">&nbsp;<label for="addhourforecast">&nbsp;Forecast for each hour for 48 hours (if available).</label></td>
+				<td align="right" style="width:110px"><label for="addhourforecast"><span data-i18n="Hourly forecast">Hourly forecast (hours)</span>:</label></td>
+				<td><input type="text" id="addhourforecast" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;<label for="addhourforecast">&nbsp;Forecast for each hour for 48 hours, if available (1 to 48, 0 means no forecast)).</label></td>
 			</tr>
-		</table>
+			<tr>
+				<td align="right" style="width:110px">&nbsp;</td>
+				<td>
+					<span><i>Be aware that requesting forecast information this way will create many devices! By shortening the forecast period, less devices will be created. No need to activate these forecast settings if you just want to use the <a href="/#/Forecast">Forecast screen</a> in the UI (will be fetched on the fly).</i></span>
+				</td>
+			</table>
 	</div>
 	<div id="divbuienradar">
 		<br>

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1007,21 +1007,26 @@
 			</tr>
 			<tr>
 				<td align="right" style="width:110px"><label for="useowmforecast"><span data-i18n="Use in UI">Use in UI</span>:</label></td>
-				<td><input type="checkbox" id="useowmforecast">&nbsp;<label for="useowmforecast">&nbsp;Use OpenWeatherMap forecast data in UI.</label></td>
+				<td><input type="checkbox" id="useowmforecast">&nbsp;<label for="useowmforecast">&nbsp;Use OpenWeatherMap for UI forecast screen.</label></td>
 			</tr>
-		<tr>
+			<tr>
 				<td align="right" style="width:110px"><label for="adddayforecast"><span data-i18n="Daily forecast">Daily forecast (days)</span>:</label></td>
-				<td><input type="text" id="adddayforecast" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;<label for="adddayforecast">&nbsp;Forecast for today and coming 7 days, if available (1 to 8, 0 means no forecast).</label></td>
+				<td><input type="checkbox" id="adddayforecast">&nbsp;<label for="adddayforecast">&nbsp;Forecast for today and coming 7 days (if available).</label></td>
 			</tr>
 			<tr>
 				<td align="right" style="width:110px"><label for="addhourforecast"><span data-i18n="Hourly forecast">Hourly forecast (hours)</span>:</label></td>
-				<td><input type="text" id="addhourforecast" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all">&nbsp;<label for="addhourforecast">&nbsp;Forecast for each hour for 48 hours, if available (1 to 48, 0 means no forecast)).</label></td>
+				<td><input type="checkbox" id="addhourforecast">&nbsp;<label for="addhourforecast">&nbsp;Forecast for each hour for 48 hours (if available).</label></td>
 			</tr>
 			<tr>
 				<td align="right" style="width:110px">&nbsp;</td>
 				<td>
-					<span><i>Be aware that requesting forecast information this way will create many devices! By shortening the forecast period, less devices will be created. No need to activate these forecast settings if you just want to use the <a href="/#/Forecast">Forecast screen</a> in the UI (will be fetched on the fly).</i></span>
+					<span><i>This will create 7 new devices (UV, Max Temp, Min Temp, Wind, Cloud, Precipitation, Rain/Snow) for each Forecast day and/or 4 devices for each hour.<br />And when 'forecast description devices' is enabled, 3 more devices per day/hour are created: Description, Icon and Name.<br />So 56(80) for forecasting 8 days and 192(336) for 48 hourly forecasts.<br />No need to activate these forecast settings if you just want to use the <a href="/#/Forecast">Forecast screen</a> in the UI (will be fetched on the fly).</i></span>
 				</td>
+			</tr>
+			<tr>
+				<td align="right" style="width:110px">&nbsp;</td>
+				<td><input type="checkbox" id="adddescdev">&nbsp;<label for="adddescdev">&nbsp;Add (3) devices containing forecast description information for each forecasted day and/or hour. Useful if you would like to build your own forecast dashboard.</label></td>
+			</tr>
 			</table>
 	</div>
 	<div id="divbuienradar">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -887,6 +887,8 @@ define(['app'], function (app) {
 				}
 				var adddayforecast = $("#hardwarecontent #divopenweathermap #adddayforecast").prop("checked") ? 1 : 0;
 				var addhourforecast = $("#hardwarecontent #divopenweathermap #addhourforecast").prop("checked") ? 1 : 0;
+				var adddescdev = $("#hardwarecontent #divopenweathermap #adddescdev").prop("checked") ? 1 : 0;
+				var useowmforecast = $("#hardwarecontent #divopenweathermap #useowmforecast").prop("checked") ? 1 : 0;
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -896,7 +898,7 @@ define(['app'], function (app) {
 					"&enabled=" + bEnabled +
 					"&idx=" + idx +
 					"&datatimeout=" + datatimeout +
-					"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast + "&Mode3=" + Mode3 + "&Mode4=" + Mode4 + "&Mode5=" + Mode5 + "&Mode6=" + Mode6,
+					"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast + "&Mode3=" + adddescdev + "&Mode4=" + useowmforecast + "&Mode5=" + Mode5 + "&Mode6=" + Mode6,
 					async: false,
 					dataType: 'json',
 					success: function (data) {
@@ -2267,12 +2269,15 @@ define(['app'], function (app) {
 			}
 			var adddayforecast = $("#hardwarecontent #divopenweathermap #adddayforecast").prop("checked") ? 1 : 0;
 			var addhourforecast = $("#hardwarecontent #divopenweathermap #addhourforecast").prop("checked") ? 1 : 0;
+			var adddescdev = $("#hardwarecontent #divopenweathermap #adddescdev").prop("checked") ? 1 : 0;
+			var useowmforecast = $("#hardwarecontent #divopenweathermap #useowmforecast").prop("checked") ? 1 : 0;
 			$.ajax({
 				url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + 
 				"&loglevel=" + logLevel +
 				"&username=" + encodeURIComponent(apikey) + "&password=" + encodeURIComponent(location) + 
 				"&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout +
-				"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast,
+				"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast +
+				"&Mode3=" + adddescdev + "&Mode4=" + useowmforecast,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -4090,6 +4095,8 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamsopenweathermap #location").val(data["Password"]);
 							$("#hardwarecontent #hardwareparamsopenweathermap #adddayforecast").prop("checked", data["Mode1"] == 1);
 							$("#hardwarecontent #hardwareparamsopenweathermap #addhourforecast").prop("checked", data["Mode2"] == 1);
+							$("#hardwarecontent #hardwareparamsopenweathermap #adddescdev").prop("checked", data["Mode3"] == 1);
+							$("#hardwarecontent #hardwareparamsopenweathermap #useowmforecast").prop("checked", data["Mode4"] == 1);
 						}
 						else if (data["Type"].indexOf("Buienradar") >= 0) {
 							var timeframe = parseInt(data["Mode1"]);


### PR DESCRIPTION
This PR is an extended alternative to PR #4638

It explains/warns the user on the creation of many devices if the user decides they want forecast devices.

Also now it has a clear setting to use the OWM module for the Domoticz forecast screen (instead of the default DarkSky info).

See the updated settings screen below:
![owm-settings](https://user-images.githubusercontent.com/12084477/109429307-6bf67c00-79fb-11eb-9617-affbaba59c0f.png)
