### PR TITLE
Adding support for Teleinfo connected over TCP.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,7 @@ hardware/TE923.cpp
 hardware/TE923Tool.cpp
 hardware/TeleinfoBase.cpp
 hardware/TeleinfoSerial.cpp
+hardware/TeleinfoTCP.cpp
 hardware/Tellstick.cpp
 hardware/TellstickFactory.cpp
 hardware/Thermosmart.cpp

--- a/hardware/TeleinfoTCP.cpp
+++ b/hardware/TeleinfoTCP.cpp
@@ -1,0 +1,119 @@
+#include "stdafx.h"
+#include "TeleinfoTCP.h"
+#include "../main/Logger.h"
+#include "../main/Helper.h"
+#include "../main/localtime_r.h"
+
+CTeleinfoTCP::CTeleinfoTCP(const int ID, const std::string &IPAddress, const unsigned short usIPPort, int datatimeout, const bool disable_crc, const int ratelimit):
+	m_szIPAddress(IPAddress),
+	m_usIPPort(usIPPort)
+{
+	m_HwdID = ID;
+	m_iDataTimeout = datatimeout;
+	m_bDisableCRC = disable_crc;
+	m_iRateLimit = ratelimit;
+	
+	m_iBaudRate = 1200;
+
+	if ((m_iRateLimit > m_iDataTimeout) && (m_iDataTimeout > 0))  m_iRateLimit = m_iDataTimeout;
+	Init();
+}
+
+void CTeleinfoTCP::Init()
+{
+	InitTeleinfo();
+}
+
+bool CTeleinfoTCP::StartHardware()
+{
+	RequestStart();
+
+	m_bIsStarted = true;
+
+	m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
+	SetThreadNameInt(m_thread->native_handle());
+	return (m_thread != nullptr);
+}
+
+
+bool CTeleinfoTCP::StopHardware()
+{
+	if (m_thread)
+	{
+		RequestStop();
+		m_thread->join();
+		m_thread.reset();
+	}
+	m_bIsStarted = false;
+	return true;
+}
+
+
+void CTeleinfoTCP::Do_Work()
+{
+	_log.Log(LOG_STATUS, "(%s) attempt connect to %s:%d",  m_Name.c_str(), m_szIPAddress.c_str(), m_usIPPort);
+	connect(m_szIPAddress, m_usIPPort);
+	while (!IsStopRequested(1000))
+	{
+	}
+	terminate();
+
+	_log.Log(LOG_STATUS, "(%s): TCP/IP Worker stopped...",  m_Name.c_str());
+}
+
+
+bool CTeleinfoTCP::WriteToHardware(const char *pdata, const unsigned char length)
+{
+	return isConnected();
+}
+
+
+void CTeleinfoTCP::OnConnect()
+{
+	Init();
+
+	_log.Log(LOG_STATUS, "(%s) connected to: %s:%d",  m_Name.c_str(), m_szIPAddress.c_str(), m_usIPPort);
+
+	if (m_bDisableCRC)
+		_log.Log(LOG_STATUS, "(%s) CRC checks on incoming data are disabled", m_Name.c_str());
+	else
+		_log.Log(LOG_STATUS, "(%s) CRC checks will be performed on incoming data", m_Name.c_str());
+}
+
+
+void CTeleinfoTCP::OnDisconnect()
+{
+	_log.Log(LOG_STATUS, "(%s) disconnected",  m_Name.c_str());
+}
+
+
+void CTeleinfoTCP::OnData(const unsigned char *pData, size_t length)
+{
+	ParseTeleinfoData((const char *)pData, static_cast<int>(length));
+}
+
+
+void CTeleinfoTCP::OnError(const boost::system::error_code& error)
+{
+	if (
+		(error == boost::asio::error::address_in_use) ||
+		(error == boost::asio::error::connection_refused) ||
+		(error == boost::asio::error::access_denied) ||
+		(error == boost::asio::error::host_unreachable) ||
+		(error == boost::asio::error::timed_out)
+		)
+	{
+		_log.Log(LOG_ERROR, "(%s) Can not connect to: %s:%d",  m_Name.c_str(), m_szIPAddress.c_str(), m_usIPPort);
+	}
+	else if (
+		(error == boost::asio::error::eof) ||
+		(error == boost::asio::error::connection_reset)
+		)
+	{
+		_log.Log(LOG_STATUS, "(%s) Connection reset!",  m_Name.c_str());
+	}
+	else
+	{
+		_log.Log(LOG_ERROR, "(%s) %s",  m_Name.c_str(), error.message().c_str());
+	}
+}

