### PR TITLE
TTNMQTT: Some decoded payload values might be objects. Handle it better.

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -70,15 +70,6 @@ CTTNMQTT::CTTNMQTT(const int ID, const std::string &IPAddress, const unsigned sh
 
 	m_AliassesFile = TTNMQTT_ALIASSES_FILE;
 
-#ifdef DEBUG_TTN_R
-	std::string sResult = ReadFile("ttn_mqtt_stringfields.json");
-	mosquitto_message mqtt_msg;
-	mqtt_msg.topic = "ttnmqtt/devices/tektelic_khs/up";
-	mqtt_msg.payload = (void*)sResult.c_str();
-	mqtt_msg.payloadlen = sResult.size();
-	on_message(&mqtt_msg);
-#endif
-
 	mosqdz::lib_init();
 }
 
@@ -167,6 +158,15 @@ bool CTTNMQTT::StartHardware()
 			Log(LOG_STATUS, "Could not find or open aliasses file (%s)", m_AliassesFile.c_str());
 		}
 	}
+
+#ifdef DEBUG_TTN_R
+	std::string sResult = ReadFile("ttn_mqtt_stringfields.json");
+	mosquitto_message mqtt_msg;
+	mqtt_msg.topic = "v3/testuser/devices/tektelic_khs/up";
+	mqtt_msg.payload = (void*)sResult.c_str();
+	mqtt_msg.payloadlen = sResult.size();
+	on_message(&mqtt_msg);
+#endif
 
 	//force connect the next first time
 	m_IsConnected = false;
@@ -589,7 +589,7 @@ bool CTTNMQTT::ConvertFields2Payload(const Json::Value &fields, Json::Value &pay
 		Debug(DEBUG_RECEIVED, "Processing fields payload for %d fields!", fields.size());
 		for (const auto &id : fields.getMemberNames())
 		{
-			if (!(fields[id].isNull()) && ConvertField2Payload(id, fields[id].asString(), index + 1, index, payload))
+			if (!(fields[id].isNull()) && !(fields[id].isObject()) && ConvertField2Payload(id, fields[id].asString(), index + 1, index, payload))
 			{
 				Debug(DEBUG_RECEIVED, "Converted field %s !", id.c_str());
 				index++;


### PR DESCRIPTION
Small fix to handle some (pre-)decoded payloads better.

Depending on the decoder, some decoded payload values are objects and not real values. These are now handled (ignored) and prevents the processing to be aborted.

Thanks to @jeroenkl for providing some real data examples.