### PR TITLE
MQTT-AD: Fix autodiscovery with prefix that contains slashes

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -76,7 +76,7 @@ void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 			return;
 
 		if (
-			(topic.substr(0, topic.find('/')) == m_TopicDiscoveryPrefix)
+			topic.find(m_TopicDiscoveryPrefix) == 0
 			&& (topic.find("/config") != std::string::npos)
 			)
 		{


### PR DESCRIPTION
Because I cargo-culted my esphome MQTT setup from https://esphome.io/components/mqtt.html#tls-with-esp-idf-esp32 it ended up using:

```
discovery_prefix: ${mqtt_prefix}/homeassistant
```

I only just updated to a version of Domoticz which can do HA autodiscovery, and tried to get it working.

And Domoticz doesn't cope. Not because of the weird bit that looks like a variable expansion but isn't _(it literally is using `${mqtt_prefix}`._ But because of the slash.

The prefix matching in `on_message()` does a direct comparison of `m_TopicDiscoveryPrefix` against the first element (up to the first `/`) of the topic, which doesn't work if the `m_TopicDiscoveryPrefix` contains more than one path element.