### PR TITLE
Fix XiaomiGateway cipher

### DIFF
--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -1121,8 +1121,9 @@ std::string XiaomiGateway::GetGatewayKey()
 		Log(LOG_ERROR, "GetGatewayKey Cannot Perform EVP Cipher Update");
 		return std::string("");
 	}
-	int len = cipherSize;
-	EVP_CipherFinal(ctx.get(), ciphertext + len, &cipherSize);
+	int tmplen;
+	EVP_CipherFinal(ctx.get(), ciphertext + cipherSize, &tmplen);
+	EVP_CIPHER_CTX_cleanup(ctx.get());
 
 	char gatewaykey[128];
 	for (int i = 0; i < 16; i++)

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -1121,7 +1121,8 @@ std::string XiaomiGateway::GetGatewayKey()
 		Log(LOG_ERROR, "GetGatewayKey Cannot Perform EVP Cipher Update");
 		return std::string("");
 	}
-	EVP_CipherFinal(ctx.get(), ciphertext, &cipherSize);
+	int len = cipherSize;
+	EVP_CipherFinal(ctx.get(), ciphertext + len, &cipherSize);
 
 	char gatewaykey[128];
 	for (int i = 0; i < 16; i++)


### PR DESCRIPTION
After recent changes in XiaomiGateway (commit [21f97e4](https://github.com/mce35/domoticz/commit/21f97e4adb11008f1e59fca710cfc9cd5e2a9b46) and [3da4f5e](https://github.com/mce35/domoticz/commit/3da4f5edcff05a1195844b744918bc888f3682b1)), it was not working anymore (plugin reports "invalid key" in the logs). From [here](https://www.openssl.org/docs/man1.0.2/man3/EVP_CipherFinal_ex.html), buffer passed to EVP_EncryptFinal() must be after data just encrypted to avoid overwriting it.