### PR TITLE
Minor fixes to EnOcean ESP3

### DIFF
--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -625,34 +625,32 @@ void CEnOceanESP3::CheckAndUpdateNodeRORG(NodeInfo* pNode, const uint8_t RORG)
 	if (pNode == nullptr)
 		return;
 
-	bool do_update = false;
+	if (pNode->RORG == RORG)
+		return;
 
-	if (pNode->RORG != RORG)
-	{
-		Log(LOG_NORM, "Node %08X, update EEP from %02X-%02X-%02X (%s) to %02X-%02X-%02X (%s)",
-			pNode->nodeID,
-			pNode->RORG, pNode->func, pNode->type, GetEEPLabel(pNode->RORG, pNode->func, pNode->type),
-			RORG, pNode->func, pNode->type, GetEEPLabel(RORG, pNode->func, pNode->type));
+	Log(LOG_NORM, "Node %08X, update EEP from %02X-%02X-%02X (%s) to %02X-%02X-%02X (%s)",
+		pNode->nodeID,
+		pNode->RORG, pNode->func, pNode->type, GetEEPLabel(pNode->RORG, pNode->func, pNode->type),
+		RORG, pNode->func, pNode->type, GetEEPLabel(RORG, pNode->func, pNode->type));
 
-		pNode->RORG = RORG;
-		do_update = true;
+	if (pNode->name == "" || pNode->name == "Unknown")
+		pNode->name = GetEEPLabel(RORG, pNode->func, pNode->type);		
 
-		// TODO : update name & description if need be
-	}
+	pNode->RORG = RORG;
+
+	if (pNode->description == "" || pNode->description == "Unknown")
+		pNode->description = GetEEPDescription(RORG, pNode->func, pNode->type);
+
 	if (pNode->teachin_mode == GENERIC_NODE)
 	{
 		Log(LOG_NORM, "Node %08X, update from Generic to Teached-in", pNode->nodeID);
 
 		pNode->teachin_mode = TEACHEDIN_NODE;
-		do_update = true;
 	}
-	if (do_update == false)
-		return;
-
 	uint32_t nValue = (pNode->teachin_mode & TEACHIN_MODE_MASK) << TEACHIN_MODE_SHIFT;
 
-	m_sql.safe_query("UPDATE EnOceanNodes SET RORG=%u, nValue=%u WHERE (HardwareID==%d) AND (NodeID==%u)",
-		pNode->RORG, nValue, m_HwdID, pNode->nodeID);
+	m_sql.safe_query("UPDATE EnOceanNodes SET Name='%q', RORG=%u, Description='%q', nValue=%u WHERE (HardwareID==%d) AND (NodeID==%u)",
+		pNode->name.c_str(), pNode->RORG, pNode->description.c_str(), nValue, m_HwdID, pNode->nodeID);
 }
 
 void CEnOceanESP3::DeleteNode(const uint32_t nodeID)

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -2119,7 +2119,6 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 
 		Debug(DEBUG_NORM, "Send Set Pilot Wire Mode %d (%s) to Node %08X", PilotWireMode, PilotWireModeStr[PilotWireMode], nodeID);
 		sendVld(m_id_chip, nodeID, D20100_CMD8, 8, PilotWireMode, END_ARG_DATA);
-
 		return true;
 	}
 	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x05)
@@ -2397,7 +2396,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 				uint8_t LRN = bitrange(DATA, 3, 0x01);
 
 				if (LRN == 0)
