### PR TITLE
Improve messages when opening DB at startup

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -38,7 +38,8 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 148
+#define DB_NAME "domoticz.db"
+#define DB_VERSION 149
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -611,7 +612,7 @@ CSQLHelper::CSQLHelper()
 	m_bPreviousAcceptNewHardware = false;
 	m_bLogEventScriptTrigger = false;
 
-	SetDatabaseName("domoticz.db");
+	SetDatabaseName(DB_NAME);
 }
 
 CSQLHelper::~CSQLHelper()
@@ -626,7 +627,7 @@ bool CSQLHelper::OpenDatabase()
 	int rc = sqlite3_open(m_dbase_name.c_str(), &m_dbase);
 	if (rc)
 	{
-		_log.Log(LOG_ERROR, "Error opening SQLite3 database: %s", sqlite3_errmsg(m_dbase));
+		_log.Log(LOG_ERROR, "Error opening %s database: %s", m_dbase_name.c_str(), sqlite3_errmsg(m_dbase));
 		sqlite3_close(m_dbase);
 		return false;
 	}
@@ -639,22 +640,28 @@ bool CSQLHelper::OpenDatabase()
 	std::vector<std::vector<std::string> > result = query("SELECT name FROM sqlite_master WHERE type='table' AND name='DeviceStatus'");
 	bool bNewInstall = (result.empty());
 	int dbversion = 0;
-	if (!bNewInstall)
+	if (bNewInstall)
+  		_log.Log(LOG_STATUS, "Creating %s database (version: %d)", m_dbase_name.c_str(), DB_VERSION);
+	else
 	{
 		GetPreferencesVar("DB_Version", dbversion);
-		if (dbversion > DB_VERSION)
+ 		if (dbversion == DB_VERSION)
+  			_log.Log(LOG_STATUS, "Open %s database (version: %d)", m_dbase_name.c_str(), DB_VERSION);
+		else if (dbversion < DB_VERSION)
+  			_log.Log(LOG_STATUS, "Upgrade %s database from version %d to %d", m_dbase_name.c_str(), dbversion, DB_VERSION);
+		else
 		{
 			//User is using a newer database on a old Domoticz version
 			//This is very dangerous and should not be allowed
-			_log.Log(LOG_ERROR, "Database incompatible with this Domoticz version. (You cannot downgrade to an old Domoticz version!)");
+			_log.Log(LOG_ERROR, "%s database incompatible with this Domoticz version.", m_dbase_name.c_str());
+			_log.Log(LOG_ERROR, "(Cannot downgrade version from %d to %d!)", dbversion, DB_VERSION);
 			sqlite3_close(m_dbase);
 			m_dbase = nullptr;
 			return false;
 		}
 		//Pre-SQL Patches
 	}
-
-	//create database (if not exists)
+	// Create database (if not exists)
 	sqlite3_exec(m_dbase, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
 	query(sqlCreateDeviceStatus);
 	query(sqlCreateDeviceStatusTrigger);


### PR DESCRIPTION
**Add more user frienfly messages when opening Domoticz database.**

Helpful to debug, particularly when a version upgrade occurs.
Otherwise, need to sqlite3 open the database file to get it's version number.

Helpful to locate precisely the database file.

The following messages are proposed :

Error message in case of problem when opening the database:

    Error: Error opening <database name> database: <error cause>

When opening an existing database matching the current version:

    Status, Open <database name> database (version: <current version number>)

When creating a missing database :

    Status, Creating <database name> database (version: <current version number>)

When upgrading an existing database to the current version:

    Status, Upgrade <database name> database from version <version number> to <current version number>

Error message in case an existing database version is higher than the current version:

    Error, <database name> database incompatible with this Domoticz version.
    Error, Cannot downgrade version from <current version number> to <version number>!
