### PR TITLE
Add each zwave unit as a separate hardware in the device list

### DIFF
--- a/www/app/devices/Devices.js
+++ b/www/app/devices/Devices.js
@@ -625,8 +625,17 @@ define(['app', 'livesocket'], function(app) {
                     if (response.result !== undefined) {
                         $ctrl.devices = response.result
                             .map(function(item) {
-                                var isScene = ['Group', 'Scene'].includes(item.Type);
+                                if (item.HardwareTypeVal == 21) {
+                                    var ZWID = item.ID.substr(-4, 2);
+                                    if (ZWID == '00') {
+                                        ZWID = item.ID.substr(-2, 2);
+                                    }
+                                    ZWID = '0x' + ZWID;
+                                    var ZWIDdec =  ("00" + parseInt(ZWID)).slice(-3);
+                                    item.HardwareName = item.HardwareName + " " + ZWIDdec + ' (' + ZWID + ')';   
+                                }
 
+                                var isScene = ['Group', 'Scene'].includes(item.Type);
                                 if (isScene) {
                                     item.HardwareName = 'Domoticz';
                                     item.ID = '-';


### PR DESCRIPTION
To make zwave device filtering easier in the device list. For large installations with hundreds of zwave units and thousands of Domoticz devices, filtering and searching for devices that belongs to the same zwave unit is hard. This PR adds each zwave unit as a separate "hardware" under the hardware tab in the device list filter, in addition to label each device with the same hardware name in the list accordingly.
![z-wave-devices](https://user-images.githubusercontent.com/9726307/113780180-28480e00-972f-11eb-95d3-113a43cb5f88.png)
