### PR TITLE
Rollback moisture sensor Opus-XT300 from custom to previous moisture…

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -395,8 +395,15 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	if (haveMoisture)
 	{
 		//moisture is in percentage
-		//SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, static_cast<float>(moisture), model, "%", snr);
-		SendMoistureSensor(sensoridx, batterylevel, moisture, model, snr);
+		if (haveChannel)	// Channel is used to identify each sensor
+		{
+			SendCustomSensor((uint8_t)sensoridx, (uint8_t)channel, batterylevel, static_cast<float>(moisture), model, "%", snr);
+		}
+		else
+		{
+			SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, static_cast<float>(moisture), model, "%", snr);
+		}
+		//SendMoistureSensor(sensoridx, batterylevel, moisture, model, snr);
 		bHandled = true;
 	}
 	if (havePower)

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -395,8 +395,8 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	if (haveMoisture)
 	{
 		//moisture is in percentage
-		SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, static_cast<float>(moisture), model, "%", snr);
-		//SendMoistureSensor(sensoridx, batterylevel, moisture, model, snr);
+		//SendCustomSensor((uint8_t)sensoridx, (uint8_t)unit, batterylevel, static_cast<float>(moisture), model, "%", snr);
+		SendMoistureSensor(sensoridx, batterylevel, moisture, model, snr);
 		bHandled = true;
 	}
 	if (havePower)


### PR DESCRIPTION
Hi,

Got 3 Opus-XT300 moisture sensors that were fully functional last spring (2020) in Domoticz.
This spring I put new batteries in them, the already defined sensors in Domoticz did not fully work ; the temperature was OK, however the moisture was not updated.

I delete the old sensors in Domoticz and choose to re-create the sensors.
The type of the sensor moved  from moisture type to custom type.
The issue is that there are 3 temperature sensors created with each their own ID, but only one custom sensor with ID=00000000.
This moisture sensor is updated, however we should have 3 of them.

![Domoticz Bug Opus](https://user-images.githubusercontent.com/16359046/112364812-37fb3780-8cd7-11eb-9ff7-737ed8d7f43d.png)


The program has been changed in last December : 

![Screenshot_2021-03-24 domoticz domoticz](https://user-images.githubusercontent.com/16359046/112364396-c15e3a00-8cd6-11eb-9156-f9fb0ea53ffb.png)

Since I do not find why the moisture sensor which used to be fine has been changed to custom sensor, I've rolled back the source to the previous status.

After compilation, having deleted the defective sensors and having started Domoticz, the new sensors have been created and they now work fine, as they did before.

![Domoticz - Opus rollback](https://user-images.githubusercontent.com/16359046/112365354-d6879880-8cd7-11eb-9264-88d3ae69b71f.png)

I suggest to keep those moisture sensor type, which works well and which uses the correct unit "cb" to measure soil moisture.

Thanks.