### PR TITLE
get rid of std::ptr_fun

### DIFF
--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -16,7 +16,7 @@
 */
 
 static inline std::string &rtrim(std::string &s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
 	return s;
 }
 

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -18,7 +18,7 @@
 */
 
 static inline std::string &c5_rtrim(std::string &s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
 	return s;
 }
 

--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -92,14 +92,14 @@ CPiFace::CPiFace(const int ID)
 // trim from start
 std::string & CPiFace::ltrim(std::string &s)
 {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), ::isspace));
     return s;
 }
 
 // trim from end
 std::string & CPiFace::rtrim(std::string &s)
 {
-    s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+    s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
     return s;
 }
 

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -589,7 +589,7 @@ std::string &stdstring_ltrim(std::string &s)
 			return s;
 		s = s.substr(1);
 	}
-	//	s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+	//	s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), ::isspace));
 	return s;
 }
 
@@ -601,7 +601,7 @@ std::string &stdstring_rtrim(std::string &s)
 			return s;
 		s = s.substr(0, s.size() - 1);
 	}
-	//s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+	//s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
 	return s;
 }
 


### PR DESCRIPTION
Seems it's deprecated under GCC 12

Signed-off-by: Rosen Penev <rosenp@gmail.com>