### PR TITLE
Refactor Webserver on incomingconnection and more

### DIFF
--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1626,7 +1626,7 @@ char* make_web_time(const time_t rawtime)
 	if (gmtime_r(&rawtime, &gmt) == nullptr)
 #endif
 	{
-		strcpy(buffer, "Thu, 1 Jan 1970 00:00:00 GMT");
+		strcpy(buffer, "Thu, 01 Jan 1970 00:00:00 GMT");
 	}
 	else
 	{
@@ -1638,8 +1638,6 @@ char* make_web_time(const time_t rawtime)
 			gmt.tm_hour,
 			gmt.tm_min,
 			gmt.tm_sec);
-
-
 	}
 	return buffer;
 }

--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -3671,7 +3671,7 @@ namespace http
 				std::string szSwitchMsg = std_format("User: %s initiated a switch command (%s/%s/%s)", szSwitchUser.c_str(), idx.c_str(), sSwitchName.c_str(), switchcmd.c_str());
 
 				if (!bIsOOC)
-					_log.Log(LOG_STATUS, szSwitchMsg.c_str());
+					_log.Log(LOG_STATUS, "%s", szSwitchMsg.c_str());
 
 				MainWorker::eSwitchLightReturnCode sRet;
 				sRet = m_mainworker.SwitchLight(idx, switchcmd, level, "-1", onlyonchange, 0, szSwitchUser);
@@ -3681,13 +3681,13 @@ namespace http
 						(bIsOOC)
 						&& (sRet != MainWorker::SL_OK_NO_ACTION)
 						)
-						_log.Log(LOG_STATUS, szSwitchMsg.c_str());
+						_log.Log(LOG_STATUS, "%s", szSwitchMsg.c_str());
 					root["status"] = "OK";
 				}
 				else
 				{
 					if (bIsOOC)
-						_log.Log(LOG_STATUS, szSwitchMsg.c_str());
+						_log.Log(LOG_STATUS, "%s", szSwitchMsg.c_str());
 					root["status"] = "ERROR";
 					root["message"] = "Error sending switch command, check device/hardware (idx=" + idx + ") !";
 				}

--- a/test/gherkin/conftest.py
+++ b/test/gherkin/conftest.py
@@ -1,5 +1,6 @@
 from pytest_bdd import scenario, given, when, then, parsers
 import requests, subprocess
+import re
 
 class Domoticz:
     sBaseURI = ""
@@ -75,6 +76,16 @@ def check_header(test_domoticz,headername, headervalue):
         print(test_domoticz.oResponse.headers)
         assert False
 
+@then(parsers.parse('the HTTP-header "{headername}" should comply to pattern "{headerpattern}"'))
+def check_header(test_domoticz,headername, headerpattern):
+    bExists = headername in test_domoticz.oResponse.headers
+    if bExists:
+        headervalue = test_domoticz.oResponse.headers[headername]
+        assert re.match(headerpattern, headervalue)
+    else:
+        print(test_domoticz.oResponse.headers)
+        assert False
+
 @then(parsers.parse('the HTTP-header "{headername}" should be absent'))
-def check_noheader(test_domoticz,headername, headervalue):
+def check_noheader(test_domoticz,headername):
     assert not headername in test_domoticz.oResponse.headers

--- a/test/gherkin/test_webserver_session.py
+++ b/test/gherkin/test_webserver_session.py
@@ -1,0 +1,10 @@
+from pytest_bdd import scenario, given, when, then, parsers
+import requests
+
+@scenario('webserver_session.feature', 'Receive a session cookie when requesting the index page')
+def test_cookiefromindex():
+    pass
+
+@scenario('webserver_session.feature', 'Do not receive a session cookie when calling the API')
+def test_nocookiefromapi():
+    pass

