### PR TITLE
go to settings again after save

### DIFF
--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -717,7 +717,7 @@ define(['app'], function (app) {
 					ShowNotify($.t("Problem saving settings!"), 2000, true);
 					return;
 			    }
-				$window.location = '/#Dashboard';
+				$window.location = '/#Setup';
 				$window.location.reload();
 			}, function errorCallback(response) {
 			    HideNotify();


### PR DESCRIPTION
Most times, there are some changes in the settings, and every time after save, you have go from dhashboard to settings again.
Maybe it's better, to return to settings page and if all changes are done, manually go to dhashboard or any other page.