### PR TITLE
Improved checking before default Admin is added (#5513)

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -6867,7 +6867,7 @@ namespace http
 							root["message"] = "Cannot change rights of last Admin user!";
 							return;
 						}
-						if ((senabled.compare("true") != 0) && (CountAdminUsers() <= 1))
+						if ((oldrights == URIGHTS_ADMIN) && (senabled.compare("true") != 0) && (CountAdminUsers() <= 1))
 						{
 							root["message"] = "Cannot disable last Admin user!";
 							return;


### PR DESCRIPTION
When upgrading to newer Domoticz version (coming from DB_Version < 157) a default Admin User is added when no Admin user exists.

In some situations (issue #5513) this could lead to a situation where 2 Users with the Username 'admin' end up in the Users list and therefor logging in can go wrong (if you use the password of the 2nd 'admin' User while Domoticz tries to check it against the password of the 1st 'admin' User).

Additional checks are performed:

- When moving the old 'WebUserName' setting variable (which has been removed) to the Users table, a check is performed that a User with the same name already exists before creating a new User based off the WebUserName and WebPassword variables
- If a User with the same name exists and it is not an Active User with Admin rights, the User is updated to Active and Admin
- The Preference var WebUserName was not removed properly (typo)
- Not only check if Users exist with Admin rights, but they have to be Active as well (otherwise they cannot be used to login)
- If a User called 'admin' already exists but it is either inactive or does not have Admin rights, it is renamed to 'admin_old' before adding a new 'admin' User with Admin privileges

Testing also revealed a bug as it was not possible to disable a (non-admin) User if only 1 Admin was active. This is now fixed.
