### PR TITLE
Make colon a valid rtl433 cmdline char

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -25,7 +25,7 @@ CRtl433::CRtl433(const int ID, const std::string& cmdline) :
 	m_cmdline(cmdline)
 {
 	// Basic protection from malicious command line
-	removeCharsFromString(m_cmdline, ":;/$()`<>|&");
+	removeCharsFromString(m_cmdline, ";/$()`<>|&");
 	m_HwdID = ID;
 	/*
 		#ifdef _DEBUG


### PR DESCRIPTION
Allow ":" to be a valid rtl433 command line character. This is a one character change.

Background:
The rtl433 command line option to specify device serial number is like this "-d :xxxxxx" where xxxxxx is the actual serial number string. This can be any other string you like or have. Until now the colon was filtered and therefore the serialnumber of the rtl433 device could not be set. This is needed when you have more then one rtl433 device on the system and you want to use a specific one for domoticz and another one for another app (like node-red for example). By inspecting the domoticz logfile you can verify that the "-d :xxxxxx" command is now accepted (when you have set the loglevel to info).

Note: 
The default serial number of rtl433 devices is often "1". This can be changed on linux like this: 
$ rtl_eeprom -s 12345678
$ lsusb -v shows details including the serial number of your usb devices.
By giving rtl433 devices different serial numbers you now can select the one to use for domoticz, in hardware setup by specifying "-d :12345678" for example or any other string you have set as the rtl433 device serial number.

More info:
For more info on rtl_433 command line options see: https://github.com/merbanan/rtl_433/blob/master/conf/rtl_433.example.conf