### PR TITLE
Recheck and fix int64_t and uint64_t print formats

### DIFF
--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -709,8 +709,9 @@ void CEvohomeWeb::DecodeDHWState(temperatureControlSystem* tcs)
 		}
 		else if ((result[0][1] != szId) || (result[0][2] != ndevname))
 		{
+			uint64_t DevRowIdx = (uint64_t) std::stoull(result[0][0]);
 			// also wipe StrParam1 - we do not want a double action from the old (python) script when changing the setpoint
-			m_sql.safe_query("UPDATE DeviceStatus SET DeviceID='%q', Name='%q', StrParam1='' WHERE (ID == %" PRIu64 ")", szId.c_str(), ndevname.c_str(), std::stoull(result[0][0]));
+			m_sql.safe_query("UPDATE DeviceStatus SET DeviceID='%q', Name='%q', StrParam1='' WHERE (ID == %" PRIu64 ")", szId.c_str(), ndevname.c_str(), DevRowIdx);
 		}
 	}
 

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -709,7 +709,7 @@ void CEvohomeWeb::DecodeDHWState(temperatureControlSystem* tcs)
 		}
 		else if ((result[0][1] != szId) || (result[0][2] != ndevname))
 		{
-			uint64_t DevRowIdx = (uint64_t) std::stoull(result[0][0]);
+			uint64_t DevRowIdx = std::stoull(result[0][0]);
 			// also wipe StrParam1 - we do not want a double action from the old (python) script when changing the setpoint
 			m_sql.safe_query("UPDATE DeviceStatus SET DeviceID='%q', Name='%q', StrParam1='' WHERE (ID == %" PRIu64 ")", szId.c_str(), ndevname.c_str(), DevRowIdx);
 		}

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -8,6 +8,9 @@
 #include "../main/SQLHelper.h"
 #include <wchar.h>
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
 //Note, for Windows we use OpenHardware Monitor
 //http://openhardwaremonitor.org/
 
@@ -984,7 +987,7 @@ void CHardwareMonitor::FetchUnixDisk()
 			char suse[30];
 			char smountpoint[300];
 			int64_t numblock, usedblocks, availblocks;
