### PR TITLE
teleinfo_hchp_pb

### DIFF
--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -46,7 +46,6 @@ void CTeleinfoBase::InitTeleinfo()
 {
 	m_bufferpos = 0;
 	m_teleinfo.CRCmode1 = 255;	 // Guess the CRC mode at first run
-	m_counter = 0;
 }
 
 void CTeleinfoBase::ProcessTeleinfo(Teleinfo& teleinfo)
@@ -425,7 +424,7 @@ void CTeleinfoBase::ProcessTeleinfo(const std::string& name, int rank, Teleinfo&
 		if((teleinfo.STGE & 0x80) != (teleinfo.prevSTGE & 0x80) || teleinfo.prevSTGE == UINT32_MAX)
 		{
 			int iOverload = (teleinfo.STGE >> 7) & 0x1;
-			SendAlertSensor(32 * rank + 12, 255, iOverload, (iOverload == 0)?"Pas de dépssament de la puissance de référence":"Dépassement de la puissance de référence", name + " Dépassement puissance");
+			SendAlertSensor(32 * rank + 12, 255, iOverload, (iOverload == 0)?"Pas de dépassement de la puissance de référence":"Dépassement de la puissance de référence", name + " Dépassement puissance");
 		}
 		if((teleinfo.STGE & 0x100) != (teleinfo.prevSTGE & 0x100) || teleinfo.prevSTGE == UINT32_MAX)
 		{
@@ -516,7 +515,7 @@ bool CTeleinfoBase::isCheckSumOk(const std::string& sLine, int& isMode1)
 
 void CTeleinfoBase::MatchLine()
 {
-	std::string label, vString;
+	std::string label, vString, ngtfString;
 	std::vector<std::string> splitresults;
 	unsigned long value;
 	std::string sline(m_buffer);
@@ -574,7 +573,6 @@ void CTeleinfoBase::MatchLine()
 	else if (label == "IINST2") m_teleinfo.IINST2 = value;
 	else if (label == "IINST3") m_teleinfo.IINST3 = value;
 	else if (label == "PPOT")  m_teleinfo.PPOT = value;
-	else if (label == "MOTDETAT") m_counter++;
 
 	// Standard mode
 	else if (label == "EAST") m_teleinfo.BASE = value;
@@ -589,7 +587,22 @@ void CTeleinfoBase::MatchLine()
 		m_teleinfo.IINST2 = value;
 	}
 	else if (label == "IRMS3") m_teleinfo.IINST3 = value;
-	else if (label == "NGTF") m_teleinfo.OPTARIF = stdstring_trim(vString);
+	else if (label == "NGTF") 
+	{
+		ngtfString = stdstring_trim(vString);
+		// Different abonnements existent et ca devient difficile de rester compatible du comportement historique
+		// Je ne sais pas bien si la string NGTF est dépendante ou non du fournisseur...
+		// Exemple chez totalEnergie il y a l'abonnement avec les heures super creuse qui sont sur un 3eme compteur EASF03
+		// Je le met quand même en comportement heure creuse pour l'instant : Il manquera juste les heures super creuses : @TODO
+		if (ngtfString == "H PLEINE/CREUSE" || ngtfString == "H SUPER CREUSES" || ngtfString == "HC SEM ET HC WE")
+			m_teleinfo.OPTARIF = "HC..";
+		else if (ngtfString == "PRODUCTEUR")
+			// Pour avoir un affichage sur les compteurs producteur uniquement
+			m_teleinfo.OPTARIF = "BASE";
+		else
+			// Pour compatibilite mode historique
+			m_teleinfo.OPTARIF = ngtfString;
+	}
 	else if (label == "SINSTS")
 	{
 		m_teleinfo.PAPP = value;
@@ -616,19 +629,12 @@ void CTeleinfoBase::MatchLine()
 	{ // Status register, hexadecimal string (without 0x)
 		m_teleinfo.STGE = strtoul(splitresults[1].c_str(), nullptr, 16);
 	}
-	else if (label == "ADSC")
-	{
-		m_counter++;
-	}
+	else if (label == "ADSC") m_teleinfo.ADCO = vString;
 
-	// at 1200 baud we have roughly one frame per 1,5 second, check more frequently for alerts.
-	if (m_counter >= m_iBaudRate / 600)
-	{
-		m_counter = 0;
-		Debug(DEBUG_HARDWARE, "frame complete, PAPP: %i, PTEC: %s, OPTARIF: %s", m_teleinfo.PAPP, m_teleinfo.PTEC.c_str(), m_teleinfo.OPTARIF.c_str());
-		ProcessTeleinfo(m_teleinfo);
-		mytime(&m_LastHeartbeat);// keep heartbeat happy
-	}
+	Debug(DEBUG_HARDWARE, "frame complete, PAPP: %i, PTEC: %s, OPTARIF: %s", m_teleinfo.PAPP, m_teleinfo.PTEC.c_str(), m_teleinfo.OPTARIF.c_str());
+	ProcessTeleinfo(m_teleinfo);
+	mytime(&m_LastHeartbeat);// keep heartbeat happy
+
 }
 
 void CTeleinfoBase::ParseTeleinfoData(const char* pData, int Len)

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -36,7 +36,6 @@ CTeleinfoBase::CTeleinfoBase()
 	m_p1power.ID = 1;
 	m_p2power.ID = 2;
 	m_p3power.ID = 3;
-
 	m_bDisableCRC = false;
 
 	InitTeleinfo();
@@ -515,7 +514,7 @@ bool CTeleinfoBase::isCheckSumOk(const std::string& sLine, int& isMode1)
 
 void CTeleinfoBase::MatchLine()
 {
-	std::string label, vString, ngtfString;
+	std::string label, vString;
 	std::vector<std::string> splitresults;
 	unsigned long value;
 	std::string sline(m_buffer);
@@ -589,7 +588,7 @@ void CTeleinfoBase::MatchLine()
 	else if (label == "IRMS3") m_teleinfo.IINST3 = value;
 	else if (label == "NGTF") 
 	{
-		ngtfString = stdstring_trim(vString);
+		std::string ngtfString = stdstring_trim(vString);
 		// Different abonnements existent et ca devient difficile de rester compatible du comportement historique
 		// Je ne sais pas bien si la string NGTF est dépendante ou non du fournisseur...
 		// Exemple chez totalEnergie il y a l'abonnement avec les heures super creuse qui sont sur un 3eme compteur EASF03
@@ -634,7 +633,6 @@ void CTeleinfoBase::MatchLine()
 	Debug(DEBUG_HARDWARE, "frame complete, PAPP: %i, PTEC: %s, OPTARIF: %s", m_teleinfo.PAPP, m_teleinfo.PTEC.c_str(), m_teleinfo.OPTARIF.c_str());
 	ProcessTeleinfo(m_teleinfo);
 	mytime(&m_LastHeartbeat);// keep heartbeat happy
-
 }
 
 void CTeleinfoBase::ParseTeleinfoData(const char* pData, int Len)

--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -153,7 +153,6 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 	Teleinfo m_teleinfo;
 	char m_buffer[1024];
 	int m_bufferpos;
-	unsigned int m_counter;
 };
 
 /*  Details on Teleinfo variables


### PR DESCRIPTION
Hi,
this is a fix to french teleinfo with linky set in standard mode.
Depending on Energy provider, label NGTF may differ... so no KwhMeter is displayed  
I also remove badly implemented m_counter refresh limitation base on baud rate (the higher the baud rate, the less refress !). m_iRateLimit is already here to ajust refresh rate.
