### PR TITLE
1Wire using proper logging methods (Fixes #5642)

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -47,16 +47,16 @@ void C1Wire::DetectSystem()
 	// see http://owfs.org/index.php?page=w1-project.
 	if (m_path.length() != 0)
 	{
-		m_system = new C1WireByOWFS(m_path);
+		m_system = new C1WireByOWFS(m_path, this);
 	}
 	else
 	{
 #ifdef WIN32
 		if (C1WireForWindows::IsAvailable())
-			m_system = new C1WireForWindows();
+			m_system = new C1WireForWindows(this);
 #else // WIN32
 		if (C1WireByKernel::IsAvailable())
-			m_system = new C1WireByKernel();
+			m_system = new C1WireByKernel(this);
 #endif // WIN32
 	}
 }
@@ -306,7 +306,7 @@ void C1Wire::BuildSensorList() {
 	std::vector<_t1WireDevice> devices;
 	int n1wireVersion = 0;
 
-	_log.Debug(DEBUG_HARDWARE, "1-Wire: Searching sensors");
+	Debug(DEBUG_HARDWARE, "1-Wire: Searching sensors");
 
 	m_sensors.clear();
 	m_system->GetDevices(devices);
@@ -362,7 +362,7 @@ void C1Wire::BuildSwitchList() {
 
 	std::vector<_t1WireDevice> devices;
 
-	_log.Debug(DEBUG_HARDWARE, "1-Wire: Searching switches");
+	Debug(DEBUG_HARDWARE, "1-Wire: Searching switches");
 
 	m_switches.clear();
 	m_system->GetDevices(devices);

--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -29,11 +29,12 @@
 	#define Wire1_Base_Dir "/sys/bus/w1/devices"
 #endif //_DEBUG
 
-C1WireByKernel::C1WireByKernel()
+C1WireByKernel::C1WireByKernel(C1Wire *C1WireBase)
 {
+	m_p1WireBase = C1WireBase;
 	m_thread = std::make_shared<std::thread>([this] { ThreadFunction(); });
 	SetThreadName(m_thread->native_handle(), "1WireByKernel");
-	_log.Log(LOG_STATUS, "Using 1-Wire support (kernel W1 module)...");
+	m_p1WireBase->Log(LOG_STATUS, "Using 1-Wire support (kernel W1 module)...");
 }
 
 C1WireByKernel::~C1WireByKernel()
@@ -145,7 +146,7 @@ void C1WireByKernel::ReadStates()
 		}
 		catch (const OneWireReadErrorException& e)
 		{
-			_log.Log(LOG_ERROR, "%s", e.what());
+			m_p1WireBase->Log(LOG_ERROR, "%s", e.what());
 		}
 	}
 
@@ -181,12 +182,12 @@ void C1WireByKernel::ThreadProcessPendingChanges()
 			}
 			catch (const OneWireReadErrorException& e)
 			{
-				_log.Log(LOG_ERROR, "%s", e.what());
+				m_p1WireBase->Log(LOG_ERROR, "%s", e.what());
 				continue;
 			}
 			catch (const OneWireWriteErrorException& e)
 			{
-				_log.Log(LOG_ERROR, "%s", e.what());
+				m_p1WireBase->Log(LOG_ERROR, "%s", e.what());
 				continue;
 			}
 			success = true;
@@ -241,10 +242,10 @@ void C1WireByKernel::ThreadBuildDevicesList()
 						case programmable_resolution_digital_thermometer:
 						case Temperature_memory:
 							m_Devices[device.devid] = new DeviceState(device);
-							_log.Log(LOG_STATUS, "1Wire: Added Device: %s", sLine.c_str());
+							m_p1WireBase->Log(LOG_STATUS, "1Wire: Added Device: %s", sLine.c_str());
 							break;
 						default: // Device not supported in kernel mode (maybe later...), use OWFS solution.
-							_log.Log(LOG_ERROR, "1Wire: Device not yet supported in Kernel mode (Please report!) ID:%s, family: %02X", sLine.c_str(), device.family);
+							m_p1WireBase->Log(LOG_ERROR, "1Wire: Device not yet supported in Kernel mode (Please report!) ID:%s, family: %02X", sLine.c_str(), device.family);
 							break;
 						}
 					}

