### PR TITLE
main/EventsPythonModule.cpp: Workaround scope issue

### DIFF
--- a/main/EventsPythonModule.cpp
+++ b/main/EventsPythonModule.cpp
@@ -499,7 +499,7 @@ namespace Plugins
 				PyNewRef	pCode = Py_CompileString(PyString.c_str(), filename.c_str(), Py_file_input);
 				if (pCode)
 				{
-					PyNewRef	pEval = PyEval_EvalCode(pCode, global_dict, local_dict);
+					PyNewRef	pEval = PyEval_EvalCode(pCode, global_dict, global_dict);
 				}
 				else
 				{
@@ -524,7 +524,7 @@ namespace Plugins
 					PyNewRef	pCode = Py_CompileString(PyString.c_str(), filename.c_str(), Py_file_input);
 					if (pCode)
 					{
-						PyNewRef	pEval = PyEval_EvalCode(pCode, global_dict, local_dict);
+						PyNewRef	pEval = PyEval_EvalCode(pCode, global_dict, global_dict);
 					}
 					else
 					{


### PR DESCRIPTION
The switch to python stable ABI switched to Py_CompileString+PyEval_EvalCode to run code but this leads to NameErrors at run time. For instance, simple code now fails:

```
import DomoticzEvents as DE

def print_msg(msg):
    DE.Log(msg)

def foo():
    print_msg(foo)

foo()
```

As a quick workaround, pass globals dict as locals dict to PyEval_EvalCode. I'm no python embedding expert so while it's working:
- I'm not sure it's 100% correct
- the refcount semantics of PyEval_EvalCode is not totally clear to me but it seems to be fine.