### PR TITLE
Database: changed default journal mode to WAL (write ahead) for Windows

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -2,6 +2,7 @@ Version 2021.xxxxx (xxxx)
 - Implemented: InfluxDB Data push, Influx 2.0 support
 - Updated: dzVents; version 3.1.8 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting )
 - Updated: OpenZWave; Added Electric pulse sensor
+- Changed: journal mode for windows from DELETE to WAL (write ahead)
 - For a full detailed overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits
 
 Version 2021.1 (April 17 2021)

--- a/History.txt
+++ b/History.txt
@@ -2,7 +2,7 @@ Version 2021.xxxxx (xxxx)
 - Implemented: InfluxDB Data push, Influx 2.0 support
 - Updated: dzVents; version 3.1.8 ( https://www.domoticz.com/wiki/DzVents:_next_generation_LUA_scripting )
 - Updated: OpenZWave; Added Electric pulse sensor
-- Changed: journal mode for windows from DELETE to WAL (write ahead)
+- Changed: default journal mode for windows now WAL (write ahead) add command line option to override
 - For a full detailed overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits
 
 Version 2021.1 (April 17 2021)

--- a/dzVents/documentation/README.md
+++ b/dzVents/documentation/README.md
@@ -1222,6 +1222,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
  - **levelActions**: *String*. |-separated list of url actions for selector switches.
  - **levelName**: *String*. Current level name for selector switches.
  - **levelNames**: *Table*. Table holding the level names for selector switch devices.
+ - **levelVal**: *Number*. Specific for selector switches.
  - **maxDimLevel**: *Number*.
  - **open()**: *Function*. Set device to Open if it supports it. Supports [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).
  - **quietOn()**: *Function*. Set deviceStatus to on without physically switching it. Subsequent Events are triggered. Supports some [command options](#Command_options_.28delay.2C_duration.2C_event_triggering.29).

--- a/dzVents/documentation/README.wiki
+++ b/dzVents/documentation/README.wiki
@@ -1196,6 +1196,7 @@ There are many switch-like devices. Not all methods are applicable for all switc
 * '''levelActions''': ''String''. |-separated list of url actions for selector switches.
 * '''levelName''': ''String''. Current level name for selector switches.
 * '''levelNames''': ''Table''. Table holding the level names for selector switch devices.
+* '''levelVal''': ''Number''. Specific for selector switches.
 * '''maxDimLevel''': ''Number''.
 * '''open()''': ''Function''. Set device to Open if it supports it. Supports [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].
 * '''quietOn()''': ''Function''. Set deviceStatus to on without physically switching it. Subsequent Events are triggered. Supports some [[#Command_options_.28delay.2C_duration.2C_event_triggering.29|command options]].

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -630,14 +630,12 @@ bool CSQLHelper::OpenDatabase()
 		sqlite3_close(m_dbase);
 		return false;
 	}
-#ifndef WIN32
-	//test, this could improve performance
+
 	sqlite3_exec(m_dbase, "PRAGMA synchronous = NORMAL", nullptr, nullptr, nullptr);
 	sqlite3_exec(m_dbase, "PRAGMA journal_mode = WAL", nullptr, nullptr, nullptr);
-#else
-	sqlite3_exec(m_dbase, "PRAGMA journal_mode=DELETE", NULL, NULL, NULL);
-#endif
-	sqlite3_exec(m_dbase, "PRAGMA foreign_keys = ON;", nullptr, nullptr, nullptr);
+	sqlite3_exec(m_dbase, "PRAGMA foreign_keys = ON", nullptr, nullptr, nullptr);
+	sqlite3_exec(m_dbase, "PRAGMA busy_timeout = 1000", nullptr, nullptr, nullptr);
+
 	std::vector<std::vector<std::string> > result = query("SELECT name FROM sqlite_master WHERE type='table' AND name='DeviceStatus'");
 	bool bNewInstall = (result.empty());
 	int dbversion = 0;

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -630,9 +630,9 @@ bool CSQLHelper::OpenDatabase()
 		sqlite3_close(m_dbase);
 		return false;
 	}
-
+	std::string pragma_journal_mode = "PRAGMA journal_mode = " + m_journal_mode;
+	sqlite3_exec(m_dbase, pragma_journal_mode.c_str(), nullptr, nullptr, nullptr);
 	sqlite3_exec(m_dbase, "PRAGMA synchronous = NORMAL", nullptr, nullptr, nullptr);
-	sqlite3_exec(m_dbase, "PRAGMA journal_mode = WAL", nullptr, nullptr, nullptr);
 	sqlite3_exec(m_dbase, "PRAGMA foreign_keys = ON", nullptr, nullptr, nullptr);
 	sqlite3_exec(m_dbase, "PRAGMA busy_timeout = 1000", nullptr, nullptr, nullptr);
 
@@ -3922,6 +3922,11 @@ void CSQLHelper::Do_Work()
 void CSQLHelper::SetDatabaseName(const std::string& DBName)
 {
 	m_dbase_name = DBName;
+}
+
+void CSQLHelper::SetJournalMode(const std::string& mode)
+{
+	m_journal_mode = mode;
 }
 
 bool CSQLHelper::DoesColumnExistsInTable(const std::string& columnname, const std::string& tablename)

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -327,6 +327,7 @@ class CSQLHelper : public StoppableTask
 	~CSQLHelper();
 
 	void SetDatabaseName(const std::string &DBName);
+	void SetJournalMode(const std::string &mode);
 
 	bool OpenDatabase();
 	void CloseDatabase();
@@ -393,7 +394,6 @@ class CSQLHelper : public StoppableTask
 	void ClearShortLog();
 	void VacuumDatabase();
 	void OptimizeDatabase(sqlite3 *dbase);
-
 	void DeleteHardware(const std::string &idx);
 
 	void DeleteCamera(const std::string &idx);
@@ -482,6 +482,7 @@ class CSQLHelper : public StoppableTask
 	std::mutex m_sqlQueryMutex;
 	sqlite3 *m_dbase;
 	std::string m_dbase_name;
+	std::string m_journal_mode;
 	unsigned char m_sensortimeoutcounter;
 	std::map<uint64_t, int> m_timeoutlastsend;
 	std::map<uint64_t, int> m_batterylowlastsend;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -82,6 +82,7 @@ namespace
 		"\t-nobrowser (do not start web browser (Windows Only)\n"
 #endif
 		"\t-noupdates do not use the internal update functionality\n"
+		"\t-journal_mode mode (supported modes: DELETE and WAL, default = WAL)\n"
 #if defined WIN32
 		"\t-log file_path (for example D:\\domoticz.log)\n"
 #else
@@ -998,10 +999,9 @@ int main(int argc, char**argv)
 		{
 			if (cmdLine.GetArgumentCount("-journal_mode") != 1)
 			{
-				_log.Log(LOG_ERROR, "Please specify a journal_mode (DELETE, TRUNCATE, PERSIST,  MEMORY, OFF or WAL (=default)");
+				_log.Log(LOG_ERROR, "Please specify journal_mode DELETE or WAL");
 				return 1;
 			}
-		_log.Log(LOG_ERROR, "Arguments: %d", cmdLine.GetArgumentCount("-journal_mode") );
 		}
 		journalMode = cmdLine.GetSafeArgument("-journal_mode", 0, "WAL");
 	}

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -82,7 +82,7 @@ namespace
 		"\t-nobrowser (do not start web browser (Windows Only)\n"
 #endif
 		"\t-noupdates do not use the internal update functionality\n"
-		"\t-journal_mode mode (supported modes: DELETE and WAL, default = WAL)\n"
+		"\t-dbase_disable_wal_mode\n"
 #if defined WIN32
 		"\t-log file_path (for example D:\\domoticz.log)\n"
 #else
@@ -154,7 +154,7 @@ std::string szPyVersion="None";
 int ActYear;
 time_t m_StartTime = time(nullptr);
 std::string szRandomUUID = "???";
-std::string journalMode;
+std::string journalMode="WAL";
 
 MainWorker m_mainworker;
 CLogger _log;
@@ -577,9 +577,10 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		else if (szFlag == "dbase_file") {
 			dbasefile = sLine;
 		}
-		else if (szFlag == "journal_mode") {
-			journalMode = sLine;
+		else if ( (szFlag == "dbase_disable_wal_mode") && (GetConfigBool(sLine) ) )  {
+			journalMode = "DELETE";
 		}
+
 		else if (szFlag == "startup_delay") {
 			int DelaySeconds = atoi(sLine.c_str());
 			_log.Log(LOG_STATUS, "Startup delay... waiting %d seconds...", DelaySeconds);
@@ -995,15 +996,10 @@ int main(int argc, char**argv)
 	m_sql.SetDatabaseName(dbasefile);
 
 	if (!bUseConfigFile) {
-		if (cmdLine.HasSwitch("-journal_mode"))
+		if (cmdLine.HasSwitch("-dbase_disable_wal_mode"))
 		{
-			if (cmdLine.GetArgumentCount("-journal_mode") != 1)
-			{
-				_log.Log(LOG_ERROR, "Please specify journal_mode DELETE or WAL");
-				return 1;
-			}
+			journalMode = "DELETE";
 		}
-		journalMode = cmdLine.GetSafeArgument("-journal_mode", 0, "WAL");
 	}
 	m_sql.SetJournalMode(journalMode);
 

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -153,6 +153,7 @@ std::string szPyVersion="None";
 int ActYear;
 time_t m_StartTime = time(nullptr);
 std::string szRandomUUID = "???";
+std::string journalMode;
 
 MainWorker m_mainworker;
 CLogger _log;
@@ -575,6 +576,9 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		else if (szFlag == "dbase_file") {
 			dbasefile = sLine;
 		}
+		else if (szFlag == "journal_mode") {
+			journalMode = sLine;
+		}
 		else if (szFlag == "startup_delay") {
 			int DelaySeconds = atoi(sLine.c_str());
 			_log.Log(LOG_STATUS, "Startup delay... waiting %d seconds...", DelaySeconds);
@@ -988,6 +992,20 @@ int main(int argc, char**argv)
 		}
 	}
 	m_sql.SetDatabaseName(dbasefile);
+
+	if (!bUseConfigFile) {
+		if (cmdLine.HasSwitch("-journal_mode"))
+		{
+			if (cmdLine.GetArgumentCount("-journal_mode") != 1)
+			{
+				_log.Log(LOG_ERROR, "Please specify a journal_mode (DELETE, TRUNCATE, PERSIST,  MEMORY, OFF or WAL (=default)");
+				return 1;
+			}
+		_log.Log(LOG_ERROR, "Arguments: %d", cmdLine.GetArgumentCount("-journal_mode") );
+		}
+		journalMode = cmdLine.GetSafeArgument("-journal_mode", 0, "WAL");
+	}
+	m_sql.SetJournalMode(journalMode);
 
 	if (!bUseConfigFile) {
 		if (cmdLine.HasSwitch("-webroot"))


### PR DESCRIPTION
Harmonize database pragma settings (journal mode ) between Windows and Linux type platforms.

Tested on Windows 10, Raspberry PI and Intel NUC (both Debian)