### PR TITLE
Fix (Linux)compile warnings by casting Py_ssize_t to int

### DIFF
--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -101,7 +101,7 @@ namespace Plugins
 				Py_ssize_t	tupleSize = PyTuple_Size(pArg);
 				if (tupleSize != 1)
 				{
-					pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, tupleSize);
+					pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, (int)tupleSize);
 					Py_RETURN_NONE;
 				}
 
@@ -150,7 +150,7 @@ namespace Plugins
 			Py_ssize_t	tupleSize = PyTuple_Size(pArg);
 			if (tupleSize != 1)
 			{
-				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, tupleSize);
+				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, (int)tupleSize);
 				Py_RETURN_NONE;
 			}
 
@@ -198,7 +198,7 @@ namespace Plugins
 			Py_ssize_t	tupleSize = PyTuple_Size(pArg);
 			if (tupleSize != 1)
 			{
-				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, tupleSize);
+				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, (int)tupleSize);
 				Py_RETURN_NONE;
 			}
 
@@ -246,7 +246,7 @@ namespace Plugins
 			Py_ssize_t	tupleSize = PyTuple_Size(pArg);
 			if (tupleSize != 1)
 			{
-				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, tupleSize);
+				pPlugin->Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, (int)tupleSize);
 				Py_RETURN_NONE;
 			}
 

--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -55,7 +55,7 @@ namespace Plugins
 		Py_ssize_t	tupleSize = PyTuple_Size(pArg);
 		if (tupleSize != 1)
 		{
-			_log.Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, tupleSize);
+			_log.Log(LOG_ERROR, "%s: Invalid parameter, expected single parameter, got %d parameters.", __func__, (int)tupleSize);
 			Py_RETURN_NONE;
 		}
 


### PR DESCRIPTION
PR to fix compile warnings under Linux.

Example, see [this](https://github.com/domoticz/domoticz/runs/5526926451?check_suite_focus=true) output from one of the last build actions.

And the build output from the [PR-check action of this PR](https://github.com/domoticz/domoticz/runs/5527109232?check_suite_focus=true) should be free of these compile warning :)

