### PR TITLE
TTNMQTT: Fix to use DeviceSerial (again) as mac

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -755,7 +755,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 			return;
 		}
 
-		int DeviceID = GetAddDeviceAndSensor(m_HwdID, DeviceName, AppSerial);
+		int DeviceID = GetAddDeviceAndSensor(m_HwdID, DeviceName, DeviceSerial);
 		if (DeviceID == 0) // Unable to find the Device and/or Add the new Device
 		{
 			return;


### PR DESCRIPTION
Small PR to use the correct Device Serial identifier.

This was changed in previous changes to switch to the new V3 stack, but the previous serial used was not unique. Now it should be (again as it was in V2).

See [this](https://www.domoticz.com/forum/viewtopic.php?p=286100) forum thread.