### PR TITLE
Updating from dbversion < 134 fails, hardware table already has LogLevel column

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2773,7 +2773,10 @@ bool CSQLHelper::OpenDatabase()
 		}
 		if (dbversion < 148)
 		{
-			query("ALTER TABLE Hardware ADD COLUMN [LogLevel] INTEGER DEFAULT 7"); // LOG_NORM + LOG_STATUS + LOG_ERROR
+			if(!DoesColumnExistsInTable("LogLevel", "Hardware")
+			{
+				query("ALTER TABLE Hardware ADD COLUMN [LogLevel] INTEGER DEFAULT 7"); // LOG_NORM + LOG_STATUS + LOG_ERROR
+			}
 		}
 	}
 	else if (bNewInstall)

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2773,7 +2773,7 @@ bool CSQLHelper::OpenDatabase()
 		}
 		if (dbversion < 148)
 		{
-			if(!DoesColumnExistsInTable("LogLevel", "Hardware")
+			if(!DoesColumnExistsInTable("LogLevel", "Hardware"))
 			{
 				query("ALTER TABLE Hardware ADD COLUMN [LogLevel] INTEGER DEFAULT 7"); // LOG_NORM + LOG_STATUS + LOG_ERROR
 			}


### PR DESCRIPTION
When updating from dbversion < 134, the hardware table is recreated. In dbversion < 148 the column LogLevel was then duplicate. Added check if column already exists.