### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -24,7 +24,7 @@ jobs:
       - name: lint Python code
         run: |
           python3 -m pip install --user flake8
-          python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          python3 -m flake8 plugins --count --select=E9,F63,F7,F82 --show-source --statistics
 
       # install dependencies
       - name: dependencies

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - development
       - master
-    paths:
-      - '**.py'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -21,12 +19,6 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-
-      # lint Python code
-      - name: lint Python code
-        run: |
-          python3 -m pip install --user flake8
-          python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
       # install dependencies
       - name: dependencies

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - development
       - master
+    paths:
+      - '**.py'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -24,7 +26,7 @@ jobs:
       - name: lint Python code
         run: |
           python3 -m pip install --user flake8
-          python3 -m flake8 plugins --count --select=E9,F63,F7,F82 --show-source --statistics
+          python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 
       # install dependencies
       - name: dependencies

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -20,6 +20,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # lint Python code
+      - name: lint Python code
+        run: |
+          python3 -m pip install --user flake8
+          python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
       # install dependencies
       - name: dependencies
         run: |

--- a/plugins/AwoxSMP/plugin.py
+++ b/plugins/AwoxSMP/plugin.py
@@ -16,6 +16,7 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import binascii
 import struct
 import lib.pySmartPlugSmpB16

--- a/plugins/examples/BaseTemplate.py
+++ b/plugins/examples/BaseTemplate.py
@@ -24,6 +24,8 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
+
 
 class BasePlugin:
     enabled = False

--- a/plugins/examples/DenonMarantz.py
+++ b/plugins/examples/DenonMarantz.py
@@ -46,8 +46,10 @@ Auto-discovery is known to work on Linux but may not on Windows.
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import base64
 import datetime
+
 
 class BasePlugin:
     DenonConn = None
@@ -59,11 +61,11 @@ class BasePlugin:
     mainOn = False
     mainSource = 0
     mainVolume1 = 0
-    
+
     zone2On = False
     zone2Source = 0
     zone2Volume = 0
-    
+
     zone3On = False
     zone3Source = 0
     zone3Volume = 0
@@ -75,7 +77,7 @@ class BasePlugin:
     lastHeartbeat = datetime.datetime.now()
 
     SourceOptions = {}
-    
+
     def onStart(self):
         if Parameters["Mode6"] == "Debug":
             Domoticz.Debugging(1)

--- a/plugins/examples/Dlink DSP-W215.py
+++ b/plugins/examples/Dlink DSP-W215.py
@@ -19,6 +19,7 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import hmac
 import hashlib
 import time

--- a/plugins/examples/HTTP Listener.py
+++ b/plugins/examples/HTTP Listener.py
@@ -22,6 +22,8 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
+
 
 class BasePlugin:
     enabled = False

--- a/plugins/examples/HTTP.py
+++ b/plugins/examples/HTTP.py
@@ -36,6 +36,8 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
+
 
 class BasePlugin:
     httpConn = None

--- a/plugins/examples/Kodi.py
+++ b/plugins/examples/Kodi.py
@@ -39,8 +39,10 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Images, Parameters, Settings
 import sys
 import json
+
 
 class BasePlugin:
     KodiConn = None

--- a/plugins/examples/MQTT Publish.py
+++ b/plugins/examples/MQTT Publish.py
@@ -25,7 +25,9 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import random
+
 
 class BasePlugin:
     enabled = False

--- a/plugins/examples/MQTT Subscribe.py
+++ b/plugins/examples/MQTT Subscribe.py
@@ -32,7 +32,9 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import random
+
 
 class BasePlugin:
     enabled = False

