### PR TITLE
Fix ACLF logs should be on when debugflag webserver is active

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -29,6 +29,7 @@ Version 2023.xx
 - Fixed: Settings/Floorplan, Scene Names value was not saved
 - Changed: API: Old RType calls have been replaced with normal calls
 - Changed: MQTT-AD, better Unit calculation for scene/action devices
+- Changed: Debuglogging: setting debugflags automatically sets loglevel DEBUG
 - Updated: Plugin manager: ready for Python 3.11
 - Removed: native GoodWe hardware (use the new GoodWe python plugin instead)
 

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -132,13 +132,13 @@ bool CLogger::SetDebugFlags(const std::string &sFlags)
 			continue; // invalid flag, skip but continue processing the other flags
 	}
 	SetDebugFlags(iFlags);
-	if(IsDebugLevelEnabled(DEBUG_WEBSERVER))
-		SetACLFlogFlags(LOG_ACLF_ENABLED);
 	if (iFlags && !IsLogLevelEnabled(LOG_DEBUG_INT))
 	{
 		m_log_flags |= LOG_DEBUG_INT;
 		Log(LOG_STATUS, "Enabling Debug logging!");
 	}
+	if(IsDebugLevelEnabled(DEBUG_WEBSERVER))
+		SetACLFlogFlags(LOG_ACLF_ENABLED);
 	return true;
 }
 


### PR DESCRIPTION
This now also works when Loglevel debug gets activated automatically by PR #5644 