### PR TITLE
Refactored way of serving theme files

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -812,7 +812,6 @@ namespace http
 							for (const auto &file : _ThemeFiles)
 							{
 								std::string tfname = file.first.substr(szWWWFolder.size() + 1);
-								stdreplace(tfname, "styles/" + sWebTheme, "acttheme");
 								response += tfname + '\n';
 							}
 							continue;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -337,15 +337,20 @@ namespace http
 			m_pWebEm->RegisterIncludeCode("combolanguage", [this](auto &&content_part) { DisplayLanguageCombo(content_part); });
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto &&session, auto &&req, auto &&rep) { GetJSonPage(session, req, rep); });
+			// These 'Pages' should probably be 'moved' to become Command codes handled by the 'json.htm API', so we get all API calls through one entry point
+			// And why .php or .cgi while all these commands are NOT handled by a PHP or CGI processor but by Domoticz ?? Legacy? Rename these?
+			m_pWebEm->RegisterPageCode("/logincheck", [this](auto &&session, auto &&req, auto &&rep) { PostLoginCheck(session, req, rep); }, true);
 			m_pWebEm->RegisterPageCode("/uploadcustomicon", [this](auto &&session, auto &&req, auto &&rep) { Post_UploadCustomIcon(session, req, rep); });
-			m_pWebEm->RegisterPageCode("/html5.appcache", [this](auto &&session, auto &&req, auto &&rep) { GetAppCache(session, req, rep); });
-			m_pWebEm->RegisterPageCode("/camsnapshot.jpg", [this](auto &&session, auto &&req, auto &&rep) { GetCameraSnapshot(session, req, rep); });
+			m_pWebEm->RegisterPageCode("/storesettings", [this](auto &&session, auto &&req, auto &&rep) { PostSettings(session, req, rep); });
 			m_pWebEm->RegisterPageCode("/backupdatabase.php", [this](auto &&session, auto &&req, auto &&rep) { GetDatabaseBackup(session, req, rep); });
+			m_pWebEm->RegisterPageCode("/camsnapshot.jpg", [this](auto &&session, auto &&req, auto &&rep) { GetCameraSnapshot(session, req, rep); });
 			m_pWebEm->RegisterPageCode("/raspberry.cgi", [this](auto &&session, auto &&req, auto &&rep) { GetInternalCameraSnapshot(session, req, rep); });
 			m_pWebEm->RegisterPageCode("/uvccapture.cgi", [this](auto &&session, auto &&req, auto &&rep) { GetInternalCameraSnapshot(session, req, rep); });
+			// Maybe handle these differently? (Or remove)
 			m_pWebEm->RegisterPageCode("/images/floorplans/plan", [this](auto &&session, auto &&req, auto &&rep) { GetFloorplanImage(session, req, rep); });
+			m_pWebEm->RegisterPageCode("/html5.appcache", [this](auto &&session, auto &&req, auto &&rep) { GetAppCache(session, req, rep); });
+			// End of 'Pages' to be moved...
 
-			m_pWebEm->RegisterPageCode("/storesettings", [this](auto &&session, auto &&req, auto &&rep) { PostSettings(session, req, rep); });
 			m_pWebEm->RegisterActionCode("setrfxcommode", [this](auto &&session, auto &&req, auto &&redirect_uri) { SetRFXCOMMode(session, req, redirect_uri); });
 			m_pWebEm->RegisterActionCode("rfxupgradefirmware", [this](auto &&session, auto &&req, auto &&redirect_uri) { RFXComUpgradeFirmware(session, req, redirect_uri); });
 			RegisterCommandCode(
@@ -373,21 +378,18 @@ namespace http
 				"getthemes", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetThemes(session, req, root); }, true);
 			RegisterCommandCode(
 				"gettitle", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetTitle(session, req, root); }, true);
-
 			RegisterCommandCode(
 				"logincheck", [this](auto &&session, auto &&req, auto &&root) { Cmd_LoginCheck(session, req, root); }, true);
-			m_pWebEm->RegisterPageCode(
-				"/logincheck", [this](auto &&session, auto &&req, auto &&rep) { PostLoginCheck(session, req, rep); }, true);
-
 			RegisterCommandCode(
 				"getversion", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetVersion(session, req, root); }, true);