-			int ret = sscanf(ittDF.c_str(), "%s\t%lld\t%lld\t%lld\t%s\t%s\n", dname, &numblock, &usedblocks, &availblocks, suse, smountpoint);
+			int ret = sscanf(ittDF.c_str(), "%s\t%" PRId64 "\t%" PRId64 "\t%" PRId64 "\t%s\t%s\n", dname, &numblock, &usedblocks, &availblocks, suse, smountpoint);
 			if (ret == 6)
 			{
 				auto it = _dmounts_.find(dname);

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -322,7 +322,7 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 				if (result.empty())
 				{
 					//Insert value into our database
-					m_sql.safe_query("INSERT INTO Meter_Calendar (DeviceRowID, Value, Date) VALUES ('%" PRIu64 "', '%llu', '%q')", DevID, ulCounter, szDate);
+					m_sql.safe_query("INSERT INTO Meter_Calendar (DeviceRowID, Value, Date) VALUES ('%" PRIu64 "', '%" PRIu64 "', '%q')", DevID, ulCounter, szDate);
 					Log(LOG_STATUS, "SBFSpot Import Old Month Data: Inserting %s",szDate);
 				}
 
@@ -389,7 +389,7 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 						if (result.empty())
 						{
 							//Insert value into our database
-							m_sql.safe_query("INSERT INTO Meter_Calendar (DeviceRowID, Value, Date) VALUES ('%" PRIu64 "', '%llu', '%q')",
+							m_sql.safe_query("INSERT INTO Meter_Calendar (DeviceRowID, Value, Date) VALUES ('%" PRIu64 "', '%" PRIu64 "', '%q')",
 								DevID, ulCounter, szDate);
 							Log(LOG_STATUS, "SBFSpot Import Old Month Data: Inserting %s", szDate);
 						}

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -215,8 +215,8 @@ namespace http
 									std::string acScope = m_accesscodes[iUser].Scope;
 									std::string CodeChallenge = m_accesscodes[iUser].CodeChallenge;
 									uint64_t AuthTime = m_accesscodes[iUser].AuthTime;
-									unsigned long long CodeTime = m_accesscodes[iUser].ExpTime;
-									unsigned long long CurTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+									uint64_t CodeTime = m_accesscodes[iUser].ExpTime;
+									uint64_t CurTime = (uint64_t) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
 									m_accesscodes[iUser].AuthCode = "";	// Once used, make sure it cannot be used again
 									m_accesscodes[iUser].RedirectUri = "";
@@ -292,7 +292,7 @@ namespace http
 											}
 											else
 											{
-												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Authorization code has expired (%lld) (%lld)!", CodeTime, CurTime);
+												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Authorization code has expired (%" PRIu64 ") (%" PRIu64 ")!", CodeTime, CurTime);
 												iUser = -1;
 											}
 										}

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -6370,7 +6370,7 @@ bool CSQLHelper::UpdateCalendarMeter(
 			{
 				safe_query(
 					"INSERT INTO MultiMeter (DeviceRowID, Value1, Value2, Value3, Value4, Value5, Value6, Date) "
-					"VALUES ('%" PRIu64 "', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%q')",
+					"VALUES ('%" PRIu64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%q')",
 					DeviceRowID,
 					(value1 < 0) ? 0 : value1,
 					(value2 < 0) ? 0 : value2,
@@ -6384,7 +6384,7 @@ bool CSQLHelper::UpdateCalendarMeter(
 			else
 			{
 				safe_query(
-					"UPDATE MultiMeter SET Value1='%lld', Value2='%lld', Value3='%lld', Value4='%lld', Value5='%lld', Value6='%lld' "
+					"UPDATE MultiMeter SET Value1='%" PRId64 "', Value2='%" PRId64 "', Value3='%" PRId64 "', Value4='%" PRId64 "', Value5='%" PRId64 "', Value6='%" PRId64 "' "
 					"WHERE ((DeviceRowID=='%" PRIu64 "') AND (Date=='%q'))",
 					(value1 < 0) ? 0 : value1,
 					(value2 < 0) ? 0 : value2,
@@ -6407,14 +6407,14 @@ bool CSQLHelper::UpdateCalendarMeter(
 			{
 				safe_query(
 					"INSERT INTO Meter (DeviceRowID, Value, Usage, Date) "
-					"VALUES ('%" PRIu64 "','%lld','%lld','%q')",
+					"VALUES ('%" PRIu64 "','%" PRId64 "','%" PRId64 "','%q')",
 					DeviceRowID, (value1 < 0) ? 0 : value1, (value2 < 0) ? 0 : value2, date
 				);
 			}
 			else
 			{
 				safe_query(
-					"UPDATE Meter SET DeviceRowID='%" PRIu64 "', Value='%lld', Usage='%lld', Date='%q' "
+					"UPDATE Meter SET DeviceRowID='%" PRIu64 "', Value='%" PRId64 "', Usage='%" PRId64 "', Date='%q' "
 					"WHERE ((DeviceRowID=='%" PRIu64 "') AND (Date=='%q'))",
 					DeviceRowID, (value1 < 0) ? 0 : value1, (value2 < 0) ? 0 : value2, date,
 					DeviceRowID, date
@@ -6438,7 +6438,7 @@ bool CSQLHelper::UpdateCalendarMeter(
 			{
 				safe_query(
 					"INSERT INTO MultiMeter_Calendar (DeviceRowID, Value1, Value2, Value3, Value4, Value5, Value6, Counter1, Counter2, Counter3, Counter4, Date) "
-					"VALUES ('%" PRIu64 "', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%lld', '%q')",
+					"VALUES ('%" PRIu64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%" PRId64 "', '%q')",
 					DeviceRowID,
 					(value1 < 0) ? 0 : value1,
 					(value2 < 0) ? 0 : value2,
@@ -6456,7 +6456,7 @@ bool CSQLHelper::UpdateCalendarMeter(
 			else
 			{
 				safe_query(
-					"UPDATE MultiMeter_Calendar SET Value1='%lld', Value2='%lld', Value3='%lld', Value4='%lld', Value5='%lld', Value6='%lld' , Counter1='%lld' , Counter2='%lld' , Counter3='%lld' , Counter4='%lld' "
+					"UPDATE MultiMeter_Calendar SET Value1='%" PRId64 "', Value2='%" PRId64 "', Value3='%" PRId64 "', Value4='%" PRId64 "', Value5='%" PRId64 "', Value6='%" PRId64 "' , Counter1='%" PRId64 "' , Counter2='%" PRId64 "' , Counter3='%" PRId64 "' , Counter4='%" PRId64 "' "
 					"WHERE ((DeviceRowID=='%" PRIu64 "') AND (Date=='%q'))",
 					(value1 < 0) ? 0 : value1,
 					(value2 < 0) ? 0 : value2,
@@ -6483,14 +6483,14 @@ bool CSQLHelper::UpdateCalendarMeter(
 			{
 				safe_query(
 					"INSERT INTO Meter_Calendar (DeviceRowID, Counter, Value, Date) "
-					"VALUES ('%" PRIu64 "', '%lld', '%lld', '%q')",
+					"VALUES ('%" PRIu64 "', '%" PRId64 "', '%" PRId64 "', '%q')",
 					DeviceRowID, (value1 < 0) ? 0 : value1, (value2 < 0) ? 0 : value2, date
 				);
 			}
 			else
 			{
 				safe_query(
-					"UPDATE Meter_Calendar SET DeviceRowID='%" PRIu64 "', Counter='%lld', Value='%lld', Date='%q' "
+					"UPDATE Meter_Calendar SET DeviceRowID='%" PRIu64 "', Counter='%" PRId64 "', Value='%" PRId64 "', Date='%q' "
 					"WHERE (DeviceRowID=='%" PRIu64 "') AND (Date=='%q')",
 					DeviceRowID, (value1 < 0) ? 0 : value1, (value2 < 0) ? 0 : value2, date,
 					DeviceRowID, date
@@ -6763,7 +6763,7 @@ void CSQLHelper::UpdateMeter()
 			//insert record
 			safe_query(
 				"INSERT INTO Meter (DeviceRowID, Value, [Usage]) "
-				"VALUES ('%" PRIu64 "', '%lld', '%lld')",
+				"VALUES ('%" PRIu64 "', '%" PRId64 "', '%" PRId64 "')",
 				ID,
 				MeterValue,
 				MeterUsage
@@ -6890,7 +6890,7 @@ void CSQLHelper::UpdateMultiMeter()
 			//insert record
 			safe_query(
 				"INSERT INTO MultiMeter (DeviceRowID, Value1, Value2, Value3, Value4, Value5, Value6) "
-				"VALUES ('%" PRIu64 "', '%llu', '%llu', '%llu', '%llu', '%llu', '%llu')",
+				"VALUES ('%" PRIu64 "', '%" PRIu64 "', '%" PRIu64 "', '%" PRIu64 "', '%" PRIu64 "', '%" PRIu64 "', '%" PRIu64 "')",
 				ID,
 				value1,
 				value2,
@@ -8199,7 +8199,7 @@ void CSQLHelper::AddTaskItem(const _tTaskItem& tItem, const bool cancelItem)
 		auto itt = m_background_task_queue.begin();
 		while (itt != m_background_task_queue.end())
 		{
-			_log.Debug(DEBUG_NORM, "SQLH AddTask: Comparing with item in queue: idx=%" PRId64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", itt->_idx, itt->_DelayTime, itt->_command.c_str(), itt->_level, itt->_Color.toString().c_str(), itt->_relatedEvent.c_str());
+			_log.Debug(DEBUG_NORM, "SQLH AddTask: Comparing with item in queue: idx=%" PRIu64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", itt->_idx, itt->_DelayTime, itt->_command.c_str(), itt->_level, itt->_Color.toString().c_str(), itt->_relatedEvent.c_str());
 			if (itt->_idx == tItem._idx && itt->_ItemType == tItem._ItemType)
 			{
 				float iDelayDiff = tItem._DelayTime - itt->_DelayTime;
@@ -8832,7 +8832,7 @@ void CSQLHelper::FixDaylightSaving()
 				else
 				{
 					//Update row with new Date
-					safe_query("UPDATE Meter_Calendar SET Date='%q', Value=%llu WHERE (RowID=='%q')", szDateNew.c_str(), ValueDest, sd1[1].c_str());
+					safe_query("UPDATE Meter_Calendar SET Date='%q', Value=%" PRIu64 " WHERE (RowID=='%q')", szDateNew.c_str(), ValueDest, sd1[1].c_str());
 				}
 			}
 		}
@@ -8969,7 +8969,7 @@ void CSQLHelper::FixDaylightSaving()
 				else
 				{
 					//Update row with new Date
-					safe_query("UPDATE MultiMeter_Calendar SET Date='%q', Value1=%llu, Value2=%llu, Value3=%llu, Value4=%llu, Value5=%llu, Value6=%llu WHERE (RowID=='%q')",
+					safe_query("UPDATE MultiMeter_Calendar SET Date='%q', Value1=%" PRIu64 ", Value2=%" PRIu64 ", Value3=%" PRIu64 ", Value4=%" PRIu64 ", Value5=%" PRIu64 ", Value6=%" PRIu64 " WHERE (RowID=='%q')",
 						szDateNew.c_str(), ValueDest1, ValueDest2, ValueDest3, ValueDest4, ValueDest5, ValueDest6, sd1[1].c_str());
 				}
 			}

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -10033,7 +10033,8 @@ namespace http
 							int64_t total_first = std::stoll(sd2[0]);
 							int64_t total_last = std::stoll(sValue);
 							int64_t total_real = total_last - total_first;
-							sprintf(szTmp, "%" PRIu64, total_real);
+
+							sprintf(szTmp, "%" PRId64, total_real);
 
 							double musage = 0.0F;
 							switch (metertype)
@@ -10139,10 +10140,9 @@ namespace http
 
 							uint64_t total_min = std::stoull(sd2[0]);
 							uint64_t total_max = std::stoull(sd2[1]);
-							uint64_t total_real;
+							uint64_t total_real = total_max - total_min;
 
-							total_real = total_max - total_min;
-							sprintf(szTmp, "%lld", total_real);
+							sprintf(szTmp, "%" PRIu64, total_real);
 
 							musage = 0;
 							switch (metertype)
@@ -10317,9 +10317,9 @@ namespace http
 								usagecurrent = 0;
 								delivcurrent = 0;
 							}
-							sprintf(szTmp, "%llu Watt", usagecurrent);
+							sprintf(szTmp, "%" PRIu64 " Watt", usagecurrent);
 							root["result"][ii]["Usage"] = szTmp;
-							sprintf(szTmp, "%llu Watt", delivcurrent);
+							sprintf(szTmp, "%" PRIu64 " Watt", delivcurrent);
 							root["result"][ii]["UsageDeliv"] = szTmp;
 							root["result"][ii]["Data"] = sValue;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -11213,10 +11213,9 @@ namespace http
 
 								uint64_t total_min = std::stoull(sd2[0]);
 								uint64_t total_max = std::stoull(sd2[1]);
-								uint64_t total_real;
+								uint64_t total_real = total_max - total_min;
 
-								total_real = total_max - total_min;
-								sprintf(szTmp, "%lld", total_real);
+								sprintf(szTmp, "%" PRIu64, total_real);
 							}
 							root["result"][ii]["SwitchTypeVal"] = MTYPE_COUNTER;
 							root["result"][ii]["Counter"] = sValue;
@@ -15365,6 +15364,7 @@ namespace http
 							std::string szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
 							root["result"][ii]["v"] = szTmp;
+
 							sprintf(szTmp, "%" PRIu64, total_real_usage_2);
 							szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
@@ -15374,6 +15374,7 @@ namespace http
 							szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
 							root["result"][ii]["r1"] = szTmp;
+
 							sprintf(szTmp, "%" PRIu64, total_real_deliv_2);
 							szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
@@ -15407,7 +15408,8 @@ namespace http
 							}
 
 							total_real = total_max - total_min;
-							sprintf(szTmp, "%lld", total_real);
+							sprintf(szTmp, "%" PRId64, total_real);
+
 							std::string szValue = szTmp;
 							switch (metertype)
 							{
@@ -16929,7 +16931,8 @@ namespace http
 								}
 
 								total_real = total_max - total_min;
-								sprintf(szTmp, "%lld", total_real);
+								sprintf(szTmp, "%" PRId64, total_real);
+
 								std::string szValue = szTmp;
 
 								if (!sgroupby.empty())
@@ -17582,14 +17585,16 @@ namespace http
 
 							root["result"][ii]["d"] = szDateEnd;
 
-							sprintf(szTmp, "%lld", total_real_usage);
+							sprintf(szTmp, "%" PRIu64, total_real_usage);
 							std::string szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
 							root["result"][ii]["v"] = szTmp;
+
 							sprintf(szTmp, "%" PRIu64, total_real_deliv);
 							szValue = szTmp;
 							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
 							root["result"][ii]["v2"] = szTmp;
+							
 							ii++;
 							if (bHaveDeliverd)
 							{
@@ -17619,9 +17624,8 @@ namespace http
 							}
 
 							total_real = total_max - total_min;
-							sprintf(szTmp, "%lld", total_real);
+							sprintf(szTmp, "%" PRId64, total_real);							std::string szValue = szTmp;
 
-							std::string szValue = szTmp;
 							switch (metertype)
 							{
 							case MTYPE_ENERGY:

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12712,7 +12712,7 @@ bool MainWorker::SwitchLight(const std::string& idx, const std::string& switchcm
 bool MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, const int level, _tColor color, const bool ooc, const int ExtraDelay, const std::string& User)
 {
 	//Get Device details
-	_log.Debug(DEBUG_NORM, "MAIN SwitchLight idx:%" PRId64 " cmd:%s lvl:%d ", idx, switchcmd.c_str(), level);
+	_log.Debug(DEBUG_NORM, "MAIN SwitchLight idx:%" PRIu64 " cmd:%s lvl:%d ", idx, switchcmd.c_str(), level);
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query(
 		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue2,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %" PRIu64 ")",

--- a/push/GooglePubSubPush.cpp
+++ b/push/GooglePubSubPush.cpp
@@ -150,17 +150,17 @@ void CGooglePubSubPush::DoGooglePubSubPush(const uint64_t DeviceRowIdx)
 		sendValue = sValue;
 
 		unsigned long tzoffset = get_tzoffset();
-		int localTime = lastUpdate;
-		int localTimeUtc = (int)(lastUpdate - tzoffset);
+		uint64_t localTime = lastUpdate;
+		uint64_t localTimeUtc = localTime - tzoffset;
 
 		char szLocalTime[21];
-		sprintf(szLocalTime, "%d", localTime);
+		sprintf(szLocalTime, "%" PRIu64, localTime);
 		char szLocalTimeUtc[21];
-		sprintf(szLocalTimeUtc, "%d", localTimeUtc);
+		sprintf(szLocalTimeUtc, "%" PRIu64, localTimeUtc);
 		char szLocalTimeMs[21];
-		sprintf(szLocalTimeMs, "%" PRIu64, (uint64_t)(localTime * 1000));
+		sprintf(szLocalTimeMs, "%" PRIu64, localTime * 1000);
 		char szLocalTimeUtcMs[21];
-		sprintf(szLocalTimeUtcMs, "%" PRIu64, (uint64_t)(localTimeUtc * 1000));
+		sprintf(szLocalTimeUtcMs, "%" PRIu64, localTimeUtc * 1000);
 
 		std::string llastUpdate = get_lastUpdate(localTimeUtc);
 


### PR DESCRIPTION
Just rechecked int64_t and uint64_t print formats in all code, and fixed some of them.
Have no more compilation warning about them on Ubuntu 20.04 LTS 64 bits.