### PR TITLE
Teleinfo: Combine used/delivered energy in same meter

### DIFF
--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -149,7 +149,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 
       private:
 	int AlertLevel(int Iinst, int Isousc, int Sinsts, int Pcoup, char* text);
-	P1Power m_p1power, m_p2power, m_p3power, m_pInjectpower;
+	P1Power m_p1power, m_p2power, m_p3power;
 	Teleinfo m_teleinfo;
 	char m_buffer[1024];
 	int m_bufferpos;


### PR DESCRIPTION
Teleinfo: Instead of having separate meters for used and delivered energy, combine both in the same (existing) P1 Smart Meter.