### PR TITLE
WriteToHardware now returns true to allow events to happen (Fixes #5650)

### DIFF
--- a/hardware/HttpPoller.cpp
+++ b/hardware/HttpPoller.cpp
@@ -48,7 +48,7 @@ void CHttpPoller::Init()
 
 bool CHttpPoller::WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/)
 {
-	return false;
+	return true;
 }
 
 bool CHttpPoller::StartHardware()


### PR DESCRIPTION
Small PR to fix issue #5650 