### PR TITLE
Fix:piface whitespace trim

### DIFF
--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -93,15 +93,11 @@ CPiFace::CPiFace(const int ID)
 std::string & CPiFace::preprocess(std::string &s)
 {
     std::string temp;
-    std::string tempstripped;
 
     temp.resize(s.size());
     std::transform(s.begin(),s.end(),temp.begin(),::tolower);
 
-    tempstripped = stdstring_trim(temp);
-
-    s=tempstripped;
-    return s;
+    return stdstring_trimws(temp);
 }
 
 int CPiFace::LocateValueInParameterArray(const std::string &Parametername, const std::string *ParameterArray, int Items)

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -581,6 +581,7 @@ double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d)
 	return 2.0 * earthRadiusKm * asin(sqrt(u * u + cos(lat1r) * cos(lat2r) * v * v));
 }
 
+// trim only the space character
 std::string &stdstring_ltrim(std::string &s)
 {
 	return s.erase(0, s.find_first_not_of(' '));
@@ -590,11 +591,22 @@ std::string &stdstring_rtrim(std::string &s)
 {
 	return s.erase(s.find_last_not_of(' ') + 1);
 }
-
-// trim from both ends
 std::string &stdstring_trim(std::string &s)
 {
 	return stdstring_ltrim(stdstring_rtrim(s));
+}
+// trim all whitespace
+std::string &stdstring_ltrimws(std::string &s)
+{
+	return s.erase(0, s.find_first_not_of(WHITESPACE));
+}
+std::string &stdstring_rtrimws(std::string &s)
+{
+	return s.erase(s.find_last_not_of(WHITESPACE) + 1);
+}
+std::string &stdstring_trimws(std::string &s)
+{
+	return stdstring_ltrimws(stdstring_rtrimws(s));
 }
 
 double CalculateDewPoint(double temp, int humidity)

--- a/main/Helper.h
+++ b/main/Helper.h
@@ -11,6 +11,8 @@ enum _eTimeFormat
 	TF_DateTimeMs	// 3
 };
 
+const std::string WHITESPACE = " \n\r\t\f\v";
+
 uint8_t Crc8(uint8_t crc, const uint8_t* buf, size_t size);
 unsigned int Crc32(unsigned int crc, const uint8_t* buf, size_t size);
 void StringSplit(std::string str, const std::string &delim, std::vector<std::string> &results);
@@ -68,6 +70,9 @@ double distanceEarth(double lat1d, double lon1d, double lat2d, double lon2d);
 std::string &stdstring_ltrim(std::string &s);
 std::string &stdstring_rtrim(std::string &s);
 std::string &stdstring_trim(std::string &s);
+std::string &stdstring_ltrimws(std::string &s);
+std::string &stdstring_rtrimws(std::string &s);
+std::string &stdstring_trimws(std::string &s);
 double CalculateDewPoint(double temp, int humidity);
 uint32_t IPToUInt(const std::string &ip);
 bool isInt(const std::string &s);

--- a/main/domoticz_tester.cpp
+++ b/main/domoticz_tester.cpp
@@ -139,6 +139,24 @@ bool helper_tester(const std::string szFunction, std::string &szInput, std::stri
 		szOutput = stdstring_trim(szInput);
 		bSuccess = true;
 	}
+	// stdstring_ltrimws
+	else if (szFunction == "stdstring_ltrimws")
+	{
+		szOutput = stdstring_ltrimws(szInput);
+		bSuccess = true;
+	}
+	// stdstring_rtrimws
+	else if (szFunction == "stdstring_rtrimws")
+	{
+		szOutput = stdstring_rtrimws(szInput);
+		bSuccess = true;
+	}
+	// stdstring_trimws
+	else if (szFunction == "stdstring_trimws")
+	{
+		szOutput = stdstring_trimws(szInput);
+		bSuccess = true;
+	}
 	// GenerateMD5Hash
 	else if (szFunction == "GenerateMD5Hash")
 	{

--- a/test/gherkin/helper.feature
+++ b/test/gherkin/helper.feature
@@ -31,9 +31,9 @@ Feature: Helper routines
     Scenario: Test left trim function 4
         Given I am testing the "helper" module
         When I test the function "stdstring_ltrim"
-        And I provide the following input " \r 1 left + special "
+        And I provide the following input " 	 1 left + special "
         Then I expect the function to succeed
-        And have the following result "\r 1 left + special "
+        And have the following result "	 1 left + special "
 
     Scenario: Test right trim function
         Given I am testing the "helper" module
@@ -55,6 +55,13 @@ Feature: Helper routines
         And I provide the following input "  Â°C 2 left UTF-8 Δ 1 right "
         Then I expect the function to succeed
         And have the following result "Â°C 2 left UTF-8 Δ 1 right"
+
+    Scenario: Test whitespace trim function
+        Given I am testing the "helper" module
+        When I test the function "stdstring_trimws"
+        And I provide the following input " 	 3 left with whitespace and UTF-8 Δ and 2 right  "
+        Then I expect the function to succeed
+        And have the following result "3 left with whitespace and UTF-8 Δ and 2 right"
 
     Scenario: Test MD5Hash generation function
         Given I am testing the "helper" module

--- a/test/gherkin/test_helper.py
+++ b/test/gherkin/test_helper.py
@@ -29,6 +29,10 @@ def test_trim():
 def test_trimUTF8():
     pass
 
+@scenario('helper.feature', 'Test whitespace trim function')
+def test_trimws():
+    pass
+
 @scenario('helper.feature', 'Test MD5Hash generation function')
 def test_md5hash():
     pass


### PR DESCRIPTION
Small PR adding a _whitespace_ version of the `trim()` functions and let the PiFace hardware make use of it.

The PiFace hardware module was recently changed to use the domoticz trim functions instead of its own implementation. This probably causes issue #5294 .

