### PR TITLE
Fix for updated themeprocessing to serve other relative custom theme files correctly

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2140,13 +2140,17 @@ namespace http {
 								if (file_exist((doc_root_ + theme_images_path).c_str()))
 								{
 									requestCopy.uri = myWebem->GetWebRoot() + theme_images_path;
-									_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
+									_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified images request to (%s).", uri.c_str(), requestCopy.uri.c_str());
 								}
 							}
-							else if (uri.find("/styles/default/custom.") == 0)
+							else if (uri.find("/styles/") == 0)
 							{
-								requestCopy.uri = myWebem->m_actTheme + uri.substr(15);
-								_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified to (%s).", uri.c_str(), requestCopy.uri.c_str());
+								std::string theme_styles_path = myWebem->m_actTheme + uri.substr(15);
+								if (file_exist((doc_root_ + theme_styles_path).c_str()))
+								{
+									requestCopy.uri = myWebem->GetWebRoot() + theme_styles_path;
+									_log.Debug(DEBUG_WEBSERVER, "[web:%s] modified request to (%s).", uri.c_str(), requestCopy.uri.c_str());
+								}
 							}
 						}
 

--- a/www/styles/dark-th3me/custom.css
+++ b/www/styles/dark-th3me/custom.css
@@ -9,8 +9,8 @@
 @font-face {
   font-family: "Ubuntu";
   font-style: normal;
-  src: url('../dark-th3me/fonts/Ubuntu.ttf');
-  src: local('Ubuntu'), url('../dark-th3me/fonts/Ubuntu.ttf') format('truetype');
+  src: url('fonts/Ubuntu.ttf');
+  src: local('Ubuntu'), url('fonts/Ubuntu.ttf') format('truetype');
 }
 /* Font Ubuntu everywhere */
 html * {
@@ -78,7 +78,7 @@ body {
 /*only show special background when screen is min 1000px width, so tablets show normal background*/
 @media (min-width: 1025px) {
   body {
-    background: #7d7e7d url(../dark-th3me/images/domoticz.jpg) center fixed;
+    background: #7d7e7d url(images/domoticz.jpg) center fixed;
     color: #ffffff;
   }
 }
@@ -441,7 +441,6 @@ table#itemtabletrippleicon td#name {
   margin-left: -26px !important;
 }
 select {
-  color: black;
   background-color: #f5f5f5;
 }
 .ui-widget-content {

--- a/www/styles/element-dark/custom.css
+++ b/www/styles/element-dark/custom.css
@@ -3,18 +3,18 @@
 @font-face {
 	font-family: "OpenSans";
 	font-style: normal;
-	src: url('../element-dark/fonts/OpenSans.ttf');
-	src: local('OpenSans'), url('../element-dark/fonts/OpenSans.ttf') format('truetype');
+	src: url('fonts/OpenSans.ttf');
+	src: local('OpenSans'), url('fonts/OpenSans.ttf') format('truetype');
 }
 @font-face {
 	font-family: "DroidSans";
 	font-style: normal;
-	src: url('../element-dark/fonts/DroidSans.ttf');
-	src: local('DroidSans'), url('../element-dark/fonts/DroidSans.ttf') format('truetype');
+	src: url('fonts/DroidSans.ttf');
+	src: local('DroidSans'), url('fonts/DroidSans.ttf') format('truetype');
 }
 
 body {
-	background: #202020 url(../element-dark/images/imgbg.jpg) repeat !important;
+	background: #202020 url(images/imgbg.jpg) repeat !important;
 }
 #appversion:after {
   content: " ElementMedia Dark v0.3";

--- a/www/styles/element-light/custom.css
+++ b/www/styles/element-light/custom.css
@@ -3,17 +3,17 @@
 @font-face {
 	font-family: "OpenSans";
 	font-style: normal;
-	src: url('../element-light/fonts/OpenSans.ttf');
-	src: local('OpenSans'), url('../element-light/fonts/OpenSans.ttf') format('truetype');
+	src: url('fonts/OpenSans.ttf');
+	src: local('OpenSans'), url('fonts/OpenSans.ttf') format('truetype');
 }
 @font-face {
 	font-family: "DroidSans";
 	font-style: normal;
-	src: url('../element-light/fonts/DroidSans.ttf');
-	src: local('DroidSans'), url('../element-light/fonts/DroidSans.ttf') format('truetype');
+	src: url('fonts/DroidSans.ttf');
+	src: local('DroidSans'), url('fonts/DroidSans.ttf') format('truetype');
 }
 body {
-	background: #202020 url(../element-light/images/imgbg.jpg) repeat !important;
+	background: #202020 url(images/imgbg.jpg) repeat !important;
 }
 #appversion:after {
   content: " ElementMedia Light v0.3";

--- a/www/styles/elemental/custom.css
+++ b/www/styles/elemental/custom.css
@@ -3,17 +3,17 @@
 @font-face {
 	font-family: "OpenSans";
 	font-style: normal;
-	src: url('../elemental/fonts/OpenSans.ttf');
-	src: local('OpenSans'), url('../elemental/fonts/OpenSans.ttf') format('truetype');
+	src: url('fonts/OpenSans.ttf');
+	src: local('OpenSans'), url('fonts/OpenSans.ttf') format('truetype');
 }
 @font-face {
 	font-family: "DroidSans";
 	font-style: normal;
-	src: url('../elemental/fonts/DroidSans.ttf');
-	src: local('DroidSans'), url('../elemental/fonts/DroidSans.ttf') format('truetype');
+	src: url('fonts/DroidSans.ttf');
+	src: local('DroidSans'), url('fonts/DroidSans.ttf') format('truetype');
 }
 body {
-	background: #202020 url(../elemental/images/imgbg.jpg) no-repeat center center fixed;
+	background: #202020 url(images/imgbg.jpg) no-repeat center center fixed;
 	-webkit-background-size: cover;
   	-moz-background-size: cover;
   	-o-background-size: cover;
@@ -357,7 +357,7 @@ body table#mobileitem tr td:first-child{
 	width: calc(98% - 70px) !important;
 	position: relative;
 	background-color: #8e8d8d;
-	background: url('../elemental/images/bg-track.png') repeat top left;
+	background: url('images/bg-track.png') repeat top left;
 	box-shadow: inset 0 1px 5px 0px rgba(0, 0, 0, .5),
     				  0 1px 0 0px rgba(250, 250, 250, .5);
 }


### PR DESCRIPTION
With PR #4942 a bug was introduced with serving certain theme specific assets like fonts, images, etc. due to incorrect processing.

PR #4951 was a temporary fix and this PR reverts those changes with a better solution.

Thx to @dobber81, @michahagg for finding/(temp)fixing/supporting

Should be all good now...