### PR TITLE
VisualStudio build instruction update.

### DIFF
--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -1,41 +1,50 @@
 # Building Domoticz with Visual Studio
 
-- You need Visual Studio 2019 (Community Edition is perfect and is free)
-- The project file for Visual Studio can be found inside the "msbuild" folder
-- You need to download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries	- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
-  and unpack the archive inside the "msbuild" folder.
-  This is to build a release in InnoSetup
-  For building in debug mode, please remove the 'include' and 'lib' folder!
-- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
-- Domoticz is using the excelent VCPKG C++ Library Manager, and you need to install the required packages that are in the file msbuild/packages.txt
+### Environment configuration
 
-  First you need to get VCPKG and build it with:
-```
-  git clone https://github.com/microsoft/vcpkg.git
-  cd vcpkg
-  call bootstrap-vcpkg.bat -disableMetrics
-```
-  Now we are going to get/build all Domoticz dependencies
-```
-  set VCPKG_DEFAULT_TRIPLET=x86-windows
-```  
-  Copy/past the content of msbuild/vcpkg-packages.txt after the command below
-```  
-  vcpkg install <PASTE CONTENT HERE>
-```  
-  (For example vcpkg install boost cereal curl jsoncpp lua minizip mosquitto openssl pthreads sqlite3 zlib)
+#### Requirements
+- Visual Studio 2019 (Community Edition is perfect and is free)
+- Download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries
+- Domoticz reposioty cloned locally
 
-  Integrate VCPKG system wide with:
-```  
-  vcpkg.exe integrate install
-```
+#### Dependencies configuration
+1. Navigate to `path_to_domoticz/msbuild`
+2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
+    - For building in debug mode: remove the `Windows Libraries/include` and `Windows Libraries/lib` folder.
+3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
+4. Open: `Visual Studio Command Prompt`
+    - VS 2019: `Tools`:`Visual Studio Command Prompt`
+    - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
+    > Guide is not written for `Developer PowerShell`
+5. Get VCPKG and build it with following commands:
+    ```shell
+    # Clone vcpkg
+    git clone https://github.com/microsoft/vcpkg.git
+    # Enter the vcpkg directory
+    cd vcpkg
+    call bootstrap-vcpkg.bat -disableMetrics
+    ```
+    or use one liner:
+    ```shell
+    git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
+    ```
 
