### PR TITLE
Webserver: add getLanguages command

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -375,6 +375,8 @@ namespace http
 			RegisterCommandCode(
 				"getlanguage", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetLanguage(session, req, root); }, true);
 			RegisterCommandCode(
+				"getlanguages", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetLanguages(session, req, root); }, true);
+			RegisterCommandCode(
 				"getthemes", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetThemes(session, req, root); }, true);
 			RegisterCommandCode(
 				"gettitle", [this](auto &&session, auto &&req, auto &&root) { Cmd_GetTitle(session, req, root); }, true);
@@ -903,6 +905,16 @@ namespace http
 				root["title"] = "GetLanguage";
 				root["language"] = sValue;
 			}
+		}
+
+		void CWebServer::Cmd_GetLanguages(WebEmSession &session, const request &req, Json::Value &root)
+		{
+			root["title"] = "GetLanguages";
+			for (auto &lang : guiLanguage)
+			{
+				root["result"][lang.first] = lang.second;
+			}
+			root["status"] = "OK";
 		}
 
 		void CWebServer::Cmd_GetThemes(WebEmSession &session, const request &req, Json::Value &root)

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -105,6 +105,7 @@ private:
 	//Commands
 	void Cmd_RFXComGetFirmwarePercentage(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetLanguage(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetLanguages(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetThemes(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetTitle(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_LoginCheck(WebEmSession & session, const request& req, Json::Value &root);

--- a/test/lighttpd.conf
+++ b/test/lighttpd.conf
@@ -7,7 +7,12 @@
 # sudo ./bin/domoticz -www 8080 -wwwroot www -loglevel debug,error -debuglevel webserver
 #
 # Domoticz will show the (web)requests it handles (should be the json.htm ones only)
-# And you can tail the lighttpd logfile (/tmp/lighttpd.log) to see all other static requests being handled by lighttpd 
+# And you can tail the lighttpd logfile (/tmp/lighttpd.log) to see all other static requests being handled by lighttpd
+#
+# Start this script from your Domoticz home directory with:
+# lighttpd -D -f test/lighttpd.conf
+#
+# Now you can access Domoticz on port 8888 (http://localhost:8888)
 
 server.document-root = "/home/vagrant/domoticz/www/" 
 server.port = 8888
@@ -25,17 +30,25 @@ server.modules = (
         "mod_magnet"
 )
 mimetype.assign = (
-  ".html" => "text/html", 
-  ".txt" => "text/plain",
-  ".css" => "text/css",
-  ".js" => "text/javascript",
+  ".html" => "text/html;charset=UTF-8", 
+  ".txt" => "text/plain;charset=UTF-8",
+  ".css" => "text/css;charset=UTF-8",
+  ".js" => "text/javascript;charset=UTF-8",
   ".jpg" => "image/jpeg",
-  ".png" => "image/png" 
+  ".png" => "image/png",
+  ".json" => "application/json;charset=UTF-8"
 )
 
+# Handle the zipped Javascript files
 $HTTP["url"] =~ ".js" {
   url.rewrite-if-not-file = ( "^\/js\/(.*)\.js$" => "/js/$1.js.gz" )
   magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjs.lua" )
+}
+
+# Handle the zipped language files
+$HTTP["url"] =~ ".json" {
+  url.rewrite-if-not-file = ( "^\/i18n\/(.*)\.json$" => "/i18n/$1.json.gz" )
+  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjson.lua" )
 }
 
 proxy.server = ( "/json.htm" =>

--- a/test/lighttpd_gzippedjson.lua
+++ b/test/lighttpd_gzippedjson.lua
@@ -1,0 +1,4 @@
+if (string.match(lighty.env["physical.path"],".json.gz")) then
+	lighty.header["Content-Type"] = "application/json;charset=UTF-8"
+	lighty.header["Content-Encoding"] = "gzip"
+end


### PR DESCRIPTION
This PR replace the way the combo box for the languages on the Setup screen is populated based on the available languages.

Instead of the current/old method of using a ServerSide Include (#embed tag in the View) where the view is _enriched_ with content from the ServiceSide Include method _DisplayLanguageCombo_ , now the UI uses a new _GetLanguages_ command in the same way as it does for Themes and TimerPlans.

Note for later: The _RegisterIncludeCode_ and the function code for both the Languages and Timerplans can be removed (after this PR is merged) because both are not used anymore (actually the Timerplans include isn't used anymore already).

Reason to do this is to make it possible to fully serve the _static_ content from the current UI from a different webserver without depending on the Domoticz internal webserver. And also possible for other (future?) UI's to do all the settings.