### PR TITLE
Fixing crazy blinds on MQTT auto discover blinds types

### DIFF
--- a/dzVents/runtime/device-adapters/switch_device.lua
+++ b/dzVents/runtime/device-adapters/switch_device.lua
@@ -42,7 +42,7 @@ return {
 			adapterManager.addDummyMethod(device, 'quietOn')
 			adapterManager.addDummyMethod(device, 'quietOff')
 		else
-			blindsOff2Close = { "Venetian Blinds US", "Venetian Blinds EU", "Blinds Percentage", "Blinds" }
+			blindsOff2Close = { "Venetian Blinds US", "Venetian Blinds EU", "Blinds Percentage", "Blinds", "Blinds + Stop" }
 		end
 
 		return res
@@ -97,11 +97,11 @@ return {
 		end
 
 		function device.close()
-			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and 'On') or 'Off', 'device', device.state)
+			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and device.deviceSubType ~= 'Generic' and 'On') or 'Off', 'device', device.state)
 		end
 
 		function device.open()
-			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and 'Off') or 'On', 'device', device.state)
+			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and device.deviceSubType ~= 'Generic'  and 'Off') or 'On', 'device', device.state)
 		end
 
 		function device.stop() -- blinds

--- a/dzVents/runtime/device-adapters/switch_device.lua
+++ b/dzVents/runtime/device-adapters/switch_device.lua
@@ -44,7 +44,7 @@ return {
 		else
 			blindsOff2Close = { "Venetian Blinds US", "Venetian Blinds EU", "Blinds Percentage", "Blinds", "Blinds + Stop" }
 		end
-
+ 
 		return res
 	end,
 
@@ -97,11 +97,11 @@ return {
 		end
 
 		function device.close()
-			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and device.deviceSubType ~= 'Generic' and 'On') or 'Off', 'device', device.state)
+			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and 'Off') or 'On', 'device', device.state)
 		end
 
 		function device.open()
-			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and device.deviceSubType ~= 'Generic'  and 'Off') or 'On', 'device', device.state)
+			return TimedCommand(domoticz, device.name, ( utils.inTable(blindsOff2Close, device.switchType ) and 'On') or 'Off', 'device', device.state)
 		end
 
 		function device.stop() -- blinds

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2779,7 +2779,13 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			{
 				level = (int)((100.0 / (pSensor->position_open - pSensor->position_closed)) * level);
 			}
-			if (pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+			if (   (sSwitchType ==  STYPE_Blinds ||
+					sSwitchType == STYPE_BlindsInverted ||
+					sSwitchType == STYPE_BlindsPercentage ||
+					sSwitchType == STYPE_BlindsPercentageInverted ||
+					sSwitchType == STYPE_BlindsPercentageInvertedWithStop ||
+					sSwitchType == STYPE_BlindsPercentageWithStop) && 
+				pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
 			{
 				szOnOffValue = "on";
 				level = 100;

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -10,8 +10,8 @@
 #include "../notifications/NotificationHelper.h"
 #include <iostream>
 
-MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string &Name, const std::string &IPAddress, const unsigned short usIPPort, const std::string &Username, const std::string &Password,
-			     const std::string &CAfilenameExtra, const int TLS_Version)
+MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string& Name, const std::string& IPAddress, const unsigned short usIPPort, const std::string& Username, const std::string& Password,
+	const std::string& CAfilenameExtra, const int TLS_Version)
 	: MQTT(ID, IPAddress, usIPPort, Username, Password, CAfilenameExtra, TLS_Version, (int)MQTTAutoDiscover::PT_none, std::string("Domoticz-MQTT-AutoDiscover") + GenerateUUID() + std::to_string(ID), true)
 {
 	std::vector<std::string> strarray;
@@ -240,7 +240,7 @@ std::string MQTTAutoDiscover::GetValueFromTemplate(Json::Value root, std::string
 				stdreplace(szKey, "]", "");
 				if (
 					(is_number(szKey)
-					&& (root.isArray()))
+						&& (root.isArray()))
 					)
 				{
 					int iNumber = std::stoi(szKey);
@@ -763,7 +763,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 		if (!root["state_class"].empty())
 			pSensor->state_class = root["state_class"].asString();
 		else if (!root["stat_cla"].empty())
-			pSensor->state_class = root["stat_cla"].asString();		
+			pSensor->state_class = root["stat_cla"].asString();
 
 		if (!root["device_class"].empty())
 			pSensor->device_class = root["device_class"].asString();
@@ -899,7 +899,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 				// Note: there is currently no distinction between RGB and RGBW. All will be treated as RGBW devices!
 				pSensor->supported_color_modes["rgbw"] = 1;
 				pSensor->bColor_mode = true;
-			}		
+			}
 
 			// If there is an hs_command_topic, add HS colormode
 			if (!root["hs_command_topic"].empty() || !root["hs_cmd_t"].empty())
@@ -925,7 +925,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 			{
 				pSensor->supported_color_modes["color temp"] = 1;
 				pSensor->bColor_mode = true;
-			}		
+			}
 		}
 
 		if (!root["min_mireds"].empty())
