### PR TITLE
Set dynamically & per hardware Debug Levels

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -128,15 +128,29 @@ int CDomoticzHardwareBase::SetThreadNameInt(const std::thread::native_handle_typ
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const std::string& sLogline)
 {
 	if (!(m_LogLevelEnabled & (uint32_t)level))
-		return; //this type of log is disabled
+		return; // Log level is disabled by hardware parameters
 
+	uint32_t currentLogFlags = _log.GetLogFlags();
+	_log.SetLogFlags(m_LogLevelEnabled);
+
+	// Save and force log level
+	
 	_log.Log(level, "%s: %s", m_Name.c_str(), sLogline.c_str());
+
+	// Restore previous log level
+
+	_log.SetLogFlags(currentLogFlags);
 }
 
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const char* logline, ...)
 {
 	if (!(m_LogLevelEnabled & (uint32_t)level))
-		return; // this type of log is disabled
+		return; // Log level is disabled by hardware parameters
+
+	// Save and force log level
+	
+	uint32_t currentLogFlags = _log.GetLogFlags();
+	_log.SetLogFlags(m_LogLevelEnabled);
 
 	va_list argList;
 	char cbuffer[MAX_LOG_LINE_LENGTH];
@@ -144,21 +158,55 @@ void CDomoticzHardwareBase::Log(const _eLogLevel level, const char* logline, ...
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
 	_log.Log(level, "%s: %s", m_Name.c_str(), cbuffer);
+
+	// Restore previous log level
+
+	_log.SetLogFlags(currentLogFlags);
 }
 
 void CDomoticzHardwareBase::Debug(const _eDebugLevel level, const std::string& sLogline)
 {
+	if (!(m_DebugLevelEnabled & (uint32_t)level))
+		return; // Debug level is disabled by hardware parameters
+
+	// Save and force debug level
+	
+	uint32_t currentLogFlags = _log.GetLogFlags();
+	_log.SetLogFlags(currentLogFlags | LOG_DEBUG_INT);
+	uint32_t currentDebugFlags = _log.GetDebugFlags();
+	_log.SetDebugFlags(currentDebugFlags | m_DebugLevelEnabled);
+
 	_log.Debug(level, "%s: %s", m_Name.c_str(), sLogline.c_str());
+
+	// Restore previous debug level
+
+	_log.SetLogFlags(currentLogFlags);
+	_log.SetDebugFlags(currentDebugFlags);
 }
 
 void CDomoticzHardwareBase::Debug(const _eDebugLevel level, const char* logline, ...)
 {
+	if (!(m_DebugLevelEnabled & (uint32_t)level))
+		return; // Debug level is disabled by hardware parameters
+
+	// Save and force debug level
+	
+	uint32_t currentLogFlags = _log.GetLogFlags();
+	_log.SetLogFlags(currentLogFlags | LOG_DEBUG_INT);
+	uint32_t currentDebugFlags = _log.GetDebugFlags();
+	_log.SetDebugFlags(currentDebugFlags | m_DebugLevelEnabled);
+
 	va_list argList;
 	char cbuffer[MAX_LOG_LINE_LENGTH];
 	va_start(argList, logline);
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
 	_log.Debug(level, "%s: %s", m_Name.c_str(), cbuffer);
+
+	// Restore previous debug level
+	
+	_log.SetLogFlags(currentLogFlags);
+	_log.SetDebugFlags(currentDebugFlags);
 }
 
 //Sensor Helpers

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -128,29 +128,15 @@ int CDomoticzHardwareBase::SetThreadNameInt(const std::thread::native_handle_typ
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const std::string& sLogline)
 {
 	if (!(m_LogLevelEnabled & (uint32_t)level))
-		return; // Log level is disabled by hardware parameters
+		return; //this type of log is disabled
 
-	uint32_t currentLogFlags = _log.GetLogFlags();
-	_log.SetLogFlags(m_LogLevelEnabled);
-
-	// Save and force log level
-	
 	_log.Log(level, "%s: %s", m_Name.c_str(), sLogline.c_str());
-
-	// Restore previous log level
-
-	_log.SetLogFlags(currentLogFlags);
 }
 
 void CDomoticzHardwareBase::Log(const _eLogLevel level, const char* logline, ...)
 {
 	if (!(m_LogLevelEnabled & (uint32_t)level))
-		return; // Log level is disabled by hardware parameters
-
-	// Save and force log level
-	
-	uint32_t currentLogFlags = _log.GetLogFlags();
-	_log.SetLogFlags(m_LogLevelEnabled);
+		return; // this type of log is disabled
 
 	va_list argList;
 	char cbuffer[MAX_LOG_LINE_LENGTH];
@@ -158,55 +144,21 @@ void CDomoticzHardwareBase::Log(const _eLogLevel level, const char* logline, ...
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
 	_log.Log(level, "%s: %s", m_Name.c_str(), cbuffer);
-
-	// Restore previous log level
-
-	_log.SetLogFlags(currentLogFlags);
 }
 
 void CDomoticzHardwareBase::Debug(const _eDebugLevel level, const std::string& sLogline)
 {
-	if (!(m_DebugLevelEnabled & (uint32_t)level))
-		return; // Debug level is disabled by hardware parameters
-
-	// Save and force debug level
-	
-	uint32_t currentLogFlags = _log.GetLogFlags();
-	_log.SetLogFlags(currentLogFlags | LOG_DEBUG_INT);
-	uint32_t currentDebugFlags = _log.GetDebugFlags();
-	_log.SetDebugFlags(currentDebugFlags | m_DebugLevelEnabled);
-
 	_log.Debug(level, "%s: %s", m_Name.c_str(), sLogline.c_str());
-
-	// Restore previous debug level
-
-	_log.SetLogFlags(currentLogFlags);
-	_log.SetDebugFlags(currentDebugFlags);
 }
 
 void CDomoticzHardwareBase::Debug(const _eDebugLevel level, const char* logline, ...)
 {
-	if (!(m_DebugLevelEnabled & (uint32_t)level))
-		return; // Debug level is disabled by hardware parameters
-
-	// Save and force debug level
-	
-	uint32_t currentLogFlags = _log.GetLogFlags();
-	_log.SetLogFlags(currentLogFlags | LOG_DEBUG_INT);
-	uint32_t currentDebugFlags = _log.GetDebugFlags();
-	_log.SetDebugFlags(currentDebugFlags | m_DebugLevelEnabled);
-
 	va_list argList;
 	char cbuffer[MAX_LOG_LINE_LENGTH];
 	va_start(argList, logline);
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
 	_log.Debug(level, "%s: %s", m_Name.c_str(), cbuffer);
-
-	// Restore previous debug level
-	
-	_log.SetLogFlags(currentLogFlags);
-	_log.SetDebugFlags(currentDebugFlags);
 }
 
 //Sensor Helpers

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -70,7 +70,9 @@ class CDomoticzHardwareBase : public StoppableTask
 		__attribute__((format(printf, 3, 4)))
 #endif
 		;
-	uint32_t m_LogLevelEnabled; //bitwise _eLogLevel 7 = LOG_NORM | LOG_STATUS | LOG_ERROR
+	uint32_t m_LogLevelEnabled; // Bitwise _eLogLevel 7 = LOG_NORM | LOG_STATUS | LOG_ERROR
+	uint32_t m_DebugLevelEnabled; // Bitwise _eDebugLevel 3 = DEBUG_NORM | DEBUG_HARDWARE
+
       protected:
 	virtual bool StartHardware() = 0;
 	virtual bool StopHardware() = 0;

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -70,9 +70,7 @@ class CDomoticzHardwareBase : public StoppableTask
 		__attribute__((format(printf, 3, 4)))
 #endif
 		;
-	uint32_t m_LogLevelEnabled; // Bitwise _eLogLevel 7 = LOG_NORM | LOG_STATUS | LOG_ERROR
-	uint32_t m_DebugLevelEnabled; // Bitwise _eDebugLevel 3 = DEBUG_NORM | DEBUG_HARDWARE
-
+	uint32_t m_LogLevelEnabled; //bitwise _eLogLevel 7 = LOG_NORM | LOG_STATUS | LOG_ERROR
       protected:
 	virtual bool StartHardware() = 0;
 	virtual bool StopHardware() = 0;

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -86,16 +86,6 @@ void CLogger::SetLogFlags(const uint32_t iFlags)
 	m_log_flags = iFlags;
 }
 
-uint32_t CLogger::GetLogFlags()
-{
-	return m_log_flags;
-}
-
-bool CLogger::IsLogLevelEnabled(const _eLogLevel level)
-{
-	return (m_log_flags & level);
-}
-
 // Supported flags: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql
 bool CLogger::SetDebugFlags(const std::string &sFlags)
 {
@@ -145,9 +135,9 @@ void CLogger::SetDebugFlags(const uint32_t iFlags)
 	m_debug_flags = iFlags;
 }
 
-uint32_t CLogger::GetDebugFlags()
+bool CLogger::IsLogLevelEnabled(const _eLogLevel level)
 {
-	return m_debug_flags;
+	return (m_log_flags & level);
 }
 
 bool CLogger::IsDebugLevelEnabled(const _eDebugLevel level)

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -86,6 +86,16 @@ void CLogger::SetLogFlags(const uint32_t iFlags)
 	m_log_flags = iFlags;
 }
 
+uint32_t CLogger::GetLogFlags()
+{
+	return m_log_flags;
+}
+
+bool CLogger::IsLogLevelEnabled(const _eLogLevel level)
+{
+	return (m_log_flags & level);
+}
+
 // Supported flags: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql
 bool CLogger::SetDebugFlags(const std::string &sFlags)
 {
@@ -135,9 +145,9 @@ void CLogger::SetDebugFlags(const uint32_t iFlags)
 	m_debug_flags = iFlags;
 }
 
-bool CLogger::IsLogLevelEnabled(const _eLogLevel level)
+uint32_t CLogger::GetDebugFlags()
 {
-	return (m_log_flags & level);
+	return m_debug_flags;
 }
 
 bool CLogger::IsDebugLevelEnabled(const _eDebugLevel level)

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -44,12 +44,10 @@ class CLogger
 
 	bool SetLogFlags(const std::string &sFlags);
 	void SetLogFlags(const uint32_t iFlags);
-	uint32_t GetLogFlags();
 	bool IsLogLevelEnabled(const _eLogLevel level);
 
 	bool SetDebugFlags(const std::string &sFlags);
 	void SetDebugFlags(const uint32_t iFlags);
-	uint32_t GetDebugFlags();
 	bool IsDebugLevelEnabled(const _eDebugLevel level);
 
 	void SetOutputFile(const char *OutputFile);

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -44,10 +44,12 @@ class CLogger
 
 	bool SetLogFlags(const std::string &sFlags);
 	void SetLogFlags(const uint32_t iFlags);
+	uint32_t GetLogFlags();
 	bool IsLogLevelEnabled(const _eLogLevel level);
 
 	bool SetDebugFlags(const std::string &sFlags);
 	void SetDebugFlags(const uint32_t iFlags);
+	uint32_t GetDebugFlags();
 	bool IsDebugLevelEnabled(const _eDebugLevel level);
 
 	void SetOutputFile(const char *OutputFile);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -4264,47 +4264,40 @@ namespace http
 				std::string sunitcode;
 				std::string devid;
 
