### PR TITLE
Add new fields to domoticz.db to better manage EnOcean nodes + minor fixes + indent

### DIFF
--- a/hardware/EnOceanEEP.cpp
+++ b/hardware/EnOceanEEP.cpp
@@ -683,63 +683,63 @@ float CEnOceanEEP::GetDeviceValue(const uint32_t rawValue, const uint32_t rangeM
 //convert device ID id from  buffer[] to unsigned int
 unsigned int DeviceArrayToInt(unsigned char m_buffer[])
 {
-	unsigned int id = (m_buffer[0] << 24) + (m_buffer[1] << 16) + (m_buffer[2] << 8) + m_buffer[3];
-	return id;
+    unsigned int id = (m_buffer[0] << 24) + (m_buffer[1] << 16) + (m_buffer[2] << 8) + m_buffer[3];
+    return id;
 }
-//convert device ID id from   unsigned int to buffer[]  
-void  DeviceIntToArray(unsigned int sID, unsigned char buf[])
+//convert device ID id from   unsigned int to buffer[]
+void DeviceIntToArray(unsigned int sID, unsigned char buf[])
 {
 
-	buf[0] = (sID >> 24) & 0xff;
-	buf[1] = (sID >> 16) & 0xff;
-	buf[2] = (sID >> 8) & 0xff;
-	buf[3] = sID & 0xff;
+    buf[0] = (sID >> 24) & 0xff;
+    buf[1] = (sID >> 16) & 0xff;
+    buf[2] = (sID >> 8) & 0xff;
+    buf[3] = sID & 0xff;
 }
 //convert divice ID string to long
 
-unsigned int DeviceIdStringToUInt(std::string DeviceID) {
-	unsigned int ID;
-	sscanf(DeviceID.c_str(), "%x", &ID);
-	return ID;
+unsigned int DeviceIdStringToUInt(std::string DeviceID)
+{
+    unsigned int ID;
+    sscanf(DeviceID.c_str(), "%x", &ID);
+    return ID;
 }
 
-void  ProfileToRorgFuncType(int EEP, int &Rorg, int &Func, int &Type)
+void ProfileToRorgFuncType(int EEP, int &Rorg, int &Func, int &Type)
 {
-	Type = EEP & 0xff;
-	EEP >>= 8;
-	Func = EEP & 0xff;
-	EEP >>= 8;
-	Rorg = EEP & 0xff;
+    Type = EEP & 0xff;
+    EEP >>= 8;
+    Func = EEP & 0xff;
+    EEP >>= 8;
+    Rorg = EEP & 0xff;
 }
-int RorgFuncTypeToProfile( int Rorg, int Func, int Type)
+int RorgFuncTypeToProfile(int Rorg, int Func, int Type)
 {
-	return (Rorg * 256 * 256 + Func * 256 + Type);
+    return (Rorg * 256 * 256 + Func * 256 + Type);
 }
-int   getRorg(int EEP)
+int getRorg(int EEP)
 {
-	return ( EEP >> 16 ) & 0xFF ;
+    return (EEP >> 16) & 0xFF;
 }
-int   getFunc(int EEP)
+int getFunc(int EEP)
 {
-	return (EEP >> 8) & 0xFF;
+    return (EEP >> 8) & 0xFF;
 }
-int   getType(int EEP)
+int getType(int EEP)
 {
-	return (EEP ) & 0xFF;
+    return (EEP)&0xFF;
 }
 
 std::string GetEnOceanIDToString(unsigned int DeviceID)
 {
-	char szDeviceID[20];
-	sprintf(szDeviceID, "%08X", (unsigned int)DeviceID);
-	return szDeviceID;
+    char szDeviceID[20];
+    sprintf(szDeviceID, "%08X", (unsigned int)DeviceID);
+    return szDeviceID;
 }
-void setDestination(unsigned char * opt, unsigned int destID)
+void setDestination(unsigned char *opt, unsigned int destID)
 {
-	//optionnal data
-	opt[0] = 0x03; //subtel
-	DeviceIntToArray(destID, &opt[1]);
-	opt[5] = 0xff;
-	opt[6] = 00;//RSI 
-
+    //optionnal data
+    opt[0] = 0x03; //subtel
+    DeviceIntToArray(destID, &opt[1]);
+    opt[5] = 0xff;
+    opt[6] = 00; //RSI
 }

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -1045,24 +1045,25 @@ bool CEnOceanESP2::ParseData()
 				uint16_t manID = ((pFrame->DATA_BYTE2 & 7) << 8) | pFrame->DATA_BYTE1;
 				uint8_t func = pFrame->DATA_BYTE3 >> 2;
 				uint8_t type = ((pFrame->DATA_BYTE3 & 3) << 5) | (pFrame->DATA_BYTE2 >> 3);
+
 				Log(LOG_NORM, "4BS Teach-in diagram: Node %08X Manufacturer %02X (%s) Profile %02X Type %02X (%s)",
 					nodeID, manID, GetManufacturerName(manID),
 					func, type, GetEEPLabel(RORG_4BS, func, type));
 
 				std::vector<std::vector<std::string>> result;
-				result = m_sql.safe_query("SELECT ID FROM EnoceanSensors WHERE (HardwareID==%d) AND (DeviceID=='%08X')", m_HwdID, nodeID);
+				result = m_sql.safe_query("SELECT ID FROM EnOceanNodes WHERE (HardwareID==%d) AND (NodeID==%u)", m_HwdID, nodeID);
 				if (result.empty())
 				{ // Add it to the database
 					m_sql.safe_query(
-						"INSERT INTO EnoceanSensors (HardwareID, DeviceID, Manufacturer, Profile, Type) VALUES (%d,'%08X',%u,%u,%u)",
-						m_HwdID, nodeID, manID, func, type);
+						"INSERT INTO EnOceanNodes (HardwareID, NodeID, ManufacturerID, RORG, Func, Type) VALUES (%d,%u,%u,%u,%u,%u)",
+						m_HwdID, nodeID, manID, RORG_4BS, func, type);
 				}
 			}
 		}
 		else
 		{ // Following sensors need to have had a teach-in
 			std::vector<std::vector<std::string>> result;
-			result = m_sql.safe_query("SELECT ID, Manufacturer, Profile, Type FROM EnoceanSensors WHERE (HardwareID==%d) AND (DeviceID=='%08X')", m_HwdID, nodeID);
+			result = m_sql.safe_query("SELECT ID, ManufacturerID, Func, Type FROM EnOceanNodes WHERE (HardwareID==%d) AND (NodeID==%u)", m_HwdID, nodeID);
 			if (result.empty())
 			{
 				char* pszHumenTxt = enocean_hexToHuman(pFrame);

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -50,11 +50,11 @@
 //#define ESP3_TESTS_RPS_F6_05_00
 //#define ESP3_TESTS_RPS_F6_05_01
 //#define ESP3_TESTS_RPS_F6_05_02
+//#define ESP3_TESTS_VLD_D2_01_0C
 //#define ESP3_TESTS_VLD_D2_01_12
 //#define ESP3_TESTS_VLD_D2_03_0A
-//#define ESP3_TESTS_VLD_D2_14_30
-//#define ESP3_TESTS_VLD_D2_01_0C
 //#define ESP3_TESTS_VLD_D2_05_00
+//#define ESP3_TESTS_VLD_D2_14_30
 #endif // ENABLE_ESP3_TESTS
 
 // ESP3 Packet types
@@ -108,70 +108,70 @@ enum ESP3_EVENT_CODE : uint8_t
 // ESP3 Common commands
 enum ESP3_COMMON_COMMAND : uint8_t
 {
-	CO_WR_SLEEP = 01,			  // Enter energy saving mode
-	CO_WR_RESET = 02,			  // Reset the device
-	CO_RD_VERSION = 03,			  // Read the device version information
-	CO_RD_SYS_LOG = 04,			  // Read system log
-	CO_WR_SYS_LOG = 05,			  // Reset system log
-	CO_WR_BIST = 06,			  // Perform Self Test
-	CO_WR_IDBASE = 07,			  // Set ID range base address
-	CO_RD_IDBASE = 8,			  // Read ID range base address
-	CO_WR_REPEATER = 9,			  // Set Repeater Level
-	CO_RD_REPEATER = 10,			  // Read Repeater Level
-	CO_WR_FILTER_ADD = 11,		  // Add filter to filter list
-	CO_WR_FILTER_DEL = 12,		  // Delete a specific filter from filter list
-	CO_WR_FILTER_DEL_ALL = 13,		  // Delete all filters from filter list
-	CO_WR_FILTER_ENABLE = 14,		  // Enable / disable filter list
-	CO_RD_FILTER = 15,			  // Read filters from filter list
-	CO_WR_WAIT_MATURITY = 16,		  // Wait until the end of telegram maturity time before received radio telegrams will be forwarded to the external host
-	CO_WR_SUBTEL = 17,			  // Enable / Disable transmission of additional subtelegram info to the external host
-	CO_WR_MEM = 18,			  // Write data to device memory
-	CO_RD_MEM = 19,			  // Read data from device memory
-	CO_RD_MEM_ADDRESS = 20,		  // Read address and length of the configuration area and the Smart Ack Table
-	CO_RD_SECURITY = 21,			  // DEPRECATED Read own security information (level, // key)
-	CO_WR_SECURITY = 22,			  // DEPRECATED Write own security information (level, // key)
-	CO_WR_LEARNMODE = 23,			  // Enable / disable learn mode
-	CO_RD_LEARNMODE = 24,			  // ead learn mode status
-	CO_WR_SECUREDEVICE_ADD = 25,		  // DEPRECATED Add a secure device
-	CO_WR_SECUREDEVICE_DEL = 26,		  // Delete a secure device from the link table
-	CO_RD_SECUREDEVICE_BY_INDEX = 27,	  // DEPRECATED Read secure device by index
-	CO_WR_MODE = 28,			  // Set the gateway transceiver mode
-	CO_RD_NUMSECUREDEVICES = 29,		  // Read number of secure devices in the secure link table
-	CO_RD_SECUREDEVICE_BY_ID = 30,	  // Read information about a specific secure device from the secure link table using the device ID
-	CO_WR_SECUREDEVICE_ADD_PSK = 31,	  // Add Pre-shared key for inbound secure device
-	CO_WR_SECUREDEVICE_ENDTEACHIN = 32,	  // Send Secure teach-In message
-	CO_WR_TEMPORARY_RLC_WINDOW = 33,	  // Set a temporary rolling-code window for every taught-in device
-	CO_RD_SECUREDEVICE_PSK = 34,		  // Read PSK
-	CO_RD_DUTYCYCLE_LIMIT = 35,		  // Read the status of the duty cycle limit monitor
-	CO_SET_BAUDRATE = 36,			  // Set the baud rate used to communicate with the external host
-	CO_GET_FREQUENCY_INFO = 37,		  // Read the radio frequency and protocol supported by the device
-	CO_38T_STEPCODE = 38,			  // Read Hardware Step code and Revision of the Device
-	CO_40_RESERVED = 40,			  // Reserved
-	CO_41_RESERVED = 41,			  // Reserved
-	CO_42_RESERVED = 42,			  // Reserved
-	CO_43_RESERVED = 43,			  // Reserved
-	CO_44_RESERVED = 44,			  // Reserved
-	CO_45_RESERVED = 45,			  // Reserved
-	CO_WR_REMAN_CODE = 46,		  // Set the security code to unlock Remote Management functionality via radio
-	CO_WR_STARTUP_DELAY = 47,		  // Set the startup delay (time from power up until start of operation)
-	CO_WR_REMAN_REPEATING = 48,		  // Select if REMAN telegrams originating from this module can be repeated
-	CO_RD_REMAN_REPEATING = 49,		  // Check if REMAN telegrams originating from this module can be repeated
-	CO_SET_NOISETHRESHOLD = 50,		  // Set the RSSI noise threshold level for telegram reception
-	CO_GET_NOISETHRESHOLD = 51,		  // Read the RSSI noise threshold level for telegram reception
-	CO_52_RESERVED = 52,			  // Reserved
-	CO_53_RESERVED = 53,			  // Reserved
-	CO_WR_RLC_SAVE_PERIOD = 54,		  // Set the period in which outgoing RLCs are saved to the EEPROM
-	CO_WR_RLC_LEGACY_MODE = 55,		  // Activate the legacy RLC security mode allowing roll-over and using the RLC acceptance window for 24bit explicit RLC
-	CO_WR_SECUREDEVICEV2_ADD = 56,	  // Add secure device to secure link table
-	CO_RD_SECUREDEVICEV2_BY_INDEX = 57,	  // Read secure device from secure link table using the table index
-	CO_WR_RSSITEST_MODE = 58,		  // Control the state of the RSSI-Test mode
-	CO_RD_RSSITEST_MODE = 59,		  // Read the state of the RSSI-Test Mode
+	CO_WR_SLEEP = 1,				// Enter energy saving mode
+	CO_WR_RESET = 2,				// Reset the device
+	CO_RD_VERSION = 3,				// Read the device version information
+	CO_RD_SYS_LOG = 4,				// Read system log
+	CO_WR_SYS_LOG = 5,				// Reset system log
+	CO_WR_BIST = 6,					// Perform Self Test
+	CO_WR_IDBASE = 7,				// Set ID range base address
+	CO_RD_IDBASE = 8,				// Read ID range base address
+	CO_WR_REPEATER = 9,				// Set Repeater Level
+	CO_RD_REPEATER = 10,			// Read Repeater Level
+	CO_WR_FILTER_ADD = 11,			// Add filter to filter list
+	CO_WR_FILTER_DEL = 12,			// Delete a specific filter from filter list
+	CO_WR_FILTER_DEL_ALL = 13,		// Delete all filters from filter list
+	CO_WR_FILTER_ENABLE = 14,		// Enable / disable filter list
+	CO_RD_FILTER = 15,				// Read filters from filter list
+	CO_WR_WAIT_MATURITY = 16,		// Wait until the end of telegram maturity time before received radio telegrams will be forwarded to the external host
+	CO_WR_SUBTEL = 17,				// Enable / Disable transmission of additional subtelegram info to the external host
+	CO_WR_MEM = 18,					// Write data to device memory
+	CO_RD_MEM = 19,					// Read data from device memory
+	CO_RD_MEM_ADDRESS = 20,			// Read address and length of the configuration area and the Smart Ack Table
+	CO_RD_SECURITY = 21,			// DEPRECATED Read own security information (level, key)
+	CO_WR_SECURITY = 22,			// DEPRECATED Write own security information (level, key)
+	CO_WR_LEARNMODE = 23,			// Enable / disable learn mode
+	CO_RD_LEARNMODE = 24,			// Read learn mode status
+	CO_WR_SECUREDEVICE_ADD = 25,	// DEPRECATED Add a secure device
+	CO_WR_SECUREDEVICE_DEL = 26,	// Delete a secure device from the link table
+	CO_RD_SECUREDEVICE_BY_INDEX = 27, // DEPRECATED Read secure device by index
+	CO_WR_MODE = 28,				// Set the gateway transceiver mode
+	CO_RD_NUMSECUREDEVICES = 29,	// Read number of secure devices in the secure link table
+	CO_RD_SECUREDEVICE_BY_ID = 30, 	// Read information about a specific secure device from the secure link table using the device ID
+	CO_WR_SECUREDEVICE_ADD_PSK = 31, // Add Pre-shared key for inbound secure device
+	CO_WR_SECUREDEVICE_ENDTEACHIN = 32, // Send Secure teach-In message
+	CO_WR_TEMPORARY_RLC_WINDOW = 33, // Set a temporary rolling-code window for every taught-in device
+	CO_RD_SECUREDEVICE_PSK = 34,	// Read PSK
+	CO_RD_DUTYCYCLE_LIMIT = 35,		// Read the status of the duty cycle limit monitor
+	CO_SET_BAUDRATE = 36,			// Set the baud rate used to communicate with the external host
+	CO_GET_FREQUENCY_INFO = 37,		// Read the radio frequency and protocol supported by the device
+	CO_38T_STEPCODE = 38,			// Read Hardware Step code and Revision of the Device
+	CO_40_RESERVED = 40,			// Reserved
+	CO_41_RESERVED = 41,			// Reserved
+	CO_42_RESERVED = 42,			// Reserved
+	CO_43_RESERVED = 43,			// Reserved
+	CO_44_RESERVED = 44,			// Reserved
+	CO_45_RESERVED = 45,			// Reserved
+	CO_WR_REMAN_CODE = 46,			// Set the security code to unlock Remote Management functionality via radio
+	CO_WR_STARTUP_DELAY = 47,		// Set the startup delay (time from power up until start of operation)
+	CO_WR_REMAN_REPEATING = 48,		// Select if REMAN telegrams originating from this module can be repeated
+	CO_RD_REMAN_REPEATING = 49,		// Check if REMAN telegrams originating from this module can be repeated
+	CO_SET_NOISETHRESHOLD = 50,		// Set the RSSI noise threshold level for telegram reception
+	CO_GET_NOISETHRESHOLD = 51,		// Read the RSSI noise threshold level for telegram reception
+	CO_52_RESERVED = 52,			// Reserved
+	CO_53_RESERVED = 53,			// Reserved
+	CO_WR_RLC_SAVE_PERIOD = 54,		// Set the period in which outgoing RLCs are saved to the EEPROM
+	CO_WR_RLC_LEGACY_MODE = 55,		// Activate the legacy RLC security mode allowing roll-over and using the RLC acceptance window for 24bit explicit RLC
+	CO_WR_SECUREDEVICEV2_ADD = 56,  // Add secure device to secure link table
+	CO_RD_SECUREDEVICEV2_BY_INDEX = 57, // Read secure device from secure link table using the table index
+	CO_WR_RSSITEST_MODE = 58,		// Control the state of the RSSI-Test mode
+	CO_RD_RSSITEST_MODE = 59,		// Read the state of the RSSI-Test Mode
 	CO_WR_SECUREDEVICE_MAINTENANCEKEY = 60, // Add the maintenance key information into the secure link table
 	CO_RD_SECUREDEVICE_MAINTENANCEKEY = 61, // Read by index the maintenance key information from the secure link table
-	CO_WR_TRANSPARENT_MODE = 62,		  // Control the state of the transparent mode
-	CO_RD_TRANSPARENT_MODE = 63,		  // Read the state of the transparent mode
-	CO_WR_TX_ONLY_MODE = 64,		  // Control the state of the TX only mode
-	CO_RD_TX_ONLY_MODE = 65		  // Read the state of the TX only mode} COMMON_COMMAND;
+	CO_WR_TRANSPARENT_MODE = 62,	// Control the state of the transparent mode
+	CO_RD_TRANSPARENT_MODE = 63,	// Read the state of the transparent mode
+	CO_WR_TX_ONLY_MODE = 64,		// Control the state of the TX only mode
+	CO_RD_TX_ONLY_MODE = 65			// Read the state of the TX only mode} COMMON_COMMAND;
 };
 
 // ESP3 Smart Ack codes
@@ -1340,6 +1340,17 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
 	{ ESP3_SER_SYNC, 0x00, 0x09, 0x07, PACKET_RADIO_ERP1, 0x56, RORG_VLD, 0x04, 0x61, 0x80, 0x01, RORG_VLD, 0x01, 0x12, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xAE },
 #endif // ESP3_TESTS_VLD_D2_01_12
 
+#ifdef ESP3_TESTS_VLD_D2_01_0C
+// D2-01-0C, Electronic Switches and Dimmers with Local Control, Type 0x0C, Pilotwire
+// Test Case : Teach-in Test
+//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
+    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x0C, 0x01, 0xD2, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xAE },
+// Test Case : Actuator Status Response 
+    { ESP3_SER_SYNC, 0x00, 0x08, 0x07, PACKET_RADIO_ERP1, 0x3D, RORG_VLD, 0x0A, 0x01, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xB8 },
+// Test Case : Reply Measurement Response
+    { ESP3_SER_SYNC, 0x00, 0x0C, 0x07, PACKET_RADIO_ERP1, 0x96, RORG_VLD, 0x07, 0x20, 0x00, 0x00, 0x00, 0x10, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xC9 },
+#endif
+
 #ifdef ESP3_TESTS_VLD_D2_03_0A
 // D2-03-0A, Push Button – Single Button
 // Test Case : Teach-in Test
@@ -1362,6 +1373,19 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
 //   Long press release
     { ESP3_SER_SYNC, 0x00, 0x08, 0x07, PACKET_RADIO_ERP1, 0x3D, RORG_VLD, 0x00, 0x04, 0x01, RORG_VLD, 0x03, 0x0A, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xC8 },
 #endif // ESP3_TESTS_VLD_D2_03_0A
+
+#ifdef ESP3_TESTS_VLD_D2_05_00
+// D2-05-00, Blinds Control for Position and Angle 
+// Test Case : Teach-in Test
+//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
+    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x00, 0x05, 0xD2, 0x01, 0xD2, 0x05, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xDF },
+// Test Case : senderID: 0585874A EEP:D2-05  Reply Position Position:10
+    { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_VLD, 0x0A, 0x00, 0x00, 0x04, 0x01, 0xD2, 0x05, 0x00, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x4F, 0x00, 0x22 },
+// Test Case : senderID: 0585874A EEP:D2-05  Reply Position Position:50
+    { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_VLD, 0x32, 0x00, 0x00, 0x04, 0x01, 0xD2, 0x05, 0x00, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x50, 0x00, 0xC6 },
+// Test Case : senderID: 0585874A EEP:D2-05  Reply Position Position:100
+    { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_VLD, 0x64, 0x00, 0x00, 0x04, 0x01, 0xD2, 0x05, 0x00, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x50, 0x00, 0x6A },
+#endif
 
 #ifdef ESP3_TESTS_VLD_D2_14_30
 // D2-14-30, Sensor for Smoke, Air quality, Hygrothermal comfort, Temperature and Humidity
