### PR TITLE
Add support for all D2-01-XX EEP & misc minor fixes/typos/comments

### DIFF
--- a/hardware/EnOceanEEP.cpp
+++ b/hardware/EnOceanEEP.cpp
@@ -215,12 +215,12 @@ static const _tRORGTable _RORGTable[] =
     {RORG_1BS, "1BS", "1 Byte Communication"},
     {RORG_RPS, "RPS", "Repeated Switch Communication"},
     {RORG_SYS_EX, "SYS_EX", "Remote Management"},
-    {0, nullptr, nullptr},
+    {UNKNOWN_RORG, nullptr, nullptr},
 };
 
 const char *CEnOceanEEP::GetRORGLabel(uint8_t RORG)
 {
-	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
+	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != UNKNOWN_RORG || pTable->label != nullptr; pTable++)
 		if (pTable->RORG == RORG)
 			return pTable->label;
 
@@ -229,7 +229,7 @@ const char *CEnOceanEEP::GetRORGLabel(uint8_t RORG)
 
 const char *CEnOceanEEP::GetRORGDescription(uint8_t RORG)
 {
-	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->description != nullptr; pTable++)
+	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != UNKNOWN_RORG || pTable->description != nullptr; pTable++)
 		if (pTable->RORG == RORG)
 			return pTable->description;
 
@@ -253,7 +253,7 @@ namespace http
 			}
 
 			int i = 0;
-			for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
+			for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != UNKNOWN_RORG || pTable->label != nullptr; pTable++)
 			{
 				if (pTable->RORG != RORG_4BS && pTable->RORG != RORG_VLD && pTable->RORG != RORG_1BS && pTable->RORG != RORG_RPS)
 					continue;
@@ -687,12 +687,12 @@ static const _tEEPTable _EEPTable[] = {
     { RORG_RPS, 0x10, 0x01, "F6-10-01", "Window handle", "WindowHandle.01"},
 
 	// End of table
-	{ 0, 0, 0, nullptr, nullptr, nullptr },
+	{ UNKNOWN_RORG, 0, 0, nullptr, nullptr, nullptr },
 };
 
 const char *CEnOceanEEP::GetEEP(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->EEP != nullptr; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != UNKNOWN_RORG || pTable->EEP != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->EEP;
 
@@ -701,7 +701,7 @@ const char *CEnOceanEEP::GetEEP(const int RORG, const int func, const int type)
 
 const char *CEnOceanEEP::GetEEPLabel(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != UNKNOWN_RORG || pTable->label != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->label;
 
@@ -710,7 +710,7 @@ const char *CEnOceanEEP::GetEEPLabel(const int RORG, const int func, const int t
 
 const char *CEnOceanEEP::GetEEPDescription(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->description != nullptr; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != UNKNOWN_RORG || pTable->description != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->description;
 
@@ -734,7 +734,7 @@ namespace http
 			}
 
 			int i = 0;
-			for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG; pTable++)
+			for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != UNKNOWN_RORG || pTable->EEP != nullptr; pTable++)
 			{
 //				_log.Log(LOG_NORM, "EnOcean: Cmd_EnOceanGetProfiles: %d %s", idx, pTable->eep);
 

--- a/hardware/EnOceanEEP.cpp
+++ b/hardware/EnOceanEEP.cpp
@@ -196,27 +196,31 @@ struct _tRORGTable
 	const char *description;
 };
 
-static const _tRORGTable _RORGTable[] = { { RORG_ST, "ST", "Secure telegram" },
-					  { RORG_ST_WE, "ST_WE", "Secure telegram with RORG encapsulation" },
-					  { RORG_STT_FW, "STT_FW", "Secure teach-in telegram for switch" },
-					  { RORG_4BS, "4BS", "4 Bytes Communication" },
-					  { RORG_ADT, "ADT", "Adressing Destination Telegram" },
-					  { RORG_SM_REC, "SM_REC", "Smart Ack Reclaim" },
-					  { RORG_GP_SD, "GP_SD", "Generic Profiles selective data" },
-					  { RORG_SM_LRN_REQ, "SM_LRN_REQ", "Smart Ack Learn Request" },
-					  { RORG_SM_LRN_ANS, "SM_LRN_ANS", "Smart Ack Learn Answer" },
-					  { RORG_SM_ACK_SGNL, "SM_ACK_SGNL", "Smart Acknowledge Signal telegram" },
-					  { RORG_MSC, "MSC", "Manufacturer Specific Communication" },
-					  { RORG_VLD, "VLD", "Variable length data telegram" },
-					  { RORG_UTE, "UTE", "Universal teach-in EEP based" },
-					  { RORG_1BS, "1BS", "1 Byte Communication" },
-					  { RORG_RPS, "RPS", "Repeated Switch Communication" },
-					  { RORG_SYS_EX, "SYS_EX", "Remote Management" },
-					  { 0, nullptr, nullptr } };
+static const _tRORGTable _RORGTable[] =
+{
+    {UNKNOWN_RORG, "UNKNOWN", "Unknown RORG"},
+    {RORG_ST, "ST", "Secure telegram"},
+    {RORG_ST_WE, "ST_WE", "Secure telegram with RORG encapsulation"},
+    {RORG_STT_FW, "STT_FW", "Secure teach-in telegram for switch"},
+    {RORG_4BS, "4BS", "4 Bytes Communication"},
+    {RORG_ADT, "ADT", "Adressing Destination Telegram"},
+    {RORG_SM_REC, "SM_REC", "Smart Ack Reclaim"},
+    {RORG_GP_SD, "GP_SD", "Generic Profiles selective data"},
+    {RORG_SM_LRN_REQ, "SM_LRN_REQ", "Smart Ack Learn Request"},
+    {RORG_SM_LRN_ANS, "SM_LRN_ANS", "Smart Ack Learn Answer"},
+    {RORG_SM_ACK_SGNL, "SM_ACK_SGNL", "Smart Acknowledge Signal telegram"},
+    {RORG_MSC, "MSC", "Manufacturer Specific Communication"},
+    {RORG_VLD, "VLD", "Variable length data telegram"},
+    {RORG_UTE, "UTE", "Universal teach-in EEP based"},
+    {RORG_1BS, "1BS", "1 Byte Communication"},
+    {RORG_RPS, "RPS", "Repeated Switch Communication"},
+    {RORG_SYS_EX, "SYS_EX", "Remote Management"},
+    {0, nullptr, nullptr},
+};
 
 const char *CEnOceanEEP::GetRORGLabel(uint8_t RORG)
 {
-	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG; pTable++)
+	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
 		if (pTable->RORG == RORG)
 			return pTable->label;
 
@@ -225,7 +229,7 @@ const char *CEnOceanEEP::GetRORGLabel(uint8_t RORG)
 
 const char *CEnOceanEEP::GetRORGDescription(uint8_t RORG)
 {
-	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG; pTable++)
+	for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->description != nullptr; pTable++)
 		if (pTable->RORG == RORG)
 			return pTable->description;
 
@@ -249,7 +253,7 @@ namespace http
 			}
 
 			int i = 0;
