### PR TITLE
update for CCT/RGB device detection 

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2381,8 +2381,7 @@ void MQTT::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			|| (pSensor->bBrightness)
 			);
 		bool bHaveColor = (
-			(pSensor->bColor_mode)
-			|| (pSensor->supported_color_modes.find("xy") != pSensor->supported_color_modes.end())
+			(pSensor->supported_color_modes.find("xy") != pSensor->supported_color_modes.end())
 			|| (pSensor->supported_color_modes.find("rgb") != pSensor->supported_color_modes.end())
 			|| (pSensor->supported_color_modes.find("rgbw") != pSensor->supported_color_modes.end())
 			|| (pSensor->supported_color_modes.find("rgbww") != pSensor->supported_color_modes.end())
@@ -2390,11 +2389,7 @@ void MQTT::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			);
 		bool bHaveColorTemp = (pSensor->supported_color_modes.find("color_temp") != pSensor->supported_color_modes.end());
 
-		if (bHaveColor && bHaveColorTemp)
-		{
-			pSensor->subType = sTypeColor_RGB_CW_WW_Z;
-		}
-		else if (bHaveColor)
+		if (bHaveColor)
 		{
 			if (
 				(pSensor->supported_color_modes.find("xy") != pSensor->supported_color_modes.end())


### PR DESCRIPTION
Changed the Bulb device type assignment section to make it discover RGBCCT and CWWW types correctly.

The ZIGBEE CWWW bulbs I have were detected as RGBWWZ because the config message contains ("color_mode": true), setting pSensor->bColor_mode=true. This made Domoticz think it is RGB capable setting the device to RGBWWZ.
The Milight RGBCCT bulbs were also detected as RGBWWZ as they both have the bHaveColor & bHaveColorTemp true, but won't work with that type.
This patch fixes both for me but needs checking if it doesn't screw up other types.. 

This is the config payload for the zigbee device so you can see what I mean:
 ```
 {
  "availability": [
    {
      "topic": "zigbee2mqtt/bridge/state"
    }
  ],
  "brightness": true,
  "brightness_scale": 254,
  "color_mode": true,
  "command_topic": "zigbee2mqtt/Tafel3/set",
  "device": {
    "identifiers": [
      "zigbee2mqtt_0x00158d0001273a19"
    ],
    "manufacturer": "Paulmann",
    "model": "SmartHome led spot (50064)",
    "name": "Tafel3",
    "sw_version": "Zigbee2MQTT 1.21.1"
  },
  "effect": true,
  "effect_list": [
    "blink",
    "breathe",
    "okay",
    "channel_change",
    "finish_effect",
    "stop_effect"
  ],
  "json_attributes_topic": "zigbee2mqtt/Tafel3",
  "max_mireds": 450,
  "min_mireds": 150,
  "min_mireds": 153,
  "name": "Tafel3",
  "schema": "json",
  "state_topic": "zigbee2mqtt/Tafel3",
  "supported_color_modes": [
    "color_temp"
  ],
  "unique_id": "0x00158d0001273a19_light_zigbee2mqtt"
}
```
