### PR TITLE
Webserver fix to add charset to stock reply content-type

### DIFF
--- a/test/gherkin/conftest.py
+++ b/test/gherkin/conftest.py
@@ -1,0 +1,62 @@
+from pytest_bdd import scenario, given, when, then, parsers
+import requests
+
+class Domoticz:
+    sBaseURI = ""
+    iPort = ""
+    sVersion = ""
+    oResponse = ""
+    oReqHeaders = ""
+
+@given('Domoticz is running')
+def test_domoticz():
+    Domoticz.sBaseURI = "http://localhost"
+    return Domoticz()
+
+@given(parsers.parse('accessible on port {port:d}'))
+def check_domoticz_port(test_domoticz,port):
+    oResult = requests.get(test_domoticz.sBaseURI + ":" + str(port) + "/json.htm?type=command&param=getversion")
+    if oResult.status_code == 200:
+        test_domoticz.iPort = port
+        test_domoticz.sBaseURI += ":" + str(port)
+        oJSON = oResult.json()
+        test_domoticz.sVersion = oJSON["version"]
+    assert oResult.status_code == 200
+
+@given('I am a normal Domoticz user')
+def setup_user():
+    pass
+
+@when(parsers.parse('I request the URI "{uri}"'))
+def request_uri(test_domoticz,uri):
+    oResult = requests.get(test_domoticz.sBaseURI + uri, headers=test_domoticz.oReqHeaders)
+    test_domoticz.oResponse = oResult
+
+@when(parsers.parse('I request the "{method}"'))
+def request_uri(test_domoticz,method):
+    if method == "Configuration Settings":
+        uri = '/json.htm?type=settings'
+    elif method == "Version Information":
+        uri = '/json.htm?type=command&param=getversion'
+    else:
+        uri = '/idonotexist'
+
+    oResult = requests.get(test_domoticz.sBaseURI + uri, headers=test_domoticz.oReqHeaders)
+    test_domoticz.oResponse = oResult
+
+@then(parsers.parse('the HTTP-return code should be "{returncode:d}"'))
+def check_returncode(test_domoticz,returncode):
+    assert test_domoticz.oResponse.status_code == returncode
+
+@then(parsers.parse('the HTTP-header "{headername}" should contain "{headervalue}"'))
+def check_header(test_domoticz,headername, headervalue):
+    bExists = headername in test_domoticz.oResponse.headers
+    if bExists:
+        assert test_domoticz.oResponse.headers[headername] == headervalue
+    else:
+        print(test_domoticz.oResponse.headers)
+        assert False
+
+@then(parsers.parse('the HTTP-header "{headername}" should be absent'))
+def check_noheader(test_domoticz,headername, headervalue):
+    assert not headername in test_domoticz.oResponse.headers

--- a/test/gherkin/test_webserver.py
+++ b/test/gherkin/test_webserver.py
@@ -1,13 +1,6 @@
 from pytest_bdd import scenario, given, when, then, parsers
 import requests
 
-class Domoticz:
-    sBaseURI = ""
-    iPort = ""
-    sVersion = ""
-    oResponse = ""
-    oReqHeaders = ""
-
 @scenario('webserver.feature', 'Get uncompressed source in compressed form')
 def test_compressedout():
     pass
@@ -28,23 +21,8 @@ def test_notdecompressedout():
 def test_regularfile():
     pass
 
-@given('Domoticz is running')
-def test_domoticz():
-    Domoticz.sBaseURI = "http://localhost"
-    return Domoticz()
-
-@given(parsers.parse('accessible on port {port:d}'))
-def check_domoticz_port(test_domoticz,port):
-    oResult = requests.get(test_domoticz.sBaseURI + ":" + str(port) + "/json.htm?type=command&param=getversion")
-    if oResult.status_code == 200:
-        test_domoticz.iPort = port
-        test_domoticz.sBaseURI += ":" + str(port)
-        oJSON = oResult.json()
-        test_domoticz.sVersion = oJSON["version"]
-    assert oResult.status_code == 200
-
-@given('I am a normal Domoticz user')
-def setup_user():
+@scenario('webserver.feature', 'Validate standard Not Found reply')
+def test_notfoundfile():
     pass
 
 @given(parsers.parse('my browser {gzipsupport} receiving compressed data'))
@@ -52,29 +30,7 @@ def setup_request(test_domoticz, gzipsupport):
     if gzipsupport == "supports":
         test_domoticz.oReqHeaders = {"Accept-Encoding": "gzip, deflate"}
 
-@when(parsers.parse('I request the URI "{uri}"'))
-def request_uri(test_domoticz,uri):
-    oResult = requests.get(test_domoticz.sBaseURI + uri, headers=test_domoticz.oReqHeaders)
-    test_domoticz.oResponse = oResult
-
-@then(parsers.parse('the HTTP-return code should be "{returncode:d}"'))
-def check_returncode(test_domoticz,returncode):
-    assert test_domoticz.oResponse.status_code == returncode
-
 @then(parsers.parse('I should receive the content saying "{content}"'))
 def check_content(test_domoticz,content):
     print(test_domoticz.oResponse.text)
     assert test_domoticz.oResponse.text.rstrip() == content
-    #pass
-
-@then(parsers.parse('the HTTP-header "{headername}" should contain "{headervalue}"'))
-def check_header(test_domoticz,headername, headervalue):
-    bExists = headername in test_domoticz.oResponse.headers
-    if bExists:
-        assert test_domoticz.oResponse.headers[headername] == headervalue
-    else:
-        assert False
-
-@then(parsers.parse('the HTTP-header "{headername}" should be absent'))
-def check_noheader(test_domoticz,headername, headervalue):
-    assert not headername in test_domoticz.oResponse.headers

--- a/test/gherkin/webserver.feature
+++ b/test/gherkin/webserver.feature
@@ -42,9 +42,14 @@ Feature: Webserver handling
 
     Scenario: Get regular file without extension
         Given I am a normal Domoticz user
-        And my browser supports receiving compressed data
         When I request the URI "/test/test2"
         Then the HTTP-return code should be "200"
         And I should receive the content saying "A regular file without extension!"
         And the HTTP-header "Content-Length" should contain "34"
         And the HTTP-header "Content-Type" should be absent
+
+    Scenario: Validate standard Not Found reply
+        Given I am a normal Domoticz user
+        When I request the URI "/idonotexist.png"
+        Then the HTTP-return code should be "404"
+        And the HTTP-header "Content-Type" should contain "text/html;charset=UTF-8"

--- a/webserver/reply.cpp
+++ b/webserver/reply.cpp
@@ -236,7 +236,7 @@ reply reply::stock_reply(reply::status_type status)
 		rep.headers[0].name = "Content-Length";
 		rep.headers[0].value = std::to_string(rep.content.size());
 		rep.headers[1].name = "Content-Type";
-		rep.headers[1].value = "text/html";
+		rep.headers[1].value = "text/html;charset=UTF-8";
 	}
 	return rep;
 }


### PR DESCRIPTION
This PR fixes the omission in the stock reply Content-Type. Previously it did not return the charset. Now it also returns `charset=UTF-8` to set the correct encoding of the returned `text/html`.

Also updated the (automated) functional tests to keep checking this and created a 'conftest.py' to contain generic Step Definitions that can be re-used by other Feature file implementations (instead of duplicating them).