### PR TITLE
RainRate fix for TFA 30.3233.01

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10281,7 +10281,7 @@ namespace http {
 
 								sprintf(szTmp, "%.1f", total_real);
 								root["result"][ii]["Rain"] = szTmp;
-								sprintf(szTmp, "%g", rate);
+								sprintf(szTmp, "%.1f", rate);
 								root["result"][ii]["RainRate"] = szTmp;
 								root["result"][ii]["Data"] = sValue;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3038,15 +3038,15 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;
 	uint8_t SignalLevel = pResponse->RAIN.rssi;
-	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, pResponse->RAIN.subtype == sTypeRAIN1 || pResponse->RAIN.subtype == sTypeRAIN9, pResponse->RAIN.battery_level & 0x0F);
+	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, subType == sTypeRAIN1 || subType == sTypeRAIN9, pResponse->RAIN.battery_level & 0x0F);
 
-	int Rainrate = (pResponse->RAIN.rainrateh * 256) + pResponse->RAIN.rainratel;
-
+	int Rainrate = 0;
 	float TotalRain = 0;
 	if (subType == sTypeRAIN9) {
 		TotalRain = float((pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) * 0.254F;
 	}
 	else {
+		Rainrate = (pResponse->RAIN.rainrateh * 256) + pResponse->RAIN.rainratel;
 		TotalRain = float((pResponse->RAIN.raintotal1 * 65535) + (pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) / 10.0F;
 	}
 
@@ -3174,7 +3174,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 			WriteMessage("subtype       = DarkSky for example (Only rate, no total, no counter) rate in mm/hour x 10000, so all decimals will fit");
 			break;
 		default:
-			sprintf(szTmp, "ERROR: Unknown Sub type for Packet type= %02X : %02X", pResponse->RAIN.packettype, pResponse->RAIN.subtype);
+			sprintf(szTmp, "ERROR: Unknown Sub type for Packet type= %02X : %02X", pResponse->RAIN.packettype, subType);
 			WriteMessage(szTmp);
 			break;
 		}
@@ -3185,12 +3185,12 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "ID            = %s", ID.c_str());
 		WriteMessage(szTmp);
 
-		if (pResponse->RAIN.subtype == sTypeRAIN1)
+		if (subType == sTypeRAIN1)
 		{
 			sprintf(szTmp, "Rain rate     = %d mm/h", Rainrate);
 			WriteMessage(szTmp);
 		}
-		else if (pResponse->RAIN.subtype == sTypeRAIN2)
+		else if (subType == sTypeRAIN2)
 		{
 			sprintf(szTmp, "Rain rate     = %d mm/h", Rainrate);
 			WriteMessage(szTmp);
@@ -3201,7 +3201,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(pResponse->RAIN.subtype == sTypeRAIN1 || (pResponse->RAIN.subtype == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(subType == sTypeRAIN1 || (subType == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;


### PR DESCRIPTION
For TFA Raindrop 30.3233.01 RainRate was showing as a negative value where it should be zero, example "Rate: -0.04 mm/h". Also 2 digits after the comma where shown instead of just one, example "Rate: 1.12 mm/h". Also did some minor code changes to improve code readability without functional changes.