### PR TITLE
(Non-Windows) Use stat instead of lstat to allow symlinks to be used

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1064,7 +1064,7 @@ bool dirent_is_directory(const std::string &dir, struct dirent *ent)
 	if (ent->d_type == DT_UNKNOWN) {
 		std::string fname = dir + "/" + ent->d_name;
 		struct stat st;
-		if (!lstat(fname.c_str(), &st))
+		if (!stat(fname.c_str(), &st))
 			return S_ISDIR(st.st_mode);
 	}
 #endif
@@ -1079,7 +1079,7 @@ bool dirent_is_file(const std::string &dir, struct dirent *ent)
 	if (ent->d_type == DT_UNKNOWN) {
 		std::string fname = dir + "/" + ent->d_name;
 		struct stat st;
-		if (!lstat(fname.c_str(), &st))
+		if (!stat(fname.c_str(), &st))
 			return S_ISREG(st.st_mode);
 	}
 #endif


### PR DESCRIPTION
PR to allow the usage of symlinked script files (Python, Lua, etc.) on (Non-Windows) OS'es that support symlinks.

Before, if for example a Python event script was supposed to be used by creating a symbolic link in the `script/python/` directory to the actual script file (which resides somewhere else on the filesystem, for example in a cloned GIT repo), that file did not get evaluated as the evaluation routine checks if the file is a regular file. When `lstat` is used, a symlink is _NOT_ consider a regular file (but a symlink :) ). By using `stat`, the actual file the link points to is being examined.

See issue #5097 