### PR TITLE
Better handling of remote and local proxy headers - Continued

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -11,6 +11,7 @@ Version 2022.xxxx
 - Implemented: The Security realm can be configured using the 'vhostname' option (default domoticz.com)
 - Implemented: Search option in Switches/Scenes/Temperature/Utility and Weather tab
 - Implemented: User device selection now displays type/subtype
+- Changed: The following proxy headers are now properly supported 'Forwarded' (RFC7239), 'X-Forwarder-For' and 'X-Real-IP' (in that order)
 - Changed: All security related setting are now in 1 settings tab
 - Changed: Default 'admin' user is generated with standard password (see Users)
 - Changed: By default prompt for login to only allow secure access

--- a/test/lighttpd_proxy.conf
+++ b/test/lighttpd_proxy.conf
@@ -1,16 +1,18 @@
-# A lighttpd config file for Domoticz, serving the UI as Static content and proying only API calls to Domoticz
+# A lighttpd config file for proxying Domoticz traffic
 #
 # Make sure you set the Document-root to your full-path of the Domoticz WWW directory
 #
-# All calls to 'json.htm' will be proxied to the Domoticz webserver/webservice that is expected to run on port 8080 (No SSL)
+# ALL calls will be proxied to the Domoticz webserver/webservice that is expected to run on port 8080 (No SSL)
 # You can start Domoticz for example with the following config
 # sudo ./bin/domoticz -www 8080 -wwwroot www -loglevel debug,error -debuglevel webserver
+# Adding the 'received' flag (next to the webserver flag) to the debuglevel as well, will produce detailed input header debug info.
 #
-# Domoticz will show the (web)requests it handles (should be the json.htm ones only)
-# And you can tail the lighttpd logfile (/tmp/lighttpd.log) to see all other static requests being handled by lighttpd
+# Domoticz will show the (web)requests it handles
 #
 # Start this script from your Domoticz home directory with:
 # lighttpd -D -f test/lighttpd.conf
+#
+# Because lighttpd acts as a proxy, it will add Proxy-headers to the incoming requests when sending these through to Domoticz (visible with debug flags mentioned above)
 #
 # Now you can access Domoticz on port 8888 (http://localhost:8888)
 
@@ -18,7 +20,7 @@ server.document-root = "/home/vagrant/domoticz/www/"
 server.port = 8888
 
 accesslog.format = "%h %V %u %t \"%r\" %>s %b" 
-accesslog.filename = "/tmp/lighttpd.log"
+accesslog.filename = "/tmp/lighttpd_proxy.log"
 
 index-file.names = ( "index.html" )
 

