### PR TITLE
Correction of tomorow information

### DIFF
--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -677,15 +677,12 @@ void CTeleinfoBase::MatchLine()
 		// Color of tomorow
 		int tomorow = ( m_teleinfo.STGE & 0x0C000000 ) >> 26;
 
-		// If 0 then tomorow color is identical to today's color 
-		if ( tomorow == 0 ) tomorow = ( m_teleinfo.STGE & 0x03000000 ) >> 24;
-
 		switch (tomorow)
 		{
 			case 1: m_teleinfo.DEMAIN = "BLEU"; break;
 			case 2: m_teleinfo.DEMAIN = "BLAN"; break;
 			case 3: m_teleinfo.DEMAIN = "ROUG"; break;		
-			default: break;
+			default: m_teleinfo.DEMAIN = "----"; break;
 		}
 	}
 	


### PR DESCRIPTION
Hello,
tomorow information was not right. Tomorow (witch is not realy a good name for this information but this is the name used !) information is set at 20h and valid till 6h. Then this is invalid (next tempo period unknown) from 6h to 20h. 
N.B. : "----" is the way to display unknown on linky electric meter.