### PR TITLE
Auto enable debug and prevent crash

### DIFF
--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -135,8 +135,11 @@ bool CLogger::SetDebugFlags(const std::string &sFlags)
 	SetDebugFlags(iFlags);
 	if(IsDebugLevelEnabled(DEBUG_WEBSERVER))
 		SetACLFlogFlags(LOG_ACLF_ENABLED);
-	if(!IsLogLevelEnabled(LOG_DEBUG_INT))
-		Log(LOG_STATUS,"Debug logging not active. Set loglevel DEBUG when using debug logging!");
+	if (!IsLogLevelEnabled(LOG_DEBUG_INT))
+	{
+		m_log_flags |= LOG_DEBUG_INT;
+		Log(LOG_STATUS, "Enabling Debug logging!");
+	}
 	return true;
 }
 

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -1177,15 +1177,16 @@ int main(int argc, char**argv)
 #endif
 	}
 
+	if (!m_mainworker.Start())
+	{
+		return 1;
+	}
+
 	// start Watchdog thread after daemonization
 	m_LastHeartbeat = mytime(nullptr);
 	std::thread thread_watchdog(Do_Watchdog_Work);
 	SetThreadName(thread_watchdog.native_handle(), "Watchdog");
 
-	if (!m_mainworker.Start())
-	{
-		return 1;
-	}
 	m_StartTime = time(nullptr);
 
 	/* now, lets get into an infinite loop of doing nothing. */


### PR DESCRIPTION
Small PR that

- Automatically enables 'loglevel' `debug` when the `-debuglevel <somelevel>` is specified
- Prevent crash of Domoticz when for some reason (like too high DB version) the mainworker could not start