### PR TITLE
Add helm chart to deploy domoticz in kubernetes clusters

### DIFF
--- a/helm-chart-k8s/.helmignore
+++ b/helm-chart-k8s/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm-chart-k8s/Chart.yaml
+++ b/helm-chart-k8s/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: domoticz
+description: A Helm chart for Kubernetes
+type: application
+version: 1.0.0
+appVersion: "1.0.0"

--- a/helm-chart-k8s/README.md
+++ b/helm-chart-k8s/README.md
@@ -1,0 +1,16 @@
+# helm-chart for Domoticz
+
+This is a helm-chart for deploy Domoticz on any kubernetes cluster.  This helm deploy:
+ * Internal kubernetes service (svc)
+ * Deployment with a pod (container) with Domoticz base. (stable)
+ * AWS LoadBalancer to access using UI Domotic instance. 
+
+### How to deploy it
+	helm install -n domoticz --create-namespace domoticz .
+
+### Tested with
+
+|Soft 		| version | 
+|---		|--- 	  |
+|Helm           |v3.x.x	  |
+|Kubernetes     |1.20/1.22|

--- a/helm-chart-k8s/templates/01-service.yaml
+++ b/helm-chart-k8s/templates/01-service.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-domoticz-{{ .Values.general.name }}
+  labels:
+    app: domoticz
+    environment: {{ .Values.general.environment }}
+    client: {{ .Values.general.name }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    filter.by.port.name: 'true'
+    app: domoticz
+    app.business.client: {{ .Values.general.name }}
+    app.owner: 'Domoticz'
+    app.helm-chart: 'https://hub.docker.com/repository/docker/jpradoar/'
+    app.imageregistry: 'https://hub.docker.com/r/domoticz/domoticz/' 
+spec:
+  selector:
+    app: domoticz
+    environment: {{ .Values.general.environment }}
+    client: {{ .Values.general.name }}    
+  ports:
+    - name: http
+      protocol: TCP     
+      port: 8080        
+      targetPort: 8080
+    - name: https
+      protocol: TCP     
+      port: 8443        
+      targetPort: 443      

--- a/helm-chart-k8s/templates/02-deployment.yaml
+++ b/helm-chart-k8s/templates/02-deployment.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: domoticz-{{ .Values.general.name }}
+#----------------------------------  
+  labels:
+    app: domoticz
+    environment: {{ .Values.general.environment }}
+    client: {{ .Values.general.name }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    filter.by.port.name: 'true'
+    app: domoticz
+    app.business.client: {{ .Values.general.name }}
+    app.owner: 'Domoticz'
+    app.helm-chart: 'https://hub.docker.com/repository/docker/jpradoar/'
+    app.imageregistry: 'https://hub.docker.com/r/domoticz/domoticz/' 
+spec:
+#----------------------------------
+  replicas: {{ .Values.replicaCount }}
+  strategy: 
+    type: RollingUpdate    
+    rollingUpdate:      
+       maxSurge: 50%          
+       maxUnavailable: 0  
+#-----------------------------------------        
+  selector:
+    matchLabels:
+      app: domoticz
+      environment: {{ .Values.general.environment }}
+      client: {{ .Values.general.name }}      
+  template:
+    metadata:
+      labels:
+        app: domoticz
+        environment: {{ .Values.general.environment }}
+        client: {{ .Values.general.name }}        
+      annotations:
+        prometheus.io/scrape: 'true'
+        app: domoticz
+        app.business.client: {{ .Values.general.name }}
+        app.owner: 'Domoticz'
+        app.helm-chart: 'https://hub.docker.com/repository/docker/jpradoar/'
+        app.imageregistry: 'https://hub.docker.com/r/domoticz/domoticz/'  
+    spec:
+      containers:
+      - name: domoticz-{{ .Values.general.name }}
+        image: domoticz/domoticz:stable
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+        ports:
+         - containerPort: {{ .Values.service.port }}
+        env:
+        - name: TZ
+          value: {{ .Values.general.tz }}            
+#-----------------------------------------         
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.service.path }}
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 3
+          periodSeconds: 3
+#-----------------------------------------          
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.service.path }}
+            port: {{ .Values.service.port }}
+          initialDelaySeconds: 3
+          periodSeconds: 3
+

--- a/helm-chart-k8s/templates/03-aws-loadbalancer.yaml
+++ b/helm-chart-k8s/templates/03-aws-loadbalancer.yaml
@@ -1,0 +1,40 @@
+{{- if eq .Values.service.loadBalancer "aws" }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-pub-domoticz-{{ .Values.general.name }}
+  labels:
+    app: domoticz
+    environment: {{ .Values.general.environment }}
+    client: {{ .Values.general.name }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    filter.by.port.name: 'true'
+    app: domoticz
+    app.business.client: {{ .Values.general.name }}
+    app.owner: 'Domoticz'
+    app.helm-chart: 'https://hub.docker.com/repository/docker/jpradoar/'
+    app.imageregistry: 'https://hub.docker.com/r/domoticz/domoticz/'   
+    service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "product=Domoticz"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb # (AWS NLB)
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-healthy-threshold: "3"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-unhealthy-threshold: "3"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-interval: "10"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-timeout: "10"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "TCP"
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  - name: https
+    port: 8443
+    targetPort: 443    
+  selector:
+    app: domoticz
+    environment: {{ .Values.general.environment }}
+    client: {{ .Values.general.name }}    
+{{- end }}

--- a/helm-chart-k8s/values.yaml
+++ b/helm-chart-k8s/values.yaml
@@ -1,0 +1,25 @@
+
+general:
+  name: client01  # Siempre en minuscula 
+  tz: Europe/Amsterdam
+  environment: development
+
+image:
+  #repository: domoticz/domoticz
+  imagePullPolicy: Always
+  #tag: "stable"
+
+service:
+  type: ClusterIP
+  port: 8080
+  https_port: 8443
+  path: /
+  loadBalancer: aws # none/aws
+
+resources:
+  limits:
+   cpu: 100m
+   memory: 128Mi
+  requests:
+   cpu: 100m
+   memory: 128Mi


### PR DESCRIPTION
* Add: Helm chart to deploy Domotics on kubernetes
* Add: Small readme to know how to operate

The objective is to deploy an instance of Domotics on kubernetes cluster and can access it via load-balancer url (in the future could be use a real dns).
This is usefull because I can use it like "SaaS"

If you consider this job as an interesting, I can impruve all deployment and add more usefull configurations.

Thanks a lot!
Jonathan