### PR TITLE
Fix for currentValue containing a JSON with the value field....

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2283,8 +2283,21 @@ void MQTT::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			szOnOffValue = root["state"].asString();
 		else if (!root["value"].empty())
 		{
-			int iValue = root["value"].asInt();
-			szOnOffValue = (iValue != 0) ? pSensor->payload_on : pSensor->payload_off;
+			szOnOffValue = root["value"].asString();
+			if (is_number(szOnOffValue))
+			{
+				//must be a level
+				level = atoi(szOnOffValue.c_str());
+				if (level > 0)
+				{
+					if (level != 100)
+						szOnOffValue = "Set Level";
+					else
+						szOnOffValue = "on";
+				}
+				else
+					szOnOffValue = "off";
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fix for currentValue containing a JSON with the value field not updating the device. These messages are send by the ZWAVEJS2MQTT gateway.
It works for these type of payloads:
**mosquitto_pub -h 192.168.0.30 -t 'zwave/Screen1/38/0/currentValue' -m '50'**
This one is failing and is fixed by this PR: 
**mosquitto_pub -h 192.168.0.30 -t 'zwave/Screen1/38/0/currentValue' -m '{"time":1632837866709,"value":40}'**
