### PR TITLE
Proxy handling: Also remove quotes from IPv4 addresses (fixes #5683)

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1165,13 +1165,14 @@ namespace http {
 
 			std::string cleanIP = stdstring_trimws(ip);
 			bool bIsIPv6 = (cleanIP.find(':') != std::string::npos);
+			// IPv6 and IPv4 addresses can be written as quoted strings
+			if (cleanIP.find('"') != std::string::npos)
+			{
+				cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove quotes from begin and end
+			}
 			if (bIsIPv6)
 			{
 				// IPv6 addresses can be written as quoted strings and between brackets (See RFC5952)
-				if (cleanIP.find('"') != std::string::npos)
-				{
-					cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove quotes from begin and end
-				}
 				if (cleanIP.find('[') != std::string::npos)
 				{
 					cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove brackets from begin and end

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1166,14 +1166,14 @@ namespace http {
 			std::string cleanIP = stdstring_trimws(ip);
 			bool bIsIPv6 = (cleanIP.find(':') != std::string::npos);
 			// IPv6 and IPv4 addresses can be written as quoted strings
-			if (cleanIP.find('"') != std::string::npos)
+			if (cleanIP.front() == '"' && cleanIP.back() == '"')
 			{
 				cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove quotes from begin and end
 			}
 			if (bIsIPv6)
 			{
 				// IPv6 addresses can be written as quoted strings and between brackets (See RFC5952)
-				if (cleanIP.find('[') != std::string::npos)
+				if (cleanIP.front() == '[' && cleanIP.back() == ']')
 				{
 					cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove brackets from begin and end
 				}


### PR DESCRIPTION
When a Proxy uses the 'forwarded'-header, the 'for'-field contains the IP-address of the source. For IPv6 addresses, these can be quoted and between brackets ([).

But it seems also allowed to put IPv4 addresses between quotes. It was found that the Hiawatha-proxy server puts the IPv4 addresses between quotes. This was not handled correctly as Domoticz only checked for quotes for IPv6 addresses.

This is now changed so both IPv6 and IPv4 addresses can be quoted and will be handled correctly.

This fixes #5683 