### PR TITLE
Fix 'Boost asio error: no shared cipher'

### DIFF
--- a/webserver/server.cpp
+++ b/webserver/server.cpp
@@ -184,9 +184,6 @@ ssl_server::ssl_server(const server_settings &settings, request_handler &user_re
 }
 
 void ssl_server::init_connection() {
-
-	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_, context_));
-
 	// the following line gets the passphrase for protected private server keys
 	context_.set_password_callback([this](auto &&...) { return get_passphrase(); });
 
@@ -271,12 +268,11 @@ void ssl_server::init_connection() {
 	} else {
 		_log.Log(LOG_ERROR, "[web:%s] missing SSL DH parameters file %s!", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
 	}
+	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_, context_));
 }
 
 void ssl_server::reinit_connection()
 {
-	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_, context_));
-
 	struct stat st;
 
 	if ((!settings_.certificate_chain_file_path.empty() &&
@@ -310,6 +306,7 @@ void ssl_server::reinit_connection()
 			_log.Log(LOG_ERROR, "[web:%s] missing SSL DH parameters from file %s", settings_.listening_port.c_str(), settings_.tmp_dh_file_path.c_str());
 		}
 	}
+	new_connection_.reset(new connection(io_service_, connection_manager_, request_handler_, timeout_, context_));
 }
 
 /**


### PR DESCRIPTION
Those changes fix a bug which describe in https://stackoverflow.com/questions/12217346/c-boost-asio-error-no-shared-cipher. I've seen this in connection.cpp connection::handle_handshake() when trying to connect via ssl socket.

This happens to me right after starting domoticz.