### PR TITLE
Fully responsive SelectMenu

### DIFF
--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -1342,7 +1342,7 @@ define(['app', 'livesocket'], function (app) {
 			//Create Selector selectmenu
 			$element.find('.selectorlevels select').selectmenu({
 				//Config
-				width: '75%',
+				width: false,	// prevents inline width
 				value: 0,
 				//Selector selectmenu events
 				create: function (event, ui) {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1899,9 +1899,6 @@ span.evomobile {
 	}	
 }
 
-.itemBlock{
-
-}
 .liveSearchShown{
 	float: left;
 }
@@ -1912,6 +1909,13 @@ SECTION.dashCategory{
 }
 SECTION.dashCategory .liveSearchShown{
 	margin: 0;
+}
+
+.itemBlock{
+
+}
+.itemBlock .ui-selectmenu-button{
+	width: 60%;
 }
 
 


### PR DESCRIPTION
Light/Switch Page:
 When reducing the browser windows width, the items **SELECT menus** widths are not properly resized, and they exceed on the right from the item block.
 
This PR removes the inline width style (built by $ui.selectmenu() ), so the width can now be controlled from the CSS, thus making it fully dynamic / responsive...