### PR TITLE
Improvements and refactoring of some authchecks 

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -4205,11 +4205,7 @@ namespace http {
 			std::string cparam = request::findValue(&req, "param");
 			if (cparam.empty())
 			{
-				cparam = request::findValue(&req, "dparam");
-				if (cparam.empty())
-				{
-					return;
-				}
+				return;
 			}
 
 			std::vector<std::vector<std::string> > result;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3119,12 +3119,7 @@ namespace http
 
 			int iUser = -1;
 			unsigned long UserID = -1;
-			if (session.username.empty() || (iUser = FindUser(session.username.c_str())) == -1)
-			{
-				root["message"] = "Unable to find a logged-in User!";
-				//return;
-			}
-			else
+			if (!session.username.empty() && (iUser = FindUser(session.username.c_str())) != -1)
 			{
 				UserID = m_users[iUser].ID;
 				root["UserName"] = m_users[iUser].Username;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2994,10 +2994,10 @@ namespace http
 			root["title"] = "GetAuth";
 			if (session.rights != -1)
 			{
+				root["user"] = session.username;
+				root["rights"] = session.rights;
 				root["version"] = szAppVersion;
 			}
-			root["user"] = session.username;
-			root["rights"] = session.rights;
 		}
 
 		void CWebServer::Cmd_GetUptime(WebEmSession& session, const request& req, Json::Value& root)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -815,36 +815,24 @@ namespace http
 			if (rtype == "command")
 			{
 				std::string cparam = request::findValue(&req, "param");
-				if (cparam.empty())
+				if (!cparam.empty())
 				{
-					cparam = request::findValue(&req, "dparam");
-					if (cparam.empty())
-					{
-						goto exitjson;
-					}
+					_log.Debug(DEBUG_WEBSERVER, "CWebServer::GetJSonPage() :%s :%s ", cparam.c_str(), req.uri.c_str());
+					HandleCommand(cparam, session, req, root);
 				}
-				if (cparam == "dologout")
-				{
-					session.forcelogin = true;
-					root["status"] = "OK";
-					root["title"] = "Logout";
-					goto exitjson;
-				}
-				_log.Debug(DEBUG_WEBSERVER, "CWebServer::GetJSonPage() :%s :%s ", cparam.c_str(), req.uri.c_str());
-				HandleCommand(cparam, session, req, root);
 			} //(rtype=="command")
 			else
 			{
 				HandleRType(rtype, session, req, root);
 			}
-		exitjson:
+
 			std::string jcallback = request::findValue(&req, "jsoncallback");
-			if (jcallback.empty())
+			if (!jcallback.empty())
 			{
-				reply::set_content(&rep, root.toStyledString());
+				reply::set_content(&rep, "var data=" + root.toStyledString() + '\n' + jcallback + "(data);");
 				return;
 			}
-			reply::set_content(&rep, "var data=" + root.toStyledString() + '\n' + jcallback + "(data);");
+			reply::set_content(&rep, root.toStyledString());
 		}
 
 		void CWebServer::Cmd_GetLanguage(WebEmSession& session, const request& req, Json::Value& root)

