### PR TITLE
Empty payload_stop creates STYPE_BlindsPercentage

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2534,7 +2534,10 @@ void MQTT::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		|| (!pSensor->set_position_topic.empty())
 		)
 	{
-		switchType = STYPE_BlindsPercentageWithStop;
+		if (pSensor->payload_stop.empty())
+			switchType = STYPE_BlindsPercentage;
+		else
+			switchType = STYPE_BlindsPercentageWithStop;
 	}
 	else if (pSensor->component_type == "binary_sensor")
 	{


### PR DESCRIPTION
In accordance with HA, an empty payload_close now creates a STYPE_BlindsPercentage device. If non-empty, or not defined, a STYPE_BlindsPercentageWithStop is created instead.