### PR TITLE
Feature/webserverlogs: Option for the webserver to produce Apache Combined LogFile format weblogs

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,6 @@
 Version 2022.xxxxx (xxxx)
 - Implemented: Blockly, added 'Toggle' set command
+- Implemented: Commandline option '-weblog <weblogfile>' which creates Apache Combined Logformat logs containg all webrequests
 - Fixed: Crash when secure webserver could not start and applying settings
 - Fixed: Notification system, prevent double start
 - For a full detailed overview visit: https://www.domoticz.com/wiki/Domoticz_versions_-_Commits

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -810,30 +810,34 @@ time_t GetClockTicks()
 	return(tv.tv_sec * 1000 + tv.tv_usec / 1000);
 }
 
+void CurrentDateTimeMillisecond(tm &timeinfo, timeval &tv)
+{
+#ifdef CLOCK_REALTIME
+	struct timespec ts;
+	if (!clock_gettime(CLOCK_REALTIME, &ts))
+	{
+		tv.tv_sec = ts.tv_sec;
+		tv.tv_usec = ts.tv_nsec / 1000;
+	}
+	else
+#endif
+		gettimeofday(&tv, nullptr);
+
+#ifdef WIN32
+	time_t tv_sec = tv.tv_sec;
+	localtime_r(&tv_sec, &timeinfo);
+#else
+	localtime_r(&tv.tv_sec, &timeinfo);
+#endif
+}
+
 std::string TimeToString(const time_t *ltime, const _eTimeFormat format)
 {
 	struct tm timeinfo;
 	struct timeval tv;
 	std::stringstream sstr;
 	if (ltime == nullptr) // current time
-	{
-#ifdef CLOCK_REALTIME
-		struct timespec ts;
-		if (!clock_gettime(CLOCK_REALTIME, &ts))
-		{
-			tv.tv_sec = ts.tv_sec;
-			tv.tv_usec = ts.tv_nsec / 1000;
-		}
-		else
-#endif
-			gettimeofday(&tv, nullptr);
-#ifdef WIN32
-		time_t tv_sec = tv.tv_sec;
-		localtime_r(&tv_sec, &timeinfo);
-#else
-		localtime_r(&tv.tv_sec, &timeinfo);
-#endif
-	}
+		CurrentDateTimeMillisecond(timeinfo, tv);
 	else
 		localtime_r(ltime, &timeinfo);
 

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -87,6 +87,7 @@ double ConvertTemperature(double tValue, unsigned char tSign);
 std::vector<std::string> ExecuteCommandAndReturn(const std::string &szCommand, int &returncode);
 
 time_t GetClockTicks();
+void CurrentDateTimeMillisecond(tm &timeinfo, timeval &tv);
 std::string TimeToString(const time_t *ltime, _eTimeFormat format);
 std::string GenerateMD5Hash(const std::string &InputString, const std::string &Salt="");
 

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -296,6 +296,18 @@ void CLogger::Debug(const _eDebugLevel level, const std::string &sLogline)
 	Log(LOG_DEBUG_INT, sLogline);
 }
 
+void CLogger::ACLFlog(const char *logline, ...)
+{
+	if (!IsACLFlogEnabled())
+		return;
+	va_list argList;
+	char cbuffer[MAX_LOG_LINE_LENGTH];
+	va_start(argList, logline);
+	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
+	va_end(argList);
+	std::cout << std::string(cbuffer) << std::endl;
+}
+
 bool strhasEnding(std::string const &fullString, std::string const &ending)
 {
 	return fullString.size() >= ending.size() && !fullString.compare(fullString.size() - ending.size(), ending.size(), ending);

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -387,10 +387,12 @@ void CLogger::ACLFlog(const char *logline, ...)
 		}
 	}
 
-	if(m_aclf_flags & LOG_ACLF_SYSLOG)
+#ifndef WIN32
+	if(g_bUseSyslog && (m_aclf_flags & LOG_ACLF_SYSLOG))
 	{
 		syslog(LOG_INFO|LOG_LOCAL1,"%s", cbuffer);
 	}