--- a/hardware/TeleinfoTCP.h
+++ b/hardware/TeleinfoTCP.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "ASyncTCP.h"
+#include "TeleinfoBase.h"
+
+class CTeleinfoTCP : public CTeleinfoBase, ASyncTCP
+{
+      public:
+	CTeleinfoTCP(int ID, const std::string &IPAddress, unsigned short usIPPort, int datatimeout, bool disable_crc, int ratelimit);
+	~CTeleinfoTCP() override = default;
+	bool WriteToHardware(const char *pdata, unsigned char length) override;
+	boost::signals2::signal<void()> sDisconnected;
+
+      private:
+	bool StartHardware() override;
+	bool StopHardware() override;
+	void Init();
+
+	void Do_Work();
+
+	void OnConnect() override;
+	void OnDisconnect() override;
+	void OnData(const unsigned char *pData, size_t length) override;
+	void OnError(const boost::system::error_code &error) override;
+
+	std::string m_szIPAddress;
+	unsigned short m_usIPPort;
+	std::shared_ptr<std::thread> m_thread;
+};

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -275,6 +275,7 @@ static const STR_TABLE_SINGLE HardwareTypeTable[] = {
 	{ HTYPE_OctoPrint, "OctoPrint (MQTT/Gina Haussge) with LAN interface", "OctoPrint" },
 	{ HTYPE_Meteorologisk, "Meteorologisk institutt Norway (Weather Lookup)", "Meteorologisk" },
 	{ HTYPE_AirconWithMe, "AirconWithMe Wifi Airco module", "AirconWithMe" },
+	{ HTYPE_TeleinfoMeterTCP, "Teleinfo EDF with LAN interface", "TeleInfo" },
 	{ 0, nullptr, nullptr },
 };
 
@@ -3950,6 +3951,7 @@ bool IsNetworkDevice(const _eHardwareTypes htype)
 	case HTYPE_TTN_MQTT:
 	case HTYPE_S0SmartMeterTCP:
 	case HTYPE_OctoPrint:
+	case HTYPE_TeleinfoMeterTCP:
 		return true;
 	default:
 		return false;

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -218,6 +218,7 @@ enum _eHardwareTypes {
 	HTYPE_Meteorologisk,        //121
 	HTYPE_Mercedes,				//122
 	HTYPE_AirconWithMe,         //123
+	HTYPE_TeleinfoMeterTCP,		//124
 	HTYPE_END
 };
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1116,9 +1116,9 @@ namespace http {
 					}
 				}
 
-				if (htype == HTYPE_ECODEVICES) {
-					// EcoDevices always have decimals. Chances to have a P1 and a EcoDevice/Teleinfo device on the same
-					// Domoticz instance are very low as both are national standards (NL and FR)
+				if (htype == HTYPE_ECODEVICES || htype == HTYPE_TeleinfoMeterTCP) {
+					// EcoDevices and Teleinfo always have decimals. Chances to have a P1 and a EcoDevice/Teleinfo
+					//  device on the same Domoticz instance are very low as both are national standards (NL and FR)
 					m_sql.UpdatePreferencesVar("SmartMeterType", 0);
 				}
 			}
