### PR TITLE
Sqlhelper locks and cWebem isnew connection

### DIFF
--- a/main/SQLHelper.h
+++ b/main/SQLHelper.h
@@ -499,8 +499,7 @@ class CSQLHelper : public StoppableTask
 	double m_max_kwh_usage;
 
       private:
-	std::mutex m_executeThreadMutex;
-	std::mutex m_sqlQueryMutex;
+	std::recursive_mutex m_sqlQueryMutex;
 	sqlite3 *m_dbase;
 	std::string m_dbase_name;
 	std::string m_journal_mode;

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1435,77 +1435,6 @@ namespace http {
 			return 0;
 		}
 
-		// Authorize against the internal Userlist. Credentials coming via Authorization header or URL parameters.
-		// Return 1 if authorized.
-		// Only used when webserver Authentication method is set to Auth_Basic.
-		int cWebemRequestHandler::authorize(WebEmSession & session, const request& req, reply& rep)
-		{
-			struct ah _ah;
-
-			std::string uname;
-			std::string upass;
-
-			if (!parse_auth_header(req, &_ah))
-			{	// No username, password (or other identification) found in Authorization header. Check URI for user parameters.
-				size_t uPos = req.uri.find("username=");
-				size_t pPos = req.uri.find("password=");
-				if (
-					(uPos == std::string::npos) ||
-					(pPos == std::string::npos)
-					)
-				{
-					return 0;
-				}
-				uPos += 9; //strlen("username=")
-				pPos += 9; //strlen("password=")
-				size_t uEnd = req.uri.find('&', uPos);
-				size_t pEnd = req.uri.find('&', pPos);
-				std::string tmpuname;
-				std::string tmpupass;
-				if (uEnd == std::string::npos)
-					tmpuname = req.uri.substr(uPos);
-				else
-					tmpuname = req.uri.substr(uPos, uEnd - uPos);
-				if (pEnd == std::string::npos)
-					tmpupass = req.uri.substr(pPos);
-				else
-					tmpupass = req.uri.substr(pPos, pEnd - pPos);
-				if (request_handler::url_decode(tmpuname, uname) && request_handler::url_decode(tmpupass, upass))
-				{	// Found parameters, so lets use these to check
-					_ah.user = base64_decode(uname);
-					_ah.response = base64_decode(upass);
-				}
-				else
-				{
-					m_failcounter++;
-					return 0;
-				}
-			}
-
-			// Check if valid password has been provided for the user
-			for (const auto &my : myWebem->m_userpasswords)
-			{
-				if (my.Username == _ah.user)
-				{
-					int bOK = check_password(&_ah, my.Password);
-					_log.Debug(DEBUG_AUTH, "[Authorize] User %s password check: %d", _ah.user.c_str(), bOK);
-					if (!bOK || my.userrights == URIGHTS_CLIENTID)	// User with ClientID 'rights' are not real users!
-					{
-						m_failcounter++;
-						return 0;
-					}
-					session.isnew = true;
-					session.username = my.Username;
-					session.rights = my.userrights;
-					session.rememberme = false;
-					m_failcounter = 0;
-					return 1;
-				}
-			}
-			m_failcounter++;
-			return 0;
-		}
-
 		bool cWebem::GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload)
 		{
 			bool bOk = false;
@@ -2453,7 +2382,6 @@ namespace http {
 
 			if ((session.isnew == true) &&
 				(session.rights == URIGHTS_ADMIN) &&
-				(req.uri.find("json.htm") != std::string::npos) &&
 				(req.uri.find("logincheck") == std::string::npos)
 				)
 			{

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -148,7 +148,6 @@ namespace http
 			bool parse_cookie(const request &req, std::string &sSID, std::string &sAuthToken, std::string &szTime, bool &expired);
 			bool AreWeInTrustedNetwork(const std::string &sHost);
 			bool IsIPInRange(const std::string &ip, const _tIPNetwork &ipnetwork, const bool &bIsIPv6);
-			int authorize(WebEmSession &session, const request &req, reply &rep);
 			void Logout();
 			int parse_auth_header(const request &req, struct ah *ah);
 			std::string generateAuthToken(const WebEmSession &session, const request &req);


### PR DESCRIPTION
Added more locks to sqlhelper and fixed problem with multiple incomming connection in cWebem.

Changes to fix issue: https://github.com/domoticz/domoticz/issues/5630 are in SQLHelper. I used recursive_mutex for simplicity to not care about multiple locks from the same thread, I've didn't spot any performance issue. It is possible to use mutex, but it will require much more code refactoring, so my proposition as simple fix is to use recursive_mutex. 

I've also fixed problem with multiple logs "Status: [web:80] Incoming connection from: ...". This was in specific case: when AreWeInTrustedNetwork returns true and browsers cookie is expired (for example first opening the browser in the day). In some cases browsers sends a lot of requests to domoticz in parallel (browser has cached html page and all resources, but if this is first using of domoticz that day it assumes that resources needs to be refreshed, so this is why there is a lot of requests). Because we are in trusted network, the code in CheckAuthentication (if (AreWeInTrustedNetwork... sets session.rights = 2). At the end of the CheckAuthentication there is:
if ((session.rights == URIGHTS_ADMIN) && (session.id.empty()))
This is the place where session.isnew = true; 
Code goes to this place, because there are no cookie, so parse_cookie returns false. And there is a lot of requests without cookie (something around 60 - this is the number of icons, pages and so on). In handle_request after executing CheckAuthentication  there is:
if ((session.isnew == true) &&
				(session.rights == URIGHTS_ADMIN) &&
				(req.uri.find("json.htm") != std::string::npos) &&
				(req.uri.find("logincheck") == std::string::npos)
				)
I've removed this json.htm check, because we also want to go there in all cases in Trusted Network (except logincheck, but if will probably not be used in trusted network). Note that code "session.isnew = true" is in 3 places:
- logincheck (this is excluded)
- in CheckAuthentication at the end (this is Trusted Network)
- in CheckAuthentication when parse_cookie returns true and session.rights == 2 - if rights == 2 it means that it is trusted network, but if there is cookie (parse_cookie return true), it means that it is not expired yet. This case looks like some fallback, it is not used frequently. I've removed private method authorize, because it was not used and there was "session.isnew = true".

Note also that I'm not sure if handle_request is synchronous or async method (probably it is async). Because there is incorrect lock mechanism in cWebem. "std::unique_lock<std::mutex> lock(m_sessionsMutex);" is in GetSession, AddSession, RemoveSession, CountSessions, GetExpiredSessions, but for example look at code:

```
WebEmSession* memSession = myWebem->GetSession(session.id);
if (memSession != nullptr)
{
  time_t now = mytime(nullptr);
  // Renew session expiration date if half of session duration has been exceeded ("dont remember me" sessions, 10 minutes)
  if (memSession->expires - (SHORT_SESSION_TIMEOUT / 2) < now)
  {
    memSession->expires = now + SHORT_SESSION_TIMEOUT;
    memSession->auth_token = generateAuthToken(*memSession, req); // do it after expires to save it also
    send_cookie(rep, *memSession);
  }
  // Renew session expiration date if half of session duration has been exceeded ("remember me" sessions, 30 days)
  else if ((memSession->expires > SHORT_SESSION_TIMEOUT + now) && (memSession->expires - (LONG_SESSION_TIMEOUT / 2) < now))
  {
    memSession->expires = now + LONG_SESSION_TIMEOUT;
    memSession->auth_token = generateAuthToken(*memSession, req); // do it after expires to save it also
    send_cookie(rep, *memSession);
  }
}
```
memSession is edited outside of lock guard (it means that this modification is not protected by lock). Also there is a lot of GetSession and after that RemoveSession - this also should be atomic operation. But I've didn't observe any problems with incorrect locks behaviour, so my fix for now should be enough.