-- To compile Domoticz with Visual Studio choose Win32 configuration (Debug or Release)
-- Set the projects configuration properties for Debugging/Working Directory. 
-`Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory` should be set to 
-```
-"$(ProjectDir)/.."
-```
-- Optional: Python support
-  - Install Python version x32 downloaded from the official web: www.python.org
-  - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`
+6. Build all Domoticz dependencies
+    ```shell
+    # Set target environment and install all modules from ../vcpkg-packages.txt
+    set VCPKG_DEFAULT_TRIPLET=x86-windows && vcpkg install "@../vcpkg-packages.txt"
+    ```
+7. Integrate VCPKG system wide with:
+    ```shell
+    vcpkg.exe integrate install
+    ```
+#### Visual Studio configuration
+
+1. Select `Win32` configuration (Debug or Release) if not `Win32` configuration is available restart VS
+2. Set the project's configuration properties for Debugging/Working Directory:
+    - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
+    - set the value to `"$(ProjectDir)/.."`
+
+3. Optional: Python support
+    - Install Python version x32 downloaded from the official web: www.python.org
+    - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -1,50 +1,41 @@
 # Building Domoticz with Visual Studio
 
-### Environment configuration
+- You need Visual Studio 2019 (Community Edition is perfect and is free)
+- The project file for Visual Studio can be found inside the "msbuild" folder
+- You need to download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries	- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
+  and unpack the archive inside the "msbuild" folder.
+  This is to build a release in InnoSetup
+  For building in debug mode, please remove the 'include' and 'lib' folder!
+- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
+- Domoticz is using the excelent VCPKG C++ Library Manager, and you need to install the required packages that are in the file msbuild/packages.txt
 
-#### Requirements
-- Visual Studio 2019 (Community Edition is perfect and is free)
-- Download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries
-- Domoticz reposioty cloned locally
+  First you need to get VCPKG and build it with:
+```
+  git clone https://github.com/microsoft/vcpkg.git
+  cd vcpkg
+  call bootstrap-vcpkg.bat -disableMetrics
+```
+  Now we are going to get/build all Domoticz dependencies
+```
+  set VCPKG_DEFAULT_TRIPLET=x86-windows
+```  
+  Copy/past the content of msbuild/vcpkg-packages.txt after the command below
+```  
+  vcpkg install <PASTE CONTENT HERE>
+```  
+  (For example vcpkg install boost cereal curl jsoncpp lua minizip mosquitto openssl pthreads sqlite3 zlib)
 
-#### Dependencies configuration
-1. Navigate to `path_to_domoticz/msbuild`
-2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
-    - For building in debug mode: remove the `Windows Libraries/include` and `Windows Libraries/lib` folder.
-3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
-4. Open: `Visual Studio Command Prompt`
-    - VS 2019: `Tools`:`Visual Studio Command Prompt`
-    - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
-    > Guide is not written for `Developer PowerShell`
-5. Get VCPKG and build it with following commands:
-    ```shell
-    # Clone vcpkg
-    git clone https://github.com/microsoft/vcpkg.git
-    # Enter the vcpkg directory
-    cd vcpkg
-    call bootstrap-vcpkg.bat -disableMetrics
-    ```
-    or use one liner:
-    ```bash
-    git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
-    ```
-  
-6. Build all Domoticz dependencies
-    ```shell
-    # Set target environment and install all modules from ../vcpkg-packages.txt
-    set VCPKG_DEFAULT_TRIPLET=x86-windows && vcpkg install "@../vcpkg-packages.txt"
-    ```
-7. Integrate VCPKG system wide with:
-    ```shell  
-    vcpkg.exe integrate install
-    ```
-#### Visual Studio configuration
+  Integrate VCPKG system wide with:
+```  
+  vcpkg.exe integrate install
+```
 
-1. Select Win32 configuration (Debug or Release)
-2. Set the project's configuration properties for Debugging/Working Directory: 
-    - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
-    - set the value to `"$(ProjectDir)/.."` 
-
-3. Optional: Python support
-    - Install Python version x32 downloaded from the official web: www.python.org
-    - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`
+- To compile Domoticz with Visual Studio choose Win32 configuration (Debug or Release)
+- Set the projects configuration properties for Debugging/Working Directory. 
+`Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory` should be set to 
+```
+"$(ProjectDir)/.."
+```
+- Optional: Python support
+  - Install Python version x32 downloaded from the official web: www.python.org
+  - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -3,19 +3,52 @@
 ## Environment configuration
 
 ### Requirements