-			for (const _tRORGTable *pTable = _RORGTable; pTable->RORG; pTable++)
+			for (const _tRORGTable *pTable = _RORGTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
 			{
 				if (pTable->RORG != RORG_4BS && pTable->RORG != RORG_VLD && pTable->RORG != RORG_1BS && pTable->RORG != RORG_RPS)
 					continue;
@@ -688,7 +692,7 @@ static const _tEEPTable _EEPTable[] = {
 
 const char *CEnOceanEEP::GetEEP(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->EEP != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->EEP;
 
@@ -697,7 +701,7 @@ const char *CEnOceanEEP::GetEEP(const int RORG, const int func, const int type)
 
 const char *CEnOceanEEP::GetEEPLabel(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->label != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->label;
 
@@ -706,7 +710,7 @@ const char *CEnOceanEEP::GetEEPLabel(const int RORG, const int func, const int t
 
 const char *CEnOceanEEP::GetEEPDescription(const int RORG, const int func, const int type)
 {
-	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG; pTable++)
+	for (const _tEEPTable *pTable = (const _tEEPTable *)&_EEPTable; pTable->RORG != 0 || pTable->description != nullptr; pTable++)
 		if ((pTable->RORG == RORG) && (pTable->func == func) && (pTable->type == type))
 			return pTable->description;
 

--- a/hardware/EnOceanEEP.h
+++ b/hardware/EnOceanEEP.h
@@ -126,12 +126,13 @@ enum ENOCEAN_MANUFACTURER : uint16_t
 	INABA_DENKI_SANGYO_CO_LTD = 0x075,
 	HAGER_CONTROL_SAS = 0x076,
 	DOMOTICZ_MANUFACTURER = 0x7FE, // Used as manufacturer for generic nodes
-	MULTI_USER_MANUFACTURER = 0x7FF
+	MULTI_USER_MANUFACTURER = 0x7FF,
 };
 
 // ESP3 RORGs
 enum ESP3_RORG_TYPE : uint8_t
 {
+	UNKNOWN_RORG = 0x00,	// RORG unknown (or not set) => WARNING, do not change this value !!
 	RORG_ST = 0x30,			// Secure telegram
 	RORG_ST_WE = 0x31,		// Secure telegram with RORG encapsulation
 	RORG_STT_FW = 0x35,		// Secure teach-in telegram for switch
@@ -147,7 +148,7 @@ enum ESP3_RORG_TYPE : uint8_t
 	RORG_UTE = 0xD4,		// Universal teach-in EEP based
 	RORG_1BS = 0xD5,		// 1 Byte Communication
 	RORG_RPS = 0xF6,		// Repeated Switch Communication
-	RORG_SYS_EX = 0xC5		// Remote Management
+	RORG_SYS_EX = 0xC5,		// Remote Management
 };
 
 class CEnOceanEEP

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -2433,7 +2433,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 						senderID, RORG_1BS, node_func, node_type, GetEEPLabel(RORG_1BS, node_func, node_type));
 					Log(LOG_NORM, "Please adjust by hand if need be");
 
-					TeachInNode(senderID, UNKNOWN_MANUFACTURER, RORG_1BS, node_func, node_type, GENERIC_NODE);
+					TeachInNode(senderID, DOMOTICZ_MANUFACTURER, RORG_1BS, node_func, node_type, GENERIC_NODE);
 					return;
 				}
 				// 1BS data
@@ -2519,7 +2519,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					{ // 4BS teach-in, variation 1 : without EEP
 						// EnOcean EEP 2.6.8 specification §3.3 p.321 : an EEP must be manually allocated
 
-						node_manID = UNKNOWN_MANUFACTURER;
+						node_manID = DOMOTICZ_MANUFACTURER;
 						node_func = 0x02; // Generic Temperature Sensors, Temperature Sensor ranging from 0°C to +40°C
 						node_type = 0x05;
 
@@ -3350,7 +3350,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 						senderID, RORG_RPS, node_func, node_type, GetEEPLabel(RORG_RPS, node_func, node_type));
 					Log(LOG_NORM, "Please adjust by hand if need be");
 
-					TeachInNode(senderID, UNKNOWN_MANUFACTURER, RORG_RPS, node_func, node_type, GENERIC_NODE);
+					TeachInNode(senderID, DOMOTICZ_MANUFACTURER, RORG_RPS, node_func, node_type, GENERIC_NODE);
 					return;
 				}
 				// RPS data

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -1753,7 +1753,6 @@ bool CEnOceanESP3::OpenSerialDevice()
 	for (const auto &itt : ESP3TestsCases)
 		ReadCallback((const char *)itt.data(), itt.size());
 
-	DisableLearnMode();
 	Debug(DEBUG_NORM, "------------ ESP3 tests end -----------------------------");
 #endif
 

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -631,7 +631,7 @@ void CEnOceanESP3::CheckAndUpdateNodeRORG(NodeInfo* pNode, const uint8_t RORG)
 	if (pNode == nullptr)
 		return; // Unknown node
 
-	if (pNode->RORG != 0x00)
+	if (pNode->RORG != UNKNOWN_RORG)
 		return;	// Node RORG already set : nothing to update
 
 	if (GetEEP(RORG, pNode->func, pNode->type) == nullptr)
@@ -2050,7 +2050,7 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 			nodeID, pNode->name.c_str(), switchtype);
 		return false;
 	}
