### PR TITLE
MQTT AD Scripts add Userid and Password support

### DIFF
--- a/hardware/mqtt_ad/README.md
+++ b/hardware/mqtt_ad/README.md
@@ -14,21 +14,26 @@ When you are asked to supply a copy of all MQTT messages for a device used by MQ
 
 Script that helps capturing MQTT messages for Homeassistant AD into a file, so they can be shared easily with others for debugging.
 
-### usage:
+### usage mqtt_ad_record.sh
 
-```bash
+```text
 bash mqtt_ad_record.sh [-h hostname/ip] [-p port] [-s searchstring] [-t capturetime]
    -h Hostname or Ipaddres of MQTT deamon. default is 127.0.0.1
    -p port for the MQTT deamon. default is 1883
+   -u Userid for MQTT deamon
+   -P Password for MQTT deamon
    -s only records MQTT messages that contain this string in the TOPIC or PAYLOAD. default is all messages
    -t caputure time in seconds. default is 600
 ```
 
-### examples:
+### examples mqtt_ad_record.sh
 
 ```bash
    # Records all MQTT Messages containing "/config", "_state" or "/state" for 10 minutes
    bash mqtt_ad_record.sh
+
+   # specify userid and password to access the MQTT deamon.
+   bash mqtt_ad_record.sh -u UserId -P Password
 
    #Records all MQTT Messages containing "/config", "_state" or "/state" for 30 Seconds
    bash mqtt_ad_record.sh -t 30
@@ -41,18 +46,18 @@ bash mqtt_ad_record.sh [-h hostname/ip] [-p port] [-s searchstring] [-t capturet
 ```
 
 The above command will create an **mqtt_ad_record_*XXX*.log** file in the current directory.
-   - where ***XXX*** will be ***all*** for the first 2 examples and will be ***TASMOTA_A1*** for the last 2 examples.
+
+- where ***XXX*** will be ***all*** for the first 2 examples and will be ***TASMOTA_A1*** for the last 2 examples.
 
 [Download mqtt_ad_record.sh](mqtt_ad_record.sh)
-
 
 ## mqtt_ad_send.sh
 
 Script that sends the captured mqtt records again to a server recorded in HA_Discovery_mqtt.log in dezelfde directory.
 
-### usage:
+### usage mqtt_ad_send.sh
 
-```bash
+```text
 bash mqtt_ad_send.sh [-h hostname/ip] [-p port] [-s searchstring] [-i inputfile]
    -h Hostname or Ipaddres of MQTT deamon. default is 127.0.0.1
    -p port for the MQTT deamon. default is 1883
@@ -60,6 +65,19 @@ bash mqtt_ad_send.sh [-h hostname/ip] [-p port] [-s searchstring] [-i inputfile]
    -i inputfile. default is mqtt_ad_record_all.log
    -r override retain (y/n). defaults to the retain flag in the input records
    -d When Dry-run when switch is provided, no MQTT messages will be send, just the logging.
+```
+
+### examples mqtt_ad_send.sh
+
+```bash
+   #ALL records
+   bash mqtt_ad_send.sh
+
+   #ALL records from a specific file
+   bash mqtt_ad_send.sh -i mqtt_ad_record_testDevice.log
+
+   #Send selected records from log file:
+   bash mqtt_ad_send.sh PARTIAL_DEVICE_NAME
 ```
 
 [Download mqtt_ad_send.sh](mqtt_ad_send.sh)

--- a/hardware/mqtt_ad/mqtt_ad_record.sh
+++ b/hardware/mqtt_ad/mqtt_ad_record.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 : '
-# Scriptname mqtt_ad_record.sh     Ver: 20220120-01
+# Scriptname mqtt_ad_record.sh     Ver: 20220121-01
 # Created by JvdZ
 
 Script that helps capturing MQTT messages for Homeassistant AD into a file so they can be shared easily with others for debugging.
@@ -57,8 +57,8 @@ do
 	case "${flag}" in
         h) MQTT_IP=${OPTARG};;
         p) MQTT_PORT=${OPTARG};;
