### PR TITLE
Scenes/Groups: Fix sending color_temp & RGB info for MQTT devices

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -3337,6 +3337,10 @@ bool MQTT::SendSwitchCommand(const std::string &DeviceID, const std::string &Dev
 	{
 		Json::Value root;
 
+		// Change Set Level to Set Color to send color_temp && color info in payload
+		if (command == "Set Level" && color.mode != ColorModeNone)
+			command = "Set Color";
+
 		if (
 			(command == "On")
 			|| (command == "Off"))


### PR DESCRIPTION
Groups/Scenes are not sending the set color_temp and/or RGB color settings for the Group/Scene since the command is "Set Level". Added logic to mqtt to change "Set Level" to "Set Color" for ColorMode lights.