### PR TITLE
Fix "Set Level xx" not working for the new "BlindsPercentageWithStop"

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3989,7 +3989,11 @@ int CEventSystem::calculateDimLevel(int deviceID, int percentageLevel)
 
 		if (maxDimLevel != 0)
 		{
-			if ((switchtype == STYPE_Dimmer) || (switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageInverted))
+			if (
+				(switchtype == STYPE_Dimmer)
+				|| (switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageInverted)
+				|| (switchtype == STYPE_BlindsPercentageWithStop) || (switchtype == STYPE_BlindsPercentageInvertedWithStop)
+				)
 			{
 				float fLevel = (maxDimLevel / 100.0F) * percentageLevel;
 				if (fLevel > 100)


### PR DESCRIPTION
Fix "Set Level xx" not working for the new "BlindsPercentageWithStop" and "BlindsPercentageInvertedWithStop" devicetypes.