### PR TITLE
Prevent loosing wind devices

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3217,7 +3217,6 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	char szTmp[300];
 	uint8_t devType = pTypeWIND;
 	uint8_t subType = pResponse->WIND.subtype;
-	// uint16_t windID = (pResponse->WIND.id1 * 256) + pResponse->WIND.id2;
 	uint16_t windID = 0;
 	sprintf(szTmp, "%d", windID);
 	std::string ID = szTmp;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -3217,7 +3217,8 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	char szTmp[300];
 	uint8_t devType = pTypeWIND;
 	uint8_t subType = pResponse->WIND.subtype;
-	uint16_t windID = (pResponse->WIND.id1 * 256) + pResponse->WIND.id2;
+	// uint16_t windID = (pResponse->WIND.id1 * 256) + pResponse->WIND.id2;
+	uint16_t windID = 0;
 	sprintf(szTmp, "%d", windID);
 	std::string ID = szTmp;
 	uint8_t Unit = 0;


### PR DESCRIPTION
TFA wind device keeps changing its device ID (composed using channel/rolling-code) even without battery change or power loss. As a result the device is lost in Domoticz. Forcing the device ID to 0 prevents loosing the device for both SDR433 and RFXcom wind devices.