-				if (lighttype == 70)
+				if (lighttype < 20)
 				{
-					// EnOcean (Lighting2 with Base_ID offset)
-					dtype = pTypeLighting2;
-					subtype = sTypeAC;
-					std::string sgroupcode = request::findValue(&req, "groupcode");
+					dtype = pTypeLighting1;
+					subtype = lighttype;
+					std::string shousecode = request::findValue(&req, "housecode");
 					sunitcode = request::findValue(&req, "unitcode");
-					int iUnitTest = atoi(sunitcode.c_str()); // only First Rocker_ID at the moment, gives us 128 devices we can control, should be enough!
-					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
+					if ((shousecode.empty()) || (sunitcode.empty()))
 						return;
-					sunitcode = sgroupcode; // Button A or B
-					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
-					if (pBaseHardware == nullptr)
+					devid = shousecode;
+				}
+				else if (lighttype < 30)
+				{
+					dtype = pTypeLighting2;
+					subtype = lighttype - 20;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) && (pBaseHardware->HwdType != HTYPE_USBtinGateway))
+					devid = id;
+				}
+				else if (lighttype < 68)
+				{
+					dtype = pTypeLighting5;
+					subtype = lighttype - 50;
+					if (lighttype == 59)
+						subtype = sTypeIT;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					unsigned long rID = 0;
-					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
-					{
-						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
-					{
-						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway) // Like EnOcean (Lighting2 with Base_ID offset)
-					{
-						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
-						// base ID calculate in the USBtinharwade dependant of the CAN Layer !
-						// for exemple see MultiblocV8 layer...
-						rID = pUSBtinHardware->switch_id_base;
-						std::stringstream ssunitcode;
-						ssunitcode << iUnitTest;
-						sunitcode = ssunitcode.str();
-					}
-					// convert to hex, and we have our ID
-					std::stringstream s_strid;
-					s_strid << std::hex << std::uppercase << rID;
-					devid = s_strid.str();
+					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeIT))
+						devid = "00" + id;
+					else
+						devid = id;
 				}
 				else if (lighttype == 68)
 				{
@@ -4398,405 +4391,409 @@ namespace http
 					return;
 #endif
 				}
-				else if (lighttype < 20)
+				else if (lighttype == 70)
 				{
-					dtype = pTypeLighting1;
-					subtype = lighttype;
+					// EnOcean (Lighting2 with Base_ID offset)
+					dtype = pTypeLighting2;
+					subtype = sTypeAC;
+					std::string sgroupcode = request::findValue(&req, "groupcode");
+					sunitcode = request::findValue(&req, "unitcode");
+					int iUnitTest = atoi(sunitcode.c_str()); // only First Rocker_ID at the moment, gives us 128 devices we can control, should be enough!
+					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
+						return;
+					sunitcode = sgroupcode; // Button A or B
+					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					if (pBaseHardware == nullptr)
+						return;
+					unsigned long rID = 0;
+					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
+					{
+						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
+					{
+						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway) // Like EnOcean (Lighting2 with Base_ID offset)
+					{
+						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
+						// base ID calculate in the USBtinharwade dependant of the CAN Layer !
+						// for exemple see MultiblocV8 layer...
+						rID = pUSBtinHardware->switch_id_base;
+						std::stringstream ssunitcode;
+						ssunitcode << iUnitTest;
+						sunitcode = ssunitcode.str();
+					}
+					else
+						return;
+					// convert to hex, and we have our ID
+					std::stringstream s_strid;
+					s_strid << std::hex << std::uppercase << rID;
+					devid = s_strid.str();
+				}
+				else if (lighttype == 100)
+				{
+					// Chime/ByronSX
+					dtype = pTypeChime;
+					subtype = sTypeByronSX;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					int iUnitCode = atoi(sunitcode.c_str()) - 1;
+					switch (iUnitCode)
+					{
+						case 0:
+							iUnitCode = chime_sound0;
+							break;
+						case 1:
+							iUnitCode = chime_sound1;
+							break;
+						case 2:
+							iUnitCode = chime_sound2;
+							break;
+						case 3:
+							iUnitCode = chime_sound3;
+							break;
+						case 4:
+							iUnitCode = chime_sound4;
+							break;
+						case 5:
+							iUnitCode = chime_sound5;
+							break;
+						case 6:
+							iUnitCode = chime_sound6;
+							break;
+						case 7:
+							iUnitCode = chime_sound7;
+							break;
+					}
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					devid = id;
+				}
+				else if (lighttype == 101)
+				{
+					// Curtain Harrison
+					dtype = pTypeCurtain;
+					subtype = sTypeHarrison;
 					std::string shousecode = request::findValue(&req, "housecode");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((shousecode.empty()) || (sunitcode.empty()))
 						return;
 					devid = shousecode;
 				}
-				else if (lighttype < 30)
+				else if (lighttype == 102)
 				{
-					dtype = pTypeLighting2;
-					subtype = lighttype - 20;
+					// RFY
+					dtype = pTypeRFY;
+					subtype = sTypeRFY;
 					std::string id = request::findValue(&req, "id");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return;
 					devid = id;
 				}
-				else if (lighttype < 70)
+				else if (lighttype == 103)
 				{
-					dtype = pTypeLighting5;
-					subtype = lighttype - 50;
-					if (lighttype == 59)
-						subtype = sTypeIT;
+					// Meiantech
+					dtype = pTypeSecurity1;
+					subtype = sTypeMeiantech;
+					std::string id = request::findValue(&req, "id");
+					if ((id.empty()))
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 104)
+				{
+					// HE105
+					dtype = pTypeThermostat2;
+					subtype = sTypeHE105;
+					sunitcode = request::findValue(&req, "unitcode");
+					if (sunitcode.empty())
+						return;
+					// convert to hex, and we have our Unit Code
+					std::stringstream s_strid;
+					s_strid << std::hex << std::uppercase << sunitcode;
+					int iUnitCode;
+					s_strid >> iUnitCode;
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					devid = "1";
+				}
+				else if (lighttype == 105)
+				{
+					// ASA
+					dtype = pTypeRFY;
+					subtype = sTypeASA;
 					std::string id = request::findValue(&req, "id");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeIT))
-						devid = "00" + id;
-					else
-						devid = id;
+					devid = id;
 				}
-				else
+				else if (lighttype == 106)
 				{
-					if (lighttype == 100)
-					{
-						// Chime/ByronSX
-						dtype = pTypeChime;
-						subtype = sTypeByronSX;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						int iUnitCode = atoi(sunitcode.c_str()) - 1;
-						switch (iUnitCode)
-						{
-							case 0:
-								iUnitCode = chime_sound0;
-								break;
-							case 1:
-								iUnitCode = chime_sound1;
-								break;
-							case 2:
-								iUnitCode = chime_sound2;
-								break;
-							case 3:
-								iUnitCode = chime_sound3;
-								break;
-							case 4:
-								iUnitCode = chime_sound4;
-								break;
-							case 5:
-								iUnitCode = chime_sound5;
-								break;
-							case 6:
-								iUnitCode = chime_sound6;
-								break;
-							case 7:
-								iUnitCode = chime_sound7;
-								break;
-						}
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						devid = id;
-					}
-					else if (lighttype == 101)
-					{
-						// Curtain Harrison
-						dtype = pTypeCurtain;
-						subtype = sTypeHarrison;
-						std::string shousecode = request::findValue(&req, "housecode");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((shousecode.empty()) || (sunitcode.empty()))
-							return;
-						devid = shousecode;
-					}
-					else if (lighttype == 102)
-					{
-						// RFY
-						dtype = pTypeRFY;
-						subtype = sTypeRFY;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
-					}
-					else if (lighttype == 103)
-					{
-						// Meiantech
-						dtype = pTypeSecurity1;
-						subtype = sTypeMeiantech;
-						std::string id = request::findValue(&req, "id");
-						if ((id.empty()))
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 104)
-					{
-						// HE105
-						dtype = pTypeThermostat2;
-						subtype = sTypeHE105;
-						sunitcode = request::findValue(&req, "unitcode");
-						if (sunitcode.empty())
-							return;
-						// convert to hex, and we have our Unit Code
-						std::stringstream s_strid;
-						s_strid << std::hex << std::uppercase << sunitcode;
-						int iUnitCode;
-						s_strid >> iUnitCode;
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						devid = "1";
-					}
-					else if (lighttype == 105)
-					{
-						// ASA
-						dtype = pTypeRFY;
-						subtype = sTypeASA;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
-					}
-					else if (lighttype == 106)
-					{
-						// Blyss
-						dtype = pTypeLighting6;
-						subtype = sTypeBlyss;
-						std::string sgroupcode = request::findValue(&req, "groupcode");
-						sunitcode = request::findValue(&req, "unitcode");
-						std::string id = request::findValue(&req, "id");
-						if ((sgroupcode.empty()) || (sunitcode.empty()) || (id.empty()))
-							return;
-						devid = id + sgroupcode;
-					}
-					else if (lighttype == 107)
-					{
-						// RFY2
-						dtype = pTypeRFY;
-						subtype = sTypeRFY2;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
-					}
-					else if ((lighttype >= 200) && (lighttype < 300))
-					{
-						dtype = pTypeBlinds;
-						subtype = lighttype - 200;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						int iUnitCode = atoi(sunitcode.c_str());
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						devid = id;
-					}
-					else if (lighttype == 301)
-					{
-						// Smartwares Radiator
-						dtype = pTypeRadiator1;
-						subtype = sTypeSmartwaresSwitchRadiator;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
-					}
-					else if (lighttype == 302)
-					{
-						// Home Confort
-						dtype = pTypeHomeConfort;
-						subtype = sTypeHomeConfortTEL010;
-						std::string id = request::findValue(&req, "id");
+					// Blyss
+					dtype = pTypeLighting6;
+					subtype = sTypeBlyss;
+					std::string sgroupcode = request::findValue(&req, "groupcode");
+					sunitcode = request::findValue(&req, "unitcode");
+					std::string id = request::findValue(&req, "id");
+					if ((sgroupcode.empty()) || (sunitcode.empty()) || (id.empty()))
+						return;
+					devid = id + sgroupcode;
+				}
+				else if (lighttype == 107)
+				{
+					// RFY2
+					dtype = pTypeRFY;
+					subtype = sTypeRFY2;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					devid = id;
+				}
+				else if ((lighttype >= 200) && (lighttype < 300))
+				{
+					dtype = pTypeBlinds;
+					subtype = lighttype - 200;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					int iUnitCode = atoi(sunitcode.c_str());
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					devid = id;
+				}
+				else if (lighttype == 301)
+				{
+					// Smartwares Radiator
+					dtype = pTypeRadiator1;
+					subtype = sTypeSmartwaresSwitchRadiator;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					devid = id;
+				}
+				else if (lighttype == 302)
+				{
+					// Home Confort
+					dtype = pTypeHomeConfort;
+					subtype = sTypeHomeConfortTEL010;
+					std::string id = request::findValue(&req, "id");
 
-						std::string shousecode = request::findValue(&req, "housecode");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
-							return;
+					std::string shousecode = request::findValue(&req, "housecode");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
+						return;
 
-						int iUnitCode = atoi(sunitcode.c_str());
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
-						shousecode = szTmp;
-						devid = id + shousecode;
-					}
-					else if (lighttype == 303)
+					int iUnitCode = atoi(sunitcode.c_str());
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+					shousecode = szTmp;
+					devid = id + shousecode;
+				}
+				else if (lighttype == 303)
+				{
+					// Selector Switch
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeSelector;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					devid = id;
+				}
+				else if (lighttype == 304)
+				{
+					// Itho CVE RFT
+					dtype = pTypeFan;
+					subtype = sTypeItho;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 305)
+				{
+					// Lucci Air/DC
+					dtype = pTypeFan;
+					subtype = sTypeLucciAir;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 306)
+				{
+					// Lucci Air DC
+					dtype = pTypeFan;
+					subtype = sTypeLucciAirDC;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 307)
+				{
+					// Westinghouse
+					dtype = pTypeFan;
+					subtype = sTypeWestinghouse;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 308)
+				{
+					// Casafan
+					dtype = pTypeFan;
+					subtype = sTypeCasafan;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 309)
+				{
+					// FT1211R
+					dtype = pTypeFan;
+					subtype = sTypeFT1211R;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 310)
+				{
+					// Falmec
+					dtype = pTypeFan;
+					subtype = sTypeFalmec;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 311)
+				{
+					// Lucci Air DC II
+					dtype = pTypeFan;
+					subtype = sTypeLucciAirDCII;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 312)
+				{
+					// Itho ECO
+					dtype = pTypeFan;
+					subtype = sTypeIthoECO;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 313)
+				{
+					// Novy
+					dtype = pTypeFan;
+					subtype = sTypeNovy;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 400)
+				{
+					// Openwebnet Bus Blinds
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 401)
+				{
+					// Openwebnet Bus Lights
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 402)
+				{
+					// Openwebnet Bus Auxiliary
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 403)
+				{
+					// Openwebnet Zigbee Blinds
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchBlindsT2;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 404)
+				{
+					// Light Openwebnet Zigbee
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchLightT2;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if ((lighttype == 405) || (lighttype == 406))
+				{
+					// Openwebnet Dry Contact / IR Detection
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchContactT1;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 407)
+				{
+					// Openwebnet Bus Custom
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					std::string StrParam1 = request::findValue(&req, "StrParam1");
+					if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
 					{
-						// Selector Switch
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeSelector;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
-					}
-					else if (lighttype == 304)
-					{
-						// Itho CVE RFT
-						dtype = pTypeFan;
-						subtype = sTypeItho;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 305)
-					{
-						// Lucci Air/DC
-						dtype = pTypeFan;
-						subtype = sTypeLucciAir;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 306)
-					{
-						// Lucci Air DC
-						dtype = pTypeFan;
-						subtype = sTypeLucciAirDC;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 307)
-					{
-						// Westinghouse
-						dtype = pTypeFan;
-						subtype = sTypeWestinghouse;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 308)
-					{
-						// Casafan
-						dtype = pTypeFan;
-						subtype = sTypeCasafan;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 309)
-					{
-						// FT1211R
-						dtype = pTypeFan;
-						subtype = sTypeFT1211R;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 310)
-					{
-						// Falmec
-						dtype = pTypeFan;
-						subtype = sTypeFalmec;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 311)
-					{
-						// Lucci Air DC II
-						dtype = pTypeFan;
-						subtype = sTypeLucciAirDCII;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 312)
-					{
-						// Itho ECO
-						dtype = pTypeFan;
-						subtype = sTypeIthoECO;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 313)
-					{
-						// Novy
-						dtype = pTypeFan;
-						subtype = sTypeNovy;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 400)
-					{
-						// Openwebnet Bus Blinds
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 401)
-					{
-						// Openwebnet Bus Lights
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 402)
-					{
-						// Openwebnet Bus Auxiliary
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 403)
-					{
-						// Openwebnet Zigbee Blinds
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchBlindsT2;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 404)
-					{
-						// Light Openwebnet Zigbee
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchLightT2;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if ((lighttype == 405) || (lighttype == 406))
-					{
-						// Openwebnet Dry Contact / IR Detection
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchContactT1;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 407)
-					{
-						// Openwebnet Bus Custom
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						std::string StrParam1 = request::findValue(&req, "StrParam1");
-						if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
-						{
-							root["message"] = "Some field empty or not valid.";
-							return;
-						}
+						root["message"] = "Some field empty or not valid.";
+						return;
 					}
 				}
 				// ----------- If needed convert to GeneralSwitch type (for o.a. RFlink) -----------
@@ -4885,55 +4882,41 @@ namespace http
 				}
 #endif
 
-				if (lighttype == 70)
+				if (lighttype < 20)
 				{
-					// EnOcean (Lighting2 with Base_ID offset)
-					dtype = pTypeLighting2;
-					subtype = sTypeAC;
+					dtype = pTypeLighting1;
+					subtype = lighttype;
+					std::string shousecode = request::findValue(&req, "housecode");
 					sunitcode = request::findValue(&req, "unitcode");
-					std::string sgroupcode = request::findValue(&req, "groupcode");
-					int iUnitTest = atoi(sunitcode.c_str()); // gives us 128 devices we can control, should be enough!
-					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
+					if ((shousecode.empty()) || (sunitcode.empty()))
 						return;
-					sunitcode = sgroupcode; // Button A/B
-					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
-					if (pBaseHardware == nullptr)
+					devid = shousecode;
+				}
+				else if (lighttype < 30)
+				{
+					dtype = pTypeLighting2;
+					subtype = lighttype - 20;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) && (pBaseHardware->HwdType != HTYPE_USBtinGateway))
+					devid = id;
+				}
+				else if (lighttype < 68)
+				{
+					dtype = pTypeLighting5;
+					subtype = lighttype - 50;
+					if (lighttype == 59)
+						subtype = sTypeIT;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					unsigned long rID = 0;
-					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
-					{
-						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
-						if (pEnoceanHardware->m_id_base == 0)
-						{
-							root["message"] = "BaseID not found, is the hardware running?";
-							return;
-						}
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
-					{
-						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
-						if (pEnoceanHardware->m_id_base == 0)
-						{
-							root["message"] = "BaseID not found, is the hardware running?";
-							return;
-						}
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway)
-					{
-						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
-						rID = pUSBtinHardware->switch_id_base;
-						std::stringstream ssunitcode;
-						ssunitcode << iUnitTest;
-						sunitcode = ssunitcode.str();
-					}
-					// convert to hex, and we have our ID
-					std::stringstream s_strid;
-					s_strid << std::hex << std::uppercase << rID;
-					devid = s_strid.str();
+					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeLightwaveRF) &&
+					    (subtype != sTypeIT))
+						devid = "00" + id;
+					else
+						devid = id;
 				}
 				else if (lighttype == 68)
 				{
@@ -4994,41 +4977,98 @@ namespace http
 					return;
 #endif
 				}
