### PR TITLE
Adding TEMPO support in standard mode

### DIFF
--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -5,9 +5,8 @@ Author : Blaise Thauvin
 Version : 1.5
 Description : This class is used by various Teleinfo hardware decoders to process and display data
 		  It is currently used by EcoDevices, TeleinfoSerial
-		  Detailed information on the Teleinfo protocol can be found at (version 5, 16/03/2015)
-		  http://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_02E.pdf
-		  Detailed information for Linky: https://www.enedis.fr/media/2035/download
+		  Detailed information on the Teleinfo protocol (Enedis-NOI-CPT_54E) can be found at (version 3, 01/06/2018)
+		  https://www.enedis.fr/media/2035/download
 
 History :
 0.1 2017-03-03 : Creation

--- a/hardware/TeleinfoBase.h
+++ b/hardware/TeleinfoBase.h
@@ -85,6 +85,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 		bool triphase;
 		bool withPAPP; // For meters with no PAPP
 		int CRCmode1;  // really a bool, but with a special "un-initialized state"
+		bool waitingFirstBlock;
 		_tTeleinfo()
 		{
 			ISOUSC = 0;
@@ -131,6 +132,7 @@ class CTeleinfoBase : public CDomoticzHardwareBase
 			triphase = false;
 			withPAPP = false;
 			CRCmode1 = 255; // means "bool not initialized yet", will be when running CRC Check for the first time
+			waitingFirstBlock = true;
 		}
 	} Teleinfo;
 	void ProcessTeleinfo(Teleinfo &teleinfo);


### PR DESCRIPTION
Current Teleinfo does not support TEMPO in standard mode. With this modification TEMPO is supported in the same way in historic and standard mode.