@@ -1448,35 +1472,6 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
 // VLD msg: IAQTH: Error
 	{ ESP3_SER_SYNC, 0x00, 0x0C, 0x07, PACKET_RADIO_ERP1, 0x96, RORG_VLD, 0x00, 0x00, 0x00, 0x00, 0x00, 0x70, 0x01, RORG_VLD, 0x14, 0x30, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xF5 },
 #endif // ESP3_TESTS_VLD_D2_14_30
-
-#ifdef ESP3_TESTS_VLD_D2_01_0C
-// D2-01-0C, pilot wire 
-// Test Case : Teach-in Test
-//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
-    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x0C, 0x01, 0xD2, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xAE },
-
-// Test Case : Actuator Status Response 
-    { 0x55,0x00,0x08,0x07,0x01,0x3D,0xD2,0x0A,0x01,0x01,0xD2,0x01,0x0C,0x00,0x01,0xFF,0xFF,0xFF,0xFF,0x2D,0x00,0xB8 },
-
-//Reply Measurement Response
-    { 0x55,0x00,0x0C,0x07,0x01,0x96,0xD2,0x07,0x20,0x00,0x00,0x00,0x10,0x01,0xD2,0x01,0x0C,0x00,0x01,0xFF,0xFF,0xFF,0xFF,0x2D,0x00,0xC9},
-
-#endif
-
-#ifdef ESP3_TESTS_VLD_D2_05_00
-// D2-05-00, Blinds Control for Position and Angle 
-// Test Case : Teach-in Test
-//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
-    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x00, 0x05, 0xD2, 0x01, 0xD2, 0x05, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xDF },
-//VLD: senderID: 0585874A EEP:D2-05  Reply Position Position:10
-    { 0x55,0x00,0x0A,0x07,0x01,0xEB,0xD2,0x0A,0x00,0x00,0x04,0x01,0xD2,0x05,0x00,0x00,0x01,0xFF,0xFF,0xFF,0xFF,0x4F,0x00,0x22 },
-//VLD: senderID: 0585874A EEP:D2-05  Reply Position Position:50
-    { 0x55,0x00,0x0A,0x07,0x01,0xEB,0xD2,0x32,0x00,0x00,0x04,0x01,0xD2,0x05,0x00,0x00,0x01,0xFF,0xFF,0xFF,0xFF,0x50,0x00,0xC6 },
-//VLD: senderID: 0585874A EEP:D2-05  Reply Position Position:100
-    { 0x55,0x00,0x0A,0x07,0x01,0xEB,0xD2,0x64,0x00,0x00,0x04,0x01,0xD2,0x05,0x00,0x00,0x01,0xFF,0xFF,0xFF,0xFF,0x50,0x00,0x6A },
-#endif
-
-
 };
 #endif // ENABLE_ESP3_TESTS
 
