### PR TITLE
Fix concurrency issue with scriptoutputindex (#5612)

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3694,12 +3694,10 @@ void CSQLHelper::PerformThreadedAction(const _tTaskItem tItem)
 		bool timeoutOccurred = false;
 
 		// make sure we have unique filenames
-		scriptoutputindex++;
-		if (scriptoutputindex > 10000) // should be a big number, to prevent parallel scripts having the same output files. 250 concurrent will probably never be reached
-		{
-			scriptoutputindex = 1;
-		}
-		std::string scriptoutputindextext = std::to_string(scriptoutputindex);
+		/* DGA45: fix concurrency issue with scriptoutputindex (#5612) */
+		std::stringstream ss;
+		ss << std::this_thread::get_id();
+		std::string scriptoutputindextext = ss.str();
 
 		// create filenames for stderr and stdout  ("path+domscript+index+<.out|.err>")
 		filename = path;

--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -502,7 +502,6 @@ class CSQLHelper : public StoppableTask
 	double m_max_kwh_usage;
 
       private:
-	int scriptoutputindex=0;
 	std::mutex m_executeThreadMutex;
 	std::mutex m_sqlQueryMutex;
 	sqlite3 *m_dbase;


### PR DESCRIPTION
Replace scriptoutputindex by the thread ID to ensure unique filename