@@ -1523,7 +1523,7 @@ namespace http {
 				|| (htype == HTYPE_KMTronicTCP) || (htype == HTYPE_KMTronicUDP) || (htype == HTYPE_SOLARMAXTCP) || (htype == HTYPE_RelayNet) || (htype == HTYPE_SatelIntegra) || (htype == HTYPE_eHouseTCP) || (htype == HTYPE_RFLINKTCP)
 				|| (htype == HTYPE_Comm5TCP || (htype == HTYPE_Comm5SMTCP) || (htype == HTYPE_CurrentCostMeterLAN))
 				|| (htype == HTYPE_NefitEastLAN) || (htype == HTYPE_DenkoviHTTPDevices) || (htype == HTYPE_DenkoviTCPDevices) || (htype == HTYPE_Ec3kMeterTCP) || (htype == HTYPE_MultiFun) || (htype == HTYPE_ZIBLUETCP) || (htype == HTYPE_OnkyoAVTCP)
-				|| (htype == HTYPE_OctoPrint)
+				|| (htype == HTYPE_OctoPrint) || (htype == HTYPE_TeleinfoMeterTCP)
 				) {
 				//Lan
 				if (address.empty())

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -53,6 +53,7 @@
 #include "../hardware/OTGWTCP.h"
 #include "../hardware/TeleinfoBase.h"
 #include "../hardware/TeleinfoSerial.h"
+#include "../hardware/TeleinfoTCP.h"
 #include "../hardware/Limitless.h"
 #include "../hardware/MochadTCP.h"
 #include "../hardware/EnOceanESP2.h"
@@ -1088,6 +1089,9 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_AirconWithMe:
 		pHardware = new CAirconWithMe(ID, Address, Port, Username, Password);
+		break;
+	case HTYPE_TeleinfoMeterTCP:
+		pHardware = new CTeleinfoTCP(ID, Address, Port, DataTimeout, (Mode2 != 0), Mode3);
 		break;
 	}
 
@@ -13537,6 +13541,8 @@ void MainWorker::HeartbeatCheck()
 
 bool MainWorker::UpdateDevice(const int DevIdx, const int nValue, const std::string &sValue, const std::string &userName, const int signallevel, const int batterylevel, const bool parseTrigger)
 {
+	_log.Debug(DEBUG_NORM, "MainWorker::UpdateDevice: ID: %d", DevIdx);
+
 	// Get the raw device parameters
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID==%d)", DevIdx);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -13541,8 +13541,6 @@ void MainWorker::HeartbeatCheck()
 
 bool MainWorker::UpdateDevice(const int DevIdx, const int nValue, const std::string &sValue, const std::string &userName, const int signallevel, const int batterylevel, const bool parseTrigger)
 {
-	_log.Debug(DEBUG_NORM, "MainWorker::UpdateDevice: ID: %d", DevIdx);
-
 	// Get the raw device parameters
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID==%d)", DevIdx);

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -686,6 +686,7 @@
     <ClInclude Include="..\hardware\TE923Tool.h" />
     <ClInclude Include="..\hardware\TeleinfoBase.h" />
     <ClInclude Include="..\hardware\TeleinfoSerial.h" />
+    <ClInclude Include="..\hardware\TeleinfoTCP.h" />
     <ClInclude Include="..\hardware\TelldusFunctions.h" />
     <ClInclude Include="..\hardware\Tellstick.h" />
     <ClInclude Include="..\hardware\Thermosmart.h" />
@@ -990,6 +991,7 @@
     <ClCompile Include="..\hardware\TE923Tool.cpp" />
     <ClCompile Include="..\hardware\TeleinfoBase.cpp" />
     <ClCompile Include="..\hardware\TeleinfoSerial.cpp" />
