### PR TITLE
Deployment workflow: Use Domoticz fork of OpenZwave for compilation

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           cd ..
-          git clone https://github.com/OpenZWave/open-zwave.git open-zwave-read-only
+          git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
           cd open-zwave-read-only
           make
           sudo make install >> /dev/null 2>&1


### PR DESCRIPTION
Deployment workflow should use Domoticz fork of OpenZWave instead of OpenZWave repo.