-				else if (lighttype < 20)
+				else if (lighttype == 70)
 				{
-					dtype = pTypeLighting1;
-					subtype = lighttype;
-					std::string shousecode = request::findValue(&req, "housecode");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((shousecode.empty()) || (sunitcode.empty()))
-						return;
-					devid = shousecode;
-				}
-				else if (lighttype < 30)
-				{
+					// EnOcean (Lighting2 with Base_ID offset)
 					dtype = pTypeLighting2;
-					subtype = lighttype - 20;
-					std::string id = request::findValue(&req, "id");
+					subtype = sTypeAC;
 					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					std::string sgroupcode = request::findValue(&req, "groupcode");
+					int iUnitTest = atoi(sunitcode.c_str()); // gives us 128 devices we can control, should be enough!
+					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
 						return;
-					devid = id;
-				}
-				else if (lighttype < 70)
-				{
-					dtype = pTypeLighting5;
-					subtype = lighttype - 50;
-					if (lighttype == 59)
-						subtype = sTypeIT;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					sunitcode = sgroupcode; // Button A/B
+					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					if (pBaseHardware == nullptr)
 						return;
-					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeLightwaveRF) &&
-					    (subtype != sTypeIT))
-						devid = "00" + id;
+					unsigned long rID = 0;
+					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
+					{
+						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
+						if (pEnoceanHardware->m_id_base == 0)
+						{
+							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name);
+							root["message"] = szTmp;
+							return;
+						}
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
+					{
+						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
+						if (pEnoceanHardware->m_id_base == 0)
+						{
+							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name);
+							root["message"] = szTmp;
+							return;
+						}
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway)
+					{
+						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
+						rID = pUSBtinHardware->switch_id_base;
+						std::stringstream ssunitcode;
+						ssunitcode << iUnitTest;
+						sunitcode = ssunitcode.str();
+					}
 					else
-						devid = id;
+						return;
+					// convert to hex, and we have our ID
+					std::stringstream s_strid;
+					s_strid << std::hex << std::uppercase << rID;
+					devid = s_strid.str();
+				}
+				else if (lighttype == 100)
+				{
+					// Chime/ByronSX
+					dtype = pTypeChime;
+					subtype = sTypeByronSX;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					int iUnitCode = atoi(sunitcode.c_str()) - 1;
+					switch (iUnitCode)
+					{
+						case 0:
+							iUnitCode = chime_sound0;
+							break;
+						case 1:
+							iUnitCode = chime_sound1;
+							break;
+						case 2:
+							iUnitCode = chime_sound2;
+							break;
+						case 3:
+							iUnitCode = chime_sound3;
+							break;
+						case 4:
+							iUnitCode = chime_sound4;
+							break;
+						case 5:
+							iUnitCode = chime_sound5;
+							break;
+						case 6:
+							iUnitCode = chime_sound6;
+							break;
+						case 7:
+							iUnitCode = chime_sound7;
+							break;
+					}
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					devid = id;
 				}
 				else if (lighttype == 101)
 				{
@@ -5114,329 +5154,284 @@ namespace http
 						return;
 					devid = id;
 				}
