### PR TITLE
Add built releases as assets in github versions

### DIFF
--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -56,21 +56,11 @@ jobs:
         ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
         sudo ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
 
-    - name : Build open-zwave (x86_64)
-      if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
-      run: |
-        cd $GITHUB_WORKSPACE/src
-        cd ..
-        git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
-        cd open-zwave-read-only
-        make
-        sudo make install >> /dev/null 2>&1
-
     - name : Build domoticz (x86_64)
       if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
       run: |
         cd $GITHUB_WORKSPACE/src
-        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
+        cmake -DCMAKE_BUILD_TYPE=Release CMakeLists.txt
         make
 
     - name: functional-tests domoticz (x86_64)
@@ -125,53 +115,6 @@ jobs:
         run: |
           echo "System built successfully"
 
-    - name: Build open-zwave (qemu)
-      if: ${{ ( !contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
-      uses: uraimo/run-on-arch-action@v2.5.0
-      with:
-        arch: ${{ matrix.qemu_arch }}
-        distro: ubuntu20.04
-        env: |
-          ARCHITECTURE: ${{ matrix.appimage_arch }}
-        githubToken: ${{ github.token }}
-        dockerRunArgs: |
-          --volume "${GITHUB_WORKSPACE}/:/build"
-        install: |
-          apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y --autoremove upgrade
-          apt-get -y install tar wget curl make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev libsqlite3-dev python3-pytest python3-pytest-bdd lua5.3 luarocks python3-pip
-          luarocks install busted
-          luarocks install luacov
-          python3 -m pip install requests
-          case "${{ matrix.qemu_arch }}" in 
-            aarch64)
-              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}"-linux-aarch64.tar.gz -o cmake.tar.gz;
-              tar xf cmake.tar.gz --strip 1 -C /usr/local;
-              export PATH=/usr/local/bin:$PATH;
-              ;;
-            armv7)
-              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}".tar.gz -o cmake.tar.gz;
-              tar xf cmake.tar.gz;
-              cd cmake-"${{ env.Vcmake }}";
-              ./configure;
-              make install  >> /dev/null 2>&1;
-              export PATH=/usr/local/bin:$PATH;
-              cd ..;
-              ;;
-            esac
-          wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/"${{ env.Vboost }}"/source/boost_"${{ env.Vboost_ }}".tar.gz >> /dev/null 2>&1
-          tar xfz boost_"${{ env.Vboost_ }}".tar.gz
-          cd boost_"${{ env.Vboost_ }}"/
-          ./bootstrap.sh
-          ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
-          ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
-        run: |
-          export PATH=/usr/local/bin:$PATH;
-          cd /build/src
-          git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
-          cd open-zwave-read-only
-          make
-          make install >> /dev/null 2>&1
-
     - name: Build domoticz (qemu)
       if: ${{ ( !contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
       uses: uraimo/run-on-arch-action@v2.5.0
@@ -215,7 +158,7 @@ jobs:
           export PATH=/usr/local/bin:$PATH;
           cd /build/src
           chown -R $(whoami): /build/src
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
+          cmake -DCMAKE_BUILD_TYPE=Release CMakeLists.txt
           make
 
     - name: functional-tests domoticz (qemu)
@@ -274,7 +217,7 @@ jobs:
         sudo chown -R $(whoami): ./src
         cd src
         mkdir package
-        tar czf package/domoticz_linux_${{ matrix.appimage_arch }}.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease www/ scripts/ Config/ dzVents/
+        tar czf package/domoticz_linux_${{ matrix.appimage_arch }}.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease www/ scripts/ dzVents/
         shasum -a 256 package/domoticz_linux_${{ matrix.appimage_arch }}.tgz > package/domoticz_linux_${{ matrix.appimage_arch }}.tgz.sha256sum
 
       # Artifact upload

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -11,6 +11,7 @@ on:
       - '**.md'
       - '**.txt'
 
+#used for both X86 and qemu, require to rebuild the github packages via a manual workflow_dispatch
 env:
   Vcmake: 3.26.3
   Vboost: 1.81.0
@@ -18,7 +19,6 @@ env:
 
 jobs:
   build:
-    #runs-on: ubuntu-latest   # Per Dec 2022 latest = 22.04 with GCC 11, OpenSSL3.0 and this breaks building OpenZwave
     runs-on: ubuntu-latest
 
     strategy:
@@ -73,6 +73,8 @@ jobs:
         sudo kill -s TERM `sudo cat /var/run/domoticz.pid`
       continue-on-error: false
 
+#Build a package in github with all required dependencies to build domoticz
+#The install parameter need to be exactly the same in all qemu steps
     - name : Build system (qemu)
       if: ${{ !contains(matrix.qemu_arch, 'x86') }}
       uses: uraimo/run-on-arch-action@v2.5.0

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -1,0 +1,290 @@
+name: build last version
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+    paths-ignore:
+      - 'msbuild/**'
+      - '.github/**'
+      - 'tools/**'
+      - '**.md'
+      - '**.txt'
+
+env:
+  Vcmake: 3.26.3
+  Vboost: 1.81.0
+  Vboost_ : 1_81_0
+
+jobs:
+  build:
+    #runs-on: ubuntu-latest   # Per Dec 2022 latest = 22.04 with GCC 11, OpenSSL3.0 and this breaks building OpenZwave
+    runs-on: ubuntu-20.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - { qemu_arch: x86_64,  appimage_arch: x86_64 }
+        - { qemu_arch: armv7,   appimage_arch: armhf }
+        - { qemu_arch: aarch64, appimage_arch: aarch64 }
+
+    steps:
+    - name : Checkout
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+        submodules: true
+        path: 'src'
+
+    - name : Build system (x86_64)
+      if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      run: |
+        sudo timedatectl set-timezone Europe/Amsterdam
+        sudo apt-get update && sudo apt-get --autoremove upgrade
+        sudo apt-get install make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev python3-pytest python3-pytest-bdd lua5.3 luarocks
+        sudo luarocks install busted
+        sudo luarocks install luacov
+        curl -sSL https://github.com/Kitware/CMake/releases/download/v${Vcmake}/cmake-${Vcmake}-linux-x86_64.tar.gz -o cmake.tar.gz;
+        sudo tar xf cmake.tar.gz --strip 1 -C /usr/local;
+        export PATH=/usr/local/bin:$PATH;
+        wget https://boostorg.jfrog.io/artifactory/main/release/${Vboost}/source/boost_${Vboost_}.tar.gz >> /dev/null 2>&1
+        tar xfz boost_${Vboost_}.tar.gz
+        cd boost_${Vboost_}/
+        ./bootstrap.sh
+        ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+        sudo ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+
+    - name : Build open-zwave (x86_64)
+      if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      run: |
+        cd $GITHUB_WORKSPACE/src
+        cd ..
+        git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
+        cd open-zwave-read-only
+        make
+        sudo make install >> /dev/null 2>&1
+
+    - name : Build domoticz (x86_64)
+      if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      run: |
+        cd $GITHUB_WORKSPACE/src
+        cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
+        make
+
+    - name: functional-tests domoticz (x86_64)
+      if: ${{ ( contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      run: |
+        cd $GITHUB_WORKSPACE/src
+        ln -s ../test/gherkin/resources/testwebcontent www/test
+        sudo ./domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz.pid -daemon
+        pytest-3 -rA --tb=no test/gherkin/
+        sudo kill -s TERM `sudo cat /var/run/domoticz.pid`
+      continue-on-error: false
+
+    - name : Build system (qemu)
+      if: ${{ !contains(matrix.qemu_arch, 'x86') }}
+      uses: uraimo/run-on-arch-action@v2.5.0
+      with:
+        arch: ${{ matrix.qemu_arch }}
+        distro: ubuntu20.04
+        env: |
+          ARCHITECTURE: ${{ matrix.appimage_arch }}
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${GITHUB_WORKSPACE}/:/build"
+        install: |
+          apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y --autoremove upgrade
+          apt-get -y install tar wget curl make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev libsqlite3-dev python3-pytest python3-pytest-bdd lua5.3 luarocks python3-pip
+          luarocks install busted
+          luarocks install luacov
+          python3 -m pip install requests
+          case "${{ matrix.qemu_arch }}" in 
+            aarch64)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}"-linux-aarch64.tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz --strip 1 -C /usr/local;
+              export PATH=/usr/local/bin:$PATH;
+              ;;
+            armv7)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}".tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz;
+              cd cmake-"${{ env.Vcmake }}";
+              ./configure;
+              make install  >> /dev/null 2>&1;
+              export PATH=/usr/local/bin:$PATH;
+              cd ..;
+              ;;
+            esac
+          wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/"${{ env.Vboost }}"/source/boost_"${{ env.Vboost_ }}".tar.gz >> /dev/null 2>&1
+          tar xfz boost_"${{ env.Vboost_ }}".tar.gz
+          cd boost_"${{ env.Vboost_ }}"/
+          ./bootstrap.sh
+          ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+          ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+        run: |
+          echo "System built successfully"
+
+    - name: Build open-zwave (qemu)
+      if: ${{ ( !contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      uses: uraimo/run-on-arch-action@v2.5.0
+      with:
+        arch: ${{ matrix.qemu_arch }}
+        distro: ubuntu20.04
+        env: |
+          ARCHITECTURE: ${{ matrix.appimage_arch }}
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${GITHUB_WORKSPACE}/:/build"
+        install: |
+          apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y --autoremove upgrade
+          apt-get -y install tar wget curl make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev libsqlite3-dev python3-pytest python3-pytest-bdd lua5.3 luarocks python3-pip
+          luarocks install busted
+          luarocks install luacov
+          python3 -m pip install requests
+          case "${{ matrix.qemu_arch }}" in 
+            aarch64)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}"-linux-aarch64.tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz --strip 1 -C /usr/local;
+              export PATH=/usr/local/bin:$PATH;
+              ;;
+            armv7)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}".tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz;
+              cd cmake-"${{ env.Vcmake }}";
+              ./configure;
+              make install  >> /dev/null 2>&1;
+              export PATH=/usr/local/bin:$PATH;
+              cd ..;
+              ;;
+            esac
+          wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/"${{ env.Vboost }}"/source/boost_"${{ env.Vboost_ }}".tar.gz >> /dev/null 2>&1
+          tar xfz boost_"${{ env.Vboost_ }}".tar.gz
+          cd boost_"${{ env.Vboost_ }}"/
+          ./bootstrap.sh
+          ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+          ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+        run: |
+          export PATH=/usr/local/bin:$PATH;
+          cd /build/src
+          git clone https://github.com/domoticz/open-zwave.git open-zwave-read-only
+          cd open-zwave-read-only
+          make
+          make install >> /dev/null 2>&1
+
+    - name: Build domoticz (qemu)
+      if: ${{ ( !contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      uses: uraimo/run-on-arch-action@v2.5.0
+      with:
+        arch: ${{ matrix.qemu_arch }}
+        distro: ubuntu20.04
+        env: |
+          ARCHITECTURE: ${{ matrix.appimage_arch }}
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${GITHUB_WORKSPACE}/:/build"
+        install: |
+          apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y --autoremove upgrade
+          apt-get -y install tar wget curl make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev libsqlite3-dev python3-pytest python3-pytest-bdd lua5.3 luarocks python3-pip
+          luarocks install busted
+          luarocks install luacov
+          python3 -m pip install requests
+          case "${{ matrix.qemu_arch }}" in 
+            aarch64)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}"-linux-aarch64.tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz --strip 1 -C /usr/local;
+              export PATH=/usr/local/bin:$PATH;
+              ;;
+            armv7)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}".tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz;
+              cd cmake-"${{ env.Vcmake }}";
+              ./configure;
+              make install  >> /dev/null 2>&1;
+              export PATH=/usr/local/bin:$PATH;
+              cd ..;
+              ;;
+            esac
+          wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/"${{ env.Vboost }}"/source/boost_"${{ env.Vboost_ }}".tar.gz >> /dev/null 2>&1
+          tar xfz boost_"${{ env.Vboost_ }}".tar.gz
+          cd boost_"${{ env.Vboost_ }}"/
+          ./bootstrap.sh
+          ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+          ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+        run: |
+          export PATH=/usr/local/bin:$PATH;
+          cd /build/src
+          chown -R $(whoami): /build/src
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_LIBRARY_PATH=open-zwave-read-only CMakeLists.txt
+          make
+
+    - name: functional-tests domoticz (qemu)
+      if: ${{ ( !contains(matrix.qemu_arch, 'x86') && github.event_name != 'workflow_dispatch' ) }}
+      uses: uraimo/run-on-arch-action@v2.5.0
+      with:
+        arch: ${{ matrix.qemu_arch }}
+        distro: ubuntu20.04
+        env: |
+          ARCHITECTURE: ${{ matrix.appimage_arch }}
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${GITHUB_WORKSPACE}/:/build"
+        install: |
+          apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y --autoremove upgrade
+          apt-get -y install tar wget curl make gcc g++ libssl-dev git libcurl4-gnutls-dev libusb-dev python3-dev zlib1g-dev libcereal-dev liblua5.3-dev uthash-dev libsqlite3-dev python3-pytest python3-pytest-bdd lua5.3 luarocks python3-pip
+          luarocks install busted
+          luarocks install luacov
+          python3 -m pip install requests
+          case "${{ matrix.qemu_arch }}" in 
+            aarch64)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}"-linux-aarch64.tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz --strip 1 -C /usr/local;
+              export PATH=/usr/local/bin:$PATH;
+              ;;
+            armv7)
+              curl -sSL https://github.com/Kitware/CMake/releases/download/v"${{ env.Vcmake }}"/cmake-"${{ env.Vcmake }}".tar.gz -o cmake.tar.gz;
+              tar xf cmake.tar.gz;
+              cd cmake-"${{ env.Vcmake }}";
+              ./configure;
+              make install  >> /dev/null 2>&1;
+              export PATH=/usr/local/bin:$PATH;
+              cd ..;
+              ;;
+            esac
+          wget --no-check-certificate https://boostorg.jfrog.io/artifactory/main/release/"${{ env.Vboost }}"/source/boost_"${{ env.Vboost_ }}".tar.gz >> /dev/null 2>&1
+          tar xfz boost_"${{ env.Vboost_ }}".tar.gz
+          cd boost_"${{ env.Vboost_ }}"/
+          ./bootstrap.sh
+          ./b2 stage threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+          ./b2 install threading=multi link=static --with-thread --with-system --with-chrono >> /dev/null 2>&1
+        run: |
+          cd /build/src
+          ln -s ../test/gherkin/resources/testwebcontent www/test
+          ./domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz.pid -daemon
+          pytest-3 -rA --tb=no test/gherkin/
+          kill -s TERM `cat /var/run/domoticz.pid`
+          ls -la
+      continue-on-error: false
+
+    # Packaging
+    - name: package domoticz
+      if: ${{ ( github.event_name != 'workflow_dispatch' ) }}
+      run: |
+        cd $GITHUB_WORKSPACE
+        sudo chown -R $(whoami): ./src
+        cd src
+        mkdir package
+        tar czf package/domoticz_linux_${{ matrix.appimage_arch }}.tgz domoticz History.txt License.txt domoticz.sh server_cert.pem updatebeta updaterelease www/ scripts/ Config/ dzVents/
+        shasum -a 256 package/domoticz_linux_${{ matrix.appimage_arch }}.tgz > package/domoticz_linux_${{ matrix.appimage_arch }}.tgz.sha256sum
+
+      # Artifact upload
+    - name: Upload asset
+      if: ${{ github.event_name != 'workflow_dispatch' }}
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }} 
+        asset_name: domoticz_linux_${{github.ref_name}}_${{ matrix.appimage_arch }}.tgz
+        asset_path: src/package/domoticz_linux_${{ matrix.appimage_arch }}.tgz
+        asset_content_type: application/octet-stream