-	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x01 && pNode->type != 0x0C)
+	if ((pNode->RORG == RORG_VLD || pNode->RORG == UNKNOWN_RORG) && pNode->func == 0x01 && pNode->type != 0x0C)
 	{ // D2-01-XX, Electronic Switches and Dimmers with Local Control (except Type 0x0C, Pilotwire)
 		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
@@ -2091,7 +2091,7 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		SendESP3PacketQueued(PACKET_RADIO_ERP1, buf, 9, optbuf, 7);
 		return true;
 	}
-	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x01 && pNode->type == 0x0C)
+	if ((pNode->RORG == RORG_VLD || pNode->RORG == UNKNOWN_RORG) && pNode->func == 0x01 && pNode->type == 0x0C)
 	{ // D2-01-0C, Electronic Switches and Dimmers with Local Control, Type 0x0C, Pilotwire
 		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 
@@ -2119,7 +2119,7 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		sendVld(m_id_chip, nodeID, D20100_CMD8, 8, PilotWireMode, END_ARG_DATA);
 		return true;
 	}
-	if ((pNode->RORG == RORG_VLD || pNode->RORG == 0x00) && pNode->func == 0x05)
+	if ((pNode->RORG == RORG_VLD || pNode->RORG == UNKNOWN_RORG) && pNode->func == 0x05)
 	{ // D2-05-00, Blinds Control for Position and Angle 
 		CheckAndUpdateNodeRORG(pNode, RORG_VLD);
 

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -75,7 +75,7 @@ enum ESP3_PACKET_TYPE : uint8_t
 	PACKET_CONFIG_COMMAND = 0x0B,	// RESERVED
 	PACKET_COMMAND_ACCEPTED = 0x0C,	// For long operations, informs the host the command is accepted
 	PACKET_RADIO_802_15_4 = 0x10,	// 802_15_4 Raw Packet
-	PACKET_COMMAND_2_4 = 0x11		// 2.4 GHz Command
+	PACKET_COMMAND_2_4 = 0x11,		// 2.4 GHz Command
 };
 
 // ESP3 Return codes