-				else
+				else if ((lighttype >= 200) && (lighttype < 300))
 				{
-					if (lighttype == 100)
-					{
-						// Chime/ByronSX
-						dtype = pTypeChime;
-						subtype = sTypeByronSX;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						int iUnitCode = atoi(sunitcode.c_str()) - 1;
-						switch (iUnitCode)
-						{
-							case 0:
-								iUnitCode = chime_sound0;
-								break;
-							case 1:
-								iUnitCode = chime_sound1;
-								break;
-							case 2:
-								iUnitCode = chime_sound2;
-								break;
-							case 3:
-								iUnitCode = chime_sound3;
-								break;
-							case 4:
-								iUnitCode = chime_sound4;
-								break;
-							case 5:
-								iUnitCode = chime_sound5;
-								break;
-							case 6:
-								iUnitCode = chime_sound6;
-								break;
-							case 7:
-								iUnitCode = chime_sound7;
-								break;
-						}
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						devid = id;
-					}
-					else if ((lighttype >= 200) && (lighttype < 300))
-					{
-						dtype = pTypeBlinds;
-						subtype = lighttype - 200;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						int iUnitCode = atoi(sunitcode.c_str());
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						devid = id;
-					}
-					else if (lighttype == 301)
-					{
-						// Smartwares Radiator
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = id;
+					dtype = pTypeBlinds;
+					subtype = lighttype - 200;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					int iUnitCode = atoi(sunitcode.c_str());
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					devid = id;
+				}
+				else if (lighttype == 301)
+				{
+					// Smartwares Radiator
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					devid = id;
 
-						// For this device, we will also need to add a Radiator type, do that first
-						dtype = pTypeRadiator1;
-						subtype = sTypeSmartwares;
+					// For this device, we will also need to add a Radiator type, do that first
+					dtype = pTypeRadiator1;
+					subtype = sTypeSmartwares;
 
-						// check if switch is unique
-						result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
-									  hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
-						if (!result.empty())
-						{
-							root["message"] = "Switch already exists!";
-							return;
-						}
-						bool bActEnabledState = m_sql.m_bAcceptNewHardware;
-						m_sql.m_bAcceptNewHardware = true;
-						std::string devname;
-						m_sql.UpdateValue(atoi(hwdid.c_str()), devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, "20.5", devname);
-						m_sql.m_bAcceptNewHardware = bActEnabledState;
+					// check if switch is unique
+					result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
+									hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
+					if (!result.empty())
+					{
+						root["message"] = "Switch already exists!";
+						return;
+					}
+					bool bActEnabledState = m_sql.m_bAcceptNewHardware;
+					m_sql.m_bAcceptNewHardware = true;
+					std::string devname;
+					m_sql.UpdateValue(atoi(hwdid.c_str()), devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, "20.5", devname);
+					m_sql.m_bAcceptNewHardware = bActEnabledState;
 
-						// set name and switchtype
-						result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
-									  hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
-						if (result.empty())
-						{
-							root["message"] = "Error finding switch in Database!?!?";
-							return;
-						}
-						std::string ID = result[0][0];
+					// set name and switchtype
+					result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
+									hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
+					if (result.empty())
+					{
+						root["message"] = "Error finding switch in Database!?!?";
+						return;
+					}
+					std::string ID = result[0][0];
 
-						m_sql.safe_query("UPDATE DeviceStatus SET Used=1, Name='%q', SwitchType=%d WHERE (ID == '%q')", name.c_str(), switchtype, ID.c_str());
+					m_sql.safe_query("UPDATE DeviceStatus SET Used=1, Name='%q', SwitchType=%d WHERE (ID == '%q')", name.c_str(), switchtype, ID.c_str());
 
-						// Now continue to insert the switch
-						dtype = pTypeRadiator1;
-						subtype = sTypeSmartwaresSwitchRadiator;
-					}
-					else if (lighttype == 302)
-					{
-						// Home Confort
-						dtype = pTypeHomeConfort;
-						subtype = sTypeHomeConfortTEL010;
-						std::string id = request::findValue(&req, "id");
+					// Now continue to insert the switch
+					dtype = pTypeRadiator1;
+					subtype = sTypeSmartwaresSwitchRadiator;
+				}
+				else if (lighttype == 302)
+				{
+					// Home Confort
+					dtype = pTypeHomeConfort;
+					subtype = sTypeHomeConfortTEL010;
+					std::string id = request::findValue(&req, "id");
 
-						std::string shousecode = request::findValue(&req, "housecode");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
-							return;
+					std::string shousecode = request::findValue(&req, "housecode");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
+						return;
 
-						int iUnitCode = atoi(sunitcode.c_str());
-						sprintf(szTmp, "%d", iUnitCode);
-						sunitcode = szTmp;
-						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
-						shousecode = szTmp;
-						devid = id + shousecode;
-					}
-					else if (lighttype == 303)
+					int iUnitCode = atoi(sunitcode.c_str());
+					sprintf(szTmp, "%d", iUnitCode);
+					sunitcode = szTmp;
+					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+					shousecode = szTmp;
+					devid = id + shousecode;
+				}
+				else if (lighttype == 303)
+				{
+					// Selector Switch
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeSelector;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					devid = "0" + id;
+					switchtype = STYPE_Selector;
+					if (!deviceoptions.empty())
 					{
-						// Selector Switch
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeSelector;
-						std::string id = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((id.empty()) || (sunitcode.empty()))
-							return;
-						devid = "0" + id;
-						switchtype = STYPE_Selector;
-						if (!deviceoptions.empty())
-						{
-							deviceoptions.append(";");
-						}
-						deviceoptions.append("SelectorStyle:0;LevelNames:Off|Level1|Level2|Level3");
+						deviceoptions.append(";");
 					}
-					else if (lighttype == 304)
+					deviceoptions.append("SelectorStyle:0;LevelNames:Off|Level1|Level2|Level3");
+				}
+				else if (lighttype == 304)
+				{
+					// Itho CVE RFT
+					dtype = pTypeFan;
+					subtype = sTypeItho;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 305)
+				{
+					// Lucci Air
+					dtype = pTypeFan;
+					subtype = sTypeLucciAir;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 306)
+				{
+					// Lucci Air DC
+					dtype = pTypeFan;
+					subtype = sTypeLucciAirDC;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 307)
+				{
+					// Westinghouse
+					dtype = pTypeFan;
+					subtype = sTypeWestinghouse;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 308)
+				{
+					// Casafan
+					dtype = pTypeFan;
+					subtype = sTypeCasafan;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 309)
+				{
+					// FT1211R
+					dtype = pTypeFan;
+					subtype = sTypeFT1211R;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 310)
+				{
+					// Falmec
+					dtype = pTypeFan;
+					subtype = sTypeFalmec;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 311)
+				{
+					// Lucci Air DC II
+					dtype = pTypeFan;
+					subtype = sTypeLucciAirDCII;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 312)
+				{
+					// Itho ECO
+					dtype = pTypeFan;
+					subtype = sTypeIthoECO;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 313)
+				{
+					// Novy
+					dtype = pTypeFan;
+					subtype = sTypeNovy;
+					std::string id = request::findValue(&req, "id");
+					if (id.empty())
+						return;
+					devid = id;
+					sunitcode = "0";
+				}
+				else if (lighttype == 400)
+				{
+					// Openwebnet Bus Blinds
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 401)
+				{
+					// Openwebnet Bus Lights
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 402)
+				{
+					// Openwebnet Bus Auxiliary
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 403)
+				{
+					// Openwebnet Zigbee Blinds
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchBlindsT2;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 404)
+				{
+					// Openwebnet Zigbee Lights
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchLightT2;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if ((lighttype == 405) || (lighttype == 406))
+				{
+					// Openwebnet Dry Contact / IR Detection
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchContactT1;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((devid.empty()) || (sunitcode.empty()))
+						return;
+				}
+				else if (lighttype == 407)
+				{
+					// Openwebnet Bus Custom
+					dtype = pTypeGeneralSwitch;
+					subtype = sSwitchTypeAC;
+					devid = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					StrParam1 = request::findValue(&req, "StrParam1");
+					_log.Log(LOG_STATUS, "COpenWebNetTCP: custom command: '%s'", StrParam1.c_str());
+					if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
 					{
-						// Itho CVE RFT
-						dtype = pTypeFan;
-						subtype = sTypeItho;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 305)
-					{
-						// Lucci Air
-						dtype = pTypeFan;
-						subtype = sTypeLucciAir;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 306)
-					{
-						// Lucci Air DC
-						dtype = pTypeFan;
-						subtype = sTypeLucciAirDC;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 307)
-					{
-						// Westinghouse
-						dtype = pTypeFan;
-						subtype = sTypeWestinghouse;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 308)
-					{
-						// Casafan
-						dtype = pTypeFan;
-						subtype = sTypeCasafan;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 309)
-					{
-						// FT1211R
-						dtype = pTypeFan;
-						subtype = sTypeFT1211R;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 310)
-					{
-						// Falmec
-						dtype = pTypeFan;
-						subtype = sTypeFalmec;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 311)
-					{
-						// Lucci Air DC II
-						dtype = pTypeFan;
-						subtype = sTypeLucciAirDCII;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 312)
-					{
-						// Itho ECO
-						dtype = pTypeFan;
-						subtype = sTypeIthoECO;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 313)
-					{
-						// Novy
-						dtype = pTypeFan;
-						subtype = sTypeNovy;
-						std::string id = request::findValue(&req, "id");
-						if (id.empty())
-							return;
-						devid = id;
-						sunitcode = "0";
-					}
-					else if (lighttype == 400)
-					{
-						// Openwebnet Bus Blinds
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 401)
-					{
-						// Openwebnet Bus Lights
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 402)
-					{
-						// Openwebnet Bus Auxiliary
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 403)
-					{
-						// Openwebnet Zigbee Blinds
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchBlindsT2;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 404)
-					{
-						// Openwebnet Zigbee Lights
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchLightT2;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if ((lighttype == 405) || (lighttype == 406))
-					{
-						// Openwebnet Dry Contact / IR Detection
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchContactT1;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						if ((devid.empty()) || (sunitcode.empty()))
-							return;
-					}
-					else if (lighttype == 407)
-					{
-						// Openwebnet Bus Custom
-						dtype = pTypeGeneralSwitch;
-						subtype = sSwitchTypeAC;
-						devid = request::findValue(&req, "id");
-						sunitcode = request::findValue(&req, "unitcode");
-						StrParam1 = request::findValue(&req, "StrParam1");
-						_log.Log(LOG_STATUS, "COpenWebNetTCP: custom command: '%s'", StrParam1.c_str());
-						if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
-						{
-							root["message"] = "Some field empty or not valid.";
-							return;
-						}
+						root["message"] = "Some field empty or not valid.";
+						return;
 					}
 				}
-
-				// check if switch is unique
+				// Check if switch is unique
 				result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)", hwdid.c_str(),
 							  devid.c_str(), sunitcode.c_str(), dtype, subtype);
 				if (!result.empty())
@@ -5446,12 +5441,14 @@ namespace http
 				}
 
 				// ----------- If needed convert to GeneralSwitch type (for o.a. RFlink) -----------
-				CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
-				if (pBaseHardware != nullptr)
 				{
-					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP))
+					CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
+					if (pBaseHardware != nullptr)
 					{
-						ConvertToGeneralSwitchType(devid, dtype, subtype);
+						if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP))
+						{
+							ConvertToGeneralSwitchType(devid, dtype, subtype);
+						}
 					}
 				}
 				// -----------------------------------------------
@@ -11472,7 +11469,6 @@ namespace http
 					root["result"][ii]["DataTimeout"] = atoi(sd[16].c_str());
 					root["result"][ii]["LogLevel"] = atoi(sd[17].c_str());
 
-					// Special case for openzwave (status for nodes queried)
 					CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(atoi(sd[0].c_str()));
 					if (pHardware != nullptr)
 					{
@@ -11501,17 +11497,14 @@ namespace http
 							CRFLinkBase *pMyHardware = reinterpret_cast<CRFLinkBase *>(pHardware);
 							root["result"][ii]["version"] = pMyHardware->m_Version;
 						}
-						else
-						{
 #ifdef WITH_OPENZWAVE
-							if (pHardware->HwdType == HTYPE_OpenZWave)
-							{
-								COpenZWave *pOZWHardware = reinterpret_cast<COpenZWave *>(pHardware);
-								root["result"][ii]["version"] = pOZWHardware->GetVersionLong();
-								root["result"][ii]["NodesQueried"] = (pOZWHardware->m_awakeNodesQueried || pOZWHardware->m_allNodesQueried);
-							}
-#endif
+						else if (pHardware->HwdType == HTYPE_OpenZWave)
+						{ // Special case for openzwave (status for nodes queried)
+							COpenZWave *pOZWHardware = reinterpret_cast<COpenZWave *>(pHardware);
+							root["result"][ii]["version"] = pOZWHardware->GetVersionLong();
+							root["result"][ii]["NodesQueried"] = (pOZWHardware->m_awakeNodesQueried || pOZWHardware->m_allNodesQueried);
 						}
+#endif
 					}
 					ii++;
 				}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -4997,7 +4997,7 @@ namespace http
 						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
 						if (pEnoceanHardware->m_id_base == 0)
 						{
-							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name);
+							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name.c_str());
 							root["message"] = szTmp;
 							return;
 						}
@@ -5008,7 +5008,7 @@ namespace http
 						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
 						if (pEnoceanHardware->m_id_base == 0)
 						{
-							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name);
+							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name.c_str());
 							root["message"] = szTmp;
 							return;
 						}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -4264,40 +4264,47 @@ namespace http
 				std::string sunitcode;
 				std::string devid;
 
-				if (lighttype < 20)
+				if (lighttype == 70)
 				{
-					dtype = pTypeLighting1;
-					subtype = lighttype;
-					std::string shousecode = request::findValue(&req, "housecode");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((shousecode.empty()) || (sunitcode.empty()))
-						return;
-					devid = shousecode;
-				}
-				else if (lighttype < 30)
-				{
+					// EnOcean (Lighting2 with Base_ID offset)
 					dtype = pTypeLighting2;
-					subtype = lighttype - 20;
-					std::string id = request::findValue(&req, "id");
+					subtype = sTypeAC;
+					std::string sgroupcode = request::findValue(&req, "groupcode");
 					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					int iUnitTest = atoi(sunitcode.c_str()); // only First Rocker_ID at the moment, gives us 128 devices we can control, should be enough!
+					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
 						return;
-					devid = id;
-				}
-				else if (lighttype < 68)
-				{
-					dtype = pTypeLighting5;
-					subtype = lighttype - 50;
-					if (lighttype == 59)
-						subtype = sTypeIT;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					sunitcode = sgroupcode; // Button A or B
+					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					if (pBaseHardware == nullptr)
 						return;
-					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeIT))
-						devid = "00" + id;
-					else
-						devid = id;
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) && (pBaseHardware->HwdType != HTYPE_USBtinGateway))
+						return;
+					unsigned long rID = 0;
+					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
+					{
+						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
+					{
+						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway) // Like EnOcean (Lighting2 with Base_ID offset)
+					{
+						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
+						// base ID calculate in the USBtinharwade dependant of the CAN Layer !
+						// for exemple see MultiblocV8 layer...
+						rID = pUSBtinHardware->switch_id_base;
+						std::stringstream ssunitcode;
+						ssunitcode << iUnitTest;
+						sunitcode = ssunitcode.str();
+					}
+					// convert to hex, and we have our ID
+					std::stringstream s_strid;
+					s_strid << std::hex << std::uppercase << rID;
+					devid = s_strid.str();
 				}
 				else if (lighttype == 68)
 				{
@@ -4391,409 +4398,405 @@ namespace http
 					return;
 #endif
 				}
