### PR TITLE
Change .noselect to allow selection of log text

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2248,7 +2248,7 @@ table.display thead th.sorting_disabled div.DataTables_sort_wrapper {
      -khtml-user-select:         none; /* Konqueror HTML */
        -moz-user-select:         none; /* Firefox */
         -ms-user-select:         none; /* Internet Explorer/Edge */
-            user-select:         none; /* Non-prefixed version, currently
+            user-select:         text; /* Non-prefixed version, currently
                                           supported by Chrome and Opera */
 	-webkit-tap-highlight-color: rgba(0,0,0,0);
 }


### PR DESCRIPTION

Proposal to change the "user-select: none" to: "user-select: text" to allow selection and copying of log text. 
See: https://www.domoticz.com/forum/viewtopic.php?f=6&t=38189&sid=67c41df497c0dbf532c72136083c33de )
.noselect {
  -webkit-touch-callout:         none; /* iOS Safari */
    -webkit-user-select:         none; /* Safari */
     -khtml-user-select:         none; /* Konqueror HTML */
       -moz-user-select:         none; /* Firefox */
        -ms-user-select:         none; /* Internet Explorer/Edge */
            user-select:         text; /* Non-prefixed version, currently
                                          supported by Chrome and Opera */
	-webkit-tap-highlight-color: rgba(0,0,0,0);
}