-			RegisterCommandCode("getlog", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetLog(session, req, root); });
-			RegisterCommandCode("clearlog", [this](auto &&session, auto &&req, auto &&root) { Cmd_ClearLog(session, req, root); });
 			RegisterCommandCode(
 				"getauth", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetAuth(session, req, root); }, true);
 			RegisterCommandCode(
 				"getuptime", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetUptime(session, req, root); }, true);
 
+			RegisterCommandCode("storesettings", [this](auto &&session, auto &&req, auto &&root) { Cmd_PostSettings(session, req, root); });
+			RegisterCommandCode("getlog", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetLog(session, req, root); });
+			RegisterCommandCode("clearlog", [this](auto &&session, auto &&req, auto &&root) { Cmd_ClearLog(session, req, root); });
 			RegisterCommandCode("gethardwaretypes", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetHardwareTypes(session, req, root); });
 			RegisterCommandCode("addhardware", [this](auto &&session, auto &&req, auto &&root) { Cmd_AddHardware(session, req, root); });
 			RegisterCommandCode("updatehardware", [this](auto &&session, auto &&req, auto &&root) { Cmd_UpdateHardware(session, req, root); });
@@ -508,8 +510,7 @@ namespace http
 			RegisterCommandCode("getactualhistory", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetActualHistory(session, req, root); });
 			RegisterCommandCode("getnewhistory", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetNewHistory(session, req, root); });
 
-			RegisterCommandCode(
-				"getconfig", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetConfig(session, req, root); }, true);
+			RegisterCommandCode("getconfig", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetConfig(session, req, root); }, true);
 			RegisterCommandCode("getlocation", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetLocation(session, req, root); });
 			RegisterCommandCode("getforecastconfig", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetForecastConfig(session, req, root); });
 			RegisterCommandCode("sendnotification", [this](auto &&session, auto &&req, auto &&root) { Cmd_SendNotification(session, req, root); });
@@ -582,6 +583,8 @@ namespace http
 
 			RegisterCommandCode("addArilux", [this](auto &&session, auto &&req, auto &&root) { Cmd_AddArilux(session, req, root); });
 
+			RegisterCommandCode("tellstickApplySettings", [this](auto &&session, auto &&req, auto &&root) { Cmd_TellstickApplySettings(session, req, root); });
+
 			RegisterRType("graph", [this](auto &&session, auto &&req, auto &&root) { RType_HandleGraph(session, req, root); });
 			RegisterRType("lightlog", [this](auto &&session, auto &&req, auto &&root) { RType_LightLog(session, req, root); });
 			RegisterRType("textlog", [this](auto &&session, auto &&req, auto &&root) { RType_TextLog(session, req, root); });
@@ -622,6 +625,7 @@ namespace http
 			RegisterRType("custom_light_icons", [this](auto &&session, auto &&req, auto &&root) { RType_CustomLightIcons(session, req, root); });
 			RegisterRType("plans", [this](auto &&session, auto &&req, auto &&root) { RType_Plans(session, req, root); });
 			RegisterRType("floorplans", [this](auto &&session, auto &&req, auto &&root) { RType_FloorPlans(session, req, root); });
+
 #ifdef WITH_OPENZWAVE
 			// ZWave
 			RegisterCommandCode("updatezwavenode", [this](auto &&session, auto &&req, auto &&root) { Cmd_ZWaveUpdateNode(session, req, root); });
@@ -677,7 +681,6 @@ namespace http
 			// pollpost.html
 			RegisterRType("openzwavenodes", [this](auto &&session, auto &&req, auto &&root) { RType_OpenZWaveNodes(session, req, root); });
 #endif
-			RegisterCommandCode("tellstickApplySettings", [this](auto &&session, auto &&req, auto &&root) { Cmd_TellstickApplySettings(session, req, root); });
 
 			m_pWebEm->RegisterWhitelistURLString("/html5.appcache");
 			m_pWebEm->RegisterWhitelistURLString("/images/floorplans/plan");
@@ -926,9 +929,11 @@ namespace http
 				root["Title"] = "Domoticz";
 		}
 
-		// PostSettings
+		// Depricated : This 'page' should not be used anymore. Use command instead
 		void CWebServer::PostLoginCheck(WebEmSession &session, const request &req, reply &rep)
 		{
+			_log.Log(LOG_NORM, "Depricated: Page LoginCheck! Use command instead!");
+
 			Json::Value root;
 			Cmd_LoginCheck(session, req, root);
 
@@ -7724,13 +7729,33 @@ namespace http
 			return std::any_of(m_users.begin(), m_users.end(), [](const _tWebUserPassword &user) { return user.userrights == URIGHTS_ADMIN; });
 		}
 
