### PR TITLE
Patch will fix issue #5172 to ensure only the http and https ports us…

### DIFF
--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -395,16 +395,29 @@ bool CdzVents::OpenURL(lua_State *lua_state, const std::vector<_tLuaTableValues>
 	}
 
 	// Handle situation where WebLocalNetworks is not open without password for dzVents
-	if (URL.find("127.0.0") != std::string::npos || URL.find("::") != std::string::npos || URL.find("localhost") != std::string::npos)
+	if	( URL.find("127.0.0") != std::string::npos || URL.find("::") != std::string::npos || URL.find("localhost") != std::string::npos)
 	{
-		std::string allowedNetworks;
-		int rnvalue = 0;
-		m_sql.GetPreferencesVar("WebLocalNetworks", rnvalue, allowedNetworks);
-		if ((allowedNetworks.find("127.0.0.") == std::string::npos) && (allowedNetworks.find("::") == std::string::npos))
+		// Check for the http and https ports so we only test for Domoticz api calls
+		char szTmpHTTP[8] = "";
+		char szTmpHTTPS[8] = "";
+		if (!m_webservers.our_listener_port.empty())
+			sprintf(szTmpHTTP, ":%s", m_webservers.our_listener_port.c_str());
+		if (!secure_webserver_settings.listening_port.empty())
+			sprintf(szTmpHTTPS, ":%s", secure_webserver_settings.listening_port.c_str());
+		if (
+			(strlen(szTmpHTTP) != 0 && URL.find(szTmpHTTP) != std::string::npos) ||
+			(strlen(szTmpHTTPS) != 0 && URL.find(szTmpHTTPS) != std::string::npos)
+			)
 		{
-			_log.Log(LOG_ERROR, "dzVents: local netWork not open for dzVents openURL call !");
-			_log.Log(LOG_ERROR, "dzVents: check dzVents wiki (look for 'Using dzVents with Domoticz')");
-			return false;
+			std::string allowedNetworks;
+			int rnvalue = 0;
+			m_sql.GetPreferencesVar("WebLocalNetworks", rnvalue, allowedNetworks);
+			if ((allowedNetworks.find("127.0.0.") == std::string::npos) && (allowedNetworks.find("::") == std::string::npos))
+			{
+				_log.Log(LOG_ERROR, "dzVents: local netWork not open for dzVents openURL call !");
+				_log.Log(LOG_ERROR, "dzVents: check dzVents wiki (look for 'Using dzVents with Domoticz')");
+				return false;
+			}
 		}
 	}
 


### PR DESCRIPTION
Patch will fix issue #5172 to ensure only the http and https ports used by Domoticz will be checked in OpenUrl check for "Local Networks".
This will allow OpenUrl calls to 127.0.0.1 to other ports than used by Domoticz, when the Local Networks field doesn't contain 127.0.0.*
I've tested the Patch and it is working fine, but I still do not understand what won't work in dzVents when 127.0.0* isn't in the Local Networks.  So does anybody with more integral knowledge of dzVents know why that check was put in in the first place?