### PR TITLE
Improve Trusted Network processing and no more anonymous user

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3053,6 +3053,14 @@ bool CSQLHelper::OpenDatabase()
 					_log.Log(LOG_STATUS, "A default admin User called 'admin' has been added with a default password!");
 				}
 			}
+			// Remove these Pref vars as we do not use them anymore
+			DeletePreferencesVar("EnableTabLights");
+			DeletePreferencesVar("EnableTabTemp");
+			DeletePreferencesVar("EnableTabWeather");
+			DeletePreferencesVar("EnableTabUtility");
+			DeletePreferencesVar("EnableTabCustom");
+			DeletePreferencesVar("EnableTabScenes");
+			DeletePreferencesVar("EnableTabFloorplans");
 		}
 	}
 	else if (bNewInstall)
@@ -3241,34 +3249,6 @@ bool CSQLHelper::OpenDatabase()
 	if (!GetPreferencesVar("SmartMeterType", nValue))	//0=meter has decimals, 1=meter does not have decimals, need this for the day graph
 	{
 		UpdatePreferencesVar("SmartMeterType", 0);
-	}
-	if (!GetPreferencesVar("EnableTabLights", nValue))
-	{
-		UpdatePreferencesVar("EnableTabLights", 1);
-	}
-	if (!GetPreferencesVar("EnableTabTemp", nValue))
-	{
-		UpdatePreferencesVar("EnableTabTemp", 1);
-	}
-	if (!GetPreferencesVar("EnableTabWeather", nValue))
-	{
-		UpdatePreferencesVar("EnableTabWeather", 1);
-	}
-	if (!GetPreferencesVar("EnableTabUtility", nValue))
-	{
-		UpdatePreferencesVar("EnableTabUtility", 1);
-	}
-	if (!GetPreferencesVar("EnableTabCustom", nValue))
-	{
-		UpdatePreferencesVar("EnableTabCustom", 1);
-	}
-	if (!GetPreferencesVar("EnableTabScenes", nValue))
-	{
-		UpdatePreferencesVar("EnableTabScenes", 1);
-	}
-	if (!GetPreferencesVar("EnableTabFloorplans", nValue))
-	{
-		UpdatePreferencesVar("EnableTabFloorplans", 0);
 	}
 	if (!GetPreferencesVar("NotificationSensorInterval", nValue))
 	{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -40,7 +40,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 157
+#define DB_VERSION 158
 
 #define DEFAULT_ADMINUSER "admin"
 #define DEFAULT_ADMINPWD "domoticz"
@@ -3048,11 +3048,14 @@ bool CSQLHelper::OpenDatabase()
 				nValue = atoi(result[0][0].c_str());
 				if (nValue == 0)
 				{
-					// Add a default User as no users exist
+					// Add a default Admin User as no admin users exist
 					safe_query("INSERT INTO Users (Active, Username, Password, Rights, TabsEnabled) VALUES (1, '%s', '%s', %d, 63)", base64_encode(DEFAULT_ADMINUSER).c_str(), GenerateMD5Hash(DEFAULT_ADMINPWD).c_str(), http::server::URIGHTS_ADMIN);
 					_log.Log(LOG_STATUS, "A default admin User called 'admin' has been added with a default password!");
 				}
 			}
