### PR TITLE
Testing UTF-8 proof trim functions

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -583,26 +583,12 @@ double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
 
 std::string &stdstring_ltrim(std::string &s)
 {
-	s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), ::isspace));
-/*	while (!s.empty())
-	{
-		if (s[0] != ' ')
-			return s;
-		s = s.substr(1);
-	} */
-	return s;
+	return s.erase(0, s.find_first_not_of(' ' ));
 }
 
 std::string &stdstring_rtrim(std::string &s)
 {
-	s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
-/*	while (!s.empty())
-	{
-		if (s[s.size() - 1] != ' ')
-			return s;
-		s = s.substr(0, s.size() - 1);
-	} */
-	return s;
+	return s.erase(s.find_last_not_of(" ") + 1);
 }
 
 // trim from both ends

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -588,7 +588,7 @@ std::string &stdstring_ltrim(std::string &s)
 
 std::string &stdstring_rtrim(std::string &s)
 {
-	return s.erase(s.find_last_not_of(" ") + 1);
+	return s.erase(s.find_last_not_of(' ') + 1);
 }
 
 // trim from both ends

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -583,7 +583,7 @@ double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
 
 std::string &stdstring_ltrim(std::string &s)
 {
-	return s.erase(0, s.find_first_not_of(' ' ));
+	return s.erase(0, s.find_first_not_of(' '));
 }
 
 std::string &stdstring_rtrim(std::string &s)

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -583,23 +583,26 @@ double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
 
 std::string &stdstring_ltrim(std::string &s)
 {
-	while (!s.empty())
+	s.erase(s.begin(), std::find_if_not(s.begin(), s.end(), ::isspace));
+/*	while (!s.empty())
 	{
 		if (s[0] != ' ')
 			return s;
 		s = s.substr(1);
-	}
+	} */
 	return s;
 }
 
 std::string &stdstring_rtrim(std::string &s)
 {
-	while (!s.empty())
+	s.erase(std::find_if_not(s.rbegin(), s.rend(), ::isspace).base(), s.end());
+/*	while (!s.empty())
 	{
 		if (s[s.size() - 1] != ' ')
 			return s;
 		s = s.substr(0, s.size() - 1);
-	}	return s;
+	} */
+	return s;
 }
 
 // trim from both ends

--- a/main/domoticz_tester.cpp
+++ b/main/domoticz_tester.cpp
@@ -22,9 +22,10 @@ constexpr const char *szHelp
 {
 	"Usage: Domoticz_tester\n"
 	"\t-module <module> (which module to test, for example -module helper)\n"
-	"\t-function <function> (for example -www 8080, or -www 0 to disable http)\n"
+	"\t-function <function> (for example -function stdstring_ltrim)\n"
 	"\t-input <input> (for example -input \"3,text\")\n"
 	"\t-verbose More verbose output\n"
+	"\t-binary Output the result in binary (Hexadecimal)\n"
 	"\t-measure Show measurements like execution speed\n"
 	"\t-version display version number\n"
 	"\t-h (or --help or /?) display this help information\n"
@@ -51,6 +52,8 @@ std::string szTestOutput = "";
 bool bSuccess = false;
 bool bVerbose = false;
 bool bQuiet = false;
+bool bBinary = false;
+bool bMeasure = false;
 
 #define MAX_LOG_LINE_BUFFER 100
 #define MAX_LOG_LINE_LENGTH (2048 * 3)
@@ -196,6 +199,14 @@ int main(int argc, char**argv)
 	{
 		bQuiet = true;
 	}
+	if (cmdLine.HasSwitch("-binary"))
+	{
+		bBinary = true;
+	}
+	if (cmdLine.HasSwitch("-measure"))
+	{
+		bMeasure = true;
+	}
 
 	GetAppVersion();
 	DisplayAppVersion();
@@ -297,6 +308,11 @@ int main(int argc, char**argv)
 		sstr << "Failed!";
 		if (!szTestOutput.empty())
 			sstr << " (" << szTestOutput << ")";
+	}
+	if (bBinary)
+	{
+		std::string sHex = ToHexString((uint8_t*)szTestOutput.c_str(),szTestOutput.size());
+		sstr << " (b'" << sHex << "')";
 	}
 
 	Log(sstr.str().c_str());