-				else if (lighttype == 70)
+				else if (lighttype < 20)
 				{
-					// EnOcean (Lighting2 with Base_ID offset)
-					dtype = pTypeLighting2;
-					subtype = sTypeAC;
-					std::string sgroupcode = request::findValue(&req, "groupcode");
-					sunitcode = request::findValue(&req, "unitcode");
-					int iUnitTest = atoi(sunitcode.c_str()); // only First Rocker_ID at the moment, gives us 128 devices we can control, should be enough!
-					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
-						return;
-					sunitcode = sgroupcode; // Button A or B
-					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
-					if (pBaseHardware == nullptr)
-						return;
-					unsigned long rID = 0;
-					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
-					{
-						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
-					{
-						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway) // Like EnOcean (Lighting2 with Base_ID offset)
-					{
-						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
-						// base ID calculate in the USBtinharwade dependant of the CAN Layer !
-						// for exemple see MultiblocV8 layer...
-						rID = pUSBtinHardware->switch_id_base;
-						std::stringstream ssunitcode;
-						ssunitcode << iUnitTest;
-						sunitcode = ssunitcode.str();
-					}
-					else
-						return;
-					// convert to hex, and we have our ID
-					std::stringstream s_strid;
-					s_strid << std::hex << std::uppercase << rID;
-					devid = s_strid.str();
-				}
-				else if (lighttype == 100)
-				{
-					// Chime/ByronSX
-					dtype = pTypeChime;
-					subtype = sTypeByronSX;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					int iUnitCode = atoi(sunitcode.c_str()) - 1;
-					switch (iUnitCode)
-					{
-						case 0:
-							iUnitCode = chime_sound0;
-							break;
-						case 1:
-							iUnitCode = chime_sound1;
-							break;
-						case 2:
-							iUnitCode = chime_sound2;
-							break;
-						case 3:
-							iUnitCode = chime_sound3;
-							break;
-						case 4:
-							iUnitCode = chime_sound4;
-							break;
-						case 5:
-							iUnitCode = chime_sound5;
-							break;
-						case 6:
-							iUnitCode = chime_sound6;
-							break;
-						case 7:
-							iUnitCode = chime_sound7;
-							break;
-					}
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					devid = id;
-				}
-				else if (lighttype == 101)
-				{
-					// Curtain Harrison
-					dtype = pTypeCurtain;
-					subtype = sTypeHarrison;
+					dtype = pTypeLighting1;
+					subtype = lighttype;
 					std::string shousecode = request::findValue(&req, "housecode");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((shousecode.empty()) || (sunitcode.empty()))
 						return;
 					devid = shousecode;
 				}
-				else if (lighttype == 102)
+				else if (lighttype < 30)
 				{
-					// RFY
-					dtype = pTypeRFY;
-					subtype = sTypeRFY;
+					dtype = pTypeLighting2;
+					subtype = lighttype - 20;
 					std::string id = request::findValue(&req, "id");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return;
 					devid = id;
 				}
-				else if (lighttype == 103)
+				else if (lighttype < 70)
 				{
-					// Meiantech
-					dtype = pTypeSecurity1;
-					subtype = sTypeMeiantech;
-					std::string id = request::findValue(&req, "id");
-					if ((id.empty()))
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 104)
-				{
-					// HE105
-					dtype = pTypeThermostat2;
-					subtype = sTypeHE105;
-					sunitcode = request::findValue(&req, "unitcode");
-					if (sunitcode.empty())
-						return;
-					// convert to hex, and we have our Unit Code
-					std::stringstream s_strid;
-					s_strid << std::hex << std::uppercase << sunitcode;
-					int iUnitCode;
-					s_strid >> iUnitCode;
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					devid = "1";
-				}
-				else if (lighttype == 105)
-				{
-					// ASA
-					dtype = pTypeRFY;
-					subtype = sTypeASA;
+					dtype = pTypeLighting5;
+					subtype = lighttype - 50;
+					if (lighttype == 59)
+						subtype = sTypeIT;
 					std::string id = request::findValue(&req, "id");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					devid = id;
+					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeIT))
+						devid = "00" + id;
+					else
+						devid = id;
 				}
-				else if (lighttype == 106)
+				else
 				{
-					// Blyss
-					dtype = pTypeLighting6;
-					subtype = sTypeBlyss;
-					std::string sgroupcode = request::findValue(&req, "groupcode");
-					sunitcode = request::findValue(&req, "unitcode");
-					std::string id = request::findValue(&req, "id");
-					if ((sgroupcode.empty()) || (sunitcode.empty()) || (id.empty()))
-						return;
-					devid = id + sgroupcode;
-				}
-				else if (lighttype == 107)
-				{
-					// RFY2
-					dtype = pTypeRFY;
-					subtype = sTypeRFY2;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					devid = id;
-				}
-				else if ((lighttype >= 200) && (lighttype < 300))
-				{
-					dtype = pTypeBlinds;
-					subtype = lighttype - 200;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					int iUnitCode = atoi(sunitcode.c_str());
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					devid = id;
-				}
-				else if (lighttype == 301)
-				{
-					// Smartwares Radiator
-					dtype = pTypeRadiator1;
-					subtype = sTypeSmartwaresSwitchRadiator;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					devid = id;
-				}
-				else if (lighttype == 302)
-				{
-					// Home Confort
-					dtype = pTypeHomeConfort;
-					subtype = sTypeHomeConfortTEL010;
-					std::string id = request::findValue(&req, "id");
-
-					std::string shousecode = request::findValue(&req, "housecode");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
-						return;
-
-					int iUnitCode = atoi(sunitcode.c_str());
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
-					shousecode = szTmp;
-					devid = id + shousecode;
-				}
-				else if (lighttype == 303)
-				{
-					// Selector Switch
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeSelector;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					devid = id;
-				}
-				else if (lighttype == 304)
-				{
-					// Itho CVE RFT
-					dtype = pTypeFan;
-					subtype = sTypeItho;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 305)
-				{
-					// Lucci Air/DC
-					dtype = pTypeFan;
-					subtype = sTypeLucciAir;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 306)
-				{
-					// Lucci Air DC
-					dtype = pTypeFan;
-					subtype = sTypeLucciAirDC;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 307)
-				{
-					// Westinghouse
-					dtype = pTypeFan;
-					subtype = sTypeWestinghouse;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 308)
-				{
-					// Casafan
-					dtype = pTypeFan;
-					subtype = sTypeCasafan;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 309)
-				{
-					// FT1211R
-					dtype = pTypeFan;
-					subtype = sTypeFT1211R;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 310)
-				{
-					// Falmec
-					dtype = pTypeFan;
-					subtype = sTypeFalmec;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 311)
-				{
-					// Lucci Air DC II
-					dtype = pTypeFan;
-					subtype = sTypeLucciAirDCII;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 312)
-				{
-					// Itho ECO
-					dtype = pTypeFan;
-					subtype = sTypeIthoECO;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 313)
-				{
-					// Novy
-					dtype = pTypeFan;
-					subtype = sTypeNovy;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 400)
-				{
-					// Openwebnet Bus Blinds
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 401)
-				{
-					// Openwebnet Bus Lights
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 402)
-				{
-					// Openwebnet Bus Auxiliary
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 403)
-				{
-					// Openwebnet Zigbee Blinds
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchBlindsT2;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 404)
-				{
-					// Light Openwebnet Zigbee
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchLightT2;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if ((lighttype == 405) || (lighttype == 406))
-				{
-					// Openwebnet Dry Contact / IR Detection
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchContactT1;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 407)
-				{
-					// Openwebnet Bus Custom
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					std::string StrParam1 = request::findValue(&req, "StrParam1");
-					if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
+					if (lighttype == 100)
 					{
-						root["message"] = "Some field empty or not valid.";
-						return;
+						// Chime/ByronSX
+						dtype = pTypeChime;
+						subtype = sTypeByronSX;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						int iUnitCode = atoi(sunitcode.c_str()) - 1;
+						switch (iUnitCode)
+						{
+							case 0:
+								iUnitCode = chime_sound0;
+								break;
+							case 1:
+								iUnitCode = chime_sound1;
+								break;
+							case 2:
+								iUnitCode = chime_sound2;
+								break;
+							case 3:
+								iUnitCode = chime_sound3;
+								break;
+							case 4:
+								iUnitCode = chime_sound4;
+								break;
+							case 5:
+								iUnitCode = chime_sound5;
+								break;
+							case 6:
+								iUnitCode = chime_sound6;
+								break;
+							case 7:
+								iUnitCode = chime_sound7;
+								break;
+						}
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						devid = id;
+					}
+					else if (lighttype == 101)
+					{
+						// Curtain Harrison
+						dtype = pTypeCurtain;
+						subtype = sTypeHarrison;
+						std::string shousecode = request::findValue(&req, "housecode");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((shousecode.empty()) || (sunitcode.empty()))
+							return;
+						devid = shousecode;
+					}
+					else if (lighttype == 102)
+					{
+						// RFY
+						dtype = pTypeRFY;
+						subtype = sTypeRFY;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+					}
+					else if (lighttype == 103)
+					{
+						// Meiantech
+						dtype = pTypeSecurity1;
+						subtype = sTypeMeiantech;
+						std::string id = request::findValue(&req, "id");
+						if ((id.empty()))
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 104)
+					{
+						// HE105
+						dtype = pTypeThermostat2;
+						subtype = sTypeHE105;
+						sunitcode = request::findValue(&req, "unitcode");
+						if (sunitcode.empty())
+							return;
+						// convert to hex, and we have our Unit Code
+						std::stringstream s_strid;
+						s_strid << std::hex << std::uppercase << sunitcode;
+						int iUnitCode;
+						s_strid >> iUnitCode;
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						devid = "1";
+					}
+					else if (lighttype == 105)
+					{
+						// ASA
+						dtype = pTypeRFY;
+						subtype = sTypeASA;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+					}
+					else if (lighttype == 106)
+					{
+						// Blyss
+						dtype = pTypeLighting6;
+						subtype = sTypeBlyss;
+						std::string sgroupcode = request::findValue(&req, "groupcode");
+						sunitcode = request::findValue(&req, "unitcode");
+						std::string id = request::findValue(&req, "id");
+						if ((sgroupcode.empty()) || (sunitcode.empty()) || (id.empty()))
+							return;
+						devid = id + sgroupcode;
+					}
+					else if (lighttype == 107)
+					{
+						// RFY2
+						dtype = pTypeRFY;
+						subtype = sTypeRFY2;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+					}
+					else if ((lighttype >= 200) && (lighttype < 300))
+					{
+						dtype = pTypeBlinds;
+						subtype = lighttype - 200;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						int iUnitCode = atoi(sunitcode.c_str());
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						devid = id;
+					}
+					else if (lighttype == 301)
+					{
+						// Smartwares Radiator
+						dtype = pTypeRadiator1;
+						subtype = sTypeSmartwaresSwitchRadiator;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+					}
+					else if (lighttype == 302)
+					{
+						// Home Confort
+						dtype = pTypeHomeConfort;
+						subtype = sTypeHomeConfortTEL010;
+						std::string id = request::findValue(&req, "id");
+
+						std::string shousecode = request::findValue(&req, "housecode");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
+							return;
+
+						int iUnitCode = atoi(sunitcode.c_str());
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+						shousecode = szTmp;
+						devid = id + shousecode;
+					}
+					else if (lighttype == 303)
+					{
+						// Selector Switch
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeSelector;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+					}
+					else if (lighttype == 304)
+					{
+						// Itho CVE RFT
+						dtype = pTypeFan;
+						subtype = sTypeItho;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 305)
+					{
+						// Lucci Air/DC
+						dtype = pTypeFan;
+						subtype = sTypeLucciAir;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 306)
+					{
+						// Lucci Air DC
+						dtype = pTypeFan;
+						subtype = sTypeLucciAirDC;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 307)
+					{
+						// Westinghouse
+						dtype = pTypeFan;
+						subtype = sTypeWestinghouse;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 308)
+					{
+						// Casafan
+						dtype = pTypeFan;
+						subtype = sTypeCasafan;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 309)
+					{
+						// FT1211R
+						dtype = pTypeFan;
+						subtype = sTypeFT1211R;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 310)
+					{
+						// Falmec
+						dtype = pTypeFan;
+						subtype = sTypeFalmec;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 311)
+					{
+						// Lucci Air DC II
+						dtype = pTypeFan;
+						subtype = sTypeLucciAirDCII;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 312)
+					{
+						// Itho ECO
+						dtype = pTypeFan;
+						subtype = sTypeIthoECO;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 313)
+					{
+						// Novy
+						dtype = pTypeFan;
+						subtype = sTypeNovy;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 400)
+					{
+						// Openwebnet Bus Blinds
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 401)
+					{
+						// Openwebnet Bus Lights
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 402)
+					{
+						// Openwebnet Bus Auxiliary
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 403)
+					{
+						// Openwebnet Zigbee Blinds
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchBlindsT2;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 404)
+					{
+						// Light Openwebnet Zigbee
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchLightT2;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if ((lighttype == 405) || (lighttype == 406))
+					{
+						// Openwebnet Dry Contact / IR Detection
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchContactT1;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 407)
+					{
+						// Openwebnet Bus Custom
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						std::string StrParam1 = request::findValue(&req, "StrParam1");
+						if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
+						{
+							root["message"] = "Some field empty or not valid.";
+							return;
+						}
 					}
 				}
 				// ----------- If needed convert to GeneralSwitch type (for o.a. RFlink) -----------
@@ -4882,41 +4885,55 @@ namespace http
 				}
 #endif
 
-				if (lighttype < 20)
+				if (lighttype == 70)
 				{
-					dtype = pTypeLighting1;
-					subtype = lighttype;
-					std::string shousecode = request::findValue(&req, "housecode");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((shousecode.empty()) || (sunitcode.empty()))
-						return;
-					devid = shousecode;
-				}
-				else if (lighttype < 30)
-				{
+					// EnOcean (Lighting2 with Base_ID offset)
 					dtype = pTypeLighting2;
-					subtype = lighttype - 20;
-					std::string id = request::findValue(&req, "id");
+					subtype = sTypeAC;
 					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					std::string sgroupcode = request::findValue(&req, "groupcode");
+					int iUnitTest = atoi(sunitcode.c_str()); // gives us 128 devices we can control, should be enough!
+					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
 						return;
-					devid = id;
-				}
-				else if (lighttype < 68)
-				{
-					dtype = pTypeLighting5;
-					subtype = lighttype - 50;
-					if (lighttype == 59)
-						subtype = sTypeIT;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
+					sunitcode = sgroupcode; // Button A/B
+					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					if (pBaseHardware == nullptr)
 						return;
-					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeLightwaveRF) &&
-					    (subtype != sTypeIT))
-						devid = "00" + id;
-					else
-						devid = id;
+					if ((pBaseHardware->HwdType != HTYPE_EnOceanESP2) && (pBaseHardware->HwdType != HTYPE_EnOceanESP3) && (pBaseHardware->HwdType != HTYPE_USBtinGateway))
+						return;
+					unsigned long rID = 0;
+					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
+					{
+						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
+						if (pEnoceanHardware->m_id_base == 0)
+						{
+							root["message"] = "BaseID not found, is the hardware running?";
+							return;
+						}
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
+					{
+						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
+						if (pEnoceanHardware->m_id_base == 0)
+						{
+							root["message"] = "BaseID not found, is the hardware running?";
+							return;
+						}
+						rID = pEnoceanHardware->m_id_base + iUnitTest;
+					}
+					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway)
+					{
+						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
+						rID = pUSBtinHardware->switch_id_base;
+						std::stringstream ssunitcode;
+						ssunitcode << iUnitTest;
+						sunitcode = ssunitcode.str();
+					}
+					// convert to hex, and we have our ID
+					std::stringstream s_strid;
+					s_strid << std::hex << std::uppercase << rID;
+					devid = s_strid.str();
 				}
 				else if (lighttype == 68)
 				{
@@ -4977,98 +4994,41 @@ namespace http
 					return;
 #endif
 				}
