### PR TITLE
Added double quotes around double quotes in -log file path parameter

### DIFF
--- a/msbuild/WindowsInstaller/DomoticzSetup.iss
+++ b/msbuild/WindowsInstaller/DomoticzSetup.iss
@@ -106,7 +106,7 @@ begin
   Result := '-www ' + ConfigPage.Values[0] + ' -sslwww ' + ConfigPage.Values[1];
   if (LogUseLogButton.Checked) then
     begin
-      Result := Result + ' -log "' + LogConfigPage.Values[0] + '"';
+      Result := Result + ' -log """' + LogConfigPage.Values[0] + '"""';
     end;
 end;
 


### PR DESCRIPTION
The current script used one (1) double quote. Innosetup requires double quotes around them to retain them in the path name parameter for path names with spaces in them.