### PR TITLE
Refactor of cWebem and adding webserver session gherkin tests

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -1427,7 +1427,7 @@ namespace http
 		{
 			root["status"] = "OK";
 			root["title"] = "GetVersion";
-			if (session.rights != -1 )
+			if (session.rights != URIGHTS_NONE)
 			{
 				root["version"] = szAppVersion;
 				root["hash"] = szAppHash;
@@ -1452,7 +1452,7 @@ namespace http
 		{
 			root["status"] = "OK";
 			root["title"] = "GetAuth";
-			if (session.rights != -1)
+			if (session.rights != URIGHTS_NONE)
 			{
 				root["user"] = session.username;
 				root["rights"] = session.rights;
@@ -1796,7 +1796,7 @@ namespace http
 
 		void CWebServer::Cmd_GetForecastConfig(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights == -1)
+			if (session.rights == URIGHTS_NONE)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only auth user allowed
@@ -2585,7 +2585,7 @@ namespace http
 				if (session.username.empty())
 				{
 					// Local network could be changed so lets force a check here
-					session.rights = -1;
+					session.rights = URIGHTS_NONE;
 				}
 
 				std::string SecPassword = request::findValue(&req, "SecPassword");

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -266,7 +266,7 @@ namespace http
 
 		void CWebServer::Cmd_GetHardwareTypes(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -737,7 +737,7 @@ namespace http
 
 		void CWebServer::Cmd_GetDeviceValueOptions(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -767,7 +767,7 @@ namespace http
 
 		void CWebServer::Cmd_GetDeviceValueOptionWording(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -792,7 +792,7 @@ namespace http
 
 		void CWebServer::Cmd_AddUserVariable(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				_log.Log(LOG_ERROR, "User: %s tried to add a uservariable!", session.username.c_str());
@@ -846,7 +846,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteUserVariable(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				_log.Log(LOG_ERROR, "User: %s tried to delete a uservariable!", session.username.c_str());
 				session.reply_status = reply::forbidden;
@@ -863,7 +863,7 @@ namespace http
 
 		void CWebServer::Cmd_UpdateUserVariable(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				_log.Log(LOG_ERROR, "User: %s tried to update a uservariable!", session.username.c_str());
 				session.reply_status = reply::forbidden;
@@ -991,7 +991,7 @@ namespace http
 
 		void CWebServer::Cmd_AllowNewHardware(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1007,7 +1007,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteHardware(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1078,7 +1078,7 @@ namespace http
 		// Plan Functions
 		void CWebServer::Cmd_AddPlan(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1106,7 +1106,7 @@ namespace http
 
 		void CWebServer::Cmd_UpdatePlan(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1130,7 +1130,7 @@ namespace http
 
 		void CWebServer::Cmd_DeletePlan(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1211,7 +1211,7 @@ namespace http
 
 		void CWebServer::Cmd_AddPlanActiveDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1290,7 +1290,7 @@ namespace http
 
 		void CWebServer::Cmd_DeletePlanDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1323,7 +1323,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteAllPlanDevices(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -1464,7 +1464,7 @@ namespace http
 		{
 			root["status"] = "ERR";
 			root["title"] = "GetMyProfile";
-			if (session.rights > 0)	// Viewer cannot change his profile
+			if (!(session.rights == URIGHTS_VIEWER || session.rights == URIGHTS_NONE))	// Viewer cannot change his profile
 			{
 				int iUser = FindUser(session.username.c_str());
 				if (iUser != -1)
@@ -1483,7 +1483,7 @@ namespace http
 			root["status"] = "ERR";
 			root["title"] = "UpdateMyProfile";
 
-			if (req.method == "POST" && session.rights > 0)	// Viewer cannot change his profile
+			if (req.method == "POST" && !(session.rights == URIGHTS_VIEWER || session.rights == URIGHTS_NONE))	// Viewer cannot change his profile
 			{
 				std::string sUsername = request::findValue(&req, "username");
 				int iUser = FindUser(session.username.c_str());
@@ -1943,7 +1943,7 @@ namespace http
 			if (!session.username.empty())
 				Username = session.username;
 
-			if (session.rights < 1)
+			if (session.rights == URIGHTS_VIEWER || session.rights == URIGHTS_NONE)
 			{
 				session.reply_status = reply::forbidden;
 				return; // only user or higher allowed
@@ -2060,7 +2060,7 @@ namespace http
 
 		void CWebServer::Cmd_CustomEvent(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights < 1)
+			if (session.rights == URIGHTS_VIEWER || session.rights == URIGHTS_NONE)
 			{
 				session.reply_status = reply::forbidden;
 				return; // only user or higher allowed
@@ -2115,7 +2115,7 @@ namespace http
 
 		void CWebServer::Cmd_SystemShutdown(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2136,7 +2136,7 @@ namespace http
 
 		void CWebServer::Cmd_SystemReboot(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2157,7 +2157,7 @@ namespace http
 
 		void CWebServer::Cmd_ExcecuteScript(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2211,7 +2211,7 @@ namespace http
 		// Only for Unix systems
 		void CWebServer::Cmd_ApplicationUpdate(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2340,7 +2340,7 @@ namespace http
 			root["HaveUpdate"] = false;
 			root["Revision"] = m_mainworker.m_iRevision;
 
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin users may update
@@ -2383,7 +2383,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteDateRange(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2400,7 +2400,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteDataPoint(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2419,7 +2419,7 @@ namespace http
 		// PostSettings
 		void CWebServer::Cmd_PostSettings(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2811,7 +2811,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2829,7 +2829,7 @@ namespace http
 
 		void CWebServer::Cmd_AddScene(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2867,7 +2867,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteScene(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -2883,7 +2883,7 @@ namespace http
 
 		void CWebServer::Cmd_UpdateScene(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3363,7 +3363,7 @@ namespace http
 		void CWebServer::Cmd_GetApplications(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			root["title"] = "GetApplications";
-			if (session.rights < URIGHTS_ADMIN)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 			}
@@ -3393,7 +3393,7 @@ namespace http
 		void CWebServer::Cmd_AddApplication(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			root["title"] = "AddApplication";
-			if (session.rights < URIGHTS_ADMIN)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 			}
@@ -3441,7 +3441,7 @@ namespace http
 		void CWebServer::Cmd_UpdateApplication(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			root["title"] = "UpdateApplication";
-			if (session.rights < URIGHTS_ADMIN)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 			}
@@ -3494,7 +3494,7 @@ namespace http
 		void CWebServer::Cmd_DeleteApplication(WebEmSession & session, const request& req, Json::Value &root)
 		{
 			root["title"] = "DeleteApplication";
-			if (session.rights < URIGHTS_ADMIN)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 			}
@@ -3581,7 +3581,7 @@ namespace http
 
 		void CWebServer::Cmd_GetSceneActivations(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3649,7 +3649,7 @@ namespace http
 
 		void CWebServer::Cmd_AddSceneCode(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3709,7 +3709,7 @@ namespace http
 
 		void CWebServer::Cmd_RemoveSceneCode(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3779,7 +3779,7 @@ namespace http
 
 		void CWebServer::Cmd_ClearSceneCodes(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3839,7 +3839,7 @@ namespace http
 		{
 			root["title"] = "UploadCustomIcon";
 			// Only admin user allowed
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3886,7 +3886,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteCustomIcon(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3920,7 +3920,7 @@ namespace http
 
 		void CWebServer::Cmd_UpdateCustomIcon(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3942,7 +3942,7 @@ namespace http
 
 		void CWebServer::Cmd_RenameDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3968,7 +3968,7 @@ namespace http
 
 		void CWebServer::Cmd_RenameScene(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -3989,7 +3989,7 @@ namespace http
 
 		void CWebServer::Cmd_SetDeviceUsed(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4067,7 +4067,7 @@ namespace http
 
 		void CWebServer::Cmd_ClearShortLog(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4084,7 +4084,7 @@ namespace http
 
 		void CWebServer::Cmd_VacuumDatabase(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4137,7 +4137,7 @@ namespace http
 
 		void CWebServer::Cmd_UpdateMobileDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4158,7 +4158,7 @@ namespace http
 
 		void CWebServer::Cmd_DeleteMobileDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4260,7 +4260,7 @@ namespace http
 
 		void CWebServer::Cmd_SetSharedUserDevices(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4291,7 +4291,7 @@ namespace http
 
 		void CWebServer::Cmd_ClearSharedUserDevices(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -4307,7 +4307,7 @@ namespace http
 
 		void CWebServer::Cmd_SetUsed(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -5126,7 +5126,7 @@ namespace http
 
 		void CWebServer::Cmd_RemoteWebClientsLog(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; // Only admin user allowed
@@ -5154,7 +5154,7 @@ namespace http
 
 		void CWebServer::Cmd_GetDynamicPriceDevices(WebEmSession& session, const request& req, Json::Value& root)
 		{
-			if (session.rights != 2)
+			if (session.rights != URIGHTS_ADMIN)
 			{
 				session.reply_status = reply::forbidden;
 				return; //Only admin user allowed

--- a/test/gherkin/conftest.py
+++ b/test/gherkin/conftest.py
@@ -1,5 +1,6 @@
 from pytest_bdd import scenario, given, when, then, parsers
 import requests, subprocess
+import re
 
 class Domoticz:
     sBaseURI = ""
@@ -62,6 +63,16 @@ def request_uri(test_domoticz,method):
     oResult = requests.get(test_domoticz.sBaseURI + uri, headers=test_domoticz.oReqHeaders)
     test_domoticz.oResponse = oResult
 
+@when('I submit wrong credentials to the loginpage')
+def submit_wrongcredentials(test_domoticz):
+    oResult = requests.post(test_domoticz.sBaseURI + '/json.htm?type=command&param=logincheck', headers=test_domoticz.oReqHeaders, data={'username': 'd3Jvbmc=', 'password': 'd3Jvbmd0b28='})
+    test_domoticz.oResponse = oResult
+
+@when('I submit correct credentials to the loginpage')
+def submit_credentials(test_domoticz):
+    oResult = requests.post(test_domoticz.sBaseURI + '/json.htm?type=command&param=logincheck', headers=test_domoticz.oReqHeaders, data={'username': 'YWRtaW4=', 'password': '59515f6b193071e263f14bfa94bef645'})
+    test_domoticz.oResponse = oResult
+
 @then(parsers.parse('the HTTP-return code should be "{returncode:d}"'))
 def check_returncode(test_domoticz,returncode):
     assert test_domoticz.oResponse.status_code == returncode
@@ -75,6 +86,16 @@ def check_header(test_domoticz,headername, headervalue):
         print(test_domoticz.oResponse.headers)
         assert False
 
+@then(parsers.parse('the HTTP-header "{headername}" should comply to pattern "{headerpattern}"'))
+def check_header(test_domoticz,headername, headerpattern):
+    bExists = headername in test_domoticz.oResponse.headers
+    if bExists:
+        headervalue = test_domoticz.oResponse.headers[headername]
+        assert re.match(headerpattern, headervalue)
+    else:
+        print(test_domoticz.oResponse.headers)
+        assert False
+
 @then(parsers.parse('the HTTP-header "{headername}" should be absent'))
-def check_noheader(test_domoticz,headername, headervalue):
+def check_noheader(test_domoticz,headername):
     assert not headername in test_domoticz.oResponse.headers

--- a/test/gherkin/test_webserver_session.py
+++ b/test/gherkin/test_webserver_session.py
@@ -1,0 +1,18 @@
+from pytest_bdd import scenario, given, when, then, parsers
+import requests
+
+@scenario('webserver_session.feature', 'Do not receive a session cookie when requesting the index page')
+def test_nocookiefromindex():
+    pass
+
+@scenario('webserver_session.feature', 'Do not receive a session cookie when calling the API')
+def test_nocookiefromapi():
+    pass
+
+@scenario('webserver_session.feature', 'Do not receive a session cookie when POSTing no/wrong credentials to the login page')
+def test_nocookiefromlogin():
+    pass
+
+@scenario('webserver_session.feature', 'Receive a session cookie when POSTing to the login page')
+def test_cookiefromlogin():
+    pass

--- a/test/gherkin/webserver_session.feature
+++ b/test/gherkin/webserver_session.feature
@@ -1,0 +1,31 @@
+Feature: Webserver session handling
+    The Domoticz webserver should set a session cookie when certain resources are requested.
+    But not when the API is used.
+
+    Background:
+        Given Domoticz is running
+        And accessible on port 8080
+
+    Scenario: Do not receive a session cookie when requesting the index page
+        Given I am a normal Domoticz user
+        When I request the URI "/"
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should be absent
+
+    Scenario: Do not receive a session cookie when calling the API
+        Given I am a normal Domoticz user
+        When I request the URI "/json.htm?type=command&param=getversion"
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should be absent
+
+    Scenario: Do not receive a session cookie when POSTing no/wrong credentials to the login page
+        Given I am a normal Domoticz user
+        When I submit wrong credentials to the loginpage
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should be absent
+
+    Scenario: Receive a session cookie when POSTing to the login page
+        Given I am a normal Domoticz user
+        When I submit correct credentials to the loginpage
+        Then the HTTP-return code should be "200"
+        And the HTTP-header "Set-Cookie" should comply to pattern "^DMZSID=([0-9a-f]{32})_([0-9a-zA-Z]{48,52})\.([0-9]{10}); HttpOnly; SameSite=strict; path=\/; Expires=([0-9a-zA-Z ,:]{25}) GMT$"

--- a/webserver/WebsocketHandler.cpp
+++ b/webserver/WebsocketHandler.cpp
@@ -115,7 +115,6 @@ namespace http {
 				if (outbound)
 				{
 					time_t nowAnd1Day = ((time_t)mytime(nullptr)) + WEBSOCKET_SESSION_TIMEOUT;
-					session.timeout = nowAnd1Day;
 					session.expires = nowAnd1Day;
 					session.isnew = false;
 					session.rememberme = false;
@@ -191,7 +190,6 @@ namespace http {
 				if (outbound)
 				{
 					time_t nowAnd1Day = ((time_t)mytime(nullptr)) + WEBSOCKET_SESSION_TIMEOUT;
-					session.timeout = nowAnd1Day;
 					session.expires = nowAnd1Day;
 					session.isnew = false;
 					session.rememberme = false;
@@ -231,7 +229,6 @@ namespace http {
 				if (outbound)
 				{
 					time_t nowAnd1Day = ((time_t)mytime(nullptr)) + WEBSOCKET_SESSION_TIMEOUT;
-					session.timeout = nowAnd1Day;
 					session.expires = nowAnd1Day;
 					session.isnew = false;
 					session.rememberme = false;

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -133,25 +133,6 @@ namespace http {
 
 		Create a link between a string ID and a function to calculate the dynamic content of the string
 
-		The function should return a pointer to a character buffer.  This should be contain only ASCII characters
-		( Unicode code points 1 to 127 )
-
-		@param[in] idname  string identifier
-		@param[in] fun pointer to function which calculates the string to be displayed
-
-		*/
-		/* 20230525 No Longer in Use! Will be removed Soon!
-
-		void cWebem::RegisterIncludeCode(const char *idname, const webem_include_function &fun)
-		{
-			myIncludes.insert(std::pair<std::string, webem_include_function >(std::string(idname), fun));
-		}
-		*/
-
-		/**
-
-		Create a link between a string ID and a function to calculate the dynamic content of the string
-
 		The function should return a pointer to wide character buffer.  This should contain a wide character UTF-16 encoded unicode string.
 		WEBEM will convert the string to UTF-8 encoding before sending to the browser.
 
@@ -198,70 +179,6 @@ namespace http {
 			_log.Debug(DEBUG_WEBSERVER, "cWebEm Registration: %d pages, %d actions, %d whitelist urls, %d whitelist commands",
 				(int)myPages.size(), (int)myActions.size(), (int)myWhitelistURLs.size(), (int)myWhitelistCommands.size());
 		}
-
-		/**
-
-		  Do not call from application code, used by server to include generated text.
-
-		  @param[in/out] reply  text to include generated
-
-		  The text is searched for "<!--#cWebemX-->".
-		  The X can be any string not containing "-->"
-
-		  If X has been registered with cWebem then the associated function
-		  is called to generate text to be inserted.
-
-		  returns true if any text is replaced
-
-
-		*/
-		/* 20230525 No longer in Use! Will be removed soon!
-		bool cWebem::Include(std::string& reply)
-		{
-			bool res = false;
-			size_t p = 0;
-			while (true)
-			{
-				// find next request for generated text
-				p = reply.find("<!--#embed", p);
-				if (p == std::string::npos)
-				{
-					break;
-				}
-				size_t q = reply.find("-->", p);
-				if (q == std::string::npos)
-					break;
-				q += 3;
-
-				size_t reply_len = reply.length();
-
-				// code identifying text generator
-				std::string code = reply.substr(p + 11, q - p - 15);
-
-				// find the function associated with this code
-				auto pf = myIncludes.find(code);
-				if (pf != myIncludes.end())
-				{
-					// insert generated text
-					std::string content_part;
-					try
-					{
-						pf->second(content_part);
-					}
-					catch (...)
-					{
-
-					}
-					reply.insert(p, content_part);
-					res = true;
-				}
-
-				// adjust pointer into text for insertion
-				p = q + reply.length() - reply_len;
-			}
-			return res;
-		}
-		*/
 
 		std::istream & safeGetline(std::istream & is, std::string & line)
 		{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -869,7 +869,7 @@ namespace http {
 			time_t now = mytime(nullptr);
 			for (const auto &session : m_sessions)
 			{
-				if (session.second.timeout < now)
+				if (session.second.expires < now)
 					ret.push_back(session.second.id);
 			}
 			return ret;
@@ -2275,16 +2275,13 @@ namespace http {
 
 			// 14) We handled the request, now we need to check if we need to create a new session or renew the existing one
 
-			// Set timeout to make session in use
-			session.timeout = mytime(nullptr) + SHORT_SESSION_TIMEOUT;
-
 			if (session.isnew == true && session.istrustednetwork == false)	// No session found and if we need a session (not for API calls or Trusted Network), create a new one
 			{
 				if (isLogin && !session.username.empty())	// Make sure the login was succesfull
 				{
 					// Create a new session ID
 					session.id = generateSessionID();
-					session.expires = session.timeout;
+					session.expires = mytime(nullptr) + SHORT_SESSION_TIMEOUT;
 					if (session.rememberme)
 					{
 						// Extend session by 30 days

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1975,23 +1975,6 @@ namespace http {
 
 			_log.Debug(DEBUG_AUTH, "[web:%s] CheckAuthToken(%s_%s_%s) : Session found & Token authenticated", myWebem->GetPort().c_str(), session.id.c_str(), session.auth_token.c_str(), session.username.c_str());
 
-			/*
-			if (session.rights == 2)	// Why do we do this for Admins (or at all)? Can this be removed?
-			{
-				// we are already admin - restore session from db
-				session.expires = storedSession.expires;
-				time_t now = mytime(nullptr);
-				if (session.expires < now)
-				{
-					removeAuthToken(session.id);
-					return false;
-				}
-				session.timeout = now + SHORT_SESSION_TIMEOUT;
-				myWebem->AddSession(session);
-				return true;
-			}
-			*/
-
 			if (session.username.empty())
 			{
 				// Restore session if user exists and session does not already exist

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -14,6 +14,7 @@ namespace http
 			URIGHTS_VIEWER = 0,
 			URIGHTS_SWITCHER,
 			URIGHTS_ADMIN,
+			URIGHTS_NONE=254,
 			URIGHTS_CLIENTID=255
 		};
 		enum _eAuthenticationMethod
@@ -49,13 +50,14 @@ namespace http
 			std::string local_port;
 			std::string auth_token;
 			std::string username;
-			int reply_status = 0;
+			int reply_status = http::server::reply::ok;
 			time_t timeout = 0;
 			time_t expires = 0;
-			int16_t rights = URIGHTS_VIEWER;
+			_eUserRights rights = URIGHTS_NONE;
 			bool rememberme = false;
 			bool isnew = false;
 			bool istrustednetwork = false;
+			bool seenbefore = false;
 		} WebEmSession;
 
 		typedef struct _tIPNetwork

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -50,14 +50,13 @@ namespace http
 			std::string local_port;
 			std::string auth_token;
 			std::string username;
-			int reply_status = http::server::reply::ok;
+			uint16_t reply_status = http::server::reply::ok;
 			time_t timeout = 0;
 			time_t expires = 0;
 			_eUserRights rights = URIGHTS_NONE;
 			bool rememberme = false;
 			bool isnew = false;
 			bool istrustednetwork = false;
-			bool seenbefore = false;
 		} WebEmSession;
 
 		typedef struct _tIPNetwork
@@ -141,7 +140,7 @@ namespace http
 			bool is_upgrade_request(WebEmSession &session, const request &req, reply &rep);
 			std::string compute_accept_header(const std::string &websocket_key);
 			bool CheckAuthByPass(const request& req);
-			bool CheckAuthentication(WebEmSession &session, const request &req, reply &rep);
+			bool CheckAuthentication(WebEmSession &session, const request &req, bool &authErr);
 			bool CheckUserAuthorization(std::string &user, struct ah *ah);
 			bool AllowBasicAuth();
 			void send_authorization_request(reply &rep);

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -52,9 +52,10 @@ namespace http
 			int reply_status = 0;
 			time_t timeout = 0;
 			time_t expires = 0;
-			int rights = 0;
+			int16_t rights = URIGHTS_VIEWER;
 			bool rememberme = false;
 			bool isnew = false;
+			bool istrustednetwork = false;
 		} WebEmSession;
 
 		typedef struct _tIPNetwork

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -149,7 +149,6 @@ namespace http
 			bool parse_cookie(const request &req, std::string &sSID, std::string &sAuthToken, std::string &szTime, bool &expired);
 			bool AreWeInTrustedNetwork(const std::string &sHost);
 			bool IsIPInRange(const std::string &ip, const _tIPNetwork &ipnetwork, const bool &bIsIPv6);
-			void Logout();
 			int parse_auth_header(const request &req, struct ah *ah);
 			std::string generateAuthToken(const WebEmSession &session, const request &req);
 			bool checkAuthToken(WebEmSession &session);
@@ -167,10 +166,6 @@ namespace http
 			~cWebem();
 			void Run();
 			void Stop();
-
-			// 20230525 No longer in Use! Will be removed soon!
-			//void RegisterIncludeCode(const char *idname, const webem_include_function &fun);
-			//bool Include(std::string &reply);
 
 			void RegisterPageCode(const char *pageurl, const webem_page_function &fun, bool bypassAuthentication = false);
 

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -50,9 +50,8 @@ namespace http
 			std::string local_port;
 			std::string auth_token;
 			std::string username;
-			uint16_t reply_status = http::server::reply::ok;
-			time_t timeout = 0;
 			time_t expires = 0;
+			uint16_t reply_status = http::server::reply::ok;
 			_eUserRights rights = URIGHTS_NONE;
 			bool rememberme = false;
 			bool isnew = false;


### PR DESCRIPTION
Refactor of some parts of the cWebem.cpp and removal of obsolete code.

- Removed deprecated code
- Parsing of cookie and checking of Trustednetwork now only performed once (instead of multiple times)
- Added inline documentation for better readability of what is going on
- Session and cookie creation only done when needed (not when calling the API or when in Trusted Network)
- Code moved to better/scoped locations and removed when redundant
- and more cleanup/refactoring

Also added some automated functional tests for the webserver session.

This is a replacement of parts of #5904 (other pieces of that PR are done in PR #5917).
