### PR TITLE
Use uint32_t instead of std::string to uniquely reference EnOcean nodes

### DIFF
--- a/hardware/EnOceanEEP.cpp
+++ b/hardware/EnOceanEEP.cpp
@@ -644,35 +644,18 @@ const char *CEnOceanEEP::GetEEPDescription(const int RORG, const int func, const
 	return ">>Unkown EEP... Please report!<<";
 }
 
-uint32_t CEnOceanEEP::GetINodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0)
+uint32_t CEnOceanEEP::GetNodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0)
 {
 	return (uint32_t) ((ID3 << 24) | (ID2 << 16) | (ID1 << 8) | ID0);
 }
 
-uint32_t CEnOceanEEP::GetINodeID(const std::string &nodeID)
+std::string CEnOceanEEP::GetDeviceID(const uint32_t nodeID)
 {
-    std::stringstream s_strid;
-    s_strid << std::hex << std::uppercase << nodeID;
-    uint32_t iNodeID;
-    s_strid >> iNodeID;
-
-	return iNodeID;
-}
-
-std::string CEnOceanEEP::GetNodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0)
-{
-	char szNodeID[10];
-	sprintf(szNodeID, "%02X%02X%02X%02X", ID3, ID2, ID1, ID0);
-	std::string nodeID = szNodeID;
-	return nodeID;
-}
-
-std::string CEnOceanEEP::GetNodeID(const uint32_t iNodeID)
-{
-	char szNodeID[10];
-	sprintf(szNodeID, "%08X", iNodeID);
-	std::string nodeID = szNodeID;
-	return nodeID;
+    // TODO: adapt following code in case devices with less than 4 bytes ID...
+	char szDeviceID[10];
+    sprintf(szDeviceID, (nodeID & 0xF0000000) ? "%08X" :"%07X", nodeID);
+	std::string sDeviceID = szDeviceID;
+	return sDeviceID;
 }
 
 float CEnOceanEEP::GetDeviceValue(const uint32_t rawValue, const uint32_t rangeMin, const uint32_t rangeMax, const float scaleMin, const float scaleMax)

--- a/hardware/EnOceanEEP.h
+++ b/hardware/EnOceanEEP.h
@@ -163,11 +163,9 @@ class CEnOceanEEP
 	const char *GetEEPLabel(const int RORG, const int func, const int type);
 	const char *GetEEPDescription(const int RORG, const int func, const int type);
 
-	uint32_t GetINodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0);
-	uint32_t GetINodeID(const std::string &nodeID);
+	uint32_t GetNodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0);
 
-	std::string GetNodeID(const uint8_t ID3, const uint8_t ID2, const uint8_t ID1, const uint8_t ID0);
-	std::string GetNodeID(const uint32_t iNodeID);
+	std::string GetDeviceID(const uint32_t nodeID);
 
 	float GetDeviceValue(const uint32_t rawValue, const uint32_t rangeMin, const uint32_t rangeMax, const float scaleMin, const float scaleMax);
 };

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -801,10 +801,11 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 		m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 	if (!result.empty())
 	{
-		_eSwitchType switchtype = (_eSwitchType) std::stoul(result[0][0]);
+		_eSwitchType switchtype = static_cast<_eSwitchType>(std::stoul(result[0][0]));
 		if (switchtype == STYPE_Dimmer)
 			bIsDimmer = true;
-		LastLevel = std::stoul(result[0][1]);
+
+		LastLevel = static_cast<uint8_t>(std::stoul(result[0][1]));
 	}
 
 	uint8_t iLevel = tsen->LIGHTING2.level;
@@ -1072,9 +1073,9 @@ bool CEnOceanESP2::ParseData()
 				}
 				return true;
 			}
