### PR TITLE
Fix typo on HTTPS on install.sh script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -174,7 +174,7 @@ displayFinalMessage() {
 	whiptail --msgbox --backtitle "Ready..." --title "Installation Complete!" "Point your browser to either:
 
 HTTP:	${IPv4_address%/*}:${HTTP_port%/*}
-HTPS:	${IPv4_address%/*}:${HTTPS_port}
+HTTPS:	${IPv4_address%/*}:${HTTPS_port}
 
 Wiki:  https://www.domoticz.com/wiki
 Forum: https://www.domoticz.com/forum


### PR DESCRIPTION
During the installation we can display information related to http or https protocol. Rename HTPS to HTTPS.