### PR TITLE
update automaticaly the device id of sensor that battery as been replaces

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -8323,6 +8323,12 @@ namespace http
 				m_pWebEm->SetWebTheme(SelectedTheme);
 				cntSettings++;
 
+				std::string AllowDeviceReplaceOnBatteryChanged = request::findValue(&req, "AllowDeviceReplaceOnBatteryChanged");
+				int iAllowDeviceReplaceOnBatteryChanged = (AllowDeviceReplaceOnBatteryChanged == "on" ? 1 : 0);
+				m_sql.UpdatePreferencesVar("AllowDeviceReplaceOnBatteryChanged", iAllowDeviceReplaceOnBatteryChanged);
+				cntSettings++;
+
+
 				/* To wrap up everything */
 				m_notifications.ConfigFromGetvars(req, true);
 				m_notifications.LoadConfig();
@@ -13370,6 +13376,11 @@ namespace http
 				{
 					root["IFTTTAPI"] = sValue;
 				}
+				else if (Key == "AllowDeviceReplaceOnBatteryChanged")
+				{
+					root["AllowDeviceReplaceOnBatteryChanged"] = nValue;
+				}
+
 			}
 		}
 

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -638,6 +638,9 @@ define(['app'], function (app) {
 					if (typeof data.IFTTTAPI != 'undefined') {
 						$("#ifttttable #IFTTTAPI").val(atob(data.IFTTTAPI));
 					}
+					if (typeof data.AllowDeviceReplaceOnBatteryChanged != 'undefined') {
+						$("#AllowDeviceReplaceOnBatteryChanged").prop('checked', data.AllowDeviceReplaceOnBatteryChanged == 1);
+					}
 				}
 			});
 		}

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1302,6 +1302,17 @@
 									</table>
 								</div>
 							</div>
+							<div class="row-fluid">
+								<div class="span12">
+									<h2><span data-i18n="Allow Device Replace On Battery Changed Detected">Allow Device Replace On Battery Changed Detected</span>:</h2>
+									<table class="display"  border="0" cellpadding="0" cellspacing="0">
+										<tr>
+											<td align="right" style="width:90px"><span data-i18n="Enabled"></span>:</td>
+											<td><input type="checkbox" id="AllowDeviceReplaceOnBatteryChanged" name="AllowDeviceReplaceOnBatteryChanged"><label for="AllowDeviceReplaceOnBatteryChanged"></label></td>
+										</tr>
+									</table>
+								</div>
+							</div>
 						</section>
 					</div>
 					<div class="tab-pane" id="tabbackuprestore">


### PR DESCRIPTION
hello,
this a function that will detect automatically if a battery of a device with low battery as been replaced :
it update the new device ID that have been changed due to the battery replace.
An option as been added in settings to allow this function ; other/"Allow Device Replace On Battery Changed Detected" shall be ON
a log is written .
algo

if a new device is detected with batery level 100% (new batery)
 we search if a same device type/subtype/Unit already exist with batery low
if one is found , we assume that it is the same device that we have replace batery and a new ID as been modified. the old DeviceID is replaced by the new DeviceID
to allow this , the settings option  other/"Allow Device Replace On Battery Changed Detected" shall be ON