@@ -1648,15 +1643,14 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 
 	RBUF *tsen = (RBUF *) pdata;
     const _tGeneralSwitch* xcmd = reinterpret_cast<const _tGeneralSwitch*>(pdata);
-
 	uint32_t nodeID;
 
 	if (tsen->RAW.packettype == pTypeLighting2)
 		nodeID = GetNodeID(tsen->LIGHTING2.id1, tsen->LIGHTING2.id2, tsen->LIGHTING2.id3, tsen->LIGHTING2.id4);
 	else if (tsen->RAW.packettype == pTypeGeneralSwitch)
-        nodeID=xcmd->id ;
-    else
-        return false; // Only allowed to control switches
+		nodeID = xcmd->id;
+	else
+		return false; // Only allowed to control switches
 
 	NodeInfo* pNode = GetNodeInfo(nodeID);
 
@@ -1690,12 +1684,13 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		if (!result.empty())
 		{ // Device found in the database
 			switchtype = static_cast<_eSwitchType>(std::stoul(result[0][0]));
-			LastLevel = static_cast<uint32_t>(std::stoul(result[0][1]));
+			LastLevel = static_cast<uint8_t>(std::stoul(result[0][1]));
 		}
 
 		uint8_t iLevel = tsen->LIGHTING2.level;
