### PR TITLE
Compare-chart should be able to handle new devices

### DIFF
--- a/www/app/log/CounterLog.js
+++ b/www/app/log/CounterLog.js
@@ -207,6 +207,9 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 
                                     function categoriesFromGroupingBy(groupingBy) {
                                         if (groupingBy === 'year') {
+                                            if (this.firstYear === undefined) {
+                                                return [];
+                                            }
                                             return _.range(this.firstYear, new Date().getFullYear() + 1).map(year => year.toString());
                                         } else if (groupingBy === 'quarter') {
                                             return ['Q1', 'Q2', 'Q3', 'Q4'];

--- a/www/app/log/CounterLogSeriesSupplier.js
+++ b/www/app/log/CounterLogSeriesSupplier.js
@@ -90,6 +90,9 @@ define(['app', 'log/Chart'], function (app) {
 
         function counterCompareSeriesSuppliers(ctrl) {
             return function (data) {
+                if (data.firstYear === undefined) {
+                    return [];
+                }
                 return _.range(data.firstYear, new Date().getFullYear() + 1)
                     .reduce(
                         function (seriesSuppliers, year) {

--- a/www/app/log/DataLoader.js
+++ b/www/app/log/DataLoader.js
@@ -97,7 +97,7 @@ define(function () {
 
         function analyseDataItems(dataItems, seriesSuppliers) {
             runSeriesSuppliersFunction(
-                dataItems.slice(0, 150),
+                (dataItems || []).slice(0, 150),
                 seriesSuppliers
                     .filter(function (seriesSupplier) {
                         return seriesSupplier.analyseDataItem !== undefined;
@@ -110,7 +110,7 @@ define(function () {
 
         function collectDatapoints(dataItems, seriesSuppliers) {
             runSeriesSuppliersFunction(
-                dataItems,
+                dataItems || [],
                 seriesSuppliers.filter(function (seriesSupplier) {
                     return seriesSupplier.valuesFromDataItem !== undefined;
                 }),


### PR DESCRIPTION
When a device is newly created, it does not have any data collected for it. Hence, the compare-chart should handle that situation and show nothing. This should fix #4907 and #4930.