### PR TITLE
Removes 'Return' Key event's handling from 'dialog-edittempdevice'

### DIFF
--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -460,21 +460,6 @@ define(['app', 'livesocket'], function (app) {
 			ShowTemps();
 			////WatchLiveSearch();
 
-
-			$("#dialog-edittempdevice").keydown(function (event) {
-				if (event.keyCode == 13) {
-					$(this).siblings('.ui-dialog-buttonpane').find('button:eq(0)').trigger("click");
-					return false;
-				}
-			});
-			$("#dialog-edittempdevicesmall").keydown(function (event) {
-				if (event.keyCode == 13) {
-					$(this).siblings('.ui-dialog-buttonpane').find('button:eq(0)').trigger("click");
-					return false;
-				}
-			});
-
-
 		};
 
 		//handles TopBar Links


### PR DESCRIPTION
In temperatures page, it was not possible to enter a multi-line description, 
because the Return key event is intercepted by the javacript, to rather click on the first button.

This PR fixes this, by removing keyCode 13 handling from JS.
