### PR TITLE
unique_ptr conversions

### DIFF
--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -39,10 +39,7 @@ namespace http {
 			keepalive_ = false;
 			write_in_progress = false;
 			connection_type = ConnectionType::connection_http;
-#ifdef WWW_ENABLE_SSL
-			sslsocket_ = nullptr;
-#endif
-			socket_ = new boost::asio::ip::tcp::socket(io_service);
+			socket_ = std::make_unique<boost::asio::ip::tcp::socket>(io_service);
 		}
 
 #ifdef WWW_ENABLE_SSL
@@ -65,7 +62,7 @@ namespace http {
 			write_in_progress = false;
 			connection_type = ConnectionType::connection_http;
 			socket_ = nullptr;
-			sslsocket_ = new ssl_socket(io_service, context);
+			sslsocket_ = std::make_unique<ssl_socket>(io_service, context);
 		}
 #endif
 
@@ -540,10 +537,6 @@ namespace http {
 		connection::~connection()
 		{
 			// free up resources, delete the socket pointers
-			delete socket_;
-#ifdef WWW_ENABLE_SSL
-			delete sslsocket_;
-#endif
 			delete[] send_buffer_;
 		}
 

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -104,7 +104,7 @@ namespace http {
 			void reset_abandoned_timeout();
 
 			/// Socket for the (PLAIN) connection.
-			boost::asio::ip::tcp::socket* socket_;
+			std::unique_ptr<boost::asio::ip::tcp::socket> socket_;
 			//Host EndPoint
 			std::string host_endpoint_address_;
 			std::string host_endpoint_port_;
@@ -157,7 +157,7 @@ namespace http {
 			bool secure_;
 #ifdef WWW_ENABLE_SSL
 			// the SSL socket
-			ssl_socket* sslsocket_;
+			std::unique_ptr<ssl_socket> sslsocket_;
 			void handle_handshake(const boost::system::error_code& error);
 #endif
 

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -43,7 +43,7 @@ namespace http {
 			explicit connection(boost::asio::io_service& io_service,
 				connection_manager& manager, request_handler& handler, int timeout, boost::asio::ssl::context& context);
 #endif
-			~connection();
+			~connection() = default;
 
 			/// Get the socket associated with the connection.
 #ifdef WWW_ENABLE_SSL
@@ -87,7 +87,8 @@ namespace http {
 			bool send_file(const std::string& filename, std::string& attachment_name, reply& rep);
 			std::ifstream sendfile_;
 			void handle_write_file(const boost::system::error_code& e, size_t bytes_transferred);
-			uint8_t* send_buffer_;
+#define FILE_SEND_BUFFER_SIZE 16 * 1024
+			std::unique_ptr<std::array<uint8_t, FILE_SEND_BUFFER_SIZE>> send_buffer_;
 
 			/// Initialize read timeout timer
 			void set_read_timeout();


### PR DESCRIPTION
This is C++14. new can be replaced with make_unique.

Signed-off-by: Rosen Penev <rosenp@gmail.com>