### PR TITLE
Add dzVents automated unit-tests to GitLab action for PR's

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -86,6 +86,7 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/dzVents/runtime/tests
           busted --coverage -o TAP *
+          luacov
           tail -19 luacov.report.out
         continue-on-error: true
 

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -25,6 +25,7 @@ jobs:
       # Prepare environment
       - name: prepare environment
         run: |
+          timedatectl set-timezone Europe/Amsterdam
           if [ "${GITHUB_EVENT_NAME}" == 'pull_request' ]; then
             echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
             echo "PRNUMBER=$(echo ${GITHUB_EVENT_ISSUE_NUMBER})" >> $GITHUB_ENV
@@ -38,7 +39,7 @@ jobs:
       # install dependencies
       - name: dependencies
         run: |
-          sudo apt-get update && sudo apt-get install
+          sudo apt-get update && sudo apt-get --autoremove upgrade
           sudo apt-get install make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev
           sudo apt-get install python3-pytest python3-pytest-bdd
           sudo apt-get install lua5.3 luarocks

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -41,6 +41,10 @@ jobs:
           sudo apt-get update && sudo apt-get install
           sudo apt-get install make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev
           sudo apt-get install python3-pytest python3-pytest-bdd
+          sudo apt-get install lua5.3 luarocks
+          sudo luarocks install busted
+          sudo luarocks install luacov
+          sudo luarocks install lodash
 
       # get CMake
       - name: cmake-compile
@@ -77,7 +81,14 @@ jobs:
           make
 
       # Run automated tests
-      - name: test domoticz
+      - name: unit-tests domoticz-dzVents
+        run: |
+          cd $GITHUB_WORKSPACE/dzVents/runtime/tests
+          busted --coverage -o TAP *
+          tail -19 luacov.report.out
+        continue-on-error: true
+
+      - name: functional-tests domoticz
         run: |
           cd $GITHUB_WORKSPACE
           ln -s ../test/gherkin/resources/testwebcontent www/test

--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -25,7 +25,7 @@ jobs:
       # Prepare environment
       - name: prepare environment
         run: |
-          timedatectl set-timezone Europe/Amsterdam
+          sudo timedatectl set-timezone Europe/Amsterdam
           if [ "${GITHUB_EVENT_NAME}" == 'pull_request' ]; then
             echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
             echo "PRNUMBER=$(echo ${GITHUB_EVENT_ISSUE_NUMBER})" >> $GITHUB_ENV

--- a/test/README.md
+++ b/test/README.md
@@ -8,8 +8,10 @@ Some functional testing is done by using BDD/Gherkin style tests. See the [READM
 
 ## Unit testing
 
+For _dzVents_ quite some unit-tests are available (_code-coverage above 80%_) testing many aspects of 'dzVents' ensuring that functionality does not change or break when changes are made.
+
 A start is made with the 'www' part of Domoticz. The 'www-test' folder contains tests for components in the _www_-folder. As the components in this folder are written in JavaScript, so are the tests. See the [README.md](www-test/README.md) in the _www-test_ folder for details.
 
 ## Test automation
 
-For both Unit testing as Functional testing, there is some test automation using `mocha` and `pytest-3` (using BDD plugin).
+For both Unit testing as Functional testing, there is some test automation using `mocha` (javascript), `busted` (Lua) and `pytest-3` (Python and using BDD plugin).

--- a/test/www-test/README.md
+++ b/test/www-test/README.md
@@ -1,18 +1,23 @@
 # WWW Unit tests
+
 This folder contains the unit tests for components in www.
 
 _Be warned! This is a work in progres._
 
-# Tooling
-## mocha
+## Tooling
+
+### mocha
+
 A tool called 'mocha' is used to drive the tests. The tests are written
 specifically to be used with mocha. See: https://mochajs.org/
 
 It is not written in stone that mocha be used for unit testing. A different
 framework can be used for different kind of tests.
 
-# Setup
-## Installation
+## Setup
+
+### Installation
+
 As the www-components are written in JavaScript, we need a JavaScript 
 engine to run on. For example, Node.js. See https://nodejs.org/en/. Make
 sure you have Node.js installed. Node.js comes with npm, which is the 
@@ -24,15 +29,18 @@ what it says basically is:
 
 `npm install --global mocha`
 
-# Usage
-## Structure
+## Usage
+
+### Structure
+
 main.js - contains the requirejs module configuration. It should register
 all the modules that the components under test use.  
 _path/component.js_ - the files containing the tests should be in the
 same folder structure as the components under test are,
 relative to the 'www' folder.
 
-## Running the test
+### Running the test
+
 Run the tests in a specific file with:
 
 `mocha _path_/test.js`
@@ -58,4 +66,3 @@ It should display something like this:
 
 If the test runs fine, only the test output is displayed.
 If an error occurs, mocha will show the error and complete stacktrace.
- 


### PR DESCRIPTION
This PR's extends the pull_request gitlab action to also run the dzVents unit-tests (next to the Domoticz functional tests)

Add the moment, when the tests fail, the job still continues, but in the future it should fail the job.