### PR TITLE
RTL-SDR TFA Raindrop ID

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,6 +343,9 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
+	if (!strcmp(model.c_str(), "TFA-Drop")) {
+		sensoridx = id;
+	}
 
 	if (haveTemp && haveHumidity)
 	{


### PR DESCRIPTION
For RTL-SDR only the lower 8 bits of the TFA Raindrop SensorID 30.3233.01 where used. This may lead to conflicts when using multiple Raindrop devices. 
Note: After this change the device needs to be added again. After that replace the old with the new device to keep rain history.