### PR TITLE
Better handling of remote and local proxy headers

### DIFF
--- a/test/lighttpd_proxy.conf
+++ b/test/lighttpd_proxy.conf
@@ -1,0 +1,68 @@
+# A lighttpd config file for Domoticz, serving the UI as Static content and proying only API calls to Domoticz
+#
+# Make sure you set the Document-root to your full-path of the Domoticz WWW directory
+#
+# All calls to 'json.htm' will be proxied to the Domoticz webserver/webservice that is expected to run on port 8080 (No SSL)
+# You can start Domoticz for example with the following config
+# sudo ./bin/domoticz -www 8080 -wwwroot www -loglevel debug,error -debuglevel webserver
+#
+# Domoticz will show the (web)requests it handles (should be the json.htm ones only)
+# And you can tail the lighttpd logfile (/tmp/lighttpd.log) to see all other static requests being handled by lighttpd
+#
+# Start this script from your Domoticz home directory with:
+# lighttpd -D -f test/lighttpd.conf
+#
+# Now you can access Domoticz on port 8888 (http://localhost:8888)
+
+server.document-root = "/home/vagrant/domoticz/www/" 
+server.port = 8888
+
+accesslog.format = "%h %V %u %t \"%r\" %>s %b" 
+accesslog.filename = "/tmp/lighttpd.log"
+
+index-file.names = ( "index.html" )
+
+server.modules = (
+        "mod_indexfile",
+        "mod_accesslog",
+        "mod_rewrite",
+        "mod_proxy",
+        "mod_magnet"
+)
+mimetype.assign = (
+  ".html" => "text/html;charset=UTF-8", 
+  ".txt" => "text/plain;charset=UTF-8",
+  ".css" => "text/css;charset=UTF-8",
+  ".js" => "text/javascript;charset=UTF-8",
+  ".jpg" => "image/jpeg",
+  ".png" => "image/png",
+  ".json" => "application/json;charset=UTF-8"
+)
+
+proxy.forwarded = ( "for"          => 1,
+                   "proto"        => 1,
+                    #"host"        => 1,
+                    #"by"          => 1,
+                    #"remote_user" => 1
+)
+
+# Handle the zipped Javascript files
+$HTTP["url"] =~ ".js" {
+  url.rewrite-if-not-file = ( "^\/js\/(.*)\.js$" => "/js/$1.js.gz" )
+  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjs.lua" )
+}
+
+# Handle the zipped language files
+$HTTP["url"] =~ ".json" {
+  url.rewrite-if-not-file = ( "^\/i18n\/(.*)\.json$" => "/i18n/$1.json.gz" )
+  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjson.lua" )
+}
+
+proxy.server = ( "/" =>
+    ( "domoticzservice" =>
+      (
+        "host" => "localhost",
+        "port" => "8080"
+      )
+    )
+  )

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -930,7 +930,7 @@ namespace http {
 		{
 			if (network.empty())
 			{
-				_log.Log(LOG_ERROR, "[web:%s] Empty network string provided! Skipping...", GetPort().c_str());
+				_log.Log(LOG_STATUS, "[web:%s] Empty network string provided! Skipping...", GetPort().c_str());
 				return;
 			}
 
@@ -940,7 +940,7 @@ namespace http {
 			uint8_t iASize = (!ipnetwork.bIsIPv6) ? 4 : 16;
 			int ii;
 
-			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of local networks.", (ipnetwork.bIsIPv6 ? "6" : "4"), GetPort().c_str(), network.c_str());
+			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of local networks.", GetPort().c_str(), (ipnetwork.bIsIPv6 ? "6" : "4"), network.c_str());
 
 			if (network.find('*') != std::string::npos)
 			{
@@ -2239,7 +2239,19 @@ namespace http {
 
 		void cWebemRequestHandler::handle_request(const request& req, reply& rep)
 		{
-			_log.Debug(DEBUG_WEBSERVER, "[web:%s] Host:%s Uri:%s", myWebem->GetPort().c_str(), req.host_remote_address.c_str(), req.uri.c_str());
+			if(_log.IsDebugLevelEnabled(DEBUG_WEBSERVER))
+			{
+				_log.Debug(DEBUG_WEBSERVER, "[web:%s] Host:%s Uri:%s", myWebem->GetPort().c_str(), req.host_remote_address.c_str(), req.uri.c_str());
+				if(_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
+				{
+					std::string sHeaders;
+					for (const auto &header : req.headers)
+					{
+						sHeaders += header.name + ": " + header.value + "\n";
+					}
+					_log.Debug(DEBUG_RECEIVED, "[web:%s] Request Headers:\n%s", myWebem->GetPort().c_str(), sHeaders.c_str());
+				}
+			}
 
 			if(!myWebem->CheckVHost(req))
 			{


### PR DESCRIPTION
This (draft) PR is a start to implement better processing of the Proxy headers coming from both local- and external proxies that might be used when trying to connect to the Domoticz built-in webserver.

The current (2022.2) processing of Proxy headers is limited and can cause issues with clients trying to connect, but getting rejected (HTTP 403 response) is cases where multiple proxies are involved. (see Issue #5403 for example).

Better support for multiple different proxy headers and different ways of how these headers behave. And also see if the _proposed_
'Forwarded HTTP Extension' [RFC7239](https://www.rfc-editor.org/rfc/rfc7239.html) could be supported as multiple webservers/proxies already implemented it.