### PR TITLE
replace most usages of std::list with deque

### DIFF
--- a/hardware/1Wire/1WireByKernel.h
+++ b/hardware/1Wire/1WireByKernel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "1WireSystem.h"
 #include <condition_variable>
-#include <list>
+#include <deque>
 #include "../../main/StoppableTask.h"
 
 class C1WireByKernel : public I_1WireSystem, StoppableTask
@@ -75,16 +75,20 @@ private:
    DeviceCollection m_Devices;
 
    // Pending changes queue
-   std::list<DeviceState> m_PendingChanges;
+   std::deque<DeviceState> m_PendingChanges;
    const DeviceState* GetDevicePendingState(const std::string& deviceId) const;
    std::mutex m_PendingChangesMutex;
    std::condition_variable m_PendingChangesCondition;
    class IsPendingChanges
    {
    private:
-      std::list<DeviceState>& m_List;
+     const std::deque<DeviceState> &m_List;
+
    public:
-	   explicit  IsPendingChanges(std::list<DeviceState>& list):m_List(list){}
+     explicit IsPendingChanges(const std::deque<DeviceState> &list)
+	     : m_List(list)
+     {
+     }
       bool operator()() const {return !m_List.empty();}
    };
 };

--- a/hardware/EvohomeRadio.h
+++ b/hardware/EvohomeRadio.h
@@ -149,7 +149,7 @@ class CEvohomeRadio : public CEvohomeBase
 	char m_buf[m_nBufSize];
 
 	std::map<unsigned int, fnc_evohome_decode> m_Decoders;
-	std::list<CEvohomeMsg> m_SendQueue;
+	std::deque<CEvohomeMsg> m_SendQueue;
 	std::mutex m_mtxSend;
 	int m_nSendFail;
 

--- a/hardware/MultiFun.cpp
+++ b/hardware/MultiFun.cpp
@@ -1,5 +1,3 @@
-#include <list>
-
 #include "stdafx.h"
 #include "MultiFun.h"
 #include "hardwaretypes.h"

--- a/hardware/OpenZWave.h
+++ b/hardware/OpenZWave.h
@@ -6,7 +6,6 @@
 #include <time.h>
 #include "ZWaveBase.h"
 #include "ASyncSerial.h"
-#include <list>
 #include "openzwave/control_panel/ozwcp.h"
 
 namespace OpenZWave
@@ -26,7 +25,7 @@ class COpenZWave : public ZWaveBase
       public:
 	typedef struct
 	{
-		std::list<OpenZWave::ValueID> Values;
+		std::deque<OpenZWave::ValueID> Values;
 		time_t m_LastSeen;
 	} NodeCommandClass;
 
@@ -172,7 +171,7 @@ class COpenZWave : public ZWaveBase
 
 	OpenZWave::Manager *m_pManager;
 
-	std::list<NodeInfo> m_nodes;
+	std::deque<NodeInfo> m_nodes;
 
 	std::string m_szSerialPort;
 	unsigned int m_controllerID;

--- a/hardware/SatelIntegra.cpp
+++ b/hardware/SatelIntegra.cpp
@@ -1,4 +1,4 @@
-#include <list>
+#include <deque>
 
 #include "stdafx.h"
 #include "SatelIntegra.h"
@@ -1058,9 +1058,9 @@ void SatelIntegra::UpdateAlarmAndArmName()
 	}
 }
 
-void expandForSpecialValue(std::list<unsigned char> &result)
+void expandForSpecialValue(std::deque<unsigned char> &result)
 {
-	std::list<unsigned char>::iterator it = result.begin();
+	auto it = result.begin();
 
 	const unsigned char specialValue = 0xFE;
 
@@ -1210,7 +1210,7 @@ int SatelIntegra::SendCommand(const unsigned char* cmd, const unsigned int cmdLe
 
 std::pair<unsigned char*, unsigned int> SatelIntegra::getFullFrame(const unsigned char* pCmd, const unsigned int cmdLength)
 {
-	std::list<unsigned char> result;
+	std::deque<unsigned char> result;
 
 	for (unsigned int i = 0; i < cmdLength; ++i)
 	{
@@ -1234,7 +1234,7 @@ std::pair<unsigned char*, unsigned int> SatelIntegra::getFullFrame(const unsigne
 	unsigned int resultSize = result.size();
 	unsigned char* pResult = new unsigned char[resultSize];
 	memset(pResult, 0, resultSize);
-	std::list<unsigned char>::iterator it = result.begin();
+	auto it = result.begin();
 	for (unsigned int index = 0; it != result.end(); ++it, ++index)
 	{
 		pResult[index] = *it;

--- a/hardware/XiaomiGateway.h
+++ b/hardware/XiaomiGateway.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "DomoticzHardware.h"
-#include <list>
 #include <mutex>
 #include "XiaomiDeviceSupport.h"
 

--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -66,7 +66,7 @@ uint8 SUCnodeId = 0;
 const char* cmode = "";
 int32 debug = false;
 bool MyNode::nodechanged = false;
-std::list<uint8> MyNode::removed;
+std::deque<uint8> MyNode::removed;
 extern std::string szUserDataFolder;
 
 //static Webserver *wserver;

--- a/hardware/openzwave/control_panel/ozwcp.h
+++ b/hardware/openzwave/control_panel/ozwcp.h
@@ -36,7 +36,6 @@
 // documentation will at all times remain with copyright holders.
 //-----------------------------------------------------------------------------
 
-#include <list>
 #include <algorithm>
 #include <Driver.h>
 #include <Notification.h>
@@ -141,7 +140,7 @@ class MyNode
 	time_t mtime;
 	bool changed;
 	static bool nodechanged;
-	static std::list<uint8> removed;
+	static std::deque<uint8> removed;
 	std::vector<MyGroup *> groups;
 	std::vector<MyValue *> values;
 };

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2139,7 +2139,7 @@ namespace http
 				lLevel = (_eLogLevel)atoi(sloglevel.c_str());
 			}
 
-			std::list<CLogger::_tLogLineStruct> logmessages = _log.GetLog(lLevel);
+			auto logmessages = _log.GetLog(lLevel);
 			int ii = 0;
 			for (const auto &msg : logmessages)
 			{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -13402,7 +13402,7 @@ void MainWorker::ForceLogNotificationCheck()
 
 void MainWorker::HandleLogNotifications()
 {
-	std::list<CLogger::_tLogLineStruct> _loglines = _log.GetNotificationLogs();
+	auto _loglines = _log.GetNotificationLogs();
 	if (_loglines.empty())
 		return;
 	//Assemble notification message


### PR DESCRIPTION
std::list has a massive runtime cost while not being
much better than deque.

The other places use sort() and remove() which are not
available with deque.

Signed-off-by: Rosen Penev <rosenp@gmail.com>