### PR TITLE
Correct EEP D2-01-xx status response, EnOcean EEP 2.6.8 p137-138

### DIFF
--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -2113,72 +2113,63 @@ void CEnOceanESP3::ParseRadioDatagram()
 				}
 				Log(LOG_NORM, "EnOcean message VLD: func: %02X Type: %02X", func, type);
 				if (func == 0x01)
-				{
-					// D2-01 Electr. switches/dimmers, Energy Meas. / Local Ctrl
-					switch (type)
+				{ // D2-01-XX, Electronic Switches and Dimmers with Local Control
+					unsigned char ID_BYTE3 = m_buffer[4];
+					unsigned char ID_BYTE2 = m_buffer[5];
+					unsigned char ID_BYTE1 = m_buffer[6];
+					unsigned char ID_BYTE0 = m_buffer[7];
+					long id = (ID_BYTE3 << 24) + (ID_BYTE2 << 16) + (ID_BYTE1 << 8) + ID_BYTE0;
+
+					// report status only if it is a known device else we may have an incorrect profile
+					char szDeviceID[20];
+					std::vector<std::vector<std::string> > result;
+					sprintf(szDeviceID, "%08X", (unsigned int)id);
+
+					result = m_sql.safe_query("SELECT ID, Manufacturer, Profile, [Type] FROM EnoceanSensors WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, szDeviceID);
+					if (result.empty())
 					{
-					case 0x0C:	// D2-01-0C
-					{
-						unsigned char channel = m_buffer[2] & 0x7;
-
-						unsigned char dim_power = m_buffer[3] & 0x7F;		// 0=off, 0x64=100%
-
-						unsigned char ID_BYTE3 = m_buffer[4];
-						unsigned char ID_BYTE2 = m_buffer[5];
-						unsigned char ID_BYTE1 = m_buffer[6];
-						unsigned char ID_BYTE0 = m_buffer[7];
-						long id = (ID_BYTE3 << 24) + (ID_BYTE2 << 16) + (ID_BYTE1 << 8) + ID_BYTE0;
-
-						// report status only if it is a known device else we may have an incorrect profile
-						char szDeviceID[20];
-						std::vector<std::vector<std::string> > result;
-						sprintf(szDeviceID, "%08X", (unsigned int)id);
-
-						result = m_sql.safe_query("SELECT ID, Manufacturer, Profile, [Type] FROM EnoceanSensors WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, szDeviceID);
-						if (result.empty())
-						{
-							Log(LOG_NORM, "Need Teach-In for %s", szDeviceID);
-							return;
-						}
-
-						RBUF tsen;
-						memset(&tsen, 0, sizeof(RBUF));
-						tsen.LIGHTING2.packetlength = sizeof(tsen.LIGHTING2) - 1;
-						tsen.LIGHTING2.packettype = pTypeLighting2;
-						tsen.LIGHTING2.subtype = sTypeAC;
-						tsen.LIGHTING2.seqnbr = 0;
-
-						tsen.LIGHTING2.id1 = (BYTE)ID_BYTE3;
-						tsen.LIGHTING2.id2 = (BYTE)ID_BYTE2;
-						tsen.LIGHTING2.id3 = (BYTE)ID_BYTE1;
-						tsen.LIGHTING2.id4 = (BYTE)ID_BYTE0;
-						tsen.LIGHTING2.level = dim_power;
-						tsen.LIGHTING2.rssi = rssi;
-
-						tsen.LIGHTING2.unitcode = channel + 1;
-						tsen.LIGHTING2.cmnd = (dim_power > 0) ? light2_sOn : light2_sOff;
-
-#ifdef ENOCEAN_BUTTON_DEBUG
-						Log(LOG_NORM, "EnOcean message: 0x%02X Node 0x%08x UnitID: %02X cmd: %02X ",
-							DATA_BYTE3,
-							id,
-							tsen.LIGHTING2.unitcode,
-							tsen.LIGHTING2.cmnd
-						);
-#endif //ENOCEAN_BUTTON_DEBUG
-
-						// Never learn device from D2-01-0C because subtype may be incorrect
-						sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
-
-						// Note: if a device uses simultaneously RPS and VLD (ex: nodon inwall module), it can be partially initialized.
-						//			Domoticz will show device status but some functions may not work because EnoceanSensors table has no info on this device (until teach-in is performed)
-						//       If a device has local control (ex: nodon inwall module with physically attached switched), domoticz will record the local control as unit 0.
-						//       Ex: nodon inwall 2 channels will show 3 entries. Unit 0 is the local switch, 1 is the first channel, 2 is the second channel.
-						//			(I only have attached a switch on the first channel, I have no idea which unit number a switch on the 2nd channel will have)
+						Log(LOG_NORM, "Need Teach-In for %s", szDeviceID);
 						return;
 					}
-					break;
+
+					uint8_t CMD = m_buffer[1] & 0x0F;			// Command ID
+					if (CMD != 0x04)
+					{
+						Log(LOG_NORM, "EnOcean: VLD msg: Node %s Unhandled CMD (%02X)", szDeviceID, CMD);
+						return;
 					}
+					// CMD 0x4 - Actuator Status Response
+
+					uint8_t IO = m_buffer[2] & 0x1F;	 		// I/O Channel
+					uint8_t OV = m_buffer[3] & 0x7F;			// Output Value : 0x00 = OFF, 0x01...0x64: Output value 1% to 100% or ON
+
+					RBUF tsen;
+					memset(&tsen, 0, sizeof(RBUF));
+					tsen.LIGHTING2.packetlength = sizeof(tsen.LIGHTING2) - 1;
+					tsen.LIGHTING2.packettype = pTypeLighting2;
+					tsen.LIGHTING2.subtype = sTypeAC;
+					tsen.LIGHTING2.seqnbr = 0;
+					tsen.LIGHTING2.id1 = (BYTE)ID_BYTE3;
+					tsen.LIGHTING2.id2 = (BYTE)ID_BYTE2;
+					tsen.LIGHTING2.id3 = (BYTE)ID_BYTE1;
+					tsen.LIGHTING2.id4 = (BYTE)ID_BYTE0;
+					tsen.LIGHTING2.level = OV;
+					tsen.LIGHTING2.rssi = rssi;
+					tsen.LIGHTING2.unitcode = IO + 1;
+					tsen.LIGHTING2.cmnd = (OV > 0) ? light2_sOn : light2_sOff;
+
+#ifdef ENOCEAN_BUTTON_DEBUG
+					Log(LOG_NORM, "EnOcean: VLD->RX msg: Node %s CMD: 0x%X IO: 0x%02X (UnitID: %d) OV: 0x%02X (Cmnd: %d Level: %d)",
+						szDeviceID, CMD, IO, tsen.LIGHTING2.unitcode, OV, tsen.LIGHTING2.cmnd, tsen.LIGHTING2.level);
+#endif //ENOCEAN_BUTTON_DEBUG
+
+					sDecodeRXMessage(this, (const unsigned char *)&tsen.LIGHTING2, nullptr, 255, m_Name.c_str());
+
+					// Note: if a device uses simultaneously RPS and VLD (ex: nodon inwall module), it can be partially initialized.
+					// Domoticz will show device status but some functions may not work because EnoceanSensors table has no info on this device (until teach-in is performed)
+					// If a device has local control (ex: nodon inwall module with physically attached switched), domoticz will record the local control as unit 0.
+					// Ex: nodon inwall 2 channels will show 3 entries. Unit 0 is the local switch, 1 is the first channel, 2 is the second channel.
+					return;
 				}
 				else if (func == 0x02)
 				{


### PR DESCRIPTION
Current implementation was working... but erroneous... one mistake correcting another!
I propose this new implementation for collecting EEP D2-01-XX status responses conforming to EnOcean EEP 2.6.8 document, see pages 137/138.
