### PR TITLE
Be (slightly) more robust in the face of malformed http response

### DIFF
--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -689,7 +689,12 @@ namespace Plugins {
 					if (PyDict_SetItemString(DataDict, "Verb", pObj) == -1)
 						_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", "HTTP", "Verb", sVerb.c_str());
 
-					std::string		sURL = sFirstLine.substr(sVerb.length() + 1, sFirstLine.find_first_of(' ', sVerb.length() + 1));
+					// Beware - the request may be malformed; so make sure there is more data to process before trying to parse it out
+					std::string sURL;
+					if (sFirstLine.length() > sVerb.length())
+					{
+					        sURL = sFirstLine.substr(sVerb.length() + 1, sFirstLine.find_first_of(' ', sVerb.length() + 1));
+					}
 					PyNewRef pURL = Py_BuildValue("s", sURL.c_str());
 					if (PyDict_SetItemString(DataDict, "URL", pURL) == -1)
 						_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", "HTTP", "URL", sURL.c_str());


### PR DESCRIPTION
See issue #5013

Python plugin using the HTTP protocol can cause the framework to crash if the HTTP response is badly formed.  Eg a recent update to third party Drayton Wiser API now causes it to return a badly-formed HTTP response; specifically, the response uses chunked encoding, and has two terminator chunks. I.e. it ends like this
0\r\n
\r\n
0\r\n <--- This and the next line should not be here.
\r\n

This causes the framework to crash. It processes the "real" message correctly, consuming all the data up to and including the proper terminator chunk.  However, the second chunk is left in the buffer, and gets processed as if it was the start of the next message.  The code assumes that the transaction either starts with a valid HTTP response line (HTTP/1.1 200 OK) or valid HTTP request (GET / HTTP/1.1).  Since it doesn't start with the string "HTTP" it processes it as if it was a request.  When it tries to extract the URL it crashes because it looks beyond the end of the string for a URL which isn't there.

Whilst the bug is clearly in the API rather than domoticz, the framework should nevertheless be more resilient to badly-formed data since it can't control it. This patch goes some way towards addressing that.  Ideally it would just throw away the extraneous data altogether, but I can't see an easy way to do that, so instead it "safely" parses the invalid data and passes it on to the plugin to deal with.  I.e. in this case the plugin will receive a message with
Verb: 0
URL: <empty string>
No headers
No payload

The plugin is unlikely to be expecting this either, but is better placed to decide what to do with it than the framework (given that the invalid response could be absolutely anything, it just so happens in this case it is a terminator chunk).