+
 - Visual Studio Community Edition version 2019 or higher (2022 recommended)
 - Download `WindowsLibraries.7z` from [domoticz/win32-libraries](https://github.com/domoticz/win32-libraries)
 - Locally cloned Domoticz repository
 
 ### Dependencies configuration
+
 1. Navigate to `path_to_domoticz/msbuild`
 2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
 3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
+
+#### Optional: VCPKG Configuration
+
+1. When using VCPKG remove following directories from `msbuild/Windows Libraries/`:
+   - `msbuild/Windows Libraries/include`
+   - `msbuild/Windows Libraries/lib`
+
+2. From Visual Studio open: `Visual Studio Command Prompt`
+    - VS 2019: `Tools`:`Visual Studio Command Prompt`
+    - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
+        > Do not use `Developer PowerShell` as the `set` command will fail.
+
+3. Build all Domoticz dependencies (ports)
+    ```shell
+    # Navigate to directory where VCPKG is installed
+    cd {VCPKG_INSTALLED_DIRECTORY}
+    # Set target environment
+    set VCPKG_DEFAULT_TRIPLET=x86-windows
+    # Install all modules from msbuild/vcpkg-packages.txt
+    vcpkg install "@{DOMOTICZ_PRJ_PATH}/msbuild/vcpkg-packages.txt"
+    ```
+
+    > `{DOMOTICZ_PRJ_PATH}/msbuild/vcpkg-packages.txt`
+    <br>should be a path to the file `domoticz/msbuild/vcpkg-packages.txt`
+    <br>Example: `vcpkg install "@e:\Dev\domoticz\msbuild\vcpkg-packages.txt"`
+
+4. System wide integration of VCPKG ports with command:
+    ```shell
+    vcpkg integrate install
+    ```
 
 ### Visual Studio configuration
 
 1. Select `Win32` build configuration (Debug or Release).
     - If `Win32` build configuration is not available restart VS
+
 2. Set the project's configuration properties for Debugging/Working Directory:
     - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
     - set the value to `"$(ProjectDir)/.."`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -4,8 +4,8 @@
 
 ### Requirements
 - Visual Studio 2019 (Community Edition is perfect and is free)
-- Download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries
-- Domoticz reposioty cloned locally
+- Download `WindowsLibraries.7z` from [domoticz/win32-libraries](https://github.com/domoticz/win32-libraries)
+- Locally cloned Domoticz repository
 
 ### Dependencies configuration
 1. Navigate to `path_to_domoticz/msbuild`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -3,7 +3,7 @@
 ## Environment configuration
 
 ### Requirements
-- Visual Studio 2019 (Community Edition is perfect and is free)
+- Visual Studio Community Edition version 2019 or higher (2022 recommended)
 - Download `WindowsLibraries.7z` from [domoticz/win32-libraries](https://github.com/domoticz/win32-libraries)
 - Locally cloned Domoticz repository
 
@@ -12,39 +12,6 @@
 2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
 3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
 
-#### Optional: VCPKG Configuration
-1. Remove following directories from `msbuild/Windows Libraries/`:
-   - `msbuild/Windows Libraries/include`
-   - `msbuild/Windows Libraries/lib`
-2. Launch or focus Visual Studio
-3. Open: `Visual Studio Command Prompt`
-    - VS 2019: `Tools`:`Visual Studio Command Prompt`
-    - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
-    > Guide is not written for `Developer PowerShell`
-4. Get VCPKG and build it with following commands:
-    ```shell
-    # Select target drive letter for vcpkg install
-    c:
-    # Clone vcpkg
-    git clone https://github.com/microsoft/vcpkg.git
-    # Enter the vcpkg directory
-    cd vcpkg
-    call bootstrap-vcpkg.bat -disableMetrics
-    ```
-    or use one liner:
-    ```shell
-    c: && git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
-    ```
-
-5. Build all Domoticz dependencies
-    ```shell
-    # Set target environment and install all modules from ../vcpkg-packages.txt
-    set VCPKG_DEFAULT_TRIPLET=x86-windows && vcpkg install "@../vcpkg-packages.txt"
-    ```
-6. Integrate VCPKG system wide with:
-    ```shell
-    vcpkg integrate install
-    ```
 ### Visual Studio configuration
 
 1. Select `Win32` build configuration (Debug or Release).
@@ -52,7 +19,3 @@
 2. Set the project's configuration properties for Debugging/Working Directory:
     - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
     - set the value to `"$(ProjectDir)/.."`
-
-3. Optional: Python support
-    - Install Python version x32 downloaded from the official web: www.python.org
-    - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -1,41 +1,50 @@
 # Building Domoticz with Visual Studio
 
-- You need Visual Studio 2019 (Community Edition is perfect and is free)
-- The project file for Visual Studio can be found inside the "msbuild" folder
-- You need to download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries	- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
-  and unpack the archive inside the "msbuild" folder.
-  This is to build a release in InnoSetup
-  For building in debug mode, please remove the 'include' and 'lib' folder!
-- For the Initial setup, Launch Visual Studio and from the 'Tools' menu choose 'Visual Studio Command Prompt'
-- Domoticz is using the excelent VCPKG C++ Library Manager, and you need to install the required packages that are in the file msbuild/packages.txt
+### Environment configuration
 
-  First you need to get VCPKG and build it with:
-```
-  git clone https://github.com/microsoft/vcpkg.git
-  cd vcpkg
-  call bootstrap-vcpkg.bat -disableMetrics
-```
-  Now we are going to get/build all Domoticz dependencies
-```
-  set VCPKG_DEFAULT_TRIPLET=x86-windows
-```  
-  Copy/past the content of msbuild/vcpkg-packages.txt after the command below
-```  
-  vcpkg install <PASTE CONTENT HERE>
-```  
-  (For example vcpkg install boost cereal curl jsoncpp lua minizip mosquitto openssl pthreads sqlite3 zlib)
+#### Requirements
+- Visual Studio 2019 (Community Edition is perfect and is free)
+- Download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries
+- Domoticz reposioty cloned locally
 
-  Integrate VCPKG system wide with:
-```  
-  vcpkg.exe integrate install
-```
+#### Dependencies configuration
+1. Navigate to `path_to_domoticz/msbuild`
+2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
+    - For building in debug mode: remove the `Windows Libraries/include` and `Windows Libraries/lib` folder.
+3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
+4. Open: `Visual Studio Command Prompt`
+    - VS 2019: `Tools`:`Visual Studio Command Prompt`
+    - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
+    > Guide is not written for `Developer PowerShell`
+5. Get VCPKG and build it with following commands:
+    ```shell
+    # Clone vcpkg
+    git clone https://github.com/microsoft/vcpkg.git
+    # Enter the vcpkg directory
+    cd vcpkg
+    call bootstrap-vcpkg.bat -disableMetrics
+    ```
+    or use one liner:
+    ```bash
+    git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
+    ```
+  
+6. Build all Domoticz dependencies
+    ```shell
+    # Set target environment and install all modules from ../vcpkg-packages.txt
+    set VCPKG_DEFAULT_TRIPLET=x86-windows && vcpkg install "@../vcpkg-packages.txt"
+    ```
+7. Integrate VCPKG system wide with:
+    ```shell  
+    vcpkg.exe integrate install
+    ```
+#### Visual Studio configuration
 
-- To compile Domoticz with Visual Studio choose Win32 configuration (Debug or Release)
-- Set the projects configuration properties for Debugging/Working Directory. 
-`Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory` should be set to 
-```
-"$(ProjectDir)/.."
-```
-- Optional: Python support
-  - Install Python version x32 downloaded from the official web: www.python.org
-  - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`
+1. Select Win32 configuration (Debug or Release)
+2. Set the project's configuration properties for Debugging/Working Directory: 
+    - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
+    - set the value to `"$(ProjectDir)/.."` 
+
+3. Optional: Python support
+    - Install Python version x32 downloaded from the official web: www.python.org
+    - Add path to the project: `Solution Explorer` -> `domoticz` -> `Properties` -> `Linker` -> `General` -> `Additional Library Directories` -> add `{path_to_python_install_dir}\libs`

--- a/build/README-visual-studio.md
+++ b/build/README-visual-studio.md
@@ -1,23 +1,30 @@
 # Building Domoticz with Visual Studio
 
-### Environment configuration
+## Environment configuration
 
-#### Requirements
+### Requirements
 - Visual Studio 2019 (Community Edition is perfect and is free)
 - Download `WindowsLibraries.7z` from https://github.com/domoticz/win32-libraries
 - Domoticz reposioty cloned locally
 
-#### Dependencies configuration
+### Dependencies configuration
 1. Navigate to `path_to_domoticz/msbuild`
 2. From `WindowsLibraries.7z` unpack `Windows Libraries` directory into `msbuild` folder
-    - For building in debug mode: remove the `Windows Libraries/include` and `Windows Libraries/lib` folder.
 3. Open Domoticz project file for Visual Studio `msbuild/domoticz.sln` - Visual Studio will launch
-4. Open: `Visual Studio Command Prompt`
+
+#### Optional: VCPKG Configuration
+1. Remove following directories from `msbuild/Windows Libraries/`:
+   - `msbuild/Windows Libraries/include`
+   - `msbuild/Windows Libraries/lib`
+2. Launch or focus Visual Studio
+3. Open: `Visual Studio Command Prompt`
     - VS 2019: `Tools`:`Visual Studio Command Prompt`
     - VS 2022: `Tools`:`Command Line`:`Developer Command Prompt`
     > Guide is not written for `Developer PowerShell`
-5. Get VCPKG and build it with following commands:
+4. Get VCPKG and build it with following commands:
     ```shell
+    # Select target drive letter for vcpkg install
+    c:
     # Clone vcpkg
     git clone https://github.com/microsoft/vcpkg.git
     # Enter the vcpkg directory
@@ -26,21 +33,22 @@
     ```
     or use one liner:
     ```shell
-    git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
+    c: && git clone https://github.com/microsoft/vcpkg.git && cd vcpkg && call bootstrap-vcpkg.bat -disableMetrics
     ```
 
-6. Build all Domoticz dependencies
+5. Build all Domoticz dependencies
     ```shell
     # Set target environment and install all modules from ../vcpkg-packages.txt
     set VCPKG_DEFAULT_TRIPLET=x86-windows && vcpkg install "@../vcpkg-packages.txt"
     ```
-7. Integrate VCPKG system wide with:
+6. Integrate VCPKG system wide with:
     ```shell
-    vcpkg.exe integrate install
+    vcpkg integrate install
     ```
-#### Visual Studio configuration
+### Visual Studio configuration
 
-1. Select `Win32` configuration (Debug or Release) if not `Win32` configuration is available restart VS
+1. Select `Win32` build configuration (Debug or Release).
+    - If `Win32` build configuration is not available restart VS
 2. Set the project's configuration properties for Debugging/Working Directory:
     - select `Solution Explorer` -> `domoticz` -> `Properties` -> `Debugging` -> `Working Directory`
     - set the value to `"$(ProjectDir)/.."`

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -10,9 +10,8 @@
 #include "../main/WebServer.h"
 #include "../notifications/NotificationHelper.h"
 #include <iostream>
-#include <set>
 
-std::set<std::string> allowed_components = {
+std::vector<std::string> allowed_components = {
 		"binary_sensor",
 		"button",
 		"climate",
@@ -25,16 +24,6 @@ std::set<std::string> allowed_components = {
 		"sensor",
 		"switch",
 		"fan"
-};
-
-enum SwitchCommands {
-	COMMAND_UNKNOWN = -1,
-	COMMAND_ON,
-	COMMAND_OFF,
-	COMMAND_OPEN,
-	COMMAND_STOP,
-	COMMAND_SET_LVL,
-	COMMAND_SET_COL,
 };
 
 #define CLIMATE_MODE_UNIT 1
@@ -562,7 +551,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 
 	component = strarray[0];
 
-	if (allowed_components.find(component) == allowed_components.end())
+	if (std::find(allowed_components.begin(), allowed_components.end(), component) == allowed_components.end())
 	{
 		//not for us
 		return;
@@ -3686,7 +3675,6 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 
 	std::string szSendValue;
 	std::string command_topic = pSensor->command_topic;
-	SwitchCommands eCommand = SwitchCommands::COMMAND_UNKNOWN;
 
 	if (
 		(pSensor->component_type != "climate")
@@ -3696,26 +3684,15 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 		)
 	{
 		if (command == "On")
-		{
-			eCommand = SwitchCommands::COMMAND_ON;
 			szSendValue = pSensor->payload_on;
-		}
 		else if (command == "Off")
-		{
-			eCommand = SwitchCommands::COMMAND_OFF;
 			szSendValue = pSensor->payload_off;
-		}
 		else if (command == "Stop")
-		{
-			eCommand = SwitchCommands::COMMAND_STOP;
 			szSendValue = pSensor->payload_stop;
-		}
 		else if (command == "Set Level")
 		{
-			eCommand = SwitchCommands::COMMAND_SET_LVL;
 			if (level == 0)
 			{
-				eCommand = SwitchCommands::COMMAND_OFF;
 				command = "Off";
 				szSendValue = pSensor->payload_off;
 			}
@@ -3725,7 +3702,6 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 		else if ((command == "Set Color") && (pSensor->component_type == "light"))
 		{
 			// That's valid
-			eCommand = SwitchCommands::COMMAND_SET_COL;
 		}
 		else
 		{
@@ -3749,8 +3725,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 	{
 		Json::Value root;
 
-		if (eCommand == SwitchCommands::COMMAND_ON || 
-			eCommand == SwitchCommands::COMMAND_OFF)
+		if ((command == "On") || (command == "Off"))
 		{
 			if (!pSensor->brightness_value_template.empty())
 			{
@@ -3771,8 +3746,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 				}
 			}
 		}
-		if (eCommand == SwitchCommands::COMMAND_SET_LVL || 
-			eCommand == SwitchCommands::COMMAND_SET_COL)
+		else if (command == "Set Level")
 		{
 			//root["state"] = pSensor->payload_on;
 			int slevel = level;
@@ -3820,23 +3794,11 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 				szTopic = pSensor->brightness_command_topic;
 			else if (!pSensor->set_position_topic.empty())
 				szTopic = pSensor->set_position_topic;
-
 			SendMessage(szTopic, szSendValue);
-			if (eCommand == SwitchCommands::COMMAND_SET_LVL)
-			{
-				// Set only level
-				return true;
-			}
+			return true;
 		}
-		if (eCommand == SwitchCommands::COMMAND_SET_COL)
+		else if (command == "Set Color")
 		{
-			if (root.type() != Json::nullValue)
-			{
-				// Impossible to change type of the Json::Value root thus create new instead.
-				Json::Value nullNewRoot;
-				root = nullNewRoot;
-			}
-
 			root["state"] = pSensor->payload_on;
 
 			bool bCouldUseBrightness = false;
@@ -3967,6 +3929,11 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 				else
 					root["brightness"] = slevel;
 			}
+		}
+		else
+		{
+			Log(LOG_ERROR, "Switch command not supported (%s - %s/%s)", command.c_str(), DeviceID.c_str(), DeviceName.c_str());
+			return false;
 		}
 
 		szSendValue = JSonToRawString(root);

--- a/msbuild/vcpkg-packages.txt
+++ b/msbuild/vcpkg-packages.txt
@@ -1,1 +1,11 @@
-boost cereal curl jsoncpp lua minizip mosquitto openssl pthreads sqlite3 zlib
+boost
+cereal
+curl
+jsoncpp
+lua
+minizip
+mosquitto
+openssl
+pthreads
+sqlite3
+zlib

--- a/msbuild/vcpkg-packages.txt
+++ b/msbuild/vcpkg-packages.txt
@@ -1,11 +1,1 @@
-boost
-cereal
-curl
-jsoncpp
-lua
-minizip
-mosquitto
-openssl
-pthreads
-sqlite3
-zlib
+boost cereal curl jsoncpp lua minizip mosquitto openssl pthreads sqlite3 zlib


### PR DESCRIPTION
Small update of Visual Studio prep and building instruction.

What is most wonderful thing about this PR is this line:
`vcpkg install "@../vcpkg-packages.txt"`
and changes to `vcpkg-packages.txt`

no more you will need to open and copy the content of the file.

Here you can view updated content:
https://github.com/ajarzyn/domoticz/blob/dev_vs_configuration/build/README-visual-studio.md

Enjoy.