+		}
+		if (dbversion < 158)
+		{
 			// Remove these Pref vars as we do not use them anymore
 			DeletePreferencesVar("EnableTabLights");
 			DeletePreferencesVar("EnableTabTemp");
@@ -3069,7 +3072,7 @@ bool CSQLHelper::OpenDatabase()
 		query("INSERT INTO Plans (Name) VALUES ('$Hidden Devices')");
 		// Add hardware for internal use
 		safe_query("INSERT INTO Hardware (Name, Enabled, Type, Address, Port, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) VALUES ('Domoticz Internal',1, %d,'',1,'','',0,0,0,0,0,0)", HTYPE_DomoticzInternal);
-		safe_query("INSERT INTO Users (Active, Username, Password, Rights) VALUES (1, '%s', '%s', %d)", base64_encode(DEFAULT_ADMINUSER).c_str(), GenerateMD5Hash(DEFAULT_ADMINPWD).c_str(), http::server::URIGHTS_ADMIN);
+		safe_query("INSERT INTO Users (Active, Username, Password, Rights, TabsEnabled) VALUES (1, '%s', '%s', %d, 63)", base64_encode(DEFAULT_ADMINUSER).c_str(), GenerateMD5Hash(DEFAULT_ADMINPWD).c_str(), http::server::URIGHTS_ADMIN);
 	}
 	UpdatePreferencesVar("DB_Version", DB_VERSION);
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3119,11 +3119,9 @@ namespace http
 
 		void CWebServer::Cmd_GetConfig(WebEmSession& session, const request& req, Json::Value& root)
 		{
+			Cmd_GetVersion(session, req, root);
 			root["status"] = "ERR";
 			root["title"] = "GetConfig";
-			root["version"] = szAppVersion;
-			root["hash"] = szAppHash;
-			root["build_time"] = szAppDate;
 
 			int iUser;
 			if (session.username.empty() || (iUser = FindUser(session.username.c_str())) == -1)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3184,30 +3184,21 @@ namespace http
 
 			std::vector<std::vector<std::string>> result;
 
-			if ((UserID != 0) && (UserID != 10000))
+			result = m_sql.safe_query("SELECT TabsEnabled FROM Users WHERE (ID==%lu)", UserID);
+			if (!result.empty())
 			{
-				result = m_sql.safe_query("SELECT TabsEnabled FROM Users WHERE (ID==%lu)", UserID);
-				if (!result.empty())
-				{
-					int TabsEnabled = atoi(result[0][0].c_str());
-					bEnableTabLight = (TabsEnabled & (1 << 0));
-					bEnableTabScenes = (TabsEnabled & (1 << 1));
-					bEnableTabTemp = (TabsEnabled & (1 << 2));
-					bEnableTabWeather = (TabsEnabled & (1 << 3));
-					bEnableTabUtility = (TabsEnabled & (1 << 4));
-					bEnableTabCustom = (TabsEnabled & (1 << 5));
-					bEnableTabFloorplans = (TabsEnabled & (1 << 6));
-				}
+				int TabsEnabled = atoi(result[0][0].c_str());
+				bEnableTabLight = (TabsEnabled & (1 << 0));
+				bEnableTabScenes = (TabsEnabled & (1 << 1));
+				bEnableTabTemp = (TabsEnabled & (1 << 2));
+				bEnableTabWeather = (TabsEnabled & (1 << 3));
+				bEnableTabUtility = (TabsEnabled & (1 << 4));
+				bEnableTabCustom = (TabsEnabled & (1 << 5));
+				bEnableTabFloorplans = (TabsEnabled & (1 << 6));
 			}
 			else
 			{
-				m_sql.GetPreferencesVar("EnableTabFloorplans", bEnableTabFloorplans);
-				m_sql.GetPreferencesVar("EnableTabLights", bEnableTabLight);
-				m_sql.GetPreferencesVar("EnableTabScenes", bEnableTabScenes);
-				m_sql.GetPreferencesVar("EnableTabTemp", bEnableTabTemp);
-				m_sql.GetPreferencesVar("EnableTabWeather", bEnableTabWeather);
-				m_sql.GetPreferencesVar("EnableTabUtility", bEnableTabUtility);
-				m_sql.GetPreferencesVar("EnableTabCustom", bEnableTabCustom);
+				_log.Log(LOG_ERROR,"Unable to find EnabledTabs settings for user (%d)", static_cast<int>(UserID));
 			}
 			if (iDashboardType == 3)
 			{
@@ -8570,13 +8561,6 @@ namespace http
 
 				m_sql.UpdatePreferencesVar("UseAutoUpdate", (request::findValue(&req, "checkforupdates") == "on" ? 1 : 0)); cntSettings++;
 				m_sql.UpdatePreferencesVar("UseAutoBackup", (request::findValue(&req, "enableautobackup") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabFloorplans", (request::findValue(&req, "EnableTabFloorplans") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabLights", (request::findValue(&req, "EnableTabLights") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabTemp", (request::findValue(&req, "EnableTabTemp") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabWeather", (request::findValue(&req, "EnableTabWeather") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabUtility", (request::findValue(&req, "EnableTabUtility") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabScenes", (request::findValue(&req, "EnableTabScenes") == "on" ? 1 : 0)); cntSettings++;
-				m_sql.UpdatePreferencesVar("EnableTabCustom", (request::findValue(&req, "EnableTabCustom") == "on" ? 1 : 0)); cntSettings++;
 				m_sql.UpdatePreferencesVar("HideDisabledHardwareSensors", (request::findValue(&req, "HideDisabledHardwareSensors") == "on" ? 1 : 0)); cntSettings++;
 				m_sql.UpdatePreferencesVar("ShowUpdateEffect", (request::findValue(&req, "ShowUpdateEffect") == "on" ? 1 : 0)); cntSettings++;
 				m_sql.UpdatePreferencesVar("FloorplanFullscreenMode", (request::findValue(&req, "FloorplanFullscreenMode") == "on" ? 1 : 0)); cntSettings++;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -320,19 +320,19 @@ namespace http
 
 			LoadUsers();
 
-			std::string WebLocalNetworks;
-			int nValue;
-			if (m_sql.GetPreferencesVar("WebLocalNetworks", nValue, WebLocalNetworks))
+			std::string TrustedNetworks;
+			if (m_sql.GetPreferencesVar("WebLocalNetworks", TrustedNetworks))
 			{
 				std::vector<std::string> strarray;
-				StringSplit(WebLocalNetworks, ";", strarray);
+				StringSplit(TrustedNetworks, ";", strarray);
 				for (const auto& str : strarray)
 					m_pWebEm->AddTrustedNetworks(str);
 			}
 			if (bIgnoreUsernamePassword)
 			{
-				m_pWebEm->AddTrustedNetworks("0.0.0.0/0");
-				_log.Log(LOG_STATUS, "Allowing access without username/password as all incoming traffic is considered trusted! SECURITY RISK!");
+				m_pWebEm->AddTrustedNetworks("0.0.0.0/0");	// IPv4
+				m_pWebEm->AddTrustedNetworks("::");	// IPv6
+				_log.Log(LOG_ERROR, "SECURITY RISK! Allowing access without username/password as all incoming traffic is considered trusted!");
 			}
 
 			// register callbacks

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -318,19 +318,21 @@ namespace http
 			m_pWebEm->SetDigistRealm(sRealm);
 			m_pWebEm->SetSessionStore(this);
 
-			if (!bIgnoreUsernamePassword)
-			{
-				LoadUsers();
+			LoadUsers();
 
-				std::string WebLocalNetworks;
-				int nValue;
-				if (m_sql.GetPreferencesVar("WebLocalNetworks", nValue, WebLocalNetworks))
-				{
-					std::vector<std::string> strarray;
-					StringSplit(WebLocalNetworks, ";", strarray);
-					for (const auto& str : strarray)
-						m_pWebEm->AddLocalNetworks(str);
-				}
+			std::string WebLocalNetworks;
+			int nValue;
+			if (m_sql.GetPreferencesVar("WebLocalNetworks", nValue, WebLocalNetworks))
+			{
+				std::vector<std::string> strarray;
+				StringSplit(WebLocalNetworks, ";", strarray);
+				for (const auto& str : strarray)
+					m_pWebEm->AddTrustedNetworks(str);
+			}
+			if (bIgnoreUsernamePassword)
+			{
+				m_pWebEm->AddTrustedNetworks("0.0.0.0/0");
+				_log.Log(LOG_STATUS, "Allowing access without username/password as all incoming traffic is considered trusted! SECURITY RISK!");
 			}
 
 			// register callbacks
@@ -8694,7 +8696,7 @@ namespace http
 
 				std::string WebLocalNetworks = CURLEncode::URLDecode(request::findValue(&req, "WebLocalNetworks"));
 				m_sql.UpdatePreferencesVar("WebLocalNetworks", WebLocalNetworks);
-				m_webservers.ReloadLocalNetworks();
+				m_webservers.ReloadTrustedNetworks();
 				cntSettings++;
 				cntSettings++;
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -332,7 +332,7 @@ namespace http
 			{
 				m_pWebEm->AddTrustedNetworks("0.0.0.0/0");	// IPv4
 				m_pWebEm->AddTrustedNetworks("::");	// IPv6
-				_log.Log(LOG_ERROR, "SECURITY RISK! Allowing access without username/password as all incoming traffic is considered trusted!");
+				_log.Log(LOG_ERROR, "SECURITY RISK! Allowing access without username/password as all incoming traffic is considered trusted! Change admin password asap and restart Domoticz!");
 			}
 
 			// register callbacks
@@ -3183,23 +3183,17 @@ namespace http
 			int bEnableTabCustom = 1;
 
 			std::vector<std::vector<std::string>> result;
-
 			result = m_sql.safe_query("SELECT TabsEnabled FROM Users WHERE (ID==%lu)", UserID);
-			if (!result.empty())
-			{
-				int TabsEnabled = atoi(result[0][0].c_str());
-				bEnableTabLight = (TabsEnabled & (1 << 0));
-				bEnableTabScenes = (TabsEnabled & (1 << 1));
-				bEnableTabTemp = (TabsEnabled & (1 << 2));
-				bEnableTabWeather = (TabsEnabled & (1 << 3));
-				bEnableTabUtility = (TabsEnabled & (1 << 4));
-				bEnableTabCustom = (TabsEnabled & (1 << 5));
-				bEnableTabFloorplans = (TabsEnabled & (1 << 6));
-			}
-			else
-			{
-				_log.Log(LOG_ERROR,"Unable to find EnabledTabs settings for user (%d)", static_cast<int>(UserID));
-			}
+			int TabsEnabled = atoi(result[0][0].c_str());
+
+			bEnableTabLight = (TabsEnabled & (1 << 0));
+			bEnableTabScenes = (TabsEnabled & (1 << 1));
+			bEnableTabTemp = (TabsEnabled & (1 << 2));
+			bEnableTabWeather = (TabsEnabled & (1 << 3));
+			bEnableTabUtility = (TabsEnabled & (1 << 4));
+			bEnableTabCustom = (TabsEnabled & (1 << 5));
+			bEnableTabFloorplans = (TabsEnabled & (1 << 6));
+
 			if (iDashboardType == 3)
 			{
 				// Floorplan , no need to show a tab floorplan

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -102,7 +102,7 @@ namespace http {
 			}
 		}
 
-		void CWebServerHelper::ReloadLocalNetworks()
+		void CWebServerHelper::ReloadTrustedNetworks()
 		{
 			std::string WebLocalNetworks;
 			m_sql.GetPreferencesVar("WebLocalNetworks", WebLocalNetworks);
@@ -111,12 +111,12 @@ namespace http {
 			{
 				if (it->m_pWebEm == nullptr)
 					continue;
-				it->m_pWebEm->ClearLocalNetworks();
+				it->m_pWebEm->ClearTrustedNetworks();
 
 				std::vector<std::string> strarray;
 				StringSplit(WebLocalNetworks, ";", strarray);
 				for (const auto &str : strarray)
-					it->m_pWebEm->AddLocalNetworks(str);
+					it->m_pWebEm->AddTrustedNetworks(str);
 			}
 		}
 

--- a/main/WebServerHelper.cpp
+++ b/main/WebServerHelper.cpp
@@ -104,8 +104,8 @@ namespace http {
 
 		void CWebServerHelper::ReloadTrustedNetworks()
 		{
-			std::string WebLocalNetworks;
-			m_sql.GetPreferencesVar("WebLocalNetworks", WebLocalNetworks);
+			std::string TrustedNetworks;
+			m_sql.GetPreferencesVar("WebLocalNetworks", TrustedNetworks);
 
 			for (auto &it : serverCollection)
 			{
@@ -114,7 +114,7 @@ namespace http {
 				it->m_pWebEm->ClearTrustedNetworks();
 
 				std::vector<std::string> strarray;
-				StringSplit(WebLocalNetworks, ";", strarray);
+				StringSplit(TrustedNetworks, ";", strarray);
 				for (const auto &str : strarray)
 					it->m_pWebEm->AddTrustedNetworks(str);
 			}

--- a/main/WebServerHelper.h
+++ b/main/WebServerHelper.h
@@ -22,7 +22,7 @@ namespace http {
 			void SetWebRoot(const std::string &webRoot);
 			void LoadUsers();
 			void ClearUserPasswords();
-			void ReloadLocalNetworks();
+			void ReloadTrustedNetworks();
 			// called from OTGWBase()
 			void GetJSonDevices(Json::Value &root, const std::string &rused, const std::string &rfilter, const std::string &order, const std::string &rowid, const std::string &planID,
 					    const std::string &floorID, bool bDisplayHidden, bool bDisplayDisabled, bool bFetchFavorites, time_t LastUpdate, const std::string &username,

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1980,8 +1980,6 @@ namespace http {
 				}
 				if (session.rights == -1)
 					_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, but no Admin User found!");
-				else
-					_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, so assume first Admin User (%s)!", session.username.c_str());
 			}
 
 			//Check for valid JWT token
@@ -2374,7 +2372,7 @@ namespace http {
 			// Check if this is an upgrade request to a websocket connection
 			bool isUpgradeRequest = is_upgrade_request(session, req, rep);
 			bool isAuthenticated = CheckAuthentication(session, req, rep);
-			_log.Debug(DEBUG_AUTH,"[web:%s] isPage %d isAction %d isUpgrade %d isAuthenticated %d", myWebem->GetPort().c_str(), isPage, isAction, isUpgradeRequest, isAuthenticated);
+			_log.Debug(DEBUG_AUTH,"[web:%s] isPage %d isAction %d isUpgrade %d isAuthenticated %d (%s)", myWebem->GetPort().c_str(), isPage, isAction, isUpgradeRequest, isAuthenticated, session.username.c_str());
 
 			// Check user authentication on each page or action, if it exists.
 			if ((isPage || isAction || isUpgradeRequest) && !isAuthenticated)

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -940,7 +940,7 @@ namespace http {
 			uint8_t iASize = (!ipnetwork.bIsIPv6) ? 4 : 16;
 			int ii;
 
-			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of trusted networks.", (ipnetwork.bIsIPv6 ? "6" : "4"), GetPort().c_str(), network.c_str());
+			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of trusted networks.", GetPort().c_str(), (ipnetwork.bIsIPv6 ? "6" : "4"), network.c_str());
 
 			if (network.find('*') != std::string::npos)
 			{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1589,12 +1589,12 @@ namespace http {
 					return false;
 
 			// As all segments of the given IP fit within the given network range, otherwise we wouldn't be here
-			_log.Debug(DEBUG_WEBSERVER,"[web:%s] IP (%s) is within Localnetwork range!",myWebem->GetPort().c_str(), ip.c_str());
+			_log.Debug(DEBUG_WEBSERVER,"[web:%s] IP (%s) is within Trusted network range!",myWebem->GetPort().c_str(), ip.c_str());
 			return true;
 		}
 
-		//Returns true is the connected host is in the local network
-		bool cWebemRequestHandler::AreWeInLocalNetwork(const std::string &sHost)
+		//Returns true is the connected host is in the trusted network
+		bool cWebemRequestHandler::AreWeInTrustedNetwork(const std::string &sHost)
 		{
 			//Are there any local networks to check against?
 			if (myWebem->m_localnetworks.empty())
@@ -1605,7 +1605,7 @@ namespace http {
 			uint8_t IP[16] = { 0 };
 			if ( (sHost.size() < 3) || (inet_pton((!bIsIPv6) ? AF_INET : AF_INET6, sHost.c_str(), &IP) != 1) )
 			{
-				_log.Log(LOG_STATUS,"[web:%s] Given host (%s) is not a valid Ipv4 or IPv6 address! Unable to check if in LocalNetwork!", myWebem->GetPort().c_str() ,sHost.c_str());
+				_log.Log(LOG_STATUS,"[web:%s] Given host (%s) is not a valid Ipv4 or IPv6 address! Unable to check if in Trusted Network!", myWebem->GetPort().c_str() ,sHost.c_str());
 				return false;	// The IP address is not a valid IPv4 or IPv6 address
 			}
 
@@ -1967,10 +1967,10 @@ namespace http {
 				_log.Debug(DEBUG_AUTH, "[Check] No userpasswords set, so set rights = 2 (Admin)!");
 			}
 
-			if (AreWeInLocalNetwork(session.remote_host))
+			if (AreWeInTrustedNetwork(session.remote_host))
 			{
 				session.rights = 2;
-				_log.Debug(DEBUG_AUTH, "[Check] Local network exception detected, so set rights = 2 (Admin)!");
+				_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, so set rights = 2 (Admin)!");
 			}
 
 			//Check for valid JWT token

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1969,8 +1969,19 @@ namespace http {
 
 			if (AreWeInTrustedNetwork(session.remote_host))
 			{
-				session.rights = 2;
-				_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, so set rights = 2 (Admin)!");
+				for (const auto &my : myWebem->m_userpasswords)
+				{
+					if (my.userrights == URIGHTS_ADMIN) // we found an admin
+					{
+						session.username = my.Username;
+						session.rights = my.userrights;
+						break;
+					}
+				}
+				if (session.rights == -1)
+					_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, but no Admin User found!");
+				else
+					_log.Debug(DEBUG_AUTH, "[Check] Trusted network exception detected, so assume first Admin User (%s)!", session.username.c_str());
 			}
 
 			//Check for valid JWT token

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -926,7 +926,7 @@ namespace http {
 			0b11111110, //
 		};
 
-		void cWebem::AddLocalNetworks(std::string network)
+		void cWebem::AddTrustedNetworks(std::string network)
 		{
 			if (network.empty())
 			{
@@ -940,7 +940,7 @@ namespace http {
 			uint8_t iASize = (!ipnetwork.bIsIPv6) ? 4 : 16;
 			int ii;
 
-			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of local networks.", GetPort().c_str(), (ipnetwork.bIsIPv6 ? "6" : "4"), network.c_str());
+			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of trusted networks.", (ipnetwork.bIsIPv6 ? "6" : "4"), GetPort().c_str(), network.c_str());
 
 			if (network.find('*') != std::string::npos)
 			{
@@ -1054,7 +1054,7 @@ namespace http {
 			m_localnetworks.push_back(ipnetwork);
 		}
 
-		void cWebem::ClearLocalNetworks()
+		void cWebem::ClearTrustedNetworks()
 		{
 			m_localnetworks.clear();
 		}

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -199,8 +199,8 @@ namespace http
 
 			void ClearUserPasswords();
 			std::vector<_tWebUserPassword> m_userpasswords;
-			void AddLocalNetworks(std::string network);
-			void ClearLocalNetworks();
+			void AddTrustedNetworks(std::string network);
+			void ClearTrustedNetworks();
 			std::vector<_tIPNetwork> m_localnetworks;
 			void SetDigistRealm(const std::string &realm);
 			std::string m_DigistRealm;

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -144,7 +144,7 @@ namespace http
 			std::string generateSessionID();
 			void send_cookie(reply &rep, const WebEmSession &session);
 			bool parse_cookie(const request &req, std::string &sSID, std::string &sAuthToken, std::string &szTime, bool &expired);
-			bool AreWeInLocalNetwork(const std::string &sHost);
+			bool AreWeInTrustedNetwork(const std::string &sHost);
 			bool IsIPInRange(const std::string &ip, const _tIPNetwork &ipnetwork, const bool &bIsIPv6);
 			int authorize(WebEmSession &session, const request &req, reply &rep);
 			void Logout();

--- a/www/app/LoginController.js
+++ b/www/app/LoginController.js
@@ -21,7 +21,7 @@ define(['app'], function (app) {
 			        HideNotify();
 					$scope.failcounter += 1;
 					if ($scope.failcounter > 3) {
-						window.location.href = "http://www.1112.net/lastpage.html";
+						window.location.href = "https://hmpg.net/";
 						return;
 					}
 					else {
@@ -30,16 +30,19 @@ define(['app'], function (app) {
 					return;
 			    }
 				var permissionList = {
-					isloggedin: true,
-					rights: 0
+					isloggedin: false,
+					rights: -1,
+					user: ''
 				};
 				if (data.user != "") {
 					permissionList.isloggedin = true;
+					permissionList.user = data.user;
 				}
 				permissionList.rights = parseInt(data.rights);
 				permissions.setPermissions(permissionList);
 
 				$rootScope.GetGlobalConfig();
+				$rootScope.config.userName = permissionList.user;
 
 				$location.path('/Dashboard');
 			}, function errorCallback(response) {

--- a/www/app/LoginController.js
+++ b/www/app/LoginController.js
@@ -42,7 +42,6 @@ define(['app'], function (app) {
 				permissions.setPermissions(permissionList);
 
 				$rootScope.GetGlobalConfig();
-				$rootScope.config.userName = permissionList.user;
 
 				$location.path('/Dashboard');
 			}, function errorCallback(response) {

--- a/www/app/LogoutController.js
+++ b/www/app/LogoutController.js
@@ -28,6 +28,7 @@ define(['app'], function (app) {
 						}
 					});
 					permissions.setPermissions(permissionList);
+					$rootScope.GetGlobalConfig();
 					window.location = '#/Dashboard';
 				},
 				error: function (xhr, status, error) {

--- a/www/app/LogoutController.js
+++ b/www/app/LogoutController.js
@@ -3,8 +3,9 @@ define(['app'], function (app) {
 
 		(function init() {
 			var permissionList = {
-				isloggedin: true,
-				rights: -1
+				isloggedin: false,
+				rights: -1,
+				user: ''
 			};
 			permissions.setPermissions(permissionList);
 			$.ajax({
@@ -20,6 +21,7 @@ define(['app'], function (app) {
 							if (data.status === "OK") {
 								if (data.user !== "") {
 									permissionList.isloggedin = true;
+									permissionList.user = data.user;
 								}
 								permissionList.rights = parseInt(data.rights, 10);
 							}

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -518,27 +518,6 @@ define(['app'], function (app) {
 					if (typeof data.SmartMeterType != 'undefined') {
 						$("#p1metertable #comboP1MeterType").val(data.SmartMeterType);
 					}
-					if (typeof data.EnableTabFloorplans != 'undefined') {
-						$("#activemenustable #EnableTabFloorplans").prop('checked', data.EnableTabFloorplans == 1);
-					}
-					if (typeof data.EnableTabLights != 'undefined') {
-						$("#activemenustable #EnableTabLights").prop('checked', data.EnableTabLights == 1);
-					}
-					if (typeof data.EnableTabScenes != 'undefined') {
-						$("#activemenustable #EnableTabScenes").prop('checked', data.EnableTabScenes == 1);
-					}
-					if (typeof data.EnableTabTemp != 'undefined') {
-						$("#activemenustable #EnableTabTemp").prop('checked', data.EnableTabTemp == 1);
-					}
-					if (typeof data.EnableTabWeather != 'undefined') {
-						$("#activemenustable #EnableTabWeather").prop('checked', data.EnableTabWeather == 1);
-					}
-					if (typeof data.EnableTabUtility != 'undefined') {
-						$("#activemenustable #EnableTabUtility").prop('checked', data.EnableTabUtility == 1);
-					}
-					if (typeof data.EnableTabCustom != 'undefined') {
-						$("#activemenustable #EnableTabCustom").prop('checked', data.EnableTabCustom == 1);
-					}
 					if (typeof data.NotificationSensorInterval != 'undefined') {
 						$("#nitable #comboNotificationSensorInterval").val(data.NotificationSensorInterval);
 					}

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -206,7 +206,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 					if (response && response.status === 401) {
 						var permissionList = {
 							isloggedin: false,
-							rights: -1
+							rights: -1,
+							user: ''
 						};
 						permissions.setPermissions(permissionList);
 						$location.path('/Login');
@@ -288,7 +289,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 	app.run(function ($rootScope, $location, $window, $route, $http, dzTimeAndSun, permissions) {
 		var permissionList = {
 			isloggedin: false,
-			rights: -1
+			rights: -1,
+			user: ''
 		};
 		permissions.setPermissions(permissionList);
 
@@ -356,7 +358,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 			pythonversion: "",
 			versiontooltip: "",
 			ShowUpdatedEffect: true,
-			DateFormat: "yy-mm-dd"
+			DateFormat: "yy-mm-dd",
+			userName: "Unknown"
 		};
 
 		$rootScope.GetGlobalConfig = function () {
@@ -515,6 +518,7 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				if (data.status == "OK") {
 					permissionList.isloggedin = (data.user != "");
 					permissionList.rights = parseInt(data.rights);
+					permissionList.user = data.user;
 					dashboardType = data.DashboardType;
 				}
 			},
@@ -562,6 +566,7 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 			}
 		});
 		permissions.setPermissions(permissionList);
+		$rootScope.config.userName = permissionList.user;
 
 		Highcharts.setOptions({
 			chart: {

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -374,6 +374,16 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 						$rootScope.config.appversion = data.version;
 						$rootScope.config.apphash = data.hash;
 						$rootScope.config.appdate = data.build_time;
+						$rootScope.config.dzventsversion = data.dzvents_version;
+						$rootScope.config.pythonversion = data.python_version;
+						$rootScope.config.isproxied = data.isproxied;
+						$rootScope.config.versiontooltip = "'Build Hash: <b>" + $rootScope.config.apphash + "</b><br>" + "Build Date: " + $rootScope.config.appdate + "'";
+						$("#appversion").text(data.version);
+						$rootScope.config.HaveUpdate = data.HaveUpdate;
+						$rootScope.config.UseUpdate = data.UseUpdate;
+						if ((data.HaveUpdate == true) && (data.UseUpdate)) {
+							ShowUpdateNotification(data.Revision, data.SystemName, data.DomoticzUpdateURL);
+						}
 
 						$rootScope.config.AllowWidgetOrdering = data.AllowWidgetOrdering;
 						$rootScope.config.FiveMinuteHistoryDays = data.FiveMinuteHistoryDays;
@@ -487,32 +497,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 		}
 
 		$rootScope.GetGlobalConfig();
-		$.ajax({
-			url: "json.htm?type=command&param=getversion",
-			async: false,
-			dataType: 'json',
-			success: function (data) {
-			    isOnline = true;
-				if (data.status == "OK") {
-				    $rootScope.config.appversion = data.version;
-					$rootScope.config.apphash = data.hash;
-					$rootScope.config.appdate = data.build_time;
-					$rootScope.config.dzventsversion = data.dzvents_version;
-					$rootScope.config.pythonversion = data.python_version;
-					$rootScope.config.isproxied = data.isproxied;
-					$rootScope.config.versiontooltip = "'Build Hash: <b>" + $rootScope.config.apphash + "</b><br>" + "Build Date: " + $rootScope.config.appdate + "'";
-					$("#appversion").text(data.version);
-					$rootScope.config.HaveUpdate = data.HaveUpdate;
-					$rootScope.config.UseUpdate = data.UseUpdate;
-					if ((data.HaveUpdate == true) && (data.UseUpdate)) {
-						ShowUpdateNotification(data.Revision, data.SystemName, data.DomoticzUpdateURL);
-					}
-				}
-			},
-			error: function () {
-				isOnline = false;
-			}
-		});
 
 		$.ajax({
 			url: "json.htm?type=command&param=getauth",

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -371,6 +371,10 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				success: function (data) {
 					isOnline = true;
 					if (data.status == "OK") {
+						$rootScope.config.appversion = data.version;
+						$rootScope.config.apphash = data.hash;
+						$rootScope.config.appdate = data.build_time;
+
 						$rootScope.config.AllowWidgetOrdering = data.AllowWidgetOrdering;
 						$rootScope.config.FiveMinuteHistoryDays = data.FiveMinuteHistoryDays;
 						$rootScope.config.DashboardType = data.DashboardType;
@@ -380,6 +384,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 						$rootScope.config.WindScale = data.WindScale;
 						$rootScope.config.WindSign = data.WindSign;
 						$rootScope.config.language = data.language;
+						$rootScope.config.DegreeDaysBaseTemperature = data.DegreeDaysBaseTemperature;
+						$rootScope.config.userName = data.UserName;
 						$rootScope.config.EnableTabDashboard = data.result.EnableTabDashboard,
 						$rootScope.config.EnableTabFloorplans = data.result.EnableTabFloorplans;
 						$rootScope.config.EnableTabLights = data.result.EnableTabLights;
@@ -388,7 +394,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 						$rootScope.config.EnableTabWeather = data.result.EnableTabWeather;
 						$rootScope.config.EnableTabUtility = data.result.EnableTabUtility;
 						$rootScope.config.ShowUpdatedEffect = data.result.ShowUpdatedEffect;
-						$rootScope.config.DegreeDaysBaseTemperature = data.result.DegreeDaysBaseTemperature;
 
 						SetLanguage(data.language);
 
@@ -566,7 +571,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 			}
 		});
 		permissions.setPermissions(permissionList);
-		$rootScope.config.userName = permissionList.user;
 
 		Highcharts.setOptions({
 			chart: {

--- a/www/app/app.permissions.js
+++ b/www/app/app.permissions.js
@@ -7,7 +7,8 @@ define(['angular'], function () {
             setPermissions: function (permissions) {
                 permissionList = permissions;
                 window.my_config = {
-                    userrights: permissionList.rights
+                    userrights: permissionList.rights,
+                    username: permissionList.user
                 };
                 $rootScope.$broadcast('permissionsChanged');
             },

--- a/www/index.html
+++ b/www/index.html
@@ -1307,11 +1307,11 @@ $(document).ready(function() {
 							<li class="divider"></li>
 							<li ng-class="{'current_page_item':getClass('/About')}" id="mAbout"><a id="cAbout" href="#About"><img src="images/about.png"> <span data-i18n="About">About</span></a></li>
 							<li id="dLogoutSetup" class="divider" style="display: none;" has-Login=true></li>
-							<li id="mLogoutSetup" style="display: none;" has-Login=true><a id="cLogout" href="#Logout"><img src="images/logout.png"> <span data-i18n="Logout">Logout</span></a></li>
+							<li id="mLogoutSetup" style="display: none;" has-Login=true><a id="cLogout" href="#Logout"><img src="images/logout.png"> <span data-i18n="Logout">Logout</span><br />({{config.userName}})</a></li>
 						</ul>
 					</li>
 					<li id="dLogout" class="divider-vertical" style="display: none;" has-Login-No-Admin=true></li>
-					<li id="mLogout" style="display: none;" has-Login-No-Admin=true><a id="cLogout" href="#Logout"><img src="images/logout.png"> <span class="hidden-phone hidden-tablet" data-i18n="Logout">Logout</span></a></li>
+					<li id="mLogout" style="display: none;" has-Login-No-Admin=true><a id="cLogout" href="#Logout"><img src="images/logout.png"> <span class="hidden-phone hidden-tablet" data-i18n="Logout">Logout</span><br />({{config.userName}})</a></li>
 				</ul>
 			</div>
 		</div>

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -199,35 +199,6 @@
 									</div>
 								</div>
 							</div>
-							<br>
-							<div class="row-fluid">
-								<div class="span12" id="ActiveTabs">
-									<h2><span data-i18n="ActiveMenus"></span>:</h2>
-									<table class="display" id="activemenustable" border="0" cellpadding="0" cellspacing="0">
-										<tr>
-											<td><input type="checkbox" id="EnableTabFloorplans" name="EnableTabFloorplans"> <label for="EnableTabFloorplans" data-i18n="Floorplan"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabLights" name="EnableTabLights"> <label for="EnableTabLights" data-i18n="Switches"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabScenes" name="EnableTabScenes"> <label for="EnableTabScenes" data-i18n="Scenes"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabTemp" name="EnableTabTemp"> <label for="EnableTabTemp" data-i18n="Temperature"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabWeather" name="EnableTabWeather"> <label for="EnableTabWeather" data-i18n="Weather"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabUtility" name="EnableTabUtility"> <label for="EnableTabUtility" data-i18n="Utility"></label></td>
-										</tr>
-										<tr>
-											<td><input type="checkbox" id="EnableTabCustom" name="EnableTabCustom"> <label for="EnableTabCustom" data-i18n="Custom"></label></td>
-										</tr>
-									</table>
-								</div>
-							</div>
 						</section>
 					</div>
 					<div class="tab-pane" id="tablog">


### PR DESCRIPTION
This PR improves the processing and handling of **Trusted networks**, which was called _local networks_ before.

Now, when a User connects from a Trusted network, the identity of the first _admin user_ is taken. So although no explicit User (and password) are given, **everything happens under a known identity now!**

Impact:

- There now always is a 'Logout' button in the menu (but you will get logged in immediately again when you are in a trusted network) which shows the Username of the logged-in user.
- On the `Setup/settings/system`-tab, there is no longer a system-wide option to set certain menu tabs on or off as now always the User settings will be used. (as this was actually not system-wide but only used for _anonymous_ access)
- The `-nowwwpwd` settings previously did not load any Users (so only anonymous access was possible), but now still all users are loaded. Now when this option is specified during startup, the `0.0.0.0/0` network mask (IPv4) and `::` (IPv6) is added which effectively means that _every ip-address_ (also on the Internet!) is considered part of a _trusted network_. Therefor no Username and Password are requested, allowing Users to reset the lost password(s). 

