### PR TITLE
(Refactor) Initialize Thermosmart with only relevant (checked) parameters

### DIFF
--- a/hardware/Thermosmart.cpp
+++ b/hardware/Thermosmart.cpp
@@ -56,29 +56,14 @@ std::string ReadFile(std::string filename)
 }
 #endif
 
-CThermosmart::CThermosmart(const int ID, const std::string &Username, const std::string &Password, const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6)
+CThermosmart::CThermosmart(const int ID, const std::string &Username, const std::string &Password, const int Mode1)
 {
-	if ((Password == "secret")|| (Password.empty()))
-	{
-		Log(LOG_ERROR, "Please update your username/password!...");
-	}
-	else
-	{
-		m_UserName = Username;
-		m_Password = Password;
-		stdstring_trim(m_UserName);
-		stdstring_trim(m_Password);
-	}
+	m_UserName = Username;
+	m_Password = Password;
 	m_HwdID=ID;
-	m_OutsideTemperatureIdx = 0; //use build in
+	m_OutsideTemperatureIdx = Mode1;	// 0 is build in, else idx of outside temperature sensor
 	m_LastMinute = -1;
-	SetModes(Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);
 	Init();
-}
-
-void CThermosmart::SetModes(const int Mode1, const int Mode2, const int Mode3, const int Mode4, const int Mode5, const int Mode6)
-{
-	m_OutsideTemperatureIdx = Mode1;
 }
 
 void CThermosmart::Init()
@@ -303,7 +288,6 @@ void CThermosmart::Logout()
 	m_bDoLogin = true;
 }
 
-
 bool CThermosmart::WriteToHardware(const char *pdata, const unsigned char length)
 {
 	const tRBUF *pCmd = reinterpret_cast<const tRBUF *>(pdata);
@@ -476,4 +460,3 @@ void CThermosmart::SetOutsideTemp(const float temp)
 		return;
 	}
 }
-

--- a/hardware/Thermosmart.h
+++ b/hardware/Thermosmart.h
@@ -6,7 +6,7 @@
 class CThermosmart : public CDomoticzHardwareBase
 {
       public:
-	CThermosmart(int ID, const std::string &Username, const std::string &Password, int Mode1, int Mode2, int Mode3, int Mode4, int Mode5, int Mode6);
+	CThermosmart(int ID, const std::string &Username, const std::string &Password, int Mode1);
 	~CThermosmart() override = default;
 	bool WriteToHardware(const char *pdata, unsigned char length) override;
 	void SetSetpoint(int idx, float temp);
@@ -20,7 +20,6 @@ class CThermosmart : public CDomoticzHardwareBase
 	bool Login();
 	void Logout();
 	void Init();
-	void SetModes(int Mode1, int Mode2, int Mode3, int Mode4, int Mode5, int Mode6);
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void Do_Work();

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -474,6 +474,8 @@ namespace http
 				return;
 			_eHardwareTypes htype = (_eHardwareTypes)atoi(shtype.c_str());
 
+			stdstring_trim(username);
+			stdstring_trim(password);
 			int iDataTimeout = atoi(sdatatimeout.c_str());
 			int mode1 = 0;
 			int mode2 = 0;
@@ -634,6 +636,9 @@ namespace http
 
 			if ((name.empty()) || (senabled.empty()) || (shtype.empty()))
 				return;
+
+			stdstring_trim(username);
+			stdstring_trim(password);
 
 			std::string mode1Str = request::findValue(&req, "Mode1");
 			std::string mode2Str = request::findValue(&req, "Mode2");

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -941,7 +941,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CAnnaThermostat(ID, Address, Port, Username, Password);
 		break;
 	case HTYPE_THERMOSMART:
-		pHardware = new CThermosmart(ID, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);
+		pHardware = new CThermosmart(ID, Username, Password, Mode1);
 		break;
 	case HTYPE_Tado:
 		pHardware = new CTado(ID, Username, Password);


### PR DESCRIPTION
The Thermosmart hardware was initialized with all (6) possible _Mode_ parameters while only 1 is used (and checked).

**To-do?** Make sure during Hardware validation that the device Index passed in the _Mode1_ parameters `IsTemp(...)` ?

**To-do?** Same problem (copy/paste) exist in the _AtagOne_ and the _OpenThermGateway_ (OTGW) hardware classes. Only Mode1 is used but all 6 are passed.