### PR TITLE
use stat to check if a folder exists

### DIFF
--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -948,7 +948,9 @@ namespace http {
 					int dType = atoi(sd[2].c_str());
 					int dSubType = atoi(sd[3].c_str());
 					std::string sOptions = RFX_Type_SubType_Values(dType, dSubType);
-					if (sOptions == "Status")
+					std::vector<std::string> tmpV;
+					StringSplit(sOptions, ",", tmpV);
+					if (tmpV.size() > 0 && tmpV[0] == "Status")
 					{
 						root["result"][ii]["name"] = sd[1];
 						root["result"][ii]["value"] = sd[0];

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -950,7 +950,7 @@ namespace http {
 					std::string sOptions = RFX_Type_SubType_Values(dType, dSubType);
 					std::vector<std::string> tmpV;
 					StringSplit(sOptions, ",", tmpV);
-					if (tmpV.size() > 0 && tmpV[0] == "Status")
+					if (!tmpV.empty() && tmpV[0] == "Status")
 					{
 						root["result"][ii]["name"] = sd[1];
 						root["result"][ii]["value"] = sd[0];

--- a/webserver/request_handler.hpp
+++ b/webserver/request_handler.hpp
@@ -15,8 +15,6 @@
 #include "../main/Noncopyable.h"
 #ifndef WEBSERVER_DONT_USE_ZIP
 	#include <minizip/unzip.h>
-	#define USEWIN32IOAPI
-	#include <iowin32.h>
 #endif
 
 namespace http {


### PR DESCRIPTION
path names without a '.' in them are not by definition folder paths. Use stat instead to see if the path is a folder.