+    <ClCompile Include="..\hardware\TeleinfoTCP.cpp" />
     <ClCompile Include="..\hardware\Tellstick.cpp" />
     <ClCompile Include="..\hardware\TellstickFactory.cpp" />
     <ClCompile Include="..\hardware\Thermosmart.cpp" />

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -383,7 +383,7 @@ define(['app'], function (app) {
 					Mode2 = $("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked") ? 0 : 1;
 					var ratelimitp1 = $("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val();
 					if (ratelimitp1 == "") {
-						ratelimitp1 = "0";
+						ratelimitp1 = "60";
 					}
 					Mode3 = ratelimitp1;
 				}
@@ -1607,7 +1607,7 @@ define(['app'], function (app) {
 					Mode2 = $("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked") ? 0 : 1;
 					var ratelimitp1 = $("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val();
 					if (ratelimitp1 == "") {
-						ratelimitp1 = "0";
+						ratelimitp1 = "60";
 					}
 					Mode3 = ratelimitp1;
 				}

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -200,7 +200,7 @@ define(['app'], function (app) {
 					}
 				});
 			}
-			else if (text.indexOf("USB") >= 0 || text.indexOf("Teleinfo EDF") >= 0) {
+			else if (text.indexOf("USB") >= 0 || text == "Teleinfo EDF") {
 				var Mode1 = "0";
 				var password = "";
 				var serialport = $("#hardwarecontent #divserial #comboserialport option:selected").text();
@@ -383,7 +383,7 @@ define(['app'], function (app) {
 					Mode2 = $("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked") ? 0 : 1;
 					var ratelimitp1 = $("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val();
 					if (ratelimitp1 == "") {
-						ratelimitp1 = "60";
+						ratelimitp1 = "0";
 					}
 					Mode3 = ratelimitp1;
 				}
@@ -1603,6 +1603,14 @@ define(['app'], function (app) {
 					}
 					password = decryptionkey;
 				}
+				else if (text.indexOf("Teleinfo EDF") >= 0) {
+					Mode2 = $("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked") ? 0 : 1;
+					var ratelimitp1 = $("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val();
+					if (ratelimitp1 == "") {
+						ratelimitp1 = "0";
+					}
+					Mode3 = ratelimitp1;
+				}
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -1746,7 +1754,7 @@ define(['app'], function (app) {
 					}
 				});
 			}
-			else if (text.indexOf("USB") >= 0 || text.indexOf("Teleinfo EDF") >= 0) {
+			else if (text.indexOf("USB") >= 0 || text == "Teleinfo EDF") {
 				var Mode1 = "0";
 				var extra = "";
 				var password = "";
@@ -3961,7 +3969,7 @@ define(['app'], function (app) {
 							$("#hardwarecontent #hardwareparamssysfsgpio #sysfsautoconfigure").prop("checked", data["Mode1"] == 1);
 							$("#hardwarecontent #hardwareparamssysfsgpio #sysfsdebounce").val(data["Mode2"]);
 						}
-						else if (data["Type"].indexOf("USB") >= 0 || data["Type"].indexOf("Teleinfo EDF") >= 0) {
+						else if (data["Type"].indexOf("USB") >= 0 || data["Type"] == "Teleinfo EDF") {
 							$("#hardwarecontent #hardwareparamsserial #comboserialport").val(data["IntPort"]);
 							if (data["Type"].indexOf("Evohome") >= 0) {
 								$("#hardwarecontent #divevohome #combobaudrateevohome").val(data["Mode1"]);
@@ -4010,6 +4018,10 @@ define(['app'], function (app) {
 								$("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked", data["Mode2"] == 0);
 								$("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val(data["Mode3"]);
 								$("#hardwarecontent #divkeyp1p1 #decryptionkey").val(data["Password"]);
+							}
+							if (data["Type"].indexOf("Teleinfo EDF") >= 0 ) {
+								$("#hardwarecontent #divcrcp1 #disablecrcp1").prop("checked", data["Mode2"] == 0);
+								$("#hardwarecontent #hardwareparamsratelimitp1 #ratelimitp1").val(data["Mode3"]);
 							}
 							if (data["Type"].indexOf("Eco Devices") >= 0) {
 								$("#hardwarecontent #divmodelecodevices #combomodelecodevices").val(data["Mode1"]);
@@ -4509,7 +4521,7 @@ define(['app'], function (app) {
 			else if (text.indexOf("sysfs GPIO") >= 0) {
 				$("#hardwarecontent #divsysfsgpio").show();
 			}
-			else if (text.indexOf("USB") >= 0 || text.indexOf("Teleinfo EDF") >= 0) {
+			else if (text.indexOf("USB") >= 0 || text == "Teleinfo EDF") {
 				if (text.indexOf("Evohome") >= 0) {
 					$("#hardwarecontent #divevohome").show();
 				}
@@ -4556,6 +4568,10 @@ define(['app'], function (app) {
 						$("#hardwarecontent #divratelimitp1").show();
 						$("#hardwarecontent #divcrcp1").show();
 						$("#hardwarecontent #divkeyp1p1").show();
+					}
+					if (text.indexOf("Teleinfo EDF") >= 0) {
+						$("#hardwarecontent #divratelimitp1").show();
+						$("#hardwarecontent #divcrcp1").show();
 					}
 					if (text.indexOf("Evohome") >= 0) {
 						$("#hardwarecontent #divevohometcp").show();


### PR DESCRIPTION
Support for the french smart meter Teleinfo was limited to directly connected serial. 
This adds support for Teleinfo connected to a serial-to-TCP adapter.
The TCP client code was mostly taken from P1MeterTCP.