--- a/test/gherkin/webserver_session.feature
+++ b/test/gherkin/webserver_session.feature
@@ -1,0 +1,19 @@
+Feature: Webserver session handling
+    The Domoticz webserver should set a session cookie when certain resources are requested.
+    But not when the API is used.
+
+    Background:
+        Given Domoticz is running
+        And accessible on port 8080
+
+    Scenario: Receive a session cookie when requesting the index page
+        Given I am a normal Domoticz user
+        When I request the URI "/"
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should comply to pattern "^DMZSID=([0-9a-f]{32})_([0-9a-zA-Z]{48,52})\.([0-9]{10}); HttpOnly; path=\/; Expires=([0-9a-zA-Z ,:]{25}) GMT$"
+
+    Scenario: Do not receive a session cookie when calling the API
+        Given I am a normal Domoticz user
+        When I request the URI "/json.htm?type=command&param=getversion"
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should be absent

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1972,27 +1972,6 @@ namespace http {
 			if(parse_cookie(req, sSID, sAuthToken, szTime, expired))
 			{
 				time_t now = mytime(nullptr);
-				if (session.rights == URIGHTS_ADMIN)
-				{
-					if (!sSID.empty())
-					{
-						WebEmSession* oldSession = myWebem->GetSession(sSID);
-						if (oldSession == nullptr)
-						{
-							session.id = sSID;
-							session.auth_token = sAuthToken;
-							expired = (!checkAuthToken(session));
-						}
-						else
-						{
-							session = *oldSession;
-							expired = (oldSession->expires < now);
-						}
-					}
-					if (sSID.empty() || expired)
-						session.isnew = true;	// There was a cookie, but it was expired or the session was not found
-					return true;
-				}
 
 				if (!(sSID.empty() || sAuthToken.empty() || szTime.empty()))
 				{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -2413,7 +2413,7 @@ namespace http {
 				}
 			}
 
-			if (session.isnew == true)
+			if (session.isnew == true && req.uri.find("json.htm") == std::string::npos)	// No session found and we need a session (not for API calls), create a new one
 			{
 				_log.Log(LOG_STATUS, "[web:%s] Incoming connection from: %s", myWebem->GetPort().c_str(), session.remote_host.c_str());
 				// Create a new session ID
@@ -2429,9 +2429,8 @@ namespace http {
 				myWebem->AddSession(session);
 				send_cookie(rep, session);
 			}
-			else if (!session.id.empty())
+			else if (!session.id.empty())	// Session found, Renew session expiration and authentication token
 			{
-				// Renew session expiration and authentication token
 				WebEmSession* memSession = myWebem->GetSession(session.id);
 				if (memSession != nullptr)
 				{

--- a/webserver/request_handler.cpp
+++ b/webserver/request_handler.cpp
@@ -404,16 +404,6 @@ void request_handler::handle_request(const request &req, reply &rep, modify_info
 				rep.content.append((std::istreambuf_iterator<char>(is)), (std::istreambuf_iterator<char>()));
 				rep.bIsGZIP = (bClientHasGZipSupport && bHaveLoadedgzip);
 			}
-			/* 20230525 No Longer in Use! Will be removed soon!
-			if (bIsCompressibleType && (!bHaveLoadedgzip))
-			{
-				// Find and include any special cWebem strings
-				if (myWebem->Include(rep.content))
-				{
-					_log.Debug(DEBUG_WEBSERVER,"[web:%s] Added some include in non-zipped file", request_path.c_str());
-				}
-			}
-			*/
 			if (bClientHasGZipSupport && bIsCompressibleType && (!bHaveLoadedgzip))
 			{
 				// The sourcefile is not compressed, but the client supports receiving compressed content


### PR DESCRIPTION
A PR that refactors parts of the webserver code handling the sessions, cookies and auth checking.

PR #5853 from @Krzysztof1234534 was the reason to look at this piece of the code and start the refactoring.

It does NOT (yet) solve the problem of the many 'Incoming connection' messages when in local network with no active session and the browser firing a lot of simultaneous requests (which do not have a session cookie either as they are fired in parallel).

Some older pieces of code from the old implementation of local networks (when the session was set to Admin rights but no real admin user was used) have been removed.