-        u) MQTT_Param=${MQTT_Param}' -u "'${OPTARG}'"';;
-        P) MQTT_Param=${MQTT_Param}' -P "'${OPTARG}'"';;
+        u) MQTT_Param=${MQTT_Param}' -u '${OPTARG}'';;
+        P) MQTT_Param=${MQTT_Param}' -P '${OPTARG}'';;
         s) sdev=${OPTARG};;
         t) rtime=${OPTARG};;
     esac
@@ -84,10 +84,10 @@ echo "Search For: '$sdev'";
 
 # Start Capture
 if [[ -z $sdev ]]; then
-	echo "Start Capture for $rtime seconds of all MQTT messages to Console and file: $sdev.log"
+	echo "Start Capture for $rtime seconds of all MQTT messages to Console and file: mqtt_ad_record_all.log"
 	mosquitto_sub $MQTT_Param -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i -e "\/config\|[_\/]state" | stdbuf -i0 -o0 tee "mqtt_ad_record_all.log"
 else
-	echo "Start Capture for $rtime seconds of MQTT messages containing $sdev to Console and file: $sdev.log"
+	echo "Start Capture for $rtime seconds of MQTT messages containing $sdev to Console and file: mqtt_ad_record_$sdev.log"
 	mosquitto_sub $MQTT_Param -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i "$sdev" | stdbuf -i0 -o0 tee "mqtt_ad_record_$sdev.log"
 fi
 # Capture Ended

--- a/hardware/mqtt_ad/mqtt_ad_record.sh
+++ b/hardware/mqtt_ad/mqtt_ad_record.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 : '
-# Scriptname mqtt_ad_record.sh     Ver: 20220119-02
+# Scriptname mqtt_ad_record.sh     Ver: 20220120-01
 # Created by JvdZ
 
 Script that helps capturing MQTT messages for Homeassistant AD into a file so they can be shared easily with others for debugging.
@@ -9,12 +9,17 @@ usage:
 bash mqtt_ad_record.sh [-h hostname/ip] [-p port] [-s searchstring] [-t*max capture time seconds*]
    -h Hostname or Ipaddres of MQTT deamon. default is 127.0.0.1
    -p port for the MQTT deamon. default is 1883
+   -u Userid for MQTT deamon
+   -P Password for MQTT deamon
    -s only records MQTT messages that contain this string in the TOPIC or PAYLOAD. default is all messages
    -t caputure time in seconds. default is 600
 
 examples:
    # Records all MQTT Messages containing "/config", "_state" or "/state" for 10 minutes.
    bash mqtt_ad_record.sh
+
+   # specify userid and password to access the MQTT deamon.
+   bash mqtt_ad_record.sh -u UserId -P Password
 
    #Records all MQTT Messages containing "/config", "_state" or "/state" for 30 Seconds.
    bash mqtt_ad_record.sh -t 30
@@ -30,13 +35,11 @@ The above commands will create file mqtt_ad_record_XXX.log in the current direct
    where XXX will be all for the first 2 examples and will be TASMOTA_A1 for the last 2 examples.
 '
 
-MQTT_IP="127.0.0.1"		# Define MQTT Server
-MQTT_PORT="1883"		# Define port
-rtime=600					# Define default Capture time for MQTT messages in seconds.
-						# You can always interrupt the capture process at anytime withCtrl+Break pr Ctrl+C
-
-# Set case insensitive flag for the PARTIAL_DEVICE_NAME tests
-shopt -s nocasematch
+MQTT_IP="127.0.0.1"  # Define MQTT Server
+MQTT_PORT="1883"     # Define port
+rtime=600            # Define default Capture time for MQTT messages in seconds.
+                     # You can always interrupt the capture process at anytime withCtrl+Break pr Ctrl+C
+MQTT_Param=""      # used for extram mosquitto_sub parameters
 
 # Check if mosquitto_sub is installed
 if ! command -v mosquitto_sub &> /dev/null; then
@@ -49,15 +52,20 @@ if ! command -v mosquitto_sub &> /dev/null; then
 	exit
 fi
 # process parameters
-while getopts h:p:s:t: flag
+while getopts h:p:u:P:s:t: flag
 do
-    case "${flag}" in
+	case "${flag}" in
         h) MQTT_IP=${OPTARG};;
         p) MQTT_PORT=${OPTARG};;
