### PR TITLE
avoid generating 0 values update in short log

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6688,6 +6688,10 @@ void CSQLHelper::UpdateMultiMeter()
 
 			if (difftime(now, checktime) >= SensorTimeOut * 60)
 				continue;
+
+			if (difftime(now, checktime) >= m_ShortLogInterval * 60)
+                               continue;
+
 			std::vector<std::string> splitresults;
 			StringSplit(sValue, ";", splitresults);
 


### PR DESCRIPTION
P1 meter is updated every ShortLogInterval (5mins ) but if the device did not update its accumulated values whithin this period the diff is going to be 0.
Hence it generates graph like waves ,eg:
device updates 
100 110 120 after 6mins each time
it will end up in short log as
0 10 0 20 
this fix makes sure that the data is younger than 5mins to write a value in short log