-				{ 	// 1BS teach-in
+				{ // 1BS teach-in
 					Log(LOG_NORM, "1BS teach-in request from Node %08X", senderID);
 
 					if (pNode != nullptr)
@@ -4271,7 +4270,7 @@ uint32_t CEnOceanESP3::sendVld(unsigned int srcID, unsigned int destID, T_DATAFI
 	return DataSize;
 }
 
-uint32_t CEnOceanESP3::senDatadVld(unsigned int srcID, unsigned int destID, T_DATAFIELD *OffsetDes, int *values, int NbValues)
+uint32_t CEnOceanESP3::sendDataVld(unsigned int srcID, unsigned int destID, T_DATAFIELD *OffsetDes, int *values, int NbValues)
 {
 	uint8_t data[256 + 2];
 
@@ -4281,7 +4280,7 @@ uint32_t CEnOceanESP3::senDatadVld(unsigned int srcID, unsigned int destID, T_DA
 	if (DataSize)
 		sendVld(srcID, destID, data, DataSize);
 	else
-		Log(LOG_ERROR, " Error argument number in sendVld : cmd :%s :%s ", OffsetDes->ShortCut.c_str(), OffsetDes->description.c_str());
+		Log(LOG_ERROR, "Error argument number in sendVld : cmd :%s :%s ", OffsetDes->ShortCut.c_str(), OffsetDes->description.c_str());
 
 	return DataSize;
 }

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -4285,7 +4285,7 @@ uint32_t CEnOceanESP3::sendDataVld(unsigned int srcID, unsigned int destID, T_DA
 	return DataSize;
 }
 
-bool updateSwitchType(int HardwareID, const char *deviceID, _eSwitchType SwitchType)
+bool CEnOceanESP3::updateSwitchType(int HardwareID, const char *deviceID, _eSwitchType SwitchType)
 {
 	std::vector<std::vector<std::string>> result;
 
@@ -4415,7 +4415,7 @@ bool CEnOceanESP3::manageVldMessage(uint32_t iSenderID, unsigned char *vldData, 
 }
 
 //return position 0..100% from command / level
-int getPositionFromCommandLevel(int cmnd, int pos)
+int CEnOceanESP3::getPositionFromCommandLevel(int cmnd, int pos)
 {
 	if (cmnd == light2_sOn)
 		pos = 100;

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -2097,10 +2097,7 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 
 		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
-		if (tsen->LIGHTING2.packettype == pTypeGeneralSwitch)
-			level = xcmd->level;
-		else
-			level = tsen->LIGHTING2.level;
+		level = (tsen->LIGHTING2.packettype == pTypeGeneralSwitch) ? xcmd->level : tsen->LIGHTING2.level;
 		if (level > 50)
 		{
 			Log(LOG_ERROR,"Node %08X, Invalid PiloteWire level %d", nodeID, level);

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -142,11 +142,11 @@ private:
 
 	void createOtherVldUteDevices(uint32_t iSenderID, uint8_t rorg, uint8_t func, uint8_t type, uint8_t nb_channel);
 	bool manageVldMessage(uint32_t iSenderID, unsigned char *vldData, uint8_t func, uint8_t type, std::string &m_Name, uint8_t rssi);
-    std::string GetDbValue(const char* tableName, const char* fieldName, const char* whereFieldName, const char* whereFielValue);
-    void sendVld    (unsigned int sID , unsigned int destID , int channel, int value);
-	void sendVld    (unsigned int sID , unsigned int destID , unsigned char *data, int DataLen );
-	uint32_t sendVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD * OffsetDes,  ...);
-	uint32_t sendDataVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD* OffsetDes, int* values, int NbValues);
+	bool updateSwitchType(int HardwareID, const char *deviceID, _eSwitchType SwitchType);
+	std::string GetDbValue(const char *tableName, const char *fieldName, const char *whereFieldName, const char *whereFielValue);
+	void sendVld(unsigned int sID, unsigned int destID, int channel, int value);
+	void sendVld(unsigned int sID, unsigned int destID, unsigned char *data, int DataLen);
+	uint32_t sendVld(unsigned int unitBaseAddr, unsigned int destID, T_DATAFIELD *OffsetDes, ...);
+	uint32_t sendDataVld(unsigned int unitBaseAddr, unsigned int destID, T_DATAFIELD *OffsetDes, int *values, int NbValues);
+	int getPositionFromCommandLevel(int cmnd, int pos);
 };
-
-int getPositionFromCommandLevel(int cmnd, int pos);

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -146,7 +146,7 @@ private:
     void sendVld    (unsigned int sID , unsigned int destID , int channel, int value);
 	void sendVld    (unsigned int sID , unsigned int destID , unsigned char *data, int DataLen );
 	uint32_t sendVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD * OffsetDes,  ...);
-	uint32_t senDatadVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD* OffsetDes, int* values, int NbValues);
+	uint32_t sendDataVld(unsigned int unitBaseAddr, unsigned int destID ,T_DATAFIELD* OffsetDes, int* values, int NbValues);
 };
 
 int getPositionFromCommandLevel(int cmnd, int pos);

--- a/www/app/hardware/setup/EnOceanESP3.html
+++ b/www/app/hardware/setup/EnOceanESP3.html
@@ -42,7 +42,7 @@ table, tr, td {
 								<th width="85" align="center" data-i18n="Type">Type</th>
 								<th width="150" align="left" data-i18n="Name">Name</th>
 								<th width="120" align="left" data-i18n="Manufacturer">Manufacturer</th>
-								<th width="75" align="center" data-i18n="Profile">Profile</th>
+								<th width="75" align="center" data-i18n="EEP">EEP</th>
 								<th align="left" data-i18n="Description">Description</th>
 								<th width="30" align="center"><img src="images/air_signal.png" data-i18n="[title]RF Signal Level"></th>
 								<th width="30" align="center"><img src="images/battery.png" style="transform:rotate(180deg);" data-i18n="[title]Battery Level"></th>


### PR DESCRIPTION
Fix CheckAndUpdateNodeRORG behaviour :
Change node type from Generic to Teached-in only when RORG is updated
Add EEP name/description when EEP changes and not specified manually by the user

Apply minor fixes : typos, rescope functions as class members, etc...

