### PR TITLE
TTNMQTT: Skip empty messages (and wrong external decoded messages)

### DIFF
--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -691,6 +691,11 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 		Json::Value endDeviceIds = root["end_device_ids"];
 		Json::Value applicationIds = endDeviceIds["application_ids"];
 
+		if (uplinkMessage["frm_payload"].empty())
+		{
+			return;		// When there is no frm_payload, there is no data. Not even from a payload decoder.
+		}
+
 		//Get data from message
 		std::string DeviceName = endDeviceIds["device_id"].asString();
 		std::string DeviceSerial = endDeviceIds["dev_eui"].asString();
@@ -707,6 +712,9 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 		bool Decoded = false;
 
 		switch (MessagePort) {
+			case 0:
+				Decoded = true;	// Only MAC commands and no payload data when using this port
+				break;
 			case 2:
 				if (false) //if (CayenneLPPDec::ParseLPP_Packed((const uint8_t*)lpp.c_str(), lpp.size(), payload))
 				{
@@ -740,7 +748,7 @@ void CTTNMQTT::on_message(const struct mosquitto_message *message)
 					Log(LOG_ERROR, "Invalid data received! Unable to decode the raw payload and the decoded payload does not contain any (valid) data!");
 					return;
 				}
-				Log(LOG_STATUS, "Converted decoded_payload to regular payload for processing!");
+				Log(LOG_NORM, "Converted decoded_payload to regular payload for processing!");
 			}
 			else
 			{


### PR DESCRIPTION
Small PR that skips message processing when there was not data payload in the base message (for example when only MAC commands or _ping/keepalive_ messages are send.)

Some external payload decoders generate a wrong decoded_payload message when they shouldn't as there is/was no payload data to begin with. These wrongly decoded payloads are now ignored as there is a check to see if there was any real original data payload to start with.

See [this](https://www.domoticz.com/forum/viewtopic.php?p=287052&sid=9a1cf94a066b63d39dc537d1a1d0b64e#p287052) forum topic for details.