-				else if (lighttype == 70)
+				else if (lighttype < 20)
 				{
-					// EnOcean (Lighting2 with Base_ID offset)
-					dtype = pTypeLighting2;
-					subtype = sTypeAC;
+					dtype = pTypeLighting1;
+					subtype = lighttype;
+					std::string shousecode = request::findValue(&req, "housecode");
 					sunitcode = request::findValue(&req, "unitcode");
-					std::string sgroupcode = request::findValue(&req, "groupcode");
-					int iUnitTest = atoi(sunitcode.c_str()); // gives us 128 devices we can control, should be enough!
-					if ((sunitcode.empty()) || (sgroupcode.empty()) || ((iUnitTest < 1) || (iUnitTest > 128)))
+					if ((shousecode.empty()) || (sunitcode.empty()))
 						return;
-					sunitcode = sgroupcode; // Button A/B
-					CDomoticzHardwareBase *pBaseHardware = reinterpret_cast<CDomoticzHardwareBase *>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
-					if (pBaseHardware == nullptr)
-						return;
-					unsigned long rID = 0;
-					if (pBaseHardware->HwdType == HTYPE_EnOceanESP2)
-					{
-						CEnOceanESP2 *pEnoceanHardware = reinterpret_cast<CEnOceanESP2 *>(pBaseHardware);
-						if (pEnoceanHardware->m_id_base == 0)
-						{
-							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name.c_str());
-							root["message"] = szTmp;
-							return;
-						}
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_EnOceanESP3)
-					{
-						CEnOceanESP3 *pEnoceanHardware = reinterpret_cast<CEnOceanESP3 *>(pBaseHardware);
-						if (pEnoceanHardware->m_id_base == 0)
-						{
-							sprintf(szTmp, "%s: BaseID not found, is the hardware running?", pEnoceanHardware->m_Name.c_str());
-							root["message"] = szTmp;
-							return;
-						}
-						rID = pEnoceanHardware->m_id_base + iUnitTest;
-					}
-					else if (pBaseHardware->HwdType == HTYPE_USBtinGateway)
-					{
-						USBtin *pUSBtinHardware = reinterpret_cast<USBtin *>(pBaseHardware);
-						rID = pUSBtinHardware->switch_id_base;
-						std::stringstream ssunitcode;
-						ssunitcode << iUnitTest;
-						sunitcode = ssunitcode.str();
-					}
-					else
-						return;
-					// convert to hex, and we have our ID
-					std::stringstream s_strid;
-					s_strid << std::hex << std::uppercase << rID;
-					devid = s_strid.str();
+					devid = shousecode;
 				}
-				else if (lighttype == 100)
+				else if (lighttype < 30)
 				{
-					// Chime/ByronSX
-					dtype = pTypeChime;
-					subtype = sTypeByronSX;
+					dtype = pTypeLighting2;
+					subtype = lighttype - 20;
 					std::string id = request::findValue(&req, "id");
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return;
-					int iUnitCode = atoi(sunitcode.c_str()) - 1;
-					switch (iUnitCode)
-					{
-						case 0:
-							iUnitCode = chime_sound0;
-							break;
-						case 1:
-							iUnitCode = chime_sound1;
-							break;
-						case 2:
-							iUnitCode = chime_sound2;
-							break;
-						case 3:
-							iUnitCode = chime_sound3;
-							break;
-						case 4:
-							iUnitCode = chime_sound4;
-							break;
-						case 5:
-							iUnitCode = chime_sound5;
-							break;
-						case 6:
-							iUnitCode = chime_sound6;
-							break;
-						case 7:
-							iUnitCode = chime_sound7;
-							break;
-					}
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
 					devid = id;
+				}
+				else if (lighttype < 70)
+				{
+					dtype = pTypeLighting5;
+					subtype = lighttype - 50;
+					if (lighttype == 59)
+						subtype = sTypeIT;
+					std::string id = request::findValue(&req, "id");
+					sunitcode = request::findValue(&req, "unitcode");
+					if ((id.empty()) || (sunitcode.empty()))
+						return;
+					if ((subtype != sTypeEMW100) && (subtype != sTypeLivolo) && (subtype != sTypeLivolo1to10) && (subtype != sTypeRGB432W) && (subtype != sTypeLightwaveRF) &&
+					    (subtype != sTypeIT))
+						devid = "00" + id;
+					else
+						devid = id;
 				}
 				else if (lighttype == 101)
 				{
@@ -5154,284 +5114,329 @@ namespace http
 						return;
 					devid = id;
 				}
