### PR TITLE
RTL-SDR TFA Raindrop 16bit device id, ignore 20:16

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -343,6 +343,9 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 
 	unsigned int sensoridx = (id & 0xff) | ((channel & 0xff) << 8);
+	if (model == "TFA-Drop") {
+		sensoridx = id;
+	}
 
 	if (haveTemp && haveHumidity)
 	{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3207,7 +3207,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 		sprintf(szTmp, "Signal level  = %d", pResponse->RAIN.rssi);
 		WriteMessage(szTmp);
 
-		decode_BateryLevel(subType == sTypeRAIN1 || (subType == sTypeRAIN9), pResponse->RAIN.battery_level & 0x0F);
+		decode_BateryLevel(subType == sTypeRAIN1, pResponse->RAIN.battery_level & 0x0F);
 		WriteMessageEnd();
 	}
 	procResult.DeviceRowIdx = DevRowIdx;


### PR DESCRIPTION
For more comments see closed PR #4847. Simplified a lot.
- 16bit device id for TFA Raindrop connected to RTL-SDR only to prevent duplicate id's
- Battery state for TFA Raindrop 30.3233.01 connected to both RFXtrx433 and RTL-SDR 