### PR TITLE
Webserver: Fix for dirs with a dot in name that messed up extension handling

### DIFF
--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -250,10 +250,11 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 			}
 			// Determine the file extension.
 			std::size_t last_slash_pos = full_path.find_last_of('/');
-			std::size_t last_dot_pos = full_path.find_last_of('.');
-			if (last_dot_pos != std::string::npos && last_dot_pos > last_slash_pos && last_dot_pos < full_path.length()-1)
+			std::string requested_file = full_path.substr(last_slash_pos + 1);
+			std::size_t last_dot_pos = requested_file.find_last_of('.');
+			if (last_dot_pos != std::string::npos && last_dot_pos < requested_file.length()-1)
 			{
-				extension = full_path.substr(last_dot_pos + 1);
+				extension = requested_file.substr(last_dot_pos + 1);
 				bValidUri = true;
 			}
 			else if((last_dot_pos == std::string::npos) && (iStat == 0) && ((sb.st_mode & S_IFREG) == S_IFREG))


### PR DESCRIPTION
PR is a improvement of PR #5084 . Although files without an extension are being served by that PR, it does fail when there was a '.' (dot) in one of the directory names.

The logic to determine the extension of the requested file did not handle that correctly. Now it does.

Thx fanabullunet for persisting with testing.