+#endif
 }
 
 bool strhasEnding(std::string const &fullString, std::string const &ending)

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -147,6 +147,13 @@ bool CLogger::IsDebugLevelEnabled(const _eDebugLevel level)
 	return (m_debug_flags & level);
 }
 
+bool CLogger::IsACLFlogEnabled()
+{
+	if (!(m_aclf_flags & LOG_ACLF_ENABLED))
+		return false;
+	return true;
+}
+
 void CLogger::SetOutputFile(const char *OutputFile)
 {
 	std::unique_lock<std::mutex> lock(m_mutex);

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -56,9 +56,12 @@ class CLogger
 	void SetDebugFlags(const uint32_t iFlags);
 	bool IsDebugLevelEnabled(const _eDebugLevel level);
 
+	void SetACLFlogFlags(const uint8_t iFlags);
 	bool IsACLFlogEnabled();
 
 	void SetOutputFile(const char *OutputFile);
+	void SetACLFOutputFile(const char *OutputFile);
+	void OpenACLFOutputFile();
 
 	void Log(_eLogLevel level, const std::string &sLogline);
 	void Log(_eLogLevel level, const char *logline, ...)
@@ -72,7 +75,12 @@ class CLogger
 		__attribute__((format(printf, 3, 4)))
 #endif
 		;
-	void ACLFlog(const char *logline, ...);
+	void ACLFlog(const char *logline, ...)
+#ifdef __GNUC__
+		__attribute__((format(printf, 2, 3)))
+#endif
+		;
+
 	void LogSequenceStart();
 	void LogSequenceAdd(const char *logline);
 	void LogSequenceAddNoLF(const char *logline);
@@ -93,9 +101,11 @@ class CLogger
 	uint32_t m_log_flags;
 	uint32_t m_debug_flags;
 	uint8_t m_aclf_flags;
+	uint32_t m_aclf_loggedlinescnt;
 
 	std::mutex m_mutex;
 	std::ofstream m_outputfile;
+	const char *m_aclflogfile;
 	std::ofstream m_aclfoutputfile;
 	std::map<_eLogLevel, std::deque<_tLogLineStruct>> m_lastlog;
 	std::deque<_tLogLineStruct> m_notification_log;

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -64,6 +64,7 @@ class CLogger
 		__attribute__((format(printf, 3, 4)))
 #endif
 		;
+	void ACLFlog(const char *logline, ...);
 	void LogSequenceStart();
 	void LogSequenceAdd(const char *logline);
 	void LogSequenceAddNoLF(const char *logline);

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -27,6 +27,12 @@ enum _eDebugLevel : uint32_t
 	//
 	DEBUG_ALL = 0xFFFFFFF
 };
+enum _eLogACLF : uint8_t
+{
+	LOG_ACLF_ENABLED = 0x01,
+	LOG_ACLF_FILE = 0x02,
+	LOG_ACLF_SYSLOG = 0x04
+};
 
 class CLogger
 {
@@ -49,6 +55,8 @@ class CLogger
 	bool SetDebugFlags(const std::string &sFlags);
 	void SetDebugFlags(const uint32_t iFlags);
 	bool IsDebugLevelEnabled(const _eDebugLevel level);
+
+	bool IsACLFlogEnabled();
 
 	void SetOutputFile(const char *OutputFile);
 
@@ -84,9 +92,11 @@ class CLogger
       private:
 	uint32_t m_log_flags;
 	uint32_t m_debug_flags;
+	uint8_t m_aclf_flags;
 
 	std::mutex m_mutex;
 	std::ofstream m_outputfile;
+	std::ofstream m_aclfoutputfile;
 	std::map<_eLogLevel, std::deque<_tLogLineStruct>> m_lastlog;
 	std::deque<_tLogLineStruct> m_notification_log;
 	bool m_bInSequenceMode;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -85,8 +85,10 @@ namespace
 		"\t-dbase_disable_wal_mode\n"
 #if defined WIN32
 		"\t-log file_path (for example D:\\domoticz.log)\n"
+		"\t-weblog file_path (for example D:\\domoticz_access.log)\n"
 #else
 		"\t-log file_path (for example /var/log/domoticz.log)\n"
+		"\t-weblog file_path (for example /var/log/domoticz_access.log)\n"
 #endif
 		"\t-loglevel (combination of: all,normal,status,error,debug)\n"
 		"\t-debuglevel (combination of: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql)\n"
@@ -162,6 +164,7 @@ CSQLHelper m_sql;
 CNotificationHelper m_notifications;
 
 std::string logfile;
+std::string weblogfile;
 bool g_bStopApplication = false;
 bool g_bUseSyslog = false;
 bool g_bRunAsDaemon = false;
@@ -564,6 +567,9 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		else if (szFlag == "log_file") {
 			logfile = sLine;
 		}
+		else if (szFlag == "weblog_file") {
+			weblogfile = sLine;
+		}
 		else if (szFlag == "loglevel") {
 			_log.SetLogFlags(sLine);
 		}
@@ -696,6 +702,15 @@ int main(int argc, char**argv)
 			}
 			logfile = cmdLine.GetSafeArgument("-log", 0, "domoticz.log");
 		}