--- a/hardware/1Wire/1WireByKernel.h
+++ b/hardware/1Wire/1WireByKernel.h
@@ -7,7 +7,7 @@
 class C1WireByKernel : public I_1WireSystem, StoppableTask
 {
 public:
-   C1WireByKernel();
+   C1WireByKernel(C1Wire *C1WareBase);
    ~C1WireByKernel() override;
 
    // I_1WireSystem implementation

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -14,16 +14,17 @@
 
 #include "../../main/Helper.h"
 
-C1WireByOWFS::C1WireByOWFS(const std::string& path):
+C1WireByOWFS::C1WireByOWFS(const std::string& path, C1Wire *C1WireBase):
 	m_path(path)
 {
+   m_p1WireBase = C1WireBase;
 	if (m_path.empty())
 		m_path = "/mnt/1wire";
 
 	m_simultaneousTemperaturePath = m_path;
 	m_simultaneousTemperaturePath.append("/simultaneous/temperature");
 
-   _log.Log(LOG_STATUS,"Using 1-Wire support (OWFS)...");
+   m_p1WireBase->Log(LOG_STATUS,"Using 1-Wire support (OWFS)...");
 }
 
 bool C1WireByOWFS::FindDevice(const std::string &sID, /*out*/_t1WireDevice& device) const
@@ -93,7 +94,7 @@ void C1WireByOWFS::GetDevices(const std::string &inDir, /*out*/std::vector<_t1Wi
 		    GetDevice(inDir, de->d_name, device);
 
 		    // Add device to list
-		    _log.Debug(DEBUG_HARDWARE, "1Wire (OWFS): Add device %s", device.filename.c_str());
+		    m_p1WireBase->Debug(DEBUG_HARDWARE, "1Wire (OWFS): Add device %s", device.filename.c_str());
 		    devices.push_back(device);
 
 		    // If device is a hub, scan for all hub connected devices (recursively)
@@ -194,7 +195,7 @@ float C1WireByOWFS::GetTemperature(const _t1WireDevice& device) const
 {
    std::string readValue=readRawData(std::string(device.filename+"/temperature"));
 
-   _log.Debug(DEBUG_HARDWARE, "1Wire (OWFS): Get Temperature from %s = %s", device.filename.c_str(), readValue.c_str());
+   m_p1WireBase->Debug(DEBUG_HARDWARE, "1Wire (OWFS): Get Temperature from %s = %s", device.filename.c_str(), readValue.c_str());
 
    if (readValue.empty())
       return -1000.0;
@@ -205,7 +206,7 @@ float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
 {
    std::string readValue=readRawData(std::string(device.filename+"/humidity"));
 
-   _log.Debug(DEBUG_HARDWARE, "1Wire (OWFS): Get Humidity from %s = %s", device.filename.c_str(), readValue.c_str());
+   m_p1WireBase->Debug(DEBUG_HARDWARE, "1Wire (OWFS): Get Humidity from %s = %s", device.filename.c_str(), readValue.c_str());
 
    if (readValue.empty())
 	   return -1000.0;
@@ -359,14 +360,14 @@ int C1WireByOWFS::GetWiper(const _t1WireDevice& device) const
 
 void C1WireByOWFS::StartSimultaneousTemperatureRead()
 {
-	_log.Debug(DEBUG_HARDWARE, "1Wire (OWFS): Initiating simultaneous temperature read");
+	m_p1WireBase->Debug(DEBUG_HARDWARE, "1Wire (OWFS): Initiating simultaneous temperature read");
 	std::ofstream file;
 	file.open(m_simultaneousTemperaturePath.c_str());
 	if (file.is_open())
 	{
 		file << "1";
 		file.close();
-		_log.Debug(DEBUG_HARDWARE, "1Wire (OWFS): Simultaneous temperature read successful");
+		m_p1WireBase->Debug(DEBUG_HARDWARE, "1Wire (OWFS): Simultaneous temperature read successful");
 		sleep_milliseconds(800);
 	}
 }

--- a/hardware/1Wire/1WireByOWFS.h
+++ b/hardware/1Wire/1WireByOWFS.h
@@ -15,7 +15,7 @@ private:
 	std::string m_simultaneousTemperaturePath; // OWFS mountpoint + "/simultaneous/temperature"
 
 public:
-   explicit C1WireByOWFS(const std::string& path);
+   explicit C1WireByOWFS(const std::string& path, C1Wire *C1WareBase);
    ~C1WireByOWFS() override = default;
 
    // I_1WireSystem implementation

--- a/hardware/1Wire/1WireForWindows.cpp
+++ b/hardware/1Wire/1WireForWindows.cpp
@@ -188,11 +188,12 @@ bool C1WireForWindows::IsAvailable()
 #endif
 }
 
-C1WireForWindows::C1WireForWindows()
+C1WireForWindows::C1WireForWindows(C1Wire *C1WireBase)
 {
 	// Connect to service
+	m_p1WireBase = C1WireBase;
 	m_Socket = ConnectToService();
-	_log.Log(LOG_STATUS, "Using 1-Wire support (Windows)...");
+	m_p1WireBase->Log(LOG_STATUS, "Using 1-Wire support (Windows)...");
 }
 
 C1WireForWindows::~C1WireForWindows()

--- a/hardware/1Wire/1WireForWindows.h
+++ b/hardware/1Wire/1WireForWindows.h
@@ -10,7 +10,7 @@ namespace Json
 class C1WireForWindows : public I_1WireSystem
 {
 public:
-   C1WireForWindows();
+   C1WireForWindows(C1Wire *C1WireBase);
    virtual ~C1WireForWindows();
 
    // I_1WireSystem implementation

--- a/hardware/1Wire/1WireSystem.h
+++ b/hardware/1Wire/1WireSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "1WireCommon.h"
+#include "../1Wire.h"
 
 // 1Wire system interface. Represent the mean used to access to the 1Wire bus.
 // Implementation can be C1WireByKernel, C1WireByOWFS or C1WireForWindows
@@ -24,4 +25,6 @@ public:
   virtual int GetWiper(const _t1WireDevice &device) const = 0;
   virtual void StartSimultaneousTemperatureRead() = 0;
   virtual void PrepareDevices() = 0;
+
+	C1Wire *m_p1WireBase = nullptr;
 };


### PR DESCRIPTION
This PR tries to fix #5642 

As 1 don't have the 1Wire system in use or quickly available for testing, I could not really test this other than Domoticz creating the HW device and shows proper (debug) logging.

@megamarco833 , could you test this PR build?

