### PR TITLE
Python example plugin fixed description.

### DIFF
--- a/plugins/examples/BaseTemplate.py
+++ b/plugins/examples/BaseTemplate.py
@@ -31,6 +31,7 @@
                 <option label="Connections+Queue" value="144"/>
                 <option label="All" value="-1"/>
             </options>
+        </param>
     </params>
 </plugin>
 """


### PR DESCRIPTION
Missing </param> closing tag.