### PR TITLE
remove boost::shared_ptr

### DIFF
--- a/main/clx_unzip.h
+++ b/main/clx_unzip.h
@@ -39,9 +39,7 @@
 #include <string>
 #include <ios>
 //#include "config.h"
-//#include "shared_ptr.h"
 #include <minizip/unzip.h>
-#include <boost/shared_ptr.hpp>
 
 #ifdef CLX_ENABLE_AUTOLINK
 #if defined(_MSC_VER) && (_MSC_VER >= 1200) || defined(__BORLANDC__)
@@ -105,7 +103,7 @@ namespace clx {
 		bool open(const char_type* path) {
 			handler_type h = unzOpen(path);
 			if (h == NULL) return false;
-			p_ = boost::shared_ptr<storage_impl>(new storage_impl(h));
+			p_ = std::make_shared<storage_impl>(h);
 			return true;
 		}
 		
@@ -176,7 +174,7 @@ namespace clx {
 			handler_type in_;
 		};
 		
-		boost::shared_ptr<storage_impl> p_;
+		std::shared_ptr<storage_impl> p_;
 		string_type pass_;
 	};
 	


### PR DESCRIPTION
No advantage over the std version

Signed-off-by: Rosen Penev <rosenp@gmail.com>