### PR TITLE
Also domoticstester depends on the revisiontag being present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,6 +513,7 @@ set (domoticz_VERSION_PATCH ${ProjectRevision})
 
 # explicitly say that the executable depends on the revisiontag
 add_dependencies(domoticz revisiontag)
+add_dependencies(domoticztester revisiontag)
 
 TEST_BIG_ENDIAN(BIGENDIAN)
 IF(${BIGENDIAN})


### PR DESCRIPTION
Building `domoticztester` fails on a clean system because `appversion.h` is missing.

It is generated during the building of `domoticz`. Now it is also generated before the testing utility is build.

More info in the forum: https://www.domoticz.com/forum/viewtopic.php?f=47&t=39467

Thx to forum users **meal** and **ferrosk** for diving in the details.