### PR TITLE
Improve DEBUG messages when opening DB at startup

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -39,7 +39,7 @@
 #include <inttypes.h>
 
 #define DB_NAME "domoticz.db"
-#define DB_VERSION 148
+#define DB_VERSION 149
 
 extern http::server::CWebServerHelper m_webservers;
 extern std::string szWWWFolder;
@@ -2776,9 +2776,68 @@ bool CSQLHelper::OpenDatabase()
 		}
 		if (dbversion < 148)
 		{
-			if(!DoesColumnExistsInTable("LogLevel", "Hardware"))
+			if (!DoesColumnExistsInTable("LogLevel", "Hardware"))
 			{
 				query("ALTER TABLE Hardware ADD COLUMN [LogLevel] INTEGER DEFAULT 7"); // LOG_NORM + LOG_STATUS + LOG_ERROR
+			}
+		}
+		if (dbversion < 149)
+		{
+			// Patch for MQTT: adding default in/ouput topics
+			std::stringstream szQuery;
+			std::vector<std::vector<std::string>> result;
+			szQuery << "SELECT ID, Extra FROM Hardware WHERE([Type]==" << HTYPE_MQTT << ")";
+			result = query(szQuery.str());
+			if (!result.empty())
+			{
+				for (const auto &sd : result)
+				{
+					std::string ID = sd.at(0);
+					std::string Options = sd.at(1);
+
+					std::vector<std::string> strarray;
+					StringSplit(Options, ";", strarray);
+
+					if (strarray.size()==4)
+						continue;
+
+					if (strarray.empty())
+					{
+						strarray.push_back("");
+						strarray.push_back("domoticz/in");
+						strarray.push_back("domoticz/out");
+					}
+					else if (strarray.size() == 1)
+					{
+						strarray.push_back("domoticz/in");
+						strarray.push_back("domoticz/out");
+						strarray.push_back("");
+					}
+					else if (strarray.size() == 2)
+					{
+						if (strarray[1].empty())
+							strarray[1] = "domoticz/in";
+						strarray.push_back("domoticz/out;");
+					}
+					else if (strarray.size() == 2)
+					{
+						if (strarray[1].empty())
+							strarray[1] = "domoticz/in";
+						if (strarray[2].empty())
+							strarray[2] = "domoticz/out";
+					}
+					strarray.push_back("");
+					Options.clear();
+					int iIndex = 0;
+					for (const auto ittOptions : strarray)
+					{
+						if (iIndex > 0)
+							Options += ";";
+						Options += ittOptions;
+						iIndex++;
+					}
+					safe_query("UPDATE Hardware SET Extra='%q' WHERE (ID=%s)", Options.c_str(), ID.c_str());
+				}
 			}
 		}
 	}

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -38,6 +38,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+#define DB_NAME "domoticz.db"
 #define DB_VERSION 148
 
 extern http::server::CWebServerHelper m_webservers;
@@ -611,7 +612,7 @@ CSQLHelper::CSQLHelper()
 	m_bPreviousAcceptNewHardware = false;
 	m_bLogEventScriptTrigger = false;
 
-	SetDatabaseName("domoticz.db");
+	SetDatabaseName(DB_NAME);
 }
 
 CSQLHelper::~CSQLHelper()
@@ -626,7 +627,8 @@ bool CSQLHelper::OpenDatabase()
 	int rc = sqlite3_open(m_dbase_name.c_str(), &m_dbase);
 	if (rc)
 	{
-		_log.Log(LOG_ERROR, "Error opening SQLite3 database: %s", sqlite3_errmsg(m_dbase));
+		_log.Log(LOG_ERROR, "Error opening Domoticz database: %s", sqlite3_errmsg(m_dbase));
+		_log.Debug(DEBUG_NORM, "(Database path: %s)", m_dbase_name.c_str());
 		sqlite3_close(m_dbase);
 		return false;
 	}
@@ -639,22 +641,26 @@ bool CSQLHelper::OpenDatabase()
 	std::vector<std::vector<std::string> > result = query("SELECT name FROM sqlite_master WHERE type='table' AND name='DeviceStatus'");
 	bool bNewInstall = (result.empty());
 	int dbversion = 0;
-	if (!bNewInstall)
+	if (bNewInstall)
+  		_log.Debug(DEBUG_NORM, "Creating %s database (version: %d)", m_dbase_name.c_str(), DB_VERSION);
+	else
 	{
 		GetPreferencesVar("DB_Version", dbversion);
-		if (dbversion > DB_VERSION)
+ 		if (dbversion == DB_VERSION)
+  			_log.Debug(DEBUG_NORM, "Opening %s database (version: %d)", m_dbase_name.c_str(), DB_VERSION);
+		else if (dbversion < DB_VERSION)
+  			_log.Debug(DEBUG_NORM, "Upgrading %s database from version %d to %d", m_dbase_name.c_str(), dbversion, DB_VERSION);
+		else
 		{
-			//User is using a newer database on a old Domoticz version
-			//This is very dangerous and should not be allowed
+			// Using a newer database on a old Domoticz version is not allowed
 			_log.Log(LOG_ERROR, "Database incompatible with this Domoticz version. (You cannot downgrade to an old Domoticz version!)");
+			_log.Debug(DEBUG_NORM, "(Cannot downgrade database from version %d to %d!)", dbversion, DB_VERSION);
 			sqlite3_close(m_dbase);
 			m_dbase = nullptr;
 			return false;
 		}
-		//Pre-SQL Patches
 	}
-
-	//create database (if not exists)
+	// Create database (if not exists)
 	sqlite3_exec(m_dbase, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
 	query(sqlCreateDeviceStatus);
 	query(sqlCreateDeviceStatusTrigger);

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -651,10 +651,9 @@ bool CSQLHelper::OpenDatabase()
 		else if (dbversion < DB_VERSION)
   			_log.Debug(DEBUG_NORM, "Upgrading %s database from version %d to %d", m_dbase_name.c_str(), dbversion, DB_VERSION);
 		else
-		{
-			// Using a newer database on a old Domoticz version is not allowed
+		{ // Using a newer database on a old Domoticz version is not allowed
 			_log.Log(LOG_ERROR, "Database incompatible with this Domoticz version. (You cannot downgrade to an old Domoticz version!)");
-			_log.Debug(DEBUG_NORM, "(Cannot downgrade database from version %d to %d!)", dbversion, DB_VERSION);
+			_log.Debug(DEBUG_NORM, "(Cannot downgrade %s database from version %d to %d!)", m_dbase_name.c_str(), dbversion, DB_VERSION);
 			sqlite3_close(m_dbase);
 			m_dbase = nullptr;
 			return false;


### PR DESCRIPTION
Hi @gizmocuz, @kiddigital,

This is my last attempt for this PR.

Replaced Log messages by Debug message, so :

- normal users see only the former error messages in the log,
- launching Domoticz with '-loglevel all' adds the troubleshooting complements with database path and versions numbers.

PS. another PR will follow to fix '-debuglevel all' option which is not working in the current implementation