### PR TITLE
Update AlfenEve.cpp, remove URLEncode of password

### DIFF
--- a/hardware/AlfenEve.cpp
+++ b/hardware/AlfenEve.cpp
@@ -62,7 +62,7 @@ std::string ReadFile(std::string filename)
 AlfenEve::AlfenEve(const int ID, const std::string& IPAddress, const uint16_t usIPPort, int PollInterval, const std::string& szUsername, const std::string& szPassword) :
 	m_szIPAddress(IPAddress),
 	m_szUsername(szUsername),
-	m_szPassword(CURLEncode::URLEncode(szPassword))
+	m_szPassword(CURLEncode::szPassword)
 {
 	m_HwdID = ID;
 


### PR DESCRIPTION
Remove URLEncode of the password on line 65 since URLEncode is not needed and causes login failure if the password contains special characters.
Reference issue 5768