### PR TITLE
remove const type in std::map

### DIFF
--- a/hardware/BleBox.h
+++ b/hardware/BleBox.h
@@ -53,7 +53,7 @@ class BleBox : public CDomoticzHardwareBase
       private:
 	int m_PollInterval;
 	std::shared_ptr<std::thread> m_thread;
-	std::map<const std::string, const int> m_devices;
+	std::map<std::string, int> m_devices;
 	std::mutex m_mutex;
 
 	_tColor m_RGBWColorState;


### PR DESCRIPTION
const here prevents copy elision. Remove it.

Signed-off-by: Rosen Penev <rosenp@gmail.com>