+		// Depricated : This 'page' should not be used anymore. Use command instead
 		void CWebServer::PostSettings(WebEmSession &session, const request &req, reply &rep)
+		{
+			_log.Log(LOG_NORM, "Depricated: Page StoreSettings! Use command instead!");
+
+			Json::Value root;
+			Cmd_PostSettings(session, req, root);
+
+			std::string jcallback = request::findValue(&req, "jsoncallback");
+			if (jcallback.empty())
+			{
+				reply::set_content(&rep, root.toStyledString());
+				return;
+			}
+			reply::set_content(&rep, "var data=" + root.toStyledString() + '\n' + jcallback + "(data);");
+		}
+
+		// PostSettings
+		void CWebServer::Cmd_PostSettings(WebEmSession &session, const request &req, Json::Value &root)
 		{
 			if (session.rights != 2)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
 			}
+
+			root["title"] = "StoreSettings";
 
 			std::string Latitude = request::findValue(&req, "Latitude");
 			std::string Longitude = request::findValue(&req, "Longitude");
@@ -8110,18 +8135,7 @@ namespace http
 			// Signal plugins to update Settings dictionary
 			PluginLoadConfig();
 #endif
-
-			Json::Value root;
 			root["status"] = "OK";
-			root["title"] = "StoreSettings";
-
-			std::string jcallback = request::findValue(&req, "jsoncallback");
-			if (jcallback.empty())
-			{
-				reply::set_content(&rep, root.toStyledString());
-				return;
-			}
-			reply::set_content(&rep, "var data=" + root.toStyledString() + '\n' + jcallback + "(data);");
 		}
 
 		void CWebServer::RestoreDatabase(WebEmSession &session, const request &req, std::string &redirect_uri)

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -108,6 +108,7 @@ private:
 	void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_PostSettings(WebEmSession &session, const request &req, Json::Value &root);
 	void Cmd_GetHardwareTypes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_AddHardware(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateHardware(WebEmSession & session, const request& req, Json::Value &root);

--- a/test/lighttpd.conf
+++ b/test/lighttpd.conf
@@ -1,0 +1,48 @@
+# A lighttpd config file for Domoticz, serving the UI as Static content and proying only API calls to Domoticz
+#
+# Make sure you set the Document-root to your full-path of the Domoticz WWW directory
+#
+# All calls to 'json.htm' will be proxied to the Domoticz webserver/webservice that is expected to run on port 8080 (No SSL)
+# You can start Domoticz for example with the following config
+# sudo ./bin/domoticz -www 8080 -wwwroot www -loglevel debug,error -debuglevel webserver
+#
+# Domoticz will show the (web)requests it handles (should be the json.htm ones only)
+# And you can tail the lighttpd logfile (/tmp/lighttpd.log) to see all other static requests being handled by lighttpd 
+
+server.document-root = "/home/vagrant/domoticz/www/" 
+server.port = 8888
+
+accesslog.format = "%h %V %u %t \"%r\" %>s %b" 
+accesslog.filename = "/tmp/lighttpd.log"
+
+index-file.names = ( "index.html" )
+
+server.modules = (
+        "mod_indexfile",
+        "mod_accesslog",
+        "mod_rewrite",
+        "mod_proxy",
+        "mod_magnet"
+)
+mimetype.assign = (
+  ".html" => "text/html", 
+  ".txt" => "text/plain",
+  ".css" => "text/css",
+  ".js" => "text/javascript",
+  ".jpg" => "image/jpeg",
+  ".png" => "image/png" 
+)
+
+$HTTP["url"] =~ ".js" {
+  url.rewrite-if-not-file = ( "^\/js\/(.*)\.js$" => "/js/$1.js.gz" )
+  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjs.lua" )
+}
+
+proxy.server = ( "/json.htm" =>
+    ( "domoticzservice" =>
+      (
+        "host" => "localhost",
+        "port" => "8080"
+      )
+    )
+  )

--- a/test/lighttpd_gzippedjs.lua
+++ b/test/lighttpd_gzippedjs.lua
@@ -1,0 +1,4 @@
+if (string.match(lighty.env["physical.path"],".js.gz")) then
+	lighty.header["Content-Type"] = "text/javascript"
+	lighty.header["Content-Encoding"] = "gzip"
+end

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -882,10 +882,6 @@ namespace http {
 				}
 			}
 
