### PR TITLE
Idx plugins backward compat

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -29,6 +29,8 @@ namespace Plugins {
 #define DECLARE_PYTHON_SYMBOL(type, symbol, params)	typedef type (PYTHON_CALL symbol##_t)(params); symbol##_t  symbol
 #define RESOLVE_PYTHON_SYMBOL(symbol)  symbol = (symbol##_t)RESOLVE_SYMBOL(shared_lib_, #symbol)
 
+#define DECLARE_PYTHON_DATA_SYMBOL(type, symbol) typedef const type *symbol##_t; symbol##_t symbol;
+
 	struct SharedLibraryProxy
 	{
 #ifdef WIN32
@@ -62,6 +64,7 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(const char*, PyUnicode_AsUTF8, PyObject*);
 		DECLARE_PYTHON_SYMBOL(char*, PyByteArray_AsString, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyUnicode_FromKindAndData, int COMMA const void* COMMA Py_ssize_t);
+		DECLARE_PYTHON_SYMBOL(PyObject*, PyLong_FromUnsignedLongLong, unsigned long long);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyLong_FromLong, long);
 		DECLARE_PYTHON_SYMBOL(PY_LONG_LONG, PyLong_AsLongLong, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyModule_GetDict, PyObject*);
@@ -135,6 +138,8 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyObject_GetIter, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyIter_Next, PyObject*);
 
+		DECLARE_PYTHON_DATA_SYMBOL(PyTypeObject, PyUnicode_Type);
+
 #ifdef _DEBUG
 		// In a debug build dealloc is a function but for release builds its a macro
 		DECLARE_PYTHON_SYMBOL(void, _Py_Dealloc, PyObject*);
@@ -203,6 +208,7 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyByteArray_AsString);
 					RESOLVE_PYTHON_SYMBOL(PyUnicode_FromKindAndData);
 					RESOLVE_PYTHON_SYMBOL(PyLong_FromLong);
+					RESOLVE_PYTHON_SYMBOL(PyLong_FromUnsignedLongLong);
 					RESOLVE_PYTHON_SYMBOL(PyLong_AsLongLong);
 					RESOLVE_PYTHON_SYMBOL(PyModule_GetDict);
 					RESOLVE_PYTHON_SYMBOL(PyDict_New);
@@ -277,6 +283,8 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyFloat_AsDouble);
 					RESOLVE_PYTHON_SYMBOL(PyObject_GetIter);
 					RESOLVE_PYTHON_SYMBOL(PyIter_Next);
+
+					RESOLVE_PYTHON_SYMBOL(PyUnicode_Type);
 				}
 			}
 			_Py_NoneStruct.ob_refcnt = 1;
@@ -420,6 +428,7 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyByteArray_AsString	pythonLib->PyByteArray_AsString
 #define PyUnicode_FromKindAndData  pythonLib->PyUnicode_FromKindAndData
 #define PyLong_FromLong			pythonLib->PyLong_FromLong
+#define PyLong_FromUnsignedLongLong  pythonLib->PyLong_FromUnsignedLongLong
 #define PyLong_AsLongLong		pythonLib->PyLong_AsLongLong
 #define PyModule_GetDict		pythonLib->PyModule_GetDict
 #define PyDict_New				pythonLib->PyDict_New
@@ -497,6 +506,8 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyFloat_AsDouble		pythonLib->PyFloat_AsDouble
 #define	PyObject_GetIter		pythonLib->PyObject_GetIter
 #define	PyIter_Next				pythonLib->PyIter_Next
+
+#define PyUnicode_Type (*pythonLib->PyUnicode_Type)
 
 #ifndef _Py_DEC_REFTOTAL
 /* _Py_DEC_REFTOTAL macro has been removed from Python 3.9 by: https://github.com/python/cpython/commit/49932fec62c616ec88da52642339d83ae719e924 */

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -31,6 +31,8 @@ namespace Plugins {
 		PDM_ALL = 65535
 	};
 