--- a/test/lighttpd_proxy.conf
+++ b/test/lighttpd_proxy.conf
@@ -27,9 +27,7 @@ index-file.names = ( "index.html" )
 server.modules = (
         "mod_indexfile",
         "mod_accesslog",
-        "mod_rewrite",
-        "mod_proxy",
-        "mod_magnet"
+        "mod_proxy"
 )
 mimetype.assign = (
   ".html" => "text/html;charset=UTF-8", 
@@ -47,18 +45,6 @@ proxy.forwarded = ( "for"          => 1,
                     #"by"          => 1,
                     #"remote_user" => 1
 )
-
-# Handle the zipped Javascript files
-$HTTP["url"] =~ ".js" {
-  url.rewrite-if-not-file = ( "^\/js\/(.*)\.js$" => "/js/$1.js.gz" )
-  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjs.lua" )
-}
-
-# Handle the zipped language files
-$HTTP["url"] =~ ".json" {
-  url.rewrite-if-not-file = ( "^\/i18n\/(.*)\.json$" => "/i18n/$1.json.gz" )
-  magnet.attract-physical-path-to = ( "/home/vagrant/domoticz/test/lighttpd_gzippedjson.lua" )
-}
 
 proxy.server = ( "/" =>
     ( "domoticzservice" =>

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2400,36 +2400,12 @@ namespace http {
 			}
 			else if (!realHost.empty())
 			{
-				session.remote_host = realHost;
-				rep.originHost = realHost;
-			}
-
-			/*
-			for (const auto& ittNetwork : myWebem->m_localnetworks)
-			{
-				if (ittNetwork.ip_string.empty())
-					continue;
-				if (session.remote_host == ittNetwork.ip_string)
-				{
-					const char* host_header = request::get_req_header(&req, "X-Forwarded-For");
-					if (host_header != nullptr)
-					{
-						if (strstr(host_header, ",") != nullptr)
-						{
-							//Multiple proxies are used... this is not very common
-							host_header = request::get_req_header(&req, "X-Real-IP"); //try our NGINX header
-							if (!host_header)
-							{
-								_log.Log(LOG_ERROR, "[web:%s]: Multiple proxies are used (Or possible spoofing attempt), ignoring client request (remote address: %s)", myWebem->GetPort().c_str(), session.remote_host.c_str());
-								rep = reply::stock_reply(reply::forbidden);
-								return;
-							}
-						}
-						session.remote_host = host_header;
-					}
+				if (AreWeInTrustedNetwork(session.remote_host))
+				{	// We only use Proxy header information if the connection Domotic receives comes from a Trusted network
+					session.remote_host = realHost;		// replace the host of the connection with the originating host behind the proxies
+					rep.originHost = realHost;
 				}
 			}
-			*/
 
 			std::string remoteClientKey = session.remote_host + session.local_port;
 			auto itt_rc = m_remote_web_clients.find(remoteClientKey);

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1157,6 +1157,13 @@ namespace http {
 			m_session_clean_timer.async_wait([this](auto &&) { CleanSessions(); });
 		}
 
+		bool cWebem::HandleProxies(const request &req, WebEmSession &sessions)
+		{
+			bool bStatus = true;
+			_log.Debug(DEBUG_WEBSERVER, "[web:%s] Checking proxy headers!", GetPort().c_str());
+			return bStatus;
+		}
+
 		bool cWebem::CheckVHost(const request &req)
 		{
 			if (m_settings.vhostname.empty() || !m_settings.is_secure())	// Only do vhost checking for Secure (https) server
@@ -2280,6 +2287,13 @@ namespace http {
 			session.remote_port = req.host_remote_port;
 			session.local_host = req.host_local_address;
 			session.local_port = req.host_local_port;
+
+			// Let's examine possible proxies, etc.
+			if(!myWebem->HandleProxies(req, session))
+			{
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
 
 			for (const auto& ittNetwork : myWebem->m_localnetworks)
 			{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1167,38 +1167,40 @@ namespace http {
 			// These headers can occur multiple times, so need to be 'squashed' together
 			// And a single line can contain multiple (comma separated) values in order
 
-			bool bStatus = true;
 			std::vector<std::string> headers;
 			std::vector<std::string> hosts;
 
 			if (sumProxyHeader("Forwarded", req, headers))
-			{	// We found one or more Forwarded headers that need to be processed into a list of Hosts
+			{
+				// We found one or more Forwarded headers that need to be processed into a list of Hosts
 				if (!parseForwardedProxyHeader(headers, hosts))
 				{
-					bStatus = false;
+					return false;
 				}
 			}
 			else if (sumProxyHeader("X-Forwarded-For", req, headers))
-			{	// We found one or more X-Forwarded-For headers that need to be processed into a list of Hosts
+			{
+				// We found one or more X-Forwarded-For headers that need to be processed into a list of Hosts
 				if (!parseProxyHeader(headers, hosts))
 				{
-					bStatus = false;
+					return false;
 				}
 			}
 			else if (sumProxyHeader("X-Real-IP", req, headers))
-			{	// We found one or more X-Real-IP headers that need to be processed into a list of Hosts
+			{
+				// We found one or more X-Real-IP headers that need to be processed into a list of Hosts
 				if (!parseProxyHeader(headers, hosts))
 				{
-					bStatus = false;
+					return false;
 				}
 			}
-
-			if (hosts.size() >= 1)
+			else
 			{
-				realhost = hosts[0];	// Even if we found a chain of hosts, we always use the first (= origin)
+				return false;
 			}
 
-			return bStatus;
+			realhost = hosts[0];	// Even if we found a chain of hosts, we always use the first (= origin)
+			return true;
 		}
 
 		bool cWebem::sumProxyHeader(const std::string &sHeader, const request &req, std::vector<std::string> &vHeaderLines)

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1201,45 +1201,37 @@ namespace http {
 			return bStatus;
 		}
 
-		bool cWebem::sumProxyHeader(const std::string sHeader, const request &req, std::vector<std::string> &vHeaderLines)
+		bool cWebem::sumProxyHeader(const std::string &sHeader, const request &req, std::vector<std::string> &vHeaderLines)
 		{
-			uint8_t iFound = 0;
-
 			for (const auto &header : req.headers)
 			{
-				if (sHeader.compare(header.name) == 0)
+				if (header.name.find(sHeader)==0)
 				{
-					iFound++;
 					vHeaderLines.push_back(header.value);
 				}
 			}
 
-			return (iFound > 0);
+			return !vHeaderLines.empty();		// Assuming the function is called with an empty vHeaderLines to begin with
 		}
 
-		bool cWebem::parseProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts)
+		bool cWebem::parseProxyHeader(const std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts)
 		{
-			uint8_t iFound = 0;
-
 			for (const auto sLine : vHeaderLines)
 			{
 				std::vector<std::string> vLineParts;
 				StringSplit(sLine, ",", vLineParts);
 				for (std::string sPart : vLineParts)
 				{
-					iFound++;
 					stdstring_trimws(sPart);
 					vHosts.push_back(sPart);
 				}
 			}
 
-			return (iFound > 0);
+			return !vHosts.empty();		// Assuming the function is called with an empty vHosts to begin with
 		}
 
-		bool cWebem::parseForwardedProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts)
+		bool cWebem::parseForwardedProxyHeader(const std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts)
 		{
-			uint8_t iFound = 0;
-
 			for (const auto sLine : vHeaderLines)
 			{
 				std::vector<std::string> vLineParts;
@@ -1249,7 +1241,6 @@ namespace http {
 					stdstring_trimws(sPart);
 					if (std::size_t isPos = sPart.find("for=") != std::string::npos)
 					{
-						iFound++;
 						isPos = isPos + 3;
 						std::size_t iePos = sLine.length();
 						if (sPart.find(";", isPos) != std::string::npos)
@@ -1263,7 +1254,7 @@ namespace http {
 				}
 			}
 
-			return (iFound > 0);
+			return !vHosts.empty();		// Assuming the function is called with an empty vHosts to begin with
 		}
 
 		bool cWebem::CheckVHost(const request &req)

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -244,9 +244,9 @@ namespace http
 			/// store map between pages and application functions
 			std::map<std::string, webem_page_function> myPages_w;
 			void CleanSessions();
-			bool sumProxyHeader(const std::string sHeader, const request &req, std::vector<std::string> &vHeaderLines);
-			bool parseProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
-			bool parseForwardedProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
+			bool sumProxyHeader(const std::string &sHeader, const request &req, std::vector<std::string> &vHeaderLines);
+			bool parseProxyHeader(const std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
+			bool parseForwardedProxyHeader(const std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
 			session_store_impl_ptr mySessionStore; /// session store
 			/// request handler specialized to handle webem requests
 			/// Rene: Beware: myRequestHandler should be declared BEFORE myServer

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -196,6 +196,7 @@ namespace http
 			bool GenerateJwtToken(std::string &jwttoken, const std::string clientid, const std::string clientsecret, const std::string user, const uint32_t exptime, const Json::Value jwtpayload = "");
 			bool FindAuthenticatedUser(std::string &user, const request &req, reply &rep);
 			bool CheckVHost(const request &req);
+			bool HandleProxies(const request &req, WebEmSession &sessions);
 
 			void ClearUserPasswords();
 			std::vector<_tWebUserPassword> m_userpasswords;

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -196,7 +196,7 @@ namespace http
 			bool GenerateJwtToken(std::string &jwttoken, const std::string clientid, const std::string clientsecret, const std::string user, const uint32_t exptime, const Json::Value jwtpayload = "");
 			bool FindAuthenticatedUser(std::string &user, const request &req, reply &rep);
 			bool CheckVHost(const request &req);
-			bool HandleProxies(const request &req, WebEmSession &sessions);
+			bool findRealHostBehindProxies(const request &req, std::string &realhost);
 
 			void ClearUserPasswords();
 			std::vector<_tWebUserPassword> m_userpasswords;
@@ -244,6 +244,9 @@ namespace http
 			/// store map between pages and application functions
 			std::map<std::string, webem_page_function> myPages_w;
 			void CleanSessions();
+			bool sumProxyHeader(const std::string sHeader, const request &req, std::vector<std::string> &vHeaderLines);
+			bool parseProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
+			bool parseForwardedProxyHeader(std::vector<std::string> &vHeaderLines, std::vector<std::string> &vHosts);
 			session_store_impl_ptr mySessionStore; /// session store
 			/// request handler specialized to handle webem requests
 			/// Rene: Beware: myRequestHandler should be declared BEFORE myServer

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -431,6 +431,8 @@ namespace http {
 							// LogFormat "%h %l %u %f \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
 							// 127.0.0.1 - frank [10/Oct/2000:13:55:36.012 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://my.domoticz.local/index.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
 							std::string wlHost = request_.host_remote_address;
+							if (!reply_.originHost.empty())
+								wlHost = reply_.originHost;
 							std::string wlUser = "-";	// Maybe we can fill this sometime? Or maybe not so we don't expose sensitive data?
 							std::string wlReqUri = request_.method + " " + request_.uri + " HTTP/" + std::to_string(request_.http_version_major) + (request_.http_version_minor ? "." + std::to_string(request_.http_version_minor): "");
 							std::string wlReqRef = "-";

--- a/webserver/connection.cpp
+++ b/webserver/connection.cpp
@@ -430,9 +430,7 @@ namespace http {
 							// Follow Apache's Combined Log Format, allows easy processing by 3rd party tools
 							// LogFormat "%h %l %u %f \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"" combined
 							// 127.0.0.1 - frank [10/Oct/2000:13:55:36.012 -0700] "GET /apache_pb.gif HTTP/1.0" 200 2326 "http://my.domoticz.local/index.html" "Mozilla/4.08 [en] (Win98; I ;Nav)"
-							std::string wlHost = request_.host_remote_address;
-							if (!reply_.originHost.empty())
-								wlHost = reply_.originHost;
+							std::string wlHost = (reply_.originHost.empty()) ? request_.host_remote_address : reply_.originHost;
 							std::string wlUser = "-";	// Maybe we can fill this sometime? Or maybe not so we don't expose sensitive data?
 							std::string wlReqUri = request_.method + " " + request_.uri + " HTTP/" + std::to_string(request_.http_version_major) + (request_.http_version_minor ? "." + std::to_string(request_.http_version_minor): "");
 							std::string wlReqRef = "-";

--- a/webserver/reply.hpp
+++ b/webserver/reply.hpp
@@ -53,6 +53,9 @@ struct reply
   std::string content;
   bool bIsGZIP;
 
+  /// The origin of the web request when behind proxies, etc.
+  std::string originHost;
+
   /// Convert the reply into a vector of buffers. The buffers do not own the
   /// underlying memory blocks, therefore the reply object must remain valid and
   /// not be changed until the write operation has completed.


### PR DESCRIPTION
This PR is a continuation of implementing better processing of the Proxy headers coming from both local- and external proxies that might be used when trying to connect to the Domoticz built-in webserver. (See PR #5425 )

The current (2022.2) processing of Proxy headers is limited and can cause issues with clients trying to connect, but getting rejected (HTTP 403 response) is cases where multiple proxies are involved. (see Issue #5403 for example).

The PR provides better support for multiple different proxy headers and different ways of how these headers behave. Also now it supports the proposed 'Forwarded HTTP Extension' [RFC7239](https://www.rfc-editor.org/rfc/rfc7239.html) as multiple webservers/proxies already implemented it.

It looks for the following headers, in order of importance (if it finds one, it will not look for others):

- `Forwarded` (RFC7239)
- `X-Forwarded-For`
- `X-Real-IP`

If it finds one of these headers, it will try to process it. 

_When the header can not be processed correctly because it does not comply to the specification, it is considered as an hacking attempt and the request will be denied_!