### PR TITLE
Updated some EvoHome logging messages to LOG_STATUS

### DIFF
--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -273,7 +273,7 @@ bool CEvohomeWeb::GetStatus()
 		return false;
 	}
 
-	_log.Log(LOG_NORM, "(%s) fetch data from server", m_Name.c_str());
+	_log.Log(LOG_STATUS, "(%s) fetch data from server", m_Name.c_str());
 
 	// system status
 	DecodeControllerMode(m_tcs);
@@ -298,7 +298,7 @@ bool CEvohomeWeb::SetSystemMode(uint8_t sysmode)
 	std::string sznewmode = GetWebAPIModeName(sysmode);
 	if (set_system_mode(m_tcs->systemId, (int)(m_dczToEvoWebAPIMode[sysmode])))
 	{
-		_log.Log(LOG_NORM, "(%s) changed system status to %s", m_Name.c_str(), GetControllerModeName(sysmode));
+		_log.Log(LOG_STATUS, "(%s) changed system status to %s", m_Name.c_str(), GetControllerModeName(sysmode));
 
 		if (sznewmode == "HeatingOff")
 		{


### PR DESCRIPTION
Most of the log messages are logging to LOG_STATUS or LOG_ERROR, except for two. These logged to LOG_NORM, causing those log messages to popup in the log even when no logging is selected. This update solves issue #6005 .