### PR TITLE
The Things Network (TTN): Switch to new V3 stack

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -121,6 +121,20 @@ bool CTTNMQTT::StartHardware()
 		}
 	}
 
+	// Check if there is a Certificate file given to use for TLS encryption
+	std::vector<std::string> strarray;
+	StringSplit(m_CAFilename, ";", strarray);
+
+	if (strarray.size() == 3 || strarray.size() == 4)
+	{
+		m_CAFilename = strarray[0];
+	}
+	else
+	{
+		Log(LOG_STATUS, "Unexpected parameters given! Unable to determine CA Certificate filename (%s)", m_CAFilename.c_str());
+		m_CAFilename = "";
+	}
+
 	//force connect the next first time
 	m_IsConnected = false;
 
@@ -225,7 +239,7 @@ bool CTTNMQTT::ConnectIntEx()
 			Log(LOG_ERROR, "Failed enabling TLS mode, return code: %d (CA certificate: '%s')", rc, m_CAFilename.c_str());
 			return false;
 		}
-		Log(LOG_STATUS, "Enabled TLS mode");
+		Log(LOG_STATUS, "Enabled TLS mode (CA certificate: '%s')", m_CAFilename.c_str());
 	}
 	rc = username_pw_set((!m_UserName.empty()) ? m_UserName.c_str() : nullptr, (!m_Password.empty()) ? m_Password.c_str() : nullptr);
 

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -1098,7 +1098,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 		if(iGps == 1 || !(devlat == 0 || devlon == 0))
 		{
 			uint64_t nSsrDistance = static_cast<int>(std::rint(1000 * distanceEarth(m_DomLat, m_DomLon, ssrlat, ssrlon)));
-			SendCustomSensor(DeviceID, (iGpsChannel + 64), BatteryLevel, (float)nSsrDistance, DeviceName + " Home Distance", "meters", rssi);
+			SendDistanceSensor(DeviceID, (iGpsChannel + 64), BatteryLevel, (float)nSsrDistance*100, DeviceName + " Home Distance", rssi);
 			Debug(DEBUG_RECEIVED, "Distance between Sensordevice and Domoticz Home is %f meters!", (double)nSsrDistance);
 		}
 
