### PR TITLE
Prevent a memory leak

### DIFF
--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -509,7 +509,8 @@ namespace Plugins {
 					{
 						if (self->SubType == sTypeCustom)
 						{
-							PyDict_SetItemString(self->Options, "Custom", PyUnicode_FromString(sd[13].c_str()));
+							PyNewRef str = PyUnicode_FromString(sd[13].c_str());
+							PyDict_SetItemString(self->Options, "Custom", str));
 						}
 						else
 						{

--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -510,7 +510,7 @@ namespace Plugins {
 						if (self->SubType == sTypeCustom)
 						{
 							PyNewRef str = PyUnicode_FromString(sd[13].c_str());
-							PyDict_SetItemString(self->Options, "Custom", str));
+							PyDict_SetItemString(self->Options, "Custom", str);
 						}
 						else
 						{

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -702,7 +702,9 @@ namespace Plugins {
 					{
 						if (self->SubType == sTypeCustom)
 						{
-							PyDict_SetItemString(self->Options, "Custom", PyUnicode_FromString(sd[14].c_str()));
+							PyObject* str = PyUnicode_FromString(sd[14].c_str());
+							PyDict_SetItemString(self->Options, "Custom", str);
+							Py_DECREF(str);
 						}
 						else
 						{

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -481,10 +481,26 @@ namespace Plugins {
 		{
 			if (!OptionsIn || !PyBorrowedRef(OptionsIn).IsDict()) {
 				PyDict_Clear(OptionsOut);
-				PyDict_SetItemString(OptionsOut, "LevelActions", PyUnicode_FromString("|||"));
-				PyDict_SetItemString(OptionsOut, "LevelNames", PyUnicode_FromString("Off|Level1|Level2|Level3"));
-				PyDict_SetItemString(OptionsOut, "LevelOffHidden", PyUnicode_FromString("false"));
-				PyDict_SetItemString(OptionsOut, "SelectorStyle", PyUnicode_FromString("0"));
+
+				// PyDict_SetItemString(OptionsOut, "LevelActions", PyUnicode_FromString("|||"));
+				PyObject* str_LevelActions = PyUnicode_FromString("|||");
+				PyDict_SetItemString(self->Options, "Custom", str_LevelActions);
+				Py_DECREF(str_LevelActions);
+				
+				// PyDict_SetItemString(OptionsOut, "LevelNames", PyUnicode_FromString("Off|Level1|Level2|Level3"));		
+				PyObject* str_LevelNames = PyUnicode_FromString("Off|Level1|Level2|Level3");
+				PyDict_SetItemString(self->Options, "Custom", str_LevelNames);
+				Py_DECREF(str_LevelNames);
+				
+				// PyDict_SetItemString(OptionsOut, "LevelOffHidden", PyUnicode_FromString("false"));
+				PyObject* str_LevelOffHidden = PyUnicode_FromString("false");
+				PyDict_SetItemString(self->Options, "Custom", str_LevelOffHidden);
+				Py_DECREF(str_LevelOffHidden);
+				
+				// PyDict_SetItemString(OptionsOut, "SelectorStyle", PyUnicode_FromString("0"));
+				PyObject* str_SelectorStyle = PyUnicode_FromString("0");
+				PyDict_SetItemString(self->Options, "Custom", str_SelectorStyle);
+				Py_DECREF(str_SelectorStyle);
 			}
 			Type = pTypeGeneralSwitch;
 			SubType = sSwitchTypeSelector;
@@ -525,7 +541,11 @@ namespace Plugins {
 			SubType = sTypeCustom;
 			if (!OptionsIn || !PyBorrowedRef(OptionsIn).IsDict()) {
 				PyDict_Clear(OptionsOut);
-				PyDict_SetItemString(OptionsOut, "Custom", PyUnicode_FromString("1"));
+				
+				// PyDict_SetItemString(OptionsOut, "Custom", PyUnicode_FromString("1"));
+				PyObject* str = PyUnicode_FromString("1");
+				PyDict_SetItemString(self->Options, "Custom", str);
+				Py_DECREF(str);
 			}
 		}
 		else if (sTypeName == "Security Panel")

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -485,22 +485,18 @@ namespace Plugins {
 				// PyDict_SetItemString(OptionsOut, "LevelActions", PyUnicode_FromString("|||"));
 				PyNewRef  str_LevelActions = PyUnicode_FromString("|||");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelActions);
-				Py_DECREF(str_LevelActions);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelNames", PyUnicode_FromString("Off|Level1|Level2|Level3"));		
 				PyNewRef  str_LevelNames = PyUnicode_FromString("Off|Level1|Level2|Level3");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelNames);
-				Py_DECREF(str_LevelNames);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelOffHidden", PyUnicode_FromString("false"));
 				PyNewRef  str_LevelOffHidden = PyUnicode_FromString("false");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelOffHidden);
-				Py_DECREF(str_LevelOffHidden);
 				
 				// PyDict_SetItemString(OptionsOut, "SelectorStyle", PyUnicode_FromString("0"));
 				PyNewRef  str_SelectorStyle = PyUnicode_FromString("0");
 				PyDict_SetItemString(OptionsOut, "Custom", str_SelectorStyle);
-				Py_DECREF(str_SelectorStyle);
 			}
 			Type = pTypeGeneralSwitch;
 			SubType = sSwitchTypeSelector;
@@ -545,7 +541,6 @@ namespace Plugins {
 				// PyDict_SetItemString(OptionsOut, "Custom", PyUnicode_FromString("1"));
 				PyNewRef  str = PyUnicode_FromString("1");
 				PyDict_SetItemString(OptionsOut, "Custom", str);
-				Py_DECREF(str);
 			}
 		}
 		else if (sTypeName == "Security Panel")
@@ -724,7 +719,6 @@ namespace Plugins {
 						{
 							PyNewRef  str = PyUnicode_FromString(sd[14].c_str());
 							PyDict_SetItemString(self->Options, "Custom", str);
-							Py_DECREF(str);
 						}
 						else
 						{

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -483,22 +483,22 @@ namespace Plugins {
 				PyDict_Clear(OptionsOut);
 
 				// PyDict_SetItemString(OptionsOut, "LevelActions", PyUnicode_FromString("|||"));
-				PyObject* str_LevelActions = PyUnicode_FromString("|||");
+				PyNewRef  str_LevelActions = PyUnicode_FromString("|||");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelActions);
 				Py_DECREF(str_LevelActions);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelNames", PyUnicode_FromString("Off|Level1|Level2|Level3"));		
-				PyObject* str_LevelNames = PyUnicode_FromString("Off|Level1|Level2|Level3");
+				PyNewRef  str_LevelNames = PyUnicode_FromString("Off|Level1|Level2|Level3");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelNames);
 				Py_DECREF(str_LevelNames);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelOffHidden", PyUnicode_FromString("false"));
-				PyObject* str_LevelOffHidden = PyUnicode_FromString("false");
+				PyNewRef  str_LevelOffHidden = PyUnicode_FromString("false");
 				PyDict_SetItemString(OptionsOut, "Custom", str_LevelOffHidden);
 				Py_DECREF(str_LevelOffHidden);
 				
 				// PyDict_SetItemString(OptionsOut, "SelectorStyle", PyUnicode_FromString("0"));
-				PyObject* str_SelectorStyle = PyUnicode_FromString("0");
+				PyNewRef  str_SelectorStyle = PyUnicode_FromString("0");
 				PyDict_SetItemString(OptionsOut, "Custom", str_SelectorStyle);
 				Py_DECREF(str_SelectorStyle);
 			}
@@ -543,7 +543,7 @@ namespace Plugins {
 				PyDict_Clear(OptionsOut);
 				
 				// PyDict_SetItemString(OptionsOut, "Custom", PyUnicode_FromString("1"));
-				PyObject* str = PyUnicode_FromString("1");
+				PyNewRef  str = PyUnicode_FromString("1");
 				PyDict_SetItemString(OptionsOut, "Custom", str);
 				Py_DECREF(str);
 			}
@@ -722,7 +722,7 @@ namespace Plugins {
 					{
 						if (self->SubType == sTypeCustom)
 						{
-							PyObject* str = PyUnicode_FromString(sd[14].c_str());
+							PyNewRef  str = PyUnicode_FromString(sd[14].c_str());
 							PyDict_SetItemString(self->Options, "Custom", str);
 							Py_DECREF(str);
 						}

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -484,22 +484,22 @@ namespace Plugins {
 
 				// PyDict_SetItemString(OptionsOut, "LevelActions", PyUnicode_FromString("|||"));
 				PyObject* str_LevelActions = PyUnicode_FromString("|||");
-				PyDict_SetItemString(self->Options, "Custom", str_LevelActions);
+				PyDict_SetItemString(OptionsOut, "Custom", str_LevelActions);
 				Py_DECREF(str_LevelActions);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelNames", PyUnicode_FromString("Off|Level1|Level2|Level3"));		
 				PyObject* str_LevelNames = PyUnicode_FromString("Off|Level1|Level2|Level3");
-				PyDict_SetItemString(self->Options, "Custom", str_LevelNames);
+				PyDict_SetItemString(OptionsOut, "Custom", str_LevelNames);
 				Py_DECREF(str_LevelNames);
 				
 				// PyDict_SetItemString(OptionsOut, "LevelOffHidden", PyUnicode_FromString("false"));
 				PyObject* str_LevelOffHidden = PyUnicode_FromString("false");
-				PyDict_SetItemString(self->Options, "Custom", str_LevelOffHidden);
+				PyDict_SetItemString(OptionsOut, "Custom", str_LevelOffHidden);
 				Py_DECREF(str_LevelOffHidden);
 				
 				// PyDict_SetItemString(OptionsOut, "SelectorStyle", PyUnicode_FromString("0"));
 				PyObject* str_SelectorStyle = PyUnicode_FromString("0");
-				PyDict_SetItemString(self->Options, "Custom", str_SelectorStyle);
+				PyDict_SetItemString(OptionsOut, "Custom", str_SelectorStyle);
 				Py_DECREF(str_SelectorStyle);
 			}
 			Type = pTypeGeneralSwitch;
@@ -544,7 +544,7 @@ namespace Plugins {
 				
 				// PyDict_SetItemString(OptionsOut, "Custom", PyUnicode_FromString("1"));
 				PyObject* str = PyUnicode_FromString("1");
-				PyDict_SetItemString(self->Options, "Custom", str);
+				PyDict_SetItemString(OptionsOut, "Custom", str);
 				Py_DECREF(str);
 			}
 		}

--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -467,8 +467,9 @@ namespace Plugins
 			for (auto it_var = userVariables.begin(); it_var != userVariables.end(); ++it_var)
 			{
 				CEventSystem::_tUserVariable uvitem = it_var->second;
-				PyDict_SetItemString(userVariablesDict, uvitem.variableName.c_str(),
-					PyUnicode_FromString(uvitem.variableValue.c_str()));
+
+				PyNewRef str = PyUnicode_FromString(uvitem.variableValue.c_str());
+				PyDict_SetItemString(userVariablesDict, uvitem.variableName.c_str(), str );
 			}
 
 			// Add __main__ module


### PR DESCRIPTION
In relation with #5881 but not addressing the all issue

PyUnicode_FromString returns a new reference, then PyDict_SetItemString stores that reference and increfs, but the string isn’t decrefed.

Most-likely this must be done everywhere PyDict_SetItemString()

PyDict_SetItemString(self->Options, "Custom", PyUnicode_FromString(sd[14].c_str()));

PyUnicode_FromString returns a new reference, then PyDict_SetItemString stores that reference and increfs, but the string isn’t decrefed.

Suppose that PyUnicode_FromString returned a new string. Its refcount would be1.

PyDict_SetItemString would store that string and increment the refcount to 2.