### PR TITLE
Fix/multidevicedelete (fixes #5554)

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -11346,7 +11346,7 @@ namespace http
 				return; // Only admin user allowed
 			}
 
-			std::string idx = request::findValue(&req, "idx");
+			std::string idx = CURLEncode::URLDecode(request::findValue(&req, "idx"));
 			if (idx.empty())
 				return;
 
@@ -11402,7 +11402,7 @@ namespace http
 				return; // Only admin user allowed
 			}
 
-			std::string idx = request::findValue(&req, "idx");
+			std::string idx = CURLEncode::URLDecode(request::findValue(&req, "idx"));
 			if (idx.empty())
 				return;
 			root["status"] = "OK";
@@ -12683,7 +12683,7 @@ namespace http
 		void CWebServer::RType_SetSharedUserDevices(WebEmSession& session, const request& req, Json::Value& root)
 		{
 			std::string idx = request::findValue(&req, "idx");
-			std::string userdevices = request::findValue(&req, "devices");
+			std::string userdevices = CURLEncode::URLDecode(request::findValue(&req, "devices"));
 			if (idx.empty())
 				return;
 			root["status"] = "OK";

--- a/www/app/domoticz.api.js
+++ b/www/app/domoticz.api.js
@@ -134,14 +134,14 @@ define(['app.permissions', 'livesocket'], function(appPermissionsModule, websock
         function removeDevice(deviceIdx) {
             return domoticzApi.sendRequest({
                 type: 'deletedevice',
-                idx: Array.isArray(deviceIdx) ? deviceIdx.join(';') : deviceIdx
+                idx: Array.isArray(deviceIdx) ? encodeURIComponent(deviceIdx.join(';')) : deviceIdx
             }).then(domoticzApi.errorHandler);
         }
 
         function removeScene(deviceIdx) {
             return domoticzApi.sendRequest({
                 type: 'deletescene',
-                idx: Array.isArray(deviceIdx) ? deviceIdx.join(';') : deviceIdx
+                idx: Array.isArray(deviceIdx) ? encodeURIComponent(deviceIdx.join(';')) : deviceIdx
             }).then(domoticzApi.errorHandler);
         }
 


### PR DESCRIPTION
Small PR that _fixes_ handling `;` (semi-colon) in URI-parameter fields.

Some commands use a list of values separated by semi-colon as single URI parameter. It is preferred according to [RFC3986](https://www.rfc-editor.org/rfc/rfc3986#section-2.2) to encode certain characters that are often used as delimiters (like the semi-colon).

Although not encoding is __not__ a problem for the majority of cases, there are a few cases when it is a problem. Like when using [Traefik](https://traefik.io/traefik/) as a (reverse) proxy.

With this PR, these URI variables are properly encoded and decoded up on reception by the back-end.

This way, Domoticz works properly behind a Traefik proxy. This fixed #5554 (and #5311)