### PR TITLE
Webserver Improvement: Serve files without extension (Certbot temp files for example)

### DIFF
--- a/test/gherkin/resources/testwebcontent/test2
+++ b/test/gherkin/resources/testwebcontent/test2
@@ -1,0 +1,1 @@
+A regular file without extension!

--- a/test/gherkin/test_webserver.py
+++ b/test/gherkin/test_webserver.py
@@ -20,6 +20,14 @@ def test_uncompressedout():
 def test_decompressedout():
     pass
 
+@scenario('webserver.feature', 'Get compressed source in compressed form')
+def test_notdecompressedout():
+    pass
+
+@scenario('webserver.feature', 'Get regular file without extension')
+def test_regularfile():
+    pass
+
 @given('Domoticz is running')
 def test_domoticz():
     Domoticz.sBaseURI = "http://localhost"
@@ -43,7 +51,6 @@ def setup_user():
 def setup_request(test_domoticz, gzipsupport):
     if gzipsupport == "supports":
         test_domoticz.oReqHeaders = {"Accept-Encoding": "gzip, deflate"}
-
 
 @when(parsers.parse('I request the URI "{uri}"'))
 def request_uri(test_domoticz,uri):

--- a/test/gherkin/webserver.feature
+++ b/test/gherkin/webserver.feature
@@ -30,3 +30,21 @@ Feature: Webserver handling
         And I should receive the content saying "It Works!"
         And the HTTP-header "Content-Type" should contain "text/html;charset=UTF-8"
         And the HTTP-header "Content-Encoding" should be absent
+
+    Scenario: Get compressed source in compressed form
+        Given I am a normal Domoticz user
+        And my browser supports receiving compressed data
+        When I request the URI "/test/test1.html"
+        Then the HTTP-return code should be "200"
+        And I should receive the content saying "It Works!"
+        And the HTTP-header "Content-Type" should contain "text/html;charset=UTF-8"
+        And the HTTP-header "Content-Encoding" should contain "gzip"
+
+    Scenario: Get regular file without extension
+        Given I am a normal Domoticz user
+        And my browser supports receiving compressed data
+        When I request the URI "/test/test2"
+        Then the HTTP-return code should be "200"
+        And I should receive the content saying "A regular file without extension!"
+        And the HTTP-header "Content-Length" should contain "34"
+        And the HTTP-header "Content-Type" should be absent

--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -251,10 +251,14 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 			// Determine the file extension.
 			std::size_t last_slash_pos = full_path.find_last_of('/');
 			std::size_t last_dot_pos = full_path.find_last_of('.');
-			if (last_dot_pos != std::string::npos && last_dot_pos > last_slash_pos)
+			if (last_dot_pos != std::string::npos && last_dot_pos > last_slash_pos && last_dot_pos < full_path.length()-1)
 			{
 				extension = full_path.substr(last_dot_pos + 1);
 				bValidUri = true;
+			}
+			else if((last_dot_pos == std::string::npos) && (iStat == 0) && ((sb.st_mode & S_IFREG) == S_IFREG))
+			{
+				bValidUri = true; // no extension found, but the sourcefile does exist and is a of regular file type so serve it also
 			}
 			else
 			{


### PR DESCRIPTION
This PR adds (or brings back) the functionality to the Domoticz webserver to serve regular files that _do not_ have a file extension that could be used to determine the correct mime-type which the webserver should return when serving this file.

Before this PR, a file in the webroot of the fileserver that did not contain a '.' (dot) was not served but a '400 Bad request' was returned instead. Now it does.

The updated behavior is as followed:
- Non-existing files with a dot (having an extension) will give a 404
- Non-existing files without a dot will still give a 400 (and not a 404 File not found)
- Both existing- and non-existing files ending with a dot will give a 400
- Existing files with a dot will be served (200)
- Existing files _without_ a dot will now also be served (200)

Change is made to accommodate the use of Letsencrypt SSL certificates to encrypt Domoticz web-traffic for which it is needed to serve temporary verification files generated by `certbot` when creating and updating the SSL certificate.

See also forum topic https://www.domoticz.com/forum/viewtopic.php?f=47&t=37600 