### PR TITLE
fix tfa drop rain amount and battery percentage

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3038,11 +3038,17 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;
 	uint8_t SignalLevel = pResponse->RAIN.rssi;
-	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, pResponse->RAIN.subtype == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
+	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, pResponse->RAIN.subtype == sTypeRAIN1 || pResponse->RAIN.subtype == sTypeRAIN9, pResponse->RAIN.battery_level & 0x0F);
 
 	int Rainrate = (pResponse->RAIN.rainrateh * 256) + pResponse->RAIN.rainratel;
 
-	float TotalRain = float((pResponse->RAIN.raintotal1 * 65535) + (pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) / 10.0F;
+	float TotalRain = 0;
+	if (subType == sTypeRAIN9) {
+		TotalRain = float((pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) * 0.254F;
+	}
+	else {
+		TotalRain = float((pResponse->RAIN.raintotal1 * 65535) + (pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) / 10.0F;
+	}
 
 	if (subType == sTypeRAINByRate)
 	{
@@ -3195,7 +3201,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(pResponse->RAIN.subtype == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(pResponse->RAIN.subtype == sTypeRAIN1 || (pResponse->RAIN.subtype == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;


### PR DESCRIPTION
The TFA 30.3233.01 rain sensor, in combination with RFXtrx433E and RFXtrx433XL, reported a factor 2.54 too low TotalRain. Also the battery level is now reported in steps of 10 from 10% to 100%. Note: For those who are running a build that does not include this fix can also correct total rain by setting the edit/multiply value to 2.54