### PR TITLE
Fix EcoDevices1 HP Jour Blanc (bug)

### DIFF
--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -169,7 +169,7 @@ void CEcoDevices::DecodeXML2Teleinfo(const std::string &sResult, Teleinfo &telei
 	teleinfo.BBRHCJB = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHCJB/text()");
 	teleinfo.BBRHPJB = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHPJB/text()");
 	teleinfo.BBRHCJW = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHCJW/text()");
-	teleinfo.BBRHPJW = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHPJB/text()");
+	teleinfo.BBRHPJW = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHPJW/text()");
 	teleinfo.BBRHCJR = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHCJR/text()");
 	teleinfo.BBRHPJR = i_xpath_int(XMLdoc.RootElement(), "/response/BBRHPJR/text()");
 	teleinfo.PEJP = i_xpath_int(XMLdoc.RootElement(), "/response/PEJP/text()");


### PR DESCRIPTION
On the EDF Tempo plan, there is 3 type of electricity bills. There were a mistake on HP JW (Heures Plein Jour Blanc) that still used the index of Jour Bleus (HPJB). This was maybe a typo, but fix the issue of not having HP when tarif is Jour Blanc.