+		if (cmdLine.HasSwitch("-weblog"))
+		{
+			if (cmdLine.GetArgumentCount("-weblog") != 1)
+			{
+				_log.Log(LOG_ERROR, "Please specify an output weblog file (or syslog:<facility>)");
+				return 1;
+			}
+			weblogfile = cmdLine.GetSafeArgument("-weblog", 0, "domoticz_access.log");
+		}
 		if (cmdLine.HasSwitch("-approot"))
 		{
 			if (cmdLine.GetArgumentCount("-approot") != 1)
@@ -714,6 +729,9 @@ int main(int argc, char**argv)
 
 	if (!logfile.empty())
 		_log.SetOutputFile(logfile.c_str());
+
+	if (!weblogfile.empty())
+		_log.SetACLFOutputFile(weblogfile.c_str());
 
 	if (szStartupFolder.empty())
 	{

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -437,7 +437,7 @@ namespace http {
 						std::strftime(wlReqTimeZone, sizeof(wlReqTimeZone), "%z", std::localtime(&newt));
 						wlReqTimeZone[sizeof(wlReqTimeZone) - 1] = '\0';
 
-						_log.Debug(DEBUG_WEBSERVER,"Apache Combined Log: %s - %s [%s.%s %s] \"%s\" %d %d %s %s", wlHost.c_str(), wlUser.c_str(), wlReqTime, wlReqTimeMs.c_str(), wlReqTimeZone, wlReqUri.c_str(), wlResCode, wlContentSize, wlReqRef.c_str(), wlBrowser.c_str());
+						_log.ACLFlog("%s - %s [%s.%s %s] \"%s\" %d %d %s %s", wlHost.c_str(), wlUser.c_str(), wlReqTime, wlReqTimeMs.c_str(), wlReqTimeZone, wlReqUri.c_str(), wlResCode, wlContentSize, wlReqRef.c_str(), wlBrowser.c_str());
 
 						if (reply_.status == reply::switching_protocols) {
 							// this was an upgrade request

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -376,6 +376,7 @@ namespace http {
 					}
 
 					if (result) {
+						std::time_t newt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 						size_t sizeread = begin - boost::asio::buffer_cast<const char*>(_buf.data());
 						_buf.consume(sizeread);
 						reply_.reset();
@@ -412,8 +413,7 @@ namespace http {
 						int wlContentSize = (int)reply_.content.length();
 
 						char wlReqTime[256];
-						std::time_t newt = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-						std::strftime(wlReqTime, sizeof(wlReqTime), "%d/%b/%Y:%H:%M:%S. %z", std::localtime(&newt));
+						std::strftime(wlReqTime, sizeof(wlReqTime), "%d/%b/%Y:%H:%M:%S %z", std::localtime(&newt));
 						wlReqTime[sizeof(wlReqTime) - 1] = '\0';
 
 						_log.Debug(DEBUG_WEBSERVER,"Apache Combined Log: %s - %s [%s] \"%s\" %d %d %s %s", wlHost.c_str(), wlUser.c_str(), wlReqTime, wlReqUri.c_str(), wlResCode, wlContentSize, wlReqRef.c_str(), wlBrowser.c_str());

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -15,6 +15,7 @@
 #include "mime_types.hpp"
 #include "../main/localtime_r.h"
 #include "../main/Logger.h"
+#include "../main/Helper.h"
 
 namespace http {
 	namespace server {

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -412,8 +412,8 @@ namespace http {
 						{
 							// Generate webserver logentry
 							// Follow Apache's Combined Log Format, allows easy processing by 3rd party tools
-							// LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
-							// 127.0.0.1 - frank [10/Oct/2000:13:55:36 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://www.example.com/start.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
+							// LogFormat "%h %l %u %f \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
+							// 127.0.0.1 - frank [10/Oct/2000:13:55:36.012 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://my.domoticz.local/index.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
 							std::string wlHost = request_.host_address;
 							std::string wlUser = "-";	// Maybe we can fill this sometime? Or maybe not so we don't expose sensitive data?
 							std::string wlReqUri = request_.method + " " + request_.uri + " HTTP/" + std::to_string(request_.http_version_major) + (request_.http_version_minor ? "." + std::to_string(request_.http_version_minor): "");


### PR DESCRIPTION
This PR adds a new commandline option `-weblog <weblog file>` which tells Domoticz webserver(s) to start logging all web request to the specified logfile.

The logfile uses the [Apache Combined Logfile Format](https://httpd.apache.org/docs/2.4/logs.html#accesslog) as this a very common single-line logformat that is understood by most logfile analysers. This means these logs can easily be (automatically) analyzed and presented in nice overviews.

**NOTE**: the logtime is in milliseconds and not just seconds! So instead of using the standard '%t' as time parser, here '%f' is used. This is also already common for a long time as a lot of requests are handled by webservers within a second, so having milliseconds to order these requests is very welcome. Depending on the loganalyser, you sometimes need to tell the analyser that it needs '%f' instead of '%t' to parse the time correctly.

The logfile is automatically closed and re-opened after writing 100.000 loglines (resulting in logfiles between 15-50 MB). This enables log rotating (and compression after it is closed) _without the need to re-start_ Domoticz.

A common use-case for this option is to log all access to Domoticz (webserver), done through the default UI, API's or other apps/clients, when the access to Domoticz is _open_ to the outside world, larger networks like buildings/venues or just to see the (ab)use in your own network.

Using modern tools like [ELK](https://www.elastic.co/what-is/elk-stack), [GrayLog](https://www.graylog.org/) or even [Splunk](https://www.splunk.com/), but also older/simpler command line tools like [goaccess](https://goaccess.io/man) or [AWstats](https://github.com/eldy/AWStats) can create insights from these logfiles. (Most of these tools are available in standard Debian or RPM based package managers).

Using `awstats`:
![awstats](https://user-images.githubusercontent.com/12084477/152649282-af040d49-fa06-4354-9ad6-3b8e7ab1ebd7.png)

Realtime using `goaccess`:
![goaccess](https://user-images.githubusercontent.com/12084477/152649311-e4bbc9d3-18ff-4fbe-8e15-8397e1852a45.png)

_This logging is NOT enabled by default. So if you want this logging to be generated, add this option to the Domoticz startup script._

**NOTE for Raspberry PI users**: Generating these logfiles means constant writing to the filesystem. When running Domoticz on a Raspberry Pi off a SD-card, this logging feature can really cause a lot of wear on such a card and shorten the lifespan of these cards. If you want to get these logs even when running on a Pi, either attach a separate (USB) harddrive to write to. Or have the logging forwarded to another machine using `syslog`. This can be done by specifying _'syslog:'_ as the _'weblog file'_. But this only works when you enabled `syslog` for the other logging as well! See the `-syslog` commandline option.
