### PR TITLE
Tar extract less verbose

### DIFF
--- a/updaterelease
+++ b/updaterelease
@@ -23,7 +23,7 @@ then
  echo "Problem in downloaded Domoticz archive. Stopping update!"
  exit 1
 fi
-tar xvfz domoticz_release.tgz
+tar xfz domoticz_release.tgz
 rm domoticz_release.tgz
 echo "Restarting Domoticz... (please standby...)"
 sudo service domoticz.sh restart


### PR DESCRIPTION
Outputting the entire list of files in the tar cluttered the output. Tar output is now less verbose and shows a progress bar instead of the list of files.