--- a/.github/workflows/build_arch.yml
+++ b/.github/workflows/build_arch.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   build:
     #runs-on: ubuntu-latest   # Per Dec 2022 latest = 22.04 with GCC 11, OpenSSL3.0 and this breaks building OpenZwave
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -78,7 +78,7 @@ jobs:
       uses: uraimo/run-on-arch-action@v2.5.0
       with:
         arch: ${{ matrix.qemu_arch }}
-        distro: ubuntu20.04
+        distro: ubuntu_latest
         env: |
           ARCHITECTURE: ${{ matrix.appimage_arch }}
         githubToken: ${{ github.token }}
@@ -120,7 +120,7 @@ jobs:
       uses: uraimo/run-on-arch-action@v2.5.0
       with:
         arch: ${{ matrix.qemu_arch }}
-        distro: ubuntu20.04
+        distro: ubuntu_latest
         env: |
           ARCHITECTURE: ${{ matrix.appimage_arch }}
         githubToken: ${{ github.token }}
@@ -166,7 +166,7 @@ jobs:
       uses: uraimo/run-on-arch-action@v2.5.0
       with:
         arch: ${{ matrix.qemu_arch }}
-        distro: ubuntu20.04
+        distro: ubuntu_latest
         env: |
           ARCHITECTURE: ${{ matrix.appimage_arch }}
         githubToken: ${{ github.token }}


### PR DESCRIPTION
Hello:
Related to #5622 
This add a github action that will build and upload asset for x86_64, armhf and aarch64 architecture each time a new release is created.
It is inspired from the [development.yml](https://github.com/domoticz/domoticz/blob/development/.github/workflows/development.yml) action and uses [uraimo/run-on-arch-action](https://github.com/uraimo/run-on-arch-action) to emulate alternative architecture.
It takes into account the phase-out of Openzwave .

**Prerequisite**: The Workflow permissions should be "Read and Write" in the action settings of the repo:
![image](https://github.com/domoticz/domoticz/assets/9308214/8e0ac252-c16c-46ac-996a-1ea6cd5f8009)

**How to** : 
The action needs to be run manually once via workflow_dispatch event, this will create packages in the repository that contains a docker container with everything required to compile the assets.
This may run a few hours as cmake need to be built for armv7 and as it run in qemu it is far slower as a native x86_64. This has to be done in a separate job as github limit the duration of a job to 6h and compiling both cmake and domoticz will take longer.
Once this is done, each new Github Release will trigger the action that will build 3 assets and attach them to the release. 

You may find an example for a release and a pre-release on my repo that I used to test the action: https://github.com/Krakinou/domoticz_build_on_arch/releases