### PR TITLE
Added DelayedLink support for Python 3.8 up to 3.12 on FreeBSD

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -176,6 +176,11 @@ namespace Plugins {
 				if (!shared_lib_) FindLibrary("python3.5", true);
 				if (!shared_lib_) FindLibrary("python3.4", true);
 #ifdef __FreeBSD__
+				if (!shared_lib_) FindLibrary("python3.12m", true);
+				if (!shared_lib_) FindLibrary("python3.11m", true);
+				if (!shared_lib_) FindLibrary("python3.10m", true);
+				if (!shared_lib_) FindLibrary("python3.9m", true);
+				if (!shared_lib_) FindLibrary("python3.8m", true);
 				if (!shared_lib_) FindLibrary("python3.7m", true);
 				if (!shared_lib_) FindLibrary("python3.6m", true);
 				if (!shared_lib_) FindLibrary("python3.5m", true);


### PR DESCRIPTION
This PR allow to find dynamicly Python's lib on FreeBSD for python 3.8 up 3.12