### PR TITLE
Fix protocol not set for ICMP and update Pinger plugin example

### DIFF
--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -1188,7 +1188,7 @@ namespace Plugins {
 
 		std::string		sData(Message->m_Buffer.begin(), Message->m_Buffer.end());
 		sData = sData.substr(iDataOffset, iTotalData - iDataOffset);
-		pObj = Py_BuildValue("y#", sData.c_str(), sData.length());
+		pObj = Py_BuildValue("s", sData.c_str(), sData.length());
 		if (PyDict_SetItemString(pDataDict, "Data", pObj) == -1)
 			_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", "ICMP", "Data", sData.c_str());
 

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -127,7 +127,7 @@ namespace Plugins {
 		if (!pObj || PyDict_SetItemString(pDict, key, (PyObject*)pObj) == -1)
 			_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", __func__, key, value.c_str());
 	}
-	
+
 	static void AddStringToDict(PyObject* pDict, const char* key, const std::string& value)
 	{
 		PyNewRef pObj(value);
@@ -1187,8 +1187,7 @@ namespace Plugins {
 		}
 
 		std::string		sData(Message->m_Buffer.begin(), Message->m_Buffer.end());
-		sData = sData.substr(iDataOffset, iTotalData - iDataOffset);
-		pObj = Py_BuildValue("s", sData.c_str(), sData.length());
+		pObj = PyNewRef((byte*)sData.c_str(), sData.length());
 		if (PyDict_SetItemString(pDataDict, "Data", pObj) == -1)
 			_log.Log(LOG_ERROR, "(%s) failed to add key '%s', value '%s' to dictionary.", "ICMP", "Data", sData.c_str());
 
@@ -1651,7 +1650,7 @@ namespace Plugins {
 					m_bErrored = true;
 				}
 				break;
-			case MQTT_SUBSCRIBE: 
+			case MQTT_SUBSCRIBE:
 			{
 				AddStringToDict(pMqttDict, "Verb", std::string("SUBSCRIBE"));
 				if (flags != 2)
@@ -2385,8 +2384,8 @@ namespace Plugins {
 		// Add new message to retained data, process all messages if this one is the finish of a message
 		m_sRetainedData.insert(m_sRetainedData.end(), Message->m_Buffer.begin(), Message->m_Buffer.end());
 
-		// Although messages can be fragmented, control messages can be inserted in between fragments. 
-		// see https://datatracker.ietf.org/doc/html/rfc6455#section-5.4 
+		// Although messages can be fragmented, control messages can be inserted in between fragments.
+		// see https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
 		// Always process the whole buffer because we can't know if we have whole, multiple or even complete messages unless we work through from the start
 		while (ProcessWholeMessage(m_sRetainedData, Message))
 		{

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -871,6 +871,8 @@ namespace Plugins {
 			{
 				m_Socket->async_receive_from(boost::asio::buffer(m_Buffer, sizeof m_Buffer), m_Endpoint, [this](auto &&err, auto bytes) { handleRead(err, bytes); });
 			}
+
+			m_pConnection->pPlugin->MessagePlugin(new ProtocolDirective(m_pConnection));
 		}
 		catch (std::exception& e)
 		{

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1653,6 +1653,7 @@ namespace Plugins
 				Log(LOG_ERROR, "Transport '%s' does not support secure connections.", sTransport.c_str());
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "Transport set to: '%s', %s.", sTransport.c_str(), sAddress.c_str());
+			ConnectionProtocol(pMess);
 			pConnection->pTransport = (CPluginTransport *)new CPluginTransportICMP(m_HwdID, pConnection, sAddress, sPort);
 		}
 		else

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1653,7 +1653,6 @@ namespace Plugins
 				Log(LOG_ERROR, "Transport '%s' does not support secure connections.", sTransport.c_str());
 			if (m_bDebug & PDM_CONNECTION)
 				Log(LOG_NORM, "Transport set to: '%s', %s.", sTransport.c_str(), sAddress.c_str());
-			ConnectionProtocol(pMess);
 			pConnection->pTransport = (CPluginTransport *)new CPluginTransportICMP(m_HwdID, pConnection, sAddress, sPort);
 		}
 		else


### PR DESCRIPTION
Hi,

It bugged me that the Pinger plugin did not work, so I did a little bit of investigating. 

It seems like the other Plugin Protocols set the 'ConnectionProtocol' on connect, but ICMP does not connect. 
I added the 'ConnectionProtocol' call just before creating 'CPluginTransportICMP', but I'm not sure if this is the right location. 

I have a few points before merging this PR:
- Is the 'ConnectionProtocol' call on the right position? 

- While debugging, after a while, I get the following Exception. In Release mode it runs without any crashes (tested multiple hours).
![Domoticz-debug-crash](https://user-images.githubusercontent.com/6448911/191980759-1c365fa8-d226-4898-8741-73c7f7133f5c.PNG)

- I changed the 'Py_BuildValue' from `y#` to `s` because of the following Exception. I'm not sure if this is correct. 
![Domoticz-debug-crash2](https://user-images.githubusercontent.com/6448911/191981229-eb6ba3b6-e5c5-46e8-90c9-e042297a9f89.PNG)

- Part of the Pinger.py update I took from [here](https://github.com/dnpwwo/Domoticz-Pinger-Plugin/blob/master/plugin.py). My addition is the change of `self.icmpConn.Name` to `self.icmpConn.Address`.
