### PR TITLE
Add Stale Workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,23 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+		  any-of-labels: 'PendingFeedback'
+          stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Please comment or this issue will be closed in 7 days.'
+          days-before-stale: 14
+          days-before-close: 7
+		  remove-stale-when-updated: true
+          labels-to-remove-when-stale: 'PendingFeedback'
+		  debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-	  any-of-labels: 'PendingFeedback'
+	  any-of-labels: "PendingFeedback"
           stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Please comment or this issue will be closed in 7 days.'
           days-before-stale: 14
           days-before-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-		  any-of-labels: 'PendingFeedback'
+	  any-of-labels: 'PendingFeedback'
           stale-issue-message: 'This issue is stale because it has been open 14 days with no activity. Please comment or this issue will be closed in 7 days.'
           days-before-stale: 14
           days-before-close: 7
-		  remove-stale-when-updated: true
+          remove-stale-when-updated: true
           labels-to-remove-when-stale: 'PendingFeedback'
-		  debug-only: true
+	  debug-only: true


### PR DESCRIPTION
Checks issues with a PendingFeedback Label and add a stale label when inactive for more then 14 days and close them after 7 days stale. PR's could also be checked but should be ignored now.

Currently in debug only so we can check the impact. Replaces the NoResponse action https://github.com/domoticz/domoticz/blob/development/.github/no-response.yml