### PR TITLE
Improve webserver security

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -261,7 +261,7 @@ namespace http
 			int tries = 0;
 			bool exception = false;
 
-			//_log.Log(LOG_STATUS, "CWebServer::StartServer() : settings : %s", settings.to_string().c_str());
+			_log.Debug(DEBUG_WEBSERVER, "CWebServer::StartServer() : settings : %s", settings.to_string().c_str());
 			do
 			{
 				try

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -77,10 +77,10 @@ namespace http {
 			proxymanager.Stop();
 			// restart
 #ifdef WWW_ENABLE_SSL
-			cWebem *my_pWebEm = (plainServer_ != nullptr ? plainServer_->m_pWebEm
-								     : (secureServer_ != nullptr ? secureServer_->m_pWebEm : nullptr));
+			cWebem *my_pWebEm = (plainServer_ != nullptr && plainServer_->m_pWebEm != nullptr ? plainServer_->m_pWebEm
+							     : (secureServer_ != nullptr && secureServer_->m_pWebEm != nullptr ? secureServer_->m_pWebEm : nullptr));
 #else
-			cWebem* my_pWebEm = plainServer_ != NULL ? plainServer_->m_pWebEm : NULL;
+			cWebem* my_pWebEm = plainServer_ != nullptr && plainServer_->m_pWebEm != nullptr ? plainServer_->m_pWebEm : nullptr;
 #endif
 			if (my_pWebEm == nullptr)
 			{

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -216,17 +216,18 @@ MainWorker::MainWorker()
 #ifdef WWW_ENABLE_SSL
 	m_secure_webserver_settings.listening_address = "::"; // listen to all network interfaces
 	m_secure_webserver_settings.listening_port = "443";
-	m_secure_webserver_settings.ssl_method = "sslv23";
+	m_secure_webserver_settings.ssl_method = "tls";
 	m_secure_webserver_settings.certificate_chain_file_path = "./server_cert.pem";
 	m_secure_webserver_settings.ca_cert_file_path = m_secure_webserver_settings.certificate_chain_file_path; // not used
 	m_secure_webserver_settings.cert_file_path = m_secure_webserver_settings.certificate_chain_file_path;
 	m_secure_webserver_settings.private_key_file_path = m_secure_webserver_settings.certificate_chain_file_path;
 	m_secure_webserver_settings.private_key_pass_phrase = "";
-	m_secure_webserver_settings.ssl_options = "default_workarounds,no_sslv2,no_sslv3,no_tlsv1,no_tlsv1_1,single_dh_use";
+	m_secure_webserver_settings.ssl_options = "single_dh_use";
 	m_secure_webserver_settings.tmp_dh_file_path = m_secure_webserver_settings.certificate_chain_file_path;
 	m_secure_webserver_settings.verify_peer = false;
 	m_secure_webserver_settings.verify_fail_if_no_peer_cert = false;
 	m_secure_webserver_settings.verify_file_path = "";
+	m_secure_webserver_settings.cipher_list = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384";
 #endif
 	m_bIgnoreUsernamePassword = false;
 

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -202,6 +202,9 @@ void ssl_server::init_connection() {
 	SSL_CTX_set_cipher_list(context_.native_handle(), cipher_list);
 	_log.Debug(DEBUG_WEBSERVER, "[web:%s] Enabled ciphers (TLSv1.2) %s", settings_.listening_port.c_str(), settings_.cipher_list.c_str());
 
+	SSL_CTX_set_min_proto_version(context_.native_handle(), TLS1_2_VERSION);
+	SSL_CTX_set_options(context_.native_handle(), SSL_OP_CIPHER_SERVER_PREFERENCE);
+
 	struct stat st;
 	if (settings_.certificate_chain_file_path.empty()) {
 		_log.Log(LOG_ERROR, "[web:%s] missing SSL certificate chain file parameter !", settings_.listening_port.c_str());

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -196,8 +196,11 @@ void ssl_server::init_connection() {
 	} else {
 		context_.set_options(settings_.get_ssl_options());
 	}
-	char cipher_list[] = "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS";
+
+	char cipher_list[settings_.cipher_list.size()+1];
+	strcpy(cipher_list, settings_.cipher_list.c_str());
 	SSL_CTX_set_cipher_list(context_.native_handle(), cipher_list);
+	_log.Debug(DEBUG_WEBSERVER, "[web:%s] Enabled ciphers (TLSv1.2) %s", settings_.listening_port.c_str(), settings_.cipher_list.c_str());
 
 	struct stat st;
 	if (settings_.certificate_chain_file_path.empty()) {
@@ -217,7 +220,6 @@ void ssl_server::init_connection() {
 	} else {
 		_log.Log(LOG_ERROR, "[web:%s] missing SSL certificate file %s!", settings_.listening_port.c_str(), settings_.cert_file_path.c_str());
 	}
-
 
 	if (settings_.private_key_file_path.empty()) {
 		_log.Log(LOG_ERROR, "[web:%s] missing SSL private key file parameter !", settings_.listening_port.c_str());
@@ -248,6 +250,7 @@ void ssl_server::init_connection() {
 			context_.set_verify_mode(verify_mode);
 		}
 	}
+
 	// Load DH parameters
 	if (settings_.tmp_dh_file_path.empty()) {
 		_log.Log(LOG_ERROR, "[web:%s] missing SSL DH file parameter", settings_.listening_port.c_str());
@@ -259,7 +262,7 @@ void ssl_server::init_connection() {
 				(std::istreambuf_iterator<char>()));
 		if (content.find("BEGIN DH PARAMETERS") != std::string::npos) {
 			context_.use_tmp_dh_file(settings_.tmp_dh_file_path);
-			//_log.DEBUG(DEBUG_WEBSERVER, "[web:%s] 'BEGIN DH PARAMETERS' found in file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
+			_log.Debug(DEBUG_WEBSERVER, "[web:%s] 'BEGIN DH PARAMETERS' found in file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
 		} else {
 			_log.Log(LOG_ERROR, "[web:%s] missing SSL DH parameters from file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
 		}

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -197,8 +197,7 @@ void ssl_server::init_connection() {
 		context_.set_options(settings_.get_ssl_options());
 	}
 
-	char cipher_list[settings_.cipher_list.size()+1];
-	strcpy(cipher_list, settings_.cipher_list.c_str());
+	const char* cipher_list = &settings_.cipher_list[0];
 	SSL_CTX_set_cipher_list(context_.native_handle(), cipher_list);
 	_log.Debug(DEBUG_WEBSERVER, "[web:%s] Enabled ciphers (TLSv1.2) %s", settings_.listening_port.c_str(), settings_.cipher_list.c_str());
 

--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -204,6 +204,7 @@ void ssl_server::init_connection() {
 
 	SSL_CTX_set_min_proto_version(context_.native_handle(), TLS1_2_VERSION);
 	SSL_CTX_set_options(context_.native_handle(), SSL_OP_CIPHER_SERVER_PREFERENCE);
+	SSL_CTX_set_options(context_.native_handle(), SSL_OP_NO_RENEGOTIATION);
 
 	struct stat st;
 	if (settings_.certificate_chain_file_path.empty()) {

--- a/webserver/server_settings.hpp
+++ b/webserver/server_settings.hpp
@@ -94,6 +94,7 @@ public:
 	bool verify_peer{ false };
 	bool verify_fail_if_no_peer_cert{ false };
 	std::string verify_file_path;
+	std::string cipher_list;
 
 	ssl_server_settings()
 		: server_settings(true)
@@ -136,6 +137,22 @@ public:
 		else if (ssl_method == "tlsv12_server")
 		{
 			method = boost::asio::ssl::context::tlsv12_server;
+		}
+		else if (ssl_method == "tlsv13")
+		{
+			method = boost::asio::ssl::context::tlsv13;
+		}
+		else if (ssl_method == "tlsv13_server")
+		{
+			method = boost::asio::ssl::context::tlsv13_server;
+		}
+		else if (ssl_method == "tls")
+		{
+			method = boost::asio::ssl::context::tls;
+		}
+		else if (ssl_method == "tls_server")
+		{
+			method = boost::asio::ssl::context::tls_server;
 		}
 		else
 		{


### PR DESCRIPTION
This PR makes a number of changes in the Domoticz webserver to tighten SSL security.

Next to a small fix also some settings are changes/optimized:

- Only TLS v1.2 and TSL v1.3 are allowed
- Only a limited set of Ciphers is allowed for TLS v1.2 (based on the [Mozilla Intermediate](https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29) recommendation)
- The server now presents a Cipher preference list to the Client
- The server _DOES NOT_ allow _Client initiated renegotiation_ anymore

These changes make the Domoticz webserver more secure and safe to use when offering HTTPS.

_NOTE_: Please use a good/valid certificate instead of the default (self-singed) Domoticz certificate. For example using [Lets Encrypt](https://www.domoticz.com/wiki/Native_secure_access_with_Lets_Encrypt).

It is possible to perform a self-test using different online testing tools or run such a test locally using [`testssl.sh`](https://github.com/drwetter/testssl.sh)

```
testssl.sh --color 2 --openssl /usr/bin/openssl https://127.0.0.1:8443
```

Run your Domoticz instance with the following parameters to test
```
sudo ./bin/domoticz -www 0 -sslwww 8443 -wwwroot www -loglevel all -debuglevel normal,webserver
```

Below is a left-right diff off the output of `testssl.sh` between the development branch and this PR (right-side):
_(You can neglect the _issues_ with the default Domoticz HTTPS certificate as it is the default a self-signed cert)_
```
                                                              >
No engine or GOST support via engine with your /usr/bin/opens   No engine or GOST support via engine with your /usr/bin/opens

###########################################################     ###########################################################
    testssl.sh       3.0.6 from https://testssl.sh/                 testssl.sh       3.0.6 from https://testssl.sh/
    (43ee2af49 2021-12-24 09:07:32)                           |     (bef24d63e 2021-12-31 14:44:25)

      This program is free software. Distribution and                 This program is free software. Distribution and
             modification under GPLv2 permitted.                             modification under GPLv2 permitted.
      USAGE w/o ANY WARRANTY. USE IT AT YOUR OWN RISK!                USAGE w/o ANY WARRANTY. USE IT AT YOUR OWN RISK!

       Please file bugs @ https://testssl.sh/bugs/                     Please file bugs @ https://testssl.sh/bugs/

###########################################################     ###########################################################

 Using "OpenSSL 1.1.1j  16 Feb 2021" [~79 ciphers]               Using "OpenSSL 1.1.1j  16 Feb 2021" [~79 ciphers]
 on ccdomoticz:/usr/bin/openssl                                  on ccdomoticz:/usr/bin/openssl
 (built: "Nov 24 10:32:57 2021", platform: "debian-amd64")       (built: "Nov 24 10:32:57 2021", platform: "debian-amd64")


 Start 2021-12-30 19:07:09        -->> 127.0.0.1:8443 (127.0. |  Start 2022-01-03 17:59:29        -->> 127.0.0.1:8443 (127.0.

 rDNS (127.0.0.1):       --                                      rDNS (127.0.0.1):       --
 Service detected:       HTTP                                    Service detected:       HTTP


 Testing protocols via sockets except NPN+ALPN                   Testing protocols via sockets except NPN+ALPN 

 SSLv2      not offered (OK)                                     SSLv2      not offered (OK)
 SSLv3      not offered (OK)                                     SSLv3      not offered (OK)
 TLS 1      not offered                                          TLS 1      not offered
 TLS 1.1    not offered                                          TLS 1.1    not offered
 TLS 1.2    offered (OK)                                         TLS 1.2    offered (OK)
 TLS 1.3    offered (OK): final                                  TLS 1.3    offered (OK): final
 NPN/SPDY   not offered                                          NPN/SPDY   not offered
 ALPN/HTTP2 not offered                                          ALPN/HTTP2 not offered

 Testing cipher categories                                       Testing cipher categories 

 NULL ciphers (no encryption)                  not offered (O    NULL ciphers (no encryption)                  not offered (O
 Anonymous NULL Ciphers (no authentication)    not offered (O    Anonymous NULL Ciphers (no authentication)    not offered (O
 Export ciphers (w/o ADH+NULL)                 not offered (O    Export ciphers (w/o ADH+NULL)                 not offered (O
 LOW: 64 Bit + DES, RC[2,4] (w/o export)       not offered (O    LOW: 64 Bit + DES, RC[2,4] (w/o export)       not offered (O
 Triple DES Ciphers / IDEA                     not offered       Triple DES Ciphers / IDEA                     not offered
 Obsolete CBC ciphers (AES, ARIA etc.)         offered        |  Obsolete CBC ciphers (AES, ARIA etc.)         not offered
 Strong encryption (AEAD ciphers)              offered (OK)      Strong encryption (AEAD ciphers)              offered (OK)


 Testing robust (perfect) forward secrecy, (P)FS -- omitting     Testing robust (perfect) forward secrecy, (P)FS -- omitting 

 PFS is offered (OK)          TLS_AES_256_GCM_SHA384 TLS_CHAC |  PFS is offered (OK), ciphers follow (client/browser support 
                              ECDHE-RSA-AES128-GCM-SHA256 ECD |
                                                              > Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encrypt
                                                              > -------------------------------------------------------------
                                                              >  x1302   TLS_AES_256_GCM_SHA384            ECDH 253   AESGCM 
                                                              >  x1303   TLS_CHACHA20_POLY1305_SHA256      ECDH 253   ChaCha2
                                                              >  xc030   ECDHE-RSA-AES256-GCM-SHA384       ECDH 253   AESGCM 
                                                              >  x9f     DHE-RSA-AES256-GCM-SHA384         DH 2048    AESGCM 
                                                              >  xcca8   ECDHE-RSA-CHACHA20-POLY1305       ECDH 253   ChaCha2
                                                              >  x1301   TLS_AES_128_GCM_SHA256            ECDH 253   AESGCM 
                                                              >  xc02f   ECDHE-RSA-AES128-GCM-SHA256       ECDH 253   AESGCM 
                                                              >  x9e     DHE-RSA-AES128-GCM-SHA256         DH 2048    AESGCM 
                                                              >
 Elliptic curves offered:     prime256v1 secp384r1 secp521r1     Elliptic curves offered:     prime256v1 secp384r1 secp521r1 
 DH group offered:            Unknown DH group (2048 bits)       DH group offered:            Unknown DH group (2048 bits)

 Testing server preferences                                      Testing server preferences 

 Has server cipher order?     no (NOT ok)                     |  Has server cipher order?     yes (OK) -- TLS 1.3 and below
 Negotiated protocol          TLSv1.3                            Negotiated protocol          TLSv1.3
 Negotiated cipher            TLS_AES_256_GCM_SHA384, 253 bit |  Negotiated cipher            TLS_AES_256_GCM_SHA384, 253 bit
 Negotiated cipher per proto  (limited sense as client will p |  Cipher order
     ECDHE-RSA-AES256-GCM-SHA384:   TLSv1.2                   |     TLSv1.2:   ECDHE-RSA-AES128-GCM-SHA256 ECDHE-RSA-AES256-G
     TLS_AES_256_GCM_SHA384:        TLSv1.3                   |     TLSv1.3:   TLS_AES_256_GCM_SHA384 TLS_CHACHA20_POLY1305_S
 No further cipher order check has been done as order is dete <


 Testing server defaults (Server Hello)                          Testing server defaults (Server Hello) 

 TLS extensions (standard)    "renegotiation info/#65281" "EC |  TLS extensions (standard)    "renegotiation info/#65281" "EC
 Session Ticket RFC 5077 hint 7200 seconds, session tickets k    Session Ticket RFC 5077 hint 7200 seconds, session tickets k
 SSL Session ID support       yes                                SSL Session ID support       yes
 Session Resumption           Tickets: yes, ID: no               Session Resumption           Tickets: yes, ID: no
 TLS clock skew               Random values, no fingerprintin    TLS clock skew               Random values, no fingerprintin
 Signature Algorithm          SHA256 with RSA                    Signature Algorithm          SHA256 with RSA
 Server key size              RSA 2048 bits                      Server key size              RSA 2048 bits
 Server key usage             --                                 Server key usage             --
 Server extended key usage    --                                 Server extended key usage    --
 Serial / Fingerprints        98D8985AEE509B51 / SHA1 48493AC    Serial / Fingerprints        98D8985AEE509B51 / SHA1 48493AC
                              SHA256 5B4069238C628BE8031E19D9                                 SHA256 5B4069238C628BE8031E19D9
 Common Name (CN)             *.domoticz.com                     Common Name (CN)             *.domoticz.com 
 subjectAltName (SAN)         missing (NOT ok) -- Browsers ar    subjectAltName (SAN)         missing (NOT ok) -- Browsers ar
 Issuer                       *.domoticz.com (Domoticz from N    Issuer                       *.domoticz.com (Domoticz from N
 Trust (hostname)             certificate does not match supp    Trust (hostname)             certificate does not match supp
 Chain of trust               NOT ok (self signed)               Chain of trust               NOT ok (self signed)
 EV cert (experimental)       no                                 EV cert (experimental)       no 
 ETS/"eTLS", visibility info  not present                        ETS/"eTLS", visibility info  not present
 Certificate Validity (UTC)   1236 >= 60 days (2015-05-23 06: |  Certificate Validity (UTC)   1232 >= 60 days (2015-05-23 06:
                              >= 10 years is way too long                                     >= 10 years is way too long
 # of certificates provided   1                                  # of certificates provided   1
 Certificate Revocation List  --                                 Certificate Revocation List  --
 OCSP URI                     --                                 OCSP URI                     --
                              NOT ok -- neither CRL nor OCSP                                  NOT ok -- neither CRL nor OCSP 
 OCSP stapling                not offered                        OCSP stapling                not offered
 OCSP must staple extension   --                                 OCSP must staple extension   --
 DNS CAA RR (experimental)    not offered                        DNS CAA RR (experimental)    not offered
 Certificate Transparency     --                                 Certificate Transparency     --


 Testing HTTP header response @ "/"                              Testing HTTP header response @ "/" 

 HTTP Status Code             200 OK                             HTTP Status Code             200 OK
 HTTP clock skew              Got no HTTP time, maybe try dif    HTTP clock skew              Got no HTTP time, maybe try dif
 Strict Transport Security    not offered                        Strict Transport Security    not offered
 Public Key Pinning           --                                 Public Key Pinning           --
 Server banner                (no "Server" line in header, in    Server banner                (no "Server" line in header, in
 Application banner           --                                 Application banner           --
 Cookie(s)                    (none issued at "/")               Cookie(s)                    (none issued at "/")
 Security headers             X-Content-Type-Options: nosniff    Security headers             X-Content-Type-Options: nosniff
                              Access-Control-Allow-Origin: *                                  Access-Control-Allow-Origin: *
                              X-XSS-Protection: 1; mode=block                                 X-XSS-Protection: 1; mode=block
 Reverse Proxy banner         --                                 Reverse Proxy banner         --


 Testing vulnerabilities                                         Testing vulnerabilities 

 Heartbleed (CVE-2014-0160)                not vulnerable (OK    Heartbleed (CVE-2014-0160)                not vulnerable (OK
 CCS (CVE-2014-0224)                       not vulnerable (OK    CCS (CVE-2014-0224)                       not vulnerable (OK
 Ticketbleed (CVE-2016-9244), experiment.  not vulnerable (OK    Ticketbleed (CVE-2016-9244), experiment.  not vulnerable (OK
 ROBOT                                     not vulnerable (OK |  ROBOT                                     Server does not su
 Secure Renegotiation (RFC 5746)           supported (OK)        Secure Renegotiation (RFC 5746)           supported (OK)
 Secure Client-Initiated Renegotiation     VULNERABLE (NOT ok |  Secure Client-Initiated Renegotiation     not vulnerable (OK
 CRIME, TLS (CVE-2012-4929)                not vulnerable (OK    CRIME, TLS (CVE-2012-4929)                not vulnerable (OK
 BREACH (CVE-2013-3587)                    potentially NOT ok    BREACH (CVE-2013-3587)                    potentially NOT ok
                                           Can be ignored for                                              Can be ignored for
 POODLE, SSL (CVE-2014-3566)               not vulnerable (OK    POODLE, SSL (CVE-2014-3566)               not vulnerable (OK
 TLS_FALLBACK_SCSV (RFC 7507)              No fallback possib    TLS_FALLBACK_SCSV (RFC 7507)              No fallback possib
 SWEET32 (CVE-2016-2183, CVE-2016-6329)    not vulnerable (OK    SWEET32 (CVE-2016-2183, CVE-2016-6329)    not vulnerable (OK
 FREAK (CVE-2015-0204)                     not vulnerable (OK    FREAK (CVE-2015-0204)                     not vulnerable (OK
 DROWN (CVE-2016-0800, CVE-2016-0703)      not vulnerable on     DROWN (CVE-2016-0800, CVE-2016-0703)      not vulnerable on 
                                           make sure you don'                                              make sure you don'
                                           https://censys.io/                                              https://censys.io/
 LOGJAM (CVE-2015-4000), experimental      not vulnerable (OK    LOGJAM (CVE-2015-4000), experimental      not vulnerable (OK
 BEAST (CVE-2011-3389)                     not vulnerable (OK    BEAST (CVE-2011-3389)                     not vulnerable (OK
 LUCKY13 (CVE-2013-0169), experimental     potentially VULNER |  LUCKY13 (CVE-2013-0169), experimental     not vulnerable (OK
 RC4 (CVE-2013-2566, CVE-2015-2808)        no RC4 ciphers det    RC4 (CVE-2013-2566, CVE-2015-2808)        no RC4 ciphers det


 Testing 370 ciphers via OpenSSL plus sockets against the ser    Testing 370 ciphers via OpenSSL plus sockets against the ser

Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encrypt   Hexcode  Cipher Suite Name (OpenSSL)       KeyExch.   Encrypt
-------------------------------------------------------------   -------------------------------------------------------------
 x1302   TLS_AES_256_GCM_SHA384            ECDH 253   AESGCM     x1302   TLS_AES_256_GCM_SHA384            ECDH 253   AESGCM 
 x1303   TLS_CHACHA20_POLY1305_SHA256      ECDH 253   ChaCha2    x1303   TLS_CHACHA20_POLY1305_SHA256      ECDH 253   ChaCha2
 xc030   ECDHE-RSA-AES256-GCM-SHA384       ECDH 253   AESGCM     xc030   ECDHE-RSA-AES256-GCM-SHA384       ECDH 253   AESGCM 
 xc028   ECDHE-RSA-AES256-SHA384           ECDH 253   AES     <
 xc014   ECDHE-RSA-AES256-SHA              ECDH 253   AES     <
 x9f     DHE-RSA-AES256-GCM-SHA384         DH 2048    AESGCM     x9f     DHE-RSA-AES256-GCM-SHA384         DH 2048    AESGCM 
 xc0a3   DHE-RSA-AES256-CCM8               DH 2048    AESCCM8 |  xcca8   ECDHE-RSA-CHACHA20-POLY1305       ECDH 253   ChaCha2
 xc09f   DHE-RSA-AES256-CCM                DH 2048    AESCCM  <
 x6b     DHE-RSA-AES256-SHA256             DH 2048    AES     <
 x39     DHE-RSA-AES256-SHA                DH 2048    AES     <
 x9d     AES256-GCM-SHA384                 RSA        AESGCM  <
 xc0a1   AES256-CCM8                       RSA        AESCCM8 <
 xc09d   AES256-CCM                        RSA        AESCCM  <
 x3d     AES256-SHA256                     RSA        AES     <
 x35     AES256-SHA                        RSA        AES     <
 x1301   TLS_AES_128_GCM_SHA256            ECDH 253   AESGCM     x1301   TLS_AES_128_GCM_SHA256            ECDH 253   AESGCM 
 xc02f   ECDHE-RSA-AES128-GCM-SHA256       ECDH 253   AESGCM     xc02f   ECDHE-RSA-AES128-GCM-SHA256       ECDH 253   AESGCM 
 xc027   ECDHE-RSA-AES128-SHA256           ECDH 253   AES     <
 xc013   ECDHE-RSA-AES128-SHA              ECDH 253   AES     <
 x9e     DHE-RSA-AES128-GCM-SHA256         DH 2048    AESGCM     x9e     DHE-RSA-AES128-GCM-SHA256         DH 2048    AESGCM 
 xc0a2   DHE-RSA-AES128-CCM8               DH 2048    AESCCM8 <
 xc09e   DHE-RSA-AES128-CCM                DH 2048    AESCCM  <
 xc0a0   AES128-CCM8                       RSA        AESCCM8 <
 xc09c   AES128-CCM                        RSA        AESCCM  <
 x67     DHE-RSA-AES128-SHA256             DH 2048    AES     <
 x33     DHE-RSA-AES128-SHA                DH 2048    AES     <
 x9c     AES128-GCM-SHA256                 RSA        AESGCM  <
 x3c     AES128-SHA256                     RSA        AES     <
 x2f     AES128-SHA                        RSA        AES     <


 Running client simulations (HTTP) via sockets                   Running client simulations (HTTP) via sockets 

 Android 4.4.2                TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Browser                      Protocol  Cipher Suite Name (Op
 Android 5.0.0                TLSv1.2 ECDHE-RSA-AES256-SHA, 5 | -------------------------------------------------------------
 Android 6.0                  TLSv1.2 ECDHE-RSA-AES128-GCM-SH |  Android 4.4.2                TLSv1.2   ECDHE-RSA-AES128-GCM-
 Android 7.0 (native)         TLSv1.2 ECDHE-RSA-AES128-GCM-SH |  Android 5.0.0                TLSv1.2   ECDHE-RSA-AES128-GCM-
 Android 8.1 (native)         TLSv1.2 ECDHE-RSA-AES128-GCM-SH |  Android 6.0                  TLSv1.2   ECDHE-RSA-AES128-GCM-
 Android 9.0 (native)         TLSv1.3 TLS_AES_128_GCM_SHA256, |  Android 7.0 (native)         TLSv1.2   ECDHE-RSA-AES128-GCM-
 Android 10.0 (native)        TLSv1.3 TLS_AES_128_GCM_SHA256, |  Android 8.1 (native)         TLSv1.2   ECDHE-RSA-AES128-GCM-
 Chrome 74 (Win 10)           TLSv1.3 TLS_AES_128_GCM_SHA256, |  Android 9.0 (native)         TLSv1.3   TLS_AES_256_GCM_SHA38
 Chrome 79 (Win 10)           TLSv1.3 TLS_AES_128_GCM_SHA256, |  Android 10.0 (native)        TLSv1.3   TLS_AES_256_GCM_SHA38
 Firefox 66 (Win 8.1/10)      TLSv1.3 TLS_AES_128_GCM_SHA256, |  Chrome 74 (Win 10)           TLSv1.3   TLS_AES_256_GCM_SHA38
 Firefox 71 (Win 10)          TLSv1.3 TLS_AES_128_GCM_SHA256, |  Chrome 79 (Win 10)           TLSv1.3   TLS_AES_256_GCM_SHA38
                                                              >  Firefox 66 (Win 8.1/10)      TLSv1.3   TLS_AES_256_GCM_SHA38
                                                              >  Firefox 71 (Win 10)          TLSv1.3   TLS_AES_256_GCM_SHA38
 IE 6 XP                      No connection                      IE 6 XP                      No connection
 IE 8 Win 7                   No connection                      IE 8 Win 7                   No connection
 IE 8 XP                      No connection                      IE 8 XP                      No connection
 IE 11 Win 7                  TLSv1.2 ECDHE-RSA-AES256-SHA384 |  IE 11 Win 7                  TLSv1.2   DHE-RSA-AES128-GCM-SH
 IE 11 Win 8.1                TLSv1.2 ECDHE-RSA-AES256-SHA384 |  IE 11 Win 8.1                TLSv1.2   DHE-RSA-AES128-GCM-SH
 IE 11 Win Phone 8.1          TLSv1.2 AES128-SHA256, No FS    |  IE 11 Win Phone 8.1          No connection
 IE 11 Win 10                 TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  IE 11 Win 10                 TLSv1.2   ECDHE-RSA-AES128-GCM-
 Edge 15 Win 10               TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Edge 15 Win 10               TLSv1.2   ECDHE-RSA-AES128-GCM-
 Edge 17 (Win 10)             TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Edge 17 (Win 10)             TLSv1.2   ECDHE-RSA-AES128-GCM-
 Opera 66 (Win 10)            TLSv1.3 TLS_AES_128_GCM_SHA256, |  Opera 66 (Win 10)            TLSv1.3   TLS_AES_256_GCM_SHA38
 Safari 9 iOS 9               TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Safari 9 iOS 9               TLSv1.2   ECDHE-RSA-AES128-GCM-
 Safari 9 OS X 10.11          TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Safari 9 OS X 10.11          TLSv1.2   ECDHE-RSA-AES128-GCM-
 Safari 10 OS X 10.12         TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Safari 10 OS X 10.12         TLSv1.2   ECDHE-RSA-AES128-GCM-
 Safari 12.1 (iOS 12.2)       TLSv1.3 TLS_CHACHA20_POLY1305_S |  Safari 12.1 (iOS 12.2)       TLSv1.3   TLS_AES_256_GCM_SHA38
 Safari 13.0 (macOS 10.14.6)  TLSv1.3 TLS_CHACHA20_POLY1305_S |  Safari 13.0 (macOS 10.14.6)  TLSv1.3   TLS_AES_256_GCM_SHA38
 Apple ATS 9 iOS 9            TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  Apple ATS 9 iOS 9            TLSv1.2   ECDHE-RSA-AES128-GCM-
 Java 6u45                    No connection                      Java 6u45                    No connection
 Java 7u25                    No connection                      Java 7u25                    No connection
 Java 8u161                   TLSv1.2 ECDHE-RSA-AES256-SHA384 |  Java 8u161                   TLSv1.2   ECDHE-RSA-AES128-GCM-
 Java 11.0.2 (OpenJDK)        TLSv1.3 TLS_AES_128_GCM_SHA256, |  Java 11.0.2 (OpenJDK)        TLSv1.3   TLS_AES_256_GCM_SHA38
 Java 12.0.1 (OpenJDK)        TLSv1.3 TLS_AES_128_GCM_SHA256, |  Java 12.0.1 (OpenJDK)        TLSv1.3   TLS_AES_256_GCM_SHA38
 OpenSSL 1.0.2e               TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  OpenSSL 1.0.2e               TLSv1.2   ECDHE-RSA-AES128-GCM-
 OpenSSL 1.1.0l (Debian)      TLSv1.2 ECDHE-RSA-AES256-GCM-SH |  OpenSSL 1.1.0l (Debian)      TLSv1.2   ECDHE-RSA-AES128-GCM-
 OpenSSL 1.1.1d (Debian)      TLSv1.3 TLS_AES_256_GCM_SHA384, |  OpenSSL 1.1.1d (Debian)      TLSv1.3   TLS_AES_256_GCM_SHA38
 Thunderbird (68.3)           TLSv1.3 TLS_AES_128_GCM_SHA256, |  Thunderbird (68.3)           TLSv1.3   TLS_AES_256_GCM_SHA38
                                                              >
                                                              >  Done 2022-01-03 18:00:05 [  37s] -->> 127.0.0.1:8443 (127.0.

 Done 2021-12-30 19:08:04 [  56s] -->> 127.0.0.1:8443 (127.0. <

```

Let's keep Domoticz secure :)
