### PR TITLE
replace boost::array with std version

### DIFF
--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -631,7 +631,7 @@ void CKodiNode::handleRead(const boost::system::error_code& e, std::size_t bytes
 	if (!e)
 	{
 		//do something with the data
-		std::string sData(m_Buffer.begin(), bytes_transferred);
+		std::string sData(m_Buffer.data(), bytes_transferred);
 		sData = m_RetainedData + sData;  // if there was some data left over from last time add it back in
 		int iPos = 1;
 		while (iPos) {

--- a/hardware/Kodi.h
+++ b/hardware/Kodi.h
@@ -5,7 +5,6 @@
 #include "../main/localtime_r.h"
 #include <string>
 #include <boost/asio.hpp>
-#include <boost/array.hpp>
 
 class CKodiNode : public std::enable_shared_from_this<CKodiNode>, StoppableTask
 {
@@ -211,7 +210,7 @@ class CKodiNode : public std::enable_shared_from_this<CKodiNode>, StoppableTask
 	std::string m_sLastMessage;
 	boost::asio::io_service *m_Ios;
 	boost::asio::ip::tcp::socket *m_Socket;
-	boost::array<char, 256> m_Buffer;
+	std::array<char, 256> m_Buffer;
 };
 
 class CKodi : public CDomoticzHardwareBase

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -386,7 +386,7 @@ std::string CPanasonicNode::handleWriteAndRead(const std::string &pMessageToSend
 		return "ERROR";
 	}
 
-	boost::array<char, 512> _Buffer;
+	std::array<char, 512> _Buffer;
 	size_t request_length = std::strlen(pMessageToSend.c_str());
 	_log.Debug(DEBUG_HARDWARE, "Panasonic Plugin: (%s) Attemping write.", m_Name.c_str());
 
@@ -397,7 +397,7 @@ std::string CPanasonicNode::handleWriteAndRead(const std::string &pMessageToSend
 		size_t reply_length = boost::asio::read(socket, boost::asio::buffer(_Buffer, request_length));
 		//_log.Log(LOG_NORM, "Panasonic Plugin: (%s) Error code: (%i).'.", m_Name.c_str(),error);
 		socket.close();
-		std::string pReceived(_Buffer.begin(), reply_length);
+		std::string pReceived(_Buffer.data(), reply_length);
 		return pReceived;
 	}
 	catch (...)

--- a/hardware/PanasonicTV.h
+++ b/hardware/PanasonicTV.h
@@ -5,7 +5,6 @@
 #include "../main/localtime_r.h"
 #include <string>
 #include <boost/asio.hpp>
-#include <boost/array.hpp>
 
 class CPanasonicNode;
 

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -498,7 +498,7 @@ bool XiaomiGateway::SendMessageToGateway(const std::string &controlmessage) {
 	remote_endpoint_ = boost::asio::ip::udp::endpoint(boost::asio::ip::address::from_string(m_GatewayIp), 9898);
 	socket_.send_to(boost::asio::buffer(*message1), remote_endpoint_);
 	sleep_milliseconds(150);
-	boost::array<char, 512> recv_buffer_;
+	std::array<char, 512> recv_buffer_;
 	memset(&recv_buffer_[0], 0, sizeof(recv_buffer_));
 #ifdef _DEBUG
 	_log.Log(LOG_STATUS, "XiaomiGateway: request to %s - %s", m_GatewayIp.c_str(), message.c_str());

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -402,8 +402,7 @@ bool Yeelight::WriteToHardware(const char *pdata, const unsigned char length)
 	return true;
 }
 
-
-boost::array<char, 1024> recv_buffer_;
+std::array<char, 1024> recv_buffer_;
 int hardwareId;
 
 Yeelight::udp_server::udp_server(boost::asio::io_service& io_service, int m_HwdID)

--- a/tcpserver/TCPClient.h
+++ b/tcpserver/TCPClient.h
@@ -2,7 +2,6 @@
 
 #include "../main/Noncopyable.h"
 #include <boost/asio.hpp>
-#include <boost/array.hpp>
 
 namespace http {
 	namespace server {
@@ -56,8 +55,7 @@ public:
 	void handleWrite(const boost::system::error_code& error);
 
 	/// Buffer for incoming data.
-	boost::array<char, 8192> buffer_;
-
+	std::array<char, 8192> buffer_;
 };
 
 #ifndef NOCLOUD

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -12,7 +12,6 @@
 #define HTTP_CONNECTION_HPP
 
 #include <boost/asio.hpp>
-#include <boost/array.hpp>
 #include <deque>
 #include <fstream>
 #include "reply.hpp"


### PR DESCRIPTION
The documentation says:

Update: std::array is (as of C++11) part of the C++ standard. The
differences between boost::array and std::array are minimal. If you are
using C++11, you should consider using std::array instead of boost::array.

Signed-off-by: Rosen Penev <rosenp@gmail.com>