### PR TITLE
Netatmo OAUTH2 change to auth_code grant (from password)

### DIFF
--- a/hardware/Netatmo.h
+++ b/hardware/Netatmo.h
@@ -27,6 +27,9 @@ class CNetatmo : public CDomoticzHardwareBase
 	};
 	std::string m_clientId;
 	std::string m_clientSecret;
+	std::string m_scopes;
+	std::string m_redirectUri;
+	std::string m_authCode;
 	std::string m_username;
 	std::string m_password;
 	std::string m_accessToken;


### PR DESCRIPTION
Small PR addressing issue #5766 

Not the most user friendly (_option 1_ as discussed in the issue) but not to difficult to set up. Should be done only once as long as domoticz is able to keep refreshing the tokens.

### step 1:
Setup an _App_ under __MyApps__ in the Netatmo [developers portal](https://dev.netatmo.com)
- The _Redirect_URI_ has to contain `http://localhost/netatmo`

Once configured correctly, the _Client_ID_ and _Client_Secret_ will be generated and shown.

### step 2:
In the domoticz hardware setup:
- Create/modify the Netatmo hardware
- the _username_ should contain `<client_id>:<client_secret>`
- while the password should contain the retrieved `<code>`

To retrieve the _code_ (a.k.a. authorisation_code), use the browser and type the following URL. Make sure to fill in the CLIENTID with your clientid!

```
https://api.netatmo.com/oauth2/authorize?client_id=<YOURCLIENTID>&redirect_uri=http%3A%2F%2Flocalhost%2Fnetatmo&state=teststate&scope=read_station%20read_thermostat%20write_thermostat%20read_homecoach%20read_smokedetector%20read_presence%20read_camera
```
This URL brings you to the My Netatmo page where you have to identify yourself and are asked for permission to grant access to certain devices and types (based on the _scope_ provided).

After confirmation, your browser will try to redirect you to a page it cannot find so you will get an error. But the URL of that page is visible in the browser and looks like `http://localhost/netatmo?state=teststate&code=<SOMECODE>`.

You need to pass this _SOMECODE_ as the _password_ in the domoticz hardware screen.

__NOTE__:
- At the moment, the _scopes_ are fixed to `read_station read_thermostat write_thermostat read_homecoach read_smokedetector read_presence read_camera`
- The _\<SOMECODE\>_ you retrieved is only valid for a few minutes, so if you take too long and domoticz says (check the logs) it cannot login, retrieve a new code and be a little quicker :)
- Proper documentation (on the [Wiki](https://www.domoticz.com/wiki/Netatmo)) has to be created/updated