### PR TITLE
Do not update blinds on non numeric state change.

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -4308,6 +4308,10 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 			level = atoi(szSwitchCmd.c_str());
 			szSwitchCmd = "Set Level";
 		}
+		if (pSensor->last_topic == pSensor->state_topic)
+		{
+			return;
+		}
 	}
 
 	if (level == pSensor->position_open)

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -4308,8 +4308,9 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 			level = atoi(szSwitchCmd.c_str());
 			szSwitchCmd = "Set Level";
 		}
-		if (pSensor->last_topic == pSensor->state_topic)
+		else if (pSensor->last_topic == pSensor->state_topic)
 		{
+			// Value for state_topic is not a number.
 			return;
 		}
 	}


### PR DESCRIPTION
### States
Controllers state may contain intermediate levels.
In general my controller supports following states:
```
closing
closed
stopped
opening
open
```

### Logs with MQTT value
```
2023-10-24 23:47:33.962 domoticz-mqtt: MQTT received: entry_gate (value: opening)
```

```
2023-10-24 23:48:40.720 domoticz-mqtt: MQTT received: entry_gate (value: closing)
2023-10-24 23:48:47.874 domoticz-mqtt: MQTT received: entry_gate (value: closing)
2023-10-24 23:48:48.109 domoticz-mqtt: MQTT received: entry_gate (value: closed) 
```

```
2023-10-24 23:47:33.301 domoticz-mqtt: MQTT received: entry_gate (value: stopped)
2023-10-24 23:47:36.302 domoticz-mqtt: MQTT received: entry_gate (value: stopped)
2023-10-24 23:48:40.146 domoticz-mqtt: MQTT received: entry_gate (value: stopped) 
```

### Explanation
While `open`, `opening`, `closing`, `closed` are not causing problems. Value is updated level after short period of time or on the limit reached.

`stopped` unfortunately resets the value of the switch to 0 because of this `else` statement:
https://github.com/domoticz/domoticz/blob/0fa4ed5bcf83ba1e828da78895e6f422e00b69da/hardware/MQTTAutoDiscover.cpp#L4287

As value is not json here we were expecting to receive numerical value, when we didn't we do not change level value which was declared earlier https://github.com/domoticz/domoticz/blob/0fa4ed5bcf83ba1e828da78895e6f422e00b69da/hardware/MQTTAutoDiscover.cpp#L4195

It will set `szSwitchCmd`  to value of `"Close"` here:
https://github.com/domoticz/domoticz/blob/0fa4ed5bcf83ba1e828da78895e6f422e00b69da/hardware/MQTTAutoDiscover.cpp#L4299

And later on `nValue` to 0:
https://github.com/domoticz/domoticz/blob/0fa4ed5bcf83ba1e828da78895e6f422e00b69da/hardware/MQTTAutoDiscover.cpp#L4322

### Presentation
On the left is how the instance works with the provided fix.
On the right is presentation of stable release
```
Version: 2023.2 (build 15457)
Build Hash: 25624ca14
```

![gate_controller](https://github.com/domoticz/domoticz/assets/18590439/64fdec04-7057-4ca5-a730-34497a4bcf3d)

### Additional information
I've also tested in on the freshly built instance of `development` branch with 0fa4ed5bcf83ba1e828da78895e6f422e00b69da and the behaviour is same as on the right side of the presentation animation.
Verified if Fibaro ZWave Blinds controlled by [zwave-js-ui](https://zwave-js.github.io/zwave-js-ui/) works correctly and it does.