### PR TITLE
TFA drop RainRate

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10281,7 +10281,7 @@ namespace http {
 
 								sprintf(szTmp, "%.1f", total_real);
 								root["result"][ii]["Rain"] = szTmp;
-								sprintf(szTmp, "%.1f", rate);
+								sprintf(szTmp, "%g", rate);
 								root["result"][ii]["RainRate"] = szTmp;
 								root["result"][ii]["Data"] = sValue;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3043,7 +3043,8 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	int Rainrate = 0;
 	float TotalRain = 0;
 	if (subType == sTypeRAIN9) {
-		TotalRain = float((pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3) * 0.254F;
+		uint16_t rainCount = (pResponse->RAIN.raintotal2 * 256) + pResponse->RAIN.raintotal3 + 10;
+		TotalRain = roundf(float(rainCount * 2.54F)) / 10.0F;
 	}
 	else {
 		Rainrate = (pResponse->RAIN.rainrateh * 256) + pResponse->RAIN.rainratel;


### PR DESCRIPTION
Total rain is a multiple of 0.254 mm. This value is now rounded so that rain rate can be calculated correctly. I tested it. Rain total and rate are now reported correctly and rain rate drops back to 0.0 mmh/h after one hour as required. Note: I reverted previous change in WebServer.cpp because this is no longer needed.

Due to rounding in previous PR rain-min, of an hour ago, could become a bit larger then rain-max (latest). This resulted in a sometimes negative rain rate value or non zero value after one hour. Raincount has decimal 10 added to it so that the initial value of raincount starts at zero. This prevents rollover over the TotalRain counter on fresh install of the 30.3233.01.

Note: For use of the TFA Raindrop rainsensor 30.3233.01 in combination with RFXtrx433E or RFXtrx433XL a future firmware release (likely 1044 or later) will be required.