### PR TITLE
hardware/Rtl433.cpp: Suppress channel hoping message

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -160,6 +160,12 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 	int code = 0;
 
+	if (FindField(data, "center_frequency"))
+	{
+		// Frequency hoping
+		return true;
+	}
+
 	if (FindField(data, "id"))
 	{
 		id = atoi(data["id"].c_str());


### PR DESCRIPTION
When channel hoping is enabled, rtl_433 is issuing messages like: {"time" : "...", "center_frequency" : 433800000, "frequencies" : [433920000, 433800000], "hop_times" : [20]}

They results in log "spam" like "Unhandled sensor reading, please report".

Giving it's neither important nor coming from a sensor, just ignore it.