### PR TITLE
Fix mqtt ad select

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2518,20 +2518,21 @@ void MQTT::handle_auto_discovery_select(_tMQTTASensor* pSensor, const struct mos
 	std::string current_mode;
 	if (!bIsJSON)
 	{
-		Log(LOG_ERROR, "Select device no idea how to interpretate state values (%s)", pSensor->unique_id.c_str());
-		return;
-	}
-	if (!pSensor->value_template.empty())
+		// Assume the payload is the new current value
+		current_mode = qMessage;
+	} 
+	else
 	{
-		current_mode = GetValueFromTemplate(root, pSensor->value_template);
-		if ((pSensor->state_topic == topic) && current_mode.empty())
+		if (!pSensor->value_template.empty())
 		{
-			Log(LOG_ERROR, "Select device no idea how to interpretate state values (%s)", pSensor->unique_id.c_str());
-			return;
+			current_mode = GetValueFromTemplate(root, pSensor->value_template);
+			if ((pSensor->state_topic == topic) && current_mode.empty())
+			{
+				Log(LOG_ERROR, "Select device no idea how to interpretate state values (%s)", pSensor->unique_id.c_str());
+				return;
+			}
 		}
 	}
-	else
-		current_mode = qMessage;
 
 	pSensor->devType = pTypeGeneralSwitch;
 	pSensor->subType = sSwitchGeneralSwitch;

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2130,7 +2130,7 @@ void MQTT::GuessSensorTypeValue(const _tMQTTASensor* pSensor, uint8_t& devType, 
 	{
 		devType = pTypeUsage;
 		subType = sTypeElectric;
-		sValue = pSensor->last_value;
+		sValue = std_format("%.1f", static_cast<float>(atof(pSensor->last_value.c_str())));
 	}
 	else if (szUnit == "kwh")
 	{

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2112,7 +2112,7 @@ void MQTT::GuessSensorTypeValue(const _tMQTTASensor* pSensor, uint8_t& devType, 
 	{
 		devType = pTypeGeneral;
 		subType = sTypeVoltage;
-		sValue = pSensor->last_value;
+		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())));
 	}
 	else if (szUnit == "mv")
 	{
@@ -2124,13 +2124,13 @@ void MQTT::GuessSensorTypeValue(const _tMQTTASensor* pSensor, uint8_t& devType, 
 	{
 		devType = pTypeGeneral;
 		subType = sTypeCurrent;
-		sValue = pSensor->last_value;
+		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())));
 	}
 	else if (szUnit == "w")
 	{
 		devType = pTypeUsage;
 		subType = sTypeElectric;
-		sValue = std_format("%.1f", static_cast<float>(atof(pSensor->last_value.c_str())));
+		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())));
 	}
 	else if (szUnit == "kwh")
 	{

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -2564,7 +2564,7 @@ void MQTT::handle_auto_discovery_select(_tMQTTASensor* pSensor, const struct mos
 	std::string sValue = result[0][3];
 	std::string sOptions = result[0][4];
 
-	int iActualIndex = 0;
+	int iActualIndex = ((current_mode != "") ? -1 : 0);
 
 	// Build switch options
 	int iValueIndex = 0;
@@ -2578,6 +2578,12 @@ void MQTT::handle_auto_discovery_select(_tMQTTASensor* pSensor, const struct mos
 		tmpOptionString += ittOptions;
 		iValueIndex += 10;
 	}
+
+	if (iActualIndex == -1) {
+		Log(LOG_ERROR, "Select device doesn't have the option for received STATE \"%s\")", current_mode.c_str());
+		iActualIndex = atoi(sValue.c_str());
+	}
+
 	std::map<std::string, std::string> optionsMap;
 	optionsMap["SelectorStyle"] = "0";
 	optionsMap["LevelOffHidden"] = "false";


### PR DESCRIPTION
Fix MQTT Selector switch not working when STATE payload contains the actual STATE in stead of a JSON payload.
Added MQTT AD check for valid STATE received and leave Current STATE in case an invalid STATE is received.
Fix for fixing 1 decimal for Electricity "W" Sensor.