### PR TITLE
Round brightness/dimmer level to avoid 1% becoming 0% for ZWAVE

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2894,7 +2894,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 		else if (command == "Set Level")
 		{
 			//root["state"] = pSensor->payload_on;
-			int slevel = (int)((pSensor->brightness_scale / 100.0F) * level);
+			int slevel = (int)round((pSensor->brightness_scale / 100.0F) * level);
 
 			if (!pSensor->brightness_value_template.empty())
 			{
@@ -3039,7 +3039,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 
 			if ((bCouldUseBrightness) && (pSensor->bBrightness))
 			{
-				int slevel = (int)((pSensor->brightness_scale / 100.0F) * level);
+				int slevel = (int)round((pSensor->brightness_scale / 100.0F) * level);
 
 				if (!pSensor->brightness_value_template.empty())
 				{
@@ -3103,7 +3103,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 			szValue = std::to_string(level);
 			if (!pSensor->set_position_topic.empty())
 			{
-				int iValue = (int)(pSensor->position_open - (((pSensor->position_open - pSensor->position_closed) / 100.0F) * float(level)));
+				int iValue = (int)round(pSensor->position_open - (((pSensor->position_open - pSensor->position_closed) / 100.0F) * float(level)));
 				// invert level for inverted blinds with percentage.
 				std::vector<std::vector<std::string>> result;
 				result = m_sql.safe_query("SELECT SwitchType FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, pSensor->unique_id.c_str());


### PR DESCRIPTION
Fix for ZWAVE devices sending 0% when set to 1% in DOMOTICZ.