### PR TITLE
Corrected build helper script

### DIFF
--- a/build/build-helper.sh
+++ b/build/build-helper.sh
@@ -169,7 +169,6 @@ run)
 check|updateIndexDefines|test)
     if [ -n "$PROJECT" ]; then
         do_make $PROJECT $CMD
-    else
     fi
     ;;
 shell)


### PR DESCRIPTION
Fixes a syntax error occurring in the build-helper.sh script. The issue was identified on line 173, where an unexpected token fi was encountered due to a missing condition for the do_make command execution. The absence of a condition caused a syntax error in the script, halting its execution. This fix ensures the script runs smoothly without encountering unexpected syntax issues.

**Steps to reproduce**

```
~ git clone git@github.com:domoticz/domoticz.git dev-domoticz
~ docker-compose -f dev-domoticz/build/docker-compose.yml build
~ ./dev-domoticz/build/build cmake
```

**Output error**

```
./build-helper.sh: line 173: syntax error near unexpected token `fi'
./build-helper.sh: line 173: `    fi'
```

