### PR TITLE
remove excess {} in std::array

### DIFF
--- a/hardware/BleBox.cpp
+++ b/hardware/BleBox.cpp
@@ -21,18 +21,16 @@ struct STR_DEVICE {
 	const char *api_state;
 };
 
-constexpr std::array<STR_DEVICE, 9> DevicesType{
-	{
-		{ 0, "switchBox", "Switch Box", pTypeLighting2, sTypeAC, STYPE_OnOff, "relay" },
-		{ 1, "shutterBox", "Shutter Box", pTypeLighting2, sTypeAC, STYPE_BlindsPercentageInverted, "shutter" },
-		{ 2, "wLightBoxS", "Light Box S", pTypeLighting2, sTypeAC, STYPE_Dimmer, "light" },
-		{ 3, "wLightBox", "Light Box", pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, "rgbw" },
-		{ 4, "gateBox", "Gate Box", pTypeGeneral, sTypePercentage, 0, "gate" },
-		{ 5, "dimmerBox", "Dimmer Box", pTypeLighting2, sTypeAC, STYPE_Dimmer, "dimmer" },
-		{ 6, "switchBoxD", "Switch Box D", pTypeLighting2, sTypeAC, STYPE_OnOff, "relay" },
-		{ 7, "airSensor", "Air Sensor", pTypeAirQuality, sTypeVoltcraft, 0, "air" },
-		{ 8, "tempSensor", "Temp Sensor", pTypeGeneral, sTypeTemperature, 0, "tempsensor" },
-	},
+constexpr auto DevicesType = std::array<STR_DEVICE, 9>{
+	STR_DEVICE{ 0, "switchBox", "Switch Box", pTypeLighting2, sTypeAC, STYPE_OnOff, "relay" },
+	STR_DEVICE{ 1, "shutterBox", "Shutter Box", pTypeLighting2, sTypeAC, STYPE_BlindsPercentageInverted, "shutter" },
+	STR_DEVICE{ 2, "wLightBoxS", "Light Box S", pTypeLighting2, sTypeAC, STYPE_Dimmer, "light" },
+	STR_DEVICE{ 3, "wLightBox", "Light Box", pTypeColorSwitch, sTypeColor_RGB_W, STYPE_Dimmer, "rgbw" },
+	STR_DEVICE{ 4, "gateBox", "Gate Box", pTypeGeneral, sTypePercentage, 0, "gate" },
+	STR_DEVICE{ 5, "dimmerBox", "Dimmer Box", pTypeLighting2, sTypeAC, STYPE_Dimmer, "dimmer" },
+	STR_DEVICE{ 6, "switchBoxD", "Switch Box D", pTypeLighting2, sTypeAC, STYPE_OnOff, "relay" },
+	STR_DEVICE{ 7, "airSensor", "Air Sensor", pTypeAirQuality, sTypeVoltcraft, 0, "air" },
+	STR_DEVICE{ 8, "tempSensor", "Temp Sensor", pTypeGeneral, sTypeTemperature, 0, "tempsensor" },
 };
 
 BleBox::BleBox(const int id, const int pollIntervalsec)

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -69,48 +69,48 @@ namespace http {
 			int subtype;
 		};
 
-		constexpr std::array<_mappedsensorname, 40> mappedsensorname{ {
-			{ 249, pTypeAirQuality, sTypeVoltcraft },	   // Air Quality
-			{ 7, pTypeGeneral, sTypeAlert },		   // Alert
-			{ 9, pTypeCURRENT, sTypeELEC1 },		   // Ampere (3 Phase)
-			{ 19, pTypeGeneral, sTypeCurrent },		   // Ampere (1 Phase)
-			{ 11, pTypeGeneral, sTypeBaro },		   // Barometer
-			{ 113, pTypeRFXMeter, sTypeRFXMeterCount },	   // Counter
-			{ 14, pTypeGeneral, sTypeCounterIncremental },	   // Counter Incremental
-			{ 1004, pTypeGeneral, sTypeCustom },		   // Custom Sensor
-			{ 13, pTypeGeneral, sTypeDistance },		   // Distance
-			{ 18, pTypeGeneral, sTypeKwh },			   // Electric (Instant+Counter)
-			{ 3, pTypeP1Gas, sTypeP1Gas },			   // Gas
-			{ 81, pTypeHUM, sTypeHUM1 },			   // Humidity
-			{ 16, pTypeGeneral, sTypeLeafWetness },		   // Leaf Wetness
-			{ 246, pTypeLux, sTypeLux },			   // Lux
-			{ 250, pTypeP1Power, sTypeP1Power },		   // P1 Smart Meter (Electric)
-			{ 1005, pTypeGeneral, sTypeManagedCounter },	   // Managed Counter
-			{ 2, pTypeGeneral, sTypePercentage },		   // Percentage
-			{ 1, pTypeGeneral, sTypePressure },		   // Pressure (Bar)
-			{ 85, pTypeRAIN, sTypeRAIN3 },			   // Rain
-			{ 241, pTypeColorSwitch, sTypeColor_RGB },	   // RGB Switch
-			{ 1003, pTypeColorSwitch, sTypeColor_RGB_W },	   // RGBW Switch
-			{ 93, pTypeWEIGHT, sTypeWEIGHT1 },		   // Scale
-			{ 1002, pTypeGeneralSwitch, sSwitchTypeSelector }, // Selector Switch
-			{ 15, pTypeGeneral, sTypeSoilMoisture },	   // Soil Moisture
-			{ 20, pTypeGeneral, sTypeSolarRadiation },	   // Solar Radiation
-			{ 10, pTypeGeneral, sTypeSoundLevel },		   // Sound Level
-			{ 6, pTypeGeneralSwitch, sSwitchGeneralSwitch },   // Switch
-			{ 80, pTypeTEMP, sTypeTEMP5 },			   // Temperature
-			{ 82, pTypeTEMP_HUM, sTypeTH1 },		   // Temp+Hum
-			{ 84, pTypeTEMP_HUM_BARO, sTypeTHB1 },		   // Temp+Hum+Baro
-			{ 247, pTypeTEMP_BARO, sTypeBMP085 },		   // Temp+Baro
-			{ 5, pTypeGeneral, sTypeTextStatus },		   // Text
-			{ 8, pTypeThermostat, sTypeThermSetpoint },	   // Thermostat Setpoint
-			{ 248, pTypeUsage, sTypeElectric },		   // Usage (Electric)
-			{ 87, pTypeUV, sTypeUV1 },			   // UV
-			{ 12, pTypeGeneral, sTypeVisibility },		   // Visibility
-			{ 4, pTypeGeneral, sTypeVoltage },		   // Voltage
-			{ 1000, pTypeGeneral, sTypeWaterflow },		   // Waterflow
-			{ 86, pTypeWIND, sTypeWIND1 },			   // Wind
-			{ 1001, pTypeWIND, sTypeWIND4 }			   // Wind+Temp+Chill
-		} };
+		constexpr auto mappedsensorname = std::array<_mappedsensorname, 40>{
+			_mappedsensorname{ 249, pTypeAirQuality, sTypeVoltcraft },	    // Air Quality
+			_mappedsensorname{ 7, pTypeGeneral, sTypeAlert },		    // Alert
+			_mappedsensorname{ 9, pTypeCURRENT, sTypeELEC1 },		    // Ampere (3 Phase)
+			_mappedsensorname{ 19, pTypeGeneral, sTypeCurrent },		    // Ampere (1 Phase)
+			_mappedsensorname{ 11, pTypeGeneral, sTypeBaro },		    // Barometer
+			_mappedsensorname{ 113, pTypeRFXMeter, sTypeRFXMeterCount },	    // Counter
+			_mappedsensorname{ 14, pTypeGeneral, sTypeCounterIncremental },	    // Counter Incremental
+			_mappedsensorname{ 1004, pTypeGeneral, sTypeCustom },		    // Custom Sensor
+			_mappedsensorname{ 13, pTypeGeneral, sTypeDistance },		    // Distance
+			_mappedsensorname{ 18, pTypeGeneral, sTypeKwh },		    // Electric (Instant+Counter)
+			_mappedsensorname{ 3, pTypeP1Gas, sTypeP1Gas },			    // Gas
+			_mappedsensorname{ 81, pTypeHUM, sTypeHUM1 },			    // Humidity
+			_mappedsensorname{ 16, pTypeGeneral, sTypeLeafWetness },	    // Leaf Wetness
+			_mappedsensorname{ 246, pTypeLux, sTypeLux },			    // Lux
+			_mappedsensorname{ 250, pTypeP1Power, sTypeP1Power },		    // P1 Smart Meter (Electric)
+			_mappedsensorname{ 1005, pTypeGeneral, sTypeManagedCounter },	    // Managed Counter
+			_mappedsensorname{ 2, pTypeGeneral, sTypePercentage },		    // Percentage
+			_mappedsensorname{ 1, pTypeGeneral, sTypePressure },		    // Pressure (Bar)
+			_mappedsensorname{ 85, pTypeRAIN, sTypeRAIN3 },			    // Rain
+			_mappedsensorname{ 241, pTypeColorSwitch, sTypeColor_RGB },	    // RGB Switch
+			_mappedsensorname{ 1003, pTypeColorSwitch, sTypeColor_RGB_W },	    // RGBW Switch
+			_mappedsensorname{ 93, pTypeWEIGHT, sTypeWEIGHT1 },		    // Scale
+			_mappedsensorname{ 1002, pTypeGeneralSwitch, sSwitchTypeSelector }, // Selector Switch
+			_mappedsensorname{ 15, pTypeGeneral, sTypeSoilMoisture },	    // Soil Moisture
+			_mappedsensorname{ 20, pTypeGeneral, sTypeSolarRadiation },	    // Solar Radiation
+			_mappedsensorname{ 10, pTypeGeneral, sTypeSoundLevel },		    // Sound Level
+			_mappedsensorname{ 6, pTypeGeneralSwitch, sSwitchGeneralSwitch },   // Switch
+			_mappedsensorname{ 80, pTypeTEMP, sTypeTEMP5 },			    // Temperature
+			_mappedsensorname{ 82, pTypeTEMP_HUM, sTypeTH1 },		    // Temp+Hum
+			_mappedsensorname{ 84, pTypeTEMP_HUM_BARO, sTypeTHB1 },		    // Temp+Hum+Baro
+			_mappedsensorname{ 247, pTypeTEMP_BARO, sTypeBMP085 },		    // Temp+Baro
+			_mappedsensorname{ 5, pTypeGeneral, sTypeTextStatus },		    // Text
+			_mappedsensorname{ 8, pTypeThermostat, sTypeThermSetpoint },	    // Thermostat Setpoint
+			_mappedsensorname{ 248, pTypeUsage, sTypeElectric },		    // Usage (Electric)
+			_mappedsensorname{ 87, pTypeUV, sTypeUV1 },			    // UV
+			_mappedsensorname{ 12, pTypeGeneral, sTypeVisibility },		    // Visibility
+			_mappedsensorname{ 4, pTypeGeneral, sTypeVoltage },		    // Voltage
+			_mappedsensorname{ 1000, pTypeGeneral, sTypeWaterflow },	    // Waterflow
+			_mappedsensorname{ 86, pTypeWIND, sTypeWIND1 },			    // Wind
+			_mappedsensorname{ 1001, pTypeWIND, sTypeWIND4 }		    // Wind+Temp+Chill
+		};
 
 		//TODO: Is this function called from anywhere, or can it be removed?
 		void CWebServer::RType_CreateMappedSensor(WebEmSession & session, const request& req, Json::Value &root)

--- a/hardware/MochadTCP.cpp
+++ b/hardware/MochadTCP.cpp
@@ -35,19 +35,17 @@ using MochadMatch = struct
 	int width;
 };
 