-				else if ((lighttype >= 200) && (lighttype < 300))
+				else
 				{
-					dtype = pTypeBlinds;
-					subtype = lighttype - 200;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					int iUnitCode = atoi(sunitcode.c_str());
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					devid = id;
-				}
-				else if (lighttype == 301)
-				{
-					// Smartwares Radiator
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					devid = id;
-
-					// For this device, we will also need to add a Radiator type, do that first
-					dtype = pTypeRadiator1;
-					subtype = sTypeSmartwares;
-
-					// check if switch is unique
-					result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
-									hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
-					if (!result.empty())
+					if (lighttype == 100)
 					{
-						root["message"] = "Switch already exists!";
-						return;
+						// Chime/ByronSX
+						dtype = pTypeChime;
+						subtype = sTypeByronSX;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						int iUnitCode = atoi(sunitcode.c_str()) - 1;
+						switch (iUnitCode)
+						{
+							case 0:
+								iUnitCode = chime_sound0;
+								break;
+							case 1:
+								iUnitCode = chime_sound1;
+								break;
+							case 2:
+								iUnitCode = chime_sound2;
+								break;
+							case 3:
+								iUnitCode = chime_sound3;
+								break;
+							case 4:
+								iUnitCode = chime_sound4;
+								break;
+							case 5:
+								iUnitCode = chime_sound5;
+								break;
+							case 6:
+								iUnitCode = chime_sound6;
+								break;
+							case 7:
+								iUnitCode = chime_sound7;
+								break;
+						}
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						devid = id;
 					}
-					bool bActEnabledState = m_sql.m_bAcceptNewHardware;
-					m_sql.m_bAcceptNewHardware = true;
-					std::string devname;
-					m_sql.UpdateValue(atoi(hwdid.c_str()), devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, "20.5", devname);
-					m_sql.m_bAcceptNewHardware = bActEnabledState;
-
-					// set name and switchtype
-					result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
-									hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
-					if (result.empty())
+					else if ((lighttype >= 200) && (lighttype < 300))
 					{
-						root["message"] = "Error finding switch in Database!?!?";
-						return;
+						dtype = pTypeBlinds;
+						subtype = lighttype - 200;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						int iUnitCode = atoi(sunitcode.c_str());
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						devid = id;
 					}
-					std::string ID = result[0][0];
-
-					m_sql.safe_query("UPDATE DeviceStatus SET Used=1, Name='%q', SwitchType=%d WHERE (ID == '%q')", name.c_str(), switchtype, ID.c_str());
-
-					// Now continue to insert the switch
-					dtype = pTypeRadiator1;
-					subtype = sTypeSmartwaresSwitchRadiator;
-				}
-				else if (lighttype == 302)
-				{
-					// Home Confort
-					dtype = pTypeHomeConfort;
-					subtype = sTypeHomeConfortTEL010;
-					std::string id = request::findValue(&req, "id");
-
-					std::string shousecode = request::findValue(&req, "housecode");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
-						return;
-
-					int iUnitCode = atoi(sunitcode.c_str());
-					sprintf(szTmp, "%d", iUnitCode);
-					sunitcode = szTmp;
-					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
-					shousecode = szTmp;
-					devid = id + shousecode;
-				}
-				else if (lighttype == 303)
-				{
-					// Selector Switch
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeSelector;
-					std::string id = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((id.empty()) || (sunitcode.empty()))
-						return;
-					devid = "0" + id;
-					switchtype = STYPE_Selector;
-					if (!deviceoptions.empty())
+					else if (lighttype == 301)
 					{
-						deviceoptions.append(";");
+						// Smartwares Radiator
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = id;
+
+						// For this device, we will also need to add a Radiator type, do that first
+						dtype = pTypeRadiator1;
+						subtype = sTypeSmartwares;
+
+						// check if switch is unique
+						result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
+									  hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
+						if (!result.empty())
+						{
+							root["message"] = "Switch already exists!";
+							return;
+						}
+						bool bActEnabledState = m_sql.m_bAcceptNewHardware;
+						m_sql.m_bAcceptNewHardware = true;
+						std::string devname;
+						m_sql.UpdateValue(atoi(hwdid.c_str()), devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, "20.5", devname);
+						m_sql.m_bAcceptNewHardware = bActEnabledState;
+
+						// set name and switchtype
+						result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)",
+									  hwdid.c_str(), devid.c_str(), sunitcode.c_str(), dtype, subtype);
+						if (result.empty())
+						{
+							root["message"] = "Error finding switch in Database!?!?";
+							return;
+						}
+						std::string ID = result[0][0];
+
+						m_sql.safe_query("UPDATE DeviceStatus SET Used=1, Name='%q', SwitchType=%d WHERE (ID == '%q')", name.c_str(), switchtype, ID.c_str());
+
+						// Now continue to insert the switch
+						dtype = pTypeRadiator1;
+						subtype = sTypeSmartwaresSwitchRadiator;
 					}
-					deviceoptions.append("SelectorStyle:0;LevelNames:Off|Level1|Level2|Level3");
-				}
-				else if (lighttype == 304)
-				{
-					// Itho CVE RFT
-					dtype = pTypeFan;
-					subtype = sTypeItho;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 305)
-				{
-					// Lucci Air
-					dtype = pTypeFan;
-					subtype = sTypeLucciAir;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 306)
-				{
-					// Lucci Air DC
-					dtype = pTypeFan;
-					subtype = sTypeLucciAirDC;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 307)
-				{
-					// Westinghouse
-					dtype = pTypeFan;
-					subtype = sTypeWestinghouse;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 308)
-				{
-					// Casafan
-					dtype = pTypeFan;
-					subtype = sTypeCasafan;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 309)
-				{
-					// FT1211R
-					dtype = pTypeFan;
-					subtype = sTypeFT1211R;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 310)
-				{
-					// Falmec
-					dtype = pTypeFan;
-					subtype = sTypeFalmec;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 311)
-				{
-					// Lucci Air DC II
-					dtype = pTypeFan;
-					subtype = sTypeLucciAirDCII;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 312)
-				{
-					// Itho ECO
-					dtype = pTypeFan;
-					subtype = sTypeIthoECO;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 313)
-				{
-					// Novy
-					dtype = pTypeFan;
-					subtype = sTypeNovy;
-					std::string id = request::findValue(&req, "id");
-					if (id.empty())
-						return;
-					devid = id;
-					sunitcode = "0";
-				}
-				else if (lighttype == 400)
-				{
-					// Openwebnet Bus Blinds
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 401)
-				{
-					// Openwebnet Bus Lights
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 402)
-				{
-					// Openwebnet Bus Auxiliary
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 403)
-				{
-					// Openwebnet Zigbee Blinds
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchBlindsT2;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 404)
-				{
-					// Openwebnet Zigbee Lights
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchLightT2;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if ((lighttype == 405) || (lighttype == 406))
-				{
-					// Openwebnet Dry Contact / IR Detection
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchContactT1;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					if ((devid.empty()) || (sunitcode.empty()))
-						return;
-				}
-				else if (lighttype == 407)
-				{
-					// Openwebnet Bus Custom
-					dtype = pTypeGeneralSwitch;
-					subtype = sSwitchTypeAC;
-					devid = request::findValue(&req, "id");
-					sunitcode = request::findValue(&req, "unitcode");
-					StrParam1 = request::findValue(&req, "StrParam1");
-					_log.Log(LOG_STATUS, "COpenWebNetTCP: custom command: '%s'", StrParam1.c_str());
-					if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
+					else if (lighttype == 302)
 					{
-						root["message"] = "Some field empty or not valid.";
-						return;
+						// Home Confort
+						dtype = pTypeHomeConfort;
+						subtype = sTypeHomeConfortTEL010;
+						std::string id = request::findValue(&req, "id");
+
+						std::string shousecode = request::findValue(&req, "housecode");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
+							return;
+
+						int iUnitCode = atoi(sunitcode.c_str());
+						sprintf(szTmp, "%d", iUnitCode);
+						sunitcode = szTmp;
+						sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+						shousecode = szTmp;
+						devid = id + shousecode;
+					}
+					else if (lighttype == 303)
+					{
+						// Selector Switch
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeSelector;
+						std::string id = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((id.empty()) || (sunitcode.empty()))
+							return;
+						devid = "0" + id;
+						switchtype = STYPE_Selector;
+						if (!deviceoptions.empty())
+						{
+							deviceoptions.append(";");
+						}
+						deviceoptions.append("SelectorStyle:0;LevelNames:Off|Level1|Level2|Level3");
+					}
+					else if (lighttype == 304)
+					{
+						// Itho CVE RFT
+						dtype = pTypeFan;
+						subtype = sTypeItho;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 305)
+					{
+						// Lucci Air
+						dtype = pTypeFan;
+						subtype = sTypeLucciAir;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 306)
+					{
+						// Lucci Air DC
+						dtype = pTypeFan;
+						subtype = sTypeLucciAirDC;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 307)
+					{
+						// Westinghouse
+						dtype = pTypeFan;
+						subtype = sTypeWestinghouse;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 308)
+					{
+						// Casafan
+						dtype = pTypeFan;
+						subtype = sTypeCasafan;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 309)
+					{
+						// FT1211R
+						dtype = pTypeFan;
+						subtype = sTypeFT1211R;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 310)
+					{
+						// Falmec
+						dtype = pTypeFan;
+						subtype = sTypeFalmec;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 311)
+					{
+						// Lucci Air DC II
+						dtype = pTypeFan;
+						subtype = sTypeLucciAirDCII;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 312)
+					{
+						// Itho ECO
+						dtype = pTypeFan;
+						subtype = sTypeIthoECO;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 313)
+					{
+						// Novy
+						dtype = pTypeFan;
+						subtype = sTypeNovy;
+						std::string id = request::findValue(&req, "id");
+						if (id.empty())
+							return;
+						devid = id;
+						sunitcode = "0";
+					}
+					else if (lighttype == 400)
+					{
+						// Openwebnet Bus Blinds
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 401)
+					{
+						// Openwebnet Bus Lights
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 402)
+					{
+						// Openwebnet Bus Auxiliary
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 403)
+					{
+						// Openwebnet Zigbee Blinds
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchBlindsT2;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 404)
+					{
+						// Openwebnet Zigbee Lights
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchLightT2;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if ((lighttype == 405) || (lighttype == 406))
+					{
+						// Openwebnet Dry Contact / IR Detection
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchContactT1;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						if ((devid.empty()) || (sunitcode.empty()))
+							return;
+					}
+					else if (lighttype == 407)
+					{
+						// Openwebnet Bus Custom
+						dtype = pTypeGeneralSwitch;
+						subtype = sSwitchTypeAC;
+						devid = request::findValue(&req, "id");
+						sunitcode = request::findValue(&req, "unitcode");
+						StrParam1 = request::findValue(&req, "StrParam1");
+						_log.Log(LOG_STATUS, "COpenWebNetTCP: custom command: '%s'", StrParam1.c_str());
+						if ((devid.empty()) || (sunitcode.empty()) || (StrParam1.empty()))
+						{
+							root["message"] = "Some field empty or not valid.";
+							return;
+						}
 					}
 				}
-				// Check if switch is unique
+
+				// check if switch is unique
 				result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID=='%q' AND DeviceID=='%q' AND Unit=='%q' AND Type==%d AND SubType==%d)", hwdid.c_str(),
 							  devid.c_str(), sunitcode.c_str(), dtype, subtype);
 				if (!result.empty())
@@ -5441,14 +5446,12 @@ namespace http
 				}
 
 				// ----------- If needed convert to GeneralSwitch type (for o.a. RFlink) -----------
+				CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
+				if (pBaseHardware != nullptr)
 				{
-					CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
-					if (pBaseHardware != nullptr)
+					if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP))
 					{
-						if ((pBaseHardware->HwdType == HTYPE_RFLINKUSB) || (pBaseHardware->HwdType == HTYPE_RFLINKTCP))
-						{
-							ConvertToGeneralSwitchType(devid, dtype, subtype);
-						}
+						ConvertToGeneralSwitchType(devid, dtype, subtype);
 					}
 				}
 				// -----------------------------------------------
@@ -11469,6 +11472,7 @@ namespace http
 					root["result"][ii]["DataTimeout"] = atoi(sd[16].c_str());
 					root["result"][ii]["LogLevel"] = atoi(sd[17].c_str());
 
+					// Special case for openzwave (status for nodes queried)
 					CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(atoi(sd[0].c_str()));
 					if (pHardware != nullptr)
 					{
@@ -11497,14 +11501,17 @@ namespace http
 							CRFLinkBase *pMyHardware = reinterpret_cast<CRFLinkBase *>(pHardware);
 							root["result"][ii]["version"] = pMyHardware->m_Version;
 						}
