### PR TITLE
Fixes Weather Tab

### DIFF
--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -6292,17 +6292,22 @@ function WatchLiveSearch(){
 		var div=$('.divider');
 		var cont=$('.devicesList');
 		if(query.length == 0){
-			cont.removeClass('devicesListFiltered');
-			div.css('display','block');
-			div.addClass('row');
-			div.find('.clearfix').show();
-			$('.itemBlock').show().removeClass('liveSearchShown');
+			if(cont.hasClass('devicesListFiltered')){
+				cont.removeClass('devicesListFiltered');
+				div.css('display','block');
+				div.addClass('row');
+				div.find('.clearfix').show();
+				$('.itemBlock').show().removeClass('liveSearchShown');	
+			}
 		}
 		else{
-			cont.addClass('devicesListFiltered');
-			div.css('display','inline');
+			if(! cont.hasClass('devicesListFiltered')){
+				cont.addClass('devicesListFiltered');
+				div.css('display','inline');
+			}
 			div.removeClass('row');
 			div.find('.clearfix').hide();  /* only for Wheater and Temperatures */
+
 			$('.itemBlock').each(function(index){
 				var name=$(this).find('#name').html().toUpperCase();
 				var desc=$(this).find('#name').attr('data-desc');

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -6276,16 +6276,21 @@ function fromInstanceOrFunction(functionTemplate = f => f()) {
 		}
 	}
 }
-/* LiveSearch Functions: Filters devices when typing in the INPUT field  */
+
+
+/* LiveSearch Functions: Filters devices when typing in the INPUT field ------------------------------- */
 var _debug_livesearch= false;
+
+/* Triggers LiveSearch change  */
 function RefreshLiveSearch(){
 	if(_debug_livesearch) console.log('LiveSearch: Refreshing...');
 	$('.jsLiveSearch').trigger('change');
 }
 
+/* Watch the LiveSearch INPUT field  */
 function WatchLiveSearch(){
-	/* live search*/
 	if(_debug_livesearch) console.log('LiveSearch : Start Watching ...');
+
 	$('.jsLiveSearch').off().on('keyup change',function(e){
 		if(_debug_livesearch)  console.log('LiveSearch: processing on keyup - "'+$(this).val()+'"');
 		var query=$(this).val().toUpperCase();
@@ -6327,14 +6332,11 @@ function WatchLiveSearch(){
 				}
 			});
 		}
-		//if(_debug_livesearch) console.log('LiveSearch: processing END.');
-
 	});
 
-		
 }
 
-/* Display descriptions when hovering name */
+/* Display descriptions when hovering name ------------------------------------------------------------- */
 function WatchDescriptions(){
 	/* Show description when hovering item's name */
 	$(".item-name").hover(function() {
@@ -6347,4 +6349,3 @@ function WatchDescriptions(){
 		$(this).css('cursor','auto');
 	});
 };
-


### PR DESCRIPTION
fixes #5510

### What was the issue
When the WS triggers **RefreshItem**, **RefreshLiveSearch** is launched and it changes the "#weatherwidgets" _display_ property, thus removing the _display:none_ , normally set when the Log is displayed. 

### What does this patch:
It ensures that **LIveSearch** does not change the _display_ property more than ONCE, so when **RefreshItem** retriggers the **RefreshLiveSearch**, it does not revert the _display_ property back to a "shown" state.

### Better Fix
IMHO, **RefreshItem**, should ONLY happen, when devices are supposed to be shown, but NOT when they are not displayed.
- Better coding practice
- This would avoid this patch
- Refreshing devices when not needed, adds some browser's (+ domoticz server) stress, and might even lead to memory leaks in some cases

As you said that you would refactor the whole Angular code, (to normalize pages currently served by 2 different code designs), might I suggest that you _refactor the  **RefreshItem** code , to only happens WHENEVER needed._

HTH