### PR TITLE
Fix rain forecast owm

### DIFF
--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -486,7 +486,7 @@ bool COpenWeatherMap::ProcessForecast(Json::Value &forecast, const std::string &
 	{
 		try
 		{
-			float rainmm = 9999.00F;
+			float rainmm = 0.00F;
 			float uvi = -999.9F;
 			float mintemp = -999.9F;
 			float maxtemp = -999.9F;
@@ -599,12 +599,13 @@ bool COpenWeatherMap::ProcessForecast(Json::Value &forecast, const std::string &
 			SendPercentageSensor(NodeID, 1, 255, clouds, sName.str());
 
 			NodeID++;;
-			if ((rainmm != 9999.00F) && (rainmm >= 0.00F))
+			if (rainmm >= 0.00F)
 			{
 				sName.str("");
 				sName.clear();
 				sName << "Rain(Snow) " << period << " " << (count + 0);
-				SendRainRateSensor(NodeID, 255, rainmm, sName.str());
+				std::string sVal="mm";
+				SendCustomSensor(NodeID, 0, 255, rainmm, sName.str(), sVal, 12);
 			}
 
 			NodeID++;;

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -526,6 +526,7 @@ bool COpenWeatherMap::ProcessForecast(Json::Value &forecast, const std::string &
 			else
 			{
 				//Rain (only present if there is rain (or snow))
+				rainmm = 0; // feels weird, but sometimes it seems to happen that PoP > 0 but no rain/snow data
 				if (!forecast["rain"].empty())
 				{
 					if (!forecast["rain"].isObject())


### PR DESCRIPTION
Via the OWM hardware plugin devices can be created to indicate the rain forecast for the coming days.
However, this doesn't work correctly. There are two issues:

* Rain rate devices are being created. However, this results in unreliable data, since rain rate is transformed into daily rainfall  by Domoticz, giving incorrect results.
* In case the predicted rain fall is 0mm, the OWM data doesn't contain the rain forecast data at all. That means the device is not updated, which is incorrect, because it should become 0.

Both issues will be fixed with this PR.
* Instead of devices of type rain rate the type custom will be used
* Devices will be updated to 0 in case rain rate data is not provided by OWM

Tested on Debian 10.

Remark on update:
If the rain forecast devices already exist they will not be updated or recreated automatically by Domoticz and will have the wrong device type.
Users have to manually delete the devices first. After that, they will be created again by the hardware plugin.