+	struct module_state;
+
 	class CPlugin : public CDomoticzHardwareBase
 	{
 	private:
@@ -54,10 +56,15 @@ namespace Plugins {
 		bool m_bIsStarting;
 		bool m_bIsStopped;
 
+		bool m_bUseDeviceIndex = false;
+
 		void Do_Work();
 
 		void LogPythonException();
 		void LogPythonException(const std::string &);
+
+		bool LoadDevicesByUnit(module_state *pModState);
+		bool LoadDevicesByIdx(module_state *pModState);
 
 	public:
 	  CPlugin(int HwdID, const std::string &Name, const std::string &PluginKey);
@@ -90,18 +97,20 @@ namespace Plugins {
 	  void WriteDebugBuffer(const std::vector<byte> &Buffer, bool Incoming);
 
 	  bool WriteToHardware(const char *pdata, unsigned char length) override;
-	  void SendCommand(int Unit, const std::string &command, int level, _tColor color);
-	  void SendCommand(int Unit, const std::string &command, float level);
+	  void SendCommand(uint64_t idx, int Unit, const std::string &command, int level, _tColor color);
+	  void SendCommand(uint64_t idx, int Unit, const std::string &command, float level);
 
-	  void onDeviceAdded(int Unit);
-	  void onDeviceModified(int Unit);
-	  void onDeviceRemoved(int Unit);
+	  void onDeviceAdded(uint64_t key);
+	  void onDeviceModified(uint64_t key);
+	  void onDeviceRemoved(uint64_t key);
 	  void MessagePlugin(CPluginMessageBase *pMessage);
-	  void DeviceAdded(int Unit);
-	  void DeviceModified(int Unit);
-	  void DeviceRemoved(int Unit);
+	  void DeviceAdded(uint64_t idx, int Unit);
+	  void DeviceModified(uint64_t idx, int Unit);
+	  void DeviceRemoved(uint64_t idx, int Unit);
 
-	  bool HasNodeFailed(int Unit);
+	  bool HasNodeFailed(uint64_t idx, int Unit);
+
+	  bool UseDeviceIndex() const { return m_bUseDeviceIndex; }
 
 	  std::string m_PluginKey;
 	  PyDictObject*	m_DeviceDict;
@@ -132,8 +141,8 @@ namespace Plugins {
 //
 	struct module_state {
 		CPlugin* pPlugin;
-		PyObject* error;
 		PyTypeObject*	pDeviceClass;
+		bool bUseDeviceIndex;
 	};
 
 	//

--- a/hardware/plugins/PythonObjects.h
+++ b/hardware/plugins/PythonObjects.h
@@ -85,13 +85,13 @@ namespace Plugins {
 	public:
 		PyObject_HEAD
 		PyObject*	PluginKey;
+		uint64_t			ID;
 		int			HwdID;
 		PyObject*	DeviceID;
 		int			Unit;
 		int			Type;
 		int			SubType;
 		int			SwitchType;
-		int			ID;
 		int			LastLevel;
 		PyObject*	Name;
 		PyObject*	LastUpdate;
@@ -107,6 +107,8 @@ namespace Plugins {
 		PyObject*	Color;
 		CPlugin*	pPlugin;
 	};
+
+	PyObject* CDevice_new_with_id(PyTypeObject *type, uint64_t id);
 
 	void CDevice_dealloc(CDevice* self);
 	PyObject* CDevice_new(PyTypeObject *type, PyObject *args, PyObject *kwds);

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1644,10 +1644,10 @@ void CEventSystem::EvaluateEvent(const std::vector<_tEventQueue> &items)
 			if (!result.empty())
 			{
 				std::vector<std::string> sd = result[0];
-				Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)m_mainworker.GetHardware(atoi(sd[0].c_str()));
+				Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)m_mainworker.GetHardware(std::stoi(sd[0]));
 				if (pPlugin)
 					pPlugin->MessagePlugin(new Plugins::onSecurityEventCallback(
-						pPlugin, atoi(sd[2].c_str()), item.nValue, m_szSecStatus[item.nValue]));
+						pPlugin, std::stoull(sd[1]), std::stoi(sd[2]), item.nValue, m_szSecStatus[item.nValue]));
 			}
 		}
 #endif

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -5058,7 +5058,7 @@ namespace http {
 						level = 5;
 				}
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
-				m_mainworker.SwitchLightInt(sd, switchcmd, level, NoColor, true, Username);
+				m_mainworker.SwitchLightInt(-1, sd, switchcmd, level, NoColor, true, Username);
 			}
 			else if (cparam == "addswitch")
 			{
@@ -11523,7 +11523,7 @@ namespace http {
 						if (pHardware->HwdType == HTYPE_PythonPlugin)
 						{
 							Plugins::CPlugin *pPlugin = (Plugins::CPlugin*)pHardware;
-							bHaveTimeout = pPlugin->HasNodeFailed(atoi(sd[2].c_str()));
+							bHaveTimeout = pPlugin->HasNodeFailed(std::stoull(sd[0]), std::stoi(sd[2]));
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						}
 					}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -11322,7 +11322,7 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 	return true;
 }
 
-bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string& User)
+bool MainWorker::SwitchLightInt(uint64_t idx, const std::vector<std::string> &sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string &User)
 {
 	unsigned long ID;
 	std::stringstream s_strid;
@@ -11427,7 +11427,7 @@ bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string 
 				switchcmd = "Set Color";
 			}
 		}
-		((Plugins::CPlugin*)m_hardwaredevices[hindex])->SendCommand(Unit, switchcmd, level, color);
+		((Plugins::CPlugin *)m_hardwaredevices[hindex])->SendCommand(idx, Unit, switchcmd, level, color);
 #endif
 		return true;
 	}
