### PR TITLE
Execution progress and result text not visible

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -35,7 +35,7 @@ body {
 	background: #202020 url(images/img01.jpg) repeat;
 	font-family: Arial, Helvetica, sans-serif;
 	font-size: 10pt;
-	color: #FFF;
+	color: #000;
 }
 
 .bootbox-body {


### PR DESCRIPTION
If clicked in Hardware on the "Has Node Failed" button no text is displayed in the popup during execution and when status of request is display. This is caused by this color #FFF (which is the same as the background). 
When set to #000 the text in the popup is visible during execution of the command and when result is displayed.