### PR TITLE
RTL-SDR TFA Raindrop DeviceID

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -377,6 +377,7 @@ void CDomoticzHardwareBase::SendRainSensor(const int NodeID, const int BatteryLe
 	tsen.RAIN.subtype = sTypeRAIN3;
 	tsen.RAIN.battery_level = BatteryLevel;
 	tsen.RAIN.rssi = RssiLevel;
+	tsen.RAIN.id0 = (NodeID & 0xFF0000) >> 16;
 	tsen.RAIN.id1 = (NodeID & 0xFF00) >> 8;
 	tsen.RAIN.id2 = NodeID & 0xFF;
 

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -377,7 +377,6 @@ void CDomoticzHardwareBase::SendRainSensor(const int NodeID, const int BatteryLe
 	tsen.RAIN.subtype = sTypeRAIN3;
 	tsen.RAIN.battery_level = BatteryLevel;
 	tsen.RAIN.rssi = RssiLevel;
-	tsen.RAIN.id0 = (NodeID & 0xFF0000) >> 16;
 	tsen.RAIN.id1 = (NodeID & 0xFF00) >> 8;
 	tsen.RAIN.id2 = NodeID & 0xFF;
 

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,6 +343,9 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
+	if (!model.empty() && (!strcmp(model.c_str(), "TFA-Drop"))) {
+		sensoridx = id;
+	}
 
 	if (haveTemp && haveHumidity)
 	{

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,7 +343,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
-	if (!model.empty() && (!strcmp(model.c_str(), "TFA-Drop"))) {
+	if (model == "TFA-Drop") {
 		sensoridx = id;
 	}
 

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,6 +343,9 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
+	if (!strcmp(model.c_str(), "TFA-Drop")) {
+		sensoridx = id;
+	}
 
 	if (haveTemp && haveHumidity)
 	{

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,7 +343,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
-	if (!strcmp(model.c_str(), "TFA-Drop")) {
+	if (!model.empty() && (!strcmp(model.c_str(), "TFA-Drop"))) {
 		sensoridx = id;
 	}
 

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -186,7 +186,7 @@ SDK version 7.01
 	SelectPlus200689103 Black Chime added
 
 SDK version 7.00
-	TEMP7 - TSS330 added and TH9 - TSS320 added
+	TEMP7 - TSS330 added and TH9 – TSS320 added
 	BlindsT8 = Chamberlain CS4330CN added
 	SelectPlus200689101 White Chime added
 	Interface command - start receiver added

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -186,7 +186,7 @@ SDK version 7.01
 	SelectPlus200689103 Black Chime added
 
 SDK version 7.00
-	TEMP7 - TSS330 added and TH9 � TSS320 added
+	TEMP7 - TSS330 added and TH9 - TSS320 added
 	BlindsT8 = Chamberlain CS4330CN added
 	SelectPlus200689101 White Chime added
 	Interface command - start receiver added

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -2242,7 +2242,6 @@ typedef union tRBUF {
 		BYTE	battery_level : 4;
 		BYTE	rssi : 4;
 #endif
-		BYTE	id0;
 	} RAIN;
 
 	struct {

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -186,7 +186,7 @@ SDK version 7.01
 	SelectPlus200689103 Black Chime added
 
 SDK version 7.00
-	TEMP7 - TSS330 added and TH9 – TSS320 added
+	TEMP7 - TSS330 added and TH9 - TSS320 added
 	BlindsT8 = Chamberlain CS4330CN added
 	SelectPlus200689101 White Chime added
 	Interface command - start receiver added
@@ -2242,6 +2242,7 @@ typedef union tRBUF {
 		BYTE	battery_level : 4;
 		BYTE	rssi : 4;
 #endif
+		BYTE	id0;
 	} RAIN;
 
 	struct {

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -2235,7 +2235,6 @@ typedef union tRBUF {
 		BYTE	raintotal1;
 		BYTE	raintotal2;
 		BYTE	raintotal3;
-		BYTE	id0;
 #ifdef IS_BIG_ENDIAN
 		BYTE	rssi : 4;
 		BYTE	battery_level : 4;
@@ -2243,6 +2242,7 @@ typedef union tRBUF {
 		BYTE	battery_level : 4;
 		BYTE	rssi : 4;
 #endif
+		BYTE	id0;
 	} RAIN;
 
 	struct {

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -186,7 +186,7 @@ SDK version 7.01
 	SelectPlus200689103 Black Chime added
 
 SDK version 7.00
-	TEMP7 - TSS330 added and TH9 – TSS320 added
+	TEMP7 - TSS330 added and TH9 ï¿½ TSS320 added
 	BlindsT8 = Chamberlain CS4330CN added
 	SelectPlus200689101 White Chime added
 	Interface command - start receiver added
@@ -2228,6 +2228,7 @@ typedef union tRBUF {
 		BYTE	packettype;
 		BYTE	subtype;
 		BYTE	seqnbr;
+		BYTE	id0;
 		BYTE	id1;
 		BYTE	id2;
 		BYTE	rainrateh;

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -2228,7 +2228,6 @@ typedef union tRBUF {
 		BYTE	packettype;
 		BYTE	subtype;
 		BYTE	seqnbr;
-		BYTE	id0;
 		BYTE	id1;
 		BYTE	id2;
 		BYTE	rainrateh;
@@ -2236,6 +2235,7 @@ typedef union tRBUF {
 		BYTE	raintotal1;
 		BYTE	raintotal2;
 		BYTE	raintotal3;
+		BYTE	id0;
 #ifdef IS_BIG_ENDIAN
 		BYTE	rssi : 4;
 		BYTE	battery_level : 4;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -651,7 +651,7 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RFXtrx868:
 		pHardware = new RFXComSerial(ID, SerialPort, 38400, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
 		break;
-	case HTYPE_RFXLAN:
+	case HTYPE_RFXLAN:f
 		pHardware = new RFXComTCP(ID, Address, Port, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
 		break;
 	case HTYPE_P1SmartMeter:
@@ -3033,7 +3033,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t devType = pTypeRAIN;
 	uint8_t subType = pResponse->RAIN.subtype;
 	std::string ID;
-	sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
 	ID = szTmp;
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3207,7 +3207,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(subType == sTypeRAIN1 || (subType == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(subType == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3033,7 +3033,12 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t devType = pTypeRAIN;
 	uint8_t subType = pResponse->RAIN.subtype;
 	std::string ID;
-	sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	if (subType == sTypeRAIN9) {
+		sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	}
+	else {
+		sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	}
 	ID = szTmp;
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3033,7 +3033,12 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t devType = pTypeRAIN;
 	uint8_t subType = pResponse->RAIN.subtype;
 	std::string ID;
-	sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	if (subType == sTypeRAIN3) {
+		sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	}
+	else {
+		sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	}
 	ID = szTmp;
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;
@@ -3202,7 +3207,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(subType == sTypeRAIN1 || (subType == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(subType == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -651,7 +651,7 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RFXtrx868:
 		pHardware = new RFXComSerial(ID, SerialPort, 38400, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
 		break;
-	case HTYPE_RFXLAN:f
+	case HTYPE_RFXLAN:
 		pHardware = new RFXComTCP(ID, Address, Port, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
 		break;
 	case HTYPE_P1SmartMeter:

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3033,12 +3033,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t devType = pTypeRAIN;
 	uint8_t subType = pResponse->RAIN.subtype;
 	std::string ID;
-	if (subType == sTypeRAIN3) {
-		sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
-	}
-	else {
-		sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
-	}
+	sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
 	ID = szTmp;
 	uint8_t Unit = 0;
 	uint8_t cmnd = 0;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3033,11 +3033,11 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t devType = pTypeRAIN;
 	uint8_t subType = pResponse->RAIN.subtype;
 	std::string ID;
-	if (subType == sTypeRAIN9) {
-		sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+	if (subType == sTypeRAIN3) {
+		sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
 	}
 	else {
-		sprintf(szTmp, "%d", (pResponse->RAIN.id0 * 65536) + (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
+		sprintf(szTmp, "%d", (pResponse->RAIN.id1 * 256) + pResponse->RAIN.id2);
 	}
 	ID = szTmp;
 	uint8_t Unit = 0;
@@ -3207,7 +3207,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(subType == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(subType == sTypeRAIN1 || (subType == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;


### PR DESCRIPTION
1. For RTL-SDR only the lower 8 bits of the TFA Raindrop SensorID 30.3233.01 where used but the actual DeviceID contains 20 bits (2 and a half bytes). This may lead to conflicts when using multiple Raindrop devices. This has been fixed by this change. Device ID now also matches logging of well known program rtl_433. Example: previous device id 0x7d (8bits) now shows up as 0xe3a7d (20bits).

Note: After this change, for TFA Raindrop 30.3233.01 devices connected to RTL-SDR, the device needs to be added again to Domoticz because its device id changes. After adding the new device replace the old device with the new one to keep rain history.

2. I studied the TFA message a bit more and noticed the TFA Raindrop battery states are "ok" and "low", not percentage. Changed code for RFXtrx to report these 2 states instead of percentage so it more accurate reflects actual battery state as reported by the Raindrop sensor firmware. 