### PR TITLE
Optionally use libuuid to generate UUID's

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(USE_PYTHON "Use Python for Plugins and Event-Scripts" YES)
 option(INCLUDE_LINUX_I2C "Include I2C support" YES)
 option(INCLUDE_SPI "Include SPI support" YES)
 option(WITH_LIBUSB "Enable libusb support" YES)
+option(WITH_LIBUUID "Enable libuuid support" NO)
 
 # Link static or shared, external dependencies
 option(USE_LUA_STATIC "Link LUA static" YES)
@@ -737,11 +738,29 @@ IF(WITH_LIBUSB)
 ENDIF(WITH_LIBUSB)
 
 #
+# UUID
+#
+IF(WITH_LIBUUID)
+  find_path(LIBUUID_INCLUDE_DIR uuid/uuid.h
+     HINTS ${PC_LIBUUID_INCLUDEDIR} ${PC_LIBUUID_INCLUDE_DIRS})
+  find_library(LIBUUID_LIBRARY NAMES uuid
+     HINTS ${PC_LIBUUID_LIBDIR} ${PC_LIBUUID_LIBRARY_DIRS})
+  set(LIBUUID_LIBRARIES ${LIBUUID_LIBRARY})
+
+  find_package_handle_standard_args(LIBUUID  DEFAULT_MSG  LIBUUID_LIBRARIES LIBUUID_INCLUDE_DIR)
+  IF(LIBUUID_FOUND)
+    MESSAGE(STATUS "LIBUUID library found at: ${LIBUUID_LIBRARIES}")
+    add_definitions(-DWITH_LIBUUID)
+    target_link_libraries(domoticz ${LIBUUID_LIBRARIES})
+    target_link_libraries(domoticztester ${LIBUUID_LIBRARIES})
+  ENDIF(LIBUUID_FOUND)
+ENDIF(WITH_LIBUUID)
+
+#
 # OpenZWave
 # try to find open-zwave, if found, include support
 #
 IF(USE_STATIC_OPENZWAVE)
-  find_library(OpenZWave NAMES libopenzwave.a HINTS "../open-zwave-read-only" "../open-zwave-read-only/cpp/build")
   get_filename_component(OpenZWave_dir ${OpenZWave} DIRECTORY)
   find_path(OPENZWAVE_INCLUDE_DIRS NAMES OZWException.h HINTS "${OpenZWave_dir}/cpp/src")
   set(OPENZWAVE_LIB ${OpenZWave})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,6 +761,7 @@ ENDIF(WITH_LIBUUID)
 # try to find open-zwave, if found, include support
 #
 IF(USE_STATIC_OPENZWAVE)
+  find_library(OpenZWave NAMES libopenzwave.a HINTS "../open-zwave-read-only" "../open-zwave-read-only/cpp/build")
   get_filename_component(OpenZWave_dir ${OpenZWave} DIRECTORY)
   find_path(OPENZWAVE_INCLUDE_DIRS NAMES OZWException.h HINTS "${OpenZWave_dir}/cpp/src")
   set(OPENZWAVE_LIB ${OpenZWave})

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -56,6 +56,10 @@
 #endif
 #endif
 
+#ifdef WITH_LIBUUID
+#include <uuid/uuid.h>
+#endif
+
 namespace
 {
 	constexpr std::array<uint8_t, 256> crc8_tab{
@@ -1522,6 +1526,15 @@ bool IsDebuggerPresent()
 
 std::string GenerateUUID() // DCE/RFC 4122
 {
+#ifdef WITH_LIBUUID
+	uuid_t  uu;
+	char    uuid[UUID_STR_LEN];
+
+	uuid_generate(uu);
+	uuid_unparse_lower(uu, uuid);
+
+	return std::string(uuid);
+#else
 	const std::string hexCHARS = "0123456789abcdef";
 	std::string uuid = std::string(36, ' ');
 
@@ -1545,6 +1558,7 @@ std::string GenerateUUID() // DCE/RFC 4122
 		}
 	}
 	return uuid;
+#endif
 }
 
 bool isHexRepresentation(const std::string &input)


### PR DESCRIPTION
There isn't a whole lot of randomness in the rand() function (usually 31 bits or less) and definitly not enough to provide for 120+ bits of randomness in GenerateUUID(). The libuuid library does provide enough randomness and may already be installed on the system. In these cases, it may be beneficial to use that instead.