### PR TITLE
hardware/EnOceanRawValue.h: include stdarg.h

### DIFF
--- a/hardware/EnOceanRawValue.h
+++ b/hardware/EnOceanRawValue.h
@@ -1,6 +1,7 @@
 #ifndef _SetGetRawValue
 #define _SetGetRawValue
 
+#include <stdarg.h>
 #include <stdint.h>
 #include <vector>
 #include <stdio.h>


### PR DESCRIPTION
Include `stdarg.h` to avoid the following build failure on uclibc:

```
In file included from /home/fabrice/buildroot/output/build/domoticz-2022.2/hardware/EnOceanRawValue.cpp:2: /home/fabrice/buildroot/output/build/domoticz-2022.2/hardware/EnOceanRawValue.h:109:83: error: 'va_list' has not been declared
  109 | uint32_t SetRawValuesNb(uint8_t * data, T_DATAFIELD * OffsetDes, int NbParameter, va_list value);
      |                                                                                   ^~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>