-constexpr std::array<MochadMatch, 10> matchlist{
-	{
-		{ STD, MOCHAD_STATUS, "House ", 6, 255 },	  //
-		{ STD, MOCHAD_UNIT, "Tx PL HouseUnit: ", 17, 9 }, //
-		{ STD, MOCHAD_UNIT, "Rx PL HouseUnit: ", 17, 9 }, //
-		{ STD, MOCHAD_UNIT, "Tx RF HouseUnit: ", 17, 9 }, //
-		{ STD, MOCHAD_UNIT, "Rx RF HouseUnit: ", 17, 9 }, //
-		{ STD, MOCHAD_ACTION, "Tx PL House: ", 13, 9 },	  //
-		{ STD, MOCHAD_ACTION, "Rx PL House: ", 13, 9 },	  //
-		{ STD, MOCHAD_ACTION, "Tx RF House: ", 13, 9 },	  //
-		{ STD, MOCHAD_ACTION, "Rx RF House: ", 13, 9 },	  //
-		{ STD, MOCHAD_RFSEC, "Rx RFSEC Addr: ", 15, 8 },  //
-	}							  //
+constexpr auto matchlist = std::array<MochadMatch, 10>{
+	MochadMatch{ STD, MOCHAD_STATUS, "House ", 6, 255 },	     //
+	MochadMatch{ STD, MOCHAD_UNIT, "Tx PL HouseUnit: ", 17, 9 }, //
+	MochadMatch{ STD, MOCHAD_UNIT, "Rx PL HouseUnit: ", 17, 9 }, //
+	MochadMatch{ STD, MOCHAD_UNIT, "Tx RF HouseUnit: ", 17, 9 }, //
+	MochadMatch{ STD, MOCHAD_UNIT, "Rx RF HouseUnit: ", 17, 9 }, //
+	MochadMatch{ STD, MOCHAD_ACTION, "Tx PL House: ", 13, 9 },   //
+	MochadMatch{ STD, MOCHAD_ACTION, "Rx PL House: ", 13, 9 },   //
+	MochadMatch{ STD, MOCHAD_ACTION, "Tx RF House: ", 13, 9 },   //
+	MochadMatch{ STD, MOCHAD_ACTION, "Rx RF House: ", 13, 9 },   //
+	MochadMatch{ STD, MOCHAD_RFSEC, "Rx RFSEC Addr: ", 15, 8 },  //
 };
 //end
 

--- a/hardware/MultiFun.cpp
+++ b/hardware/MultiFun.cpp
@@ -45,19 +45,18 @@ const auto warningsType = dictionary{
 	{ 0x0040, "Thermal protection has tripped" },	   //
 };
 
-constexpr std::array<std::pair<int, const char *>, 10> devicesType{
-	{
-		{ 0x0001, "C.H.1 PUMP" },	 //
-		{ 0x0002, "C.H.2 PUMP" },	 //
-		{ 0x0004, "RESERVE PUMP" },	 //
-		{ 0x0008, "H.W.U.PUMP" },	 //
-		{ 0x0010, "CIRCULATION PUMP" },	 //
-		{ 0x0020, "PUFFER PUMP" },	 //
-		{ 0x0040, "MIXER C.H.1 Close" }, //
-		{ 0x0080, "MIXER C.H.1 Open" },	 //
-		{ 0x0100, "MIXER C.H.2 Close" }, //
-		{ 0x0200, "MIXER C.H.2 Open" },	 //
-	}					 //
+using type = std::pair<int, const char *>;
+constexpr auto devicesType = std::array<type, 10>{
+	type{ 0x0001, "C.H.1 PUMP" },	     //
+	type{ 0x0002, "C.H.2 PUMP" },	     //
+	type{ 0x0004, "RESERVE PUMP" },	     //
+	type{ 0x0008, "H.W.U.PUMP" },	     //
+	type{ 0x0010, "CIRCULATION PUMP" },  //
+	type{ 0x0020, "PUFFER PUMP" },	     //
+	type{ 0x0040, "MIXER C.H.1 Close" }, //
+	type{ 0x0080, "MIXER C.H.1 Open" },  //
+	type{ 0x0100, "MIXER C.H.2 Close" }, //
+	type{ 0x0200, "MIXER C.H.2 Open" },  //
 };
 
 const auto statesType = dictionary{
@@ -68,38 +67,35 @@ const auto statesType = dictionary{
 	{ 0x0010, "Blanking" }, //
 };
 
-constexpr std::array<std::pair<const char *, float>, 16> sensors{
-	{
-		{ "External", 10.0F },		//
-		{ "Room 1", 10.0F },		//
-		{ "Room 2", 10.0F },		//
-		{ "Return", 10.0F },		//
-		{ "C.H.1", 10.0F },		//
-		{ "C.H.2", 10.0F },		//
-		{ "H.W.U.", 10.0F },		//
-		{ "Heat", 1.0F },		//
-		{ "Flue gas", 10.0F },		//
-		{ "Module", 10.0F },		//
-		{ "Boiler", 10.0F },		//
-		{ "Feeder", 10.0F },		//
-		{ "Calculated Boiler", 10.0F }, //
-		{ "Calculated H.W.U.", 10.0F }, //
-		{ "Calculated C.H.1", 10.0F },	//
-		{ "Calculated C.H.2", 10.0F },	//
-	}					//
+using sensor = std::pair<const char *, float>;
+constexpr auto sensors = std::array<sensor, 16>{
+	sensor{ "External", 10.0F },
+	sensor{ "Room 1", 10.0F },
+	sensor{ "Room 2", 10.0F },
+	sensor{ "Return", 10.0F },
+	sensor{ "C.H.1", 10.0F },
+	sensor{ "C.H.2", 10.0F },
+	sensor{ "H.W.U.", 10.0F },
+	sensor{ "Heat", 1.0F },
+	sensor{ "Flue gas", 10.0F },
+	sensor{ "Module", 10.0F },
+	sensor{ "Boiler", 10.0F },
+	sensor{ "Feeder", 10.0F },
+	sensor{ "Calculated Boiler", 10.0F },
+	sensor{ "Calculated H.W.U.", 10.0F },
+	sensor{ "Calculated C.H.1", 10.0F },
+	sensor{ "Calculated C.H.2", 10.0F },
 };
 
-constexpr std::array<std::pair<int, const char *>, 5> quickAccessType{
-	{
-		{ 0x0001, "Shower" },		//
-		{ 0x0002, "Party" },		//
-		{ 0x0004, "Comfort" },		//
-		{ 0x0008, "Airing" },		//
-		{ 0x0010, "Frost protection" }, //
-	}					//
+constexpr auto quickAccessType = std::array<type, 5>{
+	type{ 0x0001, "Shower" },	    //
+	type{ 0x0002, "Party" },	    //
+	type{ 0x0004, "Comfort" },	    //
+	type{ 0x0008, "Airing" },	    //
+	type{ 0x0010, "Frost protection" }, //
 };
 
-constexpr std::array<const char *, 4> errors{
+constexpr auto errors = std::array<const char *, 4>{
 	"Incorrect function code",
 	"Incorrect register address",
 	"Incorrect number of registers",

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -105,32 +105,29 @@ namespace
 		const struct selector_name *default_names;
 	};
 
-	constexpr std::array<_switch_types, 13> switch_types{
-		{
-			{ "MVL", "AMT", "Master volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },										    //
-			{ "ZVL", "ZMT", "Zone 2 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },										    //
-			{ "VL3", "MT3", "Zone 3 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },										    //
-			{ "VL4", "MT4", "Zone 4 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },										    //
-			{ "PWR", nullptr, "Master power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },										    //
-			{ "ZPW", nullptr, "Zone 2 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },										    //
-			{ "PW3", nullptr, "Zone 3 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },										    //
-			{ "PW4", nullptr, "Zone 4 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },										    //
-			{ "SLI", nullptr, "Master selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },	    //
-			{ "SLZ", nullptr, "Zone 2 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },	    //
-			{ "SL2", nullptr, "Zone 3 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },	    //
-			{ "SL3", nullptr, "Zone 4 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },	    //
-			{ "HDO", nullptr, "HDMI Output", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:0;LevelNames:Off|Main|Sub|Main+Sub;LevelOffHidden:true;LevelActions:00|01|02|03" }, //
-		}																						    //
+	constexpr auto switch_types = std::array<_switch_types, 13>{
+		_switch_types{ "MVL", "AMT", "Master volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },
+		_switch_types{ "ZVL", "ZMT", "Zone 2 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },
+		_switch_types{ "VL3", "MT3", "Zone 3 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },
+		_switch_types{ "VL4", "MT4", "Zone 4 volume", STYPE_Dimmer, sSwitchGeneralSwitch, 8, nullptr, nullptr },
+		_switch_types{ "PWR", nullptr, "Master power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },
+		_switch_types{ "ZPW", nullptr, "Zone 2 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },
+		_switch_types{ "PW3", nullptr, "Zone 3 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },
+		_switch_types{ "PW4", nullptr, "Zone 4 power", STYPE_OnOff, sSwitchGeneralSwitch, 5, nullptr, nullptr },
+		_switch_types{ "SLI", nullptr, "Master selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },
+		_switch_types{ "SLZ", nullptr, "Zone 2 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },
+		_switch_types{ "SL2", nullptr, "Zone 3 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },
+		_switch_types{ "SL3", nullptr, "Zone 4 selector", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:1;LevelNames:Off;LevelOffHidden:true;LevelActions:00", input_names },
+		_switch_types{ "HDO", nullptr, "HDMI Output", STYPE_Selector, sSwitchTypeSelector, 5, "SelectorStyle:0;LevelNames:Off|Main|Sub|Main+Sub;LevelOffHidden:true;LevelActions:00|01|02|03" },
 	};
 
-	constexpr std::array<std::pair<const char *, const char *>, 5> text_types{
-		{
-			{ "NAL", "Album name" },    //
-			{ "NAT", "Artist name" },   //
-			{ "NTI", "Title name" },    //
-			{ "NTM", "Playback time" }, //
-			{ "NTR", "Track info" },    //
-		}				    //
+	using text = std::pair<const char *, const char *>;
+	constexpr auto text_types = std::array<text, 5>{
+		text{ "NAL", "Album name" },	//
+		text{ "NAT", "Artist name" },	//
+		text{ "NTI", "Title name" },	//
+		text{ "NTM", "Playback time" }, //
+		text{ "NTR", "Track info" },	//
 	};
 
 #define IS_END_CHAR(x) ((x) == 0x1a)

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -38,33 +38,32 @@ extern std::string szWWWFolder;
 //This is for backwards compatability .... but should not be used
 namespace
 {
-	constexpr std::array<std::pair<const char *, uint8_t>, 24> AlarmToIndexMapping{
-		{
-			{ "General", 0x28 },
-			{ "Smoke", 0x29 },
-			{ "Carbon Monoxide", 0x2A },
-			{ "Carbon Dioxide", 0x2B },
-			{ "Heat", 0x2C },
-			{ "Water", 0x2D },
-			{ "Flood", 0x2D },
-			{ "Alarm Level", 0x32 },
-			{ "Alarm Type", 0x33 },
-			{ "Access Control", 0x34 },
-			{ "Burglar", 0x35 },
-			{ "Home Security", 0x35 },
-			{ "Power Management", 0x36 },
-			{ "System", 0x37 },
-			{ "Emergency", 0x38 },
-			{ "Clock", 0x39 },
-			{ "Appliance", 0x3A },
-			{ "HomeHealth", 0x3B },
-			{ "Siren", 0x3C },
-			{ "Water Valve", 0x3D },
-			{ "Weather", 0x3E },
-			{ "Irrigation", 0x3F },
-			{ "Gas", 0x40 },
-			{ "Volatile Organic Compound", 0x41 },
-		}
+	using map = std::pair<const char *, uint8_t>;
+	constexpr auto AlarmToIndexMapping = std::array<map, 24>{
+		map{ "General", 0x28 },
+		map{ "Smoke", 0x29 },
+		map{ "Carbon Monoxide", 0x2A },
+		map{ "Carbon Dioxide", 0x2B },
+		map{ "Heat", 0x2C },
+		map{ "Water", 0x2D },
+		map{ "Flood", 0x2D },
+		map{ "Alarm Level", 0x32 },
+		map{ "Alarm Type", 0x33 },
+		map{ "Access Control", 0x34 },
+		map{ "Burglar", 0x35 },
+		map{ "Home Security", 0x35 },
+		map{ "Power Management", 0x36 },
+		map{ "System", 0x37 },
+		map{ "Emergency", 0x38 },
+		map{ "Clock", 0x39 },
+		map{ "Appliance", 0x3A },
+		map{ "HomeHealth", 0x3B },
+		map{ "Siren", 0x3C },
+		map{ "Water Valve", 0x3D },
+		map{ "Weather", 0x3E },
+		map{ "Irrigation", 0x3F },
+		map{ "Gas", 0x40 },
+		map{ "Volatile Organic Compound", 0x41 },
 	};
 } // namespace
 

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -93,33 +93,31 @@ using P1Match = struct
 	int width;
 };
 
-constexpr std::array<P1Match, 24> p1_matchlist{
-	{
-		{ _eP1MatchType::ID, P1TYPE_SMID, P1SMID, "", 0, 0 },				      //
-		{ _eP1MatchType::EXCLMARK, P1TYPE_END, P1EOT, "", 0, 0 },			      //
-		{ _eP1MatchType::STD, P1TYPE_VERSION, P1VER, "version", 10, 2 },		      //
-		{ _eP1MatchType::STD, P1TYPE_VERSION, P1VERBE, "versionBE", 11, 5 },		      //
-		{ _eP1MatchType::STD, P1TYPE_POWERUSAGE, P1PUSG, "powerusage", 10, 9 },		      //
-		{ _eP1MatchType::STD, P1TYPE_POWERDELIV, P1PDLV, "powerdeliv", 10, 9 },		      //
-		{ _eP1MatchType::STD, P1TYPE_USAGECURRENT, P1PUC, "powerusagec", 10, 7 },	      //
-		{ _eP1MatchType::STD, P1TYPE_DELIVCURRENT, P1PDC, "powerdelivc", 10, 7 },	      //
-		{ _eP1MatchType::STD, P1TYPE_VOLTAGEL1, P1VOLTL1, "voltagel1", 11, 5 },		      //
-		{ _eP1MatchType::STD, P1TYPE_VOLTAGEL2, P1VOLTL2, "voltagel2", 11, 5 },		      //
-		{ _eP1MatchType::STD, P1TYPE_VOLTAGEL3, P1VOLTL3, "voltagel3", 11, 5 },		      //
-		{ _eP1MatchType::STD, P1TYPE_AMPERAGEL1, P1AMPEREL1, "amperagel1", 11, 3 },	      //
-		{ _eP1MatchType::STD, P1TYPE_AMPERAGEL2, P1AMPEREL2, "amperagel2", 11, 3 },	      //
-		{ _eP1MatchType::STD, P1TYPE_AMPERAGEL3, P1AMPEREL3, "amperagel3", 11, 3 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERUSEL1, P1POWUSL1, "powerusel1", 11, 6 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERUSEL2, P1POWUSL2, "powerusel2", 11, 6 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERUSEL3, P1POWUSL3, "powerusel3", 11, 6 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERDELL1, P1POWDLL1, "powerdell1", 11, 6 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERDELL2, P1POWDLL2, "powerdell2", 11, 6 },	      //
-		{ _eP1MatchType::STD, P1TYPE_POWERDELL3, P1POWDLL3, "powerdell3", 11, 6 },	      //
-		{ _eP1MatchType::DEVTYPE, P1TYPE_MBUSDEVICETYPE, P1MBTYPE, "mbusdevicetype", 11, 3 }, //
-		{ _eP1MatchType::GAS, P1TYPE_GASUSAGEDSMR4, P1GUDSMR4, "gasusage", 26, 8 },	      //
-		{ _eP1MatchType::LINE17, P1TYPE_GASTIMESTAMP, P1GTS, "gastimestamp", 11, 12 },	      //
-		{ _eP1MatchType::LINE18, P1TYPE_GASUSAGE, P1GUDSMR2, "gasusage", 1, 9 },	      //
-	}											      // must keep DEVTYPE, GAS, LINE17 and LINE18 in this order at end of p1_matchlist
+constexpr auto p1_matchlist = std::array<P1Match, 24>{
+	P1Match{ _eP1MatchType::ID, P1TYPE_SMID, P1SMID, "", 0, 0 },
+	P1Match{ _eP1MatchType::EXCLMARK, P1TYPE_END, P1EOT, "", 0, 0 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_VERSION, P1VER, "version", 10, 2 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_VERSION, P1VERBE, "versionBE", 11, 5 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERUSAGE, P1PUSG, "powerusage", 10, 9 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERDELIV, P1PDLV, "powerdeliv", 10, 9 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_USAGECURRENT, P1PUC, "powerusagec", 10, 7 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_DELIVCURRENT, P1PDC, "powerdelivc", 10, 7 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_VOLTAGEL1, P1VOLTL1, "voltagel1", 11, 5 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_VOLTAGEL2, P1VOLTL2, "voltagel2", 11, 5 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_VOLTAGEL3, P1VOLTL3, "voltagel3", 11, 5 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_AMPERAGEL1, P1AMPEREL1, "amperagel1", 11, 3 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_AMPERAGEL2, P1AMPEREL2, "amperagel2", 11, 3 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_AMPERAGEL3, P1AMPEREL3, "amperagel3", 11, 3 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERUSEL1, P1POWUSL1, "powerusel1", 11, 6 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERUSEL2, P1POWUSL2, "powerusel2", 11, 6 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERUSEL3, P1POWUSL3, "powerusel3", 11, 6 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERDELL1, P1POWDLL1, "powerdell1", 11, 6 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERDELL2, P1POWDLL2, "powerdell2", 11, 6 },
+	P1Match{ _eP1MatchType::STD, P1TYPE_POWERDELL3, P1POWDLL3, "powerdell3", 11, 6 },
+	P1Match{ _eP1MatchType::DEVTYPE, P1TYPE_MBUSDEVICETYPE, P1MBTYPE, "mbusdevicetype", 11, 3 },
+	P1Match{ _eP1MatchType::GAS, P1TYPE_GASUSAGEDSMR4, P1GUDSMR4, "gasusage", 26, 8 },
+	P1Match{ _eP1MatchType::LINE17, P1TYPE_GASTIMESTAMP, P1GTS, "gastimestamp", 11, 12 },
+	P1Match{ _eP1MatchType::LINE18, P1TYPE_GASUSAGE, P1GUDSMR2, "gasusage", 1, 9 },
 };
 
 P1MeterBase::P1MeterBase()

--- a/hardware/SatelIntegra.cpp
+++ b/hardware/SatelIntegra.cpp
@@ -29,18 +29,16 @@ using SatelModel = struct
 
 #define TOT_MODELS 9
 
-constexpr std::array<SatelModel, TOT_MODELS> models{
-	{
-		{ 0, "Integra 24", 24, 20 },		   //
-		{ 1, "Integra 32", 32, 32 },		   //
-		{ 2, "Integra 64", 64, 64 },		   //
-		{ 3, "Integra 128", 128, 128 },		   //
-		{ 4, "Integra 128 WRL SIM300", 128, 128 }, //
-		{ 132, "Integra 128 WRL LEON", 128, 128 }, //
-		{ 66, "Integra 64 Plus", 64, 64 },	   //
-		{ 67, "Integra 128 Plus", 128, 128 },	   //
-		{ 72, "Integra 256 Plus", 256, 256 },	   //
-	}						   //
+constexpr auto models = std::array<SatelModel, TOT_MODELS>{
+	SatelModel{ 0, "Integra 24", 24, 20 },		     //
+	SatelModel{ 1, "Integra 32", 32, 32 },		     //
+	SatelModel{ 2, "Integra 64", 64, 64 },		     //
+	SatelModel{ 3, "Integra 128", 128, 128 },	     //
+	SatelModel{ 4, "Integra 128 WRL SIM300", 128, 128 }, //
+	SatelModel{ 132, "Integra 128 WRL LEON", 128, 128 }, //
+	SatelModel{ 66, "Integra 64 Plus", 64, 64 },	     //
+	SatelModel{ 67, "Integra 128 Plus", 128, 128 },	     //
+	SatelModel{ 72, "Integra 256 Plus", 256, 256 },	     //
 };
 
 #define MAX_LENGTH_OF_ANSWER 63 * 2 + 4 + 1

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -83,21 +83,20 @@ extern time_t m_StartTime;
 
 extern bool g_bDontCacheWWW;
 
-struct _tGuiLanguage {
-	const char* szShort;
-	const char* szLong;
-};
-
 namespace
 {
-	constexpr std::array<std::pair<const char *, const char *>, 36> guiLanguage{ {
-		{ "en", "English" },   { "sq", "Albanian" },   { "ar", "Arabic" },   { "bs", "Bosnian" },      { "bg", "Bulgarian" }, { "ca", "Catalan" },
-		{ "zh", "Chinese" },   { "cs", "Czech" },      { "da", "Danish" },   { "nl", "Dutch" },	       { "et", "Estonian" },  { "de", "German" },
-		{ "el", "Greek" },     { "fr", "French" },     { "fi", "Finnish" },  { "he", "Hebrew" },       { "hu", "Hungarian" }, { "is", "Icelandic" },
-		{ "it", "Italian" },   { "lt", "Lithuanian" }, { "lv", "Latvian" },  { "mk", "Macedonian" },   { "no", "Norwegian" }, { "fa", "Persian" },
-		{ "pl", "Polish" },    { "pt", "Portuguese" }, { "ro", "Romanian" }, { "ru", "Russian" },      { "sr", "Serbian" },   { "sk", "Slovak" },
-		{ "sl", "Slovenian" }, { "es", "Spanish" },    { "sv", "Swedish" },  { "zh_TW", "Taiwanese" }, { "tr", "Turkish" },   { "uk", "Ukrainian" },
-	} };
+	using _tGuiLanguage = std::pair<const char *, const char *>;
+	constexpr auto guiLanguage = std::array<_tGuiLanguage, 36>{
+		_tGuiLanguage{ "en", "English" },   _tGuiLanguage{ "sq", "Albanian" },	   _tGuiLanguage{ "ar", "Arabic" },    _tGuiLanguage{ "bs", "Bosnian" },
+		_tGuiLanguage{ "bg", "Bulgarian" }, _tGuiLanguage{ "ca", "Catalan" },	   _tGuiLanguage{ "zh", "Chinese" },   _tGuiLanguage{ "cs", "Czech" },
+		_tGuiLanguage{ "da", "Danish" },    _tGuiLanguage{ "nl", "Dutch" },	   _tGuiLanguage{ "et", "Estonian" },  _tGuiLanguage{ "de", "German" },
+		_tGuiLanguage{ "el", "Greek" },	    _tGuiLanguage{ "fr", "French" },	   _tGuiLanguage{ "fi", "Finnish" },   _tGuiLanguage{ "he", "Hebrew" },
+		_tGuiLanguage{ "hu", "Hungarian" }, _tGuiLanguage{ "is", "Icelandic" },	   _tGuiLanguage{ "it", "Italian" },   _tGuiLanguage{ "lt", "Lithuanian" },
+		_tGuiLanguage{ "lv", "Latvian" },   _tGuiLanguage{ "mk", "Macedonian" },   _tGuiLanguage{ "no", "Norwegian" }, _tGuiLanguage{ "fa", "Persian" },
+		_tGuiLanguage{ "pl", "Polish" },    _tGuiLanguage{ "pt", "Portuguese" },   _tGuiLanguage{ "ro", "Romanian" },  _tGuiLanguage{ "ru", "Russian" },
+		_tGuiLanguage{ "sr", "Serbian" },   _tGuiLanguage{ "sk", "Slovak" },	   _tGuiLanguage{ "sl", "Slovenian" }, _tGuiLanguage{ "es", "Spanish" },
+		_tGuiLanguage{ "sv", "Swedish" },   _tGuiLanguage{ "zh_TW", "Taiwanese" }, _tGuiLanguage{ "tr", "Turkish" },   _tGuiLanguage{ "uk", "Ukrainian" },
+	};
 } // namespace
 
 extern http::server::CWebServerHelper m_webservers;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -101,19 +101,18 @@ namespace
 	};
 
 #ifndef WIN32
-	constexpr std::array<std::pair<const char *, int>, 10> facilities{
-		{
-			{ "daemon", LOG_DAEMON }, //
-			{ "user", LOG_USER },	  //
-			{ "local0", LOG_LOCAL0 }, //
-			{ "local1", LOG_LOCAL1 }, //
-			{ "local2", LOG_LOCAL2 }, //
-			{ "local3", LOG_LOCAL3 }, //
-			{ "local4", LOG_LOCAL4 }, //
-			{ "local5", LOG_LOCAL5 }, //
-			{ "local6", LOG_LOCAL6 }, //
-			{ "local7", LOG_LOCAL7 }, //
-		}				  //
+	using facility = std::pair<const char *, int>;
+	constexpr auto facilities = std::array<facility, 10>{
+		facility{ "daemon", LOG_DAEMON }, //
+		facility{ "user", LOG_USER },	  //
+		facility{ "local0", LOG_LOCAL0 }, //
+		facility{ "local1", LOG_LOCAL1 }, //
+		facility{ "local2", LOG_LOCAL2 }, //
+		facility{ "local3", LOG_LOCAL3 }, //
+		facility{ "local4", LOG_LOCAL4 }, //
+		facility{ "local5", LOG_LOCAL5 }, //
+		facility{ "local6", LOG_LOCAL6 }, //
+		facility{ "local7", LOG_LOCAL7 }, //
 	};
 	std::string logfacname = "user";
 #endif

--- a/webserver/mime_types.cpp
+++ b/webserver/mime_types.cpp
@@ -16,46 +16,45 @@ namespace http
 	{
 		namespace mime_types
 		{
-			constexpr std::array<std::pair<const char *, const char *>, 37> mappings{
-				{
-					{ "gif", "image/gif" },								//
-					{ "htm", "text/html" },								//
-					{ "html", "text/html" },							//
-					{ "jpg", "image/jpeg" },							//
-					{ "png", "image/png" },								//
-					{ "css", "text/css" },								//
-					{ "xml", "application/xml" },							//
-					{ "js", "application/javascript" },						//
-					{ "json", "application/json" },							//
-					{ "swf", "application/x-shockwave-flash" },					//
-					{ "manifest", "text/cache-manifest" },						//
-					{ "appcache", "text/cache-manifest" },						//
-					{ "xls", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" }, //
-					{ "m3u", "audio/mpegurl" },							//
-					{ "mp3", "audio/mpeg" },							//
-					{ "ogg", "audio/ogg" },								//
-					{ "php", "text/html" },								//
-					{ "wav", "audio/x-wav" },							//
-					{ "svg", "image/svg+xml" },							//
-					{ "ico", "image/x-icon" },							//
-					{ "db", "application/octet-stream" },						//
-					{ "otf", "application/x-font-otf" },						//
-					{ "ttf", "application/x-font-ttf" },						//
-					{ "woff", "application/x-font-woff" },						//
-					{ "flv", "video/x-flv" },							//
-					{ "mp4", "video/mp4" },								//
-					{ "m3u8", "application/x-mpegURL" },						//
-					{ "ts", "video/MP2T" },								//
-					{ "3gp", "video/3gpp" },							//
-					{ "mov", "video/quicktime" },							//
-					{ "avi", "video/x-msvideo" },							//
-					{ "wmv", "video/x-ms-wmv" },							//
-					{ "h264", "video/h264" },							//
-					{ "mp4", "video/mp4" },								//
-					{ "wmv", "video/x-ms-wmv" },							//
-					{ "txt", "text/plain" },							//
-					{ "pdf", "application/pdf" },							//
-				}											//
+			using mapping = std::pair<const char *, const char *>;
+			constexpr auto mappings = std::array<mapping, 37>{
+				mapping{ "gif", "image/gif" },
+				mapping{ "htm", "text/html" },
+				mapping{ "html", "text/html" },
+				mapping{ "jpg", "image/jpeg" },
+				mapping{ "png", "image/png" },
+				mapping{ "css", "text/css" },
+				mapping{ "xml", "application/xml" },
+				mapping{ "js", "application/javascript" },
+				mapping{ "json", "application/json" },
+				mapping{ "swf", "application/x-shockwave-flash" },
+				mapping{ "manifest", "text/cache-manifest" },
+				mapping{ "appcache", "text/cache-manifest" },
+				mapping{ "xls", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" },
+				mapping{ "m3u", "audio/mpegurl" },
+				mapping{ "mp3", "audio/mpeg" },
+				mapping{ "ogg", "audio/ogg" },
+				mapping{ "php", "text/html" },
+				mapping{ "wav", "audio/x-wav" },
+				mapping{ "svg", "image/svg+xml" },
+				mapping{ "ico", "image/x-icon" },
+				mapping{ "db", "application/octet-stream" },
+				mapping{ "otf", "application/x-font-otf" },
+				mapping{ "ttf", "application/x-font-ttf" },
+				mapping{ "woff", "application/x-font-woff" },
+				mapping{ "flv", "video/x-flv" },
+				mapping{ "mp4", "video/mp4" },
+				mapping{ "m3u8", "application/x-mpegURL" },
+				mapping{ "ts", "video/MP2T" },
+				mapping{ "3gp", "video/3gpp" },
+				mapping{ "mov", "video/quicktime" },
+				mapping{ "avi", "video/x-msvideo" },
+				mapping{ "wmv", "video/x-ms-wmv" },
+				mapping{ "h264", "video/h264" },
+				mapping{ "mp4", "video/mp4" },
+				mapping{ "wmv", "video/x-ms-wmv" },
+				mapping{ "txt", "text/plain" },
+				mapping{ "pdf", "application/pdf" },
 			};
 
 			std::string extension_to_type(const std::string &extension)


### PR DESCRIPTION
Adding the initializer explicitly avoids having extra {}. Also adds
compatibility with C++17 CTAD.

Signed-off-by: Rosen Penev <rosenp@gmail.com>