### PR TITLE
MQTT: Add option to set Retain flag for messages when using Index or Name publishing scheme

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -17,7 +17,6 @@
 #define TOPIC_OUT	"domoticz/out"
 #define TOPIC_IN	"domoticz/in"
 #define QOS         1
-#define RETAIN		true
 #define RETAIN_BIT	0x80
 
 namespace

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -17,6 +17,7 @@
 #define TOPIC_OUT	"domoticz/out"
 #define TOPIC_IN	"domoticz/in"
 #define QOS         1
+#define RETAIN		true
 
 namespace
 {
@@ -701,7 +702,7 @@ void MQTT::SendMessage(const std::string& Topic, const std::string& Message)
 			Log(LOG_STATUS, "MQTT: Not Connected, failed to send message: %s", Message.c_str());
 			return;
 		}
-		publish(nullptr, Topic.c_str(), Message.size(), Message.c_str());
+		publish(nullptr, Topic.c_str(), Message.size(), Message.c_str(), QOS, RETAIN);
 	}
 	catch (...)
 	{

--- a/hardware/MQTT.h
+++ b/hardware/MQTT.h
@@ -66,6 +66,7 @@ class MQTT : public MySensorsBase, mosqdz::mosquittodz
 	boost::signals2::connection m_sSwitchSceneConnection;
 	_ePublishTopics m_publish_scheme;
 	bool m_bPreventLoop = false;
+	bool m_bRetain = false;
 	uint64_t m_LastUpdatedDeviceRowIdx = 0;
 	uint64_t m_LastUpdatedSceneRowIdx = 0;
 };

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1380,23 +1380,27 @@
 				<td>
 					<select id="combotopicselect" style="width:200px" class="combobox ui-corner-all">
 						<option value="1">Flat</option>
-						<option value="2"><Floor>/<Room></option>
-						<option value="3">Flat + <Floor>/<Room></option>
+						<option value="2">Floor/Room</option>
+						<option value="3">Flat + Floor/Room</option>
 						<option value="4">Index</option>
+						<option value="132">Index (with Retain)</option>
 						<option value="8">Name</option>
+						<option value="136">Name (with Retain)</option>
 						<option value="0">None</option>
 					</select>
 					<br>
 					<span>
 						Select the Topic('s) Domoticz will use to publish outgoing messages. <br>
-						<b>Flat</b> - publish outgoing messagen on topic {domoticz/out}.<br>
-						<b>Hierarchical</b> - publish outgoing messagen on topic {domoticz/out}/${floorplan name}/${plan name}.<br>
+						<b>Flat</b> - publish outgoing messagen on topic <i>{domoticz/out}</i>.<br>
+						<b>Hierarchical</b> - publish outgoing messagen on topic <i>{domoticz/out}/{$floorplan name}/{$plan name}</i>.<br>
 						<b>Combined</b> - Use both <b>Flat</b> and <b>Hierarchical</b> topic schemes.<br>
-						<b>Index</b> - publish outgoing messagen on topic {domoticz/out}/$idx<br>
-						<b>Name</b> - publish outgoing messagen on topic {domoticz/out}/$name<br>
+						<b>Index</b> - publish outgoing messagen on topic <i>{domoticz/out}/{$idx}</i>.&nbsp;(with or without Retain bit)<br>
+						<b>Name</b> - publish outgoing messagen on topic <i>{domoticz/out}/{$name}</i>.&nbsp;(with or without Retain bit)<br>
 						<b>None</b> - disable outgoing messages.<br>
 						<br>
-						Note that <b>Hierarchical</b> only reports sensor updates for sensors that are placed on a floorplan/plan.
+						Note that <b>Hierarchical</b> only reports sensor updates for sensors that are placed on a floorplan/plan.<br>
+						<br>
+						Alternative topic prefixes for {domoticz/in} and {domoticz/out} can be entered below.<br>  
 				</td>
 			</tr>
 			<tr>


### PR DESCRIPTION
With this PR it is now possible to let Domoticz publish messages with the Retain bit set to True.

This option is available only for the Index and Name publishing scheme's as they are publishing on a topic per device bases.

Also, now Domoticz uses QoS = 1 for publishing messages (at least once) instead of best effort, ensuring that messages do get published.

The outgoing messages now also contain the LastUpdate data from each device, so in case of retained messages (which the client can check when looking at the Retain bit), a client can also see how old these messages are.

NOTE: When testing this, remember to clear the MQTT brokers persistancy database to actually flush Retained messages. Domoticz does not 'clean' these Retained messages when selecting a different publishing scheme!