### PR TITLE
Fix the functionaltests

### DIFF
--- a/test/gherkin/README.md
+++ b/test/gherkin/README.md
@@ -42,6 +42,8 @@ PASSED test/gherkin/test_webserver.py::test_decompressedout
 ================================================================================================ 3 passed in 0.14 seconds =================================================================================================
 ```
 
+You have to make sure that domoticz is running already (use `./domoticz -www 8080 -sslwww 0`)
+
 ### Prepare some testfiles
 
 Some tests need specific testfiles to be present in the Domoticz environment. So run the following:
@@ -53,3 +55,11 @@ ln -s ../test/gherkin/resources/testwebcontent www/test
 It will add a symbolic link to the Domoticz www directory called test pointing to some _test web content_ used by the tests for validation purposes.
 
 NOTE: This symbolic link can be removed after testing ofcourse.
+
+### Run everything in one go
+
+You can run the full functional testsuite by executing the following (bash) script:
+
+```bash
+./test/runtests.sh
+```

--- a/test/gherkin/conftest.py
+++ b/test/gherkin/conftest.py
@@ -24,8 +24,8 @@ def check_domoticz_port(test_domoticz,port):
     if oResult.status_code == 200:
         test_domoticz.iPort = port
         test_domoticz.sBaseURI += ":" + str(port)
-        oJSON = oResult.json()
-        test_domoticz.sVersion = oJSON["version"]
+        #oJSON = oResult.json()
+        #test_domoticz.sVersion = oJSON["version"]
     assert oResult.status_code == 200
 
 @given(parsers.parse('Command {command} is available'))

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# go to domoticz home dir
+cd ~/domoticz
+
+# create symbolic link for testing
+ln -s ../test/gherkin/resources/testwebcontent www/test
+
+# start domoticz
+sudo ./domoticz -sslwww 0 -wwwroot www -pidfile /var/run/domoticz.pid -daemon
+
+# run functional tests
+pytest-3 -rA --tb=no test/gherkin/
+
+# stop domoticz
+sudo kill -s TERM `sudo cat /var/run/domoticz.pid`
+
+# remove symbolic link
+rm www/test


### PR DESCRIPTION
Small fix, updated documentation and added `runtests.sh` support script (in the 'test'-directory).

PR #5708 changed the default anonymous output of the 'getversion' command which was used to check to see if domoticz itself is running and reachable before executing the functional tests. The check was looking for the versionnumber which is no longer _leaked_ under anonymous access.