### PR TITLE
Allow wildcards in MQTT auto discovery  topics

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "MQTT.h"
 #include "MQTTAutoDiscover.h"
+#include "../extern/mosquitto/include/mosquitto.h"
 #include "../main/json_helper.h"
 #include "../main/Helper.h"
 #include "../main/localtime_r.h"
@@ -47,6 +48,19 @@ MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string& Name, const 
 	}
 }
 
+bool MQTTAutoDiscover::IsWildcardMatch(std::string st_topic, std::string m_topic)
+{
+	bool result;
+	if(mosquitto_topic_matches_sub(st_topic.c_str(), m_topic.c_str(),&result) == MOSQ_ERR_SUCCESS && result == true)
+	{
+		Debug(DEBUG_HARDWARE, "Wildcard compare of %s and %s matched", st_topic.c_str(), m_topic.c_str());
+		return true;
+	}
+	
+	Debug(DEBUG_HARDWARE, "Wildcard compare of %s and %s did not match", st_topic.c_str(), m_topic.c_str());
+	return false;
+}
+	
 void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 {
 	std::string topic = message->topic;
@@ -59,12 +73,16 @@ void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 		if (qMessage.empty())
 			return;
 
-		if (m_subscribed_topics.find(topic) != m_subscribed_topics.end())
+		bool topicMatch = false;
+		for (auto& itt : m_subscribed_topics)
 		{
-			handle_auto_discovery_sensor_message(message);
-			return;
+			if (itt.first != m_TopicDiscoveryPrefix + "/#" && IsWildcardMatch(itt.first,topic))
+			{
+				handle_auto_discovery_sensor_message(message,itt.first);
+				topicMatch = true;			
+			}
 		}
-
+		if(topicMatch == true) return;
 		if (topic.substr(0, topic.find('/')) == m_TopicDiscoveryPrefix)
 		{
 			on_auto_discovery_message(message);
@@ -1209,9 +1227,9 @@ void MQTTAutoDiscover::ApplySignalLevelDevice(const _tMQTTASensor* pSensor)
 	}
 }
 
-void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquitto_message* message)
+void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquitto_message* message,std::string subscribed_topic)
 {
-	std::string topic = message->topic;
+	std::string topic = subscribed_topic;
 	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
 
 	if (qMessage.empty())

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -139,6 +139,7 @@ public:
 	void on_disconnect(int rc) override;
 
 private:
+	bool IsWildcardMatch(std::string st_topic, std::string m_topic);
 	void InsertUpdateSwitch(_tMQTTASensor* pSensor);
 
 	void UpdateBlindPosition(_tMQTTASensor* pSensor);
@@ -152,7 +153,7 @@ private:
 	void ApplySignalLevelDevice(const _tMQTTASensor* pSensor);
 
 	void on_auto_discovery_message(const struct mosquitto_message* message);
-	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message);
+	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message,std::string topic);
 
 	void handle_auto_discovery_availability(_tMQTTASensor* pSensor, const std::string& payload, const struct mosquitto_message* message);
 	void handle_auto_discovery_sensor(_tMQTTASensor* pSensor, const struct mosquitto_message* message);


### PR DESCRIPTION
Find all subscriptions which might have triggered the message delivery using a wildcard match and pass the original subscription topic downstream to allow matching to devices.

Hard code to avoid trying to match the global wildcard 'm_TopicDiscoveryPrefix'/# to continue to allow sensor data to be held in the same topic root as the sensor descriptor data.