-			if (request_path.find("/acttheme/") == 0)
-			{
-				request_path = m_actTheme + request_path.substr(9);
-			}
 			return request_path;
 		}
 
@@ -2145,7 +2141,20 @@ namespace http {
 						{
 							std::string theme_images_path = myWebem->m_actTheme + uri;
 							if (file_exist((doc_root_ + theme_images_path).c_str()))
+							{
 								requestCopy.uri = myWebem->GetWebRoot() + theme_images_path;
+								_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
+							}
+						}
+						else if (uri.find("/acttheme/") == 0)
+						{
+							requestCopy.uri = myWebem->m_actTheme + uri.substr(9);
+							_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
+						}
+						else if (uri.find("/styles/default/custom.") == 0)
+						{
+							requestCopy.uri = myWebem->m_actTheme + uri.substr(15);
+							_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
 						}
 
 						request_handler::handle_request(requestCopy, rep, mInfo);

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2136,25 +2136,24 @@ namespace http {
 					// do normal handling
 					try
 					{
-						std::string uri = myWebem->ExtractRequestPath(requestCopy.uri);
-						if (uri.find("/images/") == 0)
+						if (myWebem->m_actTheme.find("default") == std::string::npos)
 						{
-							std::string theme_images_path = myWebem->m_actTheme + uri;
-							if (file_exist((doc_root_ + theme_images_path).c_str()))
+							// A theme is being used (not default) so some theme specific processing might be neccessary
+							std::string uri = myWebem->ExtractRequestPath(requestCopy.uri);
+							if (uri.find("/images/") == 0)
 							{
-								requestCopy.uri = myWebem->GetWebRoot() + theme_images_path;
+								std::string theme_images_path = myWebem->m_actTheme + uri;
+								if (file_exist((doc_root_ + theme_images_path).c_str()))
+								{
+									requestCopy.uri = myWebem->GetWebRoot() + theme_images_path;
+									_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
+								}
+							}
+							else if (uri.find("/styles/default/custom.") == 0)
+							{
+								requestCopy.uri = myWebem->m_actTheme + uri.substr(15);
 								_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
 							}
-						}
-						else if (uri.find("/acttheme/") == 0)
-						{
-							requestCopy.uri = myWebem->m_actTheme + uri.substr(9);
-							_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
-						}
-						else if (uri.find("/styles/default/custom.") == 0)
-						{
-							requestCopy.uri = myWebem->m_actTheme + uri.substr(15);
-							_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
 						}
 
 						request_handler::handle_request(requestCopy, rep, mInfo);

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -862,12 +862,6 @@ namespace http {
 				request_path = m_webRoot + "/";
 			}
 
-			// If path ends in slash (i.e. is a directory) then add "index.html".
-			if (request_path[request_path.size() - 1] == '/')
-			{
-				request_path += "index.html";
-			}
-
 			if (!m_webRoot.empty())
 			{
 				// remove web root if present otherwise

--- a/www/app/LoginController.js
+++ b/www/app/LoginController.js
@@ -12,7 +12,7 @@ define(['app'], function (app) {
 			fd.append('username', musername);
 			fd.append('password', mpassword);
 			fd.append('rememberme', bRememberMe);
-			$http.post('logincheck', fd, {
+			$http.post('json.htm?type=command&param=logincheck', fd, {
 				transformRequest: angular.identity,
 				headers: { 'Content-Type': undefined }
 			}).then(function successCallback(response) {

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -733,7 +733,7 @@ define(['app'], function (app) {
 				}
 			}
 
-			$http.post('storesettings', new FormData(document.querySelector("#settings")), {
+			$http.post('json.htm?type=command&param=storesettings', new FormData(document.querySelector("#settings")), {
 				transformRequest: angular.identity,
 				headers: { 'Content-Type': undefined }
 			}).then(function successCallback(response) {

--- a/www/index.html
+++ b/www/index.html
@@ -88,7 +88,7 @@
 		<link rel="stylesheet" href="js/noty/relax.css">
 		<link rel="stylesheet" href="app/events/Events.css">
 		<link rel="stylesheet" href="app/devices/Devices.css">
-		<link rel="stylesheet" href="acttheme/custom.css">
+		<link rel="stylesheet" href="styles/default/custom.css">
 
 		<script src="js/babel-polyfill-6.26.0.js"></script>
 		<script src="js/jquery-3.6.0.min.js"></script>
@@ -121,7 +121,7 @@
 		<script charset="utf-8" src="js/domoticz.js"></script>
 		<script charset="utf-8" src="js/domoticzdevices.js"></script>
 		<script charset="utf-8" src="js/jquery-ui-timepicker-addon.js"></script>
-		<script charset="utf-8" src="acttheme/custom.js"></script>
+		<script charset="utf-8" src="styles/default/custom.js"></script>
 		<script data-main="app/main" src="js/require.min.js"></script>
 <script charset="utf-8" id="init-code">
 

--- a/www/styles/dark-th3me/custom.css
+++ b/www/styles/dark-th3me/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 @import url("base.css"); /* Don't remove this line! */
 
 /*

--- a/www/styles/default/custom.css
+++ b/www/styles/default/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 @import url("base.css"); /* Don't remove this line! */
 @import url("extras_and_animations.css"); /* Adds visual extras. */
 /*@import url("navigation_main_sidebar.css"); /* This transforms the main menu to a vertical menu on the left. */

--- a/www/styles/element-dark/custom.css
+++ b/www/styles/element-dark/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 
 @font-face {
 	font-family: "OpenSans";

--- a/www/styles/element-light/custom.css
+++ b/www/styles/element-light/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 
 @font-face {
 	font-family: "OpenSans";

--- a/www/styles/elemental/custom.css
+++ b/www/styles/elemental/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 
 @font-face {
 	font-family: "OpenSans";

--- a/www/styles/simple-blue/custom.css
+++ b/www/styles/simple-blue/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 
 /*
 Default Simple Blue theme for Domoticz

--- a/www/styles/simple-gray/custom.css
+++ b/www/styles/simple-gray/custom.css
@@ -1,4 +1,4 @@
-@import url("../css/legacy.css"); /* Don't remove this line! */
+@import url("../../css/legacy.css"); /* Don't remove this line! */
 
 /*
 Default Simple Gray theme for Domoticz

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -46,7 +46,7 @@
 					<li><a data-target="#tabfloorplan" data-toggle="tab" data-i18n="Floorplan"></a></li>
 					<li><a data-target="#tabother" data-toggle="tab" data-i18n="Other">Other</a></li>
 					<li><a data-target="#tabbackuprestore" data-toggle="tab" data-i18n="Backup/Restore">Backup/Restore</a></li>
-					<li class="pull-right"><a data-i18n="Apply Settings" class="btn btn-danger sub-tabs-apply" ng-click="StoreSettings()">Apply Settings</a></li>
+					<li class="pull-right"><a data-i18n="Apply Settings" class="btn-danger sub-tabs-apply" ng-click="StoreSettings()">Apply Settings</a></li>
 				</ul>
 				<div id="my-tab-content" class="tab-content">
 					<div class="tab-pane active" id="tabsystem">


### PR DESCRIPTION
This PR refactors the _theme_ processing within the Domoticz webserver(s).

- All theme processing logic  is now more in 1 place and not at different places and sourcefiles anymore.
- Theme processing is only done when not using the Default theme (so less code to run when using Default theme)
- The complete Domoticz UI (www folder) can now be served statically by any webserver (and not only the Domoticz webserver)
-- But only for the _default_ theme ofcourse

- Also refactored handling of serving _directories_ (rewrite request to serve index.html of directory if exists) as it was done at 2 places and one (request_handler) seemed broken (not working).

Main reason for this refactoring is to get a clearer separation between the UI and the Webserver (which now more and more becomes a WebService). It will make testing of the UI and testing of the WebService easier and can be done independant (for example by mocking the WebService).

Also it makes it 'easier' to develop new UI's/front-end's and/or serve the UI from a different place (webserver) than where the WebService might run. For example, one could serve the UI directly from an AWS S3 bucket (as Static files) and proxy only the JSON commands to a different (internal) location.

Have not tried it yet, but I think using AWS API gateway and AWS S3 static content serving it should be possible to create a setup now where the Domoticz UI (the 'www' folder) is served from a public location and the calls to _json.htm_ can be proxied to an internal Domoticz webserver/webservice. And therefor also secured properly! Anyone :) ?

For those on Linux: I added a [_lighttpd_](https://www.lighttpd.net/) config in the 'test' directory. If you install it, you can start Domoticz (at port 8080) and also start _lighttpd_ (`lighttpd -D -f test/lighttpd.conf`) which runs at port 8888.

Now you can request the Domoticz UI at port 8888 which gets served from lighttpd and only the API calls are handled by Domoticz :)


