### PR TITLE
Deprecated Rtype API call message is now an Info message

### DIFF
--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -548,7 +548,7 @@ namespace http
 
         void CWebServer::PresentOauth2LoginDialog(reply &rep, const std::string &sApp, const std::string &sError)
         {
-			std::string sTOTP = "required";
+			std::string sTOTP = "";	// required
 
 			rep = reply::stock_reply(reply::ok);
 

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -853,10 +853,6 @@ namespace http
 				{
 					altrtype = "getscenes";
 				}
-				else if (rtype.compare("plans") == 0)
-				{
-					altrtype = "getplans";
-				}
 				else if (rtype.compare("notifications") == 0)
 				{
 					altrtype = "getnotifications";
@@ -927,9 +923,9 @@ namespace http
 					auto pf = m_webcommands.find(altrtype);
 					if (pf != m_webcommands.end())
 					{
+						_log.Log(LOG_NORM, "[WebServer] Deprecated RType (%s) for API request. Handled via fallback (%s), please use correct API Command! (%s)", rtype.c_str(), altrtype.c_str(), req.host_remote_address.c_str());
 						pf->second(session, req, root);
 					}
-					_log.Log(LOG_STATUS, "[WebServer] Deprecated RType (%s) for API request. Handled via fallback (%s), please use correct API Command! (%s)", rtype.c_str(), altrtype.c_str(), req.host_remote_address.c_str());
 				}
 				else
 				{


### PR DESCRIPTION
Changed the deprecated RType API call message from a status message to a normal message in cases where the call is handled by the fallback functions.

When not handled by a fallback (so ignored), it is a status message.

Also noticed that the IamService login screen always required an TOTP-code to be entered, while this is optional and depends on if the user has activated 2FA. So changed it to optional