### PR TITLE
Add running automated tests to GitHub action for PR workflow (and fix buildnr and more)

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           cd ..
-          git clone https://github.com/OpenZWave/open-zwave.git open-zwave-read-only
+          git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
           cd open-zwave-read-only
           make
           sudo make install >> /dev/null 2>&1
@@ -75,7 +75,6 @@ jobs:
           cd $GITHUB_WORKSPACE
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
           make
-          cat appversion.h.txt
 
       # Run automated tests
       - name: test domoticz
@@ -88,14 +87,13 @@ jobs:
         continue-on-error: true
 
       # Upload artifacts
-      - uses: actions/upload-artifact@v2
-        with:
-          name: DomArtifacts-${{ env.BUILDNR }}-${{ env.BRANCH_NAME }}
-          path: |
-            domoticz
-            appversion.h.txt
-            test/
-            www/
-            lib/
-            !**/*.tar.gz
-          retention-days: 7
+      #- uses: actions/upload-artifact@v2
+      #  with:
+      #    name: Domoticz-${{ env.BUILDNR }}-${{ env.BRANCH_NAME }}
+      #    path: |
+      #      domoticz
+      #      appversion.h.txt
+      #      www/
+      #      lib/
+      #      !**/*.tar.gz
+      #    retention-days: 7

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install
           sudo apt-get install make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev
+          sudo apt-get install python3-pytest python3-pytest-bdd
 
       # get CMake
       - name: cmake-compile
@@ -59,3 +60,23 @@ jobs:
           cd $GITHUB_WORKSPACE
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
           make
+
+      # Run automated tests
+      - name: test domoticz
+        run: |
+          cd $GITHUB_WORKSPACE
+          pwd
+          ls -ltrR
+          #./bin/domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz -daemon
+          #pytest-3 -rA --tb=no test/gherkin/
+          #kill -s TERM `cat /var/run/domoticz.pid`
+
+      # Upload artifacts
+      - uses: actions/upload-artifact@v2
+        with:
+          name: my-artifact
+          path: |
+            domoticz/bin/
+            domoticz/test/
+            !domoticz/**/*.tmp
+          retention-days: 7

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -60,23 +60,40 @@ jobs:
           cd $GITHUB_WORKSPACE
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
           make
+          cat appversion.h.txt
 
       # Run automated tests
       - name: test domoticz
         run: |
           cd $GITHUB_WORKSPACE
-          pwd
-          ls -ltrR
-          #./bin/domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz -daemon
-          #pytest-3 -rA --tb=no test/gherkin/
-          #kill -s TERM `cat /var/run/domoticz.pid`
+          ln -s ../test/gherkin/resources/testwebcontent www/test
+          sudo ./domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz.pid -daemon
+          pytest-3 -rA --tb=no test/gherkin/
+          sudo kill -s TERM `sudo cat /var/run/domoticz.pid`
+        continue-on-error: true
+
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }}
 
       # Upload artifacts
       - uses: actions/upload-artifact@v2
         with:
-          name: my-artifact
+          name: DomArtifacts-${{ env.BRANCH_NAME }}-${{ github.sha }}
           path: |
