### PR TITLE
Update service-worker.js

### DIFF
--- a/www/service-worker.js
+++ b/www/service-worker.js
@@ -2,7 +2,7 @@
 
 const CACHE_NAME = 'offline';
 // Customize this with a different URL if needed.
-const OFFLINE_URL = '/views/offline.html';
+const OFFLINE_URL = 'views/offline.html';
 
 self.addEventListener('install', (event) => {
   event.waitUntil((async () => {
@@ -55,7 +55,7 @@ self.addEventListener('fetch', (event) => {
   }
 });
 
-self.importScripts('/js/sw-toolbox.js');
+self.importScripts('js/sw-toolbox.js');
 
 // Turn on debug logging, visible in the Developer Tools' console.
 self.toolbox.options.debug = true;


### PR DESCRIPTION
I see error messages in the console when Domoticz lives in web_root=home (Serviceworker registration failed). Changing the OFFLINE_URL and self.importScrits from absolute to relative paths fixes this.