-			uint16_t Manufacturer = std::stoul(result[0][1]);
-			uint8_t Profile = std::stoul(result[0][2]);
-			uint8_t iType = std::stoul(result[0][3]);
+			uint16_t Manufacturer = static_cast<uint16_t>(std::stoul(result[0][1]));
+			uint8_t Profile = static_cast<uint8_t>(std::stoul(result[0][2]));
+			uint8_t iType = static_cast<uint8_t>(std::stoul(result[0][3]));
 
 			if (Profile == 0x12 && iType == 0x00)
 			{ // A5-12-00, Automated Meter Reading, Counter

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -801,10 +801,10 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 		m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 	if (!result.empty())
 	{
-		_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+		_eSwitchType switchtype = (_eSwitchType) std::stoul(result[0][0]);
 		if (switchtype == STYPE_Dimmer)
 			bIsDimmer = true;
-		LastLevel = (uint8_t)atoi(result[0][1].c_str());
+		LastLevel = std::stoul(result[0][1]);
 	}
 
 	uint8_t iLevel = tsen->LIGHTING2.level;
@@ -1072,9 +1072,9 @@ bool CEnOceanESP2::ParseData()
 				}
 				return true;
 			}
-			int Manufacturer = atoi(result[0][1].c_str());
-			int Profile = atoi(result[0][2].c_str());
-			int iType = atoi(result[0][3].c_str());
+			uint16_t Manufacturer = std::stoul(result[0][1]);
+			uint8_t Profile = std::stoul(result[0][2]);
+			uint8_t iType = std::stoul(result[0][3]);
 
 			if (Profile == 0x12 && iType == 0x00)
 			{ // A5-12-00, Automated Meter Reading, Counter

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -348,12 +348,12 @@ void CEnOceanESP3::LoadNodesFromDatabase()
 	{
 		NodeInfo node;
 
-		node.idx = atoi(sd[0].c_str());
+		node.idx = std::stoul(sd[0]);
 		node.nodeID = std::stoul(sd[1], 0, 16);
-		node.manufacturerID = atoi(sd[2].c_str());
+		node.manufacturerID = std::stoul(sd[2]);
 		node.RORG = 0x00;
-		node.func = (uint8_t)atoi(sd[3].c_str());
-		node.type = (uint8_t)atoi(sd[4].c_str());
+		node.func = std::stoul(sd[3]);
+		node.type = std::stoul(sd[4]);
 		node.generic = true;
 /*
 		Debug(DEBUG_NORM, "LoadNodesFromDatabase: Idx %u Node %08X %sEEP %02X-%02X-%02X (%s) Manufacturer %03X (%s)",
@@ -395,7 +395,7 @@ void CEnOceanESP3::TeachInNode(const uint32_t nodeID, const uint16_t manID, cons
 	{
 		NodeInfo node;
 
-		node.idx = (uint32_t)atoi(result[0][0].c_str());
+		node.idx = std::stoul(result[0][0]);
 		node.nodeID = nodeID;
 		node.manufacturerID = manID;
 		node.RORG = RORG;
@@ -1609,8 +1609,8 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 			m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 		if (!result.empty())
 		{ // Device found in the database
-			switchtype = (_eSwitchType) atoi(result[0][0].c_str());
-			LastLevel = (uint8_t) atoi(result[0][1].c_str());
+			switchtype = (_eSwitchType) std::stoul(result[0][0]);
+			LastLevel = std::stoul(result[0][1]);
 		}
 
 		uint8_t iLevel = tsen->LIGHTING2.level;

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -348,12 +348,12 @@ void CEnOceanESP3::LoadNodesFromDatabase()
 	{
 		NodeInfo node;
 
-		node.idx = std::stoul(sd[0]);
-		node.nodeID = std::stoul(sd[1], 0, 16);
-		node.manufacturerID = std::stoul(sd[2]);
+		node.idx = static_cast<uint32_t>(std::stoul(sd[0]));
+		node.nodeID = static_cast<uint32_t>(std::stoul(sd[1], 0, 16));
+		node.manufacturerID = static_cast<uint16_t>(std::stoul(sd[2]));
 		node.RORG = 0x00;
-		node.func = std::stoul(sd[3]);
-		node.type = std::stoul(sd[4]);
+		node.func = static_cast<uint8_t>(std::stoul(sd[3]));
+		node.type = static_cast<uint8_t>(std::stoul(sd[4]));
 		node.generic = true;
 /*
 		Debug(DEBUG_NORM, "LoadNodesFromDatabase: Idx %u Node %08X %sEEP %02X-%02X-%02X (%s) Manufacturer %03X (%s)",
@@ -395,7 +395,7 @@ void CEnOceanESP3::TeachInNode(const uint32_t nodeID, const uint16_t manID, cons
 	{
 		NodeInfo node;
 
-		node.idx = std::stoul(result[0][0]);
+		node.idx = static_cast<uint32_t>(std::stoul(result[0][0]));
 		node.nodeID = nodeID;
 		node.manufacturerID = manID;
 		node.RORG = RORG;
@@ -1618,8 +1618,8 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 			m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 		if (!result.empty())
 		{ // Device found in the database
-			switchtype = (_eSwitchType) std::stoul(result[0][0]);
-			LastLevel = std::stoul(result[0][1]);
+			switchtype = static_cast<_eSwitchType>(std::stoul(result[0][0]));
+			LastLevel = static_cast<uint32_t>(std::stoul(result[0][1]));
 		}
 
 		uint8_t iLevel = tsen->LIGHTING2.level;

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -1980,7 +1980,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 			else if (dBm < -100)
 				rssi = 0;
 			else
-				rssi = static_cast<int>((dBm + 100) / 5);
+				rssi = static_cast<uint8_t>((dBm + 100) / 5);
 
 			if (dstID == ERP1_BROADCAST_TRANSMISSION)
 				Debug(DEBUG_HARDWARE, "Broadcast RSSI %idBm (%u/11)", dBm, rssi);

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -15,7 +15,7 @@ public:
 	struct NodeInfo
 	{
 		uint32_t idx;
-		std::string nodeID;
+		uint32_t nodeID;
 		uint16_t manufacturerID;
 		uint8_t RORG;
 		uint8_t func;
@@ -28,10 +28,9 @@ public:
 
 	bool WriteToHardware(const char *pdata, unsigned char length) override;
 
-	NodeInfo *GetNodeInfo(const uint32_t iNodeID);
-	NodeInfo *GetNodeInfo(const std::string &nodeID);
+	NodeInfo *GetNodeInfo(const uint32_t nodeID);
 
-	void TeachInNode(const std::string &nodeID, const uint16_t manID, const uint8_t RORG, const uint8_t func, const uint8_t type, const bool generic);
+	void TeachInNode(const uint32_t nodeID, const uint16_t manID, const uint8_t RORG, const uint8_t func, const uint8_t type, const bool generic);
 	void CheckAndUpdateNodeRORG(NodeInfo *pNode, const uint8_t RORG);
 
 	uint32_t m_id_base;
@@ -105,7 +104,7 @@ private:
 	std::mutex m_sendMutex;
 	std::vector<std::string> m_sendqueue;
 
-	std::string m_RPS_teachin_nodeID;
+	uint32_t m_RPS_teachin_nodeID;
 	uint8_t m_RPS_teachin_DATA;
 	uint8_t m_RPS_teachin_STATUS;
 	time_t m_RPS_teachin_timer;


### PR DESCRIPTION
Use uint32_t instead of std::string to uniquely reference EnOcean nodes to :
 - better conform to EnOcean standard (see EnOcean ERP1 v1.2 and EnOcean EEP v3.1),
 - simplify the code,
 - avoid numerous unnecessary conversions.

(Next step should be to update EnoceanSensors table in domoticz database accordingly)

Fix a few things :

- replace atoi by std::stoul, when converting strings to unsigned integers
- replace %d by %u for unsigned integers in safe_query format strings
- improve management of virtual switches
- improve management of RPS telegrams send by VLD nodes
- fix some log/debug messages
