### PR TITLE
Fix jpeg inline attachment handling for K9 mail

### DIFF
--- a/smtpclient/SMTPClient.cpp
+++ b/smtpclient/SMTPClient.cpp
@@ -333,7 +333,7 @@ std::string SMTPClient::MakeMessage()
 					ret += "Content-Type: image/gif;\r\n";
 				}
 				else if (typ == ".jpg" || typ == "jpeg") { // j-peg format presumably
-					ret += "Content-Type: image/jpg;\r\n";
+					ret += "Content-Type: image/jpeg;\r\n";
 				}
 				else if (typ == ".txt") { // text format presumably
 					ret += "Content-Type: plain/txt;\r\n";


### PR DESCRIPTION
Incorrect Mime type causes K9 mail to show image as an unknown attachment, instead of showing the picture inline.