@@ -1114,7 +1114,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 			else if (!(ssrlat == 0 && ssrlon == 0))
 			{
 				uint64_t nGwDistance = static_cast<int>(std::rint(1000 * distanceEarth(gwlat, gwlon, ssrlat, ssrlon)));
-				SendCustomSensor(DeviceID, (channel + 128), BatteryLevel, (float)nGwDistance, DeviceName + " Gateway Distance", "meters", rssi);
+				SendDistanceSensor(DeviceID, (channel + 128), BatteryLevel, (float)nGwDistance*100, DeviceName + " Gateway Distance", rssi);
 				Debug(DEBUG_RECEIVED, "Distance between Sensordevice and gateway is %f meters!", (double)nGwDistance);
 			}
 		}

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -508,12 +508,12 @@ bool CTTNMQTT::ConvertFields2Payload(const Json::Value &fields, Json::Value &pay
 
 	if (!fields.empty())
 	{
-		Debug(DEBUG_NORM, "Processing fields payload for %d fields!", fields.size());
+		Debug(DEBUG_RECEIVED, "Processing fields payload for %d fields!", fields.size());
 		for (const auto &id : fields.getMemberNames())
 		{
 			if (!(fields[id].isNull()) && ConvertField2Payload(id, fields[id].asString(), index + 1, index, payload))
 			{
-				Debug(DEBUG_NORM, "Converted field %s !", id.c_str());
+				Debug(DEBUG_RECEIVED, "Converted field %s !", id.c_str());
 				index++;
 				ret = true;
 			}
@@ -745,7 +745,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 					if (!MetaData[iGW].empty())
 					{
 						Json::Value Gateway = MetaData[iGW];
-Debug(DEBUG_HARDWARE, "Gateway (%s)", Gateway.toStyledString().c_str());
+
 						int lrssi = Gateway["rssi"].asInt();
 						float lsnr = Gateway["snr"].asFloat();
 						bool bBetter = false;
@@ -831,7 +831,7 @@ Debug(DEBUG_HARDWARE, "Gateway (%s)", Gateway.toStyledString().c_str());
 				rssi = CalcDomoticsRssiFromLora(gwrssi, gwsnr);
 			}
 		}
-Debug(DEBUG_HARDWARE, "Payload (%s)", payload.toStyledString().c_str());
+
 		// Walk over the payload to find all used channels. Each channel represents a single sensor.
 		uint8_t chanSensors [65] = {};	// CayenneLPP Data Channel ranges from 0 to 64
 		for (const auto &p : payload)

--- a/hardware/TTNMQTT.h
+++ b/hardware/TTNMQTT.h
@@ -59,7 +59,7 @@ class CTTNMQTT : public MySensorsBase, mosqdz::mosquittodz
 	bool ConnectInt();
 	bool ConnectIntEx();
 	Json::Value GetSensorWithChannel(const Json::Value &root, uint8_t sChannel);
-	std::string FindAlias(const std::string orgString);
+	bool IsSensorTypeOrAlias(const std::string orgString, const std::string sType);
 	void FlagSensorWithChannelUsed(Json::Value &root, const std::string &stype, uint8_t sChannel);
 	bool ConvertField2Payload(const std::string &sType, const std::string &sValue, uint8_t channel, uint8_t index, Json::Value &payload);
 	bool ConvertFields2Payload(const Json::Value &fields, Json::Value &payload);

--- a/hardware/TTNMQTT.h
+++ b/hardware/TTNMQTT.h
@@ -43,6 +43,7 @@ class CTTNMQTT : public MySensorsBase, mosqdz::mosquittodz
 	std::shared_ptr<std::thread> m_thread;
 	double m_DomLat;
 	double m_DomLon;
+	std::string m_AliassesFile;
 
 	bool StartHardware() override;
 	bool StopHardware() override;
@@ -53,10 +54,12 @@ class CTTNMQTT : public MySensorsBase, mosqdz::mosquittodz
 
       private:
 	std::map<std::string, CBaroForecastCalculator> m_forecast_calculators;
+	Json::Value m_Aliasses;
 
 	bool ConnectInt();
 	bool ConnectIntEx();
 	Json::Value GetSensorWithChannel(const Json::Value &root, uint8_t sChannel);
+	std::string FindAlias(const std::string orgString);
 	void FlagSensorWithChannelUsed(Json::Value &root, const std::string &stype, uint8_t sChannel);
 	bool ConvertField2Payload(const std::string &sType, const std::string &sValue, uint8_t channel, uint8_t index, Json::Value &payload);
 	bool ConvertFields2Payload(const Json::Value &fields, Json::Value &payload);

--- a/ttnmqtt_aliasses.json
+++ b/ttnmqtt_aliasses.json
@@ -1,0 +1,22 @@
+{
+  "temp": [
+    "temperature",
+    "ambient_temperature"
+  ],
+  "humidity": [
+    "hum"
+  ],
+  "baro": [
+    "barometer"
+  ],
+  "batterylevel": [
+    "battery_level"
+  ],
+  "gps": [],
+  "luminosity": [],
+  "presense": [],
+  "analog_input": [],
+  "analog_output": [],
+  "digital_output": [],
+  "digital_input": []
+}


### PR DESCRIPTION
This PR makes the TTNMQTT hardware module compatible with the new Community Edition (v3) of The Things Network.

It is only handling v3 as v2 will be turned off per 1st December 2021 (very soon).

The amount of LoRa devices I have been able to test it with is very limited, _so please test it with your devices_.

It should work (as it did before) for devices that use the [Chayenne LPP](https://www.thethingsindustries.com/docs/integrations/payload-formatters/cayenne/) encoded payloads.

You can use custom encoders and the module will try to determine if it recognizes measurements. As the module looks for certain names of the measurements, it is now also possible to specify aliasses for these measurement names using an aliasses file in JSON format (see `ttnmqtt_aliasses.json`). Most LoRa products that are registered with TTN (see [GitHub repo](https://github.com/TheThingsNetwork/lorawan-devices) have default custom en/decoders. But they all might use different names for the sensor reading, so now you can specify if these names should be interpreted as aliasses for another name that this module recognizes.