-		int cmnd = tsen->LIGHTING2.cmnd;
-		int orgcmd = cmnd;
+		BYTE cmnd = tsen->LIGHTING2.cmnd;
+		BYTE orgcmd = cmnd;
+
 		if (tsen->LIGHTING2.level == 0 && switchtype != STYPE_Dimmer)
 			cmnd = light2_sOff;
 		else
@@ -1851,70 +1846,76 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		optbuf[5] = 0xFF; // RSSI : Send = 0xFF
 		optbuf[6] = 0x00; // Seurity Level : Send = ignored
 
-        //could be replace by
-        //sendVld(m_id_chip, nodeID, D20100_CMD1, 1,0, tsen->LIGHTING2.unitcode - 1, (tsen->LIGHTING2.cmnd == light2_sOn) ? 0x64 : 0x00 , END_ARG_DATA);
-		
-        Debug(DEBUG_NORM, "Send %s switch command to Node %08X",
+		// Could be replaced by :
+		// sendVld(m_id_chip, nodeID, D20100_CMD1, 1,0, tsen->LIGHTING2.unitcode - 1, (tsen->LIGHTING2.cmnd == light2_sOn) ? 0x64 : 0x00 , END_ARG_DATA);
+
+		Debug(DEBUG_NORM, "Send switch %s to Node %08X",
 			(tsen->LIGHTING2.cmnd == light2_sOn) ? "On" : "Off", nodeID);
 
 		SendESP3PacketQueued(PACKET_RADIO_ERP1, buf, 9, optbuf, 7);
 		return true;
 	}
