### PR TITLE
Fix for brightness_topic payload.

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -3088,14 +3088,17 @@ bool MQTT::SendSwitchCommand(const std::string &DeviceID, const std::string &Dev
 			|| (command == "Off"))
 		{
 			if (
-				(pSensor->command_topic.find("zwave/") == 0)&&
-				(!pSensor->brightness_command_topic.empty()))
+				!pSensor->brightness_command_topic.empty())
 			{
 				if (!pSensor->brightness_value_template.empty())
 				{
 					std::string szKey = GetValueTemplateKey(pSensor->brightness_value_template);
-					if (!szKey.empty())
-						root[szKey] = (command == "On") ? 255 : 0;
+					if (!szKey.empty() && szKey == "value")
+						// just send the plain percentage as HA does for value in template
+						root = (command == "On") ? (int)pSensor->brightness_scale : 0;
+					else if(!szKey.empty())
+						// in case another key was requested
+						root[szKey] = (command == "On") ? (int)pSensor->brightness_scale : 0;
 					else
 					{
 						Log(LOG_ERROR, "light device unhandled brightness_value_template (%s/%s)", DeviceID.c_str(), DeviceName.c_str());
@@ -3103,7 +3106,7 @@ bool MQTT::SendSwitchCommand(const std::string &DeviceID, const std::string &Dev
 					}
 				}
 				else
-					root["brightness"] = (command == "On") ? 255 : 0;
+					root["brightness"] = (command == "On") ? (int)pSensor->brightness_scale : 0;
 			}
 			else
 			{
@@ -3123,7 +3126,12 @@ bool MQTT::SendSwitchCommand(const std::string &DeviceID, const std::string &Dev
 			if (!pSensor->brightness_value_template.empty())
 			{
 				std::string szKey = GetValueTemplateKey(pSensor->brightness_value_template);
-				if (!szKey.empty())
+
+				if (!szKey.empty() && szKey == "value")
+					// just send the plain percentage as HA does for value in template
+					root = slevel;
+				else if (!szKey.empty())
+					// in case another key was requested
 					root[szKey] = slevel;
 				else
 				{


### PR DESCRIPTION
This change will just set the payload for configs with a brightness_command_topic & brightness_value_template defined:
On will just set the payload to brightness_scale when the template is "value" else the found "keyword": brightness_scale .
Off will just set the payload to 0 when the template is "value" else the found "keyword": 0.
Set Level will just set the payload to sLevel when the template is "value" else the found "keyword": sLevel.
 