### PR TITLE
JS UI Thermostat set point onclick fix.

### DIFF
--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -1457,7 +1457,7 @@ define(['app', 'livesocket'], function (app) {
 						else if ((item.Type == "Thermostat") && (item.SubType == "SetPoint")) {
 							status = "";
 							bigtext = item.Data + '\u00B0 ' + $scope.config.TempSign;
-                            $(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
+							$(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 						}
 						else if (item.SubType == "Smartwares") {
 							status = item.Data + '\u00B0 ' + $scope.config.TempSign;

--- a/www/app/DashboardController.js
+++ b/www/app/DashboardController.js
@@ -1457,6 +1457,7 @@ define(['app', 'livesocket'], function (app) {
 						else if ((item.Type == "Thermostat") && (item.SubType == "SetPoint")) {
 							status = "";
 							bigtext = item.Data + '\u00B0 ' + $scope.config.TempSign;
+                            $(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 						}
 						else if (item.SubType == "Smartwares") {
 							status = item.Data + '\u00B0 ' + $scope.config.TempSign;

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -666,7 +666,7 @@ define(['app', 'livesocket'], function (app) {
 							}
 							else if (item.Type == "Thermostat") {
 								xhtm += item.Data + '\u00B0 ' + $scope.config.TempSign;
-                                $(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
+								$(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 							}
 							else if (item.SubType == "Waterflow") {
 								xhtm += item.Data;

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -433,6 +433,8 @@ define(['app', 'livesocket'], function (app) {
 				else if ((item.Type == "Thermostat") && (item.SubType == "SetPoint")) {
 					status = "";
 					bigtext = item.Data + '\u00B0 ' + $scope.config.TempSign;
+					const regex = /ShowSetpointPopup\(event, \d*, \w*, (\d+\.?)*\d+\);/gm;
+					img = $(id + " #img").html().replace(regex, 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ');')
 				}
 				else if (item.Type == "Radiator 1") {
 					status = item.Data + '\u00B0 ' + $scope.config.TempSign;

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -433,8 +433,7 @@ define(['app', 'livesocket'], function (app) {
 				else if ((item.Type == "Thermostat") && (item.SubType == "SetPoint")) {
 					status = "";
 					bigtext = item.Data + '\u00B0 ' + $scope.config.TempSign;
-					const regex = /ShowSetpointPopup\(event, \d*, \w*, (\d+\.?)*\d+\);/gm;
-					img = $(id + " #img").html().replace(regex, 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ');')
+					$(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 				}
 				else if (item.Type == "Radiator 1") {
 					status = item.Data + '\u00B0 ' + $scope.config.TempSign;
@@ -666,7 +665,6 @@ define(['app', 'livesocket'], function (app) {
 							}
 							else if (item.Type == "Thermostat") {
 								xhtm += item.Data + '\u00B0 ' + $scope.config.TempSign;
-								$(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 							}
 							else if (item.SubType == "Waterflow") {
 								xhtm += item.Data;

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -666,6 +666,7 @@ define(['app', 'livesocket'], function (app) {
 							}
 							else if (item.Type == "Thermostat") {
 								xhtm += item.Data + '\u00B0 ' + $scope.config.TempSign;
+                                $(id + " #img").attr('onclick', 'ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ')');
 							}
 							else if (item.SubType == "Waterflow") {
 								xhtm += item.Data;


### PR DESCRIPTION
Only bigtext was updated. Updating onclick function parameter.

On update_device only bigtext is updated.
`ShowSetpointPopup(event, 40, false, 1.0)` data value stayed the same thus after opening set point again value from page load was loaded.

```
<td id="bigtext">1.0° C</td>
<td id="img"><img src="images/override.png" class="lcursor" onclick="ShowSetpointPopup(event, 40, false, 1.0);" width="48" height="48"></td>
```

Change only for thermostat device.

PS.
I was trying to use following line:
UtilityController.js:814: `'<img src="images/' + item.Image + '" class="lcursor" onclick="ShowSetpointPopup(event, ' + item.idx + ', ' + item.Protected + ', ' + item.Data + ');" height="48" width="48" ></td>\n';` in place of regex to update img but unfortunately in `RefreshItem = function (item) {` `item` does not contain `Image` member thus regex.

It would be good to have initial definition of img field (line814) in one place not to double the code, but using regex here isn't (in my opinion) most efficient solution.

Could someone look into why there is not `Image` member?