### PR TITLE
Fix missing thermostat-climate thermostat_command_template

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -1458,6 +1458,8 @@ void MQTT::on_auto_discovery_message(const struct mosquitto_message *message)
 
 		if (!root["temperature_command_topic"].empty())
 			pSensor->temperature_command_topic = root["temperature_command_topic"].asString();
+		if (!root["temperature_command_template"].empty())
+			pSensor->temperature_command_template = root["temperature_command_template"].asString();
 		if (!root["temp_cmd_t"].empty())
 			pSensor->temperature_command_topic = root["temp_cmd_t"].asString();
 		if (!root["temperature_state_topic"].empty())
@@ -3107,20 +3109,21 @@ bool MQTT::SetSetpoint(const std::string &DeviceID, const float Temp)
 	}
 
 	Json::Value root;
-	if (!pSensor->temperature_state_template.empty())
+	std::string szSendValue;
+	if (!pSensor->temperature_command_template.empty())
 	{
-		std::string szKey = GetValueTemplateKey(pSensor->temperature_state_template);
+		std::string szKey = GetValueTemplateKey(pSensor->temperature_command_template);
 		if (!szKey.empty())
 			root[szKey] = Temp;
 		else
 		{
-			Log(LOG_ERROR, "Cover device unhandled brightness_value_template (%s/%s)", DeviceID.c_str(), pSensor->name.c_str());
+			Log(LOG_ERROR, "Climate device unhandled temperature_command_template (%s/%s)", DeviceID.c_str(), pSensor->name.c_str());
 			return false;
 		}
+		szSendValue = JSonToRawString(root);
 	}
 	else
-		root["target_temp"] = Temp;
-	std::string szSendValue = JSonToRawString(root);
+		szSendValue = std_format("%.1f", Temp);
 
 	std::string szTopic = pSensor->state_topic;
 	if (!pSensor->temperature_command_topic.empty())

--- a/hardware/MQTT.h
+++ b/hardware/MQTT.h
@@ -63,6 +63,7 @@ class MQTT : public MySensorsBase, mosqdz::mosquittodz
 		std::string mode_state_template;
 		std::vector<std::string> climate_modes;
 		std::string temperature_command_topic;
+		std::string temperature_command_template;
 		std::string temperature_state_topic;
 		std::string temperature_state_template;
 		std::string temperature_unit = "C";


### PR DESCRIPTION
The existing code was erroneously using temperature_state_template for the setsetpoint response formatting whereas it should use temperature_command_template. For my zwave and zigbee devices, the template is not defined and the response payload should just consist of a single value instead of a json message. Zwavejs seems to accept a json message but zigbee2mqtt does not and errors out. This PR fixes the issue where both now work.