### PR TITLE
Fallback to Open Hardware Monitor corrected

### DIFF
--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -87,6 +87,7 @@ class CHardwareMonitor : public CDomoticzHardwareBase
 	bool InitWMI();
 	void ExitWMI();
 	bool IsHMRunning();
+	int GetRunningHM(std::string & hmNamespace);
 	void RunWMIQuery(const char *qTable, const std::string &qType);
 	IWbemLocator *m_pLocator;
 	IWbemServices *m_pServicesHM;


### PR DESCRIPTION
Windows executables for hardware sensors are now properly checked in order, first Libre Hardware Monitor, then Open Hardware Monitor. If an executable is found running, its corresponding WMI namespace is used in subsequent sensor data lookups.

Summary of the errors in my previous PR: I assumed HRESULTs would result in FAILED when they didn't and WMI namespaces can still exist even when the related executable is no longer running.

Tested on Windows 11 Pro 22H2 build 22621.1992 with Libre Hardware Monitor 0.9.2 and Open Hardware Monitor 0.9.6