--- a/plugins/examples/Mutli-Threaded.py
+++ b/plugins/examples/Mutli-Threaded.py
@@ -26,9 +26,13 @@
 </plugin>
 """
 import Domoticz
-import sys,os
-import threading
+from Domoticz import Devices, Parameters
+import os
 import queue
+import sys
+import time
+import threading
+
 
 class BasePlugin:
     

--- a/plugins/examples/Pinger.py
+++ b/plugins/examples/Pinger.py
@@ -49,7 +49,9 @@ When remote devices are found a matching Domoticz device is created in the Devic
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 from datetime import datetime
+
 
 class IcmpDevice:
     Address = ""
@@ -84,7 +86,7 @@ class BasePlugin:
     icmpConn = None
     icmpList = []
     nextDev = 0
- 
+
     def onStart(self):
         if Parameters["Mode6"] != "0":
             DumpConfigToLog()
@@ -101,14 +103,14 @@ class BasePlugin:
             if (deviceFound == False):
                 Domoticz.Device(Name=destination, Unit=len(Devices)+1, Type=243, Subtype=31, Image=17, Options={"Custom":"1;ms"}).Create()
                 Domoticz.Device(Name=destination, Unit=len(Devices)+1, Type=17, Subtype=0, Image=17, Options={"Name":destination,"Related":str(len(Devices))}).Create()
-              
+
         # Mark all devices as connection lost if requested
         deviceLost = 0
         if Parameters["Mode5"] == "True":
             deviceLost = 1
         for Device in Devices:
             UpdateDevice(Device, Devices[Device].nValue, Devices[Device].sValue, deviceLost)
-                
+ 
     def onConnect(self, Connection, Status, Description):
         if (Status == 0):
             Domoticz.Log("Successful connect to: "+Connection.Address+" which is surprising because ICMP is connectionless.")
@@ -158,14 +160,14 @@ class BasePlugin:
                     UpdateDevice(Device, 0, "Off", TimedOut)
                     break
             self.icmpConn = None
-    
+
         Domoticz.Debug("Heartbeating '"+self.icmpList[self.nextDev]+"'")
         self.icmpConn = IcmpDevice(self.icmpList[self.nextDev])
         self.nextDev += 1
         if (self.nextDev >= len(self.icmpList)):
             self.nextDev = 0
- 
- 
+
+
 global _plugin
 _plugin = BasePlugin()
 
@@ -218,4 +220,4 @@ def DumpICMPResponseToLog(icmpList):
             else:
                 Domoticz.Log("--->'" + x + "':'" + str(icmpList[x]) + "'")
     else:
-        Domoticz.Log(Data.decode("utf-8", "ignore"))
+        Domoticz.Log(Data.decode("utf-8", "ignore"))  # noqa: F821

--- a/plugins/examples/RAVEn.py
+++ b/plugins/examples/RAVEn.py
@@ -20,6 +20,7 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
 import xml.etree.ElementTree as ET
 
 SerialConn = None

--- a/plugins/examples/UDP Discovery.py
+++ b/plugins/examples/UDP Discovery.py
@@ -39,6 +39,8 @@
 </plugin>
 """
 import Domoticz
+from Domoticz import Devices, Parameters
+
 
 class BasePlugin:
     BeaconConn = None

--- a/scripts/python/domoticz.py
+++ b/scripts/python/domoticz.py
@@ -36,13 +36,7 @@ import datetime
 import re
 
 # Enable plugins to do:
-# from Domoticz import Connections, Devices, Images, Parameters, Settings
-try:
-    Connections
-except NameError:
-    Connections = {}
-    domoticz_.Log(1, "Connections was not created by Domoticz C++ code")
-
+# from Domoticz import Devices, Images, Parameters, Settings
 try:
     Devices
 except NameError:

--- a/scripts/python/domoticz.py
+++ b/scripts/python/domoticz.py
@@ -35,7 +35,14 @@ import reloader
 import datetime
 import re
 
-# Enable plugins to do: from Domoticz import Devices, Images, Parameters, Settings
+# Enable plugins to do:
+# from Domoticz import Connections, Devices, Images, Parameters, Settings
+try:
+    Connections
+except NameError:
+    Connections = {}
+    domoticz_.Log(1, "Connections was not created by Domoticz C++ code")
+
 try:
     Devices
 except NameError:

--- a/scripts/python/domoticz.py
+++ b/scripts/python/domoticz.py
@@ -35,6 +35,31 @@ import reloader
 import datetime
 import re
 
+# Enable plugins to do: from Domoticz import Devices, Images, Parameters, Settings
+try:
+    Devices
+except NameError:
+    Devices = {}
+    domoticz_.Log(1, "Devices was not created by Domoticz C++ code")
+
+try:
+    Images
+except NameError:
+    Images = {}
+    domoticz_.Log(1, "Images was not created by Domoticz C++ code")
+
+try:
+    Parameters
+except NameError:
+    Parameters = {}
+    domoticz_.Log(1, "Parameters was not created by Domoticz C++ code")
+
+try:
+    Settings
+except NameError:
+    Settings = {}
+    domoticz_.Log(1, "Settings was not created by Domoticz C++ code")
+
 #def _log(type, text): # 'virtual' function, will be modified to call
 #	pass
 

--- a/scripts/python/googlepubsub.py
+++ b/scripts/python/googlepubsub.py
@@ -50,8 +50,7 @@ def publish_message(client,topicname,message):
 
 def main(argv):
         client = create_pubsub_client()
-        publish_message(client,PUBSUB_TOPICNAME,data)
+        publish_message(client,PUBSUB_TOPICNAME,data)  # noqa: F821
 
 if __name__ == '__main__':
         main(sys.argv)
-

--- a/scripts/python/reloader.py
+++ b/scripts/python/reloader.py
@@ -8,13 +8,17 @@ reloader.auto_reload(__name__)
 import sys
 import os
 
+try:
+	reload  # Python 2
+except NameError:
+	from importlib import reload  # Python 3
+
 
 # mark module as a module to reload
 def auto_reload(module_name):
 	import domoticz as dz
 	path = _py_source(sys.modules[module_name])
 	_module_mtimes[module_name] = os.path.getmtime(path)
-
 
 
 # below this is internal stuff


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead, these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python, they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python, a __NameError__ is raised which will halt/crash the script on the user.