+        u) MQTT_Param=${MQTT_Param}' -u "'${OPTARG}'"';;
+        P) MQTT_Param=${MQTT_Param}' -P "'${OPTARG}'"';;
         s) sdev=${OPTARG};;
         t) rtime=${OPTARG};;
     esac
 done
+
+# Set case insensitive flag for the PARTIAL_DEVICE_NAME tests
+shopt -s nocasematch
 
 # trap ctrl-c and call ctrl_c()
 trap message INT
@@ -68,18 +76,19 @@ function message() {
 }
 
 echo "================================================================================================================="
-echo "MQTT_IP: $MQTT_IP";
-echo "MQTT_PORT: $MQTT_PORT";
-echo "Recordtime: $rtime";
+echo "MQTT_IP   : '$MQTT_IP'";
+echo "MQTT_PORT : '$MQTT_PORT'";
+echo "MQTT_Param: '$MQTT_Param'";
+echo "Recordtime: '$rtime'";
 echo "Search For: '$sdev'";
 
 # Start Capture
 if [[ -z $sdev ]]; then
 	echo "Start Capture for $rtime seconds of all MQTT messages to Console and file: $sdev.log"
-	mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i -e "\/config\|[_\/]state" | stdbuf -i0 -o0 tee "mqtt_ad_record_all.log"
+	mosquitto_sub $MQTT_Param -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i -e "\/config\|[_\/]state" | stdbuf -i0 -o0 tee "mqtt_ad_record_all.log"
 else
 	echo "Start Capture for $rtime seconds of MQTT messages containing $sdev to Console and file: $sdev.log"
-	mosquitto_sub -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i "$sdev" | stdbuf -i0 -o0 tee "mqtt_ad_record_$sdev.log"
+	mosquitto_sub $MQTT_Param -h $MQTT_IP -p $MQTT_PORT -t "#" -v -W $rtime -F "%I\t%r\t%t\t%p"| stdbuf -i0 -o0 grep -i "$sdev" | stdbuf -i0 -o0 tee "mqtt_ad_record_$sdev.log"
 fi
 # Capture Ended
 if [ "$?" -eq "0" ] ; then

--- a/hardware/mqtt_ad/mqtt_ad_send.sh
+++ b/hardware/mqtt_ad/mqtt_ad_send.sh
@@ -9,6 +9,8 @@ usage:
 bash mqtt_ad_send.sh [-h hostname/ip] [-p port] [-s searchstring] [-i inputfile]
    -h Hostname or Ipaddres of MQTT deamon. default is 127.0.0.1
    -p port for the MQTT deamon. default is 1883
+   -u Userid for MQTT deamon
+   -P Password for MQTT deamon
    -s only send MQTT messages that contain this string in the TOPIC or PAYLOAD. default is all messages
    -i inputfile. default is mqtt_ad_record_all.log
    -r override retain (y/n). defaults to the retain flag in the record

--- a/hardware/mqtt_ad/mqtt_ad_send.sh
+++ b/hardware/mqtt_ad/mqtt_ad_send.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 : '
-# Scriptname mqtt_ad_send.sh     Ver: 20220120-01
+# Scriptname mqtt_ad_send.sh     Ver: 20220121-01
 # Created by JvdZ
 
 Script that sends the captured mqtt records again to a server recorded in HA_Discovery_mqtt.log in dezelfde directory.
@@ -32,8 +32,8 @@ do
     case "${flag}" in
         h) MQTT_IP=${OPTARG};;
         p) MQTT_PORT=${OPTARG};;
-        u) MQTT_Param=${MQTT_Param}' -u "'${OPTARG}'"';;
-        P) MQTT_Param=${MQTT_Param}' -P "'${OPTARG}'"';;
+        u) MQTT_Param=${MQTT_Param}' -u '${OPTARG};;
+        P) MQTT_Param=${MQTT_Param}' -P '${OPTARG};;
         s) sdev=${OPTARG};;
         i) input=${OPTARG};;
         r) retain=${OPTARG};;


### PR DESCRIPTION
Added the options -u & -P to be able to specify the Userid and Password for the MQTT daemon.