### PR TITLE
Add a Security readme (addresses #5257)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ Your first place for support is the [Domoticz Forum](http://www.domoticz.com/for
 
 The Github issue tracker is NOT for end-user support.
 
+## Security issues
+
+See the [Security](SECURITY.md) file for more information.
+
 ## Donations
 Donations are more than welcome and will be used to buy new hardware, devices, sensors, hosting and coffee.
-If you like the product or encourage the development, please use thelink:
+If you like the product or encourage the development, please use the link:
 
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=6S2CXM772QY84&currency_code=EUR&source=url)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,24 +4,28 @@ This document describes our security procedures and general policies for the Dom
 
   * [Reporting a Vulnerability](#reporting-a-vulnerability)
   * [Disclosure Policy](#disclosure-policy)
+  * [Releases under maintenance](#Releases-under-maintenance)
 
 ## Reporting a Vulnerability 
 
 The team and community of Domoticz take all security vulnerabilities seriously. Thank you for improving the security of our open source software. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security vulnerabilities by emailing the Domoticz security team at:
-    
-    security@domoticz.com
+Report security vulnerabilities by emailing the Domoticz team at:
 
-The lead maintainer will acknowledge your email within 24 hours, and will send a more detailed response within 48 hours indicating the next steps in handling your report. After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+    info@domoticz.com
 
-Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+Normally we will acknowledge your email within 24 hours, and will send a more detailed response within a week indicating the next steps in handling your report. After the initial reply to your report, the team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Please report security vulnerabilities in third-party modules to the person or team maintaining the module.
 
 ## Disclosure Policy
 
-When the security team receives a security bug report, they will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
+When the team receives a security bug report, they will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
 
-  * Confirm the problem and determine the affected versions.
+  * Confirm the problem and determine if any releases under maintenance are affected.
   * Audit code to find any potential similar problems.
-  * Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible to NPM.
+  * Prepare fixes for all releases still under maintenance.
 
+## Releases under maintenance
+
+Currently, only the latest [_Stable_](https://www.domoticz.com/downloads/) release and the latest _Beta_ release will receive security fixes addressing reported and confirmed security issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Domoticz Open Source Security Policies and Procedures
+
+This document describes our security procedures and general policies for the Domoticz Open Source projects as found on https://github.com/domoticz.
+
+  * [Reporting a Vulnerability](#reporting-a-vulnerability)
+  * [Disclosure Policy](#disclosure-policy)
+
+## Reporting a Vulnerability 
+
+The team and community of Domoticz take all security vulnerabilities seriously. Thank you for improving the security of our open source software. We appreciate your efforts and responsible disclosure and will make every effort to acknowledge your contributions.
+
+Report security vulnerabilities by emailing the Domoticz security team at:
+    
+    security@domoticz.com
+
+The lead maintainer will acknowledge your email within 24 hours, and will send a more detailed response within 48 hours indicating the next steps in handling your report. After the initial reply to your report, the security team will endeavor to keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
+
+Report security vulnerabilities in third-party modules to the person or team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it to a primary handler. This person will coordinate the fix and release process, involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes will be released as fast as possible to NPM.
+


### PR DESCRIPTION
Adding a SECURITY.md file describing the Security Policies and procedures for Domoticz.

This way people and/or teams finding security issues in Domoticz know how to responsible disclose any found issues and what they can expect from the Domoticz team to handle these finding in a good manner.

