### PR TITLE
Added cover_has_stop_command to MQTT discovery

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2974,13 +2974,14 @@ bool MQTT::SendSwitchCommand(const std::string &DeviceID, const std::string &Dev
 
 		if (command == "On")
 		{
-			level = pSensor->position_open;
-			szValue = pSensor->payload_open;
+			level = pSensor->position_closed;
+			szValue = pSensor->payload_close;
+			
 		}
 		else if (command == "Off")
 		{
-			level = pSensor->position_closed;
-			szValue = pSensor->payload_close;
+			level = pSensor->position_open;
+			szValue = pSensor->payload_open;
 		}
 		else if (command == "Stop")
 		{

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -1295,7 +1295,8 @@ void MQTT::on_auto_discovery_message(const struct mosquitto_message *message)
 		if (!root["set_pos_tpl"].empty())
 			pSensor->set_position_template = root["set_pos_tpl"].asString();
 		CleanValueTemplate(pSensor->set_position_template);
-
+		if (!root["cover_has_stop_command"].empty())
+			pSensor->bCoverHasStopCommand = root["cover_has_stop_command"].asBool();
 		if (!root["brightness_command_topic"].empty())
 			pSensor->brightness_command_topic = root["brightness_command_topic"].asString();
 		else if (!root["bri_cmd_t"].empty())
@@ -2463,7 +2464,10 @@ void MQTT::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		|| (!pSensor->set_position_topic.empty())
 		)
 	{
-		switchType = STYPE_BlindsPercentageWithStop;
+		if (pSensor->bCoverHasStopCommand)
+			switchType = STYPE_BlindsPercentageWithStop;
+		else
+			switchType = STYPE_BlindsPercentage;
 	}
 	else if (pSensor->component_type == "binary_sensor")
 	{

--- a/hardware/MQTT.h
+++ b/hardware/MQTT.h
@@ -21,6 +21,7 @@ class MQTT : public MySensorsBase, mosqdz::mosquittodz
 		std::string state_topic;
 		std::string command_topic;
 		std::string position_topic;
+		bool bCoverHasStopCommand = true;
 		std::string set_position_topic;
 		std::string brightness_command_topic;
 		std::string brightness_state_topic;


### PR DESCRIPTION
Adds a setting "cover_has_stop_command" to the MQTT config topic for blinds. 

If set to "true" a blind with STYPE_BlindsPercentageWithStop will be created, when set to false create a blind  STYPE_BlindsPercentage.

Defaults to "true" in accordance with currenct functionality.

Config json-object example:
{

  "command_topic": "tradfri/65560/blind/set",
  "position_topic": "tradfri/65560/blind",
  "set_position_topic": "tradfri/65560/blind/set",
  "cover_has_stop_command": false,
  "unique_id": "tradfri_65560_blind",
  "device": {
    "identifiers": [
      "tradfri_65560_blind"
    ],
    "manufacturer": "IKEA of Sweden",
    "model": "KADRILJ roller blind",
    "name": "Stuevindu",
    "sw_version": ""
  },
  "name": "Stuevindu"
}