### PR TITLE
MercedesMe: Changed variable type to unit32_t to prevent issues on 32-bit platforms

### DIFF
--- a/hardware/eVehicles/MercApi.h
+++ b/hardware/eVehicles/MercApi.h
@@ -57,7 +57,7 @@ private:
 	std::string m_accesstoken;
 	std::string m_refreshtoken;
 	std::string m_uservar_refreshtoken;
-	uint64_t m_uservar_refreshtoken_idx;
+	uint32_t m_uservar_refreshtoken_idx;
 
 	uint64_t m_carid;
 	uint32_t m_crc;


### PR DESCRIPTION
Fix so RefreshToken is properly stored and retrieved in the UserVariables table on 32-bit platforms (like RaspberryPi)