### PR TITLE
TTNMQTT: Fix for empty frm_payload

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -698,7 +698,6 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 		std::string AppSerial = endDeviceIds["join_eui"].asString();
 		std::string AppId = applicationIds["application_id"].asString();
 		uint8_t MessagePort = uplinkMessage["f_port"].asInt();
-		std::string lpp = base64_decode(uplinkMessage["frm_payload"].asString());
 
 		//Check if the payload_raw contains valid CayenneLPP structured data
 		//TO-DO: The current CayenneLPP Decoder assumes Dynamic Sensor Payload structure and not other possible Sensor payload structures like Packed
@@ -722,9 +721,12 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 				break;
 			case 1:
 			default:
-				if(CayenneLPPDec::ParseLPP((const uint8_t*)lpp.c_str(), lpp.size(), payload))
-				{
-					Decoded = true;
+				if (!uplinkMessage["frm_payload"].empty()) {
+					std::string lpp = base64_decode(uplinkMessage["frm_payload"].asString());
+					if(CayenneLPPDec::ParseLPP((const uint8_t*)lpp.c_str(), lpp.size(), payload))
+					{
+						Decoded = true;
+					}
 				}
 		}
 

--- a/ttnmqtt_aliasses.json
+++ b/ttnmqtt_aliasses.json
@@ -18,5 +18,8 @@
   "analog_input": [],
   "analog_output": [],
   "digital_output": [],
-  "digital_input": []
+  "digital_input": [],
+  "accel": [],
+  "gyro": [],
+  "unixtime": []
 }


### PR DESCRIPTION
It cannot be assumed that frm_payload is always there.

When using non LLP structured data from sensor and custom encoders to create a JSON payload, the frm_payload will not be present, only the 'decoded_payload'.

This PR removes the assumptions and properly checks the payload existence.