--- a/webserver/WebsocketHandler.cpp
+++ b/webserver/WebsocketHandler.cpp
@@ -47,7 +47,6 @@ namespace http {
 						session.timeout = nowAnd1Day;
 						session.expires = nowAnd1Day;
 						session.isnew = false;
-						session.forcelogin = false;
 						session.rememberme = false;
 						session.reply_status = 200;
 					}

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2462,6 +2462,10 @@ namespace http {
 				std::string sAuthToken;
 				std::string szTime;
 				bool expired = false;
+
+				session.username = "";
+				session.rights = -1;
+				rep = reply::stock_reply(reply::no_content);
 				if(parse_cookie(req, sSID, sAuthToken, szTime, expired))
 				{
 					_log.Debug(DEBUG_AUTH, "[web:%s] Logout : remove session %s", myWebem->GetPort().c_str(), sSID.c_str());
@@ -2469,9 +2473,6 @@ namespace http {
 					removeAuthToken(sSID);
 					send_remove_cookie(rep);
 				}
-				session.username = "";
-				session.rights = -1;
-				rep = reply::stock_reply(reply::no_content);
 				return;
 			}
 

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2435,7 +2435,6 @@ namespace http {
 
 			session.reply_status = reply::ok;
 			session.isnew = false;
-			session.forcelogin = false;
 			session.rememberme = false;
 
 			rep.status = reply::ok;
@@ -2472,7 +2471,6 @@ namespace http {
 				}
 				session.username = "";
 				session.rights = -1;
-				session.forcelogin = true;
 				rep = reply::stock_reply(reply::no_content);
 				return;
 			}
@@ -2639,18 +2637,6 @@ namespace http {
 				session.isnew = false;
 				myWebem->AddSession(session);
 				send_cookie(rep, session);
-			}
-			else if (session.forcelogin == true)
-			{
-				_log.Debug(DEBUG_WEBSERVER, "[web:%s] Logout : remove session %s", myWebem->GetPort().c_str(), session.id.c_str());
-
-				myWebem->RemoveSession(session.id);
-				removeAuthToken(session.id);
-				if (myWebem->m_authmethod == AUTH_BASIC)
-				{
-					send_authorization_request(rep);
-				}
-
 			}
 			else if (!session.id.empty())
 			{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -930,7 +930,7 @@ namespace http {
 		{
 			if (network.empty())
 			{
-				_log.Log(LOG_STATUS, "[web:%s] Empty network string provided! Skipping...", GetPort().c_str());
+				_log.Log(LOG_STATUS, "[web:%s] Empty trusted network string provided! Skipping...", GetPort().c_str());
 				return;
 			}
 
@@ -940,7 +940,7 @@ namespace http {
 			uint8_t iASize = (!ipnetwork.bIsIPv6) ? 4 : 16;
 			int ii;
 
-			_log.Log(LOG_STATUS, "[web:%s] Adding IPv%s network (%s) to list of trusted networks.", GetPort().c_str(), (ipnetwork.bIsIPv6 ? "6" : "4"), network.c_str());
+			_log.Debug(DEBUG_WEBSERVER, "[web:%s] Adding IPv%s network (%s) to list of trusted networks.", GetPort().c_str(), (ipnetwork.bIsIPv6 ? "6" : "4"), network.c_str());
 
 			if (network.find('*') != std::string::npos)
 			{

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -140,6 +140,7 @@ namespace http
 			std::string compute_accept_header(const std::string &websocket_key);
 			bool CheckAuthByPass(const request& req);
 			bool CheckAuthentication(WebEmSession &session, const request &req, reply &rep);
+			bool CheckUserAuthorization(std::string &user, struct ah *ah);
 			void send_authorization_request(reply &rep);
 			void send_remove_cookie(reply &rep);
 			std::string generateSessionID();

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -54,7 +54,6 @@ namespace http
 			int rights = 0;
 			bool rememberme = false;
 			bool isnew = false;
-			bool forcelogin = false;
 		} WebEmSession;
 
 		typedef struct _tIPNetwork

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -138,6 +138,7 @@ namespace http
 			/// Websocket methods
 			bool is_upgrade_request(WebEmSession &session, const request &req, reply &rep);
 			std::string compute_accept_header(const std::string &websocket_key);
+			bool CheckAuthByPass(const request& req);
 			bool CheckAuthentication(WebEmSession &session, const request &req, reply &rep);
 			void send_authorization_request(reply &rep);
 			void send_remove_cookie(reply &rep);

--- a/www/app/LogoutController.js
+++ b/www/app/LogoutController.js
@@ -22,8 +22,8 @@ define(['app'], function (app) {
 								if (data.user !== "") {
 									permissionList.isloggedin = true;
 									permissionList.user = data.user;
+									permissionList.rights = parseInt(data.rights);
 								}
-								permissionList.rights = parseInt(data.rights, 10);
 							}
 						}
 					});

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -505,16 +505,18 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 			success: function (data) {
 				isOnline = true;
 				if (data.status == "OK") {
-					permissionList.isloggedin = (data.user != "");
-					permissionList.rights = parseInt(data.rights);
-					permissionList.user = data.user;
-					dashboardType = data.DashboardType;
+					if (data.user !== "") {
+						permissionList.isloggedin = (data.user != "");
+						permissionList.rights = parseInt(data.rights);
+						permissionList.user = data.user;
+					}
 				}
 			},
 			error: function () {
 				isOnline = false;
 			}
 		});
+		permissions.setPermissions(permissionList);
 
 		$rootScope.$on("$routeChangeStart", function (scope, next, current) {
 			if (!isOnline) {
@@ -554,7 +556,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				}
 			}
 		});
-		permissions.setPermissions(permissionList);
 
 		Highcharts.setOptions({
 			chart: {

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -506,7 +506,7 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				isOnline = true;
 				if (data.status == "OK") {
 					if (data.user !== "") {
-						permissionList.isloggedin = (data.user != "");
+						permissionList.isloggedin = true;
 						permissionList.rights = parseInt(data.rights);
 						permissionList.user = data.user;
 					}

--- a/www/views/about.html
+++ b/www/views/about.html
@@ -25,6 +25,7 @@ body, #foreground, #midground{
 	<span>Compile Date</span>: {{config.appdate}}<br>
 	<span>dzVents Version</span>: {{config.dzventsversion}}<br>
 	<span>Python Version</span>: {{config.pythonversion}}<br>
+	<span>Active User</span>: {{config.userName}}<br>
 	<br>
 	<span>Uptime</span>: {{strupptime}}
 	<br>


### PR DESCRIPTION
PR which cleans up some of the code duplication, remove dead code paths, etc.

- remove of 'session.forcelogin' as it wasn't used anymore
- remove of 'dparam' command parameters as it was not used anymore
- ensure session cookie gets removed when logging-out (wasn't done at that time already)
- prevent repetitive calls to same function, so less code to execute with each handled request
- moved some code to functions instead of repeating the code
- show the active user in the 'About' box (so it is known who is logged-in)
- the 'getAuth' command now only returns user and rights when an active user is found
- handle the getAuth response better in the UI and ensure proper rights are set asap
- removed irrelevant message parameter from getConfig 
- removed sensitive information about Trusted Network from standard logging (now Debug info)