### PR TITLE
Add _FILE_OFFSET_BITS=64 to GCC builds. Fixes Python plugin issues on armv7 Debian 11 builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
   #SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-switch")
   #ADD_DEFINITIONS( -Wall -O0 -ggdb )
   #ADD_DEFINITIONS( -Wfatal-errors -Wformat=2 -Werror=format-security )
+  ADD_DEFINITIONS( -D_FILE_OFFSET_BITS=64 )
 ENDIF()
 
 ### VERSIONING SUPPORT


### PR DESCRIPTION
When trying latest stable version of Domoticz (2021.1) on Armbian Bullseye (armv7, Debian 11), the python plugins do not seem to work and domoticz is core dumping. After some investigation, is seems to originate from fact that readdir call, returns NULL with errno set to 75. It then demonstrates as domoticz not being able to find python plugins.

The easiest way to replicate this without actual hardware is to run armv7 armbian bullseye under chroot on amd64 Debian 11, with using qemu-arm-static as emulator.

With setting -D_FILE_OFFSET_BITS=64 the resulting binary runs without any issue.

This is because on 32bit systems the file handles are 64bit for a while, but I suspect that there were some workarounds in place to handle backward compatibilty to apps with 32bit file handles. This may have changed around glibc 2.28. This setting is compatible with both 32bit and 64bit binaries (i.e. armv7, arm64 or amd64) and should also work on older versions of Debian (Buster), although I have not tried it.

Please suggest if there is better place to put this.

