### PR TITLE
Log filter

### DIFF
--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -509,10 +509,10 @@ bool CLogger::NotificationLogsEnabled()
 void CLogger::SetFilter(const std::string  &pFilter)
 {
 	std::vector<std::string> FilterList;
-    _log.Log(LOG_STATUS, "debugfilter:%s", pFilter.c_str());
+	_log.Debug(DEBUG_NORM, "debugfilter:%s", pFilter.c_str());
 	FilterStringList.clear();
 	KeepStringList.clear();
-	StringSplit(pFilter, ";", FilterList);
+	StringSplit(pFilter, ",", FilterList);
 	for (size_t i = 0; i < FilterList.size(); i++)
 	{
 		if (FilterList[i][0] == '+')

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -258,6 +258,8 @@ void CLogger::Log(const _eLogLevel level, const char *logline, ...)
 	va_start(argList, logline);
 	vsnprintf(cbuffer, sizeof(cbuffer), logline, argList);
 	va_end(argList);
+	if (CheckIfMessageIsFiltered(cbuffer))
+		return;
 
 #ifndef WIN32
 	if (g_bUseSyslog)
@@ -503,4 +505,55 @@ std::list<CLogger::_tLogLineStruct> CLogger::GetNotificationLogs()
 bool CLogger::NotificationLogsEnabled()
 {
 	return m_bEnableErrorsToNotificationSystem;
+}
+void CLogger::SetFilter(const std::string  &pFilter)
+{
+	std::vector<std::string> FilterList;
+    _log.Log(LOG_STATUS, "debugfilter:%s", pFilter.c_str());
+	FilterStringList.clear();
+	KeepStringList.clear();
+	StringSplit(pFilter, ";", FilterList);
+	for (size_t i = 0; i < FilterList.size(); i++)
+	{
+		if (FilterList[i][0] == '+')
+			KeepStringList.push_back(FilterList[i].substr(1));
+		else
+			FilterStringList.push_back(FilterList[i]);
+	}
+}
+
+//return true if the log shall be filtered
+//
+bool CLogger::CheckIfMessageIsFiltered(const char *cbuffer)
+{
+	bool filtered = false; //default not filtered
+
+	//search if the log shall be filter
+	for (size_t i = 0; i < FilterStringList.size(); i++)
+	{
+		if ( FilterStringList[i] == "all" )
+		{
+			filtered = true;
+			break;
+		}
+
+		if (strstr(cbuffer, FilterStringList[i].c_str()) != 0)
+		{
+			filtered = true;
+			break;
+		}
+	}
+	//if the log as been filtered , search if it shall be kept
+	if (filtered)
+	{
+		for (size_t i = 0; i < KeepStringList.size(); i++)
+		{
+			if (strstr(cbuffer, KeepStringList[i].c_str()) != 0)
+			{
+				filtered = false;
+				break;
+			}
+		}
+	}
+	return filtered;
 }

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -98,7 +98,7 @@ class CLogger
 	std::list<_tLogLineStruct> GetNotificationLogs();
 	bool NotificationLogsEnabled();
 
-	void SetFilter(const std::string& pFilter);
+	void SetFilter(const std::string &pFilter);
 	bool CheckIfMessageIsFiltered(const char* cbuffer);
       private:
 	uint32_t m_log_flags;

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -98,6 +98,8 @@ class CLogger
 	std::list<_tLogLineStruct> GetNotificationLogs();
 	bool NotificationLogsEnabled();
 
+	void SetFilter(const std::string& pFilter);
+	bool CheckIfMessageIsFiltered(const char* cbuffer);
       private:
 	uint32_t m_log_flags;
 	uint32_t m_debug_flags;
@@ -116,5 +118,7 @@ class CLogger
 	bool m_bEnableErrorsToNotificationSystem;
 	time_t m_LastLogNotificationsSend;
 	std::stringstream m_sequencestring;
+	std::vector<std::string> FilterStringList; //list of keyword to filter
+	std::vector<std::string> KeepStringList;   //list of keyword to keep
 };
 extern CLogger _log;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -92,7 +92,7 @@ namespace
 #endif
 		"\t-loglevel (combination of: all,normal,status,error,debug)\n"
 		"\t-debuglevel (combination of: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql,auth)\n"
-		"\t-debugfilter word1;+word2;  : filter all the LOG containing word1 and +=  display all the LOG containing word2 all: filter all LOG\n"
+		"\t-debugfilter word1,+word2,  : filter all the LOG containing word1 and +=  display all the LOG containing word2 all: filter all LOG\n"
 		"\t-notimestamps (do not prepend timestamps to logs; useful with syslog, etc.)\n"
 		"\t-php_cgi_path (for example /usr/bin/php-cgi)\n"
 #ifndef WIN32
@@ -691,13 +691,13 @@ int main(int argc, char**argv)
 		{
 			std::string szLevel = cmdLine.GetSafeArgument("-loglevel", 0, "");
 			_log.SetLogFlags(szLevel);
-			_log.Log(LOG_STATUS, "loglevel:%s", szLevel.c_str());
+			_log.Debug(DEBUG_NORM, "loglevel:%s", szLevel.c_str());
 		}
 		if (cmdLine.HasSwitch("-debuglevel"))
 		{
 			std::string szLevel = cmdLine.GetSafeArgument("-debuglevel", 0, "");
 			_log.SetDebugFlags(szLevel);
-			_log.Log(LOG_STATUS, "debuglevel:%s", szLevel.c_str());
+			_log.Debug(DEBUG_NORM, "debuglevel:%s", szLevel.c_str());
 		}
 		if (cmdLine.HasSwitch("-debugfilter")){
             std::string szFilter = cmdLine.GetSafeArgument("-debugfilter", 0, "");

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -700,7 +700,7 @@ int main(int argc, char**argv)
 			_log.Debug(DEBUG_NORM, "debuglevel:%s", szLevel.c_str());
 		}
 		if (cmdLine.HasSwitch("-debugfilter")){
-            std::string szFilter = cmdLine.GetSafeArgument("-debugfilter", 0, "");
+			std::string szFilter = cmdLine.GetSafeArgument("-debugfilter", 0, "");
 			_log.SetFilter(szFilter);
 		}
 		if (cmdLine.HasSwitch("-notimestamps"))

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -92,6 +92,7 @@ namespace
 #endif
 		"\t-loglevel (combination of: all,normal,status,error,debug)\n"
 		"\t-debuglevel (combination of: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql,auth)\n"
+		"\t-debugfilter word1;+word2;  : filter all the LOG containing word1 and +=  display all the LOG containing word2 all: filter all LOG\n"
 		"\t-notimestamps (do not prepend timestamps to logs; useful with syslog, etc.)\n"
 		"\t-php_cgi_path (for example /usr/bin/php-cgi)\n"
 #ifndef WIN32
@@ -574,6 +575,9 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		else if (szFlag == "debuglevel") {
 			_log.SetDebugFlags(sLine);
 		}
+		else if (szFlag == "debugfilter") {
+			_log.SetFilter(sLine);
+		}
 		else if (szFlag == "notimestamps") {
 			_log.EnableLogTimestamps(!GetConfigBool(sLine));
 		}
@@ -687,11 +691,17 @@ int main(int argc, char**argv)
 		{
 			std::string szLevel = cmdLine.GetSafeArgument("-loglevel", 0, "");
 			_log.SetLogFlags(szLevel);
+			_log.Log(LOG_STATUS, "loglevel:%s", szLevel.c_str());
 		}
 		if (cmdLine.HasSwitch("-debuglevel"))
 		{
 			std::string szLevel = cmdLine.GetSafeArgument("-debuglevel", 0, "");
 			_log.SetDebugFlags(szLevel);
+			_log.Log(LOG_STATUS, "debuglevel:%s", szLevel.c_str());
+		}
+		if (cmdLine.HasSwitch("-debugfilter")){
+            std::string szFilter = cmdLine.GetSafeArgument("-debugfilter", 0, "");
+			_log.SetFilter(szFilter);
 		}
 		if (cmdLine.HasSwitch("-notimestamps"))
 		{


### PR DESCRIPTION
add the possibility to filter the log/debug more detailed :
- for example display only the lines with contaning specific words
- or filter  only the lines with contaning specific words ( for example device reception dump)

 add "debugfilter" switch  in command line :

-debugfilter word1 :  filter all the LOG containing word1
-debugfilter all       :  filter all the LOG : to be used with  all keyword

-debugfilter all,+word1   :  display only log contaning word2 ( filter all word except word1 )
-debugfilter all,+word1,+word2   :  display only log contaning word1 & word2 ( filter all word except word1 & word2 )
