### PR TITLE
Add timesync check script to domoticz.sh

### DIFF
--- a/domoticz.sh
+++ b/domoticz.sh
@@ -53,6 +53,46 @@ pidof_domoticz() {
 #
 do_start()
 {
+
+# Script that waits for time synchronisation before starting Domoticz to prevent a crash
+# on a cold boot when no real time clock is available.
+
+# Check if systemd-timesyncd is enabled and running, otherwise ignore script
+if systemctl --quiet is-enabled systemd-timesyncd && systemctl --quiet is-active systemd-timesyncd; then
+    # Check if time is already synced, if so start Domoticz immediately
+    if [ -f "/run/systemd/timesync/synchronized" ]; then
+        printf "Time is already synchronized, starting Domoticz...\n"
+    else
+        # Check if custom time server(s) are defined
+        if grep -q "^#NTP=" /etc/systemd/timesyncd.conf; then
+            printf "INFO: No time server(s) defined in /etc/systemd/timesyncd.conf, using default fallback server(s)\n"
+        fi
+        # Wait a maximum of 30 seconds until sync file is generated indicating successful time sync
+        printf "Waiting for time synchronization before starting Domoticz"
+        count=30
+		while [ ! -f "/run/systemd/timesync/synchronized" ]
+        do
+            count=$((count-1))
+            if [ $((count)) -lt 1 ]
+            then
+		        #If failed, print error message, exit loop and start Domoticz anyway
+                printf "\nWARNING: Time synchronization failed, check network and /etc/systemd/timesyncd.conf\n"
+                printf "Starting Domoticz without successful time synchronization...\n"
+                break
+            fi
+            printf "."
+            sleep 1
+        done
+	    #If the file was found in time, sync was successful and Domoticz will start immediately
+        if [ -f "/run/systemd/timesync/synchronized" ]
+        then
+            printf "\nTime synchronization successful, starting Domoticz...\n"
+        fi
+    fi
+else
+    printf "INFO: systemd-timesyncd is not enabled or running\nINFO: Starting Domoticz without waiting for time synchronization...\n"
+fi
+
         # Return
         #   0 if daemon has been started
         #   1 if daemon was already running

--- a/domoticz.sh
+++ b/domoticz.sh
@@ -69,7 +69,7 @@ do_start()
 		# Wait a maximum of 30 seconds until sync file is generated indicating successful time sync
 		printf "Waiting for time synchronization before starting Domoticz"
 		count=30
-			while [ ! -f "/run/systemd/timesync/synchronized" ]
+		while [ ! -f "/run/systemd/timesync/synchronized" ]
 		do
 		    count=$((count-1))
 		    if [ $((count)) -lt 1 ]
@@ -88,8 +88,6 @@ do_start()
 		    printf "\nTime synchronization successful, starting Domoticz...\n"
 		fi
 	    fi
-	else
-	    # printf "INFO: systemd-timesyncd is not enabled or running\nINFO: Starting Domoticz without waiting for time synchronization...\n"
 	fi
 
 	# Return

--- a/domoticz.sh
+++ b/domoticz.sh
@@ -53,55 +53,54 @@ pidof_domoticz() {
 #
 do_start()
 {
+	# Script that waits for time synchronisation before starting Domoticz to prevent a crash
+	# on a cold boot when no real time clock is available.
 
-# Script that waits for time synchronisation before starting Domoticz to prevent a crash
-# on a cold boot when no real time clock is available.
+	# Check if systemd-timesyncd is enabled and running, otherwise ignore script
+	if systemctl --quiet is-enabled systemd-timesyncd && systemctl --quiet is-active systemd-timesyncd; then
+	    # Check if time is already synced, if so start Domoticz immediately
+	    if [ -f "/run/systemd/timesync/synchronized" ]; then
+		printf "Time synchronized, starting Domoticz...\n"
+	    else
+		# Check if custom time server(s) are defined
+		if grep -q "^#NTP=" /etc/systemd/timesyncd.conf; then
+		    printf "INFO: No time server(s) defined in /etc/systemd/timesyncd.conf, using default fallback server(s)\n"
+		fi
+		# Wait a maximum of 30 seconds until sync file is generated indicating successful time sync
+		printf "Waiting for time synchronization before starting Domoticz"
+		count=30
+			while [ ! -f "/run/systemd/timesync/synchronized" ]
+		do
+		    count=$((count-1))
+		    if [ $((count)) -lt 1 ]
+		    then
+			# If failed, print error message, exit loop and start Domoticz anyway
+			printf "\nWARNING: Time synchronization failed, check network and /etc/systemd/timesyncd.conf\n"
+			printf "Starting Domoticz without successful time synchronization...\n"
+			break
+		    fi
+		    printf "."
+		    sleep 1
+		done
+		#If the file was found in time, sync was successful and Domoticz will start immediately
+		if [ -f "/run/systemd/timesync/synchronized" ]
+		then
+		    printf "\nTime synchronization successful, starting Domoticz...\n"
+		fi
+	    fi
+	else
+	    # printf "INFO: systemd-timesyncd is not enabled or running\nINFO: Starting Domoticz without waiting for time synchronization...\n"
+	fi
 
-# Check if systemd-timesyncd is enabled and running, otherwise ignore script
-if systemctl --quiet is-enabled systemd-timesyncd && systemctl --quiet is-active systemd-timesyncd; then
-    # Check if time is already synced, if so start Domoticz immediately
-    if [ -f "/run/systemd/timesync/synchronized" ]; then
-        printf "Time is already synchronized, starting Domoticz...\n"
-    else
-        # Check if custom time server(s) are defined
-        if grep -q "^#NTP=" /etc/systemd/timesyncd.conf; then
-            printf "INFO: No time server(s) defined in /etc/systemd/timesyncd.conf, using default fallback server(s)\n"
-        fi
-        # Wait a maximum of 30 seconds until sync file is generated indicating successful time sync
-        printf "Waiting for time synchronization before starting Domoticz"
-        count=30
-		while [ ! -f "/run/systemd/timesync/synchronized" ]
-        do
-            count=$((count-1))
-            if [ $((count)) -lt 1 ]
-            then
-		        #If failed, print error message, exit loop and start Domoticz anyway
-                printf "\nWARNING: Time synchronization failed, check network and /etc/systemd/timesyncd.conf\n"
-                printf "Starting Domoticz without successful time synchronization...\n"
-                break
-            fi
-            printf "."
-            sleep 1
-        done
-	    #If the file was found in time, sync was successful and Domoticz will start immediately
-        if [ -f "/run/systemd/timesync/synchronized" ]
-        then
-            printf "\nTime synchronization successful, starting Domoticz...\n"
-        fi
-    fi
-else
-    printf "INFO: systemd-timesyncd is not enabled or running\nINFO: Starting Domoticz without waiting for time synchronization...\n"
-fi
-
-        # Return
-        #   0 if daemon has been started
-        #   1 if daemon was already running
-        #   2 if daemon could not be started
-        start-stop-daemon --chuid $USERNAME --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
-                || return 1
-        start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
-                $DAEMON_ARGS \
-                || return 2
+	# Return
+	#   0 if daemon has been started
+	#   1 if daemon was already running
+	#   2 if daemon could not be started
+	start-stop-daemon --chuid $USERNAME --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
+		|| return 1
+	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON -- \
+		$DAEMON_ARGS \
+		|| return 2
 }
 
 #


### PR DESCRIPTION
This adds a script in the do_start() function to wait 30 seconds, or less until the file /run/systemd/timesync/synchronized is found indicating a successful time sync before starting Domoticz. This is to allow systems without a real time clock to finish synchronizing to a time server, because Domoticz can crash when the time change is larger than a set watchdog timer. The script also checks if systemd-timesyncd is active and running before executing, to avoid running it on systems that do not use it. When the time is already synchronized, the script will start Domoticz immediately. The script will always allow Domoticz to start, even if the sync fails, and all events generate a message for the user.

Resolves #5673 