@@ -91,7 +91,7 @@ enum ESP3_RETURN_CODE : uint8_t
 	RET_NO_FREE_BUFFER = 0x07,		// Currently all internal buffers are used
 	RET_MEMORY_ERROR = 0x82,		// The memory write process failed
 	RET_BASEID_OUT_OF_RANGE = 0x90, // BaseID out of range
-	RET_BASEID_MAX_REACHED = 0x91	// BaseID has already been changed 10 times, no more changes are allowed
+	RET_BASEID_MAX_REACHED = 0x91,	// BaseID has already been changed 10 times, no more changes are allowed
 };
 
 // ESP3 Event codes
@@ -105,7 +105,7 @@ enum ESP3_EVENT_CODE : uint8_t
 	CO_DUTYCYCLE_LIMIT = 0x06,		// Informs the external host about reaching the duty cycle limit
 	CO_TRANSMIT_FAILED = 0x07,		// Informs the external host about not being able to send a telegram
 	CO_TX_DONE = 0x08,				// Informs that all TX operations are done
-	CO_LRN_MODE_DISABLED = 0x09		// Informs that the learn mode has time-out
+	CO_LRN_MODE_DISABLED = 0x09,	// Informs that the learn mode has time-out
 };
 
 // ESP3 Common commands
@@ -174,7 +174,7 @@ enum ESP3_COMMON_COMMAND : uint8_t
 	CO_WR_TRANSPARENT_MODE = 62,	// Control the state of the transparent mode
 	CO_RD_TRANSPARENT_MODE = 63,	// Read the state of the transparent mode
 	CO_WR_TX_ONLY_MODE = 64,		// Control the state of the TX only mode
-	CO_RD_TX_ONLY_MODE = 65			// Read the state of the TX only mode} COMMON_COMMAND;
+	CO_RD_TX_ONLY_MODE = 65,		// Read the state of the TX only mode} COMMON_COMMAND;
 };
 
 // ESP3 Smart Ack codes
@@ -187,7 +187,7 @@ enum ESP3_SMART_ACK_CODE : uint8_t
 	SA_WR_RESET = 0x05,				// Send reset command to a Smart Ack client
 	SA_RD_LEARNEDCLIENTS = 0x06,	// Get Smart Ack learned sensors / mailboxes
 	SA_WR_RECLAIMS = 0x07,			// Set number of reclaim attempts
-	SA_WR_POSTMASTER = 0x08			// Activate/Deactivate Post master functionality
+	SA_WR_POSTMASTER = 0x08,		// Activate/Deactivate Post master functionality
 };
 
 // ESP3 Function return codes
@@ -218,7 +218,7 @@ enum ESP3_FUNC_RETURN_CODE : uint8_t
 	RC_ELEGRAM_WAIT,				// Waiting before sending broadcast message
 	RC_OUT_OF_RANGE,				// Generic out of range return code
 	RC_LOCK_SET,					// Function was not executed due to sending lock
-	RC_NEW_TX_TEL					// New telegram transmitted
+	RC_NEW_TX_TEL,					// New telegram transmitted
 };
 
 // Nb seconds between attempts to open ESP3 controller serial device
@@ -268,7 +268,7 @@ static const uint8_t crc8table[256] = {
 	0xae, 0xa9, 0xa0, 0xa7, 0xb2, 0xb5, 0xbc, 0xbb,
 	0x96, 0x91, 0x98, 0x9f, 0x8a, 0x8D, 0x84, 0x83,
 	0xde, 0xd9, 0xd0, 0xd7, 0xc2, 0xc5, 0xcc, 0xcb,
-	0xe6, 0xe1, 0xe8, 0xef, 0xfa, 0xfd, 0xf4, 0xf3
+	0xe6, 0xe1, 0xe8, 0xef, 0xfa, 0xfd, 0xf4, 0xf3,
 };
 
 #define proc_crc8(crc, data) (crc8table[crc ^ data])