-	//D2-05 : BlindsControl 
-    else if ((pNode->RORG  == 0xd2 || pNode->RORG == 0x00 ) && (pNode->func  == 0x05))
-	{
+	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x05)
+	{ // D2-05-00, Blinds Control for Position and Angle 
 		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
-        //build CMD 1 - Go to Position and Angle
+		// Build CMD 1 - Go to Position and Angle
 		int channel = tsen->LIGHTING2.unitcode - 1;
-        int cmd = tsen->LIGHTING2.cmnd ;
-		int pos ;
-        if(cmd !=  gswitch_sStop )
-		    pos = getPositionFromCommandLevel(tsen->LIGHTING2.cmnd, tsen->LIGHTING2.level);
-        else
-            pos = LastPosition;
+		int cmd = tsen->LIGHTING2.cmnd;
+		int pos;
 
-		if (LastPosition == pos) {
+		if (cmd != gswitch_sStop)
+			pos = getPositionFromCommandLevel(tsen->LIGHTING2.cmnd, tsen->LIGHTING2.level);
+		else
+			pos = LastPosition;
+
+		if (LastPosition == pos)
+		{
 			//send command stop si rappuie
-            Debug(DEBUG_NORM, "Send stop to blinds Control Node: %08X", nodeID );
-			sendVld(m_id_chip, nodeID, D20500_CMD2,  channel, 2, END_ARG_DATA);
+			Debug(DEBUG_NORM, "Send stop to Blinds Control Node %08X", nodeID);
+			sendVld(m_id_chip, nodeID, D20500_CMD2, channel, 2, END_ARG_DATA);
 			LastPosition = -1;
- 		}else{
-                Debug(DEBUG_NORM, "Send position %d %% to blinds Control Node: %08X", pos,nodeID );
-				sendVld(m_id_chip, nodeID, D20500_CMD1,  pos, 127, 0, 0, channel, 1, END_ARG_DATA);
-				LastPosition = pos;
 		}
-        return true ;
+		else
+		{
+			Debug(DEBUG_NORM, "Send position %d%% to Blinds Control Node %08X", pos, nodeID);
+			sendVld(m_id_chip, nodeID, D20500_CMD1, pos, 127, 0, 0, channel, 1, END_ARG_DATA);
+			LastPosition = pos;
+		}
+		return true;
 	}
-    //D2010C :PilotWire
-	else	if ((pNode->RORG == 0xd2 || pNode->RORG == 0x00 ) && (pNode->func == 0x01) && (pNode->type==0x0C) ){
-        const char * PilotWireModeStr[]={ "Off", "Comfort" , "Eco" ,"Anti-freeze", "Comfort-1", "Comfort-2" ,""};
-        uint8_t level = 0;
+	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x01 && pNode->type == 0x0C)
+	{ // D2-01-0C, Electronic Switches and Dimmers with Local Control, Type 0x0C, Pilotwire
+		const char *PilotWireModeStr[] = {"Off", "Comfort", "Eco", "Anti-freeze", "Comfort-1", "Comfort-2", ""};
+		uint8_t level = 0;
 
-        CheckAndUpdateNodeRORG(pNode, RORG_VLD);
+		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
-        if (tsen->LIGHTING2.packettype == pTypeGeneralSwitch)
-            level=xcmd->level;
-        else
-            level = tsen->LIGHTING2.level ;
-        if (level>50){
-            Log(LOG_ERROR,"invalide Pilote Wire level %d Node:%08X",level,nodeID);
-            return false;
-        }
-        int PilotWireMode = 0;
-        if (xcmd->cmnd == light2_sOn)
-		    PilotWireMode  = 1;
-	    else if (xcmd->cmnd == light2_sOff)
-		    PilotWireMode = 0;
-	    else if (xcmd->cmnd == light2_sSetLevel)
-                PilotWireMode = level / 10 ;
-        else
-            return false;
-        Debug(DEBUG_NORM, "Send Set Pilot Wire Mode %d:%s  to Node: %08X", PilotWireMode,PilotWireModeStr[PilotWireMode],nodeID );
-        sendVld(m_id_chip, nodeID, D20100_CMD8, 8 ,PilotWireMode , END_ARG_DATA);
+		if (tsen->LIGHTING2.packettype == pTypeGeneralSwitch)
+			level = xcmd->level;
+		else
+			level = tsen->LIGHTING2.level;
+		if (level > 50)
+		{
+			Log(LOG_ERROR,"Node %08X, Invalid PiloteWire level %d", nodeID, level);
+			return false;
+		}
+		int PilotWireMode = 0;
 
-        return true ;
-    }
+		if (xcmd->cmnd == light2_sOn)
+			PilotWireMode = 1;
+		else if (xcmd->cmnd == light2_sOff)
+			PilotWireMode = 0;
+		else if (xcmd->cmnd == light2_sSetLevel)
+			PilotWireMode = level / 10;
+		else
+			return false;
+
+		Debug(DEBUG_NORM, "Send Set Pilot Wire Mode %d (%s) to Node %08X", PilotWireMode, PilotWireModeStr[PilotWireMode], nodeID);
+		sendVld(m_id_chip, nodeID, D20100_CMD8, 8, PilotWireMode, END_ARG_DATA);
+
+		return true;
+	}
 	Log(LOG_ERROR, "Node %08X can not be used as a switch", nodeID);
 	Log(LOG_ERROR, "Create a virtual switch associated with HwdID %u", m_HwdID);
 	return false;
@@ -3394,10 +3395,9 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 
 							sDecodeRXMessage(this, (const unsigned char *) &tsen.LIGHTING2, GetEEPLabel(node_RORG, node_func, node_type), 255, m_Name.c_str());
 						}
+						return;
 					}
-					else
-                    	createOtherVldUteDevices(   senderID ,  node_RORG , node_func , node_type , num_channel  );
-
+					createOtherVldUteDevices(senderID, node_RORG, node_func, node_type, num_channel);
 					return;
 				}
 				// Node found
@@ -3445,9 +3445,6 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 				CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
 				Debug(DEBUG_NORM, "VLD msg: Node %08X EEP %02X-%02X-%02X", senderID, pNode->RORG, pNode->func, pNode->type);
-
-                if (manageVldMessage(   senderID , &data[1] ,   pNode->func , pNode->type ,  m_Name ,   rssi ) )
-                    return;
 
 				if (pNode->func == 0x01)
 				{ // D2-01-XX, Electronic Switches and Dimmers with Local Control
@@ -3593,6 +3590,9 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					}
 					return;
 				}
+                if (manageVldMessage(senderID, &data[1], pNode->func, pNode->type, m_Name, rssi))
+                    return;
+
 				Log(LOG_ERROR, "VLD msg: Node %08X EEP %02X-%02X-%02X (%s) not supported",
 					senderID, pNode->RORG, pNode->func, pNode->type, GetEEPLabel(pNode->RORG, pNode->func, pNode->type));
 			}
@@ -3912,18 +3912,20 @@ const char *CEnOceanESP3::GetFunctionReturnCodeDescription(const uint8_t RC)
 
 	return ">>Unkown function return code... Please report!<<";
 }
+
 ///---------------------------------------------------------------------------
-std::string CEnOceanESP3::GetDbValue(const char * tableName ,  const char * fieldName , const char * whereFieldName , const char * whereFielValue )
+std::string CEnOceanESP3::GetDbValue(const char *tableName, const char *fieldName, const char *whereFieldName, const char *whereFielValue)
 {
-    std::vector<std::vector<std::string>> result;
-   
-	result = m_sql.safe_query("select %s from %s  WHERE (%s = '%s' )", fieldName ,  tableName, whereFieldName, whereFielValue );
-    if (result.empty())
-		return "" ;
-    else
-        return result[0][0];
+	std::vector<std::vector<std::string>> result;
+
+	result = m_sql.safe_query("select %s from %s  WHERE (%s = '%s' )", fieldName, tableName, whereFieldName, whereFielValue);
+	if (result.empty())
+		return "";
+	else
+		return result[0][0];
 }
