### PR TITLE
Don't record NULL reads of a DS2423 1-Wire counter as a zero, NULL should be disgarded and re-read on the next interval.

### DIFF
--- a/hardware/1Wire.cpp
+++ b/hardware/1Wire.cpp
@@ -529,6 +529,9 @@ void C1Wire::ReportLightState(const std::string& deviceId, const uint8_t unit, c
 
 void C1Wire::ReportCounter(const std::string& deviceId, const int unit, const unsigned long counter)
 {
+	if (counter < 0)	//Detect NULL reads of DS2423 counter.
+		return;
+	
 	unsigned char deviceIdByteArray[DEVICE_ID_SIZE] = { 0 };
 	DeviceIdToByteArray(deviceId, deviceIdByteArray);
 

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -308,7 +308,7 @@ unsigned long C1WireByOWFS::GetCounter(const _t1WireDevice& device,int unit) con
    if (readValue.empty())
       readValue=readRawData(std::string(device.filename+"/counters.").append(1,'A'+(char)unit));
    if (readValue.empty())
-	   return 0;
+	   return -1;  // NULL read.
    return (unsigned long)atol(readValue.c_str());
 }
 


### PR DESCRIPTION
Don't record NULL reads of a DS2423 1-Wire counter as a zero, zero can be a valid read, but a NULL should be disgarded and re-read on the next interval.