### PR TITLE
dzvents - fix for #4944, skipping device without lastUpdate

### DIFF
--- a/dzVents/runtime/device-adapters/generic_device.lua
+++ b/dzVents/runtime/device-adapters/generic_device.lua
@@ -64,7 +64,7 @@ return {
 
 		if (data.lastUpdate == '' or data.lastUpdate == nil) then
 			if data.baseType ~= 'camera' and data.baseType ~= 'hardware' then
-				utils.log('Discarding device. No last update info found: ' .. utils._.str(data), utils.LOG_DEBUG)
+				utils.log('Discarding device. No last update info found: ' .. utils.toStr(data), utils.LOG_DEBUG)
 			end
 			return nil
 		end


### PR DESCRIPTION
This is a fix for issue 4944. It doesn't fix the lastUpdate not being valid, but it does fix dzVents correctly reporting the device skipped.

https://domoticz.com/forum/viewtopic.php?f=59&t=36994