-void CEnOceanESP3::sendVld(unsigned int sID,  unsigned int destID , int channel, int value)
+
+void CEnOceanESP3::sendVld(unsigned int sID, unsigned int destID, int channel, int value)
 {
 	unsigned char buff[16];
 
@@ -3931,7 +3933,7 @@ void CEnOceanESP3::sendVld(unsigned int sID,  unsigned int destID , int channel,
 	buff[1] = 0x01;
 	buff[2] = channel;
 	buff[3] = value;
-	buff[4] = (sID >> 24) & 0xff;		// Sender ID
+	buff[4] = (sID >> 24) & 0xff; // Sender ID
 	buff[5] = (sID >> 16) & 0xff;
 	buff[6] = (sID >> 8) & 0xff;
 	buff[7] = sID & 0xff;
@@ -3939,58 +3941,60 @@ void CEnOceanESP3::sendVld(unsigned int sID,  unsigned int destID , int channel,
 
 	//optionnal data
 	unsigned char opt[16];
-	setDestination(opt,destID);
+	setDestination(opt, destID);
 
 	//D2 01 00 00 FF 99 DF 01 00
 	//03 FF FF FF FF FF 00
 
 	SendESP3PacketQueued(PACKET_RADIO_ERP1, buff, 9, opt, 7);
 }
+
 //send a VLD datagramm with payload : data to device Id sID
-void CEnOceanESP3::sendVld(unsigned int sID,  unsigned int destID , unsigned char *data , int DataLen   )
+void CEnOceanESP3::sendVld(unsigned int sID, unsigned int destID, unsigned char *data, int DataLen)
 {
 	unsigned char buffer[256];
 
-	if (DataLen > sizeof(buffer)-6)
+	if (DataLen > sizeof(buffer) - 6)
 		return;
 
-	unsigned char *buff = buffer ;
+	unsigned char *buff = buffer;
 	*buff++ = RORG_VLD; //vld
 	for (int i = 0; i < DataLen; i++)
 		*buff++ = *data++;
 
-	*buff++ = (sID >> 24) & 0xff;		// Sender ID
+	*buff++ = (sID >> 24) & 0xff; // Sender ID
 	*buff++ = (sID >> 16) & 0xff;
 	*buff++ = (sID >> 8) & 0xff;
-	*buff++ =  sID & 0xff;
+	*buff++ = sID & 0xff;
 	*buff++ = 0; //status
 
-				 //optionnal data
-    unsigned char opt[16];
-    setDestination(opt,destID);
-    
-	SendESP3PacketQueued(PACKET_RADIO_ERP1, buffer, 6+DataLen, opt, 7);
+	//optionnal data
+	unsigned char opt[16];
+	setDestination(opt, destID);
+
+	SendESP3PacketQueued(PACKET_RADIO_ERP1, buffer, 6 + DataLen, opt, 7);
 }
+
 //send a VLD datagramm of the command described by descriptor OffsetDes detailed in EEP profile.to device Id sID
 // the argument are variable length
 //it shall correspond to each offset Data detailed in EnOcean_Equipment_Profiles_EEP_v2.x.x_public.
 //the list  parameter shall end with value END_ARG_DATA
-//return is the size of the daya payload in byte 
+//return is the size of the daya payload in byte
 // or 0 : if an error occured : not enough parameters passed
 //example :
 //sendVld(srcID, D20500_CMD_2, channel, 2, END_ARG_DATA);
 // send a stop command = 2 to channel 9 for EEP : D2-05-00 ; Blinds control
 //sendVld(srcID, D20500_CMD_1, 100, 127, 0, 0, 0 , 1, END_ARG_DATA);
-// send a got position and angle command = 1 to 
-// POS=100 % 
-// ANG=127 : dont change 
-// REPO=0 goto ditectly 
-// LOCK=0  dont change  , 
+// send a got position and angle command = 1 to
+// POS=100 %
+// ANG=127 : dont change
+// REPO=0 goto ditectly
+// LOCK=0  dont change  ,
 // channel 0
 // CMD = 1 goto command for EEP : D2-05-00 ; Blinds control
-uint32_t CEnOceanESP3::sendVld(unsigned int srcID,  unsigned int destID , T_DATAFIELD * OffsetDes,  ...)
+uint32_t CEnOceanESP3::sendVld(unsigned int srcID, unsigned int destID, T_DATAFIELD *OffsetDes, ...)
 {
-	uint8_t  data[256+2];
+	uint8_t data[256 + 2];
 	va_list value;
 
 	/* Initialize the va_list structure */
@@ -3998,172 +4002,163 @@ uint32_t CEnOceanESP3::sendVld(unsigned int srcID,  unsigned int destID , T_DATA
 
 	memset(data, 0, sizeof(data));
 
-	uint32_t DataSize = SetRawValues(data, OffsetDes,  value);
+	uint32_t DataSize = SetRawValues(data, OffsetDes, value);
 	if (DataSize)
-		sendVld(srcID,destID, data, DataSize);
+		sendVld(srcID, destID, data, DataSize);
 	else
 		Log(LOG_ERROR, "Error argument number in sendVld : cmd :%s :%s ", OffsetDes->ShortCut.c_str(), OffsetDes->description.c_str());
 
-
 	va_end(value);
 
-	return  DataSize;
-
+	return DataSize;
 }
-uint32_t CEnOceanESP3::senDatadVld(unsigned int srcID,  unsigned int destID , T_DATAFIELD* OffsetDes, int* values , int NbValues )
+
+uint32_t CEnOceanESP3::senDatadVld(unsigned int srcID, unsigned int destID, T_DATAFIELD *OffsetDes, int *values, int NbValues)
 {
-	uint8_t  data[256 + 2];
+	uint8_t data[256 + 2];
 
 	memset(data, 0, sizeof(data));
 
-	uint32_t DataSize = setRawDataValues(data, OffsetDes, values,NbValues );
+	uint32_t DataSize = setRawDataValues(data, OffsetDes, values, NbValues);
 	if (DataSize)
-		sendVld(srcID,destID, data, DataSize);
+		sendVld(srcID, destID, data, DataSize);
 	else
 		Log(LOG_ERROR, " Error argument number in sendVld : cmd :%s :%s ", OffsetDes->ShortCut.c_str(), OffsetDes->description.c_str());
 
-
-	return  DataSize;
-
+	return DataSize;
 }
 
-bool updateSwitchType(int HardwareID, const char* deviceID,_eSwitchType SwitchType )
+bool updateSwitchType(int HardwareID, const char *deviceID, _eSwitchType SwitchType)
 {
-std::vector<std::vector<std::string>> result;
-		result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", HardwareID, deviceID);
-		if (!result.empty())
-		{
-			m_sql.safe_query("UPDATE DeviceStatus SET SwitchType=%d WHERE (ID=='%q')", SwitchType, result[0][0].c_str());
-            return false;
-		}
-        return true;
-}
-void  CEnOceanESP3::createOtherVldUteDevices(  uint32_t iSenderID , uint8_t rorg ,uint8_t func ,uint8_t type ,uint8_t nb_channel  )
-{
+	std::vector<std::vector<std::string>> result;
 
-	//create device blinds switch
-	if ((rorg == 0xD2) && (func == 0x05) && ((type == 0x00) || (type == 0x01)))
+	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", HardwareID, deviceID);
+	if (!result.empty())
 	{
+		m_sql.safe_query("UPDATE DeviceStatus SET SwitchType=%d WHERE (ID=='%q')", SwitchType, result[0][0].c_str());
+		return false;
+	}
+	return true;
+}
+
+void CEnOceanESP3::createOtherVldUteDevices(uint32_t iSenderID, uint8_t rorg, uint8_t func, uint8_t type, uint8_t nb_channel)
+{
+	if (rorg == RORG_VLD && func == 0x05 && (type == 0x00 || type == 0x01))
+	{ // Create Blinds Control switch
 		for (int nbc = 0; nbc < nb_channel; nbc++)
 		{
 			Log(LOG_NORM, "TEACH Blinds Switch : 0xD2 Node 0x%08x UnitID: %02X cmd: %02X ", iSenderID, nbc + 1, light2_sOff);
-			SendSwitch(iSenderID, nbc + 1, -1, light2_sOff, 0, "Blinds"+GetDeviceID(iSenderID) ,"EnOcean");
-            //wait for decive creation
-            int timeout = 10 ;//1 seconds
-            while (updateSwitchType(m_HwdID,GetDeviceID(iSenderID).c_str(),STYPE_BlindsPercentageWithStop) && (timeout>0)){
-                sleep_milliseconds(100);
-                timeout--;
-            }
-//			CreateDevice(m_HwdID, GetDeviceID(iSenderID).c_str(), nbc + 1, pTypeLighting2, sTypeAC, 0, -1, light2_sOff, "0", GetDeviceID(iSenderID), STYPE_BlindsPercentage , "" , 0 );
+			SendSwitch(iSenderID, nbc + 1, -1, light2_sOff, 0, "Blinds" + GetDeviceID(iSenderID), "EnOcean");
+			// Wait for decive creation
+			int timeout = 10; // 1 second
+			while (updateSwitchType(m_HwdID, GetDeviceID(iSenderID).c_str(), STYPE_BlindsPercentageWithStop) && (timeout > 0))
+			{
+				sleep_milliseconds(100);
+				timeout--;
+			}
+			// CreateDevice(m_HwdID, GetDeviceID(iSenderID).c_str(), nbc + 1, pTypeLighting2, sTypeAC, 0, -1, light2_sOff, "0", GetDeviceID(iSenderID), STYPE_BlindsPercentage , "" , 0 );
 		}
 		return;
 	}
-	 const std::string  deviceType = GetEEPLabel(rorg,func,type) ;
-//    if (deviceType == "PilotWire" ){
-	if ((rorg == 0xD2) && (func == 0x01) && (type == 0x0C) )
-    {
-		Log(LOG_NORM, "TEACH %s  : 0xD2 Node 0x%08x UnitID: %02X ",deviceType.c_str(), iSenderID, 1 );
-    //	SendSelectorSwitch(int NodeID, uint8_t ChildID, std::string &sValue, std::string &defaultname,  int customImage,  bool bDropdown,  std::string &LevelNames,  std::string &LevelActions,  bool bHideOff,  std::string &userName)
-	    SendSelectorSwitch( iSenderID, 1              ,"0"                 ,"PilotWire"+GetDeviceID(iSenderID)       ,  0              ,  false         ,  "Off|Conf|Eco|Freeze|Conf-1|Conf-2" ,  "00|10|20|30|40|50|60"      ,  false         , ""  );
-//								CreateDevice(m_HwdID, GetDeviceID(iSenderID).c_str(),  1, pTypeLighting2, sTypeAC, 0, -1, light2_sOff, "0", GetDeviceID(iSenderID), STYPE_Selector , false, false, "Off|Conf|Eco|Freeze|Conf-1|Conf-2" ,  ""      , 0 );
-        SendKwhMeter(iSenderID, 1 , 100 , 0.0  , 0.0 , deviceType , 12 );
-        //create kwh usage
+	if (rorg == RORG_VLD && func == 0x01 && type == 0x0C)
+	{ // Create Pilot Wire devices
+		const std::string deviceType = GetEEPLabel(rorg, func, type);
 
-    }
+		Log(LOG_NORM, "TEACH %s  : VLD Node 0x%08x UnitID: %02X ", deviceType.c_str(), iSenderID, 1);
+		//	SendSelectorSwitch(int NodeID, uint8_t ChildID, std::string &sValue, std::string &defaultname,  int customImage,  bool bDropdown,  std::string &LevelNames,  std::string &LevelActions,  bool bHideOff,  std::string &userName)
+		SendSelectorSwitch(iSenderID, 1, "0", "PilotWire" + GetDeviceID(iSenderID), 0, false, "Off|Conf|Eco|Freeze|Conf-1|Conf-2", "00|10|20|30|40|50|60", false, "");
+		//								CreateDevice(m_HwdID, GetDeviceID(iSenderID).c_str(),  1, pTypeLighting2, sTypeAC, 0, -1, light2_sOff, "0", GetDeviceID(iSenderID), STYPE_Selector , false, false, "Off|Conf|Eco|Freeze|Conf-1|Conf-2" ,  ""      , 0 );
 
+		// Create kwh usage
+		SendKwhMeter(iSenderID, 1, 100, 0.0, 0.0, deviceType, 12);
+		return;
+	}
 }
-//return f  alse if not managed
-bool CEnOceanESP3::manageVldMessage(  uint32_t iSenderID , unsigned char * vldData,  uint8_t func ,uint8_t type , std::string& m_Name ,  uint8_t rssi )
-{
-	//D2-05 
-	//{ 0xD2 , 0x05 , 0x00 , "Blinds Control for Position and Angle                                            ",  "Type 0x00           
-	if ( (func==0x05)) 
-	{
-				
-		int cmd = GetRawValue(vldData, D20500_CMD1 ,  D20500_CMD1_CMD  ) ;
-		int unitcode = GetRawValue(vldData, D20500_CMD1, D20500_CMD1_CHN);
-		//if position
-		if (cmd == 4 )
-		{
-			//get position
-			int pos = GetRawValue( vldData,D20500_CMD1 ,  D20500_CMD1_POS  ) ;
-			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X EEP:D2-05  Reply Position Position:%d%%", iSenderID, pos);
-			bool bon = (pos > 0 ? 1 : 0 );
-			if (pos >= 100)	pos = 99;
 
- 			SendSwitch(iSenderID, unitcode+1, -1 , bon , pos , "", m_Name.c_str(),rssi);
+//return false if not managed
+bool CEnOceanESP3::manageVldMessage(uint32_t iSenderID, unsigned char *vldData, uint8_t func, uint8_t type, std::string &m_Name, uint8_t rssi)
+{
+	// D2-05
+	//{ 0xD2 , 0x05 , 0x00 , "Blinds Control for Position and Angle                                            ",  "Type 0x00
+	if (func == 0x05)
+	{
+		int cmd = GetRawValue(vldData, D20500_CMD1, D20500_CMD1_CMD);
+		int unitcode = GetRawValue(vldData, D20500_CMD1, D20500_CMD1_CHN);
+
+		if (cmd == 0x4)
+		{ // Get position
+			int pos = GetRawValue(vldData, D20500_CMD1, D20500_CMD1_POS);
+			bool bon = (pos > 0 ? 1 : 0);
+
+			if (pos >= 100)
+				pos = 99;
+
+			Debug(DEBUG_HARDWARE, "VLD Node %08X, EEP: D2-05 Reply Position: %d%%", iSenderID, pos);
+			SendSwitch(iSenderID, unitcode + 1, -1, bon, pos, "", m_Name.c_str(), rssi);
 			return true;
 		}
+		return false;
 	}
-	if ( (func==0x01)) 
+	if (func == 0x01)
 	{
-				
-		int cmd = GetRawValue(vldData, D20100_CMD7 ,  D20100_CMD7_CMD  ) ;
-        // TITLE:CMD 0x4 - Actuator Status Response
-        // DESC :This message is sent by an actuator if one of the following events occurs:
-        if (cmd == 4 )
-        {
-            //already managed
-            return false;
-        }
-        else
-		// TITLE:CMD 0x7 - Actuator Measurement Response
-		if (cmd ==7  )
-		{
-            std::string mes = printRawDataValues(vldData , D20100_CMD7);
-			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Reply Measurement Response %s", iSenderID, mes.c_str() );
-            int unit  = GetRawValue(vldData, D20100_CMD7 ,  D20100_CMD7_UN  ) ;
-            uint32_t mv    = GetRawValue(vldData, D20100_CMD7 ,  D20100_CMD7_MV  ) ;
-            uint32_t id =  (iSenderID << 8) | 1;
-            //get last total mesure value mtotal
-            std::string sValue = GetDbValue("DeviceStatus" ,  "sValue", "DeviceId" , GetEnOceanIDToString(id).c_str() ) ;
-            std::vector<std::string> strarray;
-	        StringSplit(sValue, ";", strarray);
-             double mtotal = 0;  
-	        if (strarray.size() >= 2)
-		          mtotal = std::stod(strarray[1]);
-            //add current
-            mtotal+=mv;
-            SendKwhMeter(iSenderID, 1 , 100 , mv  , mtotal/1000.0 , "" , 12 );
-//Value: 0x00 = Energy [Ws] 
-//Value: 0x01 = Energy [Wh] 
-//Value: 0x02 = Energy [KWh] 
-//Value: 0x03 = Power [W] 
-//Value: 0x04 = Power [KW] 
+		int cmd = GetRawValue(vldData, D20100_CMD7, D20100_CMD7_CMD);
 
-            //send CMD 0x9 - Actuator Pilot Wire Mode Query
-				//sendVld(m_id_chip, iSenderID, D20100_CMD9,  9 , END_ARG_DATA);
-            return true;
+		if (cmd == 0x4)
+		{ // Actuator Status Response
+			// This message is sent by an actuator if one of the following events occurs:
+			// Already managed
+			return false;
 		}
-        else
-        // TITLE:CMD 0xA - Actuator Pilot Wire Mode Response
-		if (cmd == 0xA   )
-		{
-            std::string mes = printRawDataValues(vldData , D20100_CMD10);
-			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Actuator Pilot Wire Mode Response %s", iSenderID, mes.c_str() );
-            int pm    = GetRawValue(vldData, D20100_CMD10 ,  D20100_CMD10_PM  ) ;
-            std::string level = std::to_string(pm*10);
-            SendSelectorSwitch( iSenderID, 1              ,level                 ,""       ,  0              ,  false         ,  "Off|Conf|Eco|Freeze|Conf-1|Conf-2" ,  "00|10|20|30|40|50|60"      ,  false         , ""  );
+		if (cmd == 0x7)
+		{ // Actuator Measurement Response
+			std::string mes = printRawDataValues(vldData, D20100_CMD7);
+			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Reply Measurement Response %s", iSenderID, mes.c_str());
+			int unit = GetRawValue(vldData, D20100_CMD7, D20100_CMD7_UN);
+			uint32_t mv = GetRawValue(vldData, D20100_CMD7, D20100_CMD7_MV);
+			uint32_t id = (iSenderID << 8) | 1;
+			//get last total mesure value mtotal
+			std::string sValue = GetDbValue("DeviceStatus", "sValue", "DeviceId", GetEnOceanIDToString(id).c_str());
+			std::vector<std::string> strarray;
+			StringSplit(sValue, ";", strarray);
+			double mtotal = 0;
+			if (strarray.size() >= 2)
+				mtotal = std::stod(strarray[1]);
+			//add current
+			mtotal += mv;
+			SendKwhMeter(iSenderID, 1, 100, mv, mtotal / 1000.0, "", 12);
+			//Value: 0x00 = Energy [Ws]
+			//Value: 0x01 = Energy [Wh]
+			//Value: 0x02 = Energy [KWh]
+			//Value: 0x03 = Power [W]
+			//Value: 0x04 = Power [KW]
 
-
-            return true;
+			//send CMD 0x9 - Actuator Pilot Wire Mode Query
+			//sendVld(m_id_chip, iSenderID, D20100_CMD9,  9 , END_ARG_DATA);
+			return true;
 		}
-        else
-        // TITLE:CMD 0xD - Actuator External Interface Settings Response
-		if (cmd == 0xD   )
-		{
-            std::string mes = printRawDataValues(vldData , D20100_CMD13);
-			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Actuator External Interface Settings Response %s", iSenderID, mes.c_str() );
-            return true;
+		if (cmd == 0xA)
+		{ // Actuator Pilot Wire Mode Response
+			std::string mes = printRawDataValues(vldData, D20100_CMD10);
+			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Actuator Pilot Wire Mode Response %s", iSenderID, mes.c_str());
+			int pm = GetRawValue(vldData, D20100_CMD10, D20100_CMD10_PM);
+			std::string level = std::to_string(pm * 10);
+			SendSelectorSwitch(iSenderID, 1, level, "", 0, false, "Off|Conf|Eco|Freeze|Conf-1|Conf-2", "00|10|20|30|40|50|60", false, "");
+
+			return true;
 		}
-
-
+		if (cmd == 0xD)
+		{ // Actuator External Interface Settings Response
+			std::string mes = printRawDataValues(vldData, D20100_CMD13);
+			Debug(DEBUG_HARDWARE, "VLD: senderID: %08X Actuator External Interface Settings Response %s", iSenderID, mes.c_str());
+			return true;
+		}
+		return false;
 	}
-	return false ;
-
+	return false;
 }
+
 //return position 0..100% from command / level
-int getPositionFromCommandLevel(int cmnd , int pos )
+int getPositionFromCommandLevel(int cmnd, int pos)
 {
 	if (cmnd == light2_sOn)
 		pos = 100;

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -7,21 +7,31 @@
 #include "DomoticzHardware.h"
 
 #include "EnOceanRawValue.h"
+
 // 550 bytes buffer is enough for one ESP3 packet, EnOceanLink 1.8.1.0, eoPacket.h
 #define ESP3_PACKET_BUFFER_SIZE 550
 
 class CEnOceanESP3 : public CEnOceanEEP, public AsyncSerial, public CDomoticzHardwareBase
 {
 public:
+	enum TeachinMode : uint8_t
+	{
+		GENERIC_NODE = 0,
+		TEACHEDIN_NODE = 1,
+		VIRTUAL_NODE = 2
+	};
+
 	struct NodeInfo
 	{
 		uint32_t idx;
 		uint32_t nodeID;
+		std::string name;
 		uint16_t manufacturerID;
 		uint8_t RORG;
 		uint8_t func;
 		uint8_t type;
-		bool generic;
+		std::string description;
+		TeachinMode teachin_mode;
 	};
 
 	CEnOceanESP3(int ID, const std::string &devname, int type);
@@ -31,7 +41,9 @@ public:
 
 	NodeInfo *GetNodeInfo(const uint32_t nodeID);
 
-	void TeachInNode(const uint32_t nodeID, const uint16_t manID, const uint8_t RORG, const uint8_t func, const uint8_t type, const bool generic);
+	void TeachInNode(const uint32_t nodeID, const uint16_t manID,
+		const uint8_t RORG, const uint8_t func, const uint8_t type,
+		const TeachinMode teachin_mode);
 	void CheckAndUpdateNodeRORG(NodeInfo *pNode, const uint8_t RORG);
 
 	uint32_t m_id_base;
@@ -110,7 +122,9 @@ private:
 	uint8_t m_RPS_teachin_STATUS;
 	time_t m_RPS_teachin_timer;
 	uint8_t m_RPS_teachin_count;
+
 	int LastPosition = -1;
+
 	void createOtherVldUteDevices(uint32_t iSenderID, uint8_t rorg, uint8_t func, uint8_t type, uint8_t nb_channel);
 	bool manageVldMessage(uint32_t iSenderID, unsigned char *vldData, uint8_t func, uint8_t type, std::string &m_Name, uint8_t rssi);
     std::string GetDbValue(const char* tableName, const char* fieldName, const char* whereFieldName, const char* whereFielValue);
@@ -119,4 +133,5 @@ private:
 	uint32_t sendVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD * OffsetDes,  ...);
 	uint32_t senDatadVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD* OffsetDes, int* values, int NbValues);
 };
+
 int getPositionFromCommandLevel(int cmnd, int pos);


### PR DESCRIPTION
This PR is a last step before adding a new screen to Domoticz hardware to manage EnOcean nodes.

**Add new fields to domoticz.db to better manage EnOcean nodes :**

- Rename DeviceID as NodeID, since an EnOcean Node may propose multiple Domoticz devices
- Add Name and Description fields to better define a given Node
- Add RORG field to have a full EEP (RORG-Func-Type) in the database and better identify node capabilities
- Rename Manufacturer to ManufacturerID, just because it is an integer ID and not a string value
- Rename EnoceanSensors table to EnOceanNodes, since all nodes are not sensors and may also be actuators

**Adapt EnoceanESP2 and EnOceeanESP3 to take that change into account**

**+ Some minor fixes**
**+ Some code reindent**
