### PR TITLE
Flowchart fixes for SECURITY_SETUP.md

### DIFF
--- a/SECURITY_SETUP.md
+++ b/SECURITY_SETUP.md
@@ -25,9 +25,7 @@ There are a number of 'components'/'functions' involved when it comes to Domotic
   * The Domoticz __'IAM server'__ (Identity & Access Management)
         _(actually part of the core server at the moment)_
 
-<details>
-  <summary>A graphical representation looks like this:</summary>
-  (_Assuming the __Mermaid__ graph is rendered nicely_)
+A graphical representation looks like this:
 
 ```mermaid
   flowchart TB
@@ -55,7 +53,6 @@ There are a number of 'components'/'functions' involved when it comes to Domotic
   sUI -. "Could use to request access Token" .-> exIAM
   exIAM -. "Has trust relation with" .- sCORE
 ```
-</details>
 
 ## Isn't Domoticz just 1 Application?
 

--- a/SECURITY_SETUP.md
+++ b/SECURITY_SETUP.md
@@ -28,14 +28,11 @@ There are a number of 'components'/'functions' involved when it comes to Domotic
 A graphical representation looks like this:
 
 ```mermaid
-  flowchart TB
-  subgraph sUI["User Interface's"]
-    direction LR
-    subgraph UIs
-      DUI[Domoticz Web Interface]
-      OUI(Any Other Web Interface)
-      APP(Any Domoticz capable App)
-    end
+flowchart TD
+  subgraph sUI[User Interfaces]
+    DUI[Domoticz Web Interface]
+    OUI(Any Other Web Interface)
+    APP(Any Domoticz capable App)
   end
   subgraph sCORE[Domoticz Core Services]
     direction LR


### PR DESCRIPTION
Two commits:

1. Un-hide Mermaid graph to prevent breakage
   It's a [reported issue][1] that Mermaid graphs containing labeled links (lines with text on them) fail to render inside a `<details>` section. If not collapsed, they render fine.

2. Clean up, simplify flowchart

    - There's no need for the inner "UIs" subgraph, if the flowchart is configured `TD` instead of `TB`. (I don't know why that matters, and it probably shouldn't. Seems to be a bug. But, it matters.)
    - "User Interfaces" has no apostrophe in it

[1]: https://github.com/mermaid-js/mermaid/issues/3504