@@ -1152,7 +1152,7 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquit
 	for (auto& itt : m_discovered_sensors)
 	{
 		_tMQTTASensor* pSensor = &itt.second;
-		
+
 		if (
 			(pSensor->state_topic == topic)
 			|| (pSensor->position_topic == topic)
@@ -1605,21 +1605,21 @@ void MQTTAutoDiscover::GuessSensorTypeValue(const _tMQTTASensor* pSensor, uint8_
 		subType = sTypeLux;
 		sValue = pSensor->last_value;
 	}
-/*
-	else if (pSensor->state_class == "total_increasing")
-	{
-		devType = pTypeRFXMeter;
-		subType = sTypeRFXMeterCount;
-		sValue = pSensor->last_value;
-	}
-*/
+	/*
+		else if (pSensor->state_class == "total_increasing")
+		{
+			devType = pTypeRFXMeter;
+			subType = sTypeRFXMeterCount;
+			sValue = pSensor->last_value;
+		}
+	*/
 	else
 	{
 		devType = pTypeGeneral;
 		subType = sTypeCustom;
 		szOptions = pSensor->unit_of_measurement;
 		sValue = pSensor->last_value;
-	 }
+	}
 
 	if ((devType == pTypeGeneral) && (subType == sTypeCustom) && pSensor->szOptions.empty())
 		szOptions = "??";
@@ -2514,8 +2514,6 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		|| (!pSensor->set_position_topic.empty())
 		)
 	{
-		pSensor->devType = pTypeBlinds;
-		pSensor->subType = sTypeBlindsT21;
 		if (pSensor->payload_stop.empty())
 			switchType = STYPE_BlindsPercentage;
 		else
@@ -2645,7 +2643,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 	color_old.mode = ColorModeCustom;
 	color_new.mode = ColorModeCustom;
 	bool bHaveColorChange = false;
-	bool bDoNotUpdateLevel=false;
+	bool bDoNotUpdateLevel = false;
 
 	if (bIsJSON)
 	{
@@ -2656,17 +2654,17 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			root.removeMember("value");
 		}
 
-		if(root["color"].isObject() && !root["color"]["red"].empty())
+		if (root["color"].isObject() && !root["color"]["red"].empty())
 		{
 			// The device uses "red", "green"... to specify the color components, default for domoticz would be "r", "g"... (e.g. Fibaro FGRGBW)
-			JSonRenameKey(root["color"],"red","r");
-			JSonRenameKey(root["color"],"green","g");
-			JSonRenameKey(root["color"],"blue","b");
-			JSonRenameKey(root["color"],"warmWhite","w");
-			JSonRenameKey(root["color"],"coldWhite","c");
+			JSonRenameKey(root["color"], "red", "r");
+			JSonRenameKey(root["color"], "green", "g");
+			JSonRenameKey(root["color"], "blue", "b");
+			JSonRenameKey(root["color"], "warmWhite", "w");
+			JSonRenameKey(root["color"], "coldWhite", "c");
 		}
 
-		if(root["state"].empty() && root["color"].isObject())
+		if (root["state"].empty() && root["color"].isObject())
 		{
 			// The on/off state is omitted in the message, so guess it from the color components (e.g. Fibaro FGRGBW)
 			int r = root["color"]["r"].asInt();
@@ -2674,7 +2672,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			int b = root["color"]["b"].asInt();
 			int w = root["color"]["w"].asInt();
 			int c = root["color"]["c"].asInt();
-			if(r == 0 && g == 0 && b == 0 && w == 0 && c == 0)
+			if (r == 0 && g == 0 && b == 0 && w == 0 && c == 0)
 			{
 				root["state"] = "OFF";
 			}
@@ -2882,7 +2880,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			// ensure the level is correct when we receive "on"/"off" in the payload
 			if (szOnOffValue == "on")
 				level = pSensor->position_open;
-			if (szOnOffValue == "off")
+			else if (szOnOffValue == "off")
 				level = pSensor->position_closed;
 
 			// COVERS: Always recalculate to make level relative to 100 and invert when needed
@@ -2950,7 +2948,8 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		{
 			nValue = gswitch_sSetLevel;
 		}
-		nValue = (bOn) ? gswitch_sOn : gswitch_sOff;
+		else
+			nValue = (bOn) ? gswitch_sOn : gswitch_sOff;
 	}
 	else
 	{
@@ -3023,6 +3022,11 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 				command = "Off";
 				szSendValue = pSensor->payload_off;
 			}
+			else if (level == 100)
+			{
+				command = "On";
+				szSendValue = pSensor->payload_on;
+			}
 		}
 		else if ((command == "Set Color") && (pSensor->component_type == "light"))
 		{
@@ -3046,16 +3050,14 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 	{
 		Json::Value root;
 
-		if (
-			(command == "On")
-			|| (command == "Off"))
+		if ((command == "On") || (command == "Off"))
 		{
 			if (!pSensor->brightness_value_template.empty())
 			{
 				SendMessage(pSensor->command_topic, szSendValue);
 				return true;
 			}
-			else 
+			else
 			{
 				if (szSendValue == "true")
 					root["state"] = true;
@@ -3171,7 +3173,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 					root["color"]["w"] = color.ww;
 
 				// Check if the rgb_command_template suggests to use "red", "green"... instead of the default "r", "g"... (e.g. Fibaro FGRGBW)
-				if (!pSensor->rgb_command_template.empty() && pSensor->rgb_command_template.find("red: red") != std::string::npos) 
+				if (!pSensor->rgb_command_template.empty() && pSensor->rgb_command_template.find("red: red") != std::string::npos)
 				{
 					// For the Fibaro FGRGBW dimmer:
 					//  "rgb_command_template": "{{ {'red': red, 'green': green, 'blue': blue}|to_json }}",  

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -3371,6 +3371,8 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 					level = 100;
 				else if (command == "Off")
 					level = 0;
+				if (pSensor->component_type == "cover" && pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+					level = 100;
 				int nValue = (level > 0) ? 1 : 0;
 				m_sql.safe_query(
 					"UPDATE DeviceStatus SET nValue=%d, LastLevel=%d, LastUpdate='%s' WHERE (ID = %s)",

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2723,6 +2723,11 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 							{
 								level = (int)((100.0 / (pSensor->position_open - pSensor->position_closed)) * level);
 							}
+							if (pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+							{
+								szOnOffValue = "on";
+								level = 100;
+							}
 						}
 					}
 				}
@@ -2773,6 +2778,11 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			else
 			{
 				level = (int)((100.0 / (pSensor->position_open - pSensor->position_closed)) * level);
+			}
+			if (pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+			{
+				szOnOffValue = "on";
+				level = 100;
 			}
 		}
 		if (!root["color"].empty())
@@ -2862,6 +2872,11 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 				szOnOffValue = "off";
 			else if (pSensor->component_type == "lock" && szOnOffValue == pSensor->payload_lock)
 				szOnOffValue = "on";
+			else if (pSensor->component_type == "cover" && pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+			{
+				level = 100;
+				szOnOffValue = "on";
+			}
 			else if (level > 0)
 			{
 				if (level != 100)
@@ -2896,6 +2911,12 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			else
 			{
 				level = (int)((100.0 / (pSensor->position_open - pSensor->position_closed)) * level);
+			}
+			
+			if (pSensor->component_type == "cover" && pSensor->unique_id.find("zwavejs2mqtt_") == 0 && level == 99)
+			{
+				level = 100;
+				szOnOffValue = "on";
 			}
 		}
 	}

--- a/hardware/OpenWebNetUSB.cpp
+++ b/hardware/OpenWebNetUSB.cpp
@@ -116,11 +116,11 @@ bool COpenWebNetUSB::WriteToHardware(const char *pdata, const unsigned char leng
 
 					if (pCmd->cmnd == gswitch_sOff)
 					{
-						what = AUTOMATION_WHAT_UP;
+						what = AUTOMATION_WHAT_DOWN;
 					}
 					else if (pCmd->cmnd == gswitch_sOn)
 					{
-						what = AUTOMATION_WHAT_DOWN;
+						what = AUTOMATION_WHAT_UP;
 					}
 					else if (pCmd->cmnd == gswitch_sStop)
 					{

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -2551,7 +2551,7 @@ namespace Plugins {
 			byte *pbMask = nullptr;
 			if (bMaskBit)
 			{
-				retVal.push_back(llMaskingKey >> 24);
+				retVal.push_back((byte)(llMaskingKey >> 24));
 				pbMask = &retVal[retVal.size() - 1];
 				retVal.push_back((llMaskingKey >> 16) & 0xFF);
 				retVal.push_back((llMaskingKey >> 8) & 0xFF);

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3846,33 +3846,17 @@ std::string CEventSystem::nValueToWording(const uint8_t dType, const uint8_t dSu
 		|| (switchtype == STYPE_BlindsPercentageWithStop)
 		)
 	{
-		if (dSubType == sTypeBlindsT21) {
-			if (lstatus == "On")
-			{
-				lstatus = "Open";
-			}
-			else if (lstatus == "Stop")
-			{
-				lstatus = "Stopped";
-			}
-			else
-			{
-				lstatus = "Closed";
-			}
+		if (lstatus == "On")
+		{
+			lstatus = "Open";
 		}
-		else {
-			if (lstatus == "On")
-			{
-				lstatus = "Closed";
-			}
-			else if (lstatus == "Stop")
-			{
-				lstatus = "Stopped";
-			}
-			else
-			{
-				lstatus = "Open";
-			}
+		else if (lstatus == "Stop")
+		{
+			lstatus = "Stopped";
+		}
+		else
+		{
+			lstatus = "Closed";
 		}
 	}
 	else if (
@@ -3881,33 +3865,17 @@ std::string CEventSystem::nValueToWording(const uint8_t dType, const uint8_t dSu
 		|| (switchtype == STYPE_BlindsPercentageInvertedWithStop)
 		)
 	{
-		if (dSubType == sTypeBlindsT21) {
-			if (lstatus == "Off")
-			{
-				lstatus = "Open";
-			}
-			else if (lstatus == "Stop")
-			{
-				lstatus = "Stopped";
-			}
-			else
-			{
-				lstatus = "Closed";
-			}
+		if (lstatus == "Off")
+		{
+			lstatus = "Open";
 		}
-		else {
-			if (lstatus == "Off")
-			{
-				lstatus = "Closed";
-			}
-			else if (lstatus == "Stop")
-			{
-				lstatus = "Stopped";
-			}
-			else
-			{
-				lstatus = "Open";
-			}
+		else if (lstatus == "Stop")
+		{
+			lstatus = "Stopped";
+		}
+		else
+		{
+			lstatus = "Closed";
 		}
 	}
 	else if (switchtype == STYPE_Media)
@@ -3988,7 +3956,7 @@ void CEventSystem::WWWGetItemStates(std::vector<_tDeviceStatus> &iStates)
 
 	iStates.clear();
 	std::transform(m_devicestates.begin(), m_devicestates.end(), std::back_inserter(iStates),
-		       [](const std::pair<const uint64_t, CEventSystem::_tDeviceStatus> &m) { return m.second; });
+		[](const std::pair<const uint64_t, CEventSystem::_tDeviceStatus> &m) { return m.second; });
 }
 
 int CEventSystem::getSunRiseSunSetMinutes(const std::string &what)
@@ -4020,7 +3988,7 @@ bool CEventSystem::isEventscheduled(const std::string &eventName)
 		return false;
 
 	return std::any_of(currentTasks.begin(), currentTasks.end(),
-			   [&](const _tTaskItem &currentTask) { return currentTask._relatedEvent == eventName; });
+		[&](const _tTaskItem &currentTask) { return currentTask._relatedEvent == eventName; });
 }
 
 int CEventSystem::calculateDimLevel(int deviceID, int percentageLevel)
@@ -4055,6 +4023,7 @@ int CEventSystem::calculateDimLevel(int deviceID, int percentageLevel)
 				float fLevel = (maxDimLevel / 100.0F) * percentageLevel;
 				if (fLevel > 100)
 					fLevel = 100;
+
 				iLevel = int(fLevel);
 			}
 			else if (switchtype == STYPE_Selector)

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3846,17 +3846,33 @@ std::string CEventSystem::nValueToWording(const uint8_t dType, const uint8_t dSu
 		|| (switchtype == STYPE_BlindsPercentageWithStop)
 		)
 	{
-		if (lstatus == "On")
-		{
-			lstatus = "Closed";
+		if (dSubType == sTypeBlindsT21) {
+			if (lstatus == "On")
+			{
+				lstatus = "Open";
+			}
+			else if (lstatus == "Stop")
+			{
+				lstatus = "Stopped";
+			}
+			else
+			{
+				lstatus = "Closed";
+			}
 		}
-		else if (lstatus == "Stop")
-		{
-			lstatus = "Stopped";
-		}
-		else
-		{
-			lstatus = "Open";
+		else {
+			if (lstatus == "On")
+			{
+				lstatus = "Closed";
+			}
+			else if (lstatus == "Stop")
+			{
+				lstatus = "Stopped";
+			}
+			else
+			{
+				lstatus = "Open";
+			}
 		}
 	}
 	else if (
@@ -3865,17 +3881,33 @@ std::string CEventSystem::nValueToWording(const uint8_t dType, const uint8_t dSu
 		|| (switchtype == STYPE_BlindsPercentageInvertedWithStop)
 		)
 	{
-		if (lstatus == "Off")
-		{
-			lstatus = "Closed";
+		if (dSubType == sTypeBlindsT21) {
+			if (lstatus == "Off")
+			{
+				lstatus = "Open";
+			}
+			else if (lstatus == "Stop")
+			{
+				lstatus = "Stopped";
+			}
+			else
+			{
+				lstatus = "Closed";
+			}
 		}
-		else if (lstatus == "Stop")
-		{
-			lstatus = "Stopped";
-		}
-		else
-		{
-			lstatus = "Open";
+		else {
+			if (lstatus == "Off")
+			{
+				lstatus = "Closed";
+			}
+			else if (lstatus == "Stop")
+			{
+				lstatus = "Stopped";
+			}
+			else
+			{
+				lstatus = "Open";
+			}
 		}
 	}
 	else if (switchtype == STYPE_Media)

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1802,11 +1802,11 @@ void GetLightStatus(
 		switch (nValue)
 		{
 		case curtain_sOpen:
-			lstatus = "On";
-			break;
-		case curtain_sClose:
 			lstatus = "Off";
 			break;
+		case curtain_sClose:
+			lstatus = "On";
+			break; 
 		case curtain_sStop:
 			lstatus = "Stop";
 			break;
@@ -1828,10 +1828,16 @@ void GetLightStatus(
 		switch (nValue)
 		{
 		case blinds_sOpen:
-			lstatus = "On";
+			if (dSubType == sTypeBlindsT10)
+				lstatus = "On";
+			else
+				lstatus = "Off";
 			break;
 		case blinds_sClose:
-			lstatus = "Off";
+			if (dSubType == sTypeBlindsT10)
+				lstatus = "Off";
+			else
+				lstatus = "On";
 			break;
 		case blinds_sStop:
 			lstatus = "Stop";

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -691,6 +691,7 @@ const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeBlinds, sTypeBlindsT16, "Zemismart" },
 		{ pTypeBlinds, sTypeBlindsT17, "Gaposa" },
 		{ pTypeBlinds, sTypeBlindsT18, "Cherubini" },
+		{ pTypeBlinds, sTypeBlindsT21, "Generic" },
 
 		{ pTypeSecurity1, sTypeSecX10, "X10 security" },
 		{ pTypeSecurity1, sTypeSecX10M, "X10 security motion" },
@@ -1813,6 +1814,13 @@ void GetLightStatus(
 		}
 		break;
 	case pTypeBlinds:
+		if (dSubType == sTypeBlindsT21)
+		{
+			bHaveDimmer = true;
+			maxDimLevel = 100;
+			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		}
+
 		switch (nValue)
 		{
 		case blinds_sOpen:
@@ -1824,6 +1832,11 @@ void GetLightStatus(
 		case blinds_sClose:
 			if (dSubType == sTypeBlindsT10)
 				lstatus = "Off";
+			else if (dSubType == sTypeBlindsT21 && (llevel > 0) && (llevel < 100))
+			{
+				sprintf(szTmp, "Set Level: %d %%", llevel);
+				lstatus = szTmp;
+			}
 			else
 				lstatus = "On";
 			break;
@@ -3329,14 +3342,14 @@ bool GetLightCommand(
 	{
 		if (switchcmd == "On")
 		{
-			if (dSubType == sTypeBlindsT10)
+			if (dSubType == sTypeBlindsT10 || dSubType == sTypeBlindsT21)
 				cmd = blinds_sOpen;
 			else
 				cmd = blinds_sClose;
 		}
 		else if (switchcmd == "Off")
 		{
-			if (dSubType == sTypeBlindsT10)
+			if (dSubType == sTypeBlindsT10 || dSubType == sTypeBlindsT21)
 				cmd = blinds_sClose;
 			else
 				cmd = blinds_sOpen;
@@ -4036,13 +4049,13 @@ void ConvertToGeneralSwitchType(std::string& devid, int& dtype, int& subtype)
 		subtype = sSwitchTypeHomeConfort;
 	}
 	else if (dtype == pTypeBlinds) {
-		dtype = pTypeGeneralSwitch;
 		if (subtype == sTypeBlindsT5) subtype = sSwitchTypeBofu;
 		else if (subtype == sTypeBlindsT6) subtype = sSwitchTypeBrel;
 		else if (subtype == sTypeBlindsT7) subtype = sSwitchTypeDooya;
 		else if (subtype == sTypeBlindsT8) subtype = sSwitchTypeBofu;
 		else if (subtype == sTypeBlindsT9) subtype = sSwitchTypeBrel;
 		else if (subtype == sTypeBlindsT10) subtype = sSwitchTypeDooya;
+		else if (subtype == sTypeBlindsT21) subtype = sSwitchGeneralSwitch;
 		std::stringstream s_strid;
 		s_strid << std::hex << strtoul(devid.c_str(), nullptr, 16);
 		unsigned long deviceid = 0;

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1802,10 +1802,10 @@ void GetLightStatus(
 		switch (nValue)
 		{
 		case curtain_sOpen:
-			lstatus = "Off";
+			lstatus = "On";
 			break;
 		case curtain_sClose:
-			lstatus = "On";
+			lstatus = "Off";
 			break;
 		case curtain_sStop:
 			lstatus = "Stop";
@@ -3318,11 +3318,11 @@ bool GetLightCommand(
 	{
 		if (switchcmd == "On")
 		{
-			cmd = curtain_sClose;
+			cmd = curtain_sOpen;
 		}
 		else if (switchcmd == "Off")
 		{
-			cmd = curtain_sOpen;
+			cmd = curtain_sClose;
 		}
 		else
 		{

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -691,7 +691,6 @@ const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeBlinds, sTypeBlindsT16, "Zemismart" },
 		{ pTypeBlinds, sTypeBlindsT17, "Gaposa" },
 		{ pTypeBlinds, sTypeBlindsT18, "Cherubini" },
-		{ pTypeBlinds, sTypeBlindsT21, "Generic" },
 
 		{ pTypeSecurity1, sTypeSecX10, "X10 security" },
 		{ pTypeSecurity1, sTypeSecX10M, "X10 security motion" },
@@ -1016,7 +1015,7 @@ NULL
 };
 */
 const char *ZWave_Thermostat_Fan_Modes[]
-	= { "Auto Low", "On Low", "Auto High", "On High", "Unknown 4", "Unknown 5", "Circulate", "Unknown", nullptr };
+= { "Auto Low", "On Low", "Auto High", "On High", "Unknown 4", "Unknown 5", "Circulate", "Unknown", nullptr };
 
 int Lookup_ZWave_Thermostat_Modes(const std::vector<std::string>& Modes, const std::string& sMode)
 {
@@ -1814,31 +1813,25 @@ void GetLightStatus(
 		}
 		break;
 	case pTypeBlinds:
-		if (dSubType == sTypeBlindsT21)
+		if (switchtype == STYPE_BlindsPercentage || 
+			switchtype == STYPE_BlindsPercentageInverted ||
+			switchtype == STYPE_BlindsPercentageInvertedWithStop ||
+			switchtype == STYPE_BlindsPercentageWithStop)
 		{
 			bHaveDimmer = true;
 			maxDimLevel = 100;
+
+		// Calculate % that the light is currently on, taking the maxdimlevel into account.
 			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
 		}
 
 		switch (nValue)
 		{
 		case blinds_sOpen:
-			if (dSubType == sTypeBlindsT10)
-				lstatus = "On";
-			else
-				lstatus = "Off";
+			lstatus = "On";
 			break;
 		case blinds_sClose:
-			if (dSubType == sTypeBlindsT10)
-				lstatus = "Off";
-			else if (dSubType == sTypeBlindsT21 && (llevel > 0) && (llevel < 100))
-			{
-				sprintf(szTmp, "Set Level: %d %%", llevel);
-				lstatus = szTmp;
-			}
-			else
-				lstatus = "On";
+			lstatus = "Off";
 			break;
 		case blinds_sStop:
 			lstatus = "Stop";
@@ -3342,17 +3335,11 @@ bool GetLightCommand(
 	{
 		if (switchcmd == "On")
 		{
-			if (dSubType == sTypeBlindsT10 || dSubType == sTypeBlindsT21)
-				cmd = blinds_sOpen;
-			else
-				cmd = blinds_sClose;
+			cmd = blinds_sOpen;
 		}
 		else if (switchcmd == "Off")
 		{
-			if (dSubType == sTypeBlindsT10 || dSubType == sTypeBlindsT21)
-				cmd = blinds_sClose;
-			else
-				cmd = blinds_sOpen;
+			cmd = blinds_sClose;
 		}
 		else
 		{
@@ -4055,7 +4042,6 @@ void ConvertToGeneralSwitchType(std::string& devid, int& dtype, int& subtype)
 		else if (subtype == sTypeBlindsT8) subtype = sSwitchTypeBofu;
 		else if (subtype == sTypeBlindsT9) subtype = sSwitchTypeBrel;
 		else if (subtype == sTypeBlindsT10) subtype = sSwitchTypeDooya;
-		else if (subtype == sTypeBlindsT21) subtype = sSwitchGeneralSwitch;
 		std::stringstream s_strid;
 		s_strid << std::hex << strtoul(devid.c_str(), nullptr, 16);
 		unsigned long deviceid = 0;

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -8,11 +8,11 @@
 //
 
 /*
-                                                                   
+
 Copyright 2011-2022, RFXCOM
 
 ALL RIGHTS RESERVED. This code is owned by RFXCOM, and is protected under
-Netherlands Copyright Laws and Treaties and shall be subject to the 
+Netherlands Copyright Laws and Treaties and shall be subject to the
 exclusive jurisdiction of the Netherlands Courts. The information from this
 file may freely be used to create programs to exclusively interface with
 RFXCOM products only. Any other use or unauthorized reprint of this material
@@ -85,7 +85,7 @@ SDK version 9.22	Aug 18, 2018
 	Zemismart blinds added
 	Async port added
 	Firmware types added
-	Livolo 1-10 device changed 
+	Livolo 1-10 device changed
 
 SDK version 9.21	June 18, 2018
 	Fan LucciAir DC added
@@ -301,7 +301,7 @@ SDK version 6.07
 	CHIME structure and pTypeChime added for Byron SX Chime
 
 SDK version 6.06a
-    RFU4 changed to RSLenabled in IRESPONSE
+	RFU4 changed to RSLenabled in IRESPONSE
 
 SDK version 6.06
 	Lighting1 Energenie added
@@ -337,7 +337,7 @@ SDK version 5.00
 		cmdENABLEALL 0x04, cmdUNDEC 0x05
 		cmdDISX10 0x10   to    cmdDISFS20 0x1C
 	CM180i CURRENT_ENERGY - ELEC4 added
-	code for pTypeGAS and pTypeWATER changed (not yet used) 
+	code for pTypeGAS and pTypeWATER changed (not yet used)
 
 SDK version 4.36
 	security - #define sStatusIRbeam 0x8 added
@@ -881,10 +881,9 @@ SDK version 4.9
 #define sTypeBlindsT18 0x12	//Cherubini
 #define sTypeBlindsT19 0x13	//Louvolite vertical
 #define sTypeBlindsT20 0x14	//Ozroll E-Trans
-#define sTypeBlindsT21 0x15	//Generic
 
-#define blinds_sOpen 0x0
-#define blinds_sClose 0x1
+#define blinds_sClose 0x0
+#define blinds_sOpen 0x1
 #define blinds_sStop 0x2
 #define blinds_sConfirm 0x3
 #define blinds_sLimit 0x4
@@ -1418,14 +1417,14 @@ typedef union tRBUF {
 		BYTE	X10enabled : 1; //note: keep this order
 
 		//BYTE    msg6;
-        BYTE    MSG6Reserved7 : 1;
-        BYTE    MSG6Reserved6 : 1;
-        BYTE    MSG6Reserved5 : 1;
-        BYTE    MSG6Reserved4 : 1;
-        BYTE    MSG6Reserved3 : 1;
-        BYTE    MSG6Reserved2 : 1;
+		BYTE    MSG6Reserved7 : 1;
+		BYTE    MSG6Reserved6 : 1;
+		BYTE    MSG6Reserved5 : 1;
+		BYTE    MSG6Reserved4 : 1;
+		BYTE    MSG6Reserved3 : 1;
+		BYTE    MSG6Reserved2 : 1;
 		BYTE    HCEnabled : 1;
-        BYTE    KEELOQenabled : 1;
+		BYTE    KEELOQenabled : 1;
 #else
 		//BYTE	msg3;
 		BYTE	AEenabled : 1;
@@ -1457,27 +1456,27 @@ typedef union tRBUF {
 		BYTE	ATIenabled : 1;
 		BYTE	VISONICenabled : 1;
 
-        //BYTE	msg6;
-        BYTE    KEELOQenabled : 1;
+		//BYTE	msg6;
+		BYTE    KEELOQenabled : 1;
 		BYTE    HCEnabled : 1;
-        BYTE    DDenabled : 1;
-        BYTE    MSG6Reserved3 : 1;
-        BYTE    MSG6Reserved4 : 1;
-        BYTE    MSG6Reserved5 : 1;
-        BYTE    MSG6Reserved6 : 1;
-        BYTE    MSG6Reserved7 : 1;
+		BYTE    DDenabled : 1;
+		BYTE    MSG6Reserved3 : 1;
+		BYTE    MSG6Reserved4 : 1;
+		BYTE    MSG6Reserved5 : 1;
+		BYTE    MSG6Reserved6 : 1;
+		BYTE    MSG6Reserved7 : 1;
 #endif
 
 		BYTE	msg7;
 		BYTE	msg8;
 		BYTE	msg9;
 		BYTE	msg10;
-        BYTE	msg11;
-        BYTE	msg12;
-        BYTE	msg13;
-        BYTE	msg14;
-        BYTE	msg15;
-        BYTE	msg16;
+		BYTE	msg11;
+		BYTE	msg12;
+		BYTE	msg13;
+		BYTE	msg14;
+		BYTE	msg15;
+		BYTE	msg16;
 	} IRESPONSE;
 
 	struct {	//response on a mode command from the application
@@ -2284,7 +2283,7 @@ typedef union tRBUF {
 		BYTE	seqnbr;
 		BYTE	id1;
 		BYTE	id2;
-		BYTE	humidity; 
+		BYTE	humidity;
 		BYTE	humidity_status;
 #ifdef IS_BIG_ENDIAN
 		BYTE	rssi : 4;
@@ -2307,7 +2306,7 @@ typedef union tRBUF {
 		BYTE	temperatureh : 7;
 
 		BYTE	temperaturel;
-		BYTE	humidity; 
+		BYTE	humidity;
 		BYTE	humidity_status;
 
 		BYTE	rssi : 4;
@@ -2317,7 +2316,7 @@ typedef union tRBUF {
 		BYTE	tempsign : 1;
 
 		BYTE	temperaturel;
-		BYTE	humidity; 
+		BYTE	humidity;
 		BYTE	humidity_status;
 
 		BYTE	battery_level : 4;
@@ -2359,7 +2358,7 @@ typedef union tRBUF {
 		BYTE	tempsign : 1;
 #endif
 		BYTE	temperaturel;
-		BYTE	humidity; 
+		BYTE	humidity;
 		BYTE	humidity_status;
 		BYTE	baroh;
 		BYTE	barol;
@@ -2566,29 +2565,29 @@ typedef union tRBUF {
 	} CURRENT_ENERGY;
 
 	struct {
-        BYTE	packetlength;
-        BYTE	packettype;
-        BYTE	subtype;
-        BYTE	seqnbr;
-        BYTE	id1;
-        BYTE	id2;
-        BYTE	voltage;
-        BYTE	currentH;
-        BYTE	currentL;
-        BYTE	powerH;
-        BYTE	powerL;
-        BYTE	energyH;
-        BYTE	energyL;
-        BYTE	pf;
-        BYTE	freq;
+		BYTE	packetlength;
+		BYTE	packettype;
+		BYTE	subtype;
+		BYTE	seqnbr;
+		BYTE	id1;
+		BYTE	id2;
+		BYTE	voltage;
+		BYTE	currentH;
+		BYTE	currentL;
+		BYTE	powerH;
+		BYTE	powerL;
+		BYTE	energyH;
+		BYTE	energyL;
+		BYTE	pf;
+		BYTE	freq;
 #ifdef IS_BIG_ENDIAN
-        BYTE	rssi : 4;
-        BYTE	filler : 4;
+		BYTE	rssi : 4;
+		BYTE	filler : 4;
 #else
-        BYTE	filler : 4;
-        BYTE	rssi : 4;
+		BYTE	filler : 4;
+		BYTE	rssi : 4;
 #endif
-    } POWER;
+	} POWER;
 
 	struct {
 		BYTE	packetlength;
@@ -2764,23 +2763,23 @@ typedef union tRBUF {
 	} RFXMETER;
 
 	struct {
-	BYTE	packetlength;
-	BYTE	packettype;
-	BYTE	subtype;
-	BYTE	seqnbr;
-	BYTE	hc1;
-	BYTE	hc2;
-	BYTE	addr;
-	BYTE	cmd1;
-	BYTE	cmd2;
+		BYTE	packetlength;
+		BYTE	packettype;
+		BYTE	subtype;
+		BYTE	seqnbr;
+		BYTE	hc1;
+		BYTE	hc2;
+		BYTE	addr;
+		BYTE	cmd1;
+		BYTE	cmd2;
 #ifdef IS_BIG_ENDIAN
-	BYTE	rssi : 4;
-	BYTE	filler : 4;
+		BYTE	rssi : 4;
+		BYTE	filler : 4;
 #else
-	BYTE	filler : 4;
-	BYTE	rssi : 4;
+		BYTE	filler : 4;
+		BYTE	rssi : 4;
 #endif
-    } FS20;
+	} FS20;
 
 	struct {
 		BYTE	packetlength;
@@ -2885,16 +2884,16 @@ typedef union tRBUF {
 	} SOLAR;
 
 	struct {
-	BYTE	packetlength;
-	BYTE	packettype;
-	BYTE	subtype;
-	BYTE	seqnbr;
-	BYTE	repeat;
-	struct{
-		BYTE	uint_msb;
-		BYTE	uint_lsb;
-	} pulse[124];
-    } RAW;
+		BYTE	packetlength;
+		BYTE	packettype;
+		BYTE	subtype;
+		BYTE	seqnbr;
+		BYTE	repeat;
+		struct{
+			BYTE	uint_msb;
+			BYTE	uint_lsb;
+		} pulse[124];
+	} RAW;
 } RBUF;
 
 #endif //_RXFCOMLIB_F11DD459_E67E_4B26_8E44_B964E99304BF

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -853,8 +853,8 @@ SDK version 4.9
 //types for Curtain
 #define pTypeCurtain 0x18
 #define sTypeHarrison 0x0
-#define curtain_sClose 0x0
-#define curtain_sOpen 0x1
+#define curtain_sOpen 0x0
+#define curtain_sClose 0x1
 #define curtain_sStop 0x2
 #define curtain_sProgram 0x3
 
@@ -882,8 +882,8 @@ SDK version 4.9
 #define sTypeBlindsT19 0x13	//Louvolite vertical
 #define sTypeBlindsT20 0x14	//Ozroll E-Trans
 
-#define blinds_sClose 0x0
-#define blinds_sOpen 0x1
+#define blinds_sOpen 0x0
+#define blinds_sClose 0x1
 #define blinds_sStop 0x2
 #define blinds_sConfirm 0x3
 #define blinds_sLimit 0x4

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -853,8 +853,8 @@ SDK version 4.9
 //types for Curtain
 #define pTypeCurtain 0x18
 #define sTypeHarrison 0x0
-#define curtain_sOpen 0x0
-#define curtain_sClose 0x1
+#define curtain_sClose 0x0
+#define curtain_sOpen 0x1
 #define curtain_sStop 0x2
 #define curtain_sProgram 0x3
 

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -881,6 +881,7 @@ SDK version 4.9
 #define sTypeBlindsT18 0x12	//Cherubini
 #define sTypeBlindsT19 0x13	//Louvolite vertical
 #define sTypeBlindsT20 0x14	//Ozroll E-Trans
+#define sTypeBlindsT21 0x15	//Generic
 
 #define blinds_sOpen 0x0
 #define blinds_sClose 0x1

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5274,20 +5274,11 @@ uint64_t CSQLHelper::UpdateValueInt(
 				|| (switchtype == STYPE_BlindsPercentageInvertedWithStop)
 				)
 			{
-				if (
-					(HWtype != HTYPE_MQTTAutoDiscovery)
-					&&
-					(switchtype == STYPE_BlindsPercentage
-					|| switchtype == STYPE_BlindsPercentageWithStop
-					|| switchtype == STYPE_BlindsPercentageInverted
-					|| switchtype == STYPE_BlindsPercentageInvertedWithStop)
-					)
-				{
-					if (nValue == light2_sOn)
-						llevel = 100;
-					else if (nValue == light2_sOff)
-						llevel = 0;
-				}
+				if (nValue == light2_sOn)
+					llevel = 100;
+				else if (nValue == light2_sOff)
+					llevel = 0;
+
 				//update level for device
 				safe_query(
 					"UPDATE DeviceStatus SET LastLevel='%d' WHERE (ID = %" PRIu64 ")",

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -9225,35 +9225,69 @@ namespace http
 						}
 						else if ((switchtype == STYPE_Blinds) || (switchtype == STYPE_VenetianBlindsUS) || (switchtype == STYPE_VenetianBlindsEU))
 						{
+							root["result"][ii]["Image"] = "blinds";
 							root["result"][ii]["TypeImg"] = "blinds";
-							if ((lstatus == "On") || (lstatus == "Close inline relay"))
-							{
-								lstatus = "Closed";
+							if (dSubType == sTypeBlindsT21) {
+								if (lstatus == "Off")
+								{
+									lstatus = "Closed";
+								}
+								else if (lstatus == "Stop")
+								{
+									lstatus = "Stopped";
+								}
+								else if(lstatus == "On")
+								{
+									lstatus = "Open";
+								}
 							}
-							else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
-							{
-								lstatus = "Stopped";
-							}
-							else
-							{
-								lstatus = "Open";
+							else {
+								if ((lstatus == "On") || (lstatus == "Close inline relay"))
+								{
+									lstatus = "Closed";
+								}
+								else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
+								{
+									lstatus = "Stopped";
+								}
+								else
+								{
+									lstatus = "Open";
+								}
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
 						else if (switchtype == STYPE_BlindsInverted)
 						{
+							root["result"][ii]["Image"] = "blinds";
 							root["result"][ii]["TypeImg"] = "blinds";
-							if (lstatus == "On")
-							{
-								lstatus = "Open";
+							if (dSubType == sTypeBlindsT21) {
+								if (lstatus == "Off")
+								{
+									lstatus = "Open";
+								}
+								else if (lstatus == "Stop")
+								{
+									lstatus = "Stopped";
+								}
+								else if (lstatus == "On")
+								{
+									lstatus = "Closed";
+								}
 							}
-							else if (lstatus == "Off")
-							{
-								lstatus = "Closed";
-							}
-							else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
-							{
-								lstatus = "Stopped";
+							else {
+								if (lstatus == "On")
+								{
+									lstatus = "Open";
+								}
+								else if (lstatus == "Off")
+								{
+									lstatus = "Closed";
+								}
+								else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
+								{
+									lstatus = "Stopped";
+								}
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
@@ -9264,6 +9298,7 @@ namespace http
 							|| (switchtype == STYPE_BlindsPercentageInvertedWithStop)
 							)
 						{
+							root["result"][ii]["Image"] = "blinds";
 							root["result"][ii]["TypeImg"] = "blinds";
 							root["result"][ii]["Level"] = LastLevel;
 							int iLevel = round((float(maxDimLevel) / 100.0F) * LastLevel);
@@ -9275,17 +9310,33 @@ namespace http
 							}
 							else if (lstatus == "On")
 */
-							if (lstatus == "On")
-							{
-								lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
+							if (dSubType == sTypeBlindsT21) {
+								if (lstatus == "Off")
+								{
+									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
+								}
+								else if (lstatus == "Stop")
+								{
+									lstatus = "Stopped";
+								}
+								else if (lstatus == "On")
+								{
+									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
+								}
 							}
-							else if (lstatus == "Off")
-							{
-								lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
-							}
-							else if (lstatus == "Stop")
-							{
-								lstatus = "Stopped";
+							else {
+								if (lstatus == "On")
+								{
+									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
+								}
+								else if (lstatus == "Off")
+								{
+									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
+								}
+								else if (lstatus == "Stop")
+								{
+									lstatus = "Stopped";
+								}
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
@@ -13319,23 +13370,35 @@ namespace http
 						case STYPE_Blinds:
 						case STYPE_VenetianBlindsEU:
 						case STYPE_VenetianBlindsUS:
-							ldata = (ldata == "On") ? "Closed" : "Open";
+							if (dSubType == sTypeBlindsT21)
+								ldata = (ldata == "On") ? "Open" : "Closed";
+							else
+								ldata = (ldata == "On") ? "Closed" : "Open";
 							break;
 						case STYPE_BlindsInverted:
-							ldata = (ldata == "On") ? "Open" : "Closed";
+							if (dSubType == sTypeBlindsT21)
+								ldata = (ldata == "On") ? "Closed" : "Open";
+							else
+								ldata = (ldata == "On") ? "Open" : "Closed";
 							break;
 						case STYPE_BlindsPercentage:
 						case STYPE_BlindsPercentageWithStop:
 							if ((ldata == "On") || (ldata == "Off"))
 							{
-								ldata = (ldata == "On") ? "Closed" : "Open";
+								if (dSubType == sTypeBlindsT21)
+									ldata = (ldata == "On") ? "Open" : "Closed";
+								else
+									ldata = (ldata == "On") ? "Closed" : "Open";
 							}
 							break;
 						case STYPE_BlindsPercentageInverted:
 						case STYPE_BlindsPercentageInvertedWithStop:
 							if ((ldata == "On") || (ldata == "Off"))
 							{
-								ldata = (ldata == "On") ? "Open" : "Closed";
+								if (dSubType == sTypeBlindsT21)
+									ldata = (ldata == "On") ? "Closed" : "Open";
+								else
+									ldata = (ldata == "On") ? "Open" : "Closed";
 							}
 							break;
 					}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -9047,8 +9047,8 @@ namespace http
 							int iLevel = round((float(maxDimLevel) / 100.0F) * LastLevel);
 							root["result"][ii]["LevelInt"] = iLevel;
 							if ((dType == pTypeColorSwitch) || (dType == pTypeLighting5 && dSubType == sTypeTRC02) ||
-							    (dType == pTypeLighting5 && dSubType == sTypeTRC02_2) || (dType == pTypeGeneralSwitch && dSubType == sSwitchTypeTRC02) ||
-							    (dType == pTypeGeneralSwitch && dSubType == sSwitchTypeTRC02_2))
+								(dType == pTypeLighting5 && dSubType == sTypeTRC02_2) || (dType == pTypeGeneralSwitch && dSubType == sSwitchTypeTRC02) ||
+								(dType == pTypeGeneralSwitch && dSubType == sSwitchTypeTRC02_2))
 							{
 								_tColor color(sColor);
 								std::string jsonColor = color.toJSONString();
@@ -9075,10 +9075,10 @@ namespace http
 							{
 								// Milight V4/V5 bridges do not support absolute dimming for RGB or CW_WW lights
 								if (_hardwareNames[hardwareID].HardwareTypeVal == HTYPE_LimitlessLights &&
-								    atoi(_hardwareNames[hardwareID].Mode2.c_str()) != CLimitLess::LBTYPE_V6 &&
-								    (atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_RGB ||
-								     atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_White ||
-								     atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_CW_WW))
+									atoi(_hardwareNames[hardwareID].Mode2.c_str()) != CLimitLess::LBTYPE_V6 &&
+									(atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_RGB ||
+										atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_White ||
+										atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_CW_WW))
 								{
 									DimmerType = "rel";
 								}
@@ -9227,33 +9227,17 @@ namespace http
 						{
 							root["result"][ii]["Image"] = "blinds";
 							root["result"][ii]["TypeImg"] = "blinds";
-							if (dSubType == sTypeBlindsT21) {
-								if (lstatus == "Off")
-								{
-									lstatus = "Closed";
-								}
-								else if (lstatus == "Stop")
-								{
-									lstatus = "Stopped";
-								}
-								else if(lstatus == "On")
-								{
-									lstatus = "Open";
-								}
+							if ((lstatus == "On") || (lstatus == "Open inline relay"))
+							{
+								lstatus = "Open";
 							}
-							else {
-								if ((lstatus == "On") || (lstatus == "Close inline relay"))
-								{
-									lstatus = "Closed";
-								}
-								else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
-								{
-									lstatus = "Stopped";
-								}
-								else
-								{
-									lstatus = "Open";
-								}
+							else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
+							{
+								lstatus = "Stopped";
+							}
+							else
+							{
+								lstatus = "Closed";
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
@@ -9261,33 +9245,17 @@ namespace http
 						{
 							root["result"][ii]["Image"] = "blinds";
 							root["result"][ii]["TypeImg"] = "blinds";
-							if (dSubType == sTypeBlindsT21) {
-								if (lstatus == "Off")
-								{
-									lstatus = "Open";
-								}
-								else if (lstatus == "Stop")
-								{
-									lstatus = "Stopped";
-								}
-								else if (lstatus == "On")
-								{
-									lstatus = "Closed";
-								}
+							if (lstatus == "On")
+							{
+								lstatus = "Closed";
 							}
-							else {
-								if (lstatus == "On")
-								{
-									lstatus = "Open";
-								}
-								else if (lstatus == "Off")
-								{
-									lstatus = "Closed";
-								}
-								else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
-								{
-									lstatus = "Stopped";
-								}
+							else if (lstatus == "Off")
+							{
+								lstatus = "Open";
+							}
+							else if ((lstatus == "Stop") || (lstatus == "Stop inline relay"))
+							{
+								lstatus = "Stopped";
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
@@ -9303,40 +9271,24 @@ namespace http
 							root["result"][ii]["Level"] = LastLevel;
 							int iLevel = round((float(maxDimLevel) / 100.0F) * LastLevel);
 							root["result"][ii]["LevelInt"] = iLevel;
-/*
-							if ((iLevel > 0) && (iLevel < maxDimLevel))
+							/*
+														if ((iLevel > 0) && (iLevel < maxDimLevel))
+														{
+															lstatus = std_format("%d %%", iLevel);
+														}
+														else if (lstatus == "On")
+							*/
+							if (lstatus == "On")
 							{
-								lstatus = std_format("%d %%", iLevel);
+								lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
 							}
-							else if (lstatus == "On")
-*/
-							if (dSubType == sTypeBlindsT21) {
-								if (lstatus == "Off")
-								{
-									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
-								}
-								else if (lstatus == "Stop")
-								{
-									lstatus = "Stopped";
-								}
-								else if (lstatus == "On")
-								{
-									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
-								}
+							else if (lstatus == "Off")
+							{
+								lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
 							}
-							else {
-								if (lstatus == "On")
-								{
-									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Closed" : "Open";
-								}
-								else if (lstatus == "Off")
-								{
-									lstatus = ((switchtype == STYPE_BlindsPercentage) || (switchtype == STYPE_BlindsPercentageWithStop)) ? "Open" : "Closed";
-								}
-								else if (lstatus == "Stop")
-								{
-									lstatus = "Stopped";
-								}
+							else if (lstatus == "Stop")
+							{
+								lstatus = "Stopped";
 							}
 							root["result"][ii]["Status"] = lstatus;
 						}
@@ -13370,37 +13322,25 @@ namespace http
 						case STYPE_Blinds:
 						case STYPE_VenetianBlindsEU:
 						case STYPE_VenetianBlindsUS:
-							if (dSubType == sTypeBlindsT21)
-								ldata = (ldata == "On") ? "Open" : "Closed";
-							else
-								ldata = (ldata == "On") ? "Closed" : "Open";
-							break;
-						case STYPE_BlindsInverted:
-							if (dSubType == sTypeBlindsT21)
-								ldata = (ldata == "On") ? "Closed" : "Open";
-							else
-								ldata = (ldata == "On") ? "Open" : "Closed";
-							break;
-						case STYPE_BlindsPercentage:
-						case STYPE_BlindsPercentageWithStop:
-							if ((ldata == "On") || (ldata == "Off"))
-							{
-								if (dSubType == sTypeBlindsT21)
-									ldata = (ldata == "On") ? "Open" : "Closed";
-								else
-									ldata = (ldata == "On") ? "Closed" : "Open";
-							}
-							break;
-						case STYPE_BlindsPercentageInverted:
-						case STYPE_BlindsPercentageInvertedWithStop:
-							if ((ldata == "On") || (ldata == "Off"))
-							{
-								if (dSubType == sTypeBlindsT21)
-									ldata = (ldata == "On") ? "Closed" : "Open";
-								else
-									ldata = (ldata == "On") ? "Open" : "Closed";
-							}
-							break;
+						ldata = (ldata == "On") ? "Open" : "Closed";
+						break;
+					case STYPE_BlindsInverted:
+						ldata = (ldata == "On") ? "Closed" : "Open";
+						break;
+					case STYPE_BlindsPercentage:
+					case STYPE_BlindsPercentageWithStop:
+						if ((ldata == "On") || (ldata == "Off"))
+						{
+							ldata = (ldata == "On") ? "Closed" : "Open";
+						}
+						break;
+					case STYPE_BlindsPercentageInverted:
+					case STYPE_BlindsPercentageInvertedWithStop:
+						if ((ldata == "On") || (ldata == "Off"))
+						{
+							ldata = (ldata == "On") ? "Closed" : "Open";
+						}
+						break;
 					}
 
 					root["result"][ii]["idx"] = lidx;

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -256,7 +256,6 @@ define(['app', 'livesocket'], function (app) {
 							}
 						}
 						else if ((item.SwitchType.indexOf("Blinds")>=0)) {
-							console.log(item);
 							item.Image = item.TypeImg;
 			
 							isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
@@ -564,7 +563,6 @@ define(['app', 'livesocket'], function (app) {
 							}
 						}
 						else if ((item.SwitchType.indexOf("Blinds")>=0) || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
-							console.log(item);
 							item.Image = item.TypeImg;
 			
 							isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
@@ -1883,7 +1881,6 @@ define(['app', 'livesocket'], function (app) {
 										}
 									}
 									else if (item.SwitchType.indexOf("Blinds")>=0) {
-										console.log(item);
 										item.Image = item.TypeImg;
 						
 										isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
@@ -2295,7 +2292,6 @@ define(['app', 'livesocket'], function (app) {
 										status = item.Data;
 									}
 									else if (item.SwitchType.indexOf("Blinds")>=0) {
-										console.log(item);
 										item.Image = item.TypeImg;
 						
 										isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -255,7 +255,27 @@ define(['app', 'livesocket'], function (app) {
 								status = '<button class="btn btn-mini btn-info" href="#/Devices/' + item.idx + '/Log">' + $.t("Open") + '</button>';
 							}
 						}
-						else if ((item.SwitchType == "Blinds") || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+						else if ((item.SwitchType.indexOf("Blinds")>=0)) {
+							console.log(item);
+							item.Image = item.TypeImg;
+			
+							isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+			
+							const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+							const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+			
+							const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? " btn-info" : "";
+							const selCloseImage = ((item.Status == 'Closed')) ? " btn-info" : "";
+							const closedText = ((item.Status == 'Closed')) ? $.t("Closed") : $.t("Close");
+							
+							const openImage = '<button class="btn btn-mini' + selOpenImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');">' + $.t("Open") + '</button>';
+							const closeImage = '<button class="btn btn-mini' + selCloseImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');">' + closedText + '</button>';
+			
+							const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+							const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+			
+							status = firstImage;
+
 							if (
 								(item.SubType == "RAEX") ||
 								(item.SubType.indexOf('A-OK') == 0) ||
@@ -271,132 +291,12 @@ define(['app', 'livesocket'], function (app) {
 								(item.SubType.indexOf('ASA') == 0) ||
 								(item.SubType.indexOf('DC106') == 0) ||
 								(item.SubType.indexOf('Confexx') == 0) ||
-								(item.SwitchType.indexOf("Venetian Blinds") == 0)
+								(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+								(item.SwitchType.indexOf("Stop") >= 0)
 							) {
-								if (item.Status == 'Closed') {
-									status =
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-								}
-								else {
-									status =
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-								}
+								status += '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ';
 							}
-							else {
-								if (item.Status == 'Closed') {
-									status =
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-								}
-								else {
-									status =
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-								}
-							}
-						}
-						else if (item.SwitchType == "Blinds Inverted") {
-							if (
-								(item.SubType == "RAEX") ||
-								(item.SubType.indexOf('A-OK') == 0) ||
-								(item.SubType.indexOf('Hasta') >= 0) ||
-								(item.SubType.indexOf('Media Mount') == 0) ||
-								(item.SubType.indexOf('Forest') == 0) ||
-								(item.SubType.indexOf('Chamberlain') == 0) ||
-								(item.SubType.indexOf('Sunpery') == 0) ||
-								(item.SubType.indexOf('Dolat') == 0) ||
-								(item.SubType.indexOf('ASP') == 0) ||
-								(item.SubType == "Harrison") ||
-								(item.SubType.indexOf('RFY') == 0) ||
-								(item.SubType.indexOf('ASA') == 0) ||
-								(item.SubType.indexOf('DC106') == 0) ||
-								(item.SubType.indexOf('Confexx') == 0)
-							) {
-								if (item.Status == 'Closed') {
-									status =
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-								}
-								else {
-									status =
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-								}
-							}
-							else {
-								if (item.Status == 'Closed') {
-									status =
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-								}
-								else {
-									status =
-										'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-										'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-								}
-							}
-						}
-						else if (item.SwitchType == "Blinds Percentage") {
-							isdimmer = true;
-							if (item.Status == 'Open') {
-								status =
-									'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-									'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-							}
-							else {
-								status =
-									'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-									'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-							}
-						}
-						else if (item.SwitchType == "Blinds Percentage Inverted") {
-							isdimmer = true;
-							if (item.Status == 'Closed') {
-								status =
-									'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-									'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-							}
-							else {
-								status =
-									'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-									'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-							}
-						}
-						else if (item.SwitchType == "Blinds + Stop") {
-						  isdimmer = true;
-						  if (item.Status == 'Closed') {
-							status =
-							  '<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-							  '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-							  '<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-						  }
-						  else {
-							status =
-							  '<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-							  '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-							  '<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-						  }
-						}
-						else if (item.SwitchType == "Blinds Inverted + Stop") {
-						  isdimmer = true;
-						  if (item.Status == 'Closed') {
-							status =
-							  '<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-							  '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-							  '<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-						  }
-						  else {
-							status =
-							  '<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-							  '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-							  '<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-						  }
+							status += secondImage
 						}
 						else if (item.SwitchType == "Dimmer") {
 							isdimmer = true;
@@ -663,7 +563,26 @@ define(['app', 'livesocket'], function (app) {
 								img = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '48_On.png" class="lcursor" height="40" width="40"></a>';
 							}
 						}
-						else if ((item.SwitchType == "Blinds") || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+						else if ((item.SwitchType.indexOf("Blinds")>=0) || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+							console.log(item);
+							item.Image = item.TypeImg;
+			
+							isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+			
+							const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+							const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+			
+							const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
+							const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
+							
+							const openImage = '<img src="images/blindsopen48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
+							const closeImage = '<img src="images/blinds48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
+			
+							const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+							const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+			
+							img = firstImage;
+
 							if (
 								(item.SubType == "RAEX") ||
 								(item.SubType.indexOf('A-OK') == 0) ||
@@ -679,108 +598,14 @@ define(['app', 'livesocket'], function (app) {
 								(item.SubType.indexOf('ASA') == 0) ||
 								(item.SubType.indexOf('DC106') == 0) ||
 								(item.SubType.indexOf('Confexx') == 0) ||
-								(item.SwitchType.indexOf("Venetian Blinds") == 0)
+								(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+								(item.SwitchType.indexOf("Stop") >= 0)
 							) {
-								if (item.Status == 'Closed') {
-									img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-								else {
-									img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
+								img3 = secondImage;
 							}
 							else {
-								if (item.Status == 'Closed') {
-									img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-								else {
-									img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
+								img2 = secondImage;
 							}
-						}
-						else if (item.SwitchType == "Blinds Inverted") {
-							if (
-								(item.SubType == "RAEX") ||
-								(item.SubType.indexOf('A-OK') == 0) ||
-								(item.SubType.indexOf('Hasta') >= 0) ||
-								(item.SubType.indexOf('Media Mount') == 0) ||
-								(item.SubType.indexOf('Forest') == 0) ||
-								(item.SubType.indexOf('Chamberlain') == 0) ||
-								(item.SubType.indexOf('Sunpery') == 0) ||
-								(item.SubType.indexOf('Dolat') == 0) ||
-								(item.SubType.indexOf('ASP') == 0) ||
-								(item.SubType == "Harrison") ||
-								(item.SubType.indexOf('RFY') == 0) ||
-								(item.SubType.indexOf('ASA') == 0) ||
-								(item.SubType.indexOf('DC106') == 0) ||
-								(item.SubType.indexOf('Confexx') == 0)
-							) {
-								if (item.Status == 'Closed') {
-									img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-								else {
-									img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-							}
-							else {
-								if (item.Status == 'Closed') {
-									img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-								else {
-									img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-									img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								}
-							}
-						}
-						else if (item.SwitchType == "Blinds Percentage") {
-							isdimmer = true;
-							if (item.Status == 'Open') {
-								img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							}
-							else {
-								img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							}
-						}
-						else if (item.SwitchType == "Blinds Percentage Inverted") {
-							isdimmer = true;
-							if (item.Status == 'Closed') {
-								img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							}
-							else {
-								img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-								img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							}
-						}
-						else if (item.SwitchType == "Blinds + Stop") {
-						  isdimmer = true;
-						  if (item.Status == 'Open') {
-							img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-						  }
-						  else {
-							img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="0" width="40">';
-						  }
-						}
-						else if (item.SwitchType == "Blinds Inverted + Stop") {
-						  isdimmer = true;
-						  if (item.Status == 'Closed') {
-							img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-						  }
-						  else if ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) {
-							img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-							img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
-						  }
 						}
 						else if (item.SwitchType == "Dimmer") {
 							isdimmer = true;
@@ -947,9 +772,15 @@ define(['app', 'livesocket'], function (app) {
 							}
 						}
 						if (isdimmer == true) {
-							var dslider = $(id + " #slider");
+							var dslider = $(id + "_slider");
 							if (typeof dslider != 'undefined') {
 								dslider.slider("value", item.LevelInt);
+							}
+							else{
+								dslider = $(id + " #slider");
+								if (typeof dslider != 'undefined') {
+									dslider.slider("value", item.LevelInt);
+								}
 							}
 						}
 						if (item.SwitchType === "Selector") {
@@ -2051,7 +1882,27 @@ define(['app', 'livesocket'], function (app) {
 											status = '<a class="btn btn-mini btn-info" href="#/Devices/' + item.idx + '/Log">' + $.t("Open") + '</button>';
 										}
 									}
-									else if ((item.SwitchType == "Blinds") || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+									else if (item.SwitchType.indexOf("Blinds")>=0) {
+										console.log(item);
+										item.Image = item.TypeImg;
+						
+										isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+						
+										const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+										const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+						
+										const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? " btn-info" : "";
+										const selCloseImage = ((item.Status == 'Closed')) ? " btn-info" : "";
+										const closedText = ((item.Status == 'Closed')) ? $.t("Closed") : $.t("Close");
+										
+										const openImage = '<button class="btn btn-mini' + selOpenImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');">' + $.t("Open") + '</button>';
+										const closeImage = '<button class="btn btn-mini' + selCloseImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');">' + closedText + '</button>';
+						
+										const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+										const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+						
+										status = firstImage;
+			
 										if (
 											(item.SubType == "RAEX") ||
 											(item.SubType.indexOf('A-OK') == 0) ||
@@ -2067,128 +1918,12 @@ define(['app', 'livesocket'], function (app) {
 											(item.SubType.indexOf('ASA') == 0) ||
 											(item.SubType.indexOf('DC106') == 0) ||
 											(item.SubType.indexOf('Confexx') == 0) ||
-											(item.SwitchType.indexOf("Venetian Blinds") == 0)
+											(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+											(item.SwitchType.indexOf("Stop") >= 0)
 										) {
-											if (item.Status == 'Closed') {
-												status =
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-											}
-											else {
-												status =
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-											}
+											status += '<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ';
 										}
-										else {
-											if (item.Status == 'Closed') {
-												status =
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-											}
-											else {
-												status =
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-											}
-										}
-									}
-									else if (item.SwitchType == "Blinds Inverted") {
-										if (
-											(item.SubType == "RAEX") ||
-											(item.SubType.indexOf('A-OK') == 0) ||
-											(item.SubType.indexOf('Hasta') >= 0) ||
-											(item.SubType.indexOf('Media Mount') == 0) ||
-											(item.SubType.indexOf('Forest') == 0) ||
-											(item.SubType.indexOf('Chamberlain') == 0) ||
-											(item.SubType.indexOf('Sunpery') == 0) ||
-											(item.SubType.indexOf('Dolat') == 0) ||
-											(item.SubType.indexOf('ASP') == 0) ||
-											(item.SubType == "Harrison") ||
-											(item.SubType.indexOf('RFY') == 0) ||
-											(item.SubType.indexOf('ASA') == 0) ||
-											(item.SubType.indexOf('DC106') == 0) ||
-											(item.SubType.indexOf('Confexx') == 0)
-										) {
-											if (item.Status == 'Closed') {
-												status =
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-											}
-											else {
-												status =
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-											}
-										}
-										else {
-											if (item.Status == 'Closed') {
-												status =
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-											}
-											else {
-												status =
-													'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-													'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-											}
-										}
-									}
-									else if (item.SwitchType == "Blinds Percentage") {
-										if ((item.Status == 'Open')) {
-											status =
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-										}
-										else {
-											status =
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-										}
-									}
-									else if (item.SwitchType == "Blinds Percentage Inverted") {
-										if (item.Status == 'Closed') {
-											status =
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-										}
-										else {
-											status =
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-										}
-									}
-									else if (item.SwitchType == "Blinds + Stop") {
-										if (item.Status == 'Closed') {
-											status =
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-										}
-										else {
-											status =
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-										}
-									}
-									else if (item.SwitchType == "Blinds Inverted + Stop") {
-										if (item.Status == 'Closed') {
-											status =
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Closed") + '</button>';
-										}
-										else {
-											status =
-												'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Open") + '</button> ' +
-												'<button class="btn btn-mini btn-danger" type="button" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');">' + $.t("Stop") + '</button> ' +
-												'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Close") + '</button>';
-										}
+										status += secondImage;
 									}
 									else if (item.SwitchType == "Dimmer") {
 										var img = "";
@@ -2376,7 +2111,7 @@ define(['app', 'livesocket'], function (app) {
 											) {
 										xhtm += '<tr>';
 										xhtm += '<td colspan="2" style="border:0px solid red; padding-top:10px; padding-bottom:10px;">';
-										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
+										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
 										xhtm += '</td>';
 										xhtm += '</tr>';
 									}
@@ -2386,7 +2121,7 @@ define(['app', 'livesocket'], function (app) {
 											) {
 										xhtm += '<tr>';
 										xhtm += '<td colspan="2" style="border:0px solid red; padding-top:10px; padding-bottom:10px;">';
-										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
+										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
 										xhtm += '</td>';
 										xhtm += '</tr>';
 									}
@@ -2559,7 +2294,26 @@ define(['app', 'livesocket'], function (app) {
 										}
 										status = item.Data;
 									}
-									else if ((item.SwitchType == "Blinds") || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+									else if (item.SwitchType.indexOf("Blinds")>=0) {
+										console.log(item);
+										item.Image = item.TypeImg;
+						
+										isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+						
+										const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+										const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+						
+										const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
+										const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
+										
+										const openImage = '<img src="images/blindsopen48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
+										const closeImage = '<img src="images/blinds48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="40" width="40">';
+						
+										const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+										const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+						
+										xhtm += '\t      <td id="img" class="img img1">' + firstImage + '</td>\n';
+			
 										if (
 											(item.SubType == "RAEX") ||
 											(item.SubType.indexOf('A-OK') == 0) ||
@@ -2575,111 +2329,14 @@ define(['app', 'livesocket'], function (app) {
 											(item.SubType.indexOf('ASA') == 0) ||
 											(item.SubType.indexOf('DC106') == 0) ||
 											(item.SubType.indexOf('Confexx') == 0) ||
-											(item.SwitchType.indexOf("Venetian Blinds") == 0)
+											(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+											(item.SwitchType.indexOf("Stop") >= 0)
 										) {
-											if (item.Status == 'Closed') {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-												xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-											else {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-												xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-										}
-										else {
-											if (item.Status == 'Closed') {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-											else {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-										}
-									}
-									else if (item.SwitchType == "Blinds Inverted") {
-										if (
-											(item.SubType == "RAEX") ||
-											(item.SubType.indexOf('A-OK') == 0) ||
-											(item.SubType.indexOf('Hasta') >= 0) ||
-											(item.SubType.indexOf('Media Mount') == 0) ||
-											(item.SubType.indexOf('Forest') == 0) ||
-											(item.SubType.indexOf('Chamberlain') == 0) ||
-											(item.SubType.indexOf('Sunpery') == 0) ||
-											(item.SubType.indexOf('Dolat') == 0) ||
-											(item.SubType.indexOf('ASP') == 0) ||
-											(item.SubType == "Harrison") ||
-											(item.SubType.indexOf('RFY') == 0) ||
-											(item.SubType.indexOf('ASA') == 0) ||
-											(item.SubType.indexOf('DC106') == 0) ||
-											(item.SubType.indexOf('Confexx') == 0)
-										) {
-											if (item.Status == 'Closed') {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-												xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-											else {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-												xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-										}
-										else {
-											if (item.Status == 'Closed') {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-											else {
-												xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-												xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											}
-										}
-									}
-									else if (item.SwitchType == "Blinds Percentage") {
-										if (item.Status == 'Open') {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-										else {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-									}
-									else if (item.SwitchType == "Blinds Percentage Inverted") {
-										if (item.Status == 'Closed') {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-										else {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-									}
-									else if (item.SwitchType == "Blinds + Stop") {
-										if (item.Status == 'Closed') {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
 											xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-											xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
+											xhtm += '\t      <td id="img3" class="img3">' + secondImage + '</td>\n';
 										}
 										else {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-											xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-									}
-									else if (item.SwitchType == "Blinds Inverted + Stop") {
-										if (item.Status == 'Closed') {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-											xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-										}
-										else {
-											xhtm += '\t      <td id="img" class="img img1"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
-											xhtm += '\t      <td id="img2" class="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="40" width="24"></td>\n';
-											xhtm += '\t      <td id="img3" class="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
+											xhtm += '\t      <td id="img2" class="img2">' + secondImage + '</td>\n';
 										}
 									}
 									else if (item.SwitchType == "Dimmer") {
@@ -2823,11 +2480,17 @@ define(['app', 'livesocket'], function (app) {
 											xhtm += ' data-disabled="true"';
 										xhtm += '></div></td>';
 									}
-									else if ((item.SwitchType == "Blinds Percentage") || (item.SwitchType == "Blinds Percentage Inverted")) {
-										xhtm += '<td class="input"><div style="margin-left:94px; margin-top: 7px;" class="dimslider dimslidersmalldouble" id="slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
+									else if (item.SwitchType == "Blinds Percentage") {
+										xhtm += '<td class="input"><div style="margin-left:94px; margin-top: 7px;" class="dimslider dimslidersmalldouble" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
 									}
-									else if ((item.SwitchType == "Blinds + Stop") || (item.SwitchType == "Blinds Inverted + Stop")) {
-										xhtm += '<td class="input"><div style="margin-left:124px; margin-top: 7px;" class="dimslider dimslidersmalltripple" id="slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
+									else if (item.SwitchType == "Blinds Percentage Inverted") {
+										xhtm += '<td class="input"><div style="margin-left:94px; margin-top: 7px;" class="dimslider dimslidersmalldouble" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds_inv" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
+									}
+									else if (item.SwitchType == "Blinds + Stop") {
+										xhtm += '<td class="input"><div style="margin-left:124px; margin-top: 7px;" class="dimslider dimslidersmalltripple" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
+									}
+									else if (item.SwitchType == "Blinds Inverted + Stop") {
+										xhtm += '<td class="input"><div style="margin-left:124px; margin-top: 7px;" class="dimslider dimslidersmalltripple" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds_inv" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div></td>';
 									}
 									else if (item.SwitchType == "Selector") {
 										if (item.SelectorStyle === 0) {

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -26,9 +26,9 @@ define(['app', 'livesocket'], function (app) {
 			//(the status can flick back to the previous status after an update)...now implemented with script side lockout
 			$.ajax({
 				url: "json.htm?type=command&param=switchmodal" +
-				"&idx=" + idx +
-				"&status=" + status +
-				"&action=1",
+					"&idx=" + idx +
+					"&status=" + status +
+					"&action=1",
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -177,21 +177,21 @@ define(['app', 'livesocket'], function (app) {
 			//Lights
 			var isdimmer = false;
 			if (
-					(item.Type.indexOf('Light') == 0) ||
-					(item.Type.indexOf('Blind') == 0) ||
-					(item.Type.indexOf('Curtain') == 0) ||
-					(item.Type.indexOf('Thermostat 2') == 0) ||
-					(item.Type.indexOf('Thermostat 3') == 0) ||
-					(item.Type.indexOf('Chime') == 0) ||
-					(item.Type.indexOf('Color Switch') == 0) ||
-					(item.Type.indexOf('RFY') == 0) ||
-					(item.Type.indexOf('ASA') == 0) ||
-					(item.SubType == "Smartwares Mode") ||
-					(item.SubType == "Relay") ||
-					((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Itho') == 0)) ||
-					((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Lucci') == 0)) ||
-					((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Westinghouse') == 0))
-				) {
+				(item.Type.indexOf('Light') == 0) ||
+				(item.Type.indexOf('Blind') == 0) ||
+				(item.Type.indexOf('Curtain') == 0) ||
+				(item.Type.indexOf('Thermostat 2') == 0) ||
+				(item.Type.indexOf('Thermostat 3') == 0) ||
+				(item.Type.indexOf('Chime') == 0) ||
+				(item.Type.indexOf('Color Switch') == 0) ||
+				(item.Type.indexOf('RFY') == 0) ||
+				(item.Type.indexOf('ASA') == 0) ||
+				(item.SubType == "Smartwares Mode") ||
+				(item.SubType == "Relay") ||
+				((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Itho') == 0)) ||
+				((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Lucci') == 0)) ||
+				((typeof item.SubType != 'undefined') && (item.SubType.indexOf('Westinghouse') == 0))
+			) {
 				id = "#light_" + item.idx;
 				var obj = $(id);
 				if (typeof obj != 'undefined') {
@@ -208,10 +208,10 @@ define(['app', 'livesocket'], function (app) {
 						}
 						else if (item.SwitchType == "Door Contact") {
 							if (item.InternalState == "Open") {
-                                status = '<button class="btn btn-mini btn-info" type="button">' + $.t(item.InternalState) + '</button>';
+								status = '<button class="btn btn-mini btn-info" type="button">' + $.t(item.InternalState) + '</button>';
 							}
 							else {
-                                status = '<button class="btn btn-mini" type="button">' + $.t(item.InternalState) + '</button>';
+								status = '<button class="btn btn-mini" type="button">' + $.t(item.InternalState) + '</button>';
 							}
 						}
 						else if (item.SwitchType == "Door Lock") {
@@ -224,7 +224,7 @@ define(['app', 'livesocket'], function (app) {
 									'<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Locked") + '</button>';
 							}
 						}
-							else if (item.SwitchType == "Door Lock Inverted") {
+						else if (item.SwitchType == "Door Lock Inverted") {
 							if (item.InternalState == "Unlocked") {
 								status = '<button class="btn btn-mini btn-info" type="button" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');">' + $.t("Unlocked") + '</button> ' +
 									'<button class="btn btn-mini" type="button" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');">' + $.t("Locked") + '</button>';
@@ -257,22 +257,22 @@ define(['app', 'livesocket'], function (app) {
 						}
 						else if ((item.SwitchType.indexOf("Blinds")>=0)) {
 							item.Image = item.TypeImg;
-			
+
 							isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
-			
+
 							const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
 							const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
-			
+
 							const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? " btn-info" : "";
 							const selCloseImage = ((item.Status == 'Closed')) ? " btn-info" : "";
 							const closedText = ((item.Status == 'Closed')) ? $.t("Closed") : $.t("Close");
-							
+
 							const openImage = '<button class="btn btn-mini' + selOpenImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');">' + $.t("Open") + '</button>';
 							const closeImage = '<button class="btn btn-mini' + selCloseImage + ' type="button" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');">' + closedText + '</button>';
-			
+
 							const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
 							const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
-			
+
 							status = firstImage;
 
 							if (
@@ -519,10 +519,10 @@ define(['app', 'livesocket'], function (app) {
 						}
 						else if (item.SwitchType == "Door Contact") {
 							if (item.InternalState == "Open") {
-                                img = '<img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="40" width="40">';
+								img = '<img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="40" width="40">';
 							}
 							else {
-                                img = '<img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="40" width="40">';
+								img = '<img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="40" width="40">';
 							}
 						}
 						else if (item.SwitchType == "Door Lock") {
@@ -618,7 +618,7 @@ define(['app', 'livesocket'], function (app) {
 								if (isLED(item.SubType)) {
 									if (item.Image == "Dimmer") {
 										img = '<img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
-									} 
+									}
 									else {
 										img = '<img src="images/' + item.Image + '48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
 									}
@@ -631,7 +631,7 @@ define(['app', 'livesocket'], function (app) {
 								if (isLED(item.SubType)) {
 									if (item.Image == "Dimmer") {
 										img = '<img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
-									} 
+									}
 									else {
 										img = '<img src="images/' + item.Image + '48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40">';
 									}
@@ -724,7 +724,7 @@ define(['app', 'livesocket'], function (app) {
 							(item.SubType.indexOf("Itho") == 0) ||
 							(item.SubType.indexOf("Lucci") == 0) ||
 							(item.SubType.indexOf("Westinghouse") == 0)
-							) {
+						) {
 							img = $(id + " #img").html();
 						}
 						else {
@@ -939,10 +939,10 @@ define(['app', 'livesocket'], function (app) {
 
 			//Temperature Sensors
 			if (
-				 (typeof item.Temp != 'undefined') ||
-				 (typeof item.Humidity != 'undefined') ||
-				  (typeof item.Chill != 'undefined')
-				) {
+				(typeof item.Temp != 'undefined') ||
+				(typeof item.Humidity != 'undefined') ||
+				(typeof item.Chill != 'undefined')
+			) {
 				id = "#temp_" + item.idx;
 				var obj = $(id);
 				if (typeof obj != 'undefined') {
@@ -954,10 +954,10 @@ define(['app', 'livesocket'], function (app) {
 						var status = "";
 						var bHaveBefore = false;
 						if (typeof item.Temp != 'undefined') {
-              if ($rootScope.DisplayTrend(item.trend))
-              {
-                status += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
-              }
+							if ($rootScope.DisplayTrend(item.trend))
+							{
+								status += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
+							}
 							status += item.Temp + '&deg; ' + $scope.config.TempSign;
 							bHaveBefore = true;
 						}
@@ -1069,13 +1069,13 @@ define(['app', 'livesocket'], function (app) {
 
 			//Weather Sensors
 			if (
-				 (typeof item.Rain != 'undefined') ||
-				 (typeof item.Visibility != 'undefined') ||
-				 (typeof item.UVI != 'undefined') ||
-				 (typeof item.Radiation != 'undefined') ||
-				 (typeof item.Direction != 'undefined') ||
-				 (typeof item.Barometer != 'undefined')
-				) {
+				(typeof item.Rain != 'undefined') ||
+				(typeof item.Visibility != 'undefined') ||
+				(typeof item.UVI != 'undefined') ||
+				(typeof item.Radiation != 'undefined') ||
+				(typeof item.Direction != 'undefined') ||
+				(typeof item.Barometer != 'undefined')
+			) {
 				id = "#weather_" + item.idx;
 				var obj = $(id);
 				if (typeof obj != 'undefined') {
@@ -1232,7 +1232,7 @@ define(['app', 'livesocket'], function (app) {
 					}
 				}
 			} //weather devices
-	
+
 			//Utility Sensors
 			if (
 				(typeof item.Counter != 'undefined') ||
@@ -1263,7 +1263,7 @@ define(['app', 'livesocket'], function (app) {
 				(item.SubType == "Waterflow") ||
 				(item.SubType == "Sound Level") ||
 				(item.SubType == "Custom Sensor")
-			   ) {
+			) {
 				id = "#utility_" + item.idx;
 				var obj = $(id);
 				if (typeof obj != 'undefined') {
@@ -1597,7 +1597,7 @@ define(['app', 'livesocket'], function (app) {
 
 			var bFavorites = 1;
 			var roomPlanId = $routeParams.room || window.myglobals.LastPlanSelected;
-			
+
 			if (typeof roomPlanId != 'undefined') {
 				if (roomPlanId > 0) {
 					bFavorites = 0;
@@ -1833,10 +1833,10 @@ define(['app', 'livesocket'], function (app) {
 									}
 									else if (item.SwitchType == "Door Contact") {
 										if (item.InternalState == "Open") {
-                                            status = '<button class="btn btn-mini btn-info" type="button">' + $.t(item.InternalState) + '</button>';
+											status = '<button class="btn btn-mini btn-info" type="button">' + $.t(item.InternalState) + '</button>';
 										}
 										else {
-                                            status = '<button class="btn btn-mini" type="button">' + $.t(item.InternalState) + '</button>';
+											status = '<button class="btn btn-mini" type="button">' + $.t(item.InternalState) + '</button>';
 										}
 									}
 									else if (item.SwitchType == "Door Lock") {
@@ -2011,7 +2011,7 @@ define(['app', 'livesocket'], function (app) {
 									else if (
 										(item.SubType.indexOf("Lucci") == 0) ||
 										(item.SubType.indexOf("Westinghouse") == 0)
-										) {
+									) {
 										var class_1 = "btn btn-mini";
 										var class_2 = "btn btn-mini";
 										var class_3 = "btn btn-mini";
@@ -2040,23 +2040,23 @@ define(['app', 'livesocket'], function (app) {
 											'<button class="' + class_timer + '" type="button" onclick="SwitchLight(' + item.idx + ',\'light\',' + item.Protected + ');">' + $.t("Light") + '</button>';
 									}
 									else if (item.SubType.indexOf("Lucci Air DC") == 0) {
-									    var class_1 = "btn btn-mini";
-									    var class_2 = "btn btn-mini";
-									    var class_3 = "btn btn-mini";
-									    var class_4 = "btn btn-mini";
-									    if (item.Status == "pow") {
-									        class_1 += " btn-info";
-									    }
-									    else if (item.Status == "plus") {
-									        class_2 += " btn-info";
-									    }
-									    else if (item.Status == "min") {
-									        class_3 += " btn-info";
-									    }
-									    else if (item.Status == "light") {
-									        class_4 += " btn-info";
-									    }
-									    status =
+										var class_1 = "btn btn-mini";
+										var class_2 = "btn btn-mini";
+										var class_3 = "btn btn-mini";
+										var class_4 = "btn btn-mini";
+										if (item.Status == "pow") {
+											class_1 += " btn-info";
+										}
+										else if (item.Status == "plus") {
+											class_2 += " btn-info";
+										}
+										else if (item.Status == "min") {
+											class_3 += " btn-info";
+										}
+										else if (item.Status == "light") {
+											class_4 += " btn-info";
+										}
+										status =
 											'<button class="' + class_1 + '" type="button" onclick="SwitchLight(' + item.idx + ',\'pow\',' + item.Protected + ');">' + $.t("pow") + '</button> ' +
 											'<button class="' + class_2 + '" type="button" onclick="SwitchLight(' + item.idx + ',\'plus\',' + item.Protected + ');">' + $.t("plus") + '</button> ' +
 											'<button class="' + class_3 + '" type="button" onclick="SwitchLight(' + item.idx + ',\'min\',' + item.Protected + ');">' + $.t("min") + '</button> ' +
@@ -2103,9 +2103,9 @@ define(['app', 'livesocket'], function (app) {
 										xhtm += '</tr>';
 									}
 									else if (
-											(item.SwitchType == "Blinds Percentage")
-											|| (item.SwitchType == "Blinds Percentage Inverted")
-											) {
+										(item.SwitchType == "Blinds Percentage")
+										|| (item.SwitchType == "Blinds Percentage Inverted")
+									) {
 										xhtm += '<tr>';
 										xhtm += '<td colspan="2" style="border:0px solid red; padding-top:10px; padding-bottom:10px;">';
 										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
@@ -2113,9 +2113,9 @@ define(['app', 'livesocket'], function (app) {
 										xhtm += '</tr>';
 									}
 									else if (
-											(item.SwitchType == "Blinds + Stop")
-											|| (item.SwitchType == "Blinds Inverted + Stop")
-											) {
+										(item.SwitchType == "Blinds + Stop")
+										|| (item.SwitchType == "Blinds Inverted + Stop")
+									) {
 										xhtm += '<tr>';
 										xhtm += '<td colspan="2" style="border:0px solid red; padding-top:10px; padding-bottom:10px;">';
 										xhtm += '<div style="margin-top: -11px; margin-left: 24px;" class="dimslider dimslidersmall" id="light_' + item.idx + '_slider" data-idx="' + item.idx + '" data-type="blinds" data-maxlevel="' + item.MaxDimLevel + '" data-isprotected="' + item.Protected + '" data-svalue="' + item.LevelInt + '"></div>';
@@ -2179,7 +2179,7 @@ define(['app', 'livesocket'], function (app) {
 										|| (item.SwitchType == "Blinds Inverted + Stop")
 										|| (item.SwitchType.indexOf("Venetian Blinds") == 0)
 										|| (item.SwitchType.indexOf("Media Player") == 0)
-										) {
+									) {
 										if (
 											(item.SubType == "RAEX")
 											|| (item.SubType.indexOf('A-OK') == 0)
@@ -2232,10 +2232,10 @@ define(['app', 'livesocket'], function (app) {
 									}
 									else if (item.SwitchType == "Door Contact") {
 										if (item.InternalState == "Open") {
-                                            xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="40" width="40"></td>\n';
+											xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="40" width="40"></td>\n';
 										}
 										else {
-                                            xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="40" width="40"></td>\n';
+											xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="40" width="40"></td>\n';
 										}
 									}
 									else if (item.SwitchType == "Door Lock") {
@@ -2246,7 +2246,7 @@ define(['app', 'livesocket'], function (app) {
 											xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_Off.png" title="' + $.t("Unlock") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
 										}
 									}
-										else if (item.SwitchType == "Door Lock Inverted") {
+									else if (item.SwitchType == "Door Lock Inverted") {
 										if (item.InternalState == "Unlocked") {
 											xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_On.png" title="' + $.t("Lock") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="40" width="40"></td>\n';
 										}
@@ -2349,7 +2349,7 @@ define(['app', 'livesocket'], function (app) {
 											if (isLED(item.SubType)) {
 												if (item.Image == "Dimmer") {
 													xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
-												} 
+												}
 												else {
 													xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_On.png" onclick="ShowRGBWPopup(event, ' + item.idx + ', ' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
 												}
@@ -2362,7 +2362,7 @@ define(['app', 'livesocket'], function (app) {
 											if (isLED(item.SubType)) {
 												if (item.Image == "Dimmer") {
 													xhtm += '\t      <td id="img" class="img img1"><img src="images/RGB48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
-												} 
+												}
 												else {
 													xhtm += '\t      <td id="img" class="img img1"><img src="images/' + item.Image + '48_Off.png" onclick="ShowRGBWPopup(event, ' + item.idx + ',' + item.Protected + ',' + item.MaxDimLevel + ',' + item.LevelInt + ',\'' + item.Color.replace(/\"/g , '\&quot;') + '\',\'' + item.SubType + '\',\'' + item.DimmerType + '\');" class="lcursor" height="40" width="40"></td>\n';
 												}
@@ -2431,8 +2431,8 @@ define(['app', 'livesocket'], function (app) {
 									else if (
 										(item.SubType.indexOf("Lucci") == 0) ||
 										(item.SubType.indexOf("Westinghouse") == 0)
-										) {
-									    xhtm += '\t      <td id="img" class="img img1"><img src="images/Fan48_On.png" height="40" width="40" class="lcursor" onclick="ShowLucciPopup(event, ' + item.idx + ',  ' + item.Protected + ');"></td>\n';
+									) {
+										xhtm += '\t      <td id="img" class="img img1"><img src="images/Fan48_On.png" height="40" width="40" class="lcursor" onclick="ShowLucciPopup(event, ' + item.idx + ',  ' + item.Protected + ');"></td>\n';
 									}
 									else {
 										if (
@@ -2592,10 +2592,10 @@ define(['app', 'livesocket'], function (app) {
 									var status = "";
 									var bHaveBefore = false;
 									if (typeof item.Temp != 'undefined') {
-                    if ($rootScope.DisplayTrend(item.trend))
-                    {
-                      status += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
-                    }
+										if ($rootScope.DisplayTrend(item.trend))
+										{
+											status += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
+										}
 										status += item.Temp + '&deg; ' + $scope.config.TempSign;
 										bHaveBefore = true;
 									}
@@ -2636,10 +2636,10 @@ define(['app', 'livesocket'], function (app) {
 									xhtm += '\t      <td id="bigtext" class="bigtext"><span>';
 									var bigtext = "";
 									if (typeof item.Temp != 'undefined') {
-                    if ($rootScope.DisplayTrend(item.trend))
-                    {
-                      bigtext += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
-                    }
+										if ($rootScope.DisplayTrend(item.trend))
+										{
+											bigtext += '<img src="images/arrow_' + $rootScope.TrendState(item.trend) + '.png" width="14" height="15">';
+										}
 										bigtext += item.Temp + '\u00B0 ' + $scope.config.TempSign;
 									}
 									if (typeof item.Humidity != 'undefined') {
@@ -3072,97 +3072,97 @@ define(['app', 'livesocket'], function (app) {
 
 						//Gizmocuz: Don't know how did this ? But this should be under utility devices!
 						//Please do so
-/*
-						//evohome devices
-						jj = 0;
-						bHaveAddedDivider = false;
-						$.each(data.result, function (i, item) {
-							if (item.Type.indexOf('Heating') == 0) {
-								totdevices += 1;
-								if (jj == 0) {
-									//first time
-									htmlcontent += '<section class="dashCategory" id="dashEvohome">';
-									if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
-										if (htmlcontent != "") {
-											htmlcontent += '<br>';
-										}
-										htmlcontent += '\t    <table class="mobileitem">\n';
-										htmlcontent += '\t    <thead>\n';
-										htmlcontent += '\t    <tr>\n';
-										htmlcontent += '\t    		<th>' + $.t('evohome Devices') + '</th>\n';
-										htmlcontent += '\t    		<th style="text-align:right"><a id="cevohome" href="javascript:SwitchLayout(\'LightSwitches\')"><img src="images/next.png"></a></th>\n';
-										htmlcontent += '\t    </tr>\n';
-										htmlcontent += '\t    </thead>\n';
-									}
-									else {
-										htmlcontent += '<h2>' + $.t('evohome Devices') + ':</h2>\n';
-									}
-								}
-								if (jj % rowItems == 0) {
-									//add devider
-									if (bHaveAddedDivider == true) {
-										//close previous devider
-										htmlcontent += '</div>\n';
-									}
-									htmlcontent += '<div class="row divider">\n';
-									bHaveAddedDivider = true;
-								}
-								var xhtm = "";
-								if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
-									if (item.SubType == "Evohome") {
-										xhtm +=
-											'\t    <tr id="evohome_' + item.idx + '">\n' +
-											'\t      <td id="name" class="name">' + item.Name + '</td>\n';
-										xhtm += EvohomePopupMenu(item, 'evomobile');
-										xhtm += '\n\r  </tr>\n';
-									}
-								}
-								else {
-									if (item.SubType == "Evohome") {
-										if ($scope.config.DashboardType == 0) {
-											xhtm = '\t<div class="span4 movable" id="evohome_' + item.idx + '">\n';
-										}
-										else if ($scope.config.DashboardType == 1) {
-											xhtm = '\t<div class="span3 movable" id="evohome_' + item.idx + '">\n';
-										}
-										xhtm += '\t  <div class="item">\n';
-										if ($scope.config.DashboardType == 0) {
-											xhtm += '\t    <table id="itemtablesmall" class="itemtablesmall" border="0" cellpadding="0" cellspacing="0">\n';
-										}
-										else if ($scope.config.DashboardType == 1) {
-											xhtm += '\t    <table id="itemtablesmall" class="itemtablesmall" border="0" cellpadding="0" cellspacing="0">\n';
-										}
-										var backgroundClass = $rootScope.GetItemBackgroundStatus(item);
-
-										xhtm +=
-											'\t    <tr class="' + backgroundClass + '">\n' +
-											'\t      <td id="name" class="name ' + backgroundClass + '">' + item.Name + '</td>\n' +
-											'\t      <td id="bigtext" class="bigtext"><span></span></td>\n';
-										xhtm += EvohomePopupMenu(item, 'evomini');
-										xhtm +=
-											'\t      <td id="status" class="status">' + TranslateStatus(EvoDisplayTextMode(item.Status)) + '</td>\n' +
-											'\t      <td id="lastupdate" class="lastupdate"><span>' + item.LastUpdate + '</span></td>\n' +
-											'\t    </tr>\n' +
-											'\t    </table>\n' +
-											'\t  </div><!--item end-->\n' +
-											'\t</div>\n';
-									}
-								}
-								htmlcontent += xhtm;
-								jj += 1;
-							}
-						}); //evohome devices
-						if (bHaveAddedDivider == true) {
-							//close previous devider
-							htmlcontent += '</div>\n';
-						}
-						if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
-							htmlcontent += '\t    </table>\n';
-						}
-						if (jj > 0) {
-							htmlcontent += '</section>';
-						}
-*/
+						/*
+												//evohome devices
+												jj = 0;
+												bHaveAddedDivider = false;
+												$.each(data.result, function (i, item) {
+													if (item.Type.indexOf('Heating') == 0) {
+														totdevices += 1;
+														if (jj == 0) {
+															//first time
+															htmlcontent += '<section class="dashCategory" id="dashEvohome">';
+															if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
+																if (htmlcontent != "") {
+																	htmlcontent += '<br>';
+																}
+																htmlcontent += '\t    <table class="mobileitem">\n';
+																htmlcontent += '\t    <thead>\n';
+																htmlcontent += '\t    <tr>\n';
+																htmlcontent += '\t    		<th>' + $.t('evohome Devices') + '</th>\n';
+																htmlcontent += '\t    		<th style="text-align:right"><a id="cevohome" href="javascript:SwitchLayout(\'LightSwitches\')"><img src="images/next.png"></a></th>\n';
+																htmlcontent += '\t    </tr>\n';
+																htmlcontent += '\t    </thead>\n';
+															}
+															else {
+																htmlcontent += '<h2>' + $.t('evohome Devices') + ':</h2>\n';
+															}
+														}
+														if (jj % rowItems == 0) {
+															//add devider
+															if (bHaveAddedDivider == true) {
+																//close previous devider
+																htmlcontent += '</div>\n';
+															}
+															htmlcontent += '<div class="row divider">\n';
+															bHaveAddedDivider = true;
+														}
+														var xhtm = "";
+														if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
+															if (item.SubType == "Evohome") {
+																xhtm +=
+																	'\t    <tr id="evohome_' + item.idx + '">\n' +
+																	'\t      <td id="name" class="name">' + item.Name + '</td>\n';
+																xhtm += EvohomePopupMenu(item, 'evomobile');
+																xhtm += '\n\r  </tr>\n';
+															}
+														}
+														else {
+															if (item.SubType == "Evohome") {
+																if ($scope.config.DashboardType == 0) {
+																	xhtm = '\t<div class="span4 movable" id="evohome_' + item.idx + '">\n';
+																}
+																else if ($scope.config.DashboardType == 1) {
+																	xhtm = '\t<div class="span3 movable" id="evohome_' + item.idx + '">\n';
+																}
+																xhtm += '\t  <div class="item">\n';
+																if ($scope.config.DashboardType == 0) {
+																	xhtm += '\t    <table id="itemtablesmall" class="itemtablesmall" border="0" cellpadding="0" cellspacing="0">\n';
+																}
+																else if ($scope.config.DashboardType == 1) {
+																	xhtm += '\t    <table id="itemtablesmall" class="itemtablesmall" border="0" cellpadding="0" cellspacing="0">\n';
+																}
+																var backgroundClass = $rootScope.GetItemBackgroundStatus(item);
+						
+																xhtm +=
+																	'\t    <tr class="' + backgroundClass + '">\n' +
+																	'\t      <td id="name" class="name ' + backgroundClass + '">' + item.Name + '</td>\n' +
+																	'\t      <td id="bigtext" class="bigtext"><span></span></td>\n';
+																xhtm += EvohomePopupMenu(item, 'evomini');
+																xhtm +=
+																	'\t      <td id="status" class="status">' + TranslateStatus(EvoDisplayTextMode(item.Status)) + '</td>\n' +
+																	'\t      <td id="lastupdate" class="lastupdate"><span>' + item.LastUpdate + '</span></td>\n' +
+																	'\t    </tr>\n' +
+																	'\t    </table>\n' +
+																	'\t  </div><!--item end-->\n' +
+																	'\t</div>\n';
+															}
+														}
+														htmlcontent += xhtm;
+														jj += 1;
+													}
+												}); //evohome devices
+												if (bHaveAddedDivider == true) {
+													//close previous devider
+													htmlcontent += '</div>\n';
+												}
+												if (($scope.config.DashboardType == 2) || (window.myglobals.ismobile == true)) {
+													htmlcontent += '\t    </table>\n';
+												}
+												if (jj > 0) {
+													htmlcontent += '</section>';
+												}
+						*/
 						//Utility Sensors
 						jj = 0;
 						bHaveAddedDivider = false;
@@ -3239,7 +3239,7 @@ define(['app', 'livesocket'], function (app) {
 										vname = '<img src="images/next.png" onclick="ShowCurrentLog(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\', ' + item.displaytype + ');" height="16" width="16">' + " " + item.Name;
 									}
 									else if ((item.Type == "Energy") || (item.SubType == "kWh") || (item.SubType == "Power")) {
-                                        vname = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/next.png" height="16" width="16"></a>' + " " + item.Name;
+										vname = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/next.png" height="16" width="16"></a>' + " " + item.Name;
 									}
 									else if (item.Type == "Air Quality") {
 										vname = '<img src="images/next.png" onclick="ShowAirQualityLog(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\');" height="16" width="16">' + " " + item.Name;
@@ -3490,33 +3490,33 @@ define(['app', 'livesocket'], function (app) {
 									if (typeof item.Counter != 'undefined') {
 										if ((item.Type == "RFXMeter") || (item.Type == "YouLess Meter") || (item.SubType == "Counter Incremental") || (item.SubType == "Managed Counter")) {
 											if (item.SwitchTypeVal == 1) {
-												item.Image = (item.CustomImage == 0)  ? 'Gas48.png' : item.Image + '48_On.png';
-												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image +'" class="lcursor" height="40" width="40"></a></td>\n';
+												item.Image = (item.CustomImage == 0) ? 'Gas48.png' : item.Image + '48_On.png';
+												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 											else if (item.SwitchTypeVal == 2) {
-												item.Image = (item.CustomImage == 0)  ? 'Water48_On.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'Water48_On.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 											else if (item.SwitchTypeVal == 3) {
-												item.Image = (item.CustomImage == 0)  ? 'Counter48.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'Counter48.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 											else if (item.SwitchTypeVal == 4) {
-												item.Image = (item.CustomImage == 0)  ? 'PV48.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'PV48.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 											else {
-												item.Image = (item.CustomImage == 0)  ? 'Counter48.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'Counter48.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 										}
 										else {
 											if ((item.Type == "P1 Smart Meter") && (item.SubType == "Gas")) {
-												item.Image = (item.CustomImage == 0)  ? 'Gas48.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'Gas48.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 											else {
-												item.Image = (item.CustomImage == 0)  ? 'Counter48.png' : item.Image + '48_On.png';
+												item.Image = (item.CustomImage == 0) ? 'Counter48.png' : item.Image + '48_On.png';
 												imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 											}
 										}
@@ -3537,27 +3537,27 @@ define(['app', 'livesocket'], function (app) {
 									}
 									else if ((item.Type == "Energy") || (item.Type == "Power") || (item.SubType == "kWh")) {
 										if (((item.Type == "Energy") || (item.Type == "Power") || (item.SubType == "kWh")) && (item.SwitchTypeVal == 4)) {
-											item.Image = (item.CustomImage == 0)  ? 'PV48.png' : item.Image + '48_On.png';
+											item.Image = (item.CustomImage == 0) ? 'PV48.png' : item.Image + '48_On.png';
 											imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										}
 										else {
-											item.Image = (item.CustomImage == 0)  ? 'current48.png' : item.Image + '48_On.png';
+											item.Image = (item.CustomImage == 0) ? 'current48.png' : item.Image + '48_On.png';
 											imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										}
 										statushtml = "";
 									}
 									else if ((item.Type == "Current") || (item.Type == "Current/Energy")) {
-										item.Image = (item.CustomImage == 0)  ? 'current48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'current48.png' : item.Image + '48_On.png';
 										imagehtml += item.Image + '" class="lcursor" onclick="ShowCurrentLog(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\', ' + item.displaytype + ');" height="40" width="40"></td>\n';
 										statushtml = "";
 									}
 									else if (item.Type == "Air Quality") {
-										item.Image = (item.CustomImage == 0)  ? 'air48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'air48.png' : item.Image + '48_On.png';
 										imagehtml += item.Image + '" class="lcursor" onclick="ShowAirQualityLog(\'#dashcontent\',\'ShowFavorites\',' + item.idx + ',\'' + escape(item.Name) + '\');" height="40" width="40"></td>\n';
 										statushtml = item.Quality;
 									}
 									else if (item.SubType == "Percentage") {
-										item.Image = (item.CustomImage == 0)  ? 'Percentage48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'Percentage48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
@@ -3566,17 +3566,17 @@ define(['app', 'livesocket'], function (app) {
 										statushtml = "";
 									}
 									else if (item.Type == "Lux") {
-										item.Image = (item.CustomImage == 0)  ? 'lux48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'lux48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
 									else if (item.Type == "Weight") {
-										item.Image = (item.CustomImage == 0)  ? 'scale48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'scale48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
 									else if (item.Type == "Usage") {
-										item.Image = (item.CustomImage == 0)  ? 'current48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'current48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
@@ -3593,23 +3593,23 @@ define(['app', 'livesocket'], function (app) {
 										statushtml = "";
 									}
 									else if (item.SubType == "Leaf Wetness") {
-										item.Image = (item.CustomImage == 0)  ? 'leaf48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'leaf48.png' : item.Image + '48_On.png';
 										imagehtml += item.Image + '" height="40" width="40"></td>\n';
 										statushtml = "";
 									}
 									else if (item.SubType == "Distance") {
-										item.Image = (item.CustomImage == 0)  ? 'visibility48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'visibility48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
 									else if ((item.SubType == "Voltage") || (item.SubType == "Current") || (item.SubType == "A/D")) {
-										item.Image = (item.CustomImage == 0)  ? 'current48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'current48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
 									else if (item.SubType == "Text") {
 										var logLink = '#/Devices/' + item.idx + '/Log';
-										item.Image = (item.CustomImage == 0)  ? 'text48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'text48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="' + logLink + '"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = item.Data.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br />$2');
 									}
@@ -3620,7 +3620,7 @@ define(['app', 'livesocket'], function (app) {
 										statushtml = item.Data.replace(/([^>\r\n]?)(\r\n|\n\r|\r|\n)/g, '$1<br />$2');
 									}
 									else if (item.SubType == "Pressure") {
-										item.Image = (item.CustomImage == 0)  ? 'gauge48.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'gauge48.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}
@@ -3637,7 +3637,7 @@ define(['app', 'livesocket'], function (app) {
 										statushtml = "";
 									}
 									else if (item.SubType == "Sound Level") {
-										item.Image = (item.CustomImage == 0)  ? 'Speaker48_On.png' : item.Image + '48_On.png';
+										item.Image = (item.CustomImage == 0) ? 'Speaker48_On.png' : item.Image + '48_On.png';
 										imagehtml = '<a href="#/Devices/' + item.idx + '/Log"><img src="images/' + item.Image + '" class="lcursor" height="40" width="40"></a></td>\n';
 										statushtml = "";
 									}

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -1181,11 +1181,8 @@ define(['app', 'livesocket'], function (app) {
 							}
 							xhtm +=
 								'\t      <td id="status">' + status + '</td>\n' +
-								'\t      <td id="lastupdate">' + item.LastUpdate + '</td>\n';
-							if(item.HardwareTypeVal != 125)
-								xhtm += '\t      <td id="type">' + item.Type + ', ' + item.SubType + ', ' + item.SwitchType;
-							else
-								xhtm += '\t      <td id="type">' + item.Type + ', ' + item.SwitchType;
+								'\t      <td id="lastupdate">' + item.LastUpdate + '</td>\n' +
+							  '\t      <td id="type">' + item.Type + ', ' + item.SubType + ', ' + item.SwitchType;
 
 							if (item.SwitchType == "Dimmer") {
 								if (item.DimmerType && item.DimmerType != "abs") {

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -160,7 +160,7 @@ define(['app', 'livesocket'], function (app) {
 			$("#dialog-addmanuallightdevice #lighttable #combohardware").change(function () {
 				UpdateAddManualDialog();
 			});
-			
+
 			RefreshGpioComboArray();
 			$("#combogpio").html("");
 			$.each($.ComboGpio, function (i, item) {
@@ -175,7 +175,7 @@ define(['app', 'livesocket'], function (app) {
 				var option = $('<option />');
 				option.attr('value', item.idx).text(item.name);
 				$("#combosysfsgpio").append(option);
-            });
+			});
 		}
 
 		RefreshHardwareComboArray = function () {
@@ -247,9 +247,9 @@ define(['app', 'livesocket'], function (app) {
 			//(the status can flick back to the previous status after an update)...now implemented with script side lockout
 			$.ajax({
 				url: "json.htm?type=command&param=switchmodal" +
-				"&idx=" + idx +
-				"&status=" + status +
-				"&action=1",
+					"&idx=" + idx +
+					"&status=" + status +
+					"&action=1",
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -401,7 +401,7 @@ define(['app', 'livesocket'], function (app) {
 
 				const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
 				const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
-				
+
 				const openImage = '<img src="images/' + item.Image + 'open48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
 				const closeImage = '<img src="images/' + item.Image + '48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
 
@@ -597,7 +597,7 @@ define(['app', 'livesocket'], function (app) {
 				(item.SubType.indexOf("Itho") == 0) ||
 				(item.SubType.indexOf("Lucci") == 0) ||
 				(item.SubType.indexOf("Westinghouse") == 0)
-				) {
+			) {
 				img = $(id + " #img").html();
 			}
 			else {
@@ -821,9 +821,9 @@ define(['app', 'livesocket'], function (app) {
 								'\t<div class="item span4 ' + backgroundClass + '" id="' + item.idx + '">\n' +
 								'\t  <section>\n';
 							if (
-                  (item.SwitchType.indexOf("Blinds")>=0)
-                  || (item.SwitchType.indexOf("Media Player") == 0)
-                  ) {
+								(item.SwitchType.indexOf("Blinds")>=0)
+								|| (item.SwitchType.indexOf("Media Player") == 0)
+							) {
 								if (
 									(item.SubType == "RAEX")
 									|| (item.SubType.indexOf('A-OK') == 0)
@@ -836,13 +836,13 @@ define(['app', 'livesocket'], function (app) {
 									|| (item.SubType.indexOf('ASP') == 0)
 									|| (item.SubType == "Harrison")
 									|| (item.SubType.indexOf('RFY') == 0)
-                  || (item.SubType.indexOf('RTS') == 0)
+									|| (item.SubType.indexOf('RTS') == 0)
 									|| (item.SubType.indexOf('ASA') == 0)
 									|| (item.SubType.indexOf('DC106') == 0)
 									|| (item.SubType.indexOf('Confexx') == 0)
 									|| (item.SwitchType.indexOf("Venetian Blinds") == 0)
-                  || (item.SwitchType == "Blinds + Stop")
-                  || (item.SwitchType == "Blinds Inverted + Stop")
+									|| (item.SwitchType == "Blinds + Stop")
+									|| (item.SwitchType == "Blinds Inverted + Stop")
 								) {
 									xhtm += '\t    <table id="itemtabletrippleicon" border="0" cellpadding="0" cellspacing="0">\n';
 								}
@@ -869,7 +869,7 @@ define(['app', 'livesocket'], function (app) {
 							}
 							if (permissions.hasPermission("Admin")) {
 								if (item.Type == "RFY") {
-									var rfysetup = '<img src="images/devices.png" title="' + $.t('Setup') + '" height="16" width="16" onclick="ShowRFYPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + window.myglobals.ismobile +');">';
+									var rfysetup = '<img src="images/devices.png" title="' + $.t('Setup') + '" height="16" width="16" onclick="ShowRFYPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + window.myglobals.ismobile + ');">';
 									bigtext += "&nbsp;" + rfysetup;
 								}
 							}
@@ -905,10 +905,10 @@ define(['app', 'livesocket'], function (app) {
 							}
 							else if (item.SwitchType == "Door Contact") {
 								if (item.InternalState == "Open") {
-                                    xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="48" width="48"></td>\n';
+									xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_On.png" title="' + $.t(item.InternalState) + '" height="48" width="48"></td>\n';
 								}
 								else {
-                                    xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="48" width="48"></td>\n';
+									xhtm += '\t      <td id="img"><img src="images/' + item.Image + '48_Off.png" title="' + $.t(item.InternalState) + '" height="48" width="48"></td>\n';
 								}
 								bAddTimer = false;
 							}
@@ -963,13 +963,13 @@ define(['app', 'livesocket'], function (app) {
 
 								const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
 								const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
-				
+
 								const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
 								const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
-								
+
 								const openImage = '<img src="images/' + item.Image + 'open48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
 								const closeImage = '<img src="images/' + item.Image + '48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				
+
 								const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
 								const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
 
@@ -1150,9 +1150,9 @@ define(['app', 'livesocket'], function (app) {
 							else if (
 								(item.SubType.indexOf("Lucci") == 0) ||
 								(item.SubType.indexOf("Westinghouse") == 0)
-								) {
-							    bAddTimer = false;
-							    xhtm += '\t      <td id="img"><img src="images/Fan48_On.png" height="48" width="48" class="lcursor" onclick="ShowLucciPopup(event, ' + item.idx + ', ShowLights, ' + item.Protected + ');"></td>\n';
+							) {
+								bAddTimer = false;
+								xhtm += '\t      <td id="img"><img src="images/Fan48_On.png" height="48" width="48" class="lcursor" onclick="ShowLucciPopup(event, ' + item.idx + ', ShowLights, ' + item.Protected + ');"></td>\n';
 							}
 							else {
 								if (
@@ -1181,10 +1181,14 @@ define(['app', 'livesocket'], function (app) {
 							}
 							xhtm +=
 								'\t      <td id="status">' + status + '</td>\n' +
-								'\t      <td id="lastupdate">' + item.LastUpdate + '</td>\n' +
-								'\t      <td id="type">' + item.Type + ', ' + item.SubType + ', ' + item.SwitchType;
+								'\t      <td id="lastupdate">' + item.LastUpdate + '</td>\n';
+							if(item.HardwareTypeVal != 125)
+								xhtm += '\t      <td id="type">' + item.Type + ', ' + item.SubType + ', ' + item.SwitchType;
+							else
+								xhtm += '\t      <td id="type">' + item.Type + ', ' + item.SwitchType;
+
 							if (item.SwitchType == "Dimmer") {
-								if (item.DimmerType && item.DimmerType!="abs") {
+								if (item.DimmerType && item.DimmerType != "abs") {
 									// Don't show dimmer slider if the device does not support absolute dimming
 								}
 								else {
@@ -1257,12 +1261,12 @@ define(['app', 'livesocket'], function (app) {
 								xhtm +=
 									'<a class="btnsmall" href="#/Devices/' + item.idx + '/LightEdit" data-i18n="Edit">Edit</a> ';
 								if (bAddTimer == true) {
-									var timerLink = '#/Devices/'+item.idx+'/Timers';
+									var timerLink = '#/Devices/' + item.idx + '/Timers';
 									if (item.Timers == "true") {
-										xhtm += '<a class="btnsmall-sel" href="'+timerLink+'" data-i18n="Timers">Timers</a> ';
+										xhtm += '<a class="btnsmall-sel" href="' + timerLink + '" data-i18n="Timers">Timers</a> ';
 									}
 									else {
-										xhtm += '<a class="btnsmall" href="'+timerLink+'" data-i18n="Timers">Timers</a> ';
+										xhtm += '<a class="btnsmall" href="' + timerLink + '" data-i18n="Timers">Timers</a> ';
 									}
 								}
 								if (item.SwitchType == "Smoke Detector") {
@@ -1276,7 +1280,7 @@ define(['app', 'livesocket'], function (app) {
 										xhtm += '<a id="resetbtn" class="btnsmall-dis" onclick="ResetSecurityStatus(' + item.idx + ',\'Normal\',ShowLights);" data-i18n="Reset">Reset</a> ';
 									}
 								}
-								var notificationLink = '#/Devices/'+item.idx+'/Notifications';
+								var notificationLink = '#/Devices/' + item.idx + '/Notifications';
 								if (item.Notifications == "true")
 									xhtm += '<a class="btnsmall-sel" href="' + notificationLink + '" data-i18n="Notifications">Notifications</a>';
 								else
@@ -1498,7 +1502,7 @@ define(['app', 'livesocket'], function (app) {
 				option.attr('value', item.idx).text(item.name);
 				$("#dialog-addmanuallightdevice #lighttable #combolighttype2").append(option);
 			});
-			
+
 			$("#dialog-addmanuallightdevice #he105params").hide();
 			$("#dialog-addmanuallightdevice #blindsparams").hide();
 			$("#dialog-addmanuallightdevice #lightingparams_enocean").hide();
@@ -1553,11 +1557,11 @@ define(['app', 'livesocket'], function (app) {
 		UpdateAddManualDialog = function () {
 			var hwdId = $("#dialog-addmanuallightdevice #lighttable #combohardware option:selected").val();
 			var hardware;
-			
+
 			$.each($.ComboHardware, function (i, item) {
 				if (item.idx == hwdId) {
 					hardware = item;
-                }
+				}
 			});
 			if (hardware != undefined && hardware.config != undefined) {
 				UpdateAddManualDialogForConfiguredHardware(hardware);
@@ -1565,7 +1569,7 @@ define(['app', 'livesocket'], function (app) {
 			} else {
 				$("#dialog-addmanuallightdevice #lighttable #combolighttype").show();
 				$("#dialog-addmanuallightdevice #lighttable #combolighttype2").hide();
-            }
+			}
 			var lighttype = $("#dialog-addmanuallightdevice #lighttable #combolighttype option:selected").val();
 			var bIsARCType = ((lighttype < 20) || (lighttype == 101));
 			var bIsType5 = 0;
@@ -1693,12 +1697,12 @@ define(['app', 'livesocket'], function (app) {
 				//Openwebnet Bus IR Detection
 				totrooms = 10;
 				totpointofloads = 10
-            }
-            else if (lighttype == 407) {
-                //Openwebnet Bus Custom
-                totrooms = 200;
-                totbus = 10;//maximum 10 local buses
-            }
+			}
+			else if (lighttype == 407) {
+				//Openwebnet Bus Custom
+				totrooms = 200;
+				totbus = 10;//maximum 10 local buses
+			}
 
 
 			$("#dialog-addmanuallightdevice #he105params").hide();
@@ -1888,23 +1892,23 @@ define(['app', 'livesocket'], function (app) {
 				$("#dialog-addmanuallightdevice #lighting2params").hide();
 				$("#dialog-addmanuallightdevice #lighting3params").hide();
 				$("#dialog-addmanuallightdevice #openwebnetparamsIRdetec").show();
-            }
-            else if (lighttype == 407) {
-                //Openwebnet Bus Custom
-                $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1  >option").remove();
-                for (ii = 1; ii < totrooms + 1; ii++) {
-                    $('#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1').append($('<option></option>').val(ii).html(ii));
-                }
-                $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2  >option").remove();
-                $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2").append($('<option></option>').val(0).html("local bus"));
-                for (ii = 1; ii < totbus; ii++) {
-                    $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2").append($('<option></option>').val(ii).html(ii));
-                }
-                $("#dialog-addmanuallightdevice #lighting1params").hide();
-                $("#dialog-addmanuallightdevice #lighting2params").hide();
-                $("#dialog-addmanuallightdevice #lighting3params").hide();
-                $("#dialog-addmanuallightdevice #openwebnetparamsCustom").show();
-            }
+			}
+			else if (lighttype == 407) {
+				//Openwebnet Bus Custom
+				$("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1  >option").remove();
+				for (ii = 1; ii < totrooms + 1; ii++) {
+					$('#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1').append($('<option></option>').val(ii).html(ii));
+				}
+				$("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2  >option").remove();
+				$("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2").append($('<option></option>').val(0).html("local bus"));
+				for (ii = 1; ii < totbus; ii++) {
+					$("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2").append($('<option></option>').val(ii).html(ii));
+				}
+				$("#dialog-addmanuallightdevice #lighting1params").hide();
+				$("#dialog-addmanuallightdevice #lighting2params").hide();
+				$("#dialog-addmanuallightdevice #lighting3params").hide();
+				$("#dialog-addmanuallightdevice #openwebnetparamsCustom").show();
+			}
 			else if (bIsARCType == 1) {
 				$('#dialog-addmanuallightdevice #lightparams1 #combohousecode >option').remove();
 				$('#dialog-addmanuallightdevice #lightparams1 #combounitcode >option').remove();
@@ -1987,7 +1991,7 @@ define(['app', 'livesocket'], function (app) {
 					hardware = item;
 				}
 			});
-			
+
 			mParams += "&hwdid=" + hwdID;
 
 			var name = $("#dialog-addmanuallightdevice #devicename");
@@ -2009,7 +2013,7 @@ define(['app', 'livesocket'], function (app) {
 			var lighttype = $("#dialog-addmanuallightdevice #lighttable #combolighttype option:selected").val();
 			mParams += "&lighttype=" + lighttype;
 
-			
+
 
 			if (lighttype == 106) {
 				//Blyss
@@ -2031,17 +2035,17 @@ define(['app', 'livesocket'], function (app) {
 			}
 			else if (lighttype == 68) {
 				//GPIO
-                mParams += "&id=GPIO&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_gpio #combogpio option:selected").val();
+				mParams += "&id=GPIO&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_gpio #combogpio option:selected").val();
 			}
 			else if (lighttype == 69) {
 				//SysfsGpio
-                ID =
-                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd1 option:selected").text() +
-                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd2 option:selected").text() +
-                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd3 option:selected").text() +
-                    $("#dialog-addmanuallightdevice #lightparams2 #combocmd4 option:selected").text();
-                mParams += "&id=" + ID + "&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_sysfsgpio #combosysfsgpio option:selected").val();
-            }
+				ID =
+					$("#dialog-addmanuallightdevice #lightparams2 #combocmd1 option:selected").text() +
+					$("#dialog-addmanuallightdevice #lightparams2 #combocmd2 option:selected").text() +
+					$("#dialog-addmanuallightdevice #lightparams2 #combocmd3 option:selected").text() +
+					$("#dialog-addmanuallightdevice #lightparams2 #combocmd4 option:selected").text();
+				mParams += "&id=" + ID + "&unitcode=" + $("#dialog-addmanuallightdevice #lightingparams_sysfsgpio #combosysfsgpio option:selected").val();
+			}
 			else if ((lighttype < 20) || (lighttype == 101)) {
 				mParams += "&housecode=" + $("#dialog-addmanuallightdevice #lightparams1 #combohousecode option:selected").val();
 				mParams += "&unitcode=" + $("#dialog-addmanuallightdevice #lightparams1 #combounitcode option:selected").val();
@@ -2069,7 +2073,7 @@ define(['app', 'livesocket'], function (app) {
 				mParams += "&housecode=" + $("#dialog-addmanuallightdevice #homeconfortparams #combohousecode option:selected").val();
 				mParams += "&unitcode=" + $("#dialog-addmanuallightdevice #homeconfortparams #combounitcode option:selected").val();
 			}
-			else if ((lighttype >= 304)&&(lighttype <= 313)) {
+			else if ((lighttype >= 304) && (lighttype <= 313)) {
 				//Fan
 				ID =
 					$("#dialog-addmanuallightdevice #fanparams #combocmd1 option:selected").text() +
@@ -2134,20 +2138,20 @@ define(['app', 'livesocket'], function (app) {
 				var ID = ("0019" + ("0000" + appID.toString(16)).slice(-4)); // WHO_DRY_CONTACT_IR_DETECTION (25 = 0x19)
 				var unitcode = "0";
 				mParams += "&id=" + ID.toUpperCase() + "&unitcode=" + unitcode;
-            }
-            else if (lighttype == 407) {
-                //Openwebnet Bus Custom
-                var appID = parseInt($("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1 option:selected").val());
-                var ID = ("F00" + ("0000" + appID.toString(16)).slice(-4));
-                var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2 option:selected").val();
+			}
+			else if (lighttype == 407) {
+				//Openwebnet Bus Custom
+				var appID = parseInt($("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd1 option:selected").val());
+				var ID = ("F00" + ("0000" + appID.toString(16)).slice(-4));
+				var unitcode = $("#dialog-addmanuallightdevice #openwebnetparamsCustom #combocmd2 option:selected").val();
 
-                //var intRegex = /^[0-9*#]$/; 
-                //if (!intRegex.test(cmdText)) {
-                //    ShowNotify($.t('Open command error. Please use only number, \'*\' or \'#\''), 2500, true);
-                //    return "";
-                //}
-                mParams += "&id=" + ID + "&unitcode=" + unitcode + "&StrParam1=" + encodeURIComponent($("#dialog-addmanuallightdevice #openwebnetparamsCustom #inputcmd1").val());
-            }
+				//var intRegex = /^[0-9*#]$/; 
+				//if (!intRegex.test(cmdText)) {
+				//    ShowNotify($.t('Open command error. Please use only number, \'*\' or \'#\''), 2500, true);
+				//    return "";
+				//}
+				mParams += "&id=" + ID + "&unitcode=" + unitcode + "&StrParam1=" + encodeURIComponent($("#dialog-addmanuallightdevice #openwebnetparamsCustom #inputcmd1").val());
+			}
 			else {
 				//AC
 				var ID = "";

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -958,7 +958,6 @@ define(['app', 'livesocket'], function (app) {
 								bAddTimer = false;
 							}
 							else if (item.SwitchType.indexOf("Blinds") >= 0) {
-								console.log(item);
 								item.Image = item.TypeImg;
 								bIsdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
 

--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -391,10 +391,24 @@ define(['app', 'livesocket'], function (app) {
 					img = '<img src="images/' + item.Image + '48_On.png" height="48" width="48">';
 				}
 			}
-			else if (
-            (item.SwitchType == "Blinds")
-            || (item.SwitchType.indexOf("Venetian Blinds") == 0)
-            ) {
+			else if (item.SwitchType.indexOf("Blinds") >= 0) {
+				item.Image = item.TypeImg;
+
+				isdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+
+				const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+				const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+
+				const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
+				const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
+				
+				const openImage = '<img src="images/' + item.Image + 'open48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
+				const closeImage = '<img src="images/' + item.Image + '48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
+
+				const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+				const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+
+				img = firstImage;
 				if (
 					(item.SubType == "RAEX") ||
 					(item.SubType.indexOf('A-OK') == 0) ||
@@ -411,108 +425,13 @@ define(['app', 'livesocket'], function (app) {
 					(item.SubType.indexOf('ASA') == 0) ||
 					(item.SubType.indexOf('DC106') == 0) ||
 					(item.SubType.indexOf('Confexx') == 0) ||
-					(item.SwitchType.indexOf("Venetian Blinds") == 0)
+					(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+					(item.SwitchType.indexOf("Stop") >= 0)
 				) {
-					if (item.Status == 'Closed') {
-						img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-					else {
-						img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
+					img3 = secondImage;
 				}
 				else {
-					if (item.Status == 'Closed') {
-						img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-					else {
-						img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-				}
-			}
-			else if (item.SwitchType == "Blinds Inverted") {
-				if (
-					(item.SubType == "RAEX") ||
-					(item.SubType.indexOf('A-OK') == 0) ||
-					(item.SubType.indexOf('Hasta') >= 0) ||
-					(item.SubType.indexOf('Media Mount') == 0) ||
-					(item.SubType.indexOf('Forest') == 0) ||
-					(item.SubType.indexOf('Chamberlain') == 0) ||
-					(item.SubType.indexOf('Sunpery') == 0) ||
-					(item.SubType.indexOf('Dolat') == 0) ||
-					(item.SubType.indexOf('ASP') == 0) ||
-					(item.SubType == "Harrison") ||
-					(item.SubType.indexOf('RFY') == 0) ||
-					(item.SubType.indexOf('RTS') == 0) ||
-					(item.SubType.indexOf('ASA') == 0) ||
-					(item.SubType.indexOf('DC106') == 0) ||
-					(item.SubType.indexOf('Confexx') == 0)
-				) {
-					if (item.Status == 'Closed') {
-						img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-					else {
-						img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-				}
-				else {
-					if (item.Status == 'Closed') {
-						img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-					else {
-						img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-						img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					}
-				}
-			}
-			else if (item.SwitchType == "Blinds Percentage") {
-				isdimmer = true;
-				if (item.Status == 'Open') {
-					img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-				else {
-					img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-			}
-			else if (item.SwitchType == "Blinds Percentage Inverted") {
-				isdimmer = true;
-				if (item.Status == 'Closed') {
-					img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img2 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-				else if ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) {
-					img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img2 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-			}
-			else if (item.SwitchType == "Blinds + Stop") {
-				isdimmer = true;
-				if (item.Status == 'Open') {
-					img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-				else {
-					img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-			}
-			else if (item.SwitchType == "Blinds Inverted + Stop") {
-				isdimmer = true;
-				if (item.Status == 'Closed') {
-					img = '<img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img3 = '<img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-				}
-				else if ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) {
-					img = '<img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
-					img3 = '<img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
+					img2 = secondImage;
 				}
 			}
 			else if (item.SwitchType == "Smoke Detector") {
@@ -902,13 +821,7 @@ define(['app', 'livesocket'], function (app) {
 								'\t<div class="item span4 ' + backgroundClass + '" id="' + item.idx + '">\n' +
 								'\t  <section>\n';
 							if (
-                  (item.SwitchType == "Blinds")
-                  || (item.SwitchType == "Blinds Inverted")
-                  || (item.SwitchType == "Blinds Percentage")
-                  || (item.SwitchType == "Blinds Percentage Inverted")
-                  || (item.SwitchType == "Blinds + Stop")
-                  || (item.SwitchType == "Blinds Inverted + Stop")
-                  || (item.SwitchType.indexOf("Venetian Blinds") == 0)
+                  (item.SwitchType.indexOf("Blinds")>=0)
                   || (item.SwitchType.indexOf("Media Player") == 0)
                   ) {
 								if (
@@ -1044,7 +957,24 @@ define(['app', 'livesocket'], function (app) {
 								status = item.Data;
 								bAddTimer = false;
 							}
-							else if ((item.SwitchType == "Blinds") || (item.SwitchType.indexOf("Venetian Blinds") == 0)) {
+							else if (item.SwitchType.indexOf("Blinds") >= 0) {
+								console.log(item);
+								item.Image = item.TypeImg;
+								bIsdimmer = (item.SwitchType.indexOf("Percentage") >= 0 || item.SwitchType.indexOf("Stop") >= 0);
+
+								const openAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "Off" : "On";
+								const closeAction = (item.SwitchType.indexOf("Inverted") >= 0) ? "On" : "Off";
+				
+								const selOpenImage = ((item.Status == 'Open') || (item.Status.indexOf('Set ') == 0)) ? "sel" : "";
+								const selCloseImage = ((item.Status == 'Closed')) ? "sel" : "";
+								
+								const openImage = '<img src="images/' + item.Image + 'open48' + selOpenImage + '.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + openAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
+								const closeImage = '<img src="images/' + item.Image + '48' + selCloseImage + '.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'' + closeAction + '\',' + item.Protected + ');" class="lcursor" height="48" width="48">';
+				
+								const firstImage = (item.SwitchType.indexOf("Inverted") >= 0) ? openImage : closeImage;
+								const secondImage = (item.SwitchType.indexOf("Inverted") >= 0) ? closeImage : openImage;
+
+								xhtm += '\t      <td id="img">' + firstImage + '</td>\n';
 								if (
 									(item.SubType == "RAEX") ||
 									(item.SubType.indexOf('A-OK') == 0) ||
@@ -1061,116 +991,14 @@ define(['app', 'livesocket'], function (app) {
 									(item.SubType.indexOf('ASA') == 0) ||
 									(item.SubType.indexOf('DC106') == 0) ||
 									(item.SubType.indexOf('Confexx') == 0) ||
-									(item.SwitchType.indexOf("Venetian Blinds") == 0)
+									(item.SwitchType.indexOf("Venetian Blinds") == 0) ||
+									(item.SwitchType.indexOf("Stop") >= 0)
 								) {
-									if (item.Status == 'Closed') {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-										xhtm += '\t      <td id="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-									else {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-										xhtm += '\t      <td id="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
+									xhtm += '\t      <td id="img2"><img src="images/' + item.Image + 'stop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
+									xhtm += '\t      <td id="img3">' + secondImage + '</td>\n';
 								}
 								else {
-									if (item.Status == 'Closed') {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-									else {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-								}
-							}
-							else if (item.SwitchType == "Blinds Inverted") {
-								if (
-									(item.SubType == "RAEX") ||
-									(item.SubType.indexOf('A-OK') == 0) ||
-									(item.SubType.indexOf('Hasta') >= 0) ||
-									(item.SubType.indexOf('Media Mount') == 0) ||
-									(item.SubType.indexOf('Forest') == 0) ||
-									(item.SubType.indexOf('Chamberlain') == 0) ||
-									(item.SubType.indexOf('Sunpery') == 0) ||
-									(item.SubType.indexOf('Dolat') == 0) ||
-									(item.SubType.indexOf('ASP') == 0) ||
-									(item.SubType == "Harrison") ||
-									(item.SubType.indexOf('RFY') == 0) ||
-									(item.SubType.indexOf('RTS') == 0) ||
-									(item.SubType.indexOf('ASA') == 0) ||
-									(item.SubType.indexOf('DC106') == 0) ||
-									(item.SubType.indexOf('Confexx') == 0)
-								) {
-									if (item.Status == 'Closed') {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-										xhtm += '\t      <td id="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-									else {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-										xhtm += '\t      <td id="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-								}
-								else {
-									if (item.Status == 'Closed') {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-									else {
-										xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-										xhtm += '\t      <td id="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-									}
-								}
-							}
-							else if (item.SwitchType == "Blinds Percentage") {
-								bIsDimmer = true;
-								if (item.Status == 'Open') {
-									xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-									xhtm += '\t      <td id="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-								}
-								else {
-									xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-									xhtm += '\t      <td id="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-								}
-							}
-							else if (item.SwitchType == "Blinds Percentage Inverted") {
-								bIsDimmer = true;
-								if (item.Status == 'Closed') {
-									xhtm += '\t	  <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-									xhtm += '\t	  <td id="img2"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-								}
-								else {
-									xhtm += '\t	  <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-									xhtm += '\t	  <td id="img2"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48"></td>\n';
-								}
-							}
-							else if (item.SwitchType == "Blinds + Stop") {
-								bIsDimmer = true;
-								if (item.Status == 'Closed') {
-								  xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								  xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-								  xhtm += '\t      <td id="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								}
-								else {
-								  xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								  xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-								  xhtm += '\t      <td id="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								}
-							}
-							else if (item.SwitchType == "Blinds Inverted + Stop") {
-								bIsDimmer = true;
-								if (item.Status == 'Open') {
-								  xhtm += '\t      <td id="img"><img src="images/blindsopen48.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								  xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-								  xhtm += '\t      <td id="img3"><img src="images/blinds48sel.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								}
-								else {
-								  xhtm += '\t      <td id="img"><img src="images/blindsopen48sel.png" title="' + $.t("Open Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'On\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
-								  xhtm += '\t      <td id="img2"><img src="images/blindsstop.png" title="' + $.t("Stop Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Stop\',' + item.Protected + ');" class="lcursor" height="48" width="24"></td>\n';
-								  xhtm += '\t      <td id="img3"><img src="images/blinds48.png" title="' + $.t("Close Blinds") + '" onclick="SwitchLight(' + item.idx + ',\'Off\',' + item.Protected + ');" class="lcursor" height="48" width="48"></td>\n';
+									xhtm += '\t      <td id="img2">' + secondImage + '</td>\n';
 								}
 							}
 							else if (item.SwitchType == "Smoke Detector") {


### PR DESCRIPTION
Fixing #5217 on MQTT auto discover blinds devices:
- Adding sTypeBlindsT21 as generic MQTT blinds
- Setting MQTT Autodiscover code to match generic blinds
- Changing WebServer to send good values to web site and good action to MQTT Auto discover
- Changing LightController and DashboardController to reflect changes

Tested with a Tasmota dual R3 as blind switch on Compact, Normal and Mobile Dashboard of web site