@@ -12433,7 +12433,7 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 
 bool MainWorker::SwitchLight(const std::string& idx, const std::string& switchcmd, const std::string& level, const std::string& color, const std::string& ooc, const int ExtraDelay, const std::string& User)
 {
-	uint64_t ID = std::strtoull(idx.c_str(), nullptr, 10);
+	uint64_t ID = std::stoull(idx);
 	int ilevel = -1;
 	if (!level.empty())
 		ilevel = atoi(level.c_str());
@@ -12485,7 +12485,7 @@ bool MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, c
 		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(static_cast<float>(iOnDelay + ExtraDelay), idx, switchcmd, level, color, "Switch with Delay", User));
 		return true;
 	}
-	return SwitchLightInt(sd, switchcmd, level, color, false, User);
+	return SwitchLightInt(idx, sd, switchcmd, level, color, false, User);
 }
 
 bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue, const std::string& newMode, const std::string& until)
@@ -12509,7 +12509,7 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue, cons
 		return false;
 
 	if (pHardware->HwdType != HTYPE_EVOHOME_SCRIPT && pHardware->HwdType != HTYPE_EVOHOME_SERIAL && pHardware->HwdType != HTYPE_EVOHOME_WEB && pHardware->HwdType != HTYPE_EVOHOME_TCP)
-		return SetSetPointInt(sd, TempValue);
+		return SetSetPointInt(std::stoull(idx), sd, TempValue);
 
 	int nEvoMode = 0;
 	if (newMode == "PermanentOverride" || newMode.empty())
@@ -12575,10 +12575,10 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue)
 		return false;
 
 	std::vector<std::string> sd = result[0];
-	return SetSetPointInt(sd, TempValue);
+	return SetSetPointInt(std::stoull(idx), sd, TempValue);
 }
 
-bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float TempValue)
+bool MainWorker::SetSetPointInt(uint64_t idx, const std::vector<std::string> &sd, const float TempValue)
 {
 	int HardwareID = atoi(sd[0].c_str());
 	int hindex = FindDomoticzHardware(HardwareID);
@@ -12609,7 +12609,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	if (pHardware->HwdType == HTYPE_PythonPlugin)
 	{
 #ifdef ENABLE_PYTHON
-		((Plugins::CPlugin*)pHardware)->SendCommand(Unit, "Set Level", TempValue);
+		((Plugins::CPlugin *)pHardware)->SendCommand(idx, Unit, "Set Level", TempValue);
 #endif
 	}
 	else if (

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -54,7 +54,7 @@ public:
 
 	bool SwitchLight(const std::string &idx, const std::string &switchcmd, const std::string &level, const std::string &color, const std::string &ooc, int ExtraDelay, const std::string &User);
 	bool SwitchLight(uint64_t idx, const std::string &switchcmd, int level, _tColor color, bool ooc, int ExtraDelay, const std::string &User);
-	bool SwitchLightInt(const std::vector<std::string> &sd, std::string switchcmd, int level, _tColor color, bool IsTesting, const std::string &User);
+	bool SwitchLightInt(uint64_t idx, const std::vector<std::string> &sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string &User);
 
 	bool SwitchScene(const std::string &idx, const std::string &switchcmd, const std::string& User);
 	bool SwitchScene(uint64_t idx, std::string switchcmd, const std::string &User);
@@ -63,7 +63,7 @@ public:
 
 	bool SetSetPoint(const std::string &idx, float TempValue);
 	bool SetSetPoint(const std::string &idx, float TempValue, const std::string &newMode, const std::string &until);
-	bool SetSetPointInt(const std::vector<std::string> &sd, float TempValue);
+	bool SetSetPointInt(uint64_t idx, const std::vector<std::string> &sd, const float TempValue);
 	bool SetThermostatState(const std::string &idx, int newState);
 	bool SetClock(const std::string &idx, const std::string &clockstr);
 	bool SetClockInt(const std::vector<std::string> &sd, const std::string &clockstr);


### PR DESCRIPTION
Here's a rough proposal for using Device Idx based addressing in plugins with backward and easy forward compatibility (updated plugins can continue to work on old stable). 
Note the use of Type+Subtype for uniqueness rather than just DeviceID + Unit is a trivial modification - I'll fix it.

To use this a plugin calls Domoticz.UseDeviceIndex() at module load time.
After this Devices is now indexed by Idx and creating devices doesn't require a Unit - it changes the Devices constructor. Otherwise the API is similar, so this has minimal impact on existing plugins.
There are alternatives, but the advantage of this way is the plugin can detect the feature at load time and support both indexing methods easily - obviously just not doing the allocation of a Unit number if the Idx feature is available.
