### PR TITLE
handle change of type subtype switchtype when TypeName is specified

### DIFF
--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -755,6 +755,31 @@ namespace Plugins {
 				nValue = 0;
 				sValue = stdsValue;
 			}
+                        // Type change
+                        if (iType != self->Type)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Type", iType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // SubType change
+                        if (iSubType != self->SubType)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("SubType", iSubType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // SwitchType change
+                        if (iSwitchType != self->SwitchType)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("SwitchType", iSwitchType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+
 
 			uint64_t DevRowIdx = -1;
 


### PR DESCRIPTION
As in legacy python framework, when we update the python device and a typename is specified, we need to udpate the device type,subtype and switchtype of the current device if it is not the same as before.
it should address (partly) : https://github.com/domoticz/domoticz/issues/6027