### PR TITLE
TFA 30.3233.01 RainRate fix

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10281,7 +10281,7 @@ namespace http {
 
 								sprintf(szTmp, "%.1f", total_real);
 								root["result"][ii]["Rain"] = szTmp;
-								sprintf(szTmp, "%.1f", rate);
+								sprintf(szTmp, "%g", rate);
 								root["result"][ii]["RainRate"] = szTmp;
 								root["result"][ii]["Data"] = sValue;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3043,7 +3043,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	int Rainrate = 0;
 	float TotalRain = 0;
 	if (subType == sTypeRAIN9) {
-		TotalRain = float((pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) * 0.254F;
+		TotalRain = roundf(float((pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) * 2.54F) / 10.0F;
 	}
 	else {
 		Rainrate = (pResponse->RAIN.rainrateh * 256) + pResponse->RAIN.rainratel;


### PR DESCRIPTION
Total rain is a multiple of 0.254 mm. This value is now rounded so that rain rate can be calculated correctly. I tested it. Rain total and rate are now reported correctly and rain rate drops back to 0.0 mmh/h after one hour as required. Note: I reverted previous change in WebServer.cpp because this is no longer need.

Due to rounding in previous PR rain-min, of an hour ago, could become a bit larger then rain-max (latest). This resulted in a sometimes negative rain rate value or non zero value after one hour. 

Note: For use of the TFA Raindrop rainsensor 30.3233.01 in combination with RFXtrx433E or RFXtrx433XL a future firmware release (likely 1044 or later) will be required. 