@@ -291,7 +291,7 @@ static const uint8_t crc8table[256] = {
 typedef enum
 {
 	UTE_UNIDIRECTIONAL = 0,	// Unidirectional
-	UTE_BIDIRECTIONAL = 1	// Bidirectional
+	UTE_BIDIRECTIONAL = 1,	// Bidirectional
 } UTE_DIRECTION;
 
 // UTE Response codes
@@ -300,14 +300,14 @@ typedef enum
 	GENERAL_REASON = 0,		// Request not accepted because of general reason
 	TEACHIN_ACCEPTED = 1, 	// Request accepted, teach-in successful
 	TEACHOUT_ACCEPTED = 2, 	// Request accepted, teach-out successful
-	EEP_NOT_SUPPORTED = 3 	// Request not accepted, EEP not supported
+	EEP_NOT_SUPPORTED = 3, 	// Request not accepted, EEP not supported
 } UTE_RESPONSE_CODE;
 
 // UTE Direction response codes
 typedef enum
 {
 	UTE_QUERY = 0,		// Teach-in query command
-	UTE_RESPONSE = 1	// Teach-in response command
+	UTE_RESPONSE = 1,	// Teach-in response command
 } UTE_CMD;
 
 CEnOceanESP3::CEnOceanESP3(const int ID, const std::string &devname, const int type)