+						else
+						{
 #ifdef WITH_OPENZWAVE
-						else if (pHardware->HwdType == HTYPE_OpenZWave)
-						{ // Special case for openzwave (status for nodes queried)
-							COpenZWave *pOZWHardware = reinterpret_cast<COpenZWave *>(pHardware);
-							root["result"][ii]["version"] = pOZWHardware->GetVersionLong();
-							root["result"][ii]["NodesQueried"] = (pOZWHardware->m_awakeNodesQueried || pOZWHardware->m_allNodesQueried);
-						}
+							if (pHardware->HwdType == HTYPE_OpenZWave)
+							{
+								COpenZWave *pOZWHardware = reinterpret_cast<COpenZWave *>(pHardware);
+								root["result"][ii]["version"] = pOZWHardware->GetVersionLong();
+								root["result"][ii]["NodesQueried"] = (pOZWHardware->m_awakeNodesQueried || pOZWHardware->m_allNodesQueried);
+							}
 #endif
+						}
 					}
 					ii++;
 				}

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1076,7 +1076,8 @@ bool MainWorker::AddHardwareFromParams(
 	if (pHardware)
 	{
 		pHardware->HwdType = Type;
-		pHardware->m_LogLevelEnabled = LogLevelEnabled;
+		pHardware->m_LogLevelEnabled = LogLevelEnabled & 0x0000FFFF;
+		pHardware->m_DebugLevelEnabled = (LogLevelEnabled & 0xFFFF0000) >> 16;
 		pHardware->m_Name = Name;
 		pHardware->m_ShortName = Hardware_Short_Desc(Type);
 		pHardware->m_DataTimeout = DataTimeout;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1076,8 +1076,7 @@ bool MainWorker::AddHardwareFromParams(
 	if (pHardware)
 	{
 		pHardware->HwdType = Type;
-		pHardware->m_LogLevelEnabled = LogLevelEnabled & 0x0000FFFF;
-		pHardware->m_DebugLevelEnabled = (LogLevelEnabled & 0xFFFF0000) >> 16;
+		pHardware->m_LogLevelEnabled = LogLevelEnabled;
 		pHardware->m_Name = Name;
 		pHardware->m_ShortName = Hardware_Short_Desc(Type);
 		pHardware->m_DataTimeout = DataTimeout;

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -480,13 +480,6 @@
 				<input type="checkbox" id="loglevelError" checked="checked" name="loglevelError"><label for="loglevelError"><span data-i18n="Error">Error</span></label>
 			</td>
 		</tr>
-		<tr>
-			<td align="right" style="width:110px"><label for="combotype"><span data-i18n="Debug Level"></span>:</label></td>
-			<td>
-				<input type="checkbox" id="debuglevelNormal" name="debuglevelNormal"><label for="debuglevelNormal"><span data-i18n="Normal">Normal</span></label>&nbsp;&nbsp;
-				<input type="checkbox" id="debuglevelHardware" name="debuglevelHardware"><label for="debuglevelHardware"><span data-i18n="Hardware">Hardware</span></label>
-			</td>
-		</tr>
 		<tr valign="top">
 			<td align="right" style="width:110px"><label for="combodatatimeout"><span data-i18n="Data Timeout">Data Timeout</span>:</label></td>
 			<td>

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -480,6 +480,13 @@
 				<input type="checkbox" id="loglevelError" checked="checked" name="loglevelError"><label for="loglevelError"><span data-i18n="Error">Error</span></label>
 			</td>
 		</tr>
+		<tr>
+			<td align="right" style="width:110px"><label for="combotype"><span data-i18n="Debug Level"></span>:</label></td>
+			<td>
+				<input type="checkbox" id="debuglevelNormal" name="debuglevelNormal"><label for="debuglevelNormal"><span data-i18n="Normal">Normal</span></label>&nbsp;&nbsp;
+				<input type="checkbox" id="debuglevelHardware" name="debuglevelHardware"><label for="debuglevelHardware"><span data-i18n="Hardware">Hardware</span></label>
+			</td>
+		</tr>
 		<tr valign="top">
 			<td align="right" style="width:110px"><label for="combodatatimeout"><span data-i18n="Data Timeout">Data Timeout</span>:</label></td>
 			<td>

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -42,13 +42,17 @@ define(['app'], function (app) {
 			var bEnabled = $('#hardwarecontent #hardwareparamstable #enabled').is(":checked");
 			var datatimeout = $('#hardwarecontent #hardwareparamstable #combodatatimeout').val();
 			
-			var logLevel = 0;
+			var logLevel = 0x00000000;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelInfo").prop("checked"))
-				logLevel |= 1;
+				logLevel |= 0x00000001;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelStatus").prop("checked"))
-				logLevel |= 2;
+				logLevel |= 0x00000002;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelError").prop("checked"))
-				logLevel |= 4;
+				logLevel |= 0x00000004;
+			if ($("#hardwarecontent #hardwareparamstable #debuglevelNormal").prop("checked"))
+				logLevel |= 0x00010000;
+			if ($("#hardwarecontent #hardwareparamstable #debuglevelHardware").prop("checked"))
+				logLevel |= 0x00020000;
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 
@@ -1444,13 +1448,17 @@ define(['app'], function (app) {
 			var bEnabled = $('#hardwarecontent #hardwareparamstable #enabled').is(":checked");
 			var datatimeout = $('#hardwarecontent #hardwareparamstable #combodatatimeout').val();
 
-			var logLevel = 0;
+			var logLevel = 0x00000000;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelInfo").prop("checked"))
-				logLevel |= 1;
+				logLevel |= 0x00000001;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelStatus").prop("checked"))
-				logLevel |= 2;
+				logLevel |= 0x00000002;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelError").prop("checked"))
-				logLevel |= 4;
+				logLevel |= 0x00000004;
+			if ($("#hardwarecontent #hardwareparamstable #debuglevelNormal").prop("checked"))
+				logLevel |= 0x00010000;
+			if ($("#hardwarecontent #hardwareparamstable #debuglevelHardware").prop("checked"))
+				logLevel |= 0x00020000;
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 
@@ -3925,18 +3933,22 @@ define(['app'], function (app) {
 							$("#hardwarecontent #divpythonplugin #" + data["Extra"] + " #Mode6").val(data["Mode6"]);
 							$("#hardwarecontent #divpythonplugin #" + data["Extra"] + " #Extra").val(data["Extra"]);
 							UpdateHardwareParamControls();
-							$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 1)!=0));
-							$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 2)!=0));
-							$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 4)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 0x00000001)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 0x00000002)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 0x00000004)!=0));
+							$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', ((data["LogLevel"] & 0x00010000)!=0));
+							$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', ((data["LogLevel"] & 0x00020000)!=0));
 							return;
 						}
 						
 						UpdateHardwareParamControls();
 
 						$('#hardwarecontent #hardwareparamstable #enabled').prop('checked', (data["Enabled"] == "true"));
-						$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 1)!=0));
-						$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 2)!=0));
-						$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 4)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 0x00000001)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 0x00000002)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 0x00000004)!=0));
+						$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', ((data["LogLevel"] & 0x00010000)!=0));
+						$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', ((data["LogLevel"] & 0x00020000)!=0));
 						$('#hardwarecontent #hardwareparamstable #combodatatimeout').val(data["DataTimeout"]);
 
 						if (
@@ -4447,6 +4459,8 @@ define(['app'], function (app) {
 			$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', true);
 			$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', true);
 			$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', true);
+			$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', false);
+			$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', false);
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 			$("#hardwarecontent #username").show();

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -42,17 +42,13 @@ define(['app'], function (app) {
 			var bEnabled = $('#hardwarecontent #hardwareparamstable #enabled').is(":checked");
 			var datatimeout = $('#hardwarecontent #hardwareparamstable #combodatatimeout').val();
 			
-			var logLevel = 0x00000000;
+			var logLevel = 0;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelInfo").prop("checked"))
-				logLevel |= 0x00000001;
+				logLevel |= 1;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelStatus").prop("checked"))
-				logLevel |= 0x00000002;
+				logLevel |= 2;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelError").prop("checked"))
-				logLevel |= 0x00000004;
-			if ($("#hardwarecontent #hardwareparamstable #debuglevelNormal").prop("checked"))
-				logLevel |= 0x00010000;
-			if ($("#hardwarecontent #hardwareparamstable #debuglevelHardware").prop("checked"))
-				logLevel |= 0x00020000;
+				logLevel |= 4;
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 
@@ -1448,17 +1444,13 @@ define(['app'], function (app) {
 			var bEnabled = $('#hardwarecontent #hardwareparamstable #enabled').is(":checked");
 			var datatimeout = $('#hardwarecontent #hardwareparamstable #combodatatimeout').val();
 
-			var logLevel = 0x00000000;
+			var logLevel = 0;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelInfo").prop("checked"))
-				logLevel |= 0x00000001;
+				logLevel |= 1;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelStatus").prop("checked"))
-				logLevel |= 0x00000002;
+				logLevel |= 2;
 			if ($("#hardwarecontent #hardwareparamstable #loglevelError").prop("checked"))
-				logLevel |= 0x00000004;
-			if ($("#hardwarecontent #hardwareparamstable #debuglevelNormal").prop("checked"))
-				logLevel |= 0x00010000;
-			if ($("#hardwarecontent #hardwareparamstable #debuglevelHardware").prop("checked"))
-				logLevel |= 0x00020000;
+				logLevel |= 4;
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 
@@ -3933,22 +3925,18 @@ define(['app'], function (app) {
 							$("#hardwarecontent #divpythonplugin #" + data["Extra"] + " #Mode6").val(data["Mode6"]);
 							$("#hardwarecontent #divpythonplugin #" + data["Extra"] + " #Extra").val(data["Extra"]);
 							UpdateHardwareParamControls();
-							$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 0x00000001)!=0));
-							$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 0x00000002)!=0));
-							$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 0x00000004)!=0));
-							$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', ((data["LogLevel"] & 0x00010000)!=0));
-							$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', ((data["LogLevel"] & 0x00020000)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 1)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 2)!=0));
+							$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 4)!=0));
 							return;
 						}
 						
 						UpdateHardwareParamControls();
 
 						$('#hardwarecontent #hardwareparamstable #enabled').prop('checked', (data["Enabled"] == "true"));
-						$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 0x00000001)!=0));
-						$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 0x00000002)!=0));
-						$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 0x00000004)!=0));
-						$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', ((data["LogLevel"] & 0x00010000)!=0));
-						$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', ((data["LogLevel"] & 0x00020000)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', ((data["LogLevel"] & 1)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', ((data["LogLevel"] & 2)!=0));
+						$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', ((data["LogLevel"] & 4)!=0));
 						$('#hardwarecontent #hardwareparamstable #combodatatimeout').val(data["DataTimeout"]);
 
 						if (
@@ -4459,8 +4447,6 @@ define(['app'], function (app) {
 			$('#hardwarecontent #hardwareparamstable #loglevelInfo').prop('checked', true);
 			$('#hardwarecontent #hardwareparamstable #loglevelStatus').prop('checked', true);
 			$('#hardwarecontent #hardwareparamstable #loglevelError').prop('checked', true);
-			$('#hardwarecontent #hardwareparamstable #debuglevelNormal').prop('checked', false);
-			$('#hardwarecontent #hardwareparamstable #debuglevelHardware').prop('checked', false);
 
 			var text = $("#hardwarecontent #hardwareparamstable #combotype option:selected").text();
 			$("#hardwarecontent #username").show();


### PR DESCRIPTION
**As currently proposed for Log Levels, allow to set dynamically & per hardware Debug Levels  in domoticz hardware setup screen**

Log/Debug levels can be set either when creating a new hardware, or by updating an existing one.

This can be very useful for troobleshooting, making it possible to get debug information without recompiling or launching Domoticz manually with debug option enabled from the command line. In EnOcean ESP3 protocol, for instance, Normal debug will show how EnOcean telegrams are interpreted and Hardware debug will show exchanged ERP1 protocol data .

For that purpose, add 2 new checkboxes on Hardware setup screen and implement necessary logic.

**Hardware.html:**
Add 2 checkboxes => Debug Level : Nomal/Hardware

**Hardware.js / Mainworker.cpp / DomoticzHardware.h:**
_Unmodified:_
Use LogLevelEnabled 4 LSB bytes to exchange Log Level:
    0x00000001=LOG_NORM, 0x00000002=LOG_STATUS, 0x00000004=LOG_ERROR

Store current log level for hardware in m_LogLevelEnabled.

_New:_
Use LogLevelEnabled 4 MSB bytes to exchange Debug Level:
    0x00010000=DEBUG_NORM, 0x00020000=DEBUG_HARDWARE

Store current debug level for hardware in m_DebugLevelEnabled.

**DomoticzHardware.cpp:**
Implement necessary logic to follow what the user has defined in hardware setup screen.

**Logger.h/Logger.cpp**
Add 2 utility functions to get current Log/Debug flags:
	uint32_t GetLogFlags();
	uint32_t GetDebugFlags();

nb. The last commit "Set dynamically & per hardware Debug Levels" carries all the files changed by this PR. The others first 10  result in a noop...