### PR TITLE
Add ability to set an EvoHomeWeb setpoint until next in schedule

### DIFF
--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -1052,7 +1052,9 @@ Note that if you do not find your specific device type here you can always inspe
  - **setPoint**: *Number*.
  - **mode**: *string* .
  - **untilDate**: *string in ISO 8601 format* or n/a .
- - **updateSetPoint(setPoint, mode, until)**: *Function*. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`). Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
+ - **updateSetPoint(setPoint, mode, until)**: *Function*. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: `os.date("!%Y-%m-%dT%TZ")`). 
+When leaving out untilDate for mode domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE the untilDate will be the next scheduled zone-update time/date.
+Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
 
 #### Gas
  - **counter**: *Number*. Value in m<sup>3</sup>

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -1003,7 +1003,7 @@ Note that if you do not find your specific device type here you can always inspe
 * '''setPoint''': ''Number''.
 * '''mode''': ''string'' .
 * '''untilDate''': ''string in ISO 8601 format'' or n/a .
-* '''updateSetPoint(setPoint, mode, until)''': ''Function''. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>). Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
+* '''updateSetPoint(setPoint, mode, until)''': ''Function''. Update set point. Mode can be domoticz.EVOHOME_MODE_AUTO, domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE, domoticz.EVOHOME_MODE_FOLLOW_SCHEDULE or domoticz.EVOHOME_MODE_PERMANENT_OVERRIDE. You can provide an until date (in ISO 8601 format e.g.: <code>os.date(&quot;!%Y-%m-%dT%TZ&quot;)</code>). When leaving out untilDate for mode domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE the untilDate will be the next scheduled zone-update time/date. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 
 ==== Gas ====
 

--- a/dzVents/runtime/device-adapters/evohome_device.lua
+++ b/dzVents/runtime/device-adapters/evohome_device.lua
@@ -59,11 +59,15 @@ return {
 			device.untilDate = tostring(device.rawData[4] or "n/a")
 
 			function device.updateSetPoint(setPoint, mode, untilDate)
-				return TimedCommand(domoticz,
-					'SetSetPoint:' .. tostring(device.id),
-					tostring(setPoint) .. '#' ..
-					tostring(mode) .. '#' ..
-					tostring(untilDate) , 'setpoint')
+				if mode == domoticz.EVOHOME_MODE_TEMPORARY_OVERRIDE and not(untilDate) then 
+					return TimedCommand(domoticz, 'SetSetPoint:' .. tostring(device.id), tostring(setPoint) .. '#' .. mode, 'setpoint' )
+				else
+					return TimedCommand(domoticz,
+						'SetSetPoint:' .. tostring(device.id),
+						tostring(setPoint) .. '#' ..
+						tostring(mode) .. '#' ..
+						tostring(untilDate) , 'setpoint')
+				end
 			end
 
 			function device.setMode(mode, dParm, action, ooc)

--- a/hardware/EvohomeBase.h
+++ b/hardware/EvohomeBase.h
@@ -390,6 +390,8 @@ class CEvohomeDateTime : public CEvohomeDataType
 	template <class T> static void DecodeISODate(T &out, const char *str)
 	{
 		unsigned int y, m, d, h, n;
+		if(!str[0])
+			return;
 		sscanf(str, "%04u-%02u-%02uT%02u:%02u:", &y, &m, &d, &h, &n);
 		out.year = static_cast<uint16_t>(y);
 		out.month = static_cast<uint8_t>(m);

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -445,6 +445,22 @@ bool CEvohomeWeb::SetSetpoint(const char *pdata)
 	if ((pEvo->mode) == 2) // temporary override
 	{
 		std::string szISODate(CEvohomeDateTime::GetISODate(pEvo));
+		if((!pEvo->year) && !pEvo->hrs)
+		{
+			std::string szsetpoint_tmp;
+			if ((!hz->schedule.isNull()) || get_zone_schedule(zoneId))
+			{
+				szISODate = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint_tmp));
+				if (!szISODate.empty())
+				{
+					pEvo->year = (uint16_t)(atoi(szISODate.substr(0, 4).c_str()));
+					pEvo->month = (uint8_t)(atoi(szISODate.substr(5, 2).c_str()));
+					pEvo->day = (uint8_t)(atoi(szISODate.substr(8, 2).c_str()));
+					pEvo->hrs = (uint8_t)(atoi(szISODate.substr(11, 2).c_str()));
+					pEvo->mins = (uint8_t)(atoi(szISODate.substr(14, 2).c_str()));
+				}
+			}
+		}
 		return set_temperature(zoneId, s_setpoint.str(), szISODate);
 	}
 	return false;


### PR DESCRIPTION
If no "until time" is specified in the set setpoint command in TemporaryOverride
mode, use the next switchpoint time if possible. Also fixes a bug that used
uninitialised date if no until time was given.