### PR TITLE
Setpoint selector bottom limit removal

### DIFF
--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -581,7 +581,7 @@ std::string CBasePush::ProcessSendValue(const uint64_t DeviceRowIdx, const std::
 				sprintf(szData, "%g", vis * 0.3937007874015748F);
 			}
 		}
-		else if (vType == "Status")
+		else if ((vType == "Status") || (vType == "Alert"))
 		{
 			sprintf(szData, "%d", nValue);
 		}
@@ -604,7 +604,7 @@ std::string CBasePush::ProcessSendValue(const uint64_t DeviceRowIdx, const std::
 
 			sprintf(szData, "%d", level);
 		}
-		else if ((vType == "Current 1") || (vType == "Current 2") || (vType == "Current 3"))
+		else if ((vType == "Current") || (vType == "Current 1") || (vType == "Current 2") || (vType == "Current 3"))
 		{
 			strcpy(szData, rawsendValue.c_str());
 		}
@@ -790,11 +790,11 @@ std::string CBasePush::getUnit(const int devType, const int devSubType, const in
 	{
 		strcpy(szData, "dB");
 	}
-	else if (vType == "Status")
+	else if ((vType == "Status") || (vType == "Alert"))
 	{
 		strcpy(szData, "");
 	}
-	else if ((vType == "Current 1") || (vType == "Current 2") || (vType == "Current 3"))
+	else if ((vType == "Current") || (vType == "Current 1") || (vType == "Current 2") || (vType == "Current 3"))
 	{
 		strcpy(szData, "");
 	}

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -5913,9 +5913,6 @@ function SetpointDown() {
 	var curValue = parseFloat($('#setpoint_popup #popup_setpoint').val());
 	curValue -= 0.5;
 	curValue = Math.round(curValue / 0.5) * 0.5;
-	if (curValue < 0) {
-		curValue = 0;
-	}
 	var curValueStr = curValue.toFixed(1);
 	$('#setpoint_popup #popup_setpoint').val(curValueStr);
 }


### PR DESCRIPTION
Following issue #4055

I've created pull request to remove bottom limit for Thermostat object.

Please correct me if I'm doing something incorrectly but there is this line in [CONTRIBUTING.md](https://github.com/domoticz/domoticz/blob/0d7c380825dbd76567d3b1e487bc6ce8788aa33e/.github/CONTRIBUTING.md)

> All changes should be based against the master branch, unless advised by a Maintainer to use a different branch.

And I'm not sure if I correctly PR against **development** and not **master**, as it clearly stated in the linked file.

This activity shall have two steps:

- [x] Remove bottom limit to allow negative values on thermostat
- [ ] Update thermostat device TBD
 - implement set top, bottom and none - limits
 - set step size
 - long press buttons operations (incrementing/decrementing value) or swiping
 - back to default value


