### PR TITLE
Prevent info leakage with getVersion Cmd

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2552,22 +2552,25 @@ namespace http
 		{
 			root["status"] = "OK";
 			root["title"] = "GetVersion";
-			root["version"] = szAppVersion;
-			root["hash"] = szAppHash;
-			root["build_time"] = szAppDate;
-			CdzVents* dzvents = CdzVents::GetInstance();
-			root["dzvents_version"] = dzvents->GetVersion();
-			root["python_version"] = szPyVersion;
-			root["UseUpdate"] = false;
-			root["HaveUpdate"] = false;
-
-			if (session.rights == URIGHTS_ADMIN)
+			if (session.rights != -1 )
 			{
-				root["UseUpdate"] = g_bUseUpdater;
-				root["HaveUpdate"] = m_mainworker.IsUpdateAvailable(false);
-				root["DomoticzUpdateURL"] = m_mainworker.m_szDomoticzUpdateURL;
-				root["SystemName"] = m_mainworker.m_szSystemName;
-				root["Revision"] = m_mainworker.m_iRevision;
+				root["version"] = szAppVersion;
+				root["hash"] = szAppHash;
+				root["build_time"] = szAppDate;
+				CdzVents* dzvents = CdzVents::GetInstance();
+				root["dzvents_version"] = dzvents->GetVersion();
+				root["python_version"] = szPyVersion;
+				root["UseUpdate"] = false;
+				root["HaveUpdate"] = false;
+
+				if (session.rights == URIGHTS_ADMIN)
+				{
+					root["UseUpdate"] = g_bUseUpdater;
+					root["HaveUpdate"] = m_mainworker.IsUpdateAvailable(false);
+					root["DomoticzUpdateURL"] = m_mainworker.m_szDomoticzUpdateURL;
+					root["SystemName"] = m_mainworker.m_szSystemName;
+					root["Revision"] = m_mainworker.m_iRevision;
+				}
 			}
 		}
 

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -371,13 +371,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				success: function (data) {
 					isOnline = true;
 					if (data.status == "OK") {
-						$rootScope.config.appversion = data.version;
-						$rootScope.config.apphash = data.hash;
-						$rootScope.config.appdate = data.build_time;
-						$rootScope.config.dzventsversion = data.dzvents_version;
-						$rootScope.config.pythonversion = data.python_version;
-						$rootScope.config.isproxied = data.isproxied;
-						$rootScope.config.versiontooltip = "'Build Hash: <b>" + $rootScope.config.apphash + "</b><br>" + "Build Date: " + $rootScope.config.appdate + "'";
 						$rootScope.config.AllowWidgetOrdering = data.AllowWidgetOrdering;
 						$rootScope.config.FiveMinuteHistoryDays = data.FiveMinuteHistoryDays;
 						$rootScope.config.DashboardType = data.DashboardType;
@@ -388,7 +381,6 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 						$rootScope.config.WindSign = data.WindSign;
 						$rootScope.config.language = data.language;
 						$rootScope.config.DegreeDaysBaseTemperature = data.DegreeDaysBaseTemperature;
-						$rootScope.config.userName = data.UserName;
 						$rootScope.config.EnableTabDashboard = data.result.EnableTabDashboard,
 						$rootScope.config.EnableTabFloorplans = data.result.EnableTabFloorplans;
 						$rootScope.config.EnableTabLights = data.result.EnableTabLights;
@@ -397,6 +389,16 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 						$rootScope.config.EnableTabWeather = data.result.EnableTabWeather;
 						$rootScope.config.EnableTabUtility = data.result.EnableTabUtility;
 						$rootScope.config.ShowUpdatedEffect = data.result.ShowUpdatedEffect;
+						if (typeof data.UserName != 'undefined') {
+							$rootScope.config.userName = data.UserName;
+							$rootScope.config.appversion = data.version;
+							$rootScope.config.apphash = data.hash;
+							$rootScope.config.appdate = data.build_time;
+							$rootScope.config.dzventsversion = data.dzvents_version;
+							$rootScope.config.pythonversion = data.python_version;
+							$rootScope.config.isproxied = data.isproxied;
+							$rootScope.config.versiontooltip = "'Build Hash: <b>" + $rootScope.config.apphash + "</b><br>" + "Build Date: " + $rootScope.config.appdate + "'";
+						}
 
 						SetLanguage(data.language);
 

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -646,6 +646,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
                         dzTimeAndSun.updateData(response.data);
 						$rootScope.SetTimeAndSun(data.Sunrise, data.Sunset, data.ServerTime);
 					}
+				}, function errorCallback(response) {
+					return;
 				});
 			}
 		};


### PR DESCRIPTION
Small PR based on forum discussion to disclose less information via the `getversion` command when a request is not coming from an authenticated user.

From a security perspective it is best to provide only the minimum of information to fulfill the request. Any other, although interesting, information can be _abused_ by bad actors.

See forum info at : https://www.domoticz.com/forum/viewtopic.php?t=40418

With this PR when a request is done without any authorisation, only the following is returned:
```
{
	"status" : "OK",
	"title" : "GetVersion"
}
```

When requested by a (non-admin) User, it gives (_which is the current default response without this PR_):
```
{
	"HaveUpdate" : false,
	"UseUpdate" : false,
	"build_time" : "2023-06-04 16:08:09",
	"dzvents_version" : "3.1.8",
	"hash" : "98a7d1eef-modified",
	"python_version" : "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]",
	"status" : "OK",
	"title" : "GetVersion",
	"version" : "2023.1 (build 15331)"
}
```

And for admins
```
{
	"DomoticzUpdateURL" : "https://www.domoticz.com/download.php?channel=stable&type=release&system=linux&machine=x86_64",
	"HaveUpdate" : false,
	"Revision" : 15091,
	"SystemName" : "linux",
	"UseUpdate" : true,
	"build_time" : "2023-06-04 16:08:09",
	"dzvents_version" : "3.1.8",
	"hash" : "98a7d1eef-modified",
	"python_version" : "3.8.10 (default, Nov 14 2022, 12:59:47) \n[GCC 9.4.0]",
	"status" : "OK",
	"title" : "GetVersion",
	"version" : "2023.1 (build 15331)"
}
```

Also the `getconfig` command now gives reduces information when called without any authorization.