### PR TITLE
(Linux)compile time warnings fix. Ensure correct integer sizes.

### DIFF
--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -292,7 +292,7 @@ namespace Plugins {
 
 		if (m_pPlugins.size())
 		{
-			_log.Log(LOG_STATUS, "PluginSystem: %ld plugins started.", m_pPlugins.size());
+			_log.Log(LOG_STATUS, "PluginSystem: %d plugins started.", (int)m_pPlugins.size());
 		}
 
 		// Create initial IO Service thread

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -292,7 +292,7 @@ namespace Plugins {
 
 		if (m_pPlugins.size())
 		{
-			_log.Log(LOG_STATUS, "PluginSystem: %d plugins started.", m_pPlugins.size());
+			_log.Log(LOG_STATUS, "PluginSystem: %ld plugins started.", m_pPlugins.size());
 		}
 
 		// Create initial IO Service thread

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1950,11 +1950,11 @@ namespace Plugins
 						if (pDevice->ob_refcnt > 1)
 						{
 							std::string sName = PyUnicode_AsUTF8(((CDevice*)pDevice)->Name);
-							_log.Log(LOG_ERROR, "%s: Device '%s' Reference Count not one: %ld.", __func__, sName.c_str(), pDevice->ob_refcnt);
+							_log.Log(LOG_ERROR, "%s: Device '%s' Reference Count not one: %d.", __func__, sName.c_str(), (int)pDevice->ob_refcnt);
 						}
 						else if (pDevice->ob_refcnt < 1)
 						{
-							_log.Log(LOG_ERROR, "%s: Device Reference Count is less than one: %ld.", __func__, pDevice->ob_refcnt);
+							_log.Log(LOG_ERROR, "%s: Device Reference Count is less than one: %d.", __func__, (int)pDevice->ob_refcnt);
 						}
 					}
 				}

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1950,11 +1950,11 @@ namespace Plugins
 						if (pDevice->ob_refcnt > 1)
 						{
 							std::string sName = PyUnicode_AsUTF8(((CDevice*)pDevice)->Name);
-							_log.Log(LOG_ERROR, "%s: Device '%s' Reference Count not one: %d.", __func__, sName.c_str(), pDevice->ob_refcnt);
+							_log.Log(LOG_ERROR, "%s: Device '%s' Reference Count not one: %ld.", __func__, sName.c_str(), pDevice->ob_refcnt);
 						}
 						else if (pDevice->ob_refcnt < 1)
 						{
-							_log.Log(LOG_ERROR, "%s: Device Reference Count is less than one: %d.", __func__, pDevice->ob_refcnt);
+							_log.Log(LOG_ERROR, "%s: Device Reference Count is less than one: %ld.", __func__, pDevice->ob_refcnt);
 						}
 					}
 				}


### PR DESCRIPTION
Current Plugin code gives compile warnings because Integer sizes do not correspond.