-            domoticz/bin/
-            domoticz/test/
-            !domoticz/**/*.tmp
+            domoticz
+            appversion.h.txt
+            test/
+            www/
+            lib/
+            !**/*.tar.gz
           retention-days: 7

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -32,14 +32,8 @@ jobs:
             echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
             echo "PRNUMBER=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
           fi
-
-      - name: Debug
-        run: |
-          echo "Branchname: ${{ env.BRANCH_NAME }}"
-          echo "PR number: ${{ env.PRNUMBER }}"
-          git branch -a
-          git rev-list HEAD --count
-          git log --oneline
+          buildnr=$(git rev-list HEAD --count)
+          echo "BUILDNR=$(($buildnr + 2107))" >> $GITHUB_ENV
 
       # install dependencies
       - name: dependencies
@@ -96,7 +90,7 @@ jobs:
       # Upload artifacts
       - uses: actions/upload-artifact@v2
         with:
-          name: DomArtifacts-${{ env.BRANCH_NAME }}-${{ env.PRNUMBER }}
+          name: DomArtifacts-${{ env.BUILDNR }}-${{ env.BRANCH_NAME }}
           path: |
             domoticz
             appversion.h.txt

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       # Prepare environment
       - name: prepare environment

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -20,6 +20,25 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
+      # Prepare environment
+      - name: prepare environment
+        run: |
+          if [ "${GITHUB_EVENT_NAME}" == 'pull_request' ]; then
+            echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+            echo "PRNUMBER=$(echo ${GITHUB_EVENT_ISSUE_NUMBER})" >> $GITHUB_ENV
+          else
+            echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+            echo "PRNUMBER=$(echo ${GITHUB_SHA})" >> $GITHUB_ENV
+          fi
+
+      - name: Debug
+        run: |
+          echo "Branchname: ${{ env.BRANCH_NAME }}"
+          echo "PR number: ${{ env.PRNUMBER }}"
+          git branch -a
+          git rev-list HEAD --count
+          git log --oneline
+
       # install dependencies
       - name: dependencies
         run: |
@@ -72,23 +91,10 @@ jobs:
           sudo kill -s TERM `sudo cat /var/run/domoticz.pid`
         continue-on-error: true
 
-      - name: Get branch name (merge)
-        if: github.event_name != 'pull_request'
-        shell: bash
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-
-      - name: Get branch name (pull request)
-        if: github.event_name == 'pull_request'
-        shell: bash
-        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
-
-      - name: Debug
-        run: echo ${{ env.BRANCH_NAME }}
-
       # Upload artifacts
       - uses: actions/upload-artifact@v2
         with:
-          name: DomArtifacts-${{ env.BRANCH_NAME }}-${{ github.sha }}
+          name: DomArtifacts-${{ env.BRANCH_NAME }}-${{ env.PRNUMBER }}
           path: |
             domoticz
             appversion.h.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ ENDIF()
 #
 #
 
+MESSAGE("Working from source dir .${CMAKE_SOURCE_DIR}.")
+
 MACRO(History_GET_REVISION variable)
   IF(EXISTS ${CMAKE_SOURCE_DIR}/History.txt)
     MESSAGE(STATUS "Read ProjectRevision from History.txt")
@@ -87,21 +89,24 @@ MACRO(History_GET_REVISION variable)
 ENDMACRO(History_GET_REVISION)
 
 MACRO(Gitversion_GET_REVISION dir variable)
+  MESSAGE("Executing Gitversion_GET_REVISION Macro (${GIT_EXECUTABLE})")
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} --git-dir ./.git rev-list HEAD --count
     WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    ECHO_OUTPUT_VARIABLE)
 ENDMACRO(Gitversion_GET_REVISION)
 
 find_package(Git QUIET)
 
 Gitversion_GET_REVISION("${CMAKE_SOURCE_DIR}" ProjectRevision)
+MESSAGE("ProjectRevision from Macro ${ProjectRevision}")
 IF(NOT ProjectRevision)
   MESSAGE(STATUS "Failed to get ProjectRevision from git")
   History_GET_REVISION(ProjectRevision)
 ELSE(NOT ProjectRevision)
   MATH(EXPR ProjectRevision "${ProjectRevision}+2107")
 ENDIF(NOT ProjectRevision)
+MESSAGE("ProjectRevision set to ${ProjectRevision}")
 
 ### SUBMODULE / BUNDLED SOFTWARE
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,8 +70,6 @@ ENDIF()
 #
 #
 
-MESSAGE("Working from source dir .${CMAKE_SOURCE_DIR}.")
-
 MACRO(History_GET_REVISION variable)
   IF(EXISTS ${CMAKE_SOURCE_DIR}/History.txt)
     MESSAGE(STATUS "Read ProjectRevision from History.txt")
@@ -89,24 +87,21 @@ MACRO(History_GET_REVISION variable)
 ENDMACRO(History_GET_REVISION)
 
 MACRO(Gitversion_GET_REVISION dir variable)
-  MESSAGE("Executing Gitversion_GET_REVISION Macro (${GIT_EXECUTABLE})")
   EXECUTE_PROCESS(COMMAND ${GIT_EXECUTABLE} --git-dir ./.git rev-list HEAD --count
     WORKING_DIRECTORY ${dir}
     OUTPUT_VARIABLE ${variable}
-    ECHO_OUTPUT_VARIABLE)
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
 ENDMACRO(Gitversion_GET_REVISION)
 
 find_package(Git QUIET)
 
 Gitversion_GET_REVISION("${CMAKE_SOURCE_DIR}" ProjectRevision)
-MESSAGE("ProjectRevision from Macro ${ProjectRevision}")
 IF(NOT ProjectRevision)
   MESSAGE(STATUS "Failed to get ProjectRevision from git")
   History_GET_REVISION(ProjectRevision)
 ELSE(NOT ProjectRevision)
   MATH(EXPR ProjectRevision "${ProjectRevision}+2107")
 ENDIF(NOT ProjectRevision)
-MESSAGE("ProjectRevision set to ${ProjectRevision}")
 
 ### SUBMODULE / BUNDLED SOFTWARE
 #

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,15 @@
-This folder is used to introduce unit testing.
+# Domoticz (automated) testing
 
-A start is made with the 'www' part of Domoticz. The 'www-test' 
-folder contains tests for components in www. As the components in 
-www are written in JavaScript, so are the tests. See the README.md in 
-www-test for details.
+This folder is used for everything around (automated) testing of Domoticz.
+
+## Functional testing
+
+Some functional testing is done by using BDD/Gherkin style tests. See the [README.md](gherkin/README.md) in the _gherkin_ folder for more information.
+
+## Unit testing
+
+A start is made with the 'www' part of Domoticz. The 'www-test' folder contains tests for components in the _www_-folder. As the components in this folder are written in JavaScript, so are the tests. See the [README.md](www-test/README.md) in the _www-test_ folder for details.
+
+## Test automation
+
+For both Unit testing as Functional testing, there is some test automation using `mocha` and `pytest-3` (using BDD plugin).


### PR DESCRIPTION
This PR extends the GitHub action for _pull_requests_ with:

- Setting up some environment variables
- Make sure to fetch full GIT history to be able to create the proper BUILD number (was wrong)
- Runs the available automated Functional tests (added with PR 4962)
  - Currently does __NOT _fail___ when not all tests succeed (but they should)
  - Other automated tests (UI and dzVents) are not yet added (on to-do list)
- Creates an _Artifact_ of the build that can be downloaded
  - Could be used for example with Docker so without the need to compile, people can create a Docker container running a PR specific build.
  - This would allow people to start testing a PR build _before_ it is merged into development/Beta
  - To-do: create an example Docker file on how to use these PR builds
  - PR build artifacts are only stored for a period of _7 Days_
 
See [here](https://github.com/kiddigital/domoticz/actions/runs/1402535308) for the output of a run.

_I suggest to make it mandatory that all tests succeed in the near future forcing developers to act on failed tests._