@@ -623,7 +623,7 @@ void CEnOceanESP3::UpdateNode(const uint32_t nodeID,
 void CEnOceanESP3::CheckAndUpdateNodeRORG(NodeInfo* pNode, const uint8_t RORG)
 {
 	if (pNode == nullptr)
-		return;
+		return; // Unknown node
 
 	if (pNode->RORG == RORG)
 		return;
@@ -840,7 +840,7 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
 // A5-02-03, Temperature Sensor Range -20C to +20C
 // Test Case : Teach-in Test
 //  Unidirectional Teach-in Test
-    { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_4BS, 0x08, 0x18, 0x88, 0x80, 0x01, RORG_4BS, 0x02, 0x03, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0x6D },
+    { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_4BS, 0x08, 0x18, 0x00, 0x80, 0x01, RORG_4BS, 0x02, 0x03, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0x89 },
 // Test Case : Temperature Tests
 //  Min Temperature Test
     { ESP3_SER_SYNC, 0x00, 0x0A, 0x07, PACKET_RADIO_ERP1, 0xEB, RORG_4BS, 0x00, 0x00, 0xFF, 0x08, 0x01, RORG_4BS, 0x02, 0x03, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0x36 },
@@ -1534,6 +1534,17 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
     { ESP3_SER_SYNC, 0x00, 0x07, 0x07, PACKET_RADIO_ERP1, 0x7A, RORG_RPS, 0x30, 0x01, RORG_RPS, 0x05, 0x02, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0x52 },
 #endif // ESP3_TESTS_RPS_F6_05_02
 
+#ifdef ESP3_TESTS_VLD_D2_01_0C
+// D2-01-0C, Electronic Switches and Dimmers with Local Control, Type 0x0C, Pilotwire
+// Test Case : Teach-in Test
+//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
+    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x0C, 0x01, 0xD2, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xAE },
+// Test Case : Actuator Status Response 
+    { ESP3_SER_SYNC, 0x00, 0x08, 0x07, PACKET_RADIO_ERP1, 0x3D, RORG_VLD, 0x0A, 0x01, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xB8 },
+// Test Case : Reply Measurement Response
+    { ESP3_SER_SYNC, 0x00, 0x0C, 0x07, PACKET_RADIO_ERP1, 0x96, RORG_VLD, 0x07, 0x20, 0x00, 0x00, 0x00, 0x10, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xC9 },
+#endif
+
 #ifdef ESP3_TESTS_VLD_D2_01_12
 // D2-01-12, Slot-in module, dual channels, with external button control
 // Test Case : Teach-in Test
@@ -1569,17 +1580,6 @@ static const std::vector<uint8_t> ESP3TestsCases[] =
 // VLD msg: Actuator Status Response, Channel 1 status Off
 	{ ESP3_SER_SYNC, 0x00, 0x09, 0x07, PACKET_RADIO_ERP1, 0x56, RORG_VLD, 0x04, 0x61, 0x80, 0x01, RORG_VLD, 0x01, 0x12, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xAE },
 #endif // ESP3_TESTS_VLD_D2_01_12
-
-#ifdef ESP3_TESTS_VLD_D2_01_0C
-// D2-01-0C, Electronic Switches and Dimmers with Local Control, Type 0x0C, Pilotwire
-// Test Case : Teach-in Test
-//  Bi-directional teach-in or teach-out request from Node 00D2010C, response expected
-    { ESP3_SER_SYNC, 0x00, 0x0D, 0x07, PACKET_RADIO_ERP1, 0xFD, RORG_UTE, 0x40, 0x01, 0x46, 0x00, 0x0C, 0x01, 0xD2, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x29, 0x00, 0xAE },
-// Test Case : Actuator Status Response 
-    { ESP3_SER_SYNC, 0x00, 0x08, 0x07, PACKET_RADIO_ERP1, 0x3D, RORG_VLD, 0x0A, 0x01, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xB8 },
-// Test Case : Reply Measurement Response
-    { ESP3_SER_SYNC, 0x00, 0x0C, 0x07, PACKET_RADIO_ERP1, 0x96, RORG_VLD, 0x07, 0x20, 0x00, 0x00, 0x00, 0x10, 0x01, 0xD2, 0x01, 0x0C, 0x00, 0x01, 0xFF, 0xFF, 0xFF, 0xFF, 0x2D, 0x00, 0xC9 },
-#endif
 
 #ifdef ESP3_TESTS_VLD_D2_03_0A
 // D2-03-0A, Push Button – Single Button
@@ -1740,6 +1740,7 @@ bool CEnOceanESP3::OpenSerialDevice()
 
 #ifdef ENABLE_ESP3_TESTS
 	Debug(DEBUG_NORM, "------------ ESP3 tests begin ---------------------------");
+	
 	EnableLearnMode(1);
 
 	for (const auto &itt : ESP3TestsCases)
@@ -1884,7 +1885,6 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		return false; // Only allowed to control switches or selectors
 
 	NodeInfo* pNode = GetNodeInfo(nodeID);
-
 	if (pNode == nullptr)
 	{ // May happend if database contains invalid devices
 		Log(LOG_ERROR, "Node %08X can not be used as a switch", nodeID);
@@ -2126,7 +2126,7 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 		int channel = tsen->LIGHTING2.unitcode - 1;
 		int cmd = tsen->LIGHTING2.cmnd;
 		int pos;
-		
+
 		// don't keep the last position if the request is for a different node!
 		if (m_last_requested_blind_nodeID != nodeID)
 		{
@@ -2140,9 +2140,9 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 			pos = m_last_requested_blind_position;
 
 		if (m_last_requested_blind_position == pos)
-		{
-			//send command stop si rappuie
+		{ // Send stop command when pressed again
 			Debug(DEBUG_NORM, "Send stop to Blinds Control Node %08X", nodeID);
+
 			sendVld(m_id_chip, nodeID, D20500_CMD2, channel, 2, END_ARG_DATA);
 			m_last_requested_blind_position = -1;
 		}
@@ -2564,6 +2564,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					Log(LOG_NORM, "4BS msg: Unknown Node %08X, please proceed to teach-in", senderID);
 					return;
 				}
+
 				CheckAndUpdateNodeRORG(pNode, RORG_4BS);
 
 				Debug(DEBUG_NORM, "4BS msg: Node %08X EEP %02X-%02X-%02X (%s) Data %02X %02X %02X %02X",
@@ -3300,7 +3301,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					}
 					time_t now = GetClockTicks();
 					if (m_RPS_teachin_timer != 0 && now > (m_RPS_teachin_timer + TEACH_MAX_DELAY))
-					{ // Max delay expired => teach-in request ignored
+					{ // Max delay expired => teach-in request timed out
 						m_RPS_teachin_nodeID = 0;
 						Log(LOG_NORM, "RPS teach-in request from Node %08X (timed out)", senderID);
 						return;
@@ -3310,7 +3311,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 						Log(LOG_NORM, "RPS teach-in request #%u from Node %08X", m_RPS_teachin_count, senderID);
 						return;
 					}
-					// Received 3 identical telegrams from the node within delay
+					// Received TEACH_NB_REQUESTS identical telegrams from the node within delay
 					// RPS teachin
 
 					m_RPS_teachin_nodeID = 0;
@@ -3648,7 +3649,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 							tsen.LIGHTING2.id3 = (BYTE) ID_BYTE1;
 							tsen.LIGHTING2.id4 = (BYTE) ID_BYTE0;
 							tsen.LIGHTING2.level = 0;
-							tsen.LIGHTING2.unitcode = nbc;
+							tsen.LIGHTING2.unitcode = (BYTE) nbc;
 							tsen.LIGHTING2.cmnd = light2_sOff;
 							tsen.LIGHTING2.rssi = rssi;
 
@@ -4174,7 +4175,6 @@ const char *CEnOceanESP3::GetFunctionReturnCodeDescription(const uint8_t RC)
 	return ">>Unkown function return code... Please report!<<";
 }
 
-///---------------------------------------------------------------------------
 std::string CEnOceanESP3::GetDbValue(const char *tableName, const char *fieldName, const char *whereFieldName, const char *whereFielValue)
 {
 	std::vector<std::vector<std::string>> result;
@@ -4210,7 +4210,7 @@ void CEnOceanESP3::sendVld(unsigned int sID, unsigned int destID, int channel, i
 	SendESP3PacketQueued(PACKET_RADIO_ERP1, buff, 9, opt, 7);
 }
 
-//send a VLD datagramm with payload : data to device Id sID
+// Send a VLD datagramm with payload : data to device Id sID
 void CEnOceanESP3::sendVld(unsigned int sID, unsigned int destID, unsigned char *data, int DataLen)
 {
 	unsigned char buffer[256];
@@ -4491,7 +4491,7 @@ namespace http
 
 			int rc = pESP3Hardware->IsNodeTeachedInJSON(root);
 
-			pESP3Hardware->Debug(DEBUG_NORM, "Cmd_EnOceanESP3IsNodeTeachedIn: %s", (rc == 0) ? "waiting..." : (rc == 1) ? "OK" : "Timed out!");
+			pESP3Hardware->Debug(DEBUG_NORM, "Cmd_EnOceanESP3IsNodeTeachedIn: %s", (rc == 0) ? "waiting..." : ((rc == 1) ? "OK" : "Timed out!"));
 
 			root["status"] = "OK";
 			root["title"] = "EnOceanESP3IsNodeTeachedIn";

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -3556,10 +3556,10 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 				uint8_t node_func = data[6];
 				uint8_t node_RORG = data[7];
 
-				Log(LOG_NORM, "UTE %s-directional %s request from Node %08X, nb_channels %u, %sresponse expected",
+				Log(LOG_NORM, "UTE %s-directional %s request from Node %08X, %sresponse expected",
 					(ute_direction == 0) ? "uni" : "bi",
 					(ute_request == 0) ? "teach-in" : ((ute_request == 1) ? "teach-out" : "teach-in or teach-out"),
-					senderID, num_channel,
+					senderID,
 					(ute_response == 0) ? "" : "no ");
 
 				uint8_t buf[13];
@@ -3622,10 +3622,15 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					}
 					// Node not found and learn mode enabled and teach-in request : add it to the database
 
-					Log(LOG_NORM, "Creating Node %08X Manufacturer %03X (%s) EEP %02X-%02X-%02X (%s), %u channel%s",
-						senderID, node_manID, GetManufacturerName(node_manID),
-						node_RORG, node_func, node_type, GetEEPLabel(node_RORG, node_func, node_type),
-						num_channel, (num_channel > 1) ? "s" : "");
+					if (num_channel != 0xFF)
+						Log(LOG_NORM, "Creating Node %08X Manufacturer %03X (%s) EEP %02X-%02X-%02X (%s), %u channel%s",
+							senderID, node_manID, GetManufacturerName(node_manID),
+							node_RORG, node_func, node_type, GetEEPLabel(node_RORG, node_func, node_type),
+							num_channel, (num_channel > 1) ? "s" : "");
+					else
+						Log(LOG_NORM, "Creating Node %08X Manufacturer %03X (%s) EEP %02X-%02X-%02X (%s)",
+							senderID, node_manID, GetManufacturerName(node_manID),
+							node_RORG, node_func, node_type, GetEEPLabel(node_RORG, node_func, node_type));
 
 					TeachInNode(senderID, node_manID, node_RORG, node_func, node_type, TEACHEDIN_NODE);
 
@@ -3689,7 +3694,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					}
 					if (pNode->RORG == RORG_VLD && pNode->func == 0x05 && (pNode->type == 0x00 || pNode->type == 0x01))
 					{ // Create for D2-05-0X, Blind Control for Position and Angle, Type 0x00
-						for (int nbc = 0; nbc < num_channel; nbc++)
+						for (uint8_t nbc = 0; nbc < num_channel; nbc++)
 						{
 							Log(LOG_NORM, "TEACH Blinds Switch : 0xD2 Node 0x%08x UnitID: %02X cmd: %02X ", senderID, nbc + 1, light2_sOff);
 

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -3808,7 +3808,6 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					if (CMD == 0x7)
 					{ // Actuator Measurement Response
 						std::string mes = printRawDataValues(&data[1], D20100_CMD7);
-
 						Debug(DEBUG_NORM, "VLD msg: Node %08X (%s) Reply Measurement Response\n%s",
 							senderID, pNode->name.c_str(), mes.c_str());
 
@@ -3840,7 +3839,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 						uint8_t PM = GetRawValue(&data[1], D20100_CMD10, D20100_CMD10_PM);
 
 						std::string mes = printRawDataValues(&data[1], D20100_CMD10);
-						Debug(DEBUG_NORM, "VLD msg: Node %08X (%s) status\n%s", senderID, pNode->name.c_str(), mes);
+						Debug(DEBUG_NORM, "VLD msg: Node %08X (%s) status\n%s", senderID, pNode->name.c_str(), mes.c_str());
 
 						std::string sValue = std::to_string(PM * 10);
 						SendSelectorSwitch(senderID, 1, sValue, pNode->name, 0, false, "Off|Conf|Eco|Freeze|Conf-1|Conf-2", "00|10|20|30|40|50|60", false, m_Name);

--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -16,7 +16,7 @@ class CEnOceanESP3 : public CEnOceanEEP, public AsyncSerial, public CDomoticzHar
 public:
 	enum TeachinMode : uint8_t
 	{
-		GENERIC_NODE = 0,
+		GENERIC_NODE = 0, // WARNING : Do not change this value !!
 		TEACHEDIN_NODE = 1,
 		VIRTUAL_NODE = 2
 	};

--- a/www/app/hardware/setup/EnOceanESP3.js
+++ b/www/app/hardware/setup/EnOceanESP3.js
@@ -262,6 +262,9 @@ define(['app'], function (app) {
 			// Populate EnOcean RORG combo
 			$("#noderorg").html("");
 			$.each($.rorgtbl, function (i, item) {
+
+				// TODO : if node is virtual, put only allowed values in RORG combo
+
 				var option = $("<option />");
 				option.attr("value", item.rorg).text(item.label + " (" + addLeadingZeros(parseInt(item.rorg).toString(16).toUpperCase(), 2) +")");
 				$("#noderorg").append(option);
@@ -300,6 +303,9 @@ define(['app'], function (app) {
 			var eepfound = false;
 			$.each($.eeptbl, function (i, item) {
 				if (item.rorg == rorg) {
+
+					// TODO : if node is virtual, put only allowed values in EEP combo
+
 					var option = $("<option />");
 					option.attr("value", item.eep).text(item.eep);
 					$("#nodeeep").append(option);
@@ -383,7 +389,7 @@ define(['app'], function (app) {
 				dataType: "json",
 				success: function (data, status) {
 					if (data.result === 1) { // An EnOcean node has been teached-in
-						$scope.esp3_nodeid = data.nodeid;
+						$scope.esp3_nodeid = addLeadingZeros(parseInt(data.nodeid).toString(16).toUpperCase(), 8);
 						$scope.esp3_manufacturername = data.manufacturername;
 						$scope.esp3_eep = data.eep;
 						$scope.esp3_description = data.description;


### PR DESCRIPTION
Add support for all D2-01-XX EEP nodes that conform to EnOcean Equipment Profiles (EEP) - Version: 2.6.8.
Create necessary devices to operate these nodes from domoticz (switches for switches/dimmers modules, selector for pilot wire module, blind controller for blind modules).

Tested with Permundo PSC234 smart plug (EEP : D2-01-09) which I own.
Should also work for other D2-01-XX EEP, but probably need some beta testing !
Wiki documentation will be updated once this PR has been merged.

Other fixes and misc. :
- Add node name to log/debug msg to improve readability
- Fix devices default_name and battery_level when sending EnOcean commands
- Fix NodeID in EnOcean teach-in dialog
- Add and use UNKNOW_RORG value... when an EnOcean node RORG isn't known yet
- Fix EEP lookup member functions
- Fix ESP3 tests
- Add some integrity checks to CheckAndUpdateNodeRORG
- Add some integrity checks when receiving unexpected telegrams ou searching nodes in the database
- Tag generic/virtual nodes created by domotics as DOMOTICZ_MANUFACTURER instead of UNKNOWN_MANUFACTURER
- Inline added VLD management functs : createOtherVldUteDevices and manageVldMessage (no functional changes)
+ several misc. small fixes, typos, comments