--- a/test/gherkin/helper.feature
+++ b/test/gherkin/helper.feature
@@ -49,12 +49,19 @@ Feature: Helper routines
         Then I expect the function to succeed
         And have the following result "1 left and 1 right"
 
+    Scenario: Test trim function UTF-8
+        Given I am testing the "helper" module
+        When I test the function "stdstring_trim"
+        And I provide the following input "  2 left Δn©l UTF-8° 1 right "
+        Then I expect the function to succeed
+        And have the following result "2 left Δn©l UTF-8° 1 right"
+
     Scenario: Test MD5Hash generation function
         Given I am testing the "helper" module
         When I test the function "GenerateMD5Hash"
-        And I provide the following input "MD5 \#Hash Input wïth Speca1 (h@ract3r$!"
+        And I provide the following input "MD5 \#Hash Input wïth Specia1 (h@ract3r$!"
         Then I expect the function to succeed
-        And have the following result "6c97df5a126629b446babadb6c5a619c"
+        And have the following result "a175fd87223b1b548c72f5d37a9984c1"
 
     Scenario: Test CalculateDewPoint function
         Given I am testing the "helper" module

--- a/test/gherkin/helper.feature
+++ b/test/gherkin/helper.feature
@@ -52,9 +52,9 @@ Feature: Helper routines
     Scenario: Test trim function UTF-8
         Given I am testing the "helper" module
         When I test the function "stdstring_trim"
-        And I provide the following input "  2 left Δn©l UTF-8° 1 right "
+        And I provide the following input "  Â°C 2 left UTF-8 Δ 1 right "
         Then I expect the function to succeed
-        And have the following result "2 left Δn©l UTF-8° 1 right"
+        And have the following result "Â°C 2 left UTF-8 Δ 1 right"
 
     Scenario: Test MD5Hash generation function
         Given I am testing the "helper" module

--- a/test/gherkin/test_helper.py
+++ b/test/gherkin/test_helper.py
@@ -1,10 +1,6 @@
 from pytest_bdd import scenario, given, when, then, parsers
 import requests, subprocess
 
-@scenario('helper.feature', 'Test trim function')
-def test_trim():
-    pass
-
 @scenario('helper.feature', 'Test right trim function')
 def test_rtrim():
     pass
@@ -25,6 +21,14 @@ def test_ltrim3():
 def test_ltrim4():
     pass
 
+@scenario('helper.feature', 'Test trim function')
+def test_trim():
+    pass
+
+@scenario('helper.feature', 'Test trim function UTF-8')
+def test_trimUTF8():
+    pass
+
 @scenario('helper.feature', 'Test MD5Hash generation function')
 def test_md5hash():
     pass
@@ -32,7 +36,6 @@ def test_md5hash():
 @scenario('helper.feature', 'Test CalculateDewPoint function')
 def test_calculatedewpoint():
     pass
-
 
 @given(parsers.parse('I am testing the "{module}" module'))
 def setup_test_module(test_domoticz, module):


### PR DESCRIPTION
This PR adds a few more tests to testing the trim helper functions.

The proposed changes of PR #5256 have been applied to the Helper functions. See [this](https://github.com/domoticz/domoticz/commit/7d4e8eddaa31118bfc531928b8c3654b4eb57cd2) commit.

But they also have been [reverted](https://github.com/domoticz/domoticz/commit/81ce5798b496b153a7c8ede8c8d81bdeffa60705) afterwards as it was suspected that they do not work correctly with UTF-8 string input.

Therefor some tests have been added to test with UTF-8 input as well.

And it works ok.

The `domoticztester` utility now has an extra option to show the output as binary (Hexadecimal representation).

For example running ` ./domoticztester -module helper -function stdstring_trim -input " Δ€ UTF-8°  " -binary`
will show
```
Domoticz_tester V2022.1 (build 14420) (c)2022-2022 KidDigital
Build Hash: 81ce5798b, Date: 2022-07-22 12:02:09

Domoticztester testing function stdstring_trim of Module helper with input: . Δ€ UTF-8°  .
Executing : stdstring_trim (helper) | Result : .Δ€ UTF-8°. (b'0xCE 0x94 0xE2 0x82 0xAC 0x20 0x55 0x54 0x46 0x2D 0x38 0xC2 0xB0')
```
