### PR TITLE
(IsValidIP) Remove IPv6 zone-index for link-local addresses

### DIFF
--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -997,6 +997,12 @@ namespace http {
 				{
 					cleanIP = cleanIP.substr(1,cleanIP.size()-2);	// Remove brackets from begin and end
 				}
+				// Link-local IPv6 addresses could have a 'zone-index' identifiyng which interface is used
+				// on a machine which has multiple interface. Can be discarded for checking
+				if ((cleanIP.find("fe80::") == 0) && (cleanIP.find('%') != std::string::npos))
+				{
+					cleanIP = cleanIP.substr(0,cleanIP.find('%'));
+				}
 			}
 		#ifndef WIN32
 			else

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1595,16 +1595,15 @@ namespace http {
 				return false;
 
 			//Is the given 'host' a valid IP address?
-			bool bIsIPv6 = (sHost.find(':') != std::string::npos);
-			uint8_t IP[16] = { 0 };
-			if ( (sHost.size() < 3) || (inet_pton((!bIsIPv6) ? AF_INET : AF_INET6, sHost.c_str(), &IP) != 1) )
-			{
+			std::string sCleanHost = sHost;
+			if (!cWebem::isValidIP(sCleanHost))			{
 				_log.Log(LOG_STATUS,"[web:%s] Given host (%s) is not a valid Ipv4 or IPv6 address! Unable to check if in Trusted Network!", myWebem->GetPort().c_str() ,sHost.c_str());
 				return false;	// The IP address is not a valid IPv4 or IPv6 address
 			}
+			bool bIsIPv6 = (sCleanHost.find(':') != std::string::npos);
 
 			return std::any_of(myWebem->m_localnetworks.begin(), myWebem->m_localnetworks.end(),
-					   [&](const _tIPNetwork &my) { return IsIPInRange(sHost, my, bIsIPv6); });
+					   [&](const _tIPNetwork &my) { return IsIPInRange(sCleanHost, my, bIsIPv6); });
 		}
 
 		std::string cWebemRequestHandler::generateSessionID()

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -200,6 +200,7 @@ namespace http
 			bool FindAuthenticatedUser(std::string &user, const request &req, reply &rep);
 			bool CheckVHost(const request &req);
 			bool findRealHostBehindProxies(const request &req, std::string &realhost);
+			static bool isValidIP(std::string& ip);
 
 			void ClearUserPasswords();
 			std::vector<_tWebUserPassword> m_userpasswords;
@@ -244,8 +245,6 @@ namespace http
 			std::map<std::string, webem_action_function> myActions;
 			/// store name walue pairs for form submit action
 			std::map<std::string, webem_page_function> myPages;
-
-			static bool isValidIP(std::string& ip);
 
 			void CleanSessions();
 			bool sumProxyHeader(const std::string &sHeader, const request &req, std::vector<std::string> &vHeaderLines);


### PR DESCRIPTION
Small PR addressing #5760 

Domoticz now is able to handle link-local IPv6 addresses that contain a zone-index identifying the used machine interface.

Actually we just remote the zone-index information as it is not used during checking of valid IP addresses.