### PR TITLE
Added specific notification handler for alert sensor

### DIFF
--- a/notifications/NotificationHelper.h
+++ b/notifications/NotificationHelper.h
@@ -79,6 +79,7 @@ class CNotificationHelper
 	bool CheckAndHandleValueNotification(uint64_t Idx, const std::string &DeviceName, int value);
 	bool CheckAndHandleRainNotification(uint64_t Idx, const std::string &DeviceName, unsigned char devType, unsigned char subType, _eNotificationTypes ntype, float mvalue);
 	bool CheckAndHandleAmpere123Notification(uint64_t Idx, const std::string &DeviceName, float Ampere1, float Ampere2, float Ampere3);
+	bool CheckAndHandleAlertNotification(uint64_t Idx, const std::string &DeviceName, const std::string &sValue);
 
 	std::string ParseCustomMessage(const std::string &cMessage, const std::string &sName, const std::string &sValue);
 	bool ApplyRule(const std::string &rule, bool equal, bool less);


### PR DESCRIPTION
This PR addresses an issue related to the sensor alert functionality. The $value parameter injected and used for sensor alerts has been replaced with a more informative approach instead of focusing on the level associated.

This adjustment eliminates the useless need for displaying the level number since it can be mapped to a corresponding level in the notification settings. This modification ensures that alert notifications provide a clearer understanding of the issue at hand by focusing on the descriptive text rather than a numeric value, thereby enhancing the overall system's usability and comprehension.

**Test**

1. Create a Dummy Hardware.
2. Create an Alert called "House".
3. Add the notification:

```
Type: Usage
When: Greater or Equal
Value: 0
Priority: Emergency
Ignore Interval: true
Recovery Notification: false
Custom Message: House is $value
Active Systems: browser
```

4. Add the following script: _dev-domoticz/scripts/dzVents/scripts/test.lua_

```
return {
  active = true,
  on = {
    ['timer'] = {
      'every minute'
    }
  },
  execute = function(domoticz)
    domoticz.devices('House').updateAlertSensor(domoticz.ALERTLEVEL_RED, 'burning!')
  end
}
```
