### PR TITLE
Replace SetCurrentCostUSBType action with new proper API command

### DIFF
--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -115,12 +115,6 @@ void CurrentCostMeterSerial::Do_Work()
 //Webserver helpers
 namespace http {
 	namespace server {
-		void CWebServer::SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri)
-		{
-			redirect_uri = "/index.html";
-			Json::Value root;
-			Cmd_SetCurrentCostUSBType(session, req, root);
-		}
 
 		void CWebServer::Cmd_SetCurrentCostUSBType(WebEmSession & session, const request& req, Json::Value& root)
 		{

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -118,6 +118,13 @@ namespace http {
 		void CWebServer::SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri)
 		{
 			redirect_uri = "/index.html";
+			Json::Value root;
+			Cmd_SetCurrentCostUSBType(session, req, root);
+		}
+
+		void CWebServer::Cmd_SetCurrentCostUSBType(WebEmSession & session, const request& req, Json::Value& root)
+		{
+			root["title"] = "SetCurrentCostUSBType";
 			if (session.rights != 2)
 			{
 				session.reply_status = reply::forbidden;
@@ -145,6 +152,7 @@ namespace http {
 			m_sql.UpdateRFXCOMHardwareDetails(atoi(idx.c_str()), Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);
 
 			m_mainworker.RestartHardware(idx);
+			root["status"] = "OK";
 		}
 	} // namespace server
 } // namespace http

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -376,7 +376,6 @@ namespace http
 			m_pWebEm->RegisterActionCode("setopenthermsettings", [this](auto&& session, auto&& req, auto&& redirect_uri) { SetOpenThermSettings(session, req, redirect_uri); });
 
 			m_pWebEm->RegisterActionCode("reloadpiface", [this](auto&& session, auto&& req, auto&& redirect_uri) { ReloadPiFace(session, req, redirect_uri); });
-			m_pWebEm->RegisterActionCode("setcurrentcostmetertype", [this](auto&& session, auto&& req, auto&& redirect_uri) { SetCurrentCostUSBType(session, req, redirect_uri); });
 			m_pWebEm->RegisterActionCode("restoredatabase", [this](auto&& session, auto&& req, auto&& redirect_uri) { RestoreDatabase(session, req, redirect_uri); });
 			m_pWebEm->RegisterActionCode("sbfspotimportolddata", [this](auto&& session, auto&& req, auto&& redirect_uri) { SBFSpotImportOldData(session, req, redirect_uri); });
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -639,6 +639,9 @@ namespace http
 			RegisterCommandCode("rclientslog", [this](auto&& session, auto&& req, auto&& root) { Cmd_RemoteWebClientsLog(session, req, root); });
 			RegisterCommandCode("setused", [this](auto&& session, auto&& req, auto&& root) { Cmd_SetUsed(session, req, root); });
 
+			// Migrated ActionCodes to regular commands
+			RegisterCommandCode("setccmetertype", [this](auto&& session, auto&& req, auto&& root) { Cmd_SetCurrentCostUSBType(session, req, root); });
+
 			RegisterCommandCode("clearuserdevices", [this](auto&& session, auto&& req, auto&& root) { Cmd_ClearUserDevices(session, req, root); });
 
 			//MQTT-AD

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -60,7 +60,6 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void ReloadPiFace(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void RestoreDatabase(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void SBFSpotImportOldData(WebEmSession & session, const request& req, std::string & redirect_uri);
-	void SetCurrentCostUSBType(WebEmSession & session, const request& req, std::string & redirect_uri);
 
 	cWebem *m_pWebEm;
 

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -341,6 +341,9 @@ private:
 	void Cmd_RemoteWebClientsLog(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_SetUsed(WebEmSession & session, const request& req, Json::Value &root);
 
+	//Migrated ActionCodes
+	void Cmd_SetCurrentCostUSBType(WebEmSession& session, const request& req, Json::Value& root);
+
 	void Cmd_ClearUserDevices(WebEmSession& session, const request& req, Json::Value& root);
 
 	//MQTT-AD

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -13,7 +13,7 @@ define(['app'], function (app) {
 		'RFLink Gateway MQTT': ['MQTTParams', 4],
 	};
 	
-	app.controller('HardwareController', function ($scope, $rootScope, $timeout) {
+	app.controller('HardwareController', function ($scope, $rootScope, $timeout, $http) {
 
 		$scope.SerialPortStr = [];
 		$scope.calledFetch = 0;
@@ -3028,8 +3028,16 @@ define(['app'], function (app) {
 		}
 
 		SetCCUSBType = function () {
-			$.post("setcurrentcostmetertype.webem", $("#hardwarecontent #ccusbtype").serialize(), function (data) {
+			$http({
+				url: "json.htm?type=command&param=setccmetertype&idx=" + $('#hardwarecontent #ccusbtype #idx').val() + "&CCBaudrate=" + $('#hardwarecontent #ccusbtype #CCBaudrate').val()
+			}).then(function successCallback(response) {
+				var data = response.data;
+				if (data.status != "OK") {
+					ShowNotify($.t(data.error), 2500, true);
+					return;
+				}
 				ShowHardware();
+				return;
 			});
 		}
 
@@ -3937,7 +3945,7 @@ define(['app'], function (app) {
 								HwTypeStr += ' <span class="label label-info lcursor" onclick="EditRego6XXType(' + item.idx + ',\'' + item.Name + '\',' + item.Mode1 + ',' + item.Mode2 + ',' + item.Mode3 + ',' + item.Mode4 + ',' + item.Mode5 + ',' + item.Mode6 + ');">Change Type</span>';
 							}
 							else if (HwTypeStr.indexOf("CurrentCost Meter USB") >= 0) {
-								HwTypeStr += ' <span class="label label-info lcursor" onclick="EditCCUSB(' + item.idx + ',\'' + item.Name + '\',\'' + item.Address + '\');">' + $.t("Set Mode") + '</span>';
+								HwTypeStr += ' <span class="label label-info lcursor" onclick="EditCCUSB(' + item.idx + ',\'' + item.Name + '\',\'' + item.Mode1 + '\');">' + $.t("Set Mode") + '</span>';
 							}
 							else if (HwTypeStr.indexOf("Tellstick") >= 0) {
 								HwTypeStr += ' <span class="label label-info lcursor" onclick="TellstickSettings(' + item.idx + ',\'' + item.Name + '\',' + item.Mode1 + ',' + item.Mode2 + ');">' + $.t("Settings") + '</span>';


### PR DESCRIPTION
Instead of using the old 'webem' POST request form handling, now use a proper API command to set the correct values for this hardware type.

- Cmd added to hardware class
- Registered the new command to webserver API commands
- Updated the UI to use the new API command instead of the form POST

And fixed UI issue (not showing the current value) in the process.