### PR TITLE
Allow wildcards in MQTT auto discovery topics

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -50,19 +50,6 @@ MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string& Name, const 
 	}
 }
 
-bool MQTTAutoDiscover::IsWildcardMatch(const std::string st_topic,const std::string m_topic)
-{
-	bool result;
-	if(mosquitto_topic_matches_sub(st_topic.c_str(), m_topic.c_str(),&result) == MOSQ_ERR_SUCCESS && result == true)
-	{
-		Debug(DEBUG_HARDWARE, "Wildcard compare of %s and %s matched", st_topic.c_str(), m_topic.c_str());
-		return true;
-	}
-	
-	Debug(DEBUG_HARDWARE, "Wildcard compare of %s and %s did not match", st_topic.c_str(), m_topic.c_str());
-	return false;
-}
-
 void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 {
 	std::string topic = message->topic;
@@ -78,7 +65,10 @@ void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 		bool topicMatch = false;
 		for (auto& itt : m_subscribed_topics)
 		{
-			if (itt.first != m_TopicDiscoveryPrefix + "/#" && IsWildcardMatch(itt.first,topic))
+			bool result = false;
+			mosquitto_topic_matches_sub(itt.first.c_str(), topic.c_str(),&result);
+
+			if (itt.first != m_TopicDiscoveryPrefix + "/#" && result == true)
 			{
 				handle_auto_discovery_sensor_message(message,itt.first);
 				topicMatch = true;			

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -50,7 +50,7 @@ MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string& Name, const 
 	}
 }
 
-bool MQTTAutoDiscover::IsWildcardMatch(std::string st_topic, std::string m_topic)
+bool MQTTAutoDiscover::IsWildcardMatch(const std::string st_topic,const std::string m_topic)
 {
 	bool result;
 	if(mosquitto_topic_matches_sub(st_topic.c_str(), m_topic.c_str(),&result) == MOSQ_ERR_SUCCESS && result == true)
@@ -1230,7 +1230,7 @@ void MQTTAutoDiscover::ApplySignalLevelDevice(const _tMQTTASensor* pSensor)
 	}
 }
 
-void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquitto_message* message,std::string subscribed_topic)
+void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquitto_message* message,const std::string subscribed_topic)
 {
 	std::string topic = subscribed_topic;
 	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -62,13 +62,19 @@ void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 		if (qMessage.empty())
 			return;
 
+		if (topic.substr(0, topic.find('/')) == m_TopicDiscoveryPrefix)
+		{
+			on_auto_discovery_message(message);
+			return;
+		}
+
 		bool topicMatch = false;
 		for (auto& itt : m_subscribed_topics)
 		{
 			bool result = false;
 			mosquitto_topic_matches_sub(itt.first.c_str(), topic.c_str(),&result);
 
-			if (itt.first != m_TopicDiscoveryPrefix + "/#" && result == true)
+			if (result == true)
 			{
 				handle_auto_discovery_sensor_message(message,itt.first);
 				topicMatch = true;			
@@ -76,11 +82,6 @@ void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 		}
 		if(topicMatch == true) return;
 
-		if (topic.substr(0, topic.find('/')) == m_TopicDiscoveryPrefix)
-		{
-			on_auto_discovery_message(message);
-			return;
-		}
 		return;
 	}
 	catch (const std::exception& e)

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -139,7 +139,7 @@ public:
 	void on_disconnect(int rc) override;
 
 private:
-	bool IsWildcardMatch(std::string st_topic, std::string m_topic);
+	bool IsWildcardMatch(const std::string st_topic,const std::string m_topic);
 	void InsertUpdateSwitch(_tMQTTASensor* pSensor);
 
 	void UpdateBlindPosition(_tMQTTASensor* pSensor);
@@ -153,7 +153,7 @@ private:
 	void ApplySignalLevelDevice(const _tMQTTASensor* pSensor);
 
 	void on_auto_discovery_message(const struct mosquitto_message* message);
-	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message,std::string subscribed_topic);
+	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message,const std::string subscribed_topic);
 
 	void handle_auto_discovery_availability(_tMQTTASensor* pSensor, const std::string& payload, const struct mosquitto_message* message);
 	void handle_auto_discovery_sensor(_tMQTTASensor* pSensor, const struct mosquitto_message* message);

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -139,6 +139,7 @@ public:
 	void on_disconnect(int rc) override;
 
 private:
+	bool IsWildcardMatch(std::string st_topic, std::string m_topic);
 	void InsertUpdateSwitch(_tMQTTASensor* pSensor);
 
 	void UpdateBlindPosition(_tMQTTASensor* pSensor);
@@ -152,7 +153,7 @@ private:
 	void ApplySignalLevelDevice(const _tMQTTASensor* pSensor);
 
 	void on_auto_discovery_message(const struct mosquitto_message* message);
-	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message);
+	void handle_auto_discovery_sensor_message(const struct mosquitto_message* message,std::string subscribed_topic);
 
 	void handle_auto_discovery_availability(_tMQTTASensor* pSensor, const std::string& payload, const struct mosquitto_message* message);
 	void handle_auto_discovery_sensor(_tMQTTASensor* pSensor, const struct mosquitto_message* message);

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -139,7 +139,6 @@ public:
 	void on_disconnect(int rc) override;
 
 private:
-	bool IsWildcardMatch(const std::string st_topic,const std::string m_topic);
 	void InsertUpdateSwitch(_tMQTTASensor* pSensor);
 
 	void UpdateBlindPosition(_tMQTTASensor* pSensor);


### PR DESCRIPTION
Find all subscriptions which might have triggered the message delivery using a wildcard match and pass the original subscription topic downstream to allow matching to devices.

Hard code to avoid trying to match the global wildcard 'm_TopicDiscoveryPrefix'/# to continue to allow sensor data to be held in the same topic root as the sensor descriptor data.