### PR TITLE
Fix tracking of EnOcean blind position when using multiple blinds.

### DIFF
--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -2126,24 +2126,31 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		int channel = tsen->LIGHTING2.unitcode - 1;
 		int cmd = tsen->LIGHTING2.cmnd;
 		int pos;
+		
+		// don't keep the last position if the request is for a different node!
+		if (m_last_requested_blind_nodeID != nodeID)
+		{
+			m_last_requested_blind_position = -1;
+			m_last_requested_blind_nodeID = nodeID;
+		}
 
 		if (cmd != gswitch_sStop)
 			pos = getPositionFromCommandLevel(tsen->LIGHTING2.cmnd, tsen->LIGHTING2.level);
 		else
-			pos = LastPosition;
+			pos = m_last_requested_blind_position;
 
-		if (LastPosition == pos)
+		if (m_last_requested_blind_position == pos)
 		{
 			//send command stop si rappuie
 			Debug(DEBUG_NORM, "Send stop to Blinds Control Node %08X", nodeID);
 			sendVld(m_id_chip, nodeID, D20500_CMD2, channel, 2, END_ARG_DATA);
-			LastPosition = -1;
+			m_last_requested_blind_position = -1;
 		}
 		else
 		{
 			Debug(DEBUG_NORM, "Send position %d%% to Blinds Control Node %08X", pos, nodeID);
 			sendVld(m_id_chip, nodeID, D20500_CMD1, pos, 127, 0, 0, channel, 1, END_ARG_DATA);
-			LastPosition = pos;
+			m_last_requested_blind_position = pos;
 		}
 		return true;
 	}

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -138,7 +138,13 @@ private:
 	time_t m_RPS_teachin_timer;
 	uint8_t m_RPS_teachin_count;
 
-	int LastPosition = -1;
+	/* Used to keep track of requested blind position.
+	If the same position request is sent twice to the same device, it is translated to a "stop" request.
+	For example:
+		- press the button to close the blind, it starts to close
+		- press the button again, it stops where it is */
+	uint32_t m_last_requested_blind_nodeID = 0;
+	int m_last_requested_blind_position = -1;
 
 	void createOtherVldUteDevices(uint32_t iSenderID, uint8_t rorg, uint8_t func, uint8_t type, uint8_t nb_channel);
 	bool manageVldMessage(uint32_t iSenderID, unsigned char *vldData, uint8_t func, uint8_t type, std::string &m_Name, uint8_t rssi);


### PR DESCRIPTION
Fix for the issue discussed on the forum at https://www.domoticz.com/forum/viewtopic.php?p=288803 by adding tracking of the last used blind node id.
Also renamed the LastPosition member to match the naming convention of the rest of the class.

I compiled and tested my fix on my Raspberry Pi and checked that it now works as expected.

It's my first ever pull request, please be indulgent if I didn't do it right ;-)