### PR TITLE
main/LuaTable.cpp: fix compilation with GCC12

### DIFF
--- a/main/LuaTable.cpp
+++ b/main/LuaTable.cpp
@@ -6,9 +6,9 @@ extern "C" {
 #include <lua.h>
 #include <lualib.h>
 #include <lauxlib.h>
+}
 
 #include <utility>
-}
 
 CLuaTable::CLuaTable(lua_State *lua_state, const std::string &Name)
 {


### PR DESCRIPTION
Building domoticz fails under GCC12 with the following error:
```
In file included from /usr/include/c++/12/utility:68,
                 from /home/abuild/rpmbuild/BUILD/domoticz-2022.1/main/LuaTable.cpp:10:
/usr/include/c++/12/bits/stl_relops.h:86:5: error: template with C linkage
   86 |     template <class _Tp>
      |     ^~~~~~~~
```
This patch fixes the above.