### PR TITLE
code cleaning : replace C style string to numbers conversions by C++ style

### DIFF
--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -396,7 +396,7 @@ float C1WireByKernel::ThreadReadRawDataHighPrecisionDigitalThermometer(const std
 	if (bFoundCrcOk)
 	{
 		if (is_number(data))
-			return stof(data) / 1000.0F; // Temperature given by kernel is in thousandths of degrees
+			return static_cast<float>(stod(data) / 1000.0); // Temperature given by kernel is in thousandths of degrees
 	}
 
 	throw OneWireReadErrorException(deviceFileName);

--- a/hardware/1Wire/1WireByKernel.cpp
+++ b/hardware/1Wire/1WireByKernel.cpp
@@ -396,7 +396,7 @@ float C1WireByKernel::ThreadReadRawDataHighPrecisionDigitalThermometer(const std
 	if (bFoundCrcOk)
 	{
 		if (is_number(data))
-			return (float)atoi(data.c_str()) / 1000.0F; // Temperature given by kernel is in thousandths of degrees
+			return stof(data) / 1000.0F; // Temperature given by kernel is in thousandths of degrees
 	}
 
 	throw OneWireReadErrorException(deviceFileName);

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -283,12 +283,12 @@ bool C1WireByOWFS::GetLightState(const _t1WireDevice& device,int unit) const
       {
          // 1 = Unconditionally off (non-conducting)
          // 2 = Unconditionally on (conducting)
-         // FIXME: in following code iValue is a bool and cannot equal 2
-         int iValue=stoi(readValue)==2;
-         if (iValue!=1 && iValue!=2)
+         int iValue=(stoi(readValue) == 2);
+         // FIXME: iValue is a bool (i.e. 0 or 1), it cannot equal 2
+         if (iValue != 1 && iValue != 2)
             return false;
 
-	 return (iValue == 2);
+	      return (iValue == 2);
       }
    }
    return false;

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -199,7 +199,7 @@ float C1WireByOWFS::GetTemperature(const _t1WireDevice& device) const
 
    if (readValue.empty())
       return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return stof(readValue);
 }
 
 float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
@@ -210,7 +210,7 @@ float C1WireByOWFS::GetHumidity(const _t1WireDevice& device) const
 
    if (readValue.empty())
 	   return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return stof(readValue);
 }
 
 float C1WireByOWFS::GetPressure(const _t1WireDevice& device) const
@@ -220,7 +220,7 @@ float C1WireByOWFS::GetPressure(const _t1WireDevice& device) const
    std::string readValue=readRawData(std::string(realFilename+"/pressure"));
    if (readValue.empty())
 	   return -1000.0;
-   return static_cast<float>(atof(readValue.c_str()));
+   return stof(readValue);
 }
 
 bool C1WireByOWFS::GetLightState(const _t1WireDevice& device,int unit) const
@@ -283,7 +283,8 @@ bool C1WireByOWFS::GetLightState(const _t1WireDevice& device,int unit) const
       {
          // 1 = Unconditionally off (non-conducting)
          // 2 = Unconditionally on (conducting)
-         int iValue=atoi(readValue.c_str())==2;
+         // FIXME: in following code iValue is a bool and cannot equal 2
+         int iValue=stoi(readValue)==2;
          if (iValue!=1 && iValue!=2)
             return false;
 
@@ -298,7 +299,7 @@ unsigned int C1WireByOWFS::GetNbChannels(const _t1WireDevice& device) const
    std::string readValue=readRawData(std::string(device.filename+"/channels"));
    if (readValue.empty())
       return 0;
-   return atoi(readValue.c_str());
+   return (unsigned int) stoul(readValue);
 }
 
 unsigned long C1WireByOWFS::GetCounter(const _t1WireDevice& device,int unit) const
@@ -309,7 +310,7 @@ unsigned long C1WireByOWFS::GetCounter(const _t1WireDevice& device,int unit) con
       readValue=readRawData(std::string(device.filename+"/counters.").append(1,'A'+(char)unit));
    if (readValue.empty())
 	   return -1;  // NULL read.
-   return (unsigned long)atol(readValue.c_str());
+   return stoul(readValue);
 }
 
 int C1WireByOWFS::GetVoltage(const _t1WireDevice& device,int unit) const
@@ -336,7 +337,7 @@ int C1WireByOWFS::GetVoltage(const _t1WireDevice& device,int unit) const
    std::string readValue=readRawData(fileName);
    if (readValue.empty())
 	   return -1000;
-   return static_cast<int>((atof(readValue.c_str())*1000.0));
+   return static_cast<int>(stof(readValue) * 1000.0F);
 }
 
 float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
@@ -346,8 +347,8 @@ float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
    if (readValue.empty())
       readValue=readRawData(std::string(device.filename+"/S3-R1-A/illumination"));
    if (readValue.empty())
-	   return -1000.0;
-   return (float)(atof(readValue.c_str())*1000.0);
+	   return -1000.0F;
+   return stof(readValue) * 1000.0F;
 }
 
 int C1WireByOWFS::GetWiper(const _t1WireDevice& device) const
@@ -355,7 +356,7 @@ int C1WireByOWFS::GetWiper(const _t1WireDevice& device) const
 	std::string readValue = readRawData(std::string(device.filename + "/wiper"));
 	if (readValue.empty())
 		return -1;
-	return atoi(readValue.c_str());
+	return stoi(readValue);
 }
 
 void C1WireByOWFS::StartSimultaneousTemperatureRead()

--- a/hardware/1Wire/1WireByOWFS.cpp
+++ b/hardware/1Wire/1WireByOWFS.cpp
@@ -337,7 +337,7 @@ int C1WireByOWFS::GetVoltage(const _t1WireDevice& device,int unit) const
    std::string readValue=readRawData(fileName);
    if (readValue.empty())
 	   return -1000;
-   return static_cast<int>(stof(readValue) * 1000.0F);
+   return static_cast<int>(stod(readValue) * 1000.0);
 }
 
 float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
@@ -348,7 +348,7 @@ float C1WireByOWFS::GetIlluminance(const _t1WireDevice& device) const
       readValue=readRawData(std::string(device.filename+"/S3-R1-A/illumination"));
    if (readValue.empty())
 	   return -1000.0F;
-   return stof(readValue) * 1000.0F;
+   return static_cast<float>(stod(readValue) * 1000.0);
 }
 
 int C1WireByOWFS::GetWiper(const _t1WireDevice& device) const

--- a/hardware/AccuWeather.cpp
+++ b/hardware/AccuWeather.cpp
@@ -245,7 +245,7 @@ void CAccuWeather::GetMeterDetails()
 		}
 		if (!root["Pressure"].empty())
 		{
-			barometric = atoi(root["Pressure"]["Metric"]["Value"].asString().c_str());
+			barometric = stoi(root["Pressure"]["Metric"]["Value"].asString());
 			if (barometric < 1000)
 				barometric_forcast = baroForecastRain;
 			else if (barometric < 1020)
@@ -257,7 +257,7 @@ void CAccuWeather::GetMeterDetails()
 
 			if (!root["WeatherIcon"].empty())
 			{
-				int forcasticon = atoi(root["WeatherIcon"].asString().c_str());
+				int forcasticon = stoi(root["WeatherIcon"].asString());
 				switch (forcasticon)
 				{
 				case 1:
@@ -360,7 +360,7 @@ void CAccuWeather::GetMeterDetails()
 		//UV
 		if (!root["UVIndex"].empty())
 		{
-			float UV = static_cast<float>(atof(root["UVIndex"].asString().c_str()));
+			float UV = stof(root["UVIndex"].asString());
 			if ((UV < 16) && (UV >= 0))
 			{
 				SendUVSensor(0, 1, 255, UV, "UV");
@@ -372,7 +372,7 @@ void CAccuWeather::GetMeterDetails()
 		{
 			if (!root["PrecipitationSummary"]["Precipitation"].empty())
 			{
-				float RainCount = static_cast<float>(atof(root["PrecipitationSummary"]["Precipitation"]["Metric"]["Value"].asString().c_str()));
+				float RainCount = stof(root["PrecipitationSummary"]["Precipitation"]["Metric"]["Value"].asString());
 				if ((RainCount != -9999.00F) && (RainCount >= 0.00F))
 				{
 					RBUF tsen;
@@ -390,7 +390,7 @@ void CAccuWeather::GetMeterDetails()
 
 					if (!root["PrecipitationSummary"]["PastHour"].empty())
 					{
-						float rainrateph = static_cast<float>(atof(root["PrecipitationSummary"]["PastHour"]["Metric"]["Value"].asString().c_str()));
+						float rainrateph = stof(root["PrecipitationSummary"]["PastHour"]["Metric"]["Value"].asString());
 						if (rainrateph != -9999.00F)
 						{
 							int at10 = ground(std::abs(rainrateph * 10.0F));

--- a/hardware/AirconWithMe.cpp
+++ b/hardware/AirconWithMe.cpp
@@ -404,7 +404,7 @@ void CAirconWithMe::UpdateSelectorSwitch(const int32_t uid, const int32_t value,
 			options["LevelOffHidden"] = "true";
 			options["LevelNames"] = deviceInfo.mSelectorStates;
 
-			int sIdx = std::stoi(result[0][0]);
+			int sIdx = stoi(result[0][0]);
 			m_sql.SetDeviceOptions(sIdx, options);
 		}
 	}

--- a/hardware/AlfenEve.cpp
+++ b/hardware/AlfenEve.cpp
@@ -96,7 +96,7 @@ bool AlfenEve::StartHardware()
 	std::string sValue = GetTextSensorText(1, 1, bExits);
 	if (bExits)
 	{
-		m_LastBootcount = atoi(sValue.c_str());
+		m_LastBootcount = stoi(sValue);
 	}
 
 	RequestStart();

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -513,7 +513,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendTempSensor(sAnnaTemperature, 255, temperature, sname);
 				}
 			}
@@ -522,7 +522,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float illuminance = (float)atof(tmpstr.c_str());
+					float illuminance = stof(tmpstr);
 					SendLuxSensor(sAnnaIlluminance, 1, 255, illuminance, sname);
 				}
 			}
@@ -531,7 +531,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendSetPointSensor(sAnnaThermostat, temperature, sname);
 				}
 			}
@@ -540,7 +540,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendTempSensor(sAnnaIntendedBoilerTemperature, 255, temperature, sname);
 				}
 			}
@@ -549,7 +549,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendTempSensor(sAnnaReturnWaterTemperature, 255, temperature, sname);
 				}
 			}
@@ -558,7 +558,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendTempSensor(sAnnaBoilerTemperature, 255, temperature, sname);
 				}
 			}
@@ -567,7 +567,7 @@ void CAnnaThermostat::GetMeterDetails()
 				tmpstr = GetPeriodMeasurement(pElem);
 				if (!tmpstr.empty())
 				{
-					float temperature = (float)atof(tmpstr.c_str());
+					float temperature = stof(tmpstr);
 					SendTempSensor(sAnnaMaxBoilerTemperature, 255, temperature, sname);
 				}
 			}
@@ -680,7 +680,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float level = (float)atof(tmpstr.c_str()) * 100.F;
+                    float level = stof(tmpstr) * 100.F;
                     SendPercentageSensor(sAnnaModulationLevel, 1, 255, level, sname);
                 }
             }
@@ -689,7 +689,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float pressure = (float)atof(tmpstr.c_str());
+                    float pressure = stof(tmpstr);
                     SendPressureSensor(sAnnaWaterPressure, 1, 255, pressure, sname);
                 }
             }
@@ -698,7 +698,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float dbm = (float)atof(tmpstr.c_str());
+                    float dbm = stof(tmpstr);
                     SendCustomSensor(sAnnaSignalStrength, 1, 255, dbm, sname, "dBm");
                 }
             }
@@ -707,7 +707,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float starts = (float)atof(tmpstr.c_str());
+                    float starts = stof(tmpstr);
                     SendCustomSensor(sAnnaBurnerStarts, 1, 255, starts, sname, "");
                 }
             }
@@ -716,7 +716,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float starts = (float)atof(tmpstr.c_str());
+                    float starts = stof(tmpstr);
                     SendCustomSensor(sAnnaFailedBurnerStarts, 1, 255, starts, sname, "");
                 }
             }
@@ -725,7 +725,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float hour = (float)atof(tmpstr.c_str());
+                    float hour = stof(tmpstr);
                     SendCustomSensor(sAnnaBurnerOperationTime, 1, 255, hour, sname, "Hour(s)");
                 }
             }
@@ -734,7 +734,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float hour = (float)atof(tmpstr.c_str());
+                    float hour = stof(tmpstr);
                     SendCustomSensor(sAnnaHotWaterBurnerOperationTime, 1, 255, hour, sname, "Hour(s)");
                 }
             }
@@ -743,7 +743,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float flow = (float)atof(tmpstr.c_str());
+                    float flow = stof(tmpstr);
                     SendWaterflowSensor(sAnnaHotWaterFlow, 1, 255, flow, sname);
                 }
             }
@@ -752,7 +752,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float temperature = (float)atof(tmpstr.c_str());
+                    float temperature = stof(tmpstr);
                     SendTempSensor(sAnnaHotWaterTemperature, 255, temperature, sname);
                 }
             }

--- a/hardware/AnnaThermostat.cpp
+++ b/hardware/AnnaThermostat.cpp
@@ -680,7 +680,7 @@ void CAnnaThermostat::GetMeterDetails()
                 tmpstr = GetPeriodMeasurement(pElem);
                 if (!tmpstr.empty())
                 {
-                    float level = stof(tmpstr) * 100.F;
+                    float level = static_cast<float>(stod(tmpstr) * 100.0);
                     SendPercentageSensor(sAnnaModulationLevel, 1, 255, level, sname);
                 }
             }

--- a/hardware/Arilux.cpp
+++ b/hardware/Arilux.cpp
@@ -218,10 +218,10 @@ namespace http {
 				return;
 			root["status"] = "OK";
 
-			int HwdID = atoi(idx.c_str());
+			int HwdID = stoi(idx);
 
 			// stype values aligned to ColorSwitch.h enum values in Hardware.html
-			int subtype = std::stoi(stype);
+			int subtype = stoi(stype);
 			if ( (subtype <= 0) || (subtype > 8) ) subtype = 1;
 
 			Arilux Arilux(HwdID);

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -195,21 +195,21 @@ bool CAtagOne::GetDeviceDetails(const std::string& ThermostatID)
 		Log(LOG_ERROR, "Invalid/no data received (1)...");
 		return false;
 	}
-	root["roomTemperature"] = stod(sret);
+	root["roomTemperature"] = static_cast<float>(stod(sret));
 	//root["deviceAlias"] = GetHTMLPageValue(sResult, "Apparaat alias|Device alias", false);
 	//root["latestReportTime"] = GetHTMLPageValue(sResult, "Laatste rapportagetijd|Latest report time", false);
 	//root["connectedTo"] = GetHTMLPageValue(sResult, "Verbonden met|Connected to", false);
-	root["burningHours"] = stod(GetHTMLPageValue(sResult, "Branduren|Burning hours", true));
+	root["burningHours"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "Branduren|Burning hours", true)));
 	//root["boilerHeatingFor"] = GetHTMLPageValue(sResult, "Ketel in bedrijf voor|Boiler heating for", false);
 	sret = GetHTMLPageValue(sResult, "Brander status|Flame status|Brennerstatus", false);
 	root["flameStatus"] = ((sret == "Aan") || (sret == "On") || (sret == "An")) ? true : false;
-	root["outsideTemperature"] = stod(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true));
-	root["dhwSetpoint"] = stod(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true));
-	root["dhwWaterTemperature"] = stod(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true));
-	root["chSetpoint"] = stod(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true));
-	root["chWaterTemperature"] = stod(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true));
-	root["chWaterPressure"] = stod(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true));
-	root["chReturnTemperature"] = stod(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true));
+	root["outsideTemperature"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true)));
+	root["dhwSetpoint"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true)));
+	root["dhwWaterTemperature"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true)));
+	root["chSetpoint"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true)));
+	root["chWaterTemperature"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true)));
+	root["chWaterPressure"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true)));
+	root["chReturnTemperature"] = static_cast<float>(stod(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true)));
 
 #ifdef DEBUG_AtagOneThermostat_read
 	sResult = ReadFile("E:\\AtagOne_gettargetsetpoint.txt");

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -195,21 +195,21 @@ bool CAtagOne::GetDeviceDetails(const std::string& ThermostatID)
 		Log(LOG_ERROR, "Invalid/no data received (1)...");
 		return false;
 	}
-	root["roomTemperature"] = stof(sret);
+	root["roomTemperature"] = stod(sret);
 	//root["deviceAlias"] = GetHTMLPageValue(sResult, "Apparaat alias|Device alias", false);
 	//root["latestReportTime"] = GetHTMLPageValue(sResult, "Laatste rapportagetijd|Latest report time", false);
 	//root["connectedTo"] = GetHTMLPageValue(sResult, "Verbonden met|Connected to", false);
-	root["burningHours"] = stof(GetHTMLPageValue(sResult, "Branduren|Burning hours", true));
+	root["burningHours"] = stod(GetHTMLPageValue(sResult, "Branduren|Burning hours", true));
 	//root["boilerHeatingFor"] = GetHTMLPageValue(sResult, "Ketel in bedrijf voor|Boiler heating for", false);
 	sret = GetHTMLPageValue(sResult, "Brander status|Flame status|Brennerstatus", false);
 	root["flameStatus"] = ((sret == "Aan") || (sret == "On") || (sret == "An")) ? true : false;
-	root["outsideTemperature"] = stof(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true));
-	root["dhwSetpoint"] = stof(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true));
-	root["dhwWaterTemperature"] = stof(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true));
-	root["chSetpoint"] = stof(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true));
-	root["chWaterTemperature"] = stof(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true));
-	root["chWaterPressure"] = stof(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true));
-	root["chReturnTemperature"] = stof(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true));
+	root["outsideTemperature"] = stod(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true));
+	root["dhwSetpoint"] = stod(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true));
+	root["dhwWaterTemperature"] = stod(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true));
+	root["chSetpoint"] = stod(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true));
+	root["chWaterTemperature"] = stod(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true));
+	root["chWaterPressure"] = stod(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true));
+	root["chReturnTemperature"] = stod(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true));
 
 #ifdef DEBUG_AtagOneThermostat_read
 	sResult = ReadFile("E:\\AtagOne_gettargetsetpoint.txt");
@@ -239,7 +239,7 @@ bool CAtagOne::GetDeviceDetails(const std::string& ThermostatID)
 		Log(LOG_ERROR, "Invalid/no data received (3)...");
 		return false;
 	}
-	root["targetTemperature"] = stof(root2["targetTemp"].asString());
+	root["targetTemperature"] = stod(root2["targetTemp"].asString());
 	root["currentMode"] = root2["currentMode"].asString();
 	root["vacationPlanned"] = root2["vacationPlanned"].asBool();
 

--- a/hardware/AtagOne.cpp
+++ b/hardware/AtagOne.cpp
@@ -195,21 +195,21 @@ bool CAtagOne::GetDeviceDetails(const std::string& ThermostatID)
 		Log(LOG_ERROR, "Invalid/no data received (1)...");
 		return false;
 	}
-	root["roomTemperature"] = static_cast<float>(atof(sret.c_str()));
+	root["roomTemperature"] = stof(sret);
 	//root["deviceAlias"] = GetHTMLPageValue(sResult, "Apparaat alias|Device alias", false);
 	//root["latestReportTime"] = GetHTMLPageValue(sResult, "Laatste rapportagetijd|Latest report time", false);
 	//root["connectedTo"] = GetHTMLPageValue(sResult, "Verbonden met|Connected to", false);
-	root["burningHours"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Branduren|Burning hours", true).c_str()));
+	root["burningHours"] = stof(GetHTMLPageValue(sResult, "Branduren|Burning hours", true));
 	//root["boilerHeatingFor"] = GetHTMLPageValue(sResult, "Ketel in bedrijf voor|Boiler heating for", false);
 	sret = GetHTMLPageValue(sResult, "Brander status|Flame status|Brennerstatus", false);
 	root["flameStatus"] = ((sret == "Aan") || (sret == "On") || (sret == "An")) ? true : false;
-	root["outsideTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true).c_str()));
-	root["dhwSetpoint"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true).c_str()));
-	root["dhwWaterTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true).c_str()));
-	root["chSetpoint"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true).c_str()));
-	root["chWaterTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true).c_str()));
-	root["chWaterPressure"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true).c_str()));
-	root["chReturnTemperature"] = static_cast<float>(atof(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true).c_str()));
+	root["outsideTemperature"] = stof(GetHTMLPageValue(sResult, "Buitentemperatuur|Outside temperature|Au&#223;entemperatur", true));
+	root["dhwSetpoint"] = stof(GetHTMLPageValue(sResult, "Setpoint warmwater|DHW setpoint", true));
+	root["dhwWaterTemperature"] = stof(GetHTMLPageValue(sResult, "Warmwatertemperatuur|DHW water temperature|Warmwassertemperatur", true));
+	root["chSetpoint"] = stof(GetHTMLPageValue(sResult, "Setpoint cv|CH setpoint", true));
+	root["chWaterTemperature"] = stof(GetHTMLPageValue(sResult, "CV-aanvoertemperatuur|CH water temperature", true));
+	root["chWaterPressure"] = stof(GetHTMLPageValue(sResult, "CV-waterdruk|CH water pressure|Anlagendruck", true));
+	root["chReturnTemperature"] = stof(GetHTMLPageValue(sResult, "CV retourtemperatuur|CH return temperature|HZ R&#252;cklauftemperatur", true));
 
 #ifdef DEBUG_AtagOneThermostat_read
 	sResult = ReadFile("E:\\AtagOne_gettargetsetpoint.txt");
@@ -239,7 +239,7 @@ bool CAtagOne::GetDeviceDetails(const std::string& ThermostatID)
 		Log(LOG_ERROR, "Invalid/no data received (3)...");
 		return false;
 	}
-	root["targetTemperature"] = static_cast<float>(atof(root2["targetTemp"].asString().c_str()));
+	root["targetTemperature"] = stof(root2["targetTemp"].asString());
 	root["currentMode"] = root2["currentMode"].asString();
 	root["vacationPlanned"] = root2["vacationPlanned"].asBool();
 

--- a/hardware/BleBox.cpp
+++ b/hardware/BleBox.cpp
@@ -246,8 +246,7 @@ void BleBox::GetDevicesState()
 						}
 
 						std::string temperature = sensor["value"].asString(); // xxxx (xx.xx = temperature)
-						float ftemp = static_cast<float>(std::stoi(temperature.substr(0, 2))
-										 + std::stoi(temperature.substr(2, 2)) / 100.0);
+						float ftemp = static_cast<float>(stoi(temperature.substr(0, 2)) + stoi(temperature.substr(2, 2)) / 100.0F);
 
 						// TODO - how save IP address ??
 						SendTempSensor(IP, 255, ftemp, DevicesType[device.second].name);
@@ -298,7 +297,7 @@ std::string BleBox::IPToHex(const std::string & IPAddress, const int type)
 	// because exists inconsistency when comparing deviceID in method decode_xxx in mainworker(Limitless uses small letter, lighting2 etc uses capital letter)
 	if (type != pTypeColorSwitch)
 	{
-		uint32_t uID = (uint32_t)(atoi(strarray[0].c_str()) << 24) | (uint32_t)(atoi(strarray[1].c_str()) << 16) | (atoi(strarray[2].c_str()) << 8) | atoi(strarray[3].c_str());
+		uint32_t uID = (((uint32_t) stoi(strarray[0])) << 24) | (((uint32_t) stoi(strarray[1])) << 16) | (((uint32_t) stoi(strarray[2])) << 8) | ((uint32_t) stoi(strarray[3]));
 		return std_format("%08X", uID);
 	}
 
@@ -678,13 +677,13 @@ void BleBox::SendSwitch(const int NodeID, const uint8_t ChildID, const int Batte
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == light2_sOff))
 			return;
 		if ((bOn && (nvalue != light2_sOff)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -804,8 +803,8 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "BleBoxSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
+			int iMode1 = stoi(mode1);
+			int iMode2 = stoi(mode2);
 
 			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')", iMode1, iMode2, hwid.c_str());
 			pHardware->SetSettings(iMode1);
@@ -855,7 +854,7 @@ namespace http {
 
 			root["status"] = "OK";
 			root["title"] = "BleBoxRemoveNode";
-			int ID = atoi(nodeid.c_str());
+			int ID = stoi(nodeid);
 			pHardware->RemoveNode(ID);
 		}
 

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -320,7 +320,7 @@ bool CBuienRadar::GetStationDetails()
 				m_sStationRegion = measurement["regio"].asString();
 				m_szMyLatitude = std::to_string(measurement["lat"].asDouble());
 				m_szMyLongitude = std::to_string(measurement["lon"].asDouble());
-				Log(LOG_STATUS, "Using Station: %s (%s), ID: %d, Lat/Lon: %g,%g", m_sStationName.c_str(), m_sStationRegion.c_str(), m_iStationID, stof(m_szMyLatitude), stof(m_szMyLongitude));
+				Log(LOG_STATUS, "Using Station: %s (%s), ID: %d, Lat/Lon: %g,%g", m_sStationName.c_str(), m_sStationRegion.c_str(), m_iStationID, stod(m_szMyLatitude), stod(m_szMyLongitude));
 			}
 			ParseMeterDetails(measurement);
 			return true;

--- a/hardware/Buienradar.cpp
+++ b/hardware/Buienradar.cpp
@@ -79,7 +79,7 @@ void CBuienRadar::Init()
 				if (is_number(strarray[0]))
 				{
 					try {
-						m_iStationID = std::stoi(strarray[0]);
+						m_iStationID = stoi(strarray[0]);
 						if (m_iStationID == 0)
 						{
 							// No station ID provided
@@ -264,8 +264,8 @@ bool CBuienRadar::GetStationDetails()
 
 	if (m_iStationID == 0)
 	{
-		double MyLatitude = std::stod(m_szMyLatitude);
-		double MyLongitude = std::stod(m_szMyLongitude);
+		double MyLatitude = stod(m_szMyLatitude);
+		double MyLongitude = stod(m_szMyLongitude);
 
 		double shortest_distance_km = 200.0;//start with 200 km
 		double shortest_station_lat = 0;
@@ -320,7 +320,7 @@ bool CBuienRadar::GetStationDetails()
 				m_sStationRegion = measurement["regio"].asString();
 				m_szMyLatitude = std::to_string(measurement["lat"].asDouble());
 				m_szMyLongitude = std::to_string(measurement["lon"].asDouble());
-				Log(LOG_STATUS, "Using Station: %s (%s), ID: %d, Lat/Lon: %g,%g", m_sStationName.c_str(), m_sStationRegion.c_str(), m_iStationID, atof(m_szMyLatitude.c_str()), atof(m_szMyLongitude.c_str()));
+				Log(LOG_STATUS, "Using Station: %s (%s), ID: %d, Lat/Lon: %g,%g", m_sStationName.c_str(), m_sStationRegion.c_str(), m_iStationID, stof(m_szMyLatitude), stof(m_szMyLongitude));
 			}
 			ParseMeterDetails(measurement);
 			return true;
@@ -446,7 +446,7 @@ void CBuienRadar::ParseMeterDetails(const Json::Value& root)
 
 void CBuienRadar::GetRainPrediction()
 {
-	if (m_szMyLatitude.empty() || m_szMyLongitude.empty() ||  std::stoi(m_szMyLatitude)<1 || std::stoi(m_szMyLongitude)<1)
+	if (m_szMyLatitude.empty() || m_szMyLongitude.empty() ||  stoi(m_szMyLatitude)<1 || stoi(m_szMyLongitude)<1)
 		return;
 
 	std::string sResult;
@@ -533,7 +533,7 @@ void CBuienRadar::GetRainPrediction()
 			if (strarray.size() != 2)
 				return;
 
-			int rain_value = std::stoi(strarray[0]);
+			int rain_value = stoi(strarray[0]);
 
 			if (line == 0)
 			{
@@ -541,8 +541,8 @@ void CBuienRadar::GetRainPrediction()
 				if (strarray.size() != 2)
 					return;
 
-				int hour = std::stoi(strarray[0]);
-				int min = std::stoi(strarray[1]);
+				int hour = stoi(strarray[0]);
+				int min = stoi(strarray[1]);
 
 				rain_time = (hour * 60) + min;
 

--- a/hardware/Comm5SMTCP.cpp
+++ b/hardware/Comm5SMTCP.cpp
@@ -118,7 +118,7 @@ void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			float temperature = static_cast<float>(atof(tokens[1].c_str()));
+			float temperature = stof(tokens[1]);
 			SendTempSensor(1, 255, temperature, "TEMPERATURE");
 		}
 		else if (startsWith(line, "281")) {
@@ -126,7 +126,7 @@ void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			int humidity = atoi(tokens[1].c_str());
+			int humidity = stoi(tokens[1]);
 			SendHumiditySensor(1, 255, humidity, "HUMIDITY");
 		}
 		else if (startsWith(line, "282")) {
@@ -134,7 +134,7 @@ void Comm5SMTCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			float baro = static_cast<float>(atof(tokens[1].c_str()));
+			float baro = stof(tokens[1]);
 			SendBaroSensor(1, 0, 255, baro, 0, "BAROMETRIC");
 		}
 	}

--- a/hardware/Comm5TCP.cpp
+++ b/hardware/Comm5TCP.cpp
@@ -114,7 +114,7 @@ void Comm5TCP::processSensorData(const std::string& line)
 	if (tokens.size() < 2)
 		return;
 
-	unsigned int sensorbitfield = ::strtol(tokens[1].c_str(), nullptr, 16);
+	unsigned int sensorbitfield = stol(tokens[1], nullptr, 16);
 	for (int i = 0; i < 16; ++i) {
 		bool on = (sensorbitfield & (1 << i)) != 0 ? true : false;
 		if (((lastKnownSensorState & (1 << i)) ^ (sensorbitfield & (1 << i))) || initSensorData) {
@@ -139,7 +139,7 @@ void Comm5TCP::ParseData(const unsigned char* data, const size_t len)
 			if (tokens.size() < 2)
 				break;
 
-			unsigned int relaybitfield = ::strtol(tokens[1].c_str(), nullptr, 16);
+			unsigned int relaybitfield = stol(tokens[1], nullptr, 16);
 			for (int i = 0; i < 16; ++i) {
 				bool on = (relaybitfield & (1 << i)) != 0 ? true : false;
 				SendSwitch(i + 1, 1, 255, on, 0, "Relay " + std::to_string(i + 1), m_Name);

--- a/hardware/CounterHelper.cpp
+++ b/hardware/CounterHelper.cpp
@@ -33,7 +33,7 @@ void CounterHelper::Init(const std::string& szUservariableName, CDomoticzHardwar
 	}
 	if (!result.empty())
 	{
-		m_CounterOffset = std::stod(result[0][1]);
+		m_CounterOffset = stod(result[0][1]);
 	}
 }
 

--- a/hardware/CurrentCostMeterSerial.cpp
+++ b/hardware/CurrentCostMeterSerial.cpp
@@ -137,13 +137,13 @@ namespace http {
 			if (result.empty())
 				return;
 
-			int Mode1 = atoi(request::findValue(&req, "CCBaudrate").c_str());
+			int Mode1 = stoi(request::findValue(&req, "CCBaudrate"));
 			int Mode2 = 0;
 			int Mode3 = 0;
 			int Mode4 = 0;
 			int Mode5 = 0;
 			int Mode6 = 0;
-			m_sql.UpdateRFXCOMHardwareDetails(atoi(idx.c_str()), Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);
+			m_sql.UpdateRFXCOMHardwareDetails(stoi(idx), Mode1, Mode2, Mode3, Mode4, Mode5, Mode6);
 
 			m_mainworker.RestartHardware(idx);
 			root["status"] = "OK";

--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -415,7 +415,7 @@ void CDaikin::GetControlInfo()
 			if (m_otemp != results2[1])
 			{
 				m_otemp = results2[1];
-				SendTempSensor(10, -1, static_cast<float>(atof(results2[1].c_str())), "Outside Temperature");
+				SendTempSensor(10, -1, stof(results2[1]), "Outside Temperature");
 			}
 		}
 		else if (results2[0] == "stemp")
@@ -423,7 +423,7 @@ void CDaikin::GetControlInfo()
 			if (m_stemp != results2[1])
 			{
 				m_stemp = results2[1];
-				SendSetPointSensor(20, 1, 1, static_cast<float>(atof(results2[1].c_str())), "Target Temperature");
+				SendSetPointSensor(20, 1, 1, stof(results2[1]), "Target Temperature");
 			}
 		}
 		else if (results2[0] == "f_rate")
@@ -544,16 +544,16 @@ void CDaikin::GetSensorInfo()
 			continue;
 		if (results2[0] == "htemp")
 		{
-			htemp = static_cast<float>(atof(results2[1].c_str()));
+			htemp = stof(results2[1]);
 		}
 		else if (results2[0] == "hhum")
 		{
 			if (results2[1] != "-")
-				hhum = static_cast<int>(atoi(results2[1].c_str()));
+				hhum = stoi(results2[1]);
 		}
 		else if (results2[0] == "otemp")
 		{
-			SendTempSensor(10, -1, static_cast<float>(atof(results2[1].c_str())), "Outside Temperature");
+			SendTempSensor(10, -1, stof(results2[1]), "Outside Temperature");
 		}
 	}
 	if (htemp != -1)
@@ -623,7 +623,7 @@ void CDaikin::GetYearPower()
 			StringSplit(results2[1], "/", months);
 			for (const auto &month : months)
 			{
-				cooltotalkWh += std::stof(month) / 10; // energy saved as 0.1 kWh units
+				cooltotalkWh += stof(month) / 10; // energy saved as 0.1 kWh units
 			}
 			SendKwhMeter(30, 30, 255, 0, cooltotalkWh, "Cool kWh");
 		}
@@ -633,7 +633,7 @@ void CDaikin::GetYearPower()
 			StringSplit(results2[1], "/", months);
 			for (const auto &month : months)
 			{
-				heattotalkWh += std::stof(month) / 10; // energy saved as 0.1 kWh units
+				heattotalkWh += stof(month) / 10; // energy saved as 0.1 kWh units
 			}
 			SendKwhMeter(31, 31, 255, 0, heattotalkWh, "Heat kWh");
 		}
@@ -755,21 +755,21 @@ void CDaikin::InsertUpdateSwitchSelector(uint32_t Idx, const bool bIsOn, const i
 			if (defaultname == "Mode")
 			{
 				m_sql.SetDeviceOptions(
-					atoi(sIdx.c_str()),
+					stoi(sIdx),
 					m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|AUTO|DEHUMDIFICATOR|COLD|HOT|FAN;LevelOffHidden:true;LevelActions:00|01|02|03|04|06", false));
 			}
 			else if (defaultname == "Ventillation")
 			{
 				// for the Fans
 				m_sql.SetDeviceOptions(
-					atoi(sIdx.c_str()),
+					stoi(sIdx),
 					m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|AUTO|Silence|Lev 1|Lev 2|Lev 3|Lev 4|Lev 5;LevelOffHidden:true;LevelActions:00|10|20|30|40|50|60|70",
 								 false));
 			}
 			else if (defaultname == "Winds")
 			{
 				// for the Wings
-				m_sql.SetDeviceOptions(atoi(sIdx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Stopped|Vert|Horiz|Both;LevelOffHidden:true", false));
+				m_sql.SetDeviceOptions(stoi(sIdx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Stopped|Vert|Horiz|Both;LevelOffHidden:true", false));
 			}
 		}
 	}

--- a/hardware/Daikin.cpp
+++ b/hardware/Daikin.cpp
@@ -623,7 +623,7 @@ void CDaikin::GetYearPower()
 			StringSplit(results2[1], "/", months);
 			for (const auto &month : months)
 			{
-				cooltotalkWh += stof(month) / 10; // energy saved as 0.1 kWh units
+				cooltotalkWh += static_cast<float>(stod(month) / 10.0); // energy saved as 0.1 kWh units
 			}
 			SendKwhMeter(30, 30, 255, 0, cooltotalkWh, "Cool kWh");
 		}
@@ -633,7 +633,7 @@ void CDaikin::GetYearPower()
 			StringSplit(results2[1], "/", months);
 			for (const auto &month : months)
 			{
-				heattotalkWh += stof(month) / 10; // energy saved as 0.1 kWh units
+				heattotalkWh += static_cast<float>(stod(month) / 10.0); // energy saved as 0.1 kWh units
 			}
 			SendKwhMeter(31, 31, 255, 0, heattotalkWh, "Heat kWh");
 		}

--- a/hardware/DarkSky.cpp
+++ b/hardware/DarkSky.cpp
@@ -176,7 +176,7 @@ void CDarkSky::GetMeterDetails()
 	}
 	if (root["currently"]["pressure"].empty() == false)
 	{
-		barometric = atoi(root["currently"]["pressure"].asString().c_str());
+		barometric = stoi(root["currently"]["pressure"].asString());
 		if (barometric < 1000)
 			barometric_forcast = baroForecastRain;
 		else if (barometric < 1020)
@@ -235,13 +235,13 @@ void CDarkSky::GetMeterDetails()
 
 	if (root["currently"]["windBearing"].empty() == false)
 	{
-		wind_degrees = atoi(root["currently"]["windBearing"].asString().c_str());
+		wind_degrees = stoi(root["currently"]["windBearing"].asString());
 	}
 	if (root["currently"]["windSpeed"].empty() == false)
 	{
 		if ((root["currently"]["windSpeed"] != "N/A") && (root["currently"]["windSpeed"] != "--"))
 		{
-			float temp_wind_mph = static_cast<float>(atof(root["currently"]["windSpeed"].asString().c_str()));
+			float temp_wind_mph = stof(root["currently"]["windSpeed"].asString());
 			if (temp_wind_mph != -9999.00F)
 			{
 				//convert to m/s
@@ -253,7 +253,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["windGust"] != "N/A") && (root["currently"]["windGust"] != "--"))
 		{
-			float temp_wind_gust_mph = static_cast<float>(atof(root["currently"]["windGust"].asString().c_str()));
+			float temp_wind_gust_mph = stof(root["currently"]["windGust"].asString());
 			if (temp_wind_gust_mph != -9999.00F)
 			{
 				//convert to m/s
@@ -265,7 +265,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["apparentTemperature"] != "N/A") && (root["currently"]["apparentTemperature"] != "--"))
 		{
-			wind_chill = static_cast<float>(atof(root["currently"]["apparentTemperature"].asString().c_str()));
+			wind_chill = stof(root["currently"]["apparentTemperature"].asString());
 			//Convert to celcius
 			wind_chill = float((wind_chill - 32) * (5.0 / 9.0));
 		}
@@ -341,7 +341,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["precipIntensity"] != "N/A") && (root["currently"]["precipIntensity"] != "--"))
 		{
-			float rainrateph = static_cast<float>(atof(root["currently"]["precipIntensity"].asString().c_str())) * 25.4F; // inches to mm
+			float rainrateph = stof(root["currently"]["precipIntensity"].asString()) * 25.4F; // inches to mm
 			if ((rainrateph != -9999.00F) && (rainrateph >= 0.00F))
 			{
 				SendRainRateSensor(1, 255, rainrateph, "Rain");
@@ -354,7 +354,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["visibility"] != "N/A") && (root["currently"]["visibility"] != "--"))
 		{
-			float visibility = static_cast<float>(atof(root["currently"]["visibility"].asString().c_str())) * 1.60934F; // miles to km
+			float visibility = stof(root["currently"]["visibility"].asString()) * 1.60934F; // miles to km
 			if (visibility >= 0)
 			{
 				_tGeneralDevice gdevice;
@@ -369,7 +369,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["ozone"] != "N/A") && (root["currently"]["ozone"] != "--"))
 		{
-			float radiation = static_cast<float>(atof(root["currently"]["ozone"].asString().c_str()));
+			float radiation = stof(root["currently"]["ozone"].asString());
 			if (radiation >= 0.0F)
 			{
 				SendCustomSensor(1, 0, 255, radiation, "Ozone Sensor", "DU"); //(dobson units)
@@ -381,7 +381,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["cloudCover"] != "N/A") && (root["currently"]["cloudCover"] != "--"))
 		{
-			float cloudcover = static_cast<float>(atof(root["currently"]["cloudCover"].asString().c_str()));
+			float cloudcover = stof(root["currently"]["cloudCover"].asString());
 			if (cloudcover >= 0.0F)
 			{
 				SendPercentageSensor(1, 0, 255, cloudcover * 100.0F, "Cloud Cover");

--- a/hardware/DarkSky.cpp
+++ b/hardware/DarkSky.cpp
@@ -341,7 +341,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["precipIntensity"] != "N/A") && (root["currently"]["precipIntensity"] != "--"))
 		{
-			float rainrateph = stof(root["currently"]["precipIntensity"].asString()) * 25.4F; // inches to mm
+			float rainrateph = static_cast<float>(stod(root["currently"]["precipIntensity"].asString()) * 25.4); // inches to mm
 			if ((rainrateph != -9999.00F) && (rainrateph >= 0.00F))
 			{
 				SendRainRateSensor(1, 255, rainrateph, "Rain");
@@ -354,7 +354,7 @@ void CDarkSky::GetMeterDetails()
 	{
 		if ((root["currently"]["visibility"] != "N/A") && (root["currently"]["visibility"] != "--"))
 		{
-			float visibility = stof(root["currently"]["visibility"].asString()) * 1.60934F; // miles to km
+			float visibility = static_cast<float>(stod(root["currently"]["visibility"].asString()) * 1.60934); // miles to km
 			if (visibility >= 0)
 			{
 				_tGeneralDevice gdevice;

--- a/hardware/DenkoviDevices.cpp
+++ b/hardware/DenkoviDevices.cpp
@@ -556,7 +556,7 @@ int CDenkoviDevices::DenkoviCheckForIO(std::string tmpstr, const std::string &tm
 		tmpstr = tmpstr.substr(pos1 + strlen(ioType.c_str()));
 		pos1 = tmpstr.find('>');
 		if (pos1 != std::string::npos)
-			Idx = atoi(tmpstr.substr(0, pos1).c_str());
+			Idx = stoi(tmpstr.substr(0, pos1));
 	}
 	return Idx;
 }
@@ -570,7 +570,7 @@ int CDenkoviDevices::DenkoviGetIntParameter(std::string tmpstr, const std::strin
 		tmpstr = tmpstr.substr(pos1 + strlen(parameter.c_str()));
 		pos1 = tmpstr.find('<');
 		if (pos1 != std::string::npos)
-			lValue = atoi(tmpstr.substr(0, pos1).c_str());
+			lValue = stoi(tmpstr.substr(0, pos1));
 	}
 	return lValue;
 }
@@ -600,7 +600,7 @@ float CDenkoviDevices::DenkoviGetFloatParameter(std::string tmpstr, const std::s
 		tmpstr = tmpstr.substr(pos1 + strlen(parameter.c_str()));
 		pos1 = tmpstr.find('<');
 		if (pos1 != std::string::npos)
-			value = static_cast<float>(atof(tmpstr.substr(0, pos1).c_str()));
+			value = stof(tmpstr.substr(0, pos1));
 	}
 	return value;
 }
@@ -868,13 +868,13 @@ void CDenkoviDevices::GetMeterDetails()
 				StringSplit(tmpMeasure, " ", vMeasure); 
 				size_t len = tmpMeasure.length() - tmpMeasure.find_first_of('.', 0) - 2;
 				std::string units = tmpMeasure.substr(tmpMeasure.find_first_of('.',0)+2, len);
-				SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled (" + name + ")", units);
+				SendCustomSensor(Idx, 1, 255, stof(vMeasure[0]), "Analog Input Scaled (" + name + ")", units);
 
 				std::vector<std::string> vRaw;
 				tmpstr = results[ii - 1];
 				std::string tmpRawValue = DenkoviGetStrParameter(tmpstr, DAE_VALUE_DEF);
 				StringSplit(tmpRawValue, " ", vRaw);
-				SendCustomSensor(Idx+1, 1, 255, static_cast<float>(atof(vRaw[0].c_str())), "Analog Input (" + name + ")", "");
+				SendCustomSensor(Idx+1, 1, 255, stof(vRaw[0]), "Analog Input (" + name + ")", "");
 
 				Idx = -1;
 				bHaveAnalogInput = false;
@@ -886,7 +886,7 @@ void CDenkoviDevices::GetMeterDetails()
 				name = "Temperature Input (" + name + ")";
 				std::vector<std::string> vMeasure;
 				StringSplit(tmpMeasure, " ", vMeasure);
-				tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+				tmpTiValue = stof(tmpMeasure);
 				if (tmpMeasure.find('F') != std::string::npos)
 					tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
 				SendTempSensor(Idx, 255, tmpTiValue, name);
@@ -986,7 +986,7 @@ void CDenkoviDevices::GetMeterDetails()
 		break;
 	}
 	case DDEV_DAEnet_IP3: {
-		unsigned int pins = std::stoul(DAEnetIP3GetIo(sResult, DAENETIP3_PORTA_MDO_DEF), nullptr, 16);
+		unsigned int pins = stoul(DAEnetIP3GetIo(sResult, DAENETIP3_PORTA_MDO_DEF), nullptr, 16);
 		for (ii = 0; ii < 16; ii++)//16 digital outputs
 		{
 			std::stringstream io;
@@ -996,7 +996,7 @@ void CDenkoviDevices::GetMeterDetails()
 			SendSwitch(DIOType_DO, (uint8_t)(ii + 1), 255, ((pins & (0x0001 << ii)) != 0) ? true : false, 0, name, m_Name);
 		}
 
-		pins = std::stoul(DAEnetIP3GetIo(sResult, DAENETIP3_PORTB_MDI_DEF), nullptr, 16);
+		pins = stoul(DAEnetIP3GetIo(sResult, DAENETIP3_PORTB_MDI_DEF), nullptr, 16);
 		for (ii = 0; ii < 8; ii++)//8 digital inputs
 		{
 			std::stringstream io;
@@ -1011,7 +1011,7 @@ void CDenkoviDevices::GetMeterDetails()
 			tmpMeasure = DAEnetIP3GetAi(sResult, (DAENETIP3_PORTC_SVAL_DEF + std::to_string(ii)), DAENETIP3_AI_VALUE);
 			tmpstr = DAEnetIP3GetAi(sResult, (DAENETIP3_PORTC_SVAL_DEF + std::to_string(ii)), DAENETIP3_AI_DIMENSION);
 			tmpName = DAEnetIP3GetIo(sResult2, DAENETIP3_PORTC_SNAME_DEF + std::to_string(ii)); 
-			SendCustomSensor(DIOType_AI, (uint8_t)(ii + 1), 255, static_cast<float>(atoi(tmpMeasure.c_str())), "Analog Input Scaled " + std::to_string(ii + 1) + " (" + tmpName + ")", tmpstr);
+			SendCustomSensor(DIOType_AI, (uint8_t)(ii + 1), 255, static_cast<float>(stoi(tmpMeasure)), "Analog Input Scaled " + std::to_string(ii + 1) + " (" + tmpName + ")", tmpstr);
 		}
 	}
 	case DDEV_SmartDEN_IP_16_R_MT://has only relays
@@ -1137,7 +1137,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, stof(vMeasure[0]), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;
@@ -1153,7 +1153,7 @@ void CDenkoviDevices::GetMeterDetails()
 				
 				if ((tmpMeasure.find("---") == std::string::npos))
 				{
-					tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+					tmpTiValue = stof(tmpMeasure);
 
 					if (tmpMeasure[tmpMeasure.size() - 1] == -119)//Check if F is found
 						tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
@@ -1230,7 +1230,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, stof(vMeasure[0]), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;
@@ -1245,7 +1245,7 @@ void CDenkoviDevices::GetMeterDetails()
 
 				if ((tmpMeasure.find("---") == std::string::npos))
 				{
-					tmpTiValue = static_cast<float>(atof(tmpMeasure.c_str()));
+					tmpTiValue = stof(tmpMeasure);
 
 					if (tmpMeasure[tmpMeasure.size() - 1] == -119)//Check if F is found
 						tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
@@ -1322,7 +1322,7 @@ void CDenkoviDevices::GetMeterDetails()
 				if (Idx <= 4)
 				{
 					//scaled value				 
-					SendCustomSensor(Idx, DIOType_AI, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+					SendCustomSensor(Idx, DIOType_AI, 255, stof(vMeasure[0]), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					//raw value					
 					tmp_adc_raw_value = stdstring_trim(results[ii-1]);
 					SendCustomSensor(Idx+8, DIOType_AI, 255, DenkoviGetFloatParameter(tmp_adc_raw_value, DAE_VALUE_DEF), "Analog Input Raw " + std::to_string(Idx) + " (" + name + ")","");
@@ -1331,7 +1331,7 @@ void CDenkoviDevices::GetMeterDetails()
 				else {
 					name = "Analog Input " + std::to_string(Idx) + " (" + name + ")";
 					if (vMeasure.size() == 2) {
-						tmpTiValue = static_cast<float>(atof(vMeasure[0].c_str()));
+						tmpTiValue = stof(vMeasure[0]);
 						if (vMeasure[1] == "degF")
 							tmpTiValue = (float)ConvertToCelsius((double)tmpTiValue);
 						SendTempSensor(Idx, 255, tmpTiValue, name);
@@ -1433,7 +1433,7 @@ void CDenkoviDevices::GetMeterDetails()
 					StringSplit(tmpMeasure, " ", vMeasure);
 					if (vMeasure.size() == 2)
 					{
-						SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
+						SendCustomSensor(Idx, 1, 255, stof(vMeasure[0]), "Analog Input Scaled " + std::to_string(Idx) + " (" + name + ")", vMeasure[1]);
 					}
 				}
 				Idx = -1;

--- a/hardware/DenkoviSmartdenIPInOut.cpp
+++ b/hardware/DenkoviSmartdenIPInOut.cpp
@@ -169,13 +169,13 @@ void CDenkoviSmartdenIPInOut::UpdateSwitch(const unsigned char Idx, const int Su
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -268,7 +268,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find(">");
 				if (pos1 != std::string::npos)
 				{
-					Idx = atoi(tmpstr.substr(0, pos1).c_str());
+					Idx = stoi(tmpstr.substr(0, pos1));
 					bHaveDigitalInput = true;
 					continue;
 				}
@@ -281,7 +281,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find(">");
 				if (pos1 != std::string::npos)
 				{
-					Idx = atoi(tmpstr.substr(0, pos1).c_str());
+					Idx = stoi(tmpstr.substr(0, pos1));
 					bHaveDigitalOutput = true;
 					continue;
 				}
@@ -294,7 +294,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find(">");
 				if (pos1 != std::string::npos)
 				{
-					Idx = atoi(tmpstr.substr(0, pos1).c_str());
+					Idx = stoi(tmpstr.substr(0, pos1));
 					bHaveAnalogInput = true;
 					continue;
 				}
@@ -307,7 +307,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find(">");
 				if (pos1 != std::string::npos)
 				{
-					Idx = atoi(tmpstr.substr(0, pos1).c_str());
+					Idx = stoi(tmpstr.substr(0, pos1));
 					bHaveTemperatureInput = true;
 					continue;
 				}
@@ -336,7 +336,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
 				{
-					int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+					int lValue = stoi(tmpstr.substr(0, pos1));
 					std::stringstream sstr;
 					sstr << "Input " << Idx << " (" << name << ")";
 					UpdateSwitch(1, Idx, (lValue == 1) ? true : false, 100, sstr.str());
@@ -357,7 +357,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
 				{
-					int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+					int lValue = stoi(tmpstr.substr(0, pos1));
 					std::stringstream sstr;
 					sstr << "Output " << Idx << " (" << name << ")";
 					UpdateSwitch(2, Idx, (lValue == 1) ? true : false, 100, sstr.str());
@@ -385,7 +385,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 						StringSplit(sMeasure, " ", vMeasure);
 						if (vMeasure.size() == 2)
 						{
-							SendCustomSensor(Idx, 1, 255, static_cast<float>(atof(vMeasure[0].c_str())), name, vMeasure[1]);
+							SendCustomSensor(Idx, 1, 255, stof(vMeasure[0]), name, vMeasure[1]);
 						}
 					}
 					Idx = -1;
@@ -407,7 +407,7 @@ void CDenkoviSmartdenIPInOut::GetMeterDetails()
 					pos1 = tmpstr.find('<');
 					if (pos1 != std::string::npos)
 					{
-						SendTempSensor(Idx, 255, static_cast<float>(atof(tmpstr.substr(0, pos1).c_str())), name);
+						SendTempSensor(Idx, 255, stof(tmpstr.substr(0, pos1)), name);
 					}
 					Idx = -1;
 					bHaveTemperatureInput = false;

--- a/hardware/DenkoviSmartdenLan.cpp
+++ b/hardware/DenkoviSmartdenLan.cpp
@@ -142,13 +142,13 @@ void CDenkoviSmartdenLan::UpdateSwitch(const unsigned char Idx, const int SubUni
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -221,7 +221,7 @@ void CDenkoviSmartdenLan::GetMeterDetails()
 			pos1 = tmpstr.find(">");
 			if (pos1 != std::string::npos)
 			{
-				Idx = atoi(tmpstr.substr(0, pos1).c_str());
+				Idx = stoi(tmpstr.substr(0, pos1));
 				continue;
 			}
 		}
@@ -234,7 +234,7 @@ void CDenkoviSmartdenLan::GetMeterDetails()
 			pos1 = tmpstr.find("</State>");
 			if (pos1 != std::string::npos)
 			{
-				int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+				int lValue = stoi(tmpstr.substr(0, pos1));
 				std::stringstream sstr;
 				sstr << "Relay " << Idx;
 				UpdateSwitch(1, Idx, (lValue == 1) ? true : false, 100, sstr.str());

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -465,7 +465,7 @@ float CDomoticzHardwareBase::GetRainSensorValue(const int NodeID, bool& bExists)
 		return 0.0F;
 	}
 	bExists = true;
-	return (float)atof(splitresults[1].c_str());
+	return stof(splitresults[1]);
 }
 
 bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, float& WindSpeed, float& WindGust, float& WindTemp, float& WindChill, bool bHaveWindTemp, bool& bExists)
@@ -494,11 +494,11 @@ bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, f
 		return 0.0F;
 	}
 	bExists = true;
-	WindDir = (int)atof(splitresults[0].c_str());
-	WindSpeed = (float)atof(splitresults[2].c_str());
-	WindGust = (float)atof(splitresults[3].c_str());
-	WindTemp = (float)atof(splitresults[4].c_str());
-	WindChill = (float)atof(splitresults[5].c_str());
+	WindDir = (int) stof(splitresults[0]);
+	WindSpeed = stof(splitresults[2]);
+	WindGust = stof(splitresults[3]);
+	WindTemp = stof(splitresults[4]);
+	WindChill = stof(splitresults[5]);
 	return bExists;
 }
 
@@ -566,7 +566,7 @@ double CDomoticzHardwareBase::GetKwhMeter(const int NodeID, const int ChildID, b
 		return 0.0F;
 	}
 	bExists = true;
-	return atof(splitresults[1].c_str());
+	return stof(splitresults[1]);
 }
 
 void CDomoticzHardwareBase::SendMeterSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float metervalue, const std::string& defaultname, const int RssiLevel /* =12 */)
@@ -693,13 +693,13 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == light2_sOff))
 			return;
 		if ((bOn && (nvalue != light2_sOff)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -1060,7 +1060,7 @@ void CDomoticzHardwareBase::SendSelectorSwitch(const int NodeID, const uint8_t C
 	xcmd.subtype = sSwitchTypeSelector;
 	xcmd.id = NodeID;
 	xcmd.unitcode = ChildID; //Do we support multiple copies of the same selector switch ??
-	xcmd.level = std::stoi(sValue);
+	xcmd.level = stoi(sValue);
 
 	_eSwitchType switchtype;
 	switchtype = STYPE_Selector;
@@ -1092,7 +1092,7 @@ void CDomoticzHardwareBase::SendSelectorSwitch(const int NodeID, const uint8_t C
 	else
 	{ 
 		//Check Level (sValue in SQL Query)
-		if (xcmd.level == std::stoi(result[0][1]))
+		if (xcmd.level == stoi(result[0][1]))
 			return; // no need to uodate
 		result = m_sql.safe_query("UPDATE DeviceStatus SET sValue=%i WHERE (HardwareID==%d) AND (DeviceID=='%08X')", xcmd.level, m_HwdID, NodeID);
 	}

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -494,7 +494,7 @@ bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, f
 		return 0.0F;
 	}
 	bExists = true;
-	WindDir = (int) stof(splitresults[0]);
+	WindDir = static_cast<int>(stod(splitresults[0]));
 	WindSpeed = stof(splitresults[2]);
 	WindGust = stof(splitresults[3]);
 	WindTemp = stof(splitresults[4]);

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -566,7 +566,7 @@ double CDomoticzHardwareBase::GetKwhMeter(const int NodeID, const int ChildID, b
 		return 0.0F;
 	}
 	bExists = true;
-	return stof(splitresults[1]);
+	return stod(splitresults[1]);
 }
 
 void CDomoticzHardwareBase::SendMeterSensor(const int NodeID, const int ChildID, const int BatteryLevel, const float metervalue, const std::string& defaultname, const int RssiLevel /* =12 */)

--- a/hardware/DomoticzTCP.cpp
+++ b/hardware/DomoticzTCP.cpp
@@ -126,7 +126,7 @@ void DomoticzTCP::OnData(const uint8_t* pData, size_t length)
 
 		auto result = m_sql.safe_query("SELECT SwitchType, Options, Color FROM DeviceStatus WHERE (ID==%q)", std::to_string(idx).c_str());
 
-		int oldSwitchType = atoi(result[0][0].c_str());
+		int oldSwitchType = stoi(result[0][0]);
 		std::string oldOptions = result[0][1];
 		std::string oldColor = result[0][2];
 
@@ -202,11 +202,11 @@ bool AssambleDeviceInfo(const std::string& idx, Json::Value& root)
 	if (result.empty())
 		return false;
 	int iIndex = 0;
-	root["HardwareID"] = atoi(result[0][iIndex++].c_str());
+	root["HardwareID"] = stoi(result[0][iIndex++]);
 	root["DeviceID"] = result[0][iIndex++];
-	root["Unit"] = atoi(result[0][iIndex++].c_str());
-	root["Type"] = atoi(result[0][iIndex++].c_str());
-	root["SubType"] = atoi(result[0][iIndex++].c_str());
+	root["Unit"] = stoi(result[0][iIndex++]);
+	root["Type"] = stoi(result[0][iIndex++]);
+	root["SubType"] = stoi(result[0][iIndex++]);
 	return true;
 }
 

--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -132,7 +132,7 @@ namespace http {
 			if ((idx.empty()) || (ssensortype.empty()) || (ssensorname.empty()))
 				return;
 
-			int sensortype = atoi(ssensortype.c_str());
+			int sensortype = stoi(ssensortype);
 			unsigned int type = 0;
 			unsigned int subType = 0;
 			uint64_t DeviceRowIdx = (uint64_t )-1;
@@ -144,7 +144,7 @@ namespace http {
 					type = sensor.type;
 					subType = sensor.subtype;
 
-					int HwdID = atoi(idx.c_str());
+					int HwdID = stoi(idx);
 
 					//Make a unique number for ID
 					std::vector<std::vector<std::string> > result;
@@ -154,7 +154,7 @@ namespace http {
 
 					if (!result.empty())
 					{
-						nid = atol(result[0][0].c_str()) + 1;
+						nid = stol(result[0][0]) + 1;
 					}
 					unsigned long vs_idx = nid; // OTO keep idx to be returned before masking
 					nid += 82000;
@@ -217,13 +217,13 @@ namespace http {
 			else
 				if (!devicetype.empty() && !devicesubtype.empty())
 				{ // for creating any device (type=x&subtype=y) from json api or code
-					type = atoi(devicetype.c_str());
-					subType = atoi(devicesubtype.c_str());
+					type = stoi(devicetype);
+					subType = stoi(devicesubtype);
 				}
 				else
 					return;
 
-			int HwdID = atoi(idx.c_str());
+			int HwdID = stoi(idx);
 
 			//Make a unique number for ID
 			std::vector<std::vector<std::string> > result;
@@ -233,7 +233,7 @@ namespace http {
 
 			if (!result.empty())
 			{
-				nid = atol(result[0][0].c_str()) + 1;
+				nid = stol(result[0][0]) + 1;
 			}
 
 			bool bPrevAcceptNewHardware = m_sql.m_bAcceptNewHardware;

--- a/hardware/ETH8020.cpp
+++ b/hardware/ETH8020.cpp
@@ -135,13 +135,13 @@ void CETH8020::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, cons
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -218,12 +218,12 @@ void CETH8020::GetMeterDetails()
 			pos1 = tmpstr.find('>');
 			if (pos1 != std::string::npos)
 			{
-				Idx = (uint8_t)atoi(tmpstr.substr(0, pos1).c_str());
+				Idx = (uint8_t) stoi(tmpstr.substr(0, pos1));
 				tmpstr = tmpstr.substr(pos1+1);
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
 				{
-					int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+					int lValue = stoi(tmpstr.substr(0, pos1));
 					std::stringstream sstr;
 					sstr << "Relay " << Idx;
 					UpdateSwitch(1, Idx, (lValue == 1) ? true : false, 100, sstr.str());
@@ -236,12 +236,12 @@ void CETH8020::GetMeterDetails()
 			pos1 = tmpstr.find('>');
 			if (pos1 != std::string::npos)
 			{
-				Idx = (uint8_t)atoi(tmpstr.substr(0, pos1).c_str());
+				Idx = (uint8_t) stoi(tmpstr.substr(0, pos1));
 				tmpstr = tmpstr.substr(pos1 + 1);
 				pos1 = tmpstr.find('<');
 				if (pos1 != std::string::npos)
 				{
-					int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+					int lValue = stoi(tmpstr.substr(0, pos1));
 					float voltage = (float)(5.0F / 1023.0F) * lValue;
 					if (voltage > 5.0F)
 						voltage = 5.0F;

--- a/hardware/EcoCompteur.cpp
+++ b/hardware/EcoCompteur.cpp
@@ -130,27 +130,27 @@ void CEcoCompteur::GetScript()
 	// Sending kWh meter data
 	if (!root["data1"].empty())
 	{
-		SendKwhMeter(m_HwdID, 1, 255, root["data1"].asFloat(), atof(fields[7].c_str()), "Conso 1");
+		SendKwhMeter(m_HwdID, 1, 255, root["data1"].asFloat(), stof(fields[7]), "Conso 1");
 	}
 
 	if (!root["data2"].empty())
 	{
-		SendKwhMeter(m_HwdID, 2, 255, root["data2"].asFloat(), atof(fields[9].c_str()), "Conso 2");
+		SendKwhMeter(m_HwdID, 2, 255, root["data2"].asFloat(), stof(fields[9]), "Conso 2");
 	}
 
 	if (!root["data3"].empty())
 	{
-		SendKwhMeter(m_HwdID, 3, 255, root["data3"].asFloat(), atof(fields[11].c_str()), "Conso 3");
+		SendKwhMeter(m_HwdID, 3, 255, root["data3"].asFloat(), stof(fields[11]), "Conso 3");
 	}
 
 	if (!root["data4"].empty())
 	{
-		SendKwhMeter(m_HwdID, 4, 255, root["data4"].asFloat(), atof(fields[13].c_str()), "Conso 4");
+		SendKwhMeter(m_HwdID, 4, 255, root["data4"].asFloat(), stof(fields[13]), "Conso 4");
 	}
 
 	if (!root["data5"].empty())
 	{
-		SendKwhMeter(m_HwdID, 5, 255, root["data5"].asFloat(), atof(fields[15].c_str()), "Conso 5");
+		SendKwhMeter(m_HwdID, 5, 255, root["data5"].asFloat(), stof(fields[15]), "Conso 5");
 	}
 }
 

--- a/hardware/EcoCompteur.cpp
+++ b/hardware/EcoCompteur.cpp
@@ -130,27 +130,27 @@ void CEcoCompteur::GetScript()
 	// Sending kWh meter data
 	if (!root["data1"].empty())
 	{
-		SendKwhMeter(m_HwdID, 1, 255, root["data1"].asFloat(), stof(fields[7]), "Conso 1");
+		SendKwhMeter(m_HwdID, 1, 255, root["data1"].asFloat(), stod(fields[7]), "Conso 1");
 	}
 
 	if (!root["data2"].empty())
 	{
-		SendKwhMeter(m_HwdID, 2, 255, root["data2"].asFloat(), stof(fields[9]), "Conso 2");
+		SendKwhMeter(m_HwdID, 2, 255, root["data2"].asFloat(), stod(fields[9]), "Conso 2");
 	}
 
 	if (!root["data3"].empty())
 	{
-		SendKwhMeter(m_HwdID, 3, 255, root["data3"].asFloat(), stof(fields[11]), "Conso 3");
+		SendKwhMeter(m_HwdID, 3, 255, root["data3"].asFloat(), stod(fields[11]), "Conso 3");
 	}
 
 	if (!root["data4"].empty())
 	{
-		SendKwhMeter(m_HwdID, 4, 255, root["data4"].asFloat(), stof(fields[13]), "Conso 4");
+		SendKwhMeter(m_HwdID, 4, 255, root["data4"].asFloat(), stod(fields[13]), "Conso 4");
 	}
 
 	if (!root["data5"].empty())
 	{
-		SendKwhMeter(m_HwdID, 5, 255, root["data5"].asFloat(), stof(fields[15]), "Conso 5");
+		SendKwhMeter(m_HwdID, 5, 255, root["data5"].asFloat(), stod(fields[15]), "Conso 5");
 	}
 }
 

--- a/hardware/EcoDevices.cpp
+++ b/hardware/EcoDevices.cpp
@@ -229,11 +229,11 @@ void CEcoDevices::GetMeterDetails()
 	Debug(DEBUG_HARDWARE, "XML output for /status.xml\n%s", MakeHtml(sResult).c_str());
 
 	m_status.version = m_status.version + "..";
-	major = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	major = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version.erase(0, m_status.version.find('.') + 1);
-	minor = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	minor = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version.erase(0, m_status.version.find('.') + 1);
-	release = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	release = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version = S_xpath_string(XMLdoc.RootElement(), "/response/version/text()").c_str();
 
 	if ((major > min_major) || ((major == min_major) && (minor > min_minor)) || ((major == min_major) && (minor == min_minor) && (release >= min_release)))
@@ -421,11 +421,11 @@ void CEcoDevices::GetMeterRT2Details()
 	Debug(DEBUG_HARDWARE, "XML output for /admin/status.xml\n%s", MakeHtml(sResult).c_str());
 
 	m_status.version = m_status.version + "..";
-	major = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	major = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version.erase(0, m_status.version.find('.') + 1);
-	minor = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	minor = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version.erase(0, m_status.version.find('.') + 1);
-	release = atoi(m_status.version.substr(0, m_status.version.find('.')).c_str());
+	release = stoi(m_status.version.substr(0, m_status.version.find('.')));
 	m_status.version = S_xpath_string(XMLdoc.RootElement(), "/response/version/text()").c_str();
 
 	if (!((major > min_major) || ((major == min_major) && (minor > min_minor)) || ((major == min_major) && (minor == min_minor) && (release >= min_release))))
@@ -463,29 +463,29 @@ void CEcoDevices::GetMeterRT2Details()
 	m_teleinfo1.OPTARIF = XMLmap["OPTARIF"];
 	m_teleinfo1.PTEC = XMLmap["PTEC"];
 	m_teleinfo1.DEMAIN = XMLmap["DEMAIN"];
-	m_teleinfo1.ISOUSC = atoi(XMLmap["ISOUSC"].c_str());
-	m_teleinfo1.PAPP = atoi(XMLmap["PAPP"].c_str());
+	m_teleinfo1.ISOUSC = stoi(XMLmap["ISOUSC"]);
+	m_teleinfo1.PAPP = stoi(XMLmap["PAPP"]);
 	if ( m_teleinfo1.PAPP > 0 ) {
 		m_teleinfo1.withPAPP = true;
 	}
-	m_teleinfo1.BASE = atoi(XMLmap["BASE"].c_str());
-	m_teleinfo1.HCHC = atoi(XMLmap["HCHC"].c_str());
-	m_teleinfo1.HCHP = atoi(XMLmap["HCHP"].c_str());
-	m_teleinfo1.EJPHN = atoi(XMLmap["EJPHN"].c_str());
-	m_teleinfo1.EJPHPM = atoi(XMLmap["EJPHPM"].c_str());
-	m_teleinfo1.BBRHCJB = atoi(XMLmap["BBRHCJB"].c_str());
-	m_teleinfo1.BBRHPJB = atoi(XMLmap["BBRHPJB"].c_str());
-	m_teleinfo1.BBRHCJW = atoi(XMLmap["BBRHCJW"].c_str());
-	m_teleinfo1.BBRHPJW = atoi(XMLmap["BBRHPJW"].c_str());
-	m_teleinfo1.BBRHCJR = atoi(XMLmap["BBRHCJR"].c_str());
-	m_teleinfo1.BBRHPJR = atoi(XMLmap["BBRPJR"].c_str());
-	m_teleinfo1.PEJP = atoi(XMLmap["PEJP"].c_str());
-	m_teleinfo1.IINST = atoi(XMLmap["IINST"].c_str());
-	m_teleinfo1.IINST1 = atoi(XMLmap["IINST1"].c_str());
-	m_teleinfo1.IINST2 = atoi(XMLmap["IINST2"].c_str());
-	m_teleinfo1.IINST3 = atoi(XMLmap["IISNT3"].c_str());
-	m_teleinfo1.PPOT = atoi(XMLmap["PPOT"].c_str());
-	m_teleinfo1.ADPS = atoi(XMLmap["ADPS"].c_str());
+	m_teleinfo1.BASE = stoi(XMLmap["BASE"]);
+	m_teleinfo1.HCHC = stoi(XMLmap["HCHC"]);
+	m_teleinfo1.HCHP = stoi(XMLmap["HCHP"]);
+	m_teleinfo1.EJPHN = stoi(XMLmap["EJPHN"]);
+	m_teleinfo1.EJPHPM = stoi(XMLmap["EJPHPM"]);
+	m_teleinfo1.BBRHCJB = stoi(XMLmap["BBRHCJB"]);
+	m_teleinfo1.BBRHPJB = stoi(XMLmap["BBRHPJB"]);
+	m_teleinfo1.BBRHCJW = stoi(XMLmap["BBRHCJW"]);
+	m_teleinfo1.BBRHPJW = stoi(XMLmap["BBRHPJW"]);
+	m_teleinfo1.BBRHCJR = stoi(XMLmap["BBRHCJR"]);
+	m_teleinfo1.BBRHPJR = stoi(XMLmap["BBRPJR"]);
+	m_teleinfo1.PEJP = stoi(XMLmap["PEJP"]);
+	m_teleinfo1.IINST = stoi(XMLmap["IINST"]);
+	m_teleinfo1.IINST1 = stoi(XMLmap["IINST1"]);
+	m_teleinfo1.IINST2 = stoi(XMLmap["IINST2"]);
+	m_teleinfo1.IINST3 = stoi(XMLmap["IISNT3"]);
+	m_teleinfo1.PPOT = stoi(XMLmap["PPOT"]);
+	m_teleinfo1.ADPS = stoi(XMLmap["ADPS"]);
 
 	Debug(DEBUG_HARDWARE, "OPTARIF: '%s'", m_teleinfo1.OPTARIF.c_str());
 	Debug(DEBUG_HARDWARE, "PTEC:    '%s'", m_teleinfo1.PTEC.c_str());
@@ -504,14 +504,14 @@ void CEcoDevices::GetMeterRT2Details()
 		if (splitresults[0].empty())
 			break;
 
-		fvalue1 = (float)atof(splitresults[0].c_str());
+		fvalue1 = stof(splitresults[0]);
 		if (fvalue1 > 0) {
 			if (major >= 3)
 				SendMeterSensor(m_HwdID, (uint8_t)i, 255, fvalue1, m_status.hostname + " " + label);
 			else
 				SendMeterSensor(m_HwdID, (uint8_t)i, 255, fvalue1 / 1000, m_status.hostname + " " + label);
 		}
-		fvalue2 = (float)atof(splitresults[1].c_str());
+		fvalue2 = stof(splitresults[1]);
 		if (fvalue2 > 0) {
 			if (major >= 3)
 				SendCustomSensor(m_HwdID, (uint8_t)i, 255, fvalue2, m_status.hostname + " " + label, "Eur");

--- a/hardware/EnOceanESP2.cpp
+++ b/hardware/EnOceanESP2.cpp
@@ -798,11 +798,11 @@ bool CEnOceanESP2::WriteToHardware(const char* pdata, const unsigned char /*leng
 		m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 	if (!result.empty())
 	{
-		_eSwitchType switchtype = static_cast<_eSwitchType>(std::stoul(result[0][0]));
+		_eSwitchType switchtype = static_cast<_eSwitchType>(stoul(result[0][0]));
 		if (switchtype == STYPE_Dimmer)
 			bIsDimmer = true;
 
-		LastLevel = static_cast<uint8_t>(std::stoul(result[0][1]));
+		LastLevel = static_cast<uint8_t>(stoul(result[0][1]));
 	}
 
 	uint8_t iLevel = tsen->LIGHTING2.level;
@@ -1071,9 +1071,9 @@ bool CEnOceanESP2::ParseData()
 				}
 				return true;
 			}
-			uint16_t Manufacturer = static_cast<uint16_t>(std::stoul(result[0][1]));
-			uint8_t Profile = static_cast<uint8_t>(std::stoul(result[0][2]));
-			uint8_t iType = static_cast<uint8_t>(std::stoul(result[0][3]));
+			uint16_t Manufacturer = static_cast<uint16_t>(stoul(result[0][1]));
+			uint8_t Profile = static_cast<uint8_t>(stoul(result[0][2]));
+			uint8_t iType = static_cast<uint8_t>(stoul(result[0][3]));
 
 			if (Profile == 0x12 && iType == 0x00)
 			{ // A5-12-00, Automated Meter Reading, Counter

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -367,16 +367,16 @@ void CEnOceanESP3::LoadNodesFromDatabase()
 	{
 		NodeInfo node;
 
-		node.idx = static_cast<uint32_t>(std::stoul(sd[0]));
-		node.nodeID = static_cast<uint32_t>(std::stoul(sd[1]));
+		node.idx = static_cast<uint32_t>(stoul(sd[0]));
+		node.nodeID = static_cast<uint32_t>(stoul(sd[1]));
 		node.name = sd[2];
-		node.manufacturerID = static_cast<uint16_t>(std::stoul(sd[3]));
-		node.RORG = static_cast<uint8_t>(std::stoul(sd[4]));
-		node.func = static_cast<uint8_t>(std::stoul(sd[5]));
-		node.type = static_cast<uint8_t>(std::stoul(sd[6]));
+		node.manufacturerID = static_cast<uint16_t>(stoul(sd[3]));
+		node.RORG = static_cast<uint8_t>(stoul(sd[4]));
+		node.func = static_cast<uint8_t>(stoul(sd[5]));
+		node.type = static_cast<uint8_t>(stoul(sd[6]));
 		node.description = sd[7];
 
-		uint32_t nValue = static_cast<uint32_t>(std::stoul(sd[8]));
+		uint32_t nValue = static_cast<uint32_t>(stoul(sd[8]));
 
 		node.teachin_mode = static_cast<TeachinMode>(bitrange(nValue, TEACHIN_MODE_SHIFT, TEACHIN_MODE_MASK));
 /*
@@ -462,11 +462,11 @@ void CEnOceanESP3::GetNodesJSON(Json::Value &root)
 
 				for (const auto &sd : result)
 				{
-					int signalLevel = static_cast<int>(std::stol(sd[1]));
+					int signalLevel = stoi(sd[1]);
 					if (nodeSignalLevel > signalLevel)
 						nodeSignalLevel = signalLevel;
 
-					int battery_level = static_cast<int>(std::stol(sd[2]));
+					int battery_level = stoi(sd[2]);
 					if (nodeBatteryLevel > battery_level)
 						nodeBatteryLevel = battery_level;
 
@@ -562,7 +562,7 @@ void CEnOceanESP3::TeachInNode(const uint32_t nodeID, const uint16_t manID,
 	}
 	NodeInfo node;
 
-	node.idx = static_cast<uint32_t>(std::stoul(result[0][0]));
+	node.idx = static_cast<uint32_t>(stoul(result[0][0]));
 	node.nodeID = nodeID;
 	node.name = result[0][1];
 	node.manufacturerID = manID;
@@ -1946,8 +1946,8 @@ bool CEnOceanESP3::WriteToHardware(const char *pdata, const unsigned char length
 			m_HwdID, sDeviceID.c_str(), (int) tsen->LIGHTING2.unitcode);
 		if (!result.empty())
 		{ // Device found in the database
-			switchtype = static_cast<_eSwitchType>(std::stoul(result[0][0]));
-			LastLevel = static_cast<uint8_t>(std::stoul(result[0][1]));
+			switchtype = static_cast<_eSwitchType>(stoul(result[0][0]));
+			LastLevel = static_cast<uint8_t>(stoul(result[0][1]));
 		}
 
 		uint8_t iLevel = tsen->LIGHTING2.level;
@@ -2343,7 +2343,7 @@ void CEnOceanESP3::ParseESP3Packet(uint8_t packettype, uint8_t *data, uint16_t d
 
 				for (const auto &sd : result)
 				{
-					uint32_t nodeID = static_cast<uint32_t>(std::stoul(sd[0], 0, 16));
+					uint32_t nodeID = static_cast<uint32_t>(stoul(sd[0], 0, 16));
 					if (nodeID <= m_id_base || nodeID > (m_id_base + 128))
 						continue; // Device is not a virtual switch created from m_HwdID/m_id_base
 
@@ -3859,7 +3859,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 						StringSplit(sValue, ";", strarray);
 						double mtotal = 0;
 						if (strarray.size() >= 2)
-							mtotal = std::stod(strarray[1]);
+							mtotal = stod(strarray[1]);
 						//add current
 						mtotal += mv;
 						SendKwhMeter(senderID, 1, -1, mv, mtotal / 1000.0, pNode->name, rssi);
@@ -4473,7 +4473,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 			
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4487,7 +4487,7 @@ namespace http
 			if (minutesStr.empty())
 				return;
 
-			uint32_t minutes = static_cast<uint32_t>(std::stoul(minutesStr));
+			uint32_t minutes = static_cast<uint32_t>(stoul(minutesStr));
 
 			pESP3Hardware->Debug(DEBUG_NORM, "Cmd_EnOceanESP3EnableLearnMode");
 
@@ -4503,7 +4503,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4527,7 +4527,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 			
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4557,7 +4557,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 			
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4587,7 +4587,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4601,7 +4601,7 @@ namespace http
 			if (nodeIDStr.empty())
 				return;
 
-			uint32_t nodeID = static_cast<uint32_t>(std::stoul(nodeIDStr));
+			uint32_t nodeID = static_cast<uint32_t>(stoul(nodeIDStr));
 
 			pESP3Hardware->Debug(DEBUG_NORM, "Cmd_EnOceanESP3UpdateNode: Node %08X", nodeID);
 
@@ -4615,7 +4615,7 @@ namespace http
 			if (manIDStr.empty())
 				return;
 
-			uint16_t manID = static_cast<uint16_t>(std::stoul(manIDStr));
+			uint16_t manID = static_cast<uint16_t>(stoul(manIDStr));
 			
 			std::string eepStr = request::findValue(&req, "eep");
 			if (eepStr.empty())
@@ -4652,7 +4652,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)
@@ -4666,7 +4666,7 @@ namespace http
 			if (nodeIDStr.empty())
 				return;
 
-			uint32_t nodeID = static_cast<uint32_t>(std::stoul(nodeIDStr));
+			uint32_t nodeID = static_cast<uint32_t>(stoul(nodeIDStr));
 
 			pESP3Hardware->Debug(DEBUG_NORM, "Cmd_EnOceanESP3DeleteNode: Node %08X", nodeID);
 
@@ -4682,7 +4682,7 @@ namespace http
 			if (hwdIDStr.empty())
 				return;
 
-			int hwdID = static_cast<int>(std::stol(hwdIDStr));
+			int hwdID = stoi(hwdIDStr);
 			
 			auto pHardware = m_mainworker.GetHardware(hwdID);
 			if (pHardware == nullptr)

--- a/hardware/Enever.cpp
+++ b/hardware/Enever.cpp
@@ -500,7 +500,7 @@ void Enever::parseElectricity(const std::string& szElectricityData, const bool b
 				return; //no price for this provider
 
 			std::string szProviderPrice = itt[szProviderPriceName].asString();
-			float fProviderPrice = std::stof(szProviderPrice);
+			float fProviderPrice = stof(szProviderPrice);
 
 			int64_t iRate = (int64_t)round(fProviderPrice * 10000); //4 digts after comma!
 
@@ -695,7 +695,7 @@ void Enever::parseGas()
 			return; //no price for this provider
 
 		std::string szProviderPrice = root["data"][0][szProviderPriceName].asString();
-		float fProviderPrice = std::stof(szProviderPrice);
+		float fProviderPrice = stof(szProviderPrice);
 
 		SendCustomSensor(1, 2, 255, fProviderPrice, "Actual Gas Price", "Euro / m3");
 

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -971,7 +971,7 @@ void EnphaseAPI::parseInventory(const Json::Value& root)
 				std::string sleep_enabled = itt["sleep_enabled"].asString(); //boolean
 				std::string dc_switch_off = itt["dc_switch_off"].asString(); //boolean
 
-				double dCurrentCapacity = (stod(encharge_capacity) / 100.0) * stod(percentFull);
+				double dCurrentCapacity = stod(encharge_capacity) * stod(percentFull) / 100.0;
 
 				std::string real_power_w = ""; //The current power charging/discharging the battery, in watts. Positive values indicate charging, negative values indicate discharging.
 				if (!itt["real_power_w"].empty())

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -331,8 +331,8 @@ int EnphaseAPI::getSunRiseSunSetMinutes(const bool bGetSunRise)
 		StringSplit(strarray[0], ":", sunRisearray);
 		StringSplit(strarray[1], ":", sunSetarray);
 
-		int sunRiseInMinutes = (atoi(sunRisearray[0].c_str()) * 60) + atoi(sunRisearray[1].c_str());
-		int sunSetInMinutes = (atoi(sunSetarray[0].c_str()) * 60) + atoi(sunSetarray[1].c_str());
+		int sunRiseInMinutes = (stoi(sunRisearray[0]) * 60) + stoi(sunRisearray[1]);
+		int sunSetInMinutes = (stoi(sunSetarray[0]) * 60) + stoi(sunSetarray[1]);
 
 		if (bGetSunRise) {
 			return sunRiseInMinutes;
@@ -971,7 +971,7 @@ void EnphaseAPI::parseInventory(const Json::Value& root)
 				std::string sleep_enabled = itt["sleep_enabled"].asString(); //boolean
 				std::string dc_switch_off = itt["dc_switch_off"].asString(); //boolean
 
-				double dCurrentCapacity = (std::stod(encharge_capacity) / 100.0) * std::stod(percentFull);
+				double dCurrentCapacity = (stod(encharge_capacity) / 100.0) * stod(percentFull);
 
 				std::string real_power_w = ""; //The current power charging/discharging the battery, in watts. Positive values indicate charging, negative values indicate discharging.
 				if (!itt["real_power_w"].empty())
@@ -982,7 +982,7 @@ void EnphaseAPI::parseInventory(const Json::Value& root)
 				int NodeID = 100 + (iInventoryIndex * 50);
 
 				szName = "Encharge " + serial_num + " Percent Full";
-				SendPercentageSensor(NodeID + iDeviceIndex, 1, 255, static_cast<float>(std::stod(percentFull)), szName);
+				SendPercentageSensor(NodeID + iDeviceIndex, 1, 255, stof(percentFull), szName);
 
 				szName = "Encharge " + serial_num + " Current Capacity";
 				SendWattMeter(NodeID, iDeviceIndex + 1, 255, static_cast<float>(dCurrentCapacity), szName);
@@ -996,7 +996,7 @@ void EnphaseAPI::parseInventory(const Json::Value& root)
 				//SendTextSensor((NodeID * 2) + (iDeviceIndex * 30) + 3, 1, 255, admin_state_str, szName);
 
 				std::string szStatus = "Unknown";
-				int iLedStatus = atoi(led_status.c_str());
+				int iLedStatus = stoi(led_status);
 				switch (iLedStatus)
 				{
 				case 12: //Charging
@@ -1285,7 +1285,7 @@ bool EnphaseAPI::getInverterDetails()
 				m_HwdID, szDeviceID.c_str(), 1, devType, subType);
 			if (!result.empty())
 			{
-				m_sql.SetDeviceOptions(std::stoull(result[0][0]), m_sql.BuildDeviceOptions("EnergyMeterMode:1", false));
+				m_sql.SetDeviceOptions(stoull(result[0][0]), m_sql.BuildDeviceOptions("EnergyMeterMode:1", false));
 			}
 		}
 		else

--- a/hardware/EvohomeBase.cpp
+++ b/hardware/EvohomeBase.cpp
@@ -232,9 +232,8 @@ namespace http {
 				return;
 
 			bool bCreated = false;
-			int iSensorType = atoi(ssensortype.c_str());
-
-			int HwdID = atoi(idx.c_str());
+			int iSensorType = stoi(ssensortype);
+			int HwdID = stoi(idx);
 
 			//Make a unique number for ID
 			std::vector<std::vector<std::string> > result;
@@ -243,7 +242,7 @@ namespace http {
 
 			if (!result.empty())
 			{
-				nid = atol(result[0][0].c_str());
+				nid = stol(result[0][0]);
 			}
 			nid += 92000;
 			char ID[40];
@@ -255,7 +254,7 @@ namespace http {
 			int nDevCount = 0;
 			if (!result.empty())
 			{
-				nDevCount = atol(result[0][0].c_str());
+				nDevCount = stol(result[0][0]);
 			}
 
 			std::string devname;

--- a/hardware/EvohomeRadio.cpp
+++ b/hardware/EvohomeRadio.cpp
@@ -1061,7 +1061,7 @@ bool CEvohomeRadio::DecodeZoneTemp(CEvohomeMsg& msg)//0x30C9
 				result = m_sql.safe_query("SELECT Unit FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID == '%q') AND (Type == %d)", m_HwdID, zstrid.c_str(), (int)pTypeEvohomeRelay);
 				if (!result.empty())
 				{
-					tsen.zone = (uint8_t)(stoi(result[0][0]) + 12);
+					tsen.zone = static_cast<uint8_t>(stoi(result[0][0]) + 12);
 					char zstrname[40];
 					sprintf(zstrname, "Zone %d", stoi(result[0][0]));
 					Debug(DEBUG_HARDWARE, "%s: Zone sensor msg: 0x%x: %d: %d", tag, msg.GetID(0), tsen.zone, tsen.temperature);

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -160,7 +160,7 @@ bool CEvohomeWeb::StartSession()
 			if (!splitresults.empty())
 				m_awaysetpoint = strtod(splitresults[0].c_str(), nullptr);
 			if (splitresults.size() > 1)
-				m_wdayoff = atoi(splitresults[1].c_str()) % 7;
+				m_wdayoff = stoi(splitresults[1]) % 7;
 		}
 		if (m_awaysetpoint == 0)
 			m_awaysetpoint = 15; // use default 'Away' setpoint value
@@ -317,7 +317,7 @@ bool CEvohomeWeb::SetSystemMode(uint8_t sysmode)
 					sztemperature = "-";
 					sznewmode = "Offline";
 				}
-				unsigned long evoID = atol(szId.c_str());
+				unsigned long evoID = stoul(szId);
 				std::stringstream ssUpdateStat;
 				ssUpdateStat << sztemperature << ";5;" << sznewmode;
 				std::string sdevname;
@@ -373,7 +373,7 @@ bool CEvohomeWeb::SetSystemMode(uint8_t sysmode)
 				sznewmode = "Offline";
 			}
 
-			unsigned long evoID = atol(hz->zoneId.c_str());
+			unsigned long evoID = stoul(hz->zoneId);
 			std::stringstream ssUpdateStat;
 			if (setpoint < 5) // there was an error - no schedule?
 				ssUpdateStat << sztemperature << ";5;Unknown";
@@ -421,11 +421,11 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 
 		if ((m_showschedule) && (!szuntil.empty()))
 		{
-			pEvo->year = (uint16_t)(atoi(szuntil.substr(0, 4).c_str()));
-			pEvo->month = (uint8_t)(atoi(szuntil.substr(5, 2).c_str()));
-			pEvo->day = (uint8_t)(atoi(szuntil.substr(8, 2).c_str()));
-			pEvo->hrs = (uint8_t)(atoi(szuntil.substr(11, 2).c_str()));
-			pEvo->mins = (uint8_t)(atoi(szuntil.substr(14, 2).c_str()));
+			pEvo->year = (uint16_t) stoi(szuntil.substr(0, 4));
+			pEvo->month = (uint8_t) stoi(szuntil.substr(5, 2));
+			pEvo->day = (uint8_t) stoi(szuntil.substr(8, 2));
+			pEvo->hrs = (uint8_t) stoi(szuntil.substr(11, 2));
+			pEvo->mins = (uint8_t) stoi(szuntil.substr(14, 2));
 		}
 		else
 			pEvo->year = 0;
@@ -452,11 +452,11 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 				szISODate = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint_tmp));
 				if (!szISODate.empty())
 				{
-					pEvo->year = (uint16_t)(atoi(szISODate.substr(0, 4).c_str()));
-					pEvo->month = (uint8_t)(atoi(szISODate.substr(5, 2).c_str()));
-					pEvo->day = (uint8_t)(atoi(szISODate.substr(8, 2).c_str()));
-					pEvo->hrs = (uint8_t)(atoi(szISODate.substr(11, 2).c_str()));
-					pEvo->mins = (uint8_t)(atoi(szISODate.substr(14, 2).c_str()));
+					pEvo->year = (uint16_t)(stoi(szISODate.substr(0, 4)));
+					pEvo->month = (uint8_t)(stoi(szISODate.substr(5, 2)));
+					pEvo->day = (uint8_t)(stoi(szISODate.substr(8, 2)));
+					pEvo->hrs = (uint8_t)(stoi(szISODate.substr(11, 2)));
+					pEvo->mins = (uint8_t)(stoi(szISODate.substr(14, 2)));
 				}
 			}
 		}
@@ -576,7 +576,7 @@ void CEvohomeWeb::DecodeZone(zone* hz)
 		}
 	}
 
-	unsigned long evoID = atol(szId.c_str());
+	unsigned long evoID = stoul(szId);
 	std::string szsysmode;
 	if (m_tcs->status == nullptr)
 		szsysmode = "Unknown";
@@ -708,7 +708,7 @@ void CEvohomeWeb::DecodeDHWState(temperatureControlSystem* tcs)
 		}
 		else if ((result[0][1] != szId) || (result[0][2] != ndevname))
 		{
-			uint64_t DevRowIdx = std::stoull(result[0][0]);
+			uint64_t DevRowIdx = stoull(result[0][0]);
 			// also wipe StrParam1 - we do not want a double action from the old (python) script when changing the setpoint
 			m_sql.safe_query("UPDATE DeviceStatus SET DeviceID='%q', Name='%q', StrParam1='' WHERE (ID == %" PRIu64 ")", szId.c_str(), ndevname.c_str(), DevRowIdx);
 		}
@@ -752,8 +752,8 @@ uint8_t CEvohomeWeb::GetUnit_by_ID(unsigned long evoID)
 			m_zones[row] = 0;
 		for (row = 0; row < (int)result.size(); row++)
 		{
-			int unit = atoi(result[row][0].c_str());
-			m_zones[unit] = atol(result[row][1].c_str());
+			int unit = stoi(result[row][0]);
+			m_zones[unit] = stoul(result[row][1]);
 			if (m_zones[unit] == uint64_t(unit) + 92000) // mark manually added, unlinked zone as free
 				m_zones[unit] = 0;
 		}
@@ -813,12 +813,12 @@ std::string CEvohomeWeb::local_to_utc(const std::string& local_time)
 	}
 	struct tm ltime;
 	ltime.tm_isdst = -1;
-	ltime.tm_year = atoi(local_time.substr(0, 4).c_str()) - 1900;
-	ltime.tm_mon = atoi(local_time.substr(5, 2).c_str()) - 1;
-	ltime.tm_mday = atoi(local_time.substr(8, 2).c_str());
-	ltime.tm_hour = atoi(local_time.substr(11, 2).c_str());
-	ltime.tm_min = atoi(local_time.substr(14, 2).c_str());
-	ltime.tm_sec = atoi(local_time.substr(17, 2).c_str()) + m_tzoffset;
+	ltime.tm_year = stoi(local_time.substr(0, 4)) - 1900;
+	ltime.tm_mon = stoi(local_time.substr(5, 2)) - 1;
+	ltime.tm_mday = stoi(local_time.substr(8, 2));
+	ltime.tm_hour = stoi(local_time.substr(11, 2));
+	ltime.tm_min = stoi(local_time.substr(14, 2));
+	ltime.tm_sec = stoi(local_time.substr(17, 2)) + m_tzoffset;
 	mktime(&ltime);
 	if (m_lastDST == -1)
 		m_lastDST = ltime.tm_isdst;
@@ -919,7 +919,7 @@ bool CEvohomeWeb::login(const std::string& user, const std::string& password)
 	}
 
 	m_v2refresh_token = j_login["refresh_token"].asString();
-	int v2token_expiration_time = atoi(j_login["expires_in"].asString().c_str());
+	int v2token_expiration_time = stoi(j_login["expires_in"].asString());
 	m_sessiontimer = mytime(nullptr) + v2token_expiration_time; // Honeywell will invalidate our session ID after an hour
 
 	std::stringstream atoken;
@@ -999,7 +999,7 @@ bool CEvohomeWeb::renew_login()
 	}
 
 	m_v2refresh_token = j_login["refresh_token"].asString();
-	int v2token_expiration_time = atoi(j_login["expires_in"].asString().c_str());
+	int v2token_expiration_time = stoi(j_login["expires_in"].asString());
 	m_sessiontimer = mytime(nullptr) + v2token_expiration_time; // Honeywell will invalidate our session ID after an hour
 
 	std::stringstream atoken;
@@ -1486,9 +1486,9 @@ std::string CEvohomeWeb::get_next_switchpoint_ex(Json::Value& schedule, std::str
 			ltime.tm_year = year;
 			ltime.tm_mon = month;
 			ltime.tm_mday = day + d;
-			ltime.tm_hour = atoi(sztime.substr(0, 2).c_str());
-			ltime.tm_min = atoi(sztime.substr(3, 2).c_str());
-			ltime.tm_sec = atoi(sztime.substr(6, 2).c_str());
+			ltime.tm_hour = stoi(sztime.substr(0, 2));
+			ltime.tm_min = stoi(sztime.substr(3, 2));
+			ltime.tm_sec = stoi(sztime.substr(6, 2));
 			time_t ntime = mktime(&ltime);
 			if (ntime > now)
 				found = true;
@@ -1556,12 +1556,12 @@ bool CEvohomeWeb::verify_datetime(const std::string& datetime)
 	std::string s_time = datetime.substr(11, 8);
 	struct tm mtime;
 	mtime.tm_isdst = -1;
-	mtime.tm_year = atoi(datetime.substr(0, 4).c_str()) - 1900;
-	mtime.tm_mon = atoi(datetime.substr(5, 2).c_str()) - 1;
-	mtime.tm_mday = atoi(datetime.substr(8, 2).c_str());
-	mtime.tm_hour = atoi(datetime.substr(11, 2).c_str());
-	mtime.tm_min = atoi(datetime.substr(14, 2).c_str());
-	mtime.tm_sec = atoi(datetime.substr(17, 2).c_str());
+	mtime.tm_year = stoi(datetime.substr(0, 4)) - 1900;
+	mtime.tm_mon = stoi(datetime.substr(5, 2)) - 1;
+	mtime.tm_mday = stoi(datetime.substr(8, 2));
+	mtime.tm_hour = stoi(datetime.substr(11, 2));
+	mtime.tm_min = stoi(datetime.substr(14, 2));
+	mtime.tm_sec = stoi(datetime.substr(17, 2));
 	time_t ntime = mktime(&mtime);
 	if (ntime == -1)
 		return false;

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -452,7 +452,7 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 				szISODate = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint_tmp));
 				if (!szISODate.empty())
 				{
-					pEvo->year = static_cast<uint8_t>(stoi(szISODate.substr(0, 4)));
+					pEvo->year = static_cast<uint16_t>(stoi(szISODate.substr(0, 4)));
 					pEvo->month = static_cast<uint8_t>(stoi(szISODate.substr(5, 2)));
 					pEvo->day = static_cast<uint8_t>(stoi(szISODate.substr(8, 2)));
 					pEvo->hrs = static_cast<uint8_t>(stoi(szISODate.substr(11, 2)));
@@ -499,7 +499,7 @@ bool CEvohomeWeb::SetDHWState(const char* pdata)
 
 void CEvohomeWeb::DecodeControllerMode(temperatureControlSystem* tcs)
 {
-	unsigned long ID = (unsigned long) stod(tcs->systemId);
+	unsigned long ID = static_cast<unsigned long>(stod(tcs->systemId));
 	std::string szsystemMode, szmodelType;
 	uint8_t sysmode = 0;
 

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -416,16 +416,16 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 		if ((!hz->schedule.isNull()) || get_zone_schedule(hz->zoneId))
 		{
 			szuntil = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint));
-			pEvo->temperature = (int16_t) (stod(szsetpoint) * 100);
+			pEvo->temperature = static_cast<int16_t>(stod(szsetpoint) * 100);
 		}
 
 		if ((m_showschedule) && (!szuntil.empty()))
 		{
-			pEvo->year = (uint16_t) stoi(szuntil.substr(0, 4));
-			pEvo->month = (uint8_t) stoi(szuntil.substr(5, 2));
-			pEvo->day = (uint8_t) stoi(szuntil.substr(8, 2));
-			pEvo->hrs = (uint8_t) stoi(szuntil.substr(11, 2));
-			pEvo->mins = (uint8_t) stoi(szuntil.substr(14, 2));
+			pEvo->year = static_cast<uint16_t>(stoi(szuntil.substr(0, 4)));
+			pEvo->month = static_cast<uint8_t>(stoi(szuntil.substr(5, 2)));
+			pEvo->day = static_cast<uint8_t>(stoi(szuntil.substr(8, 2)));
+			pEvo->hrs = static_cast<uint8_t>(stoi(szuntil.substr(11, 2)));
+			pEvo->mins = static_cast<uint8_t>(stoi(szuntil.substr(14, 2)));
 		}
 		else
 			pEvo->year = 0;
@@ -452,11 +452,11 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 				szISODate = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint_tmp));
 				if (!szISODate.empty())
 				{
-					pEvo->year = (uint16_t)(stoi(szISODate.substr(0, 4)));
-					pEvo->month = (uint8_t)(stoi(szISODate.substr(5, 2)));
-					pEvo->day = (uint8_t)(stoi(szISODate.substr(8, 2)));
-					pEvo->hrs = (uint8_t)(stoi(szISODate.substr(11, 2)));
-					pEvo->mins = (uint8_t)(stoi(szISODate.substr(14, 2)));
+					pEvo->year = static_cast<uint8_t>(stoi(szISODate.substr(0, 4)));
+					pEvo->month = static_cast<uint8_t>(stoi(szISODate.substr(5, 2)));
+					pEvo->day = static_cast<uint8_t>(stoi(szISODate.substr(8, 2)));
+					pEvo->hrs = static_cast<uint8_t>(stoi(szISODate.substr(11, 2)));
+					pEvo->mins = static_cast<uint8_t>(stoi(szISODate.substr(14, 2)));
 				}
 			}
 		}

--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -158,7 +158,7 @@ bool CEvohomeWeb::StartSession()
 			std::vector<std::string> splitresults;
 			StringSplit(result[0][0], ";", splitresults);
 			if (!splitresults.empty())
-				m_awaysetpoint = strtod(splitresults[0].c_str(), nullptr);
+				m_awaysetpoint = stod(splitresults[0]);
 			if (splitresults.size() > 1)
 				m_wdayoff = stoi(splitresults[1]) % 7;
 		}
@@ -354,7 +354,7 @@ bool CEvohomeWeb::SetSystemMode(uint8_t sysmode)
 				if ((!hz->schedule.isNull()) || get_zone_schedule(hz->zoneId))
 				{
 					szuntil = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint));
-					setpoint = strtod(szsetpoint.c_str(), nullptr);
+					setpoint = stod(szsetpoint);
 				}
 
 				// Eco lowers the setpoint of all zones by 3 degrees, but resets a zone mode to Normal setting
@@ -416,7 +416,7 @@ bool CEvohomeWeb::SetSetpoint(const char* pdata)
 		if ((!hz->schedule.isNull()) || get_zone_schedule(hz->zoneId))
 		{
 			szuntil = local_to_utc(get_next_switchpoint_ex(hz->schedule, szsetpoint));
-			pEvo->temperature = (int16_t)(strtod(szsetpoint.c_str(), nullptr) * 100);
+			pEvo->temperature = (int16_t) (stod(szsetpoint) * 100);
 		}
 
 		if ((m_showschedule) && (!szuntil.empty()))
@@ -499,7 +499,7 @@ bool CEvohomeWeb::SetDHWState(const char* pdata)
 
 void CEvohomeWeb::DecodeControllerMode(temperatureControlSystem* tcs)
 {
-	unsigned long ID = (unsigned long)(strtod(tcs->systemId.c_str(), nullptr));
+	unsigned long ID = (unsigned long) stod(tcs->systemId);
 	std::string szsystemMode, szmodelType;
 	uint8_t sysmode = 0;
 
@@ -584,7 +584,7 @@ void CEvohomeWeb::DecodeZone(zone* hz)
 		szsysmode = (*m_tcs->status)["systemModeStatus"]["mode"].asString();
 	if ((szsysmode == "Away") && (szmode == "FollowSchedule"))
 	{
-		double new_awaysetpoint = strtod(szsetpoint.c_str(), nullptr);
+		double new_awaysetpoint = stod(szsetpoint);
 		if (m_awaysetpoint != new_awaysetpoint)
 		{
 			m_awaysetpoint = new_awaysetpoint;

--- a/hardware/FritzboxTCP.cpp
+++ b/hardware/FritzboxTCP.cpp
@@ -198,13 +198,13 @@ void FritzboxTCP::UpdateSwitch(const unsigned char Idx, const uint8_t SubUnit, c
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -355,7 +355,7 @@ void FritzboxTCP::GetStatistics()
 			return;
 		}
 	}
-	uint64_t BytesSend = std::stoull(tempValue);
+	uint64_t BytesSend = stoull(tempValue);
 
 	if (!GetValueFromXML(Response, "NewX_AVM_DE_TotalBytesReceived64", tempValue))
 	{
@@ -365,7 +365,7 @@ void FritzboxTCP::GetStatistics()
 			return;
 		}
 	}
-	uint64_t BytesReceived = std::stoull(tempValue);
+	uint64_t BytesReceived = stoull(tempValue);
 
 	SendMeterSensor(1, 1, 255, static_cast<float>(BytesSend) / (1024.0F * 1024.0F), "Bytes Send (MB)");
 	SendMeterSensor(1, 2, 255, static_cast<float>(BytesReceived) / (1024.0F * 1024.0F), "Bytes Received (MB)");
@@ -375,14 +375,14 @@ void FritzboxTCP::GetStatistics()
 		Log(LOG_ERROR, "Invalid data response received!");
 		return;
 	}
-	uint64_t NewByteSendRate = std::stoull(tempValue) * 8;
+	uint64_t NewByteSendRate = stoull(tempValue) * 8;
 
 	if (!GetValueFromXML(Response, "NewByteReceiveRate", tempValue))
 	{
 		Log(LOG_ERROR, "Invalid data response received!");
 		return;
 	}
-	uint64_t NewByteReceiveRate = std::stoull(tempValue) * 8;
+	uint64_t NewByteReceiveRate = stoull(tempValue) * 8;
 
 	float send_bps = static_cast<float>(NewByteSendRate) / (1024.0F * 1024.0F);
 	float received_bps = static_cast<float>(NewByteReceiveRate) / (1024.0F * 1024.0F);

--- a/hardware/Gpio.cpp
+++ b/hardware/Gpio.cpp
@@ -391,7 +391,7 @@ bool CGpio::CreateDomoticzDevices()
 			if (!result.empty()) // input found
 			{
 				std::vector<std::string> sd = result[0];
-				bool bIsInput = (atoi(sd[2].c_str()) == 0);
+				bool bIsInput = (stoi(sd[2]) == 0);
 				if ((!bIsInput && it->GetIsInput()) ||
 					(bIsInput && !it->GetIsInput()))
 				{
@@ -401,7 +401,7 @@ bool CGpio::CreateDomoticzDevices()
 					createNewDevice = true;
 				}
 				else if (!it->GetIsInput()) // write actual db state to hardware in case of output
-					(atoi(sd[1].c_str()) == 1) ? GPIOWrite(it->GetPin(), !it->GetActiveLow()) : GPIOWrite(it->GetPin(), it->GetActiveLow());
+					(stoi(sd[1]) == 1) ? GPIOWrite(it->GetPin(), !it->GetActiveLow()) : GPIOWrite(it->GetPin(), it->GetActiveLow());
 			}
 		}
 		if (createNewDevice)
@@ -464,9 +464,9 @@ void CGpio::UpdateDeviceStates(bool forceUpdate)
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[3].c_str()) == 1) /* Check if device is used */
+					if (stoi(sd[3]) == 1) /* Check if device is used */
 					{
-						bool db_state = (atoi(sd[1].c_str()) == 1);
+						bool db_state = (stoi(sd[1]) == 1);
 						if (db_state != state)
 							updateDatabase = true;
 
@@ -500,7 +500,7 @@ bool CGpio::InitPins()
 			result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)",
 				m_HwdID, gpio_pin);
 			if (!result.empty())
-				db_state = atoi(result[0][0].c_str());
+				db_state = stoi(result[0][0]);
 
 			snprintf(label, sizeof(label), "GPIO pin %d", gpio_pin);
 			pins.push_back(CGpioPin(gpio_pin, label, GPIORead(gpio_pin, "value"), GPIORead(gpio_pin, "direction"), GPIORead(gpio_pin, "edge"), GPIORead(gpio_pin, "active_low"), -1, db_state));

--- a/hardware/HEOS.cpp
+++ b/hardware/HEOS.cpp
@@ -112,7 +112,7 @@ void CHEOS::ParseLine()
 
 										/* If playing request now playing information */
 										if (state == "play") {
-											int PlayerID = atoi(pid.c_str());
+											int PlayerID = stoi(pid);
 											SendCommand("getNowPlaying", PlayerID);
 										}
 
@@ -214,7 +214,7 @@ void CHEOS::ParseLine()
 
 									/* If playing request now playing information */
 									if (state == "play") {
-										int PlayerID = atoi(pid.c_str());
+										int PlayerID = stoi(pid);
 										SendCommand("getNowPlaying", PlayerID);
 									}
 
@@ -237,7 +237,7 @@ void CHEOS::ParseLine()
 							if (!SplitMessage.empty())
 							{
 								std::string pid = SplitMessage[1];
-								int PlayerID = atoi(pid.c_str());
+								int PlayerID = stoi(pid);
 								SendCommand("getPlayState", PlayerID);
 							}
 						}
@@ -691,7 +691,7 @@ void CHEOS::AddNode(const std::string &Name, const std::string &PlayerID)
 
 	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, PlayerID.c_str());
 	if (!result.empty()) {
-		int ID = atoi(result[0][0].c_str());
+		int ID = stoi(result[0][0]);
 		UpdateNode(ID, Name);
 		return;
 	}
@@ -779,10 +779,10 @@ void CHEOS::ReloadNodes()
 		for (const auto &sd : result)
 		{
 			HEOSNode pnode;
-			pnode.ID = atoi(sd[0].c_str());
-			pnode.DevID = atoi(sd[1].c_str());
+			pnode.ID = stoi(sd[0]);
+			pnode.DevID = stoi(sd[1]);
 			pnode.Name = sd[2];
-			pnode.nStatus = (_eMediaStatus)atoi(sd[3].c_str());
+			pnode.nStatus = (_eMediaStatus) stoi(sd[3]);
 			pnode.sStatus = sd[4];
 			pnode.LastOK = mytime(nullptr);
 
@@ -811,7 +811,7 @@ namespace http {
 			std::string mode2 = request::findValue(&req, "mode2");
 			if ((hwid.empty()) || (mode1.empty()) || (mode2.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -822,8 +822,8 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "HEOSSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
+			int iMode1 = stoi(mode1);
+			int iMode2 = stoi(mode2);
 
 			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')", iMode1, iMode2, hwid.c_str());
 			pHardware->SetSettings(iMode1, iMode2);
@@ -835,7 +835,7 @@ namespace http {
 			std::string sAction = request::findValue(&req, "action");
 			if (sIdx.empty())
 				return;
-			//int idx = atoi(sIdx.c_str());
+			//int idx = stoi(sIdx);
 			root["status"] = "OK";
 			root["title"] = "HEOSMediaCommand";
 
@@ -845,10 +845,10 @@ namespace http {
 
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				int PlayerID = atoi(result[0][1].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][2].c_str());
-				//int HwID = atoi(result[0][3].c_str());
+				_eSwitchType	sType = (_eSwitchType) stoi(result[0][0]);
+				int PlayerID = stoi(result[0][1]);
+				_eHardwareTypes	hType = (_eHardwareTypes) stoi(result[0][2]);
+				//int HwID = stoi(result[0][3]);
 				// Is the device a media Player?
 				if (sType == STYPE_Media)
 				{

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -221,7 +221,7 @@ void CHardwareMonitor::GetInternalTemperature()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float temperature = static_cast<float>(atof(tmpline.c_str()));
+	float temperature = stof(tmpline);
 	if (temperature == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -248,7 +248,7 @@ void CHardwareMonitor::GetInternalVoltage()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float voltage = static_cast<float>(atof(tmpline.c_str()));
+	float voltage = stof(tmpline);
 	if (voltage == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -272,7 +272,7 @@ void CHardwareMonitor::GetInternalCurrent()
 		tmpline = tmpline.substr(0, pos);
 	}
 
-	float current = static_cast<float>(atof(tmpline.c_str()));
+	float current = stof(tmpline);
 	if (current == 0)
 		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
 
@@ -289,37 +289,37 @@ void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int di
 	if (qType == "Temperature")
 	{
 		doffset = 1000;
-		float temp = static_cast<float>(atof(devValue.c_str()));
+		float temp = stof(devValue);
 		SendTempSensor(doffset + dindex, 255, temp, devName);
 	}
 	else if (qType == "Load")
 	{
 		doffset = 1100;
-		float perc = static_cast<float>(atof(devValue.c_str()));
+		float perc = stof(devValue);
 		SendPercentageSensor(doffset + dindex, 0, 255, perc, devName);
 	}
 	else if (qType == "Fan")
 	{
 		doffset = 1200;
-		int fanspeed = atoi(devValue.c_str());
+		int fanspeed = stoi(devValue);
 		SendFanSensor(doffset + dindex, 255, fanspeed, devName);
 	}
 	else if (qType == "Voltage")
 	{
 		doffset = 1300;
-		float volt = static_cast<float>(atof(devValue.c_str()));
+		float volt = stof(devValue);
 		SendVoltageSensor(0, (uint32_t)(doffset + dindex), 255, volt, devName);
 	}
 	else if (qType == "Current")
 	{
 		doffset = 1400;
-		float curr = static_cast<float>(atof(devValue.c_str()));
+		float curr = stof(devValue);
 		SendCurrent(doffset + dindex, curr, devName);
 	}
 	else if (qType == "Process")
 	{
 		doffset = 1500;
-		float usage = static_cast<float>(atof(devValue.c_str()));
+		float usage = stof(devValue);
 		SendCustomSensor(0, doffset + dindex, 255, usage, devName, "MB");
 	}
 }

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -429,7 +429,7 @@ void CHarmonyHub::Do_Work()
 void CHarmonyHub::CheckSetActivity(const std::string &activityID, const bool on)
 {
 	// get the device id from the db (if already inserted)
-	int actId=atoi(activityID.c_str());
+	int actId = stoi(activityID);
 	std::stringstream hexId ;
 	hexId << std::setw(7)  << std::hex << std::setfill('0') << std::uppercase << (int)( actId) ;
 	std::string actHex = hexId.str();
@@ -437,7 +437,7 @@ void CHarmonyHub::CheckSetActivity(const std::string &activityID, const bool on)
 	result = m_sql.safe_query("SELECT Name,DeviceID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, actHex.c_str());
 	if (!result.empty())
 	{
-		UpdateSwitch((uint8_t)(atoi(result[0][1].c_str())), activityID.c_str(),on,result[0][0]);
+		UpdateSwitch((unsigned char) stoi(result[0][1]), activityID.c_str(),on,result[0][0]);
 	}
 }
 
@@ -450,19 +450,21 @@ void CHarmonyHub::CheckSetActivity(const std::string &activityID, const bool on)
 void CHarmonyHub::UpdateSwitch(unsigned char /*idx*/, const char *realID, const bool bOn, const std::string &defaultname)
 {
 	std::stringstream hexId ;
-	hexId << std::setw(7) << std::setfill('0') << std::hex << std::uppercase << (int)( atoi(realID) );
+	int i_Id = atoi(realID);
+	
+	hexId << std::setw(7) << std::setfill('0') << std::hex << std::uppercase << i_Id;
+
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, hexId.str().c_str());
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == light2_sOff))
 			return;
 		if ((bOn && (nvalue != light2_sOff)))
 			return;
 	}
-	int i_Id = atoi( realID);
 	//Send as Lighting 2
 	tRBUF lcmd;
 	memset(&lcmd, 0, sizeof(RBUF));
@@ -902,7 +904,7 @@ void CHarmonyHub::ProcessQueryResponse(std::string *szQueryResponse)
 				std::string szCurrentActivity = szJsonString.substr(0, pos);
 				if (_log.IsDebugLevelEnabled(DEBUG_HARDWARE))
 				{
-					Debug(DEBUG_HARDWARE, "Current activity ID = %d (%s)", atoi(szCurrentActivity.c_str()), m_mapActivities[szCurrentActivity].c_str());
+					Debug(DEBUG_HARDWARE, "Current activity ID = %d (%s)", stoi(szCurrentActivity), m_mapActivities[szCurrentActivity].c_str());
 				}
 
 				if (m_szCurActivityID.empty()) // initialize all switches
@@ -1057,7 +1059,7 @@ void CHarmonyHub::ProcessHarmonyMessage(std::string *szMessageBlock)
 	}
 	pos += 16;
 	size_t valueEnd = szMessageBlock->find('"', pos);
-	int msglen = atoi(szMessageBlock->substr(pos, valueEnd - pos).c_str());
+	int msglen = stoi(szMessageBlock->substr(pos, valueEnd - pos));
 	msgStart = valueEnd + 4;
 	if (szMessageBlock->compare(msgStart, 8, "<message") != 0)
 	{

--- a/hardware/HarmonyHub.cpp
+++ b/hardware/HarmonyHub.cpp
@@ -431,7 +431,7 @@ void CHarmonyHub::CheckSetActivity(const std::string &activityID, const bool on)
 	// get the device id from the db (if already inserted)
 	int actId = stoi(activityID);
 	std::stringstream hexId ;
-	hexId << std::setw(7)  << std::hex << std::setfill('0') << std::uppercase << (int)( actId) ;
+	hexId << std::setw(7)  << std::hex << std::setfill('0') << std::uppercase << actId ;
 	std::string actHex = hexId.str();
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT Name,DeviceID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, actHex.c_str());
@@ -450,9 +450,9 @@ void CHarmonyHub::CheckSetActivity(const std::string &activityID, const bool on)
 void CHarmonyHub::UpdateSwitch(unsigned char /*idx*/, const char *realID, const bool bOn, const std::string &defaultname)
 {
 	std::stringstream hexId ;
-	int i_Id = atoi(realID);
+	int iId = atoi(realID);
 	
-	hexId << std::setw(7) << std::setfill('0') << std::hex << std::uppercase << i_Id;
+	hexId << std::setw(7) << std::setfill('0') << std::hex << std::uppercase << iId;
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q')", m_HwdID, hexId.str().c_str());
@@ -472,10 +472,10 @@ void CHarmonyHub::UpdateSwitch(unsigned char /*idx*/, const char *realID, const 
 	lcmd.LIGHTING2.packettype = pTypeLighting2;
 	lcmd.LIGHTING2.subtype = sTypeAC;
 
-	lcmd.LIGHTING2.id1 = (i_Id>> 24) & 0xFF;
-	lcmd.LIGHTING2.id2 = (i_Id>> 16) & 0xFF;
-	lcmd.LIGHTING2.id3 = (i_Id>> 8) & 0xFF;
-	lcmd.LIGHTING2.id4 = (i_Id) & 0xFF;
+	lcmd.LIGHTING2.id1 = (iId >> 24) & 0xFF;
+	lcmd.LIGHTING2.id2 = (iId >> 16) & 0xFF;
+	lcmd.LIGHTING2.id3 = (iId >> 8) & 0xFF;
+	lcmd.LIGHTING2.id4 = iId & 0xFF;
 	lcmd.LIGHTING2.unitcode = 1;
 	uint8_t level = 15;
 	if (!bOn)

--- a/hardware/Honeywell.cpp
+++ b/hardware/Honeywell.cpp
@@ -194,7 +194,7 @@ bool CHoneywell::refreshToken()
 	std::string rt = root["refresh_token"].asString();
 	std::string ei = root["expires_in"].asString();
 	if (at.length() && rt.length() && ei.length()) {
-		int expires_in = std::stoi(ei);
+		int expires_in = stoi(ei);
 		mTokenExpires = mytime(nullptr) + (expires_in > 0 ? expires_in : 600) - HWAPITIMEOUT;
 		mAccessToken = at;
 		mRefreshToken = rt;
@@ -514,7 +514,7 @@ bool CHoneywell::GetSwitchValue(const int NodeID)
 		m_HwdID, szIdx, ChildID, int(pTypeLighting2), int(sTypeAC));
 	if (!result.empty())
 	{
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		return (nvalue != light2_sOff);
 	}
 

--- a/hardware/HttpPoller.cpp
+++ b/hardware/HttpPoller.cpp
@@ -23,7 +23,7 @@ m_refresh(refresh)
 	if (strextra.size() == 3 || strextra.size() == 4 || strextra.size() == 5)
 	{
 		m_script = base64_decode(strextra[0]);
-		m_method = (unsigned short)atoi(base64_decode(strextra[1]).c_str());
+		m_method = (unsigned short) stoi(base64_decode(strextra[1]));
 		m_contenttype = base64_decode(strextra[2]);
 		if (strextra.size() >= 4)
 		{

--- a/hardware/I2C.cpp
+++ b/hardware/I2C.cpp
@@ -147,7 +147,7 @@ namespace
 
 I2C::I2C(const int ID, const _eI2CType DevType, const std::string &Address, const std::string &SerialPort, const int Mode1)
 	: m_dev_type(DevType)
-	, m_i2c_addr((uint8_t)atoi(Address.c_str()))
+	, m_i2c_addr((uint8_t) stoi(Address))
 	, m_ActI2CBus(SerialPort)
 	, m_invert_data((bool)Mode1)
 {
@@ -413,8 +413,8 @@ void I2C::MCP23017_Init()
 	{
 		for (const auto &sd : results)
 		{
-			unit = atoi(sd[0].c_str());
-			nvalue = atoi(sd[1].c_str());
+			unit = stoi(sd[0]);
+			nvalue = stoi(sd[1]);
 
 			if (m_invert_data == true)
 			{

--- a/hardware/KMTronicTCP.cpp
+++ b/hardware/KMTronicTCP.cpp
@@ -275,7 +275,7 @@ void KMTronicTCP::ParseTemps(const std::string &sResult)
 			pos1 = tmpstr.find("</temp>");
 			if (pos1 != std::string::npos)
 			{
-				float temp = (float)atof(tmpstr.substr(0, pos1).c_str());
+				float temp = stof(tmpstr.substr(0, pos1));
 				SendTempSensor(Idx++, 255, temp, name);
 				continue;
 			}

--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -152,7 +152,7 @@ CKodiNode::CKodiNode(boost::asio::io_service *pIos, const int pHwdID, const int 
 
 	m_Ios = pIos;
 	m_HwdID = pHwdID;
-	m_DevID = atoi(pID.c_str());
+	m_DevID = stoi(pID);
 	sprintf(m_szDevID, "%X%02X%02X%02X", 0, 0, (m_DevID & 0xFF00) >> 8, m_DevID & 0xFF);
 	m_Name = pName;
 	m_IP = pIP;
@@ -169,8 +169,8 @@ CKodiNode::CKodiNode(boost::asio::io_service *pIos, const int pHwdID, const int 
 	result2 = m_sql.safe_query("SELECT ID,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == 1)", m_HwdID, m_szDevID);
 	if (result2.size() == 1)
 	{
-		m_ID = atoi(result2[0][0].c_str());
-		m_PreviousStatus.Status((_eMediaStatus)atoi(result2[0][1].c_str()));
+		m_ID = stoi(result2[0][0]);
+		m_PreviousStatus.Status((_eMediaStatus) stoi(result2[0][1]));
 		m_PreviousStatus.Status(result2[0][2]);
 	}
 	m_CurrentStatus = m_PreviousStatus;
@@ -1080,7 +1080,7 @@ void CKodi::AddNode(const std::string &Name, const std::string &IPAddress, const
 	if (result.empty())
 		return;
 
-	int ID = atoi(result[0][0].c_str());
+	int ID = stoi(result[0][0]);
 
 	char szID[40];
 	sprintf(szID, "%X%02X%02X%02X", 0, 0, (ID & 0xFF00) >> 8, ID & 0xFF);
@@ -1243,7 +1243,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -1263,7 +1263,7 @@ namespace http {
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["IP"] = sd[2];
-					root["result"][ii]["Port"] = atoi(sd[3].c_str());
+					root["result"][ii]["Port"] = stoi(sd[3]);
 					ii++;
 				}
 			}
@@ -1281,7 +1281,7 @@ namespace http {
 			std::string mode2 = request::findValue(&req, "mode2");
 			if ((hwid.empty()) || (mode1.empty()) || (mode2.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1292,8 +1292,8 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "KodiSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
+			int iMode1 = stoi(mode1);
+			int iMode2 = stoi(mode2);
 
 			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')", iMode1, iMode2, hwid.c_str());
 			pHardware->SetSettings(iMode1, iMode2);
@@ -1311,10 +1311,10 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Port = atoi(request::findValue(&req, "port").c_str());
+			int Port = stoi(request::findValue(&req, "port"));
 			if ((hwid.empty()) || (name.empty()) || (ip.empty()) || (Port == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1339,10 +1339,10 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Port = atoi(request::findValue(&req, "port").c_str());
+			int Port = stoi(request::findValue(&req, "port"));
 			if ((hwid.empty()) || (nodeid.empty()) || (name.empty()) || (ip.empty()) || (Port == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1350,7 +1350,7 @@ namespace http {
 				return;
 			CKodi *pHardware = dynamic_cast<CKodi*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "KodiUpdateNode";
 			pHardware->UpdateNode(NodeID, name, ip, Port);
@@ -1368,7 +1368,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1376,7 +1376,7 @@ namespace http {
 				return;
 			CKodi *pHardware = dynamic_cast<CKodi*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "KodiRemoveNode";
 			pHardware->RemoveNode(NodeID);
@@ -1393,7 +1393,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1412,7 +1412,7 @@ namespace http {
 			std::string sAction = request::findValue(&req, "action");
 			if (sIdx.empty())
 				return;
-			int idx = atoi(sIdx.c_str());
+			int idx = stoi(sIdx);
 			root["status"] = "OK";
 			root["title"] = "KodiMediaCommand";
 
@@ -1420,9 +1420,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
-				int HwID = atoi(result[0][2].c_str());
+				_eSwitchType	sType = (_eSwitchType) stoi(result[0][0]);
+				_eHardwareTypes	hType = (_eHardwareTypes) stoi(result[0][1]);
+				int HwID = stoi(result[0][2]);
 				// Is the device a media Player?
 				if (sType == STYPE_Media)
 				{

--- a/hardware/Limitless.cpp
+++ b/hardware/Limitless.cpp
@@ -1455,11 +1455,11 @@ namespace http
 			if (result.empty())
 				return;
 
-			int Mode1 = atoi(request::findValue(&req, "LimitlessType").c_str());
-			int Mode2 = atoi(request::findValue(&req, "CCBridgeType").c_str());
-			int Mode3 = atoi(result[0][2].c_str());
-			int Mode4 = atoi(result[0][3].c_str());
-			m_sql.UpdateRFXCOMHardwareDetails(atoi(idx.c_str()), Mode1, Mode2, Mode3, Mode4, 0, 0);
+			int Mode1 = stoi(request::findValue(&req, "LimitlessType"));
+			int Mode2 = stoi(request::findValue(&req, "CCBridgeType"));
+			int Mode3 = stoi(result[0][2]);
+			int Mode4 = stoi(result[0][3]);
+			m_sql.UpdateRFXCOMHardwareDetails(stoi(idx), Mode1, Mode2, Mode3, Mode4, 0, 0);
 
 			m_mainworker.RestartHardware(idx);
 		}

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -36,7 +36,7 @@ CLogitechMediaServer::CLogitechMediaServer(const int ID) :
 	if (!result.empty())
 	{
 		m_IP = result[0][0];
-		m_Port = atoi(result[0][1].c_str());
+		m_Port = stoi(result[0][1]);
 		m_User = result[0][2];
 		m_Pwd = result[0][3];
 	}
@@ -391,7 +391,7 @@ void CLogitechMediaServer::GetPlayerInfo()
 					if (IPPort.size() < 2)
 						continue; //invalid ip:port
 					std::string ip = IPPort[0];
-					//int port = atoi(IPPort[1].c_str());
+					//int port = stoi(IPPort[1]);
 
 					if (
 						//(model == "slimp3") ||			//SliMP3
@@ -484,7 +484,7 @@ void CLogitechMediaServer::UpsertPlayer(const std::string &Name, const std::stri
 	if (result.empty())
 		return;
 
-	int ID = atoi(result[0][0].c_str());
+	int ID = stoi(result[0][0]);
 
 	char szID[40];
 	sprintf(szID, "%X%02X%02X%02X", 0, 0, (ID & 0xFF00) >> 8, ID & 0xFF);
@@ -564,7 +564,7 @@ void CLogitechMediaServer::ReloadNodes()
 		{
 			LogitechMediaServerNode pnode;
 			pnode.ID = 0;
-			pnode.DevID = atoi(sd[0].c_str());
+			pnode.DevID = stoi(sd[0]);
 			sprintf(pnode.szDevID, "%X%02X%02X%02X", 0, 0, (pnode.DevID & 0xFF00) >> 8, pnode.DevID & 0xFF);
 			pnode.Name = sd[1];
 			pnode.IP = sd[2];
@@ -576,8 +576,8 @@ void CLogitechMediaServer::ReloadNodes()
 			result2 = m_sql.safe_query("SELECT ID,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == 1)", m_HwdID, pnode.szDevID);
 			if (result2.size() == 1)
 			{
-				pnode.ID = atoi(result2[0][0].c_str());
-				pnode.nStatus = (_eMediaStatus)atoi(result2[0][1].c_str());
+				pnode.ID = stoi(result2[0][0]);
+				pnode.nStatus = (_eMediaStatus) stoi(result2[0][1]);
 				pnode.sStatus = result2[0][2];
 			}
 
@@ -799,7 +799,7 @@ namespace http {
 			std::string mode1 = request::findValue(&req, "mode1");
 			if ((hwid.empty()) || (mode1.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -810,7 +810,7 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "LMSSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
+			int iMode1 = stoi(mode1);
 
 			m_sql.safe_query("UPDATE Hardware SET Mode1=%d WHERE (ID == '%q')", iMode1, hwid.c_str());
 			pHardware->SetSettings(iMode1);
@@ -827,7 +827,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -846,7 +846,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -877,7 +877,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -906,7 +906,7 @@ namespace http {
 			std::string sAction = request::findValue(&req, "action");
 			if (sIdx.empty())
 				return;
-			int idx = atoi(sIdx.c_str());
+			int idx = stoi(sIdx);
 			root["status"] = "OK";
 			root["title"] = "LMSMediaCommand";
 
@@ -914,9 +914,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
-				int HwID = atoi(result[0][2].c_str());
+				_eSwitchType	sType = (_eSwitchType) stoi(result[0][0]);
+				_eHardwareTypes	hType = (_eHardwareTypes) stoi(result[0][1]);
+				int HwID = stoi(result[0][2]);
 				// Is the device a media Player?
 				if (sType == STYPE_Media)
 				{

--- a/hardware/LogitechMediaServer.cpp
+++ b/hardware/LogitechMediaServer.cpp
@@ -639,7 +639,7 @@ bool CLogitechMediaServer::SendCommand(const int ID, const std::string &command,
 	if (result.size() == 1)
 	{
 		// Get connection details
-		long DeviceID = strtol(result[0][0].c_str(), nullptr, 16);
+		long DeviceID = stol(result[0][0], nullptr, 16);
 		result = m_sql.safe_query("SELECT Name, MacAddress,Timeout FROM WOLNodes WHERE (HardwareID==%d) AND (ID==%d)", m_HwdID, DeviceID);
 		sPlayerId = result[0][1];
 	}

--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -251,12 +251,12 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		// Perform Actions
 		if (szCommand == "udevice")
 		{
-			int HardwareID = atoi(result[0][0].c_str());
-			int OrgHardwareID = atoi(result[0][1].c_str());
+			int HardwareID = stoi(result[0][0]);
+			int OrgHardwareID = stoi(result[0][1]);
 			std::string DeviceID = result[0][2];
-			int unit = atoi(result[0][3].c_str());
-			int devType = atoi(result[0][4].c_str());
-			int subType = atoi(result[0][5].c_str());
+			int unit = stoi(result[0][3]);
+			int devType = stoi(result[0][4]);
+			int subType = stoi(result[0][5]);
 
 			bool bnvalue = !root["nvalue"].empty();
 			bool bsvalue = !root["svalue"].empty();
@@ -320,14 +320,14 @@ void MQTT::on_message(const struct mosquitto_message *message)
 			if (!root["level"].empty())
 			{
 				if (root["level"].isString())
-					level = atoi(root["level"].asString().c_str());
+					level = stoi(root["level"].asString());
 				else
 					level = root["level"].asInt();
 			}
 
 			// Prevent MQTT update being send to client after next update
 			m_LastUpdatedDeviceRowIdx = idx;
-			const bool bIsOOC = atoi(onlyonchange.c_str()) != 0;
+			const bool bIsOOC = stoi(onlyonchange) != 0;
 
 			if (m_mainworker.SwitchLight(idx, switchcmd, level, NoColor, bIsOOC, 0, "MQTT") == MainWorker::SL_ERROR)
 			{
@@ -427,10 +427,10 @@ void MQTT::on_message(const struct mosquitto_message *message)
 				int r, g, b;
 
 				// convert hue to RGB
-				float iHue = float(atof(hue.c_str()));
+				float iHue = stof(hue);
 				float iSat = 100.0F;
 				if (!sat.empty())
-					iSat = float(atof(sat.c_str()));
+					iSat = stof(sat);
 				hsb2rgb(iHue, iSat / 100.0F, 1.0F, r, g, b, 255);
 
 				color = _tColor((uint8_t)r, (uint8_t)g, (uint8_t)b, 0, 0, ColorModeRGB);
@@ -445,7 +445,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 			}
 
 			if (!brightness.empty())
-				ival = atoi(brightness.c_str());
+				ival = stoi(brightness);
 			ival = int(ival * brightnessAdj);
 			ival = std::max(ival, 0);
 			ival = std::min(ival, 100);
@@ -481,7 +481,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 			idx = (uint64_t)root["idx"].asInt64();
 			result = m_sql.safe_query("SELECT Name, ValueType FROM UserVariables WHERE (ID==%" PRIu64 ")", idx);
 			std::string sVarName = result[0][0];
-			_eUsrVariableType varType = (_eUsrVariableType)atoi(result[0][1].c_str());
+			_eUsrVariableType varType = (_eUsrVariableType) stoi(result[0][1]);
 
 			std::string errorMessage;
 			if (!m_sql.UpdateUserVariable(root["idx"].asString(), sVarName, varType, varvalue, true, errorMessage))
@@ -554,7 +554,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 		}
 		else if (szCommand == "getdeviceinfo")
 		{
-			int HardwareID = atoi(result[0][0].c_str());
+			int HardwareID = stoi(result[0][0]);
 			SendDeviceInfo(HardwareID, idx, "request device", nullptr);
 		}
 		else if (szCommand == "getsceneinfo")
@@ -832,18 +832,18 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		std::string hwid = sd[iIndex++];
 		std::string org_hwid = sd[iIndex++];
 		std::string did = sd[iIndex++];
-		int dunit = atoi(sd[iIndex++].c_str());
+		int dunit = stoi(sd[iIndex++]);
 		std::string name = sd[iIndex++];
-		int dType = atoi(sd[iIndex++].c_str());
-		int dSubType = atoi(sd[iIndex++].c_str());
-		int nvalue = atoi(sd[iIndex++].c_str());
+		int dType = stoi(sd[iIndex++]);
+		int dSubType = stoi(sd[iIndex++]);
+		int nvalue = stoi(sd[iIndex++]);
 		std::string svalue = sd[iIndex++];
-		_eSwitchType switchType = (_eSwitchType)atoi(sd[iIndex++].c_str());
-		int RSSI = atoi(sd[iIndex++].c_str());
-		int BatteryLevel = atoi(sd[iIndex++].c_str());
+		_eSwitchType switchType = (_eSwitchType) stoi(sd[iIndex++]);
+		int RSSI = stoi(sd[iIndex++]);
+		int BatteryLevel = stoi(sd[iIndex++]);
 		std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[iIndex++]);
 		std::string description = sd[iIndex++];
-		int LastLevel = atoi(sd[iIndex++].c_str());
+		int LastLevel = stoi(sd[iIndex++]);
 		std::string sColor = sd[iIndex++];
 		std::string sLastUpdate = sd[iIndex++];
 
@@ -859,7 +859,7 @@ void MQTT::SendDeviceInfo(const int HwdID, const uint64_t DeviceRowIdx, const st
 		{
 			try
 			{
-				root["id"] = std_format("%04X", std::stoi(did));
+				root["id"] = std_format("%04X", stoi(did));
 			}
 			catch (const std::exception&)
 			{
@@ -986,19 +986,19 @@ void MQTT::SendSceneInfo(const uint64_t SceneIdx, const std::string & /*SceneNam
 	std::string sName = sd[1];
 	std::string sLastUpdate = sd[6];
 
-	unsigned char nValue = (uint8_t)atoi(sd[4].c_str());
-	unsigned char scenetype = (uint8_t)atoi(sd[5].c_str());
-	// int iProtected = atoi(sd[7].c_str());
+	unsigned char nValue = (unsigned char) stoi(sd[4]);
+	unsigned char scenetype = (unsigned char) stoi(sd[5]);
+	// int iProtected = stoi(sd[7]);
 
 	// std::string onaction = base64_encode((sd[8]);
 	// std::string offaction = base64_encode(sd[9]);
 
 	Json::Value root;
 
-	root["idx"] = atoi(sd[0].c_str());
+	root["idx"] = stoi(sd[0]);
 	root["Name"] = sName;
 	// root["Description"] = sd[10];
-	// root["Favorite"] = atoi(sd[3].c_str());
+	// root["Favorite"] = stoi(sd[3]);
 	// root["Protected"] = (iProtected != 0);
 	// root["OnAction"] = onaction;
 	// root["OffAction"] = offaction;
@@ -1052,7 +1052,7 @@ void MQTT::ReloadSharedDevices()
 	{
 		for (const auto& sd : result)
 		{
-			m_shared_devices[std::stoull(sd[0])] = true;
+			m_shared_devices[stoull(sd[0])] = true;
 		}
 	}
 }
@@ -1071,7 +1071,7 @@ namespace http {
 			std::string sidx = request::findValue(&req, "idx");
 			if (sidx.empty())
 				return;
-			int idx = atoi(sidx.c_str()) + 2000;
+			int idx = stoi(sidx) + 2000;
 			root["title"] = "GetSharedMQTTDevices";
 
 			auto result = m_sql.safe_query("SELECT DeviceRowID FROM SharedDevices WHERE (SharedUserID == %d)", idx);
@@ -1097,7 +1097,7 @@ namespace http {
 			std::string sidx = request::findValue(&req, "idx");
 			if (sidx.empty())
 				return;
-			int idx = atoi(sidx.c_str()) + 2000;
+			int idx = stoi(sidx) + 2000;
 
 			std::string userdevices = CURLEncode::URLDecode(request::findValue(&req, "devices"));
 			root["title"] = "SetSharedMQTTDevices";
@@ -1138,7 +1138,7 @@ namespace http {
 			std::string sidx = request::findValue(&req, "idx");
 			if (sidx.empty())
 				return;
-			int idx = atoi(sidx.c_str()) + 2000;
+			int idx = stoi(sidx) + 2000;
 			root["status"] = "OK";
 			root["title"] = "ClearSharedMQTTDevices";
 			m_sql.safe_query("DELETE FROM SharedDevices WHERE SharedUserID == %d", idx);

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1568,7 +1568,7 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquit
 					}
 					if (pSensor->value_template.find("RSSI") != std::string::npos)
 					{
-						pSensor->SignalLevel = (int)round((10.0F / 255.0F) * stof(szValue));
+						pSensor->SignalLevel = (int) round((10.0 / 255.0) * stod(szValue));
 						ApplySignalLevelDevice(pSensor);
 					}
 				}
@@ -1716,19 +1716,19 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeGeneral;
 		subType = sTypeVoltage;
-		sValue = std_format("%.3f", stof(pSensor->last_value));
+		sValue = std_format("%.3f", stod(pSensor->last_value));
 	}
 	else if (szUnit == "mv")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeVoltage;
-		sValue = std_format("%.3f", stof(pSensor->last_value) / 1000.0F);
+		sValue = std_format("%.3f", stod(pSensor->last_value) / 1000.0);
 	}
 	else if (szUnit == "a")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeCurrent;
-		sValue = std_format("%.3f", stof(pSensor->last_value));
+		sValue = std_format("%.3f", stod(pSensor->last_value));
 	}
 	else if (szUnit == "w")
 	{
@@ -1746,17 +1746,17 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		float fkWh = 0.0F;
 		_tMQTTASensor* pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "kwh");
 		if (pkWhSensor)
-			fkWh = stof(pkWhSensor->last_value) * 1000.0F;
+			fkWh = static_cast<float>(stod(pkWhSensor->last_value) * 1000.0);
 		else
 		{
 			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wh");
 			if (pkWhSensor)
-				fkWh = stof(pkWhSensor->last_value);
+				fkWh = static_cast<float>(stod(pkWhSensor->last_value));
 			else
 			{
 				pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
 				if (pkWhSensor)
-					fkWh = stof(pkWhSensor->last_value) / 60.0F;
+					fkWh = static_cast<float>(stod(pkWhSensor->last_value) / 60.0);
 			}
 		}
 		if (pkWhSensor)
@@ -1791,7 +1791,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 
 		float fkWh = stof(pSensor->last_value) * multiply;
 
-		if (fkWh < -1000000)
+		if (fkWh < -1000000.0F)
 		{
 			//Way to negative, probably a bug in the sensor
 			return false;
@@ -1829,7 +1829,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeLux;
 		subType = sTypeLux;
-		sValue = std_format("%.0f", stof(pSensor->last_value));
+		sValue = std_format("%.0f", stod(pSensor->last_value));
 	}
 	/*
 	*	//our distance sensor is in meters or inches
@@ -1837,14 +1837,14 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeGeneral;
 			subType = sTypeDistance;
-			sValue = std_format("%.1f", stof(pSensor->last_value) * 100.0F);
+			sValue = std_format("%.1f", stod(pSensor->last_value) * 100.0);
 		}
 	*/
 	else if (szUnit == "cm")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeDistance;
-		sValue = std_format("%.1f", stof(pSensor->last_value));
+		sValue = std_format("%.1f", stod(pSensor->last_value));
 	}
 
 	else if (
@@ -1865,7 +1865,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeRFXMeter;
 			subType = sTypeRFXMeterCount;
-			unsigned long counter = (unsigned long)(stof(pSensor->last_value) * 1000.0F);
+			unsigned long counter = static_cast<unsigned long>(stod(pSensor->last_value) * 1000.0);
 			sValue = std_format("%lu", counter);
 		}
 	}
@@ -1874,7 +1874,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		//our sensor is in Liters / minute
 		devType = pTypeGeneral;
 		subType = sTypeWaterflow;
-		sValue = std_format("%.2f", stof(pSensor->last_value) / 60.0F);
+		sValue = std_format("%.2f", stod(pSensor->last_value) / 60.0);
 	}
 	else if (
 		(szUnit == "db")

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -288,7 +288,7 @@ std::string MQTTAutoDiscover::GetValueFromTemplate(Json::Value root, std::string
 						return ""; //no index?
 
 					szKey = szKey.substr(0, szKey.find('['));
-					int iIndex = std::stoi(szIndex);
+					int iIndex = stoi(szIndex);
 					if (root[szKey].empty())
 						return ""; //key not found!
 					if (static_cast<int>(root[szKey].size()) <= iIndex)
@@ -335,7 +335,7 @@ std::string MQTTAutoDiscover::GetValueFromTemplate(Json::Value root, std::string
 						&& (root.isArray()))
 					)
 				{
-					int iNumber = std::stoi(szKey);
+					int iNumber = stoi(szKey);
 					size_t object_size = root.size();
 					if (iNumber < (int)object_size)
 					{
@@ -478,7 +478,7 @@ bool MQTTAutoDiscover::SetValueWithTemplate(Json::Value& root, std::string szVal
 				szValue = value_options_[szValue];
 			}
 			if (is_number(szValue))
-				root[szKey] = atoi(szValue.c_str());
+				root[szKey] = stoi(szValue);
 			else
 				root[szKey] = szValue;
 			return true;
@@ -931,12 +931,12 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 			pSensor->brightness_state_topic = root["bri_stat_t"].asString();
 		if (!root["brightness_scale"].empty())
 		{
-			pSensor->brightness_scale = static_cast<float>(atof(root["brightness_scale"].asString().c_str()));
+			pSensor->brightness_scale = stof(root["brightness_scale"].asString());
 			pSensor->bHave_brightness_scale = true;
 		}
 		else if (!root["bri_scl"].empty())
 		{
-			pSensor->brightness_scale = static_cast<float>(atof(root["bri_scl"].asString().c_str()));
+			pSensor->brightness_scale = stof(root["bri_scl"].asString());
 			pSensor->bHave_brightness_scale = true;
 		}
 		if (!root["brightness_value_template"].empty())
@@ -1257,11 +1257,11 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 			pSensor->temp_min = 44.6;
 		}
 		if (!root["min_temp"].empty())
-			pSensor->temp_min = atof(root["min_temp"].asString().c_str());
+			pSensor->temp_min = stod(root["min_temp"].asString());
 		if (!root["max_temp"].empty())
-			pSensor->temp_max = atof(root["max_temp"].asString().c_str());
+			pSensor->temp_max = stod(root["max_temp"].asString());
 		if (!root["temp_step"].empty())
-			pSensor->temp_step = atof(root["temp_step"].asString().c_str());
+			pSensor->temp_step = stod(root["temp_step"].asString());
 		if (!root["current_temperature_topic"].empty())
 			pSensor->current_temperature_topic = root["current_temperature_topic"].asString();
 		if (!root["curr_temp_t"].empty())
@@ -1336,14 +1336,14 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 
 		//number (some configs use strings instead of numbers)
 		if (!root["min"].empty())
-			pSensor->number_min = root["min"].isDouble() ? root["min"].asDouble() : atof(root["min"].asString().c_str());
+			pSensor->number_min = root["min"].isDouble() ? root["min"].asDouble() : stod(root["min"].asString());
 		if (!root["max"].empty())
-			pSensor->number_max = root["max"].isDouble() ? root["max"].asDouble() : atof(root["max"].asString().c_str());
+			pSensor->number_max = root["max"].isDouble() ? root["max"].asDouble() : stod(root["max"].asString());
 		if (!root["step"].empty())
-			pSensor->number_step = root["step"].isDouble() ? root["step"].asDouble() : atof(root["step"].asString().c_str());
+			pSensor->number_step = root["step"].isDouble() ? root["step"].asDouble() : stod(root["step"].asString());
 
 		if (!root["qos"].empty())
-			pSensor->qos = atoi(root["qos"].asString().c_str());
+			pSensor->qos = stoi(root["qos"].asString());
 
 		for (const auto ittMember : root.getMemberNames())
 		{
@@ -1548,7 +1548,7 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquit
 							szValue = GetValueFromTemplate(root, pSensor->value_template);
 							if (!szValue.empty())
 							{
-								pSensor->BatteryLevel = std::stoi(szValue);
+								pSensor->BatteryLevel = stoi(szValue);
 							}
 						}
 					}
@@ -1568,7 +1568,7 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquit
 					}
 					if (pSensor->value_template.find("RSSI") != std::string::npos)
 					{
-						pSensor->SignalLevel = (int)round((10.0F / 255.0F) * atof(szValue.c_str()));
+						pSensor->SignalLevel = (int)round((10.0F / 255.0F) * stof(szValue));
 						ApplySignalLevelDevice(pSensor);
 					}
 				}
@@ -1694,7 +1694,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeGeneral;
 		subType = sTypeBaro;
-		float pressure = static_cast<float>(atof(pSensor->last_value.c_str()));
+		float pressure = stof(pSensor->last_value);
 		if (szUnit == "kpa")
 			pressure *= 10.0F;
 		int nforecast = bmpbaroforecast_cloudy;
@@ -1710,32 +1710,32 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeAirQuality;
 		subType = sTypeVoc;
-		nValue = atoi(pSensor->last_value.c_str());
+		nValue = stoi(pSensor->last_value);
 	}
 	else if (szUnit == "v")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeVoltage;
-		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())));
+		sValue = std_format("%.3f", stof(pSensor->last_value));
 	}
 	else if (szUnit == "mv")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeVoltage;
-		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())) / 1000.0F);
+		sValue = std_format("%.3f", stof(pSensor->last_value) / 1000.0F);
 	}
 	else if (szUnit == "a")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeCurrent;
-		sValue = std_format("%.3f", static_cast<float>(atof(pSensor->last_value.c_str())));
+		sValue = std_format("%.3f", stof(pSensor->last_value));
 	}
 	else if (szUnit == "w")
 	{
 		devType = pTypeUsage;
 		subType = sTypeElectric;
 
-		float fUsage = static_cast<float>(atof(pSensor->last_value.c_str()));
+		float fUsage = stof(pSensor->last_value);
 
 		if (fUsage < -1000000)
 		{
@@ -1746,17 +1746,17 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		float fkWh = 0.0F;
 		_tMQTTASensor* pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "kwh");
 		if (pkWhSensor)
-			fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) * 1000.0F;
+			fkWh = stof(pkWhSensor->last_value) * 1000.0F;
 		else
 		{
 			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wh");
 			if (pkWhSensor)
-				fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str()));
+				fkWh = stof(pkWhSensor->last_value);
 			else
 			{
 				pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
 				if (pkWhSensor)
-					fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) / 60.0F;
+					fkWh = stof(pkWhSensor->last_value) / 60.0F;
 			}
 		}
 		if (pkWhSensor)
@@ -1789,7 +1789,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		else if (szUnit == "wm")
 			multiply = 1.0F / 60.0F;
 
-		float fkWh = static_cast<float>(atof(pSensor->last_value.c_str())) * multiply;
+		float fkWh = stof(pSensor->last_value) * multiply;
 
 		if (fkWh < -1000000)
 		{
@@ -1809,7 +1809,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 				StringSplit(result[0][0], ";", strarray);
 				if (strarray.size() == 2)
 				{
-					fkWh = static_cast<float>(atof(strarray[1].c_str()));
+					fkWh = stof(strarray[1]);
 				}
 			}
 		}
@@ -1817,7 +1817,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		_tMQTTASensor* pWattSensor = get_auto_discovery_sensor_WATT_unit(pSensor);
 		if (pWattSensor)
 		{
-			fUsage = static_cast<float>(atof(pWattSensor->last_value.c_str()));
+			fUsage = stof(pWattSensor->last_value);
 		}
 		sValue = std_format("%.3f;%.3f", fUsage, fkWh);
 	}
@@ -1829,7 +1829,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeLux;
 		subType = sTypeLux;
-		sValue = std_format("%.0f", static_cast<float>(atof(pSensor->last_value.c_str())));
+		sValue = std_format("%.0f", stof(pSensor->last_value));
 	}
 	/*
 	*	//our distance sensor is in meters or inches
@@ -1837,14 +1837,14 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeGeneral;
 			subType = sTypeDistance;
-			sValue = std_format("%.1f", static_cast<float>(atof(pSensor->last_value.c_str())) * 100.0F);
+			sValue = std_format("%.1f", stof(pSensor->last_value) * 100.0F);
 		}
 	*/
 	else if (szUnit == "cm")
 	{
 		devType = pTypeGeneral;
 		subType = sTypeDistance;
-		sValue = std_format("%.1f", static_cast<float>(atof(pSensor->last_value.c_str())));
+		sValue = std_format("%.1f", stof(pSensor->last_value));
 	}
 
 	else if (
@@ -1865,7 +1865,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeRFXMeter;
 			subType = sTypeRFXMeterCount;
-			unsigned long counter = (unsigned long)(atof(pSensor->last_value.c_str()) * 1000.0F);
+			unsigned long counter = (unsigned long)(stof(pSensor->last_value) * 1000.0F);
 			sValue = std_format("%lu", counter);
 		}
 	}
@@ -1874,7 +1874,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		//our sensor is in Liters / minute
 		devType = pTypeGeneral;
 		subType = sTypeWaterflow;
-		sValue = std_format("%.2f", static_cast<float>(atof(pSensor->last_value.c_str())) / 60.0F);
+		sValue = std_format("%.2f", stof(pSensor->last_value) / 60.0F);
 	}
 	else if (
 		(szUnit == "db")
@@ -1883,7 +1883,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 	{
 		devType = pTypeGeneral;
 		subType = sTypeSoundLevel;
-		sValue = std_format("%d", atoi(pSensor->last_value.c_str()));
+		sValue = std_format("%d", stoi(pSensor->last_value));
 	}
 	else if (szUnit == "text")
 	{
@@ -1919,7 +1919,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeRAIN;
 			subType = sTypeRAIN3;
-			float TotalRain = static_cast<float>(atof(pSensor->last_value.c_str()));
+			float TotalRain = stof(pSensor->last_value);
 			int Rainrate = 0;
 
 			_tMQTTASensor* pRainRateSensor = get_auto_discovery_sensor_unit(pSensor, "mm/h");
@@ -1927,7 +1927,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 			{
 				if (pRainRateSensor->last_received != 0)
 				{
-					Rainrate = atoi(pRainRateSensor->last_value.c_str());
+					Rainrate = stoi(pRainRateSensor->last_value);
 				}
 			}
 
@@ -1937,7 +1937,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeP1Gas;
 			subType = sTypeP1Gas;
-			float TotalGas = static_cast<float>(atof(pSensor->last_value.c_str()));
+			float TotalGas = stof(pSensor->last_value);
 			sValue = std_format("%.0f", TotalGas * 1000.0F);
 		}
 		else if (
@@ -1968,8 +1968,8 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			if (pRainSensor->last_received != 0)
 			{
-				float TotalRain = static_cast<float>(atof(pRainSensor->last_value.c_str()));
-				int Rainrate = atoi(pSensor->last_value.c_str());
+				float TotalRain = stof(pRainSensor->last_value);
+				int Rainrate = stoi(pSensor->last_value);
 
 				pRainSensor->sValue = std_format("%d;%.1f", Rainrate, TotalRain * 1000.0F);
 				mosquitto_message xmessage;
@@ -2001,7 +2001,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		devType = pTypeTEMP;
 		subType = sTypeTEMP1;
 
-		double temp = static_cast<float>(atof(pSensor->last_value.c_str()));
+		double temp = stod(pSensor->last_value);
 
 		if (
 			(szUnit == "°f")
@@ -2029,7 +2029,7 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 		{
 			devType = pTypeHUM;
 			subType = sTypeHUM2;
-			nValue = atoi(pSensor->last_value.c_str());
+			nValue = stoi(pSensor->last_value);
 			sValue = std_format("%d", Get_Humidity_Level(pSensor->nValue));
 		}
 		else
@@ -2230,7 +2230,7 @@ void MQTTAutoDiscover::handle_auto_discovery_battery(_tMQTTASensor* pSensor, con
 	if (!is_number(pSensor->last_value))
 		return;
 
-	int iLevel = atoi(pSensor->last_value.c_str());
+	int iLevel = stoi(pSensor->last_value);
 
 	for (auto& itt : m_discovered_sensors)
 	{
@@ -2252,7 +2252,7 @@ void MQTTAutoDiscover::handle_auto_discovery_number(_tMQTTASensor* pSensor, cons
 		return;
 
 	return;
-	int iValue = atoi(pSensor->last_value.c_str());
+	int iValue = stoi(pSensor->last_value);
 
 	for (auto& itt : m_discovered_sensors)
 	{
@@ -2445,12 +2445,12 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor(_tMQTTASensor* pSensor, cons
 		}
 
 		if (pTempSensor)
-			temp = static_cast<float>(atof(pTempSensor->sValue.c_str()));
+			temp = stof(pTempSensor->sValue);
 		if (pHumSensor)
 			humidity = pHumSensor->nValue;
 		if (pBaroSensor)
 		{
-			pressure = static_cast<float>(atof(pBaroSensor->last_value.c_str()));
+			pressure = stof(pBaroSensor->last_value);
 			if (pBaroSensor->unit_of_measurement == "kPa")
 				pressure *= 10.0F;
 		}
@@ -2661,9 +2661,9 @@ void MQTTAutoDiscover::handle_auto_discovery_fan(_tMQTTASensor* pSensor, const s
 		if (bValid)
 		{
 			std::string szIdx = result[0][0];
-			uint64_t DevRowIdx = std::stoull(szIdx);
+			uint64_t DevRowIdx = stoull(szIdx);
 			std::string szDeviceName = result[0][1];
-			int nValue = atoi(result[0][2].c_str());
+			int nValue = stoi(result[0][2]);
 			std::string sValue = result[0][3];
 			std::string sOptions = result[0][4];
 
@@ -2807,9 +2807,9 @@ void MQTTAutoDiscover::handle_auto_discovery_select(_tMQTTASensor* pSensor, cons
 	}
 
 	std::string szIdx = result[0][0];
-	uint64_t DevRowIdx = std::stoull(szIdx);
+	uint64_t DevRowIdx = stoull(szIdx);
 	std::string szDeviceName = result[0][1];
-	int nValue = atoi(result[0][2].c_str());
+	int nValue = stoi(result[0][2]);
 	std::string sValue = result[0][3];
 
 	std::string sOldOptions = result[0][4];
@@ -2832,7 +2832,7 @@ void MQTTAutoDiscover::handle_auto_discovery_select(_tMQTTASensor* pSensor, cons
 
 	if (iActualIndex == -1) {
 		Log(LOG_ERROR, "Select device \"%s\" doesn't have the option for received STATE \"%s\")", szDeviceName.c_str(), current_mode.c_str());
-		iActualIndex = atoi(sValue.c_str());
+		iActualIndex = stoi(sValue);
 	}
 
 	std::map<std::string, std::string> optionsMap;
@@ -2975,9 +2975,9 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 			if (bValid)
 			{
 				std::string szIdx = result[0][0];
-				uint64_t DevRowIdx = std::stoull(szIdx);
+				uint64_t DevRowIdx = stoull(szIdx);
 				std::string szDeviceName = result[0][1];
-				int nValue = atoi(result[0][2].c_str());
+				int nValue = stoi(result[0][2]);
 				std::string sValue = result[0][3];
 				std::string sOptions = result[0][4];
 
@@ -3083,9 +3083,9 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 			if (bValid)
 			{
 				std::string szIdx = result[0][0];
-				uint64_t DevRowIdx = std::stoull(szIdx);
+				uint64_t DevRowIdx = stoull(szIdx);
 				std::string szDeviceName = result[0][1];
-				int nValue = atoi(result[0][2].c_str());
+				int nValue = stoi(result[0][2]);
 				std::string sValue = result[0][3];
 				std::string sOptions = result[0][4];
 
@@ -3155,11 +3155,11 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 						bValid = false;
 					}
 					else
-						temp_setpoint = static_cast<double>(atof(tstring.c_str()));
+						temp_setpoint = stod(tstring);
 				}
 			}
 			else
-				temp_setpoint = static_cast<double>(atof(qMessage.c_str()));
+				temp_setpoint = stod(qMessage);
 			bHaveReceiveValue = true;
 		}
 		if (bValid)
@@ -3194,7 +3194,7 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 					pSensor->unique_id.c_str(), 1, pSensor->devType, pSensor->subType);
 				//Set options
 				std::string new_options = std_format("ValueStep:%g;ValueMin:%g;ValueMax:%g;ValueUnit:%s;", pSensor->temp_step, pSensor->temp_min, pSensor->temp_max, pSensor->temperature_unit.c_str());
-				uint64_t ullidx = std::stoull(result[0][0]);
+				uint64_t ullidx = stoull(result[0][0]);
 				m_sql.SetDeviceOptions(ullidx, m_sql.BuildDeviceOptions(new_options, false));
 			}
 			else
@@ -3236,11 +3236,11 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 					//Log(LOG_ERROR, "Climate device unhandled current_temperature_template (%s)", pSensor->unique_id.c_str());
 					bValid = false;
 				}
-				temp_current = static_cast<double>(atof(tstring.c_str()));
+				temp_current = stod(tstring);
 			}
 		}
 		else
-			temp_current = static_cast<double>(atof(qMessage.c_str()));
+			temp_current = stod(qMessage);
 
 		if (bValid)
 		{
@@ -3482,7 +3482,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 	}
 	else if (pSensor->object_id.find("scene_state_scene") != std::string::npos)
 	{
-		pSensor->devUnit = atoi(pSensor->last_value.c_str());
+		pSensor->devUnit = (uint8_t) stoi(pSensor->last_value);
 		switchType = STYPE_PushOn;
 		szSensorName += "_" + pSensor->last_value;
 		szSwitchCmd = "on";
@@ -3532,13 +3532,13 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		return;
 
 	std::string szIdx = result[0][0];
-	uint64_t DevRowIdx = std::stoull(szIdx);
+	uint64_t DevRowIdx = stoull(szIdx);
 	std::string szDeviceName = result[0][1];
-	int nValue = atoi(result[0][2].c_str());
+	int nValue = stoi(result[0][2]);
 	std::string sValue = result[0][3];
 	std::string sColor = result[0][4];
-	int subType = atoi(result[0][5].c_str());
-	_eSwitchType sSwitchType = (_eSwitchType)atoi(result[0][6].c_str());
+	int subType = stoi(result[0][5]);
+	_eSwitchType sSwitchType = (_eSwitchType) stoi(result[0][6]);
 
 	if (pSensor->subType != subType)
 		m_sql.UpdateDeviceValue("SubType", subType, szIdx);
@@ -3641,7 +3641,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 						if (is_number(szSwitchCmd))
 						{
 							//must be a level
-							level = atoi(szSwitchCmd.c_str());
+							level = stoi(szSwitchCmd);
 
 							if (pSensor->bHave_brightness_scale)
 								level = (int)round((100.0 / pSensor->brightness_scale) * level);
@@ -3678,7 +3678,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 				}
 				if (bHandledValue)
 				{
-					level = atoi(szValue.c_str());
+					level = stoi(szValue);
 
 					if (pSensor->bHave_brightness_scale)
 						level = (int)round((100.0 / pSensor->brightness_scale) * level);
@@ -3808,7 +3808,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			if (is_number(szSwitchCmd))
 			{
 				//must be a level
-				level = atoi(szSwitchCmd.c_str());
+				level = stoi(szSwitchCmd);
 				if (pSensor->component_type == "binary_sensor" && szSwitchCmd == pSensor->payload_off)
 					szSwitchCmd = "off";
 				else if (pSensor->component_type == "binary_sensor" && szSwitchCmd == pSensor->payload_on)
@@ -3858,7 +3858,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		if (level > 100)
 			level = 100;
 
-		int slevel = atoi(sValue.c_str());
+		int slevel = stoi(sValue);
 		bHaveLevelChange = (slevel != level);
 
 
@@ -3886,7 +3886,7 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 			if ((bOn && (nValue != 0)))
 			{
 				// Check Level
-				int slevel = atoi(sValue.c_str());
+				int slevel = stoi(sValue);
 				if (slevel == level)
 				{
 					if (!bHaveColorChange)
@@ -4461,12 +4461,12 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 		return;
 
 	std::string szIdx = result[0][0];
-	uint64_t DevRowIdx = std::stoull(szIdx);
+	uint64_t DevRowIdx = stoull(szIdx);
 	std::string szDeviceName = result[0][1];
-	int nValue = atoi(result[0][2].c_str());
+	int nValue = stoi(result[0][2]);
 	std::string sValue = result[0][3];
-	int subType = atoi(result[0][4].c_str());
-	_eSwitchType sSwitchType = (_eSwitchType)atoi(result[0][5].c_str());
+	int subType = stoi(result[0][4]);
+	_eSwitchType sSwitchType = (_eSwitchType) stoi(result[0][5]);
 
 	if (pSensor->subType != subType)
 		m_sql.UpdateDeviceValue("SubType", subType, szIdx);
@@ -4508,7 +4508,7 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 		if (is_number(szSwitchCmd))
 		{
 			//must be a position
-			level = atoi(szSwitchCmd.c_str());
+			level = stoi(szSwitchCmd);
 			szSwitchCmd = "Set Level";
 		}
 	}
@@ -4519,7 +4519,7 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 		if (is_number(szSwitchCmd))
 		{
 			//must be a level
-			level = atoi(szSwitchCmd.c_str());
+			level = stoi(szSwitchCmd);
 			szSwitchCmd = "Set Level";
 		}
 		else if (pSensor->last_topic == pSensor->state_topic)
@@ -4544,7 +4544,7 @@ void MQTTAutoDiscover::UpdateBlindPosition(_tMQTTASensor* pSensor)
 	if (level > 100)
 		level = 100;
 
-	int lastlevel = atoi(sValue.c_str());
+	int lastlevel = stoi(sValue);
 	bool bHaveLevelChange = (lastlevel != level);
 
 	std::string new_sValue = std_format("%d", level);
@@ -4760,7 +4760,7 @@ bool MQTTAutoDiscover::UpdateNumber(const std::string& idx, const std::string& s
 	{
 		if (itt.first == idx)
 		{
-			double dValue = atof(sValue.c_str());
+			double dValue = stod(sValue);
 			if (dValue < itt.second.number_min || dValue > itt.second.number_max)
 				return false;
 			SendMessage(itt.second.command_topic, sValue);
@@ -4806,7 +4806,7 @@ namespace http {
 			if (hwid.empty())
 				return;
 
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(std::stoi(hwid));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(hwid));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_MQTTAutoDiscovery)
@@ -4837,7 +4837,7 @@ namespace http {
 				)
 				return;
 
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(std::stoi(hwid));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(hwid));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_MQTTAutoDiscovery)

--- a/hardware/Meteorologisk.cpp
+++ b/hardware/Meteorologisk.cpp
@@ -69,16 +69,16 @@ void CMeteorologisk::Init()
 			StringSplit(m_Location, ",", strarray);
 			if (strarray.size() == 2)
 			{
-				m_Lat = strtod(strarray[0].c_str(), nullptr);
-				m_Lon = strtod(strarray[1].c_str(), nullptr);
+				m_Lat = stod(strarray[0]);
+				m_Lon = stod(strarray[1]);
 			}
 			else
 			{
 				StringSplit(m_Location, ";", strarray);
 				if (strarray.size() == 2)
 				{
-					m_Lat = strtod(strarray[0].c_str(), nullptr);
-					m_Lon = strtod(strarray[1].c_str(), nullptr);
+					m_Lat = stod(strarray[0]);
+					m_Lon = stod(strarray[1]);
 					Log(LOG_STATUS, "Found Location with semicolon as seperator instead of expected comma.");
 				}
 			}
@@ -96,8 +96,8 @@ void CMeteorologisk::Init()
 				StringSplit(sValue, ";", strarray);
 				if (strarray.size() == 2)
 				{
-					m_Lat = strtod(strarray[0].c_str(), nullptr);
-					m_Lon = strtod(strarray[1].c_str(), nullptr);
+					m_Lat = stod(strarray[0]);
+					m_Lon = stod(strarray[1]);
 					Log(LOG_STATUS, "Using Domoticz default location from Settings as Location.");
 				}
 			}

--- a/hardware/Meteostick.cpp
+++ b/hardware/Meteostick.cpp
@@ -332,8 +332,8 @@ void Meteostick::ParseLine()
 		//temperature in Celsius, pressure in hPa
 		if (results.size() >= 3)
 		{
-			float temp = static_cast<float>(atof(results[1].c_str()));
-			float baro = static_cast<float>(atof(results[2].c_str()));
+			float temp = stof(results[1]);
+			float baro = stof(results[2]);
 
 			SendTempBaroSensorInt(0, temp, baro, "Meteostick Temp+Baro");
 		}
@@ -342,11 +342,11 @@ void Meteostick::ParseLine()
 		//current wind speed in m / s, wind direction in degrees
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
+			unsigned char ID = (unsigned char) stoi(results[1]);
 			if (m_LastOutsideTemp[ID%MAX_IDS] != 12345)
 			{
-				float speed = static_cast<float>(atof(results[2].c_str()));
-				int direction = static_cast<int>(atoi(results[3].c_str()));
+				float speed = stof(results[2]);
+				int direction = stoi(results[3]);
 				SendWindSensor(ID, m_LastOutsideTemp[ID%MAX_IDS], speed, direction, "Wind");
 			}
 		}
@@ -355,9 +355,9 @@ void Meteostick::ParseLine()
 		//temperature in degree Celsius, humidity in percent
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float temp = static_cast<float>(atof(results[2].c_str()));
-			int hum = static_cast<int>(atoi(results[3].c_str()));
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			float temp = stof(results[2]);
+			int hum = stoi(results[3]);
 
 			SendTempHumSensor(ID, 255, temp, hum, "Outside Temp+Hum");
 			m_LastOutsideTemp[ID%MAX_IDS] = temp;
@@ -370,8 +370,8 @@ void Meteostick::ParseLine()
 		//it only has a small counter, so we should make the total counter ourselfses
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			int raincntr = atoi(results[2].c_str());
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			int raincntr = stoi(results[2]);
 			float Rainmm = 0;
 			if (m_LastRainValue[ID%MAX_IDS] != -1)
 			{
@@ -405,8 +405,8 @@ void Meteostick::ParseLine()
 		//solar radiation, solar radiation in W / qm
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float Radiation = static_cast<float>(atof(results[2].c_str()));
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			float Radiation = stof(results[2]);
 			SendSolarRadiationSensor(ID, Radiation, "Solar Radiation");
 		}
 		break;
@@ -414,8 +414,8 @@ void Meteostick::ParseLine()
 		//UV index
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float UV = static_cast<float>(atof(results[2].c_str()));
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			float UV = stof(results[2]);
 			CDomoticzHardwareBase::SendUVSensor(0, ID, 255, UV, "UV");
 		}
 		break;
@@ -424,9 +424,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), leaf wetness (0-15)
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			unsigned char Wetness = (unsigned char)atoi(results[3].c_str());
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			unsigned char Channel = (unsigned char) stoi(results[2]);
+			unsigned char Wetness = (unsigned char) stoi(results[3]);
 			SendLeafWetnessRainSensor(ID, Channel, Wetness, "Leaf Wetness");
 		}
 		break;
@@ -435,9 +435,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), Soil moisture in cbar(0 - 200)
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			unsigned char Moisture = (unsigned char)atoi(results[3].c_str());
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			unsigned char Channel = (unsigned char) stoi(results[2]);
+			unsigned char Moisture = (unsigned char) stoi(results[3]);
 			SendSoilMoistureSensor(ID, Channel, Moisture, "Soil Moisture");
 		}
 		break;
@@ -446,9 +446,9 @@ void Meteostick::ParseLine()
 		//channel number (1 - 4), soil / leaf temperature in degrees Celsius
 		if (results.size() >= 5)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			unsigned char Channel = (unsigned char)atoi(results[2].c_str());
-			float temp = static_cast<float>(atof(results[3].c_str()));
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			unsigned char Channel = (unsigned char) stoi(results[2]);
+			float temp = stof(results[3]);
 			unsigned char finalID = (ID * 10) + Channel;
 			SendTempSensor(finalID, 255, temp, "Soil/Leaf Temp");
 		}
@@ -457,8 +457,8 @@ void Meteostick::ParseLine()
 		//solar panel power in(0 - 100)
 		if (results.size() >= 4)
 		{
-			unsigned char ID = (unsigned char)atoi(results[1].c_str());
-			float Percentage = static_cast<float>(atof(results[2].c_str()));
+			unsigned char ID = (unsigned char) stoi(results[1]);
+			float Percentage = stof(results[2]);
 			SendPercentageSensor(ID, 0, 255, Percentage, "power of solar panel");
 		}
 		break;

--- a/hardware/MitsubishiWF.cpp
+++ b/hardware/MitsubishiWF.cpp
@@ -1033,9 +1033,9 @@ void MitsubishiWF::ParseModeSwitch(const uint8_t id, const char** vModes, const 
 	}
 
 	std::string szIdx = result[0][0];
-	uint64_t DevRowIdx = std::stoull(szIdx);
+	uint64_t DevRowIdx = stoull(szIdx);
 	std::string szDeviceName = result[0][1];
-	int nValue = atoi(result[0][2].c_str());
+	int nValue = stoi(result[0][2]);
 	std::string sValue = result[0][3];
 	std::string sOptions = result[0][4];
 

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -252,7 +252,7 @@ void MySensorsBase::LoadDevicesFromDatabase()
 	{
 		for (const auto& sd : result)
 		{
-			int ID = atoi(sd[0].c_str());
+			int ID = stoi(sd[0]);
 			std::string Name = sd[1];
 			std::string SkectName = sd[2];
 			std::string SkectVersion = sd[3];
@@ -272,14 +272,14 @@ void MySensorsBase::LoadDevicesFromDatabase()
 				{
 					_tMySensorChild mSensor;
 					mSensor.nodeID = ID;
-					mSensor.childID = atoi(sd2[0].c_str());
-					mSensor.presType = (_ePresentationType)atoi(sd2[1].c_str());
+					mSensor.childID = stoi(sd2[0]);
+					mSensor.presType = (_ePresentationType) stoi(sd2[1]);
 					gID += (int)std::count_if(mNode.m_childs.begin(), mNode.m_childs.end(),
 						[&](const _tMySensorChild& child) { return (child.presType == mSensor.presType) && (child.groupID == gID); });
 					mSensor.groupID = gID;
 					mSensor.childName = sd2[2];
-					mSensor.useAck = atoi(sd2[3].c_str()) != 0;
-					mSensor.ackTimeout = atoi(sd2[4].c_str());
+					mSensor.useAck = stoi(sd2[3]) != 0;
+					mSensor.ackTimeout = stoi(sd2[4]);
 					mNode.m_childs.push_back(mSensor);
 				}
 			}
@@ -1118,13 +1118,13 @@ void MySensorsBase::UpdateSwitch(const _eSetType vType, const unsigned char Idx,
 			)
 		{
 			//check if we have a change, if not do not update it
-			int nvalue = atoi(result[0][1].c_str());
+			int nvalue = stoi(result[0][1]);
 			if ((!bOn) && (nvalue == 0))
 				return;
 			if ((bOn && (nvalue != 0)))
 			{
 				//Check Level
-				int slevel = atoi(result[0][2].c_str());
+				int slevel = stoi(result[0][2]);
 				if (slevel == level)
 					return;
 			}
@@ -1162,7 +1162,7 @@ bool MySensorsBase::GetBlindsValue(const int NodeID, const int ChildID, int& bli
 	result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", m_HwdID, szIdx, ChildID);
 	if (result.empty())
 		return false;
-	blind_value = atoi(result[0][0].c_str());
+	blind_value = stoi(result[0][0]);
 	return true;
 }
 
@@ -1184,7 +1184,7 @@ bool MySensorsBase::GetSwitchValue(const int Idx, const int SubUnit, const int s
 	result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", m_HwdID, szIdx, SubUnit);
 	if (result.empty())
 		return false;
-	int nvalue = atoi(result[0][1].c_str());
+	int nvalue = stoi(result[0][1]);
 	if ((sub_type == V_STATUS) || (sub_type == V_TRIPPED))
 	{
 		sSwitchValue = (nvalue == light2_sOn) ? "1" : "0";
@@ -1195,7 +1195,7 @@ bool MySensorsBase::GetSwitchValue(const int Idx, const int SubUnit, const int s
 		sSwitchValue = (nvalue == Color_LedOn) ? "1" : "0";
 		return true;
 	}
-	sSwitchValue = std::to_string(atoi(result[0][2].c_str()));
+	sSwitchValue = std::to_string(stoi(result[0][2]));
 	return true;
 }
 
@@ -1637,9 +1637,9 @@ bool MySensorsBase::GetChildDBInfo(const int NodeID, const int ChildID, _ePresen
 	result = m_sql.safe_query("SELECT [Type], [Name], [UseAck] FROM MySensorsChilds WHERE (HardwareID=%d) AND (NodeID=%d) AND (ChildID=%d)", m_HwdID, NodeID, ChildID);
 	if (result.empty())
 		return false;
-	pType = (_ePresentationType)atoi(result[0][0].c_str());
+	pType = (_ePresentationType) stoi(result[0][0]);
 	Name = result[0][1];
-	UseAck = (atoi(result[0][2].c_str()) != 0);
+	UseAck = (stoi(result[0][2]) != 0);
 	return true;
 }
 
@@ -1655,11 +1655,11 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 	if (results.size() < 5)
 		return; //invalid data
 
-	uint8_t node_id = (uint8_t)atoi(results[0].c_str());
-	uint8_t child_sensor_id = (uint8_t)atoi(results[1].c_str());
-	_eMessageType message_type = (_eMessageType)atoi(results[2].c_str());
-	int ack = atoi(results[3].c_str());
-	int sub_type = atoi(results[4].c_str());
+	uint8_t node_id = (uint8_t) stoi(results[0]);
+	uint8_t child_sensor_id = (uint8_t) stoi(results[1]);
+	_eMessageType message_type = (_eMessageType) stoi(results[2]);
+	int ack = stoi(results[3]);
+	int sub_type = stoi(results[4]);
 	std::string payload;
 	if (results.size() >= 6)
 	{
@@ -1729,7 +1729,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			}
 			break;
 		case I_BATTERY_LEVEL:
-			UpdateNodeBatteryLevel(node_id, atoi(payload.c_str()));
+			UpdateNodeBatteryLevel(node_id, stoi(payload));
 			break;
 		case I_LOG_MESSAGE:
 			//Log(LOG_NORM, "'Log': %s", payload.c_str());
@@ -1778,7 +1778,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			break;
 		case I_INCLUSION_MODE:
 			Log(LOG_NORM, "Inclusion mode=%s", payload.c_str());
-			m_sql.m_bAcceptNewHardware = atoi(payload.c_str()) ? true : false;
+			m_sql.m_bAcceptNewHardware = stoi(payload) ? true : false;
 			break;
 		case I_PRE_SLEEP_NOTIFICATION:
 			//Node goes to sleep (we will buffer it's messages until it's awake again)
@@ -1868,15 +1868,15 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 		switch (vType)
 		{
 		case V_TEMP:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_HUM:
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_PRESSURE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_VAR1: //Custom value
@@ -1888,43 +1888,43 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			break;
 		case V_TRIPPED:
 			//	Tripped status of a security sensor. 1 = Tripped, 0 = Untripped
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_ARMED:
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_LOCK_STATUS:
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_STATUS:
 			//	Light status. 0 = off 1 = on
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_SCENE_ON:
 			//	Scene On
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_SCENE_OFF:
 			//	Scene Off
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_RGB:
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_RGBW:
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_PERCENTAGE:
 			//	Dimmer value. 0 - 100 %
-			pChild->SetValue(vType, atoi(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
 			bHaveValue = true;
 			break;
 		case V_UP:
@@ -1940,50 +1940,50 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			bHaveValue = true;
 			break;
 		case V_LEVEL:
-			pChild->SetValue(vType, atoi(payload.c_str()));
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stoi(payload));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_RAIN:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_WATT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_KWH:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_DISTANCE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_FLOW:
 			//Flow of water in meter
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_VOLUME:
 			//Water Volume
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_WIND:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_GUST:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_DIRECTION:
-			pChild->SetValue(vType, ground(atof(payload.c_str())));
+			pChild->SetValue(vType, ground(stof(payload)));
 			bHaveValue = true;
 			break;
 		case V_LIGHT_LEVEL:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_FORECAST:
@@ -2005,28 +2005,28 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			bHaveValue = true;
 			break;
 		case V_VOLTAGE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_UV:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_IMPEDANCE:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_WEIGHT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_CURRENT:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_HVAC_SETPOINT_HEAT:
 		case V_HVAC_SETPOINT_COOL:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		case V_TEXT:
@@ -2034,7 +2034,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			bHaveValue = true;
 			break;
 		case V_IR_RECEIVE:
-			pChild->SetValue(vType, (int)std::stoul(payload.c_str()));
+			pChild->SetValue(vType, (int) stoul(payload));
 			bHaveValue = true;
 			break;
 		case V_IR_SEND:
@@ -2044,7 +2044,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			//Request for a sensor state
 			if (!payload.empty())
 			{
-				uint64_t idx = std::stoull(payload);
+				uint64_t idx = stoull(payload);
 				int nValue;
 				std::string sValue;
 				if (m_mainworker.GetSensorData(idx, nValue, sValue))
@@ -2066,7 +2066,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 		case V_VAR:
 		case V_VA:
 		case V_POWER_FACTOR:
-			pChild->SetValue(vType, (float)atof(payload.c_str()));
+			pChild->SetValue(vType, stof(payload));
 			bHaveValue = true;
 			break;
 		default:
@@ -2346,7 +2346,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -2370,7 +2370,7 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					int NodeID = atoi(sd[0].c_str());
+					int NodeID = stoi(sd[0]);
 
 					root["result"][ii]["idx"] = NodeID;
 					root["result"][ii]["Name"] = sd[1];
@@ -2401,7 +2401,7 @@ namespace http {
 					int totChilds = 0;
 					if (!result2.empty())
 					{
-						totChilds = atoi(result2[0][0].c_str());
+						totChilds = stoi(result2[0][0]);
 					}
 					root["result"][ii]["Childs"] = totChilds;
 					ii++;
@@ -2419,7 +2419,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -2433,19 +2433,19 @@ namespace http {
 
 			root["status"] = "OK";
 			root["title"] = "MySensorsGetChilds";
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			MySensorsBase::_tMySensorNode* pNode = pMySensorsHardware->FindNode(NodeID);
 			std::vector<std::vector<std::string> > result;
 			result = m_sql.safe_query("SELECT ChildID, [Type], Name, UseAck, AckTimeout FROM MySensorsChilds WHERE (HardwareID=%d) AND (NodeID == %d) ORDER BY ChildID ASC", iHardwareID, NodeID);
 			int ii = 0;
 			for (const auto& sd2 : result)
 			{
-				int ChildID = atoi(sd2[0].c_str());
+				int ChildID = stoi(sd2[0]);
 				root["result"][ii]["child_id"] = ChildID;
-				root["result"][ii]["type"] = MySensorsBase::GetMySensorsPresentationTypeStr((MySensorsBase::_ePresentationType)atoi(sd2[1].c_str()));
+				root["result"][ii]["type"] = MySensorsBase::GetMySensorsPresentationTypeStr((MySensorsBase::_ePresentationType) stoi(sd2[1]));
 				root["result"][ii]["name"] = sd2[2];
 				root["result"][ii]["use_ack"] = (sd2[3] != "0") ? "true" : "false";
-				root["result"][ii]["ack_timeout"] = atoi(sd2[4].c_str());
+				root["result"][ii]["ack_timeout"] = stoi(sd2[4]);
 				std::string szDate = "-";
 				std::string szValues;
 				if (pNode != nullptr)
@@ -2497,7 +2497,7 @@ namespace http {
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			if ((hwid.empty()) || (nodeid.empty()) || (name.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -2508,7 +2508,7 @@ namespace http {
 				)
 				return;
 			MySensorsBase* pMySensorsHardware = dynamic_cast<MySensorsBase*>(pBaseHardware);
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "MySensorsUpdateNode";
 			pMySensorsHardware->UpdateNode(NodeID, name);
@@ -2525,7 +2525,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -2536,7 +2536,7 @@ namespace http {
 				)
 				return;
 			MySensorsBase* pMySensorsHardware = dynamic_cast<MySensorsBase*>(pBaseHardware);
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "MySensorsRemoveNode";
 			pMySensorsHardware->RemoveNode(NodeID);
@@ -2554,7 +2554,7 @@ namespace http {
 			std::string childid = request::findValue(&req, "childid");
 			if ((hwid.empty()) || (nodeid.empty()) || (childid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -2565,8 +2565,8 @@ namespace http {
 				)
 				return;
 			MySensorsBase* pMySensorsHardware = dynamic_cast<MySensorsBase*>(pBaseHardware);
-			int NodeID = atoi(nodeid.c_str());
-			int ChildID = atoi(childid.c_str());
+			int NodeID = stoi(nodeid);
+			int ChildID = stoi(childid);
 			root["status"] = "OK";
 			root["title"] = "MySensorsRemoveChild";
 			pMySensorsHardware->RemoveChild(NodeID, ChildID);
@@ -2592,7 +2592,7 @@ namespace http {
 				(ackTimeout.empty())
 				)
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -2603,12 +2603,12 @@ namespace http {
 				)
 				return;
 			MySensorsBase* pMySensorsHardware = dynamic_cast<MySensorsBase*>(pBaseHardware);
-			int NodeID = atoi(nodeid.c_str());
-			int ChildID = atoi(childid.c_str());
+			int NodeID = stoi(nodeid);
+			int ChildID = stoi(childid);
 			root["status"] = "OK";
 			root["title"] = "MySensorsUpdateChild";
 			bool bUseAck = (useack == "true") ? true : false;
-			int iAckTimeout = atoi(ackTimeout.c_str());
+			int iAckTimeout = stoi(ackTimeout);
 			if (iAckTimeout < 100)
 				iAckTimeout = 100;
 			pMySensorsHardware->UpdateChild(NodeID, ChildID, bUseAck, iAckTimeout);

--- a/hardware/MySensorsBase.cpp
+++ b/hardware/MySensorsBase.cpp
@@ -1979,7 +1979,7 @@ void MySensorsBase::ParseLine(const std::string& sLine)
 			bHaveValue = true;
 			break;
 		case V_DIRECTION:
-			pChild->SetValue(vType, ground(stof(payload)));
+			pChild->SetValue(vType, static_cast<int>(ground(stod(payload))));
 			bHaveValue = true;
 			break;
 		case V_LIGHT_LEVEL:

--- a/hardware/NefitEasy.cpp
+++ b/hardware/NefitEasy.cpp
@@ -402,7 +402,7 @@ bool CNefitEasy::GetStatusDetails()
 		tmpstr = root2["TSP"].asString();
 		if (tmpstr != "null")
 		{
-			float temp = static_cast<float>(atof(tmpstr.c_str()));
+			float temp = stof(tmpstr);
 			SendSetPointSensor(1, 1, 1, temp, "Setpoint");
 		}
 	}
@@ -411,7 +411,7 @@ bool CNefitEasy::GetStatusDetails()
 		tmpstr = root2["IHT"].asString();
 		if (tmpstr != "null")
 		{
-			float temp = static_cast<float>(atof(tmpstr.c_str()));
+			float temp = stof(tmpstr);
 			SendTempSensor(1, -1, temp, "Room Temperature");
 		}
 	}

--- a/hardware/Nest.cpp
+++ b/hardware/Nest.cpp
@@ -138,7 +138,7 @@ void CNest::UpdateSwitch(const unsigned char Idx, const bool bOn, const std::str
 	if (!result.empty())
 	{
 		// check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
@@ -287,7 +287,7 @@ void CNest::UpdateSmokeSensor(const unsigned char Idx, const bool bOn, const std
 	{
 		// check if we have a change, if not only update the LastUpdate field
 		bool bNoChange = false;
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			bNoChange = true;
 		else if ((bOn && (nvalue != 0)))

--- a/hardware/NestOAuthAPI.cpp
+++ b/hardware/NestOAuthAPI.cpp
@@ -113,7 +113,7 @@ void CNestOAuthAPI::UpdateSwitch(const unsigned char Idx, const bool bOn, const 
 	if (!result.empty())
 	{
 		// check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
@@ -313,7 +313,7 @@ void CNestOAuthAPI::UpdateSmokeSensor(const unsigned char Idx, const bool bOn, c
 	{
 		// check if we have a change, if not only update the LastUpdate field
 		bool bNoChange = false;
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			bNoChange = true;
 		else if ((bOn && (nvalue != 0)))

--- a/hardware/OTGWBase.cpp
+++ b/hardware/OTGWBase.cpp
@@ -104,7 +104,7 @@ void OTGWBase::UpdateSwitch(const unsigned char Idx, const bool bOn, const std::
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue=atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn)&&(nvalue==0))
 			return;
 		if ((bOn&&(nvalue!=0)))
@@ -409,43 +409,43 @@ void OTGWBase::ParseLine()
 			bool bDiagnosticEvent=(_status.MsgID[9+1]=='1');												UpdateSwitch(116,bDiagnosticEvent,"DiagnosticEvent");
 		}
 
-		_status.Control_setpoint = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
+		_status.Control_setpoint = stof(results[idx++]);						SendTempSensor(MsgID1, 255, _status.Control_setpoint, "Control Setpoint");
 		_status.Remote_parameter_flags=results[idx++];
 		if(bIsFirmware5)
 		{
 			idx+=2;
 		}
-		_status.Maximum_relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Maximum_relative_modulation_level = stof(results[idx++]);
 		bool bExists = CheckPercentageSensorExists(MsgID14, 1);
 		if ((_status.Maximum_relative_modulation_level != 0) || (bExists))
 		{
 			SendPercentageSensor(MsgID14, 1, 255, _status.Maximum_relative_modulation_level, "Maximum Relative Modulation Level");
 		}
 		_status.Boiler_capacity_and_modulation_limits=results[idx++];
-		_status.Room_Setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Room_Setpoint = stof(results[idx++]);
 		UpdateSetPointSensor((uint8_t)MsgID16, ((m_OverrideTemperature != 0.0F) ? m_OverrideTemperature : _status.Room_Setpoint), "Room Setpoint");
-		_status.Relative_modulation_level = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Relative_modulation_level = stof(results[idx++]);
 		bExists = CheckPercentageSensorExists(MsgID17, 1);
 		if ((_status.Relative_modulation_level != 0) || (bExists))
 		{
 			SendPercentageSensor(MsgID17, 1, 255, _status.Relative_modulation_level, "Relative modulation level");
 		}
-		_status.CH_water_pressure = static_cast<float>(atof(results[idx++].c_str()));
+		_status.CH_water_pressure = stof(results[idx++]);
 		if (_status.CH_water_pressure != 0)
 		{
 			SendPressureSensor(0, MsgID18, 255, _status.CH_water_pressure, "CH Water Pressure");
 		}
 		if(bIsFirmware5)
 		{
-			_status.DHW_flow_rate = static_cast<float>(atof(results[idx++].c_str()));						SendWaterflowSensor(MsgID19, 1, 255, _status.DHW_flow_rate, "DHW Flow Rate");
+			_status.DHW_flow_rate = stof(results[idx++]);						SendWaterflowSensor(MsgID19, 1, 255, _status.DHW_flow_rate, "DHW Flow Rate");
 			//CH2 room setpoint (MsgID=23)
 			idx+=1;
 		}
-		_status.Room_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID24, 255, _status.Room_temperature, "Room Temperature");
-		_status.Boiler_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID25, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
-		_status.DHW_temperature = static_cast<float>(atof(results[idx++].c_str()));							SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
-		_status.Outside_temperature = static_cast<float>(atof(results[idx++].c_str()));						SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
-		_status.Return_water_temperature = static_cast<float>(atof(results[idx++].c_str()));				SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
+		_status.Room_temperature = stof(results[idx++]);						SendTempSensor(MsgID24, 255, _status.Room_temperature, "Room Temperature");
+		_status.Boiler_water_temperature = stof(results[idx++]);				SendTempSensor(MsgID25, 255, _status.Boiler_water_temperature, "Boiler Water Temperature");
+		_status.DHW_temperature = stof(results[idx++]);							SendTempSensor(MsgID26, 255, _status.DHW_temperature, "DHW Temperature");
+		_status.Outside_temperature = stof(results[idx++]);						SendTempSensor(MsgID27, 255, _status.Outside_temperature, "Outside Temperature");
+		_status.Return_water_temperature = stof(results[idx++]);				SendTempSensor(MsgID28, 255, _status.Return_water_temperature, "Return Water Temperature");
 		if(bIsFirmware5)
 		{
 			//CH2 flow temperature(MsgID = 31)
@@ -454,12 +454,12 @@ void OTGWBase::ParseLine()
 		}
 		_status.DHW_setpoint_boundaries=results[idx++];
 		_status.Max_CH_setpoint_boundaries=results[idx++];
-		_status.DHW_setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.DHW_setpoint = stof(results[idx++]);
 		if (_status.DHW_setpoint != 0.0F)
 		{
 			UpdateSetPointSensor((uint8_t)MsgID56, _status.DHW_setpoint, "DHW Setpoint");
 		}
-		_status.Max_CH_water_setpoint = static_cast<float>(atof(results[idx++].c_str()));
+		_status.Max_CH_water_setpoint = stof(results[idx++]);
 		if (_status.Max_CH_water_setpoint != 0.0F)
 		{
 			UpdateSetPointSensor((uint8_t)MsgID57, _status.Max_CH_water_setpoint, "Max_CH Water Setpoint");
@@ -471,14 +471,14 @@ void OTGWBase::ParseLine()
 			//Relative ventilation(MsgID = 77)
 			idx+=3;
 		}
-		_status.Burner_starts=atol(results[idx++].c_str());
-		_status.CH_pump_starts=atol(results[idx++].c_str());
-		_status.DHW_pump_valve_starts=atol(results[idx++].c_str());
-		_status.DHW_burner_starts=atol(results[idx++].c_str());
-		_status.Burner_operation_hours=atol(results[idx++].c_str());
-		_status.CH_pump_operation_hours=atol(results[idx++].c_str());
-		_status.DHW_pump_valve_operation_hours=atol(results[idx++].c_str());
-		_status.DHW_burner_operation_hours=atol(results[idx++].c_str());
+		_status.Burner_starts = stol(results[idx++]);
+		_status.CH_pump_starts = stol(results[idx++]);
+		_status.DHW_pump_valve_starts = stol(results[idx++]);
+		_status.DHW_burner_starts = stol(results[idx++]);
+		_status.Burner_operation_hours = stol(results[idx++]);
+		_status.CH_pump_operation_hours = stol(results[idx++]);
+		_status.DHW_pump_valve_operation_hours = stol(results[idx++]);
+		_status.DHW_burner_operation_hours = stol(results[idx++]);
 		return;
 	}
 
@@ -524,7 +524,7 @@ void OTGWBase::ParseLine()
 		if (status == 'c' || status == 't')
 		{
 			// Get override setpoint value
-			m_OverrideTemperature = static_cast<float>(atof(sLine.substr(7).c_str()));
+			m_OverrideTemperature = stof(sLine.substr(7));
 		}
 	}
 	else if (sLine.find("PR: A") != std::string::npos)
@@ -571,14 +571,14 @@ namespace http {
 				return;
 
 
-			int currentMode1 = atoi(result[0][0].c_str());
+			int currentMode1 = stoi(result[0][0]);
 
 			std::string sOutsideTempSensor = request::findValue(&req, "combooutsidesensor");
-			int newMode1 = atoi(sOutsideTempSensor.c_str());
+			int newMode1 = stoi(sOutsideTempSensor);
 
 			if (currentMode1 != newMode1)
 			{
-				m_sql.UpdateRFXCOMHardwareDetails(atoi(idx.c_str()), newMode1, 0, 0, 0, 0, 0);
+				m_sql.UpdateRFXCOMHardwareDetails(stoi(idx), newMode1, 0, 0, 0, 0, 0);
 				m_mainworker.RestartHardware(idx);
 			}
 		}
@@ -607,7 +607,7 @@ namespace http {
 			stdupper(rcmnd);
 			cmnd = rcmnd + rdata;
 
-			OTGWBase *pOTGW = dynamic_cast<OTGWBase*>(m_mainworker.GetHardware(atoi(idx.c_str())));
+			OTGWBase *pOTGW = dynamic_cast<OTGWBase*>(m_mainworker.GetHardware(stoi(idx)));
 			if (pOTGW == nullptr)
 				return;
 

--- a/hardware/OctoPrintMQTT.cpp
+++ b/hardware/OctoPrintMQTT.cpp
@@ -306,11 +306,11 @@ void COctoPrintMQTT::UpdateUserVariable(const std::string &varName, const std::s
 		result = m_sql.safe_query("SELECT ID FROM UserVariables WHERE (Name=='%q')", varName.c_str());
 		if (result.empty())
 			return;
-		ID = atoi(result[0][0].c_str());
+		ID = stoi(result[0][0]);
 	}
 	else
 	{
-		ID = atoi(result[0][0].c_str());
+		ID = stoi(result[0][0]);
 		m_sql.safe_query("UPDATE UserVariables SET Value='%q', LastUpdate='%q' WHERE (ID==%d)", varValue.c_str(), sLastUpdate.c_str(), ID);
 	}
 
@@ -388,7 +388,7 @@ void COctoPrintMQTT::on_message(const struct mosquitto_message *message)
 				}
 				m_LastSendTemp[szSensorName] = atime;
 				int crcID = Crc32(0, (const unsigned char*)szSensorName.c_str(), szSensorName.length());
-				SendTempSensor(crcID, 255, std::stof(root["actual"].asString()), szSensorName);
+				SendTempSensor(crcID, 255, stof(root["actual"].asString()), szSensorName);
 			}
 			else if (szMsgType == "progress")
 			{
@@ -422,7 +422,7 @@ void COctoPrintMQTT::on_message(const struct mosquitto_message *message)
 						}
 					}
 					else
-						SendPercentageSensor(1, 1, 255, std::stof(root["progress"].asString()), "Printing Progress");
+						SendPercentageSensor(1, 1, 255, stof(root["progress"].asString()), "Printing Progress");
 
 					if (!root["path"].empty())
 					{
@@ -495,7 +495,7 @@ void COctoPrintMQTT::on_message(const struct mosquitto_message *message)
 							Log(LOG_ERROR, "Invalid ZChange data received! (no new field in JSON payload ?)");
 							return;
 						}
-						//SendCustomSensor(1, 1, 255, std::stof(root["new"].asString()), "ZChange", "Z");
+						//SendCustomSensor(1, 1, 255, stof(root["new"].asString()), "ZChange", "Z");
 						return;
 					}
 					if (bIsPrintStatus)

--- a/hardware/OnkyoAVTCP.cpp
+++ b/hardware/OnkyoAVTCP.cpp
@@ -397,20 +397,20 @@ void OnkyoAVTCP::ReceiveSwitchMsg(const char *pData, int Len, bool muting, int I
 			}
 			options["LevelActions"] = options["LevelActions"] + "|" + str;
 			options["LevelNames"] = options["LevelNames"] + "|" + level_name;
-			m_sql.SetDeviceOptions(atoi(result[0][4].c_str()), options);
+			m_sql.SetDeviceOptions(stoull(result[0][4]), options);
 		}
 		level = i;
 	}
 	if (!result.empty() && action == gswitch_sSetLevel)
 	{
 		// check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!level) && (nvalue == gswitch_sOff))
 			return;
 		if ((level && (nvalue != gswitch_sOff)))
 		{
 			// Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -693,7 +693,7 @@ namespace http
 			std::string sAction = request::findValue(&req, "action");
 			if (sIdx.empty())
 				return;
-			// int idx = atoi(sIdx.c_str());
+			// int idx = stoi(sIdx);
 
 			std::vector<std::vector<std::string>> result;
 			result = m_sql.safe_query("SELECT DS.SwitchType, DS.DeviceID, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
@@ -701,7 +701,7 @@ namespace http
 			root["status"] = "ERR";
 			if (result.size() == 1)
 			{
-				_eHardwareTypes hType = (_eHardwareTypes)atoi(result[0][2].c_str());
+				_eHardwareTypes hType = (_eHardwareTypes) stoi(result[0][2]);
 				switch (hType)
 				{
 					// We allow raw EISCP commands to be sent on *any* of the logical devices

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -411,7 +411,7 @@ std::string COpenWeatherMap::GetHourFromUTCtimestamp(const uint8_t hournr, const
 {
 	std::string sHour = "Unknown";
 
-	time_t t = (time_t)strtol(UTCtimestamp.c_str(), nullptr, 10);
+	time_t t = (time_t) stol(UTCtimestamp);
 	std::string sDate = ctime(&t);
 
 	std::vector<std::string> strarray;
@@ -443,7 +443,7 @@ std::string COpenWeatherMap::GetDayFromUTCtimestamp(const uint8_t daynr, const s
 {
 	std::string sDay = "Unknown";
 
-	time_t t = (time_t)strtol(UTCtimestamp.c_str(), nullptr, 10);
+	time_t t = (time_t) stol(UTCtimestamp);
 	std::string sDate = ctime(&t);
 
 	std::vector<std::string> strarray;

--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -187,8 +187,8 @@ bool COpenWeatherMap::StartHardware()
 
 					if (!((sLatitude == "1") && (sLongitude == "1")))
 					{
-						m_Lat = std::stod(sLatitude);
-						m_Lon = std::stod(sLongitude);
+						m_Lat = stod(sLatitude);
+						m_Lon = stod(sLongitude);
 
 						m_Location = sLatitude + "," + sLongitude;	// rewrite the default Location data to match what OWN expects
 
@@ -244,8 +244,8 @@ bool COpenWeatherMap::StartHardware()
 				}
 				else
 				{
-					m_Lat = std::stod(sLatitude);
-					m_Lon = std::stod(sLongitude);
+					m_Lat = stod(sLatitude);
+					m_Lon = stod(sLongitude);
 					Log(LOG_STATUS, "Using specified location (Lon %s, Lat %s) Unable to find nearest City!", sLongitude.c_str(), sLatitude.c_str());
 				}
 			}
@@ -259,8 +259,8 @@ bool COpenWeatherMap::StartHardware()
 				sLongitude = strarray[1];
 				if ((sLatitude.find("lat=") == 0) && (sLongitude.find("lon=") == 0))
 				{
-					m_Lat = std::stod(sLatitude.substr(4));
-					m_Lon = std::stod(sLongitude.substr(4));
+					m_Lat = stod(sLatitude.substr(4));
+					m_Lon = stod(sLongitude.substr(4));
 					Log(LOG_STATUS, "Using specified location (Lon %s, Lat %s)!", sLongitude.c_str(), sLatitude.c_str());
 				}
 				else

--- a/hardware/OpenWebNetTCP.cpp
+++ b/hardware/OpenWebNetTCP.cpp
@@ -227,7 +227,7 @@ uint32_t COpenWebNetTCP::ownCalcPass(const std::string &password, const std::str
 		{
 			if (flag)
 			{
-				num2 = (uint32_t)atoi(password.c_str());
+				num2 = stoul(password);
 				flag = false;
 			}
 		}
@@ -325,7 +325,7 @@ std::string COpenWebNetTCP::decToHexStrConvert(const std::string &paramString)
 	for (idxb = 0, idxh = 0; idxb < paramString.length(); idxb += 2, idxh++)
 	{
 		std::string str = paramString.substr(idxb, 2);
-		sprintf(&retStr[idxh], "%x", atoi(str.c_str()));
+		sprintf(&retStr[idxh], "%x", stoi(str));
 	}
 	return std::string(retStr);
 }
@@ -698,7 +698,7 @@ bool COpenWebNetTCP::GetValueMeter(const int NodeID, const int ChildID, double *
 		std::string sup, sValue = result[0][0];
 
 		if (usage)
-			*usage = (float)atof(sValue.c_str());
+			*usage = stod(sValue);
 
 		if (energy)
 		{
@@ -706,7 +706,7 @@ bool COpenWebNetTCP::GetValueMeter(const int NodeID, const int ChildID, double *
 			if (pos >= 0)
 			{
 				sup = sValue.substr(pos + 1);
-				*energy = (float)atof(sup.c_str());
+				*energy = stod(sup);
 			}
 		}
 
@@ -814,7 +814,7 @@ void COpenWebNetTCP::UpdateAlarm(const int who, const int where, const int Comma
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][0].c_str());
+		int nvalue = stoi(result[0][0]);
 		if (Command == -1 || nvalue == Command) return; // update not necessary
 	}
 
@@ -860,9 +860,9 @@ void COpenWebNetTCP::UpdateBlinds(const int who, const int where, const int Comm
 	}
 	else
 	{
-		nvalue = atoi(result[0][1].c_str());
-		slevel = atoi(result[0][2].c_str());
-		switch_type = atoi(result[0][3].c_str());
+		nvalue = stoi(result[0][1]);
+		slevel = stoi(result[0][2]);
+		switch_type = stoi(result[0][3]);
 	}
 
 	if (
@@ -938,7 +938,7 @@ void COpenWebNetTCP::UpdateCenPlus(const int who, const int where, const int Com
 	}
 	else
 	{
-		nvalue = atoi(result[0][1].c_str());
+		nvalue = stoi(result[0][1]);
 	}
 
 	//check if we have a change, if not do not update it
@@ -1005,9 +1005,9 @@ void COpenWebNetTCP::UpdateSwitch(const int who, const int where, const int what
 	}
 	else
 	{
-		nvalue = atoi(result[0][1].c_str());
-		slevel = atoi(result[0][2].c_str());
-		switch_type = atoi(result[0][3].c_str());
+		nvalue = stoi(result[0][1]);
+		slevel = stoi(result[0][2]);
+		switch_type = stoi(result[0][3]);
 	}
 
 	int level = (what > 1) ? (what * 10) : 0;
@@ -1040,7 +1040,7 @@ void COpenWebNetTCP::decodeWhereAndFill(const int who, const std::string &where,
 		/* GROUP light device */
 		if (!whereParam.empty())
 		{
-			*iWhere = atoi(whereParam[0].c_str()) + OPENWEBNET_GROUP_ID;
+			*iWhere = stoi(whereParam[0]) + OPENWEBNET_GROUP_ID;
 			*devname += " GROUP " + whereParam[0];
 		}
 	}
@@ -1056,7 +1056,7 @@ void COpenWebNetTCP::decodeWhereAndFill(const int who, const std::string &where,
 		if (wlen == 1)
 		{
 			// General o Area 1-9 command
-			int tmp = atoi(where.c_str());
+			int tmp = stoi(where);
 			if (tmp > 0) iArea = tmp;
 		}
 		else if ((wlen == 2) && (where == "00"))	// Area 0 (00) command
@@ -1069,7 +1069,7 @@ void COpenWebNetTCP::decodeWhereAndFill(const int who, const std::string &where,
 		}
 		else									// generic Area+PL command
 		{
-			*iWhere = atoi(where.c_str());
+			*iWhere = stoi(where);
 			*devname += " " + where;
 			if (wlen == 4)	// device with 4 chars command
 				*iWhere += OPENWEBNET_4CHARS;
@@ -1102,7 +1102,7 @@ void COpenWebNetTCP::decodeWhereAndFill(const int who, const std::string &where,
 	else
 	{
 		// others who..
-		*iWhere = atoi(where.c_str());
+		*iWhere = stoi(where);
 		*devname += " " + where;
 	}
 }
@@ -1124,14 +1124,14 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 	std::string devname, sCommand;
 	int iAppValue, iWhere, iLevel;
 
-	switch (atoi(who.c_str())) {
+	switch (stoi(who)) {
 	case WHO_LIGHTING:	// 1
 
 		if (!iter->IsNormalFrame())
 		{
 			if (iter->IsMeasureFrame())
 			{
-				switch (atoi(value.c_str()))
+				switch (stoi(value))
 				{
 				case LIGHTING_DIMENSION_SET_UP_LEVEL_WITH_GIVEN_SPEED:				// 1
 				case LIGHTING_DIMENSION_TEMPORISATION:								// 2
@@ -1142,7 +1142,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 					// TODO: manage lighting parameter..
 					return;
 				default:
-					Log(LOG_ERROR, "Who=%s measure error -> param=%u", who.c_str(), atoi(value.c_str()));
+					Log(LOG_ERROR, "Who=%s measure error -> param=%u", who.c_str(), stoi(value));
 					return;
 				}
 			}
@@ -1155,14 +1155,14 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		else
 		{
 			// NORMALE FRAME..
-			iAppValue = atoi(what.c_str());
+			iAppValue = stoi(what);
 			if (iAppValue == 1000) // What = 1000 (Command translation)
-				iAppValue = atoi(whatParam[0].c_str());
+				iAppValue = stoi(whatParam[0]);
 		}		
 
 		devname = OPENWEBNET_LIGHT;
 		decodeWhereAndFill(WHO_LIGHTING, where, whereParam, &devname, &iWhere);
-		UpdateSwitch(WHO_LIGHTING, iWhere, iAppValue, atoi(sInterface.c_str()), 255, devname.c_str());
+		UpdateSwitch(WHO_LIGHTING, iWhere, iAppValue, stoi(sInterface), 255, devname.c_str());
 		break;
 	case WHO_AUTOMATION:								// 2
 		if (!iter->IsNormalFrame() && !iter->IsMeasureFrame())
@@ -1173,24 +1173,24 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		if (iter->IsMeasureFrame()) // Advanced motor actuator (percentual) *#2*19*10*10*65*000*0##
 		{
 			std::string level = iter->Extract_value(1);
-			iLevel = atoi(level.c_str());
-			iAppValue = atoi(value.c_str());
+			iLevel = stoi(level);
+			iAppValue = stoi(value);
 
 			if (iAppValue == 1000) // What = 1000 (Command translation)
-				iAppValue = atoi(whatParam[0].c_str());
+				iAppValue = stoi(whatParam[0]);
 
 			devname = OPENWEBNET_AUTOMATION;
 			decodeWhereAndFill(WHO_AUTOMATION, where, whereParam, &devname, &iWhere);
-			UpdateBlinds(WHO_AUTOMATION, iWhere, iAppValue, atoi(sInterface.c_str()), iLevel, 255, devname.c_str());
+			UpdateBlinds(WHO_AUTOMATION, iWhere, iAppValue, stoi(sInterface), iLevel, 255, devname.c_str());
 		}
 		if (iter->IsNormalFrame())
 		{
-			iAppValue = atoi(what.c_str());
+			iAppValue = stoi(what);
 			if (iAppValue == 1000) // What = 1000 (Command translation)
-				iAppValue = atoi(whatParam[0].c_str());
+				iAppValue = stoi(whatParam[0]);
 
 			decodeWhereAndFill(WHO_AUTOMATION, where, whereParam, &devname, &iWhere);
-			UpdateBlinds(WHO_AUTOMATION, iWhere, iAppValue, atoi(sInterface.c_str()), -1, 255, devname.c_str());
+			UpdateBlinds(WHO_AUTOMATION, iWhere, iAppValue, stoi(sInterface), -1, 255, devname.c_str());
 		}
 		break;
 	case WHO_TEMPERATURE_CONTROL:
@@ -1200,22 +1200,22 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			// 4: this is a openwebnet termoregulation update/poll messagge, setup devname
 			devname = OPENWEBNET_TEMPERATURE;
 			devname += where;
-			switch (atoi(dimension.c_str()))
+			switch (stoi(dimension))
 			{
 				case TEMPERATURE_CONTROL_DIMENSION_TEMPERATURE:				// 0
-					UpdateTemp(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), 255, devname.c_str());
+					UpdateTemp(WHO_TEMPERATURE_CONTROL, stoi(where), stof(value) / 10.0F, stoi(sInterface), 255, devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_VALVES_STATUS:				// 19
 					devname += " Valves";
-					UpdateSwitch(WHO_TEMPERATURE_CONTROL + 600, atoi(where.c_str()), atoi(value.c_str()), atoi(sInterface.c_str()), 255, devname.c_str());
+					UpdateSwitch(WHO_TEMPERATURE_CONTROL + 600, stoi(where), stoi(value), stoi(sInterface), 255, devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_ACTUATOR_STATUS:				// 20
 					devname += " Actuator";
-					UpdateSwitch(WHO_TEMPERATURE_CONTROL + 500, atoi(where.c_str()), atoi(value.c_str()), atoi(sInterface.c_str()), 255, devname.c_str());
+					UpdateSwitch(WHO_TEMPERATURE_CONTROL + 500, stoi(where), stoi(value), stoi(sInterface), 255, devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_COMPLETE_PROBE_STATUS:		// 12
 					devname += " Setpoint";
-					UpdateSetPoint(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 10.), atoi(sInterface.c_str()), devname.c_str());
+					UpdateSetPoint(WHO_TEMPERATURE_CONTROL, stoi(where), stof(value) / 10.0F, stoi(sInterface), devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_LOCAL_SET_OFFSET:			// 13
 				{
@@ -1223,7 +1223,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 					devname += where;
 					//std::string sStatus = "";
 					std::stringstream sStatus;
-					switch (atoi(value.c_str()))
+					switch (stoi(value))
 					{
 						case TEMPERATURE_SELECTOR_0_NORMAL: // 0
 							sStatus << "No offset";
@@ -1232,13 +1232,13 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 						case TEMPERATURE_SELECTOR_02:	    // 2
 						case TEMPERATURE_SELECTOR_03:	    // 3
 							sStatus << "Offset +";
-							sStatus << atoi(value.c_str());
+							sStatus << stoi(value);
 							break;
 						case TEMPERATURE_SELECTOR_11: // 11 -> -1
 						case TEMPERATURE_SELECTOR_12: // 12 -> -2
 						case TEMPERATURE_SELECTOR_13: // 13 -> -3
 							sStatus << "Offset -";
-							sStatus << (atoi(value.c_str()) - 10);
+							sStatus << (stoi(value) - 10);
 							break;
 						case TEMPERATURE_SELECTOR_4: // 4
 							sStatus << "Local OFF";
@@ -1251,7 +1251,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 					}
 
 					if (sStatus.str() != "")
-						UpdateTempProbe(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), -1, 1, sStatus.str(), atoi(sInterface.c_str()), 255, devname.c_str());
+						UpdateTempProbe(WHO_TEMPERATURE_CONTROL, stoi(where), -1, 1, sStatus.str(), stoi(sInterface), 255, devname.c_str());
 				}
 				break;
 				case TEMPERATURE_CONTROL_DIMENSION_SET_POINT_TEMPERATURE:		// 14
@@ -1270,7 +1270,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			devname = OPENWEBNET_TEMPERATURE_STATUS;			
 			devname += " " + where;
 			std::string sStatus = "";
-			switch (atoi(what.c_str()))
+			switch (stoi(what))
 			{
 				case TEMPERATURE_WHAT_MODE_CONDITIONING:		// 0
 					sStatus = "Conditioning";
@@ -1295,7 +1295,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			if (sStatus != "")
 			{
 				//Log(LOG_STATUS, "Temperature Zone%s in %s", where.c_str(), sStatus.c_str());
-				UpdateTempProbe(WHO_TEMPERATURE_CONTROL, atoi(where.c_str()), -1, 0, sStatus, atoi(sInterface.c_str()), 255, devname.c_str());
+				UpdateTempProbe(WHO_TEMPERATURE_CONTROL, stoi(where), -1, 0, sStatus, stoi(sInterface), 255, devname.c_str());
 			}
 		}
 		else
@@ -1310,27 +1310,27 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			return;
 		}
 		
-		switch (atoi(what.c_str())) {
+		switch (stoi(what)) {
 		case 0:         //maintenace
 			//Log(LOG_STATUS, "Alarm in Maintenance");
 			iWhere = ID_DEV_BURGLAR_SYS_STATUS; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_SYS_STATUS;
 			sCommand = "Maintenance";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 2, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 2, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 		case 1:         //active
 			//Log(LOG_STATUS, "Alarm Active");
 			iWhere = ID_DEV_BURGLAR_SYS_STATUS; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_SYS_STATUS;
 			sCommand = "Active";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 		case 2:         //disabled
 			//Log(LOG_STATUS, "Alarm Inactive");
 			iWhere = ID_DEV_BURGLAR_SYS_STATUS; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_SYS_STATUS;
 			sCommand = "Inactive";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 3, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 3, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 4:         //battery fault
@@ -1338,7 +1338,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_BATTERY; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_BATTERY;
 			sCommand = "Battery Fault";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 5:         //battery ok
@@ -1346,7 +1346,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_BATTERY; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_BATTERY;
 			sCommand = "Battery Ok";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 6:			//no network
@@ -1354,7 +1354,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_NETWORK; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_NETWORK;
 			sCommand = "No network";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 7:			//network ok
@@ -1362,7 +1362,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_NETWORK; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_NETWORK;
 			sCommand = "Network OK";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 8: 	//engaged
@@ -1370,7 +1370,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_SYS_ENGAGEMENT; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_SYS_ENGAGEMENT;
 			sCommand = "Engaged";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 9:         //disengaged
@@ -1378,7 +1378,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_SYS_ENGAGEMENT; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_SYS_ENGAGEMENT;
 			sCommand = "DisEngaged";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 0, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 0, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 10:         //battery Unloads
@@ -1386,34 +1386,34 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			iWhere = ID_DEV_BURGLAR_BATTERY; // force where because not exist
 			devname = OPENWEBNET_BURGLAR_ALARM_BATTERY;
 			sCommand = "Battery Unloads";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 11:         // zone N Active
-			iWhere = atoi(whereParam[0].c_str());
+			iWhere = stoi(whereParam[0]);
 			//Log(LOG_STATUS, "Alarm Zone %d Active",iWhere);
 			devname = OPENWEBNET_BURGLAR_ALARM_SENSOR;
 			devname += " " + whereParam[0];
 			sCommand = "Active";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 1, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 15:         //zone N INTRUSION ALARM
-			iWhere = atoi(whereParam[0].c_str());
+			iWhere = stoi(whereParam[0]);
 			//Log(LOG_STATUS, "Alarm Zone %d INTRUSION ALARM", iWhere);
 			devname = OPENWEBNET_BURGLAR_ALARM_SENSOR;
 			devname += " " + whereParam[0];
 			sCommand = "Intrusion";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 4, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 18:         // zone N Not Active
-			iWhere = atoi(whereParam[0].c_str());
+			iWhere = stoi(whereParam[0]);
 			//Log(LOG_STATUS, "Alarm Zone %d Not active", iWhere);
 			devname = OPENWEBNET_BURGLAR_ALARM_SENSOR;
 			devname += " " + whereParam[0];
 			sCommand = "Inactive";
-			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 0, sCommand.c_str(), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateAlarm(WHO_BURGLAR_ALARM, iWhere, 0, sCommand.c_str(), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		default:
@@ -1440,7 +1440,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		devname = OPENWEBNET_AUXILIARY;
 		devname += " " + where;
 
-		UpdateSwitch(WHO_AUXILIARY, atoi(where.c_str()), atoi(what.c_str()), atoi(sInterface.c_str()), 255, devname.c_str());
+		UpdateSwitch(WHO_AUXILIARY, stoi(where), stoi(what), stoi(sInterface), 255, devname.c_str());
 		break;
 	case WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION:              // 25
 		if (!iter->IsNormalFrame())
@@ -1450,15 +1450,15 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		}
 
 
-		switch (atoi(what.c_str())) { //CEN PLUS / DRY CONTACT / IR DETECTION
+		switch (stoi(what)) { //CEN PLUS / DRY CONTACT / IR DETECTION
 
 		case 21:         //Short pressure
-			iWhere = atoi(where.c_str());
-			iAppValue = atoi(whatParam[0].c_str());
+			iWhere = stoi(where);
+			iAppValue = stoi(whatParam[0]);
 			Log(LOG_STATUS, "CEN PLUS Short pressure %d Button %d", iWhere, iAppValue);
 			devname = OPENWEBNET_CENPLUS;
 			devname += " " + where + " Short Press Button " + whatParam[0];
-			UpdateCenPlus(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, 1, iAppValue, atoi(what.c_str()), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateCenPlus(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, 1, iAppValue, stoi(what), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 22:         //Start of extended pressure
@@ -1470,13 +1470,13 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			break;
 
 		case 24:         //End of Extended pressure
-			iWhere = atoi(where.c_str());
-			iAppValue = atoi(whatParam[0].c_str());
+			iWhere = stoi(where);
+			iAppValue = stoi(whatParam[0]);
 
 			Log(LOG_STATUS, "CEN PLUS Long pressure %d Button %d", iWhere, iAppValue);
 			devname = OPENWEBNET_CENPLUS;
 			devname += " " + where + " Long Press Button " + whatParam[0];
-			UpdateCenPlus(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, 1, iAppValue, atoi(what.c_str()), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateCenPlus(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, 1, iAppValue, stoi(what), stoi(sInterface), 255, devname.c_str());
 			break;
 
 		case 31:
@@ -1489,15 +1489,15 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 
 			devname = OPENWEBNET_DRY_CONTACT;
 			devname += " " + where.substr(1);
-			iWhere = atoi(where.substr(1).c_str());
+			iWhere = stoi(where.substr(1));
 
-			iAppValue = atoi(what.c_str());
+			iAppValue = stoi(what);
 			if (iAppValue == DRY_CONTACT_IR_DETECTION_WHAT_ON)
 				iAppValue = 1;
 			else
 				iAppValue = 0;
 
-			UpdateSwitch(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, iAppValue, atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateSwitch(WHO_CEN_PLUS_DRY_CONTACT_IR_DETECTION, iWhere, iAppValue, stoi(sInterface), 255, devname.c_str());
 			break;
 		default:
 			Log(LOG_ERROR, "What=%s is not correct for who=%s", what.c_str(), who.c_str());
@@ -1515,16 +1515,16 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		}
 		devname = OPENWEBNET_ENERGY_MANAGEMENT;
 		devname += " " + where;
-		switch (atoi(dimension.c_str()))
+		switch (stoi(dimension))
 		{
 		case ENERGY_MANAGEMENT_DIMENSION_ACTIVE_POWER:
-			UpdatePower(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), static_cast<float>(atof(value.c_str())), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdatePower(WHO_ENERGY_MANAGEMENT, stoi(where), stod(value), stoi(sInterface), 255, devname.c_str());
 			break;
 		case ENERGY_MANAGEMENT_DIMENSION_ENERGY_TOTALIZER:
-			UpdateEnergy(WHO_ENERGY_MANAGEMENT, atoi(where.c_str()), static_cast<float>(atof(value.c_str()) / 1000.), atoi(sInterface.c_str()), 255, devname.c_str());
+			UpdateEnergy(WHO_ENERGY_MANAGEMENT, stoi(where), stod(value) / 1000.0, stoi(sInterface), 255, devname.c_str());
 			break;
 		case ENERGY_MANAGEMENT_DIMENSION_END_AUTOMATIC_UPDATE:			
-			if (atoi(value.c_str()))
+			if (stoi(value))
 				Log(LOG_STATUS, "Start sending instantaneous consumption %s for %s minutes", where.c_str(), value.c_str());
 			else
 				Log(LOG_STATUS, "Stop sending instantaneous consumption %s", where.c_str());
@@ -1537,12 +1537,12 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 
 	case WHO_GATEWAY_INTERFACES_MANAGEMENT:         // 13
 		int timezone, model;
-		switch (atoi(dimension.c_str()))
+		switch (stoi(dimension))
 		{
 		case GATEWAY_INTERFACES_MANAGEMENT_DIMENSION_TIME:					// 0,		/* Read/Write */
 			if (valueParam.size() >= 4)
 			{
-				timezone = atoi(valueParam[3].c_str());
+				timezone = stoi(valueParam[3]);
 				Log(LOG_STATUS, "Gateway Time %s:%s:%s GMT%c%u", valueParam[0].c_str(), valueParam[1].c_str(), valueParam[2].c_str(), 
 																					  (timezone > 99) ? '-' : '+', (timezone % 100));
 			}
@@ -1557,29 +1557,29 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		case GATEWAY_INTERFACES_MANAGEMENT_DIMENSION_IP_ADDRESS:			// 10,		/* Read		  */
 			if (valueParam.size() >= 4)
 			{
-				Log(LOG_STATUS, "Gateway IP Address %u.%u.%u.%u", atoi(valueParam[0].c_str()), atoi(valueParam[1].c_str()),
-																					   atoi(valueParam[2].c_str()), atoi(valueParam[3].c_str()));
+				Log(LOG_STATUS, "Gateway IP Address %u.%u.%u.%u", stoi(valueParam[0]), stoi(valueParam[1]),
+																					   stoi(valueParam[2]), stoi(valueParam[3]));
 			}
 			break;
 		case GATEWAY_INTERFACES_MANAGEMENT_DIMENSION_NET_MASK:				// 11,		/* Read		  */
 			if (valueParam.size() >= 4)
 			{
-				Log(LOG_STATUS, "Gateway Net Mask %u.%u.%u.%u", atoi(valueParam[0].c_str()), atoi(valueParam[1].c_str()),
-																					 atoi(valueParam[2].c_str()), atoi(valueParam[3].c_str()));
+				Log(LOG_STATUS, "Gateway Net Mask %u.%u.%u.%u", stoi(valueParam[0]), stoi(valueParam[1]),
+																					 stoi(valueParam[2]), stoi(valueParam[3]));
 			}
 			break;
 		case GATEWAY_INTERFACES_MANAGEMENT_DIMENSION_MAC_ADDRESS:			// 12,		/* Read		  */
 			if (valueParam.size() >= 6)
 			{
 				Log(LOG_STATUS, "Gateway MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
-														atoi(valueParam[0].c_str()), atoi(valueParam[1].c_str()), atoi(valueParam[2].c_str()),
-														atoi(valueParam[3].c_str()), atoi(valueParam[4].c_str()), atoi(valueParam[5].c_str()));
+														stoi(valueParam[0]), stoi(valueParam[1]), stoi(valueParam[2]),
+														stoi(valueParam[3]), stoi(valueParam[4]), stoi(valueParam[5]));
 			}
 			break;
 		case GATEWAY_INTERFACES_MANAGEMENT_DIMENSION_DEVICE_TYPE:			// 15,		/* Read		  */
 			if (!valueParam.empty())
 			{
-				model = atoi(valueParam[0].c_str());
+				model = stoi(valueParam[0]);
 				switch (model)
 				{
 				case GATEWAY_MODEL_MHSERVER:	// 2
@@ -1627,17 +1627,17 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 				int delta;
 				struct tm ltime, lnowtime;
 
-				timezone = atoi(valueParam[3].c_str());
+				timezone = stoi(valueParam[3]);
 				timezone = ((timezone > 99) ? -(timezone % 100) : (timezone % 100)); // 
 
 				memset(&ltime, 0, sizeof(ltime));
-				ltime.tm_hour = atoi(valueParam[0].c_str());  // hours since midnight - [0, 23]
-				ltime.tm_min = atoi(valueParam[1].c_str());   // minutes after the hour - [0, 59]
-				ltime.tm_sec = atoi(valueParam[2].c_str());   // seconds after the minute - [0, 60] including leap second
-				ltime.tm_wday = atoi(valueParam[4].c_str());  // days since Sunday - [0, 6]
-				ltime.tm_mday = atoi(valueParam[5].c_str());  // day of the month - [1, 31]
-				ltime.tm_mon = atoi(valueParam[6].c_str());   // months since January - [0, 11]
-				ltime.tm_year = atoi(valueParam[7].c_str());  // years since 1900	
+				ltime.tm_hour = stoi(valueParam[0]);  // hours since midnight - [0, 23]
+				ltime.tm_min = stoi(valueParam[1]);   // minutes after the hour - [0, 59]
+				ltime.tm_sec = stoi(valueParam[2]);   // seconds after the minute - [0, 60] including leap second
+				ltime.tm_wday = stoi(valueParam[4]);  // days since Sunday - [0, 6]
+				ltime.tm_mday = stoi(valueParam[5]);  // day of the month - [1, 31]
+				ltime.tm_mon = stoi(valueParam[6]);   // months since January - [0, 11]
+				ltime.tm_year = stoi(valueParam[7]);  // years since 1900	
 
 				Log(LOG_STATUS, "Gateway DateTime %02u/%02u/%04u - %02u:%02u:%02u GMT%c%u",
 														ltime.tm_mday, ltime.tm_mon, ltime.tm_year,
@@ -1698,11 +1698,11 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 		break;
 
 	case WHO_SOUND_DIFFUSION:						// 22
-		//iAppValue = atoi(what.c_str());
-		//iWhere = atoi(where.c_str());
+		//iAppValue = stoi(what);
+		//iWhere = stoi(where);
 		//devname = OPENWEBNET_SOUND_DIFFUSION;
 		//devname += " " + where;
-		//UpdateSoundDiffusion(WHO_SOUND_DIFFUSION, iWhere, iAppValue, atoi(sInterface.c_str()), 255, devname.c_str());
+		//UpdateSoundDiffusion(WHO_SOUND_DIFFUSION, iWhere, iAppValue, stoi(sInterface), 255, devname.c_str());
 		//break;
 
 	case WHO_SCENARIO:                              // 0

--- a/hardware/OpenWebNetTCP.cpp
+++ b/hardware/OpenWebNetTCP.cpp
@@ -1203,7 +1203,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 			switch (stoi(dimension))
 			{
 				case TEMPERATURE_CONTROL_DIMENSION_TEMPERATURE:				// 0
-					UpdateTemp(WHO_TEMPERATURE_CONTROL, stoi(where), stof(value) / 10.0F, stoi(sInterface), 255, devname.c_str());
+					UpdateTemp(WHO_TEMPERATURE_CONTROL, stoi(where), static_cast<float>(stod(value) / 10.0), stoi(sInterface), 255, devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_VALVES_STATUS:				// 19
 					devname += " Valves";
@@ -1215,7 +1215,7 @@ void COpenWebNetTCP::UpdateDeviceValue(std::vector<bt_openwebnet>::iterator iter
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_COMPLETE_PROBE_STATUS:		// 12
 					devname += " Setpoint";
-					UpdateSetPoint(WHO_TEMPERATURE_CONTROL, stoi(where), stof(value) / 10.0F, stoi(sInterface), devname.c_str());
+					UpdateSetPoint(WHO_TEMPERATURE_CONTROL, stoi(where), static_cast<float>(stod(value) / 10.0), stoi(sInterface), devname.c_str());
 					break;
 				case TEMPERATURE_CONTROL_DIMENSION_LOCAL_SET_OFFSET:			// 13
 				{

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -5051,7 +5051,7 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Decimal)
 						{
-							bRet = m_pManager->SetValue(vID, stod(ValueVal));
+							bRet = m_pManager->SetValue(vID, stof(ValueVal));
 						}
 						else
 						{

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -1018,7 +1018,7 @@ bool COpenZWave::OpenSerialConnector()
 		if (m_szSerialPort.size() < 4)
 			return false;
 		std::string szPort = m_szSerialPort.substr(3);
-		int iPort = atoi(szPort.c_str());
+		int iPort = stoi(szPort);
 		char szComm[15];
 		if (iPort < 10)
 			sprintf(szComm, "COM%d", iPort);
@@ -1681,7 +1681,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 				std::string strValue;
 				if (m_pManager->GetValueAsString(vID, &strValue) == true)
 				{
-					pNode->Application_version = (int)(atof(strValue.c_str()) * 100);
+					pNode->Application_version = (int)(stof(strValue) * 100.0F);
 				}
 			}
 			else
@@ -3680,12 +3680,12 @@ bool COpenZWave::NetworkInfo(const int hwID, std::vector< std::vector< int > >& 
 	int rowCnt = 0;
 	for (const auto &sd : result)
 	{
-		unsigned int _homeID = static_cast<unsigned int>(std::stoul(sd[0]));
+		unsigned int _homeID = static_cast<unsigned int>(stoul(sd[0]));
 
 		if (_homeID != m_controllerID)
 			continue;
 
-		uint8_t _nodeID = (uint8_t)atoi(sd[1].c_str());
+		uint8_t _nodeID = (uint8_t) stoi(sd[1]);
 		if (COpenZWave::NodeInfo * nodeInfo = GetNodeInfo(_homeID, _nodeID))
 		{
 			std::vector<int> row;
@@ -4271,7 +4271,7 @@ void COpenZWave::EnableDisableNodePolling(const uint8_t nodeID)
 		result = m_sql.safe_query("SELECT PollTime FROM ZWaveNodes WHERE (HardwareID==%d) AND (HomeID==%u) AND (NodeID==%d)", m_HwdID, m_controllerID, nodeID);
 		if (result.empty())
 			return;
-		int PollTime = atoi(result[0][0].c_str());
+		int PollTime = stoi(result[0][0]);
 
 		if (PollTime > 0)
 			EnableNodePoll(m_controllerID, nodeID, PollTime);
@@ -4858,7 +4858,7 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 		size_t vindex = 0;
 		while (vindex < results.size())
 		{
-			int rvIndex = atoi(results[vindex].c_str());
+			int rvIndex = stoi(results[vindex]);
 			std::string ValueVal = results[vindex + 1];
 			ValueVal = base64_decode(ValueVal);
 
@@ -4868,7 +4868,7 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 				if (rvIndex == 1)
 				{
 					//PollInterval
-					int intervalseconds = atoi(ValueVal.c_str());
+					int intervalseconds = stoi(ValueVal);
 					m_sql.UpdatePreferencesVar("ZWavePollInterval", intervalseconds);
 					EnableDisableNodePolling(nodeID);
 				}
@@ -4920,7 +4920,7 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 				else if (rvIndex == 5)
 				{
 					//RetryTimeout
-					int nValue = atoi(ValueVal.c_str());
+					int nValue = stoi(ValueVal);
 					int old_value = 3000;
 					m_sql.GetPreferencesVar("ZWaveRetryTimeout", old_value);
 					if (old_value != nValue)
@@ -5035,23 +5035,23 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Int)
 						{
-							bRet = m_pManager->SetValue(vID, atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, stoi(ValueVal));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_BitSet)
 						{
-							bRet = m_pManager->SetValue(vID, atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, stoi(ValueVal));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Byte)
 						{
-							bRet = m_pManager->SetValue(vID, (uint8)atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, (uint8) stoi(ValueVal));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Short)
 						{
-							bRet = m_pManager->SetValue(vID, (int16)atoi(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, (int16) stoi(ValueVal));
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Decimal)
 						{
-							bRet = m_pManager->SetValue(vID, (float)atof(ValueVal.c_str()));
+							bRet = m_pManager->SetValue(vID, stof(ValueVal));
 						}
 						else
 						{
@@ -5213,7 +5213,7 @@ void COpenZWave::UpdateDeviceBatteryStatus(const uint8_t nodeID, const int value
 			else
 			{
 				std::stringstream stream;
-				stream << std::setfill('0') << std::setw(4) << std::hex << atoi(DeviceID.c_str());
+				stream << std::setfill('0') << std::setw(4) << std::hex << stoi(DeviceID);
 				rdID = stream.str().substr(0, 2);
 			}
 		}
@@ -5247,7 +5247,7 @@ bool COpenZWave::GetBatteryLevels(Json::Value& root)
 	std::map<uint16_t, std::string> _NodeNames;
 	for (const auto &r : result)
 	{
-		uint16_t nodeID = (uint16_t)atoi(r[0].c_str());
+		uint16_t nodeID = (uint16_t) stoi(r[0]);
 		_NodeNames[nodeID] = r[1];
 	}
 
@@ -5333,7 +5333,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -5356,10 +5356,10 @@ namespace http {
 				int ii = 0;
 				for (const auto &sd : result)
 				{
-					unsigned int homeID = static_cast<unsigned int>(std::stoul(sd[1]));
+					unsigned int homeID = static_cast<unsigned int>(stoul(sd[1]));
 					if (homeID != pOZWHardware->GetControllerID())
 						continue;
-					uint8 nodeID = (uint8)atoi(sd[2].c_str());
+					uint8 nodeID = (uint8) stoi(sd[2]);
 					//if (nodeID>1) //Don't include the controller
 					{
 						COpenZWave::NodeInfo* pNode = pOZWHardware->GetNodeInfo(homeID, nodeID);
@@ -5370,7 +5370,7 @@ namespace http {
 						root["result"][ii]["NodeID"] = nodeID;
 						root["result"][ii]["Name"] = sd[3];
 						root["result"][ii]["Description"] = sd[4];
-						root["result"][ii]["PollEnabled"] = (atoi(sd[5].c_str()) == 1) ? "true" : "false";
+						root["result"][ii]["PollEnabled"] = (stoi(sd[5]) == 1) ? "true" : "false";
 						root["result"][ii]["Version"] = pNode->iVersion;
 						root["result"][ii]["Manufacturer_name"] = pNode->Manufacturer_name;
 						root["result"][ii]["Manufacturer_id"] = int_to_hex(pNode->Manufacturer_id);
@@ -5417,9 +5417,9 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "UpdateZWaveNode";
 
-			int hwid = atoi(result[0][0].c_str());
-			unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-			uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+			int hwid = stoi(result[0][0]);
+			unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+			uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(hwid);
 			if (pHardware == nullptr)
 				return; //not found!?
@@ -5447,9 +5447,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID=='%q')", idx.c_str());
 			if (result.empty())
 				return;
-			int hwid = atoi(result[0][0].c_str());
-			//unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-			uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+			int hwid = stoi(result[0][0]);
+			//unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+			uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 			if (pHardware == nullptr)
 				return;
@@ -5476,7 +5476,7 @@ namespace http {
 				return;
 			std::string ssecure = request::findValue(&req, "secure");
 			bool bSecure = (ssecure == "true");
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5500,7 +5500,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5517,7 +5517,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5540,7 +5540,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5562,7 +5562,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5592,7 +5592,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5616,7 +5616,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5638,7 +5638,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5654,7 +5654,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5677,7 +5677,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5703,7 +5703,7 @@ namespace http {
 			std::string node = request::findValue(&req, "node");
 			if (node.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware == nullptr)
 				return;
 			if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5711,7 +5711,7 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "ZWaveHealNode";
 			COpenZWave *pOZWHardware = (COpenZWave *)pHardware;
-			pOZWHardware->HealNode((uint8_t)atoi(node.c_str()));
+			pOZWHardware->HealNode((uint8_t) stoi(node));
 		}
 
 		void CWebServer::Cmd_ZWaveNetworkInfo(WebEmSession& session, const request& req, Json::Value& root)
@@ -5727,7 +5727,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			int hwID = atoi(idx.c_str());
+			int hwID = stoi(idx);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwID);
 			if (pHardware != nullptr)
 			{
@@ -5797,7 +5797,7 @@ namespace http {
 			std::string removenode = request::findValue(&req, "removenode");
 			if (removenode.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5805,7 +5805,7 @@ namespace http {
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				int nodeId = 0, instance = 0;
 				sscanf(removenode.c_str(), "%d.%d", &nodeId, &instance);
-				pOZWHardware->RemoveNodeFromGroup((uint8_t)atoi(node.c_str()), (uint8_t)atoi(group.c_str()), (uint8_t)nodeId, (uint8_t)instance);
+				pOZWHardware->RemoveNodeFromGroup((uint8_t) stoi(node), (uint8_t) stoi(group), (uint8_t)nodeId, (uint8_t)instance);
 				root["status"] = "OK";
 				root["title"] = "ZWaveRemoveGroupNode";
 			}
@@ -5831,7 +5831,7 @@ namespace http {
 			std::string addnode = request::findValue(&req, "addnode");
 			if (addnode.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5839,7 +5839,7 @@ namespace http {
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				int nodeId = 0, instance = 0;
 				sscanf(addnode.c_str(), "%d.%d", &nodeId, &instance);
-				pOZWHardware->AddNodeToGroup((uint8_t)atoi(node.c_str()), (uint8_t)atoi(group.c_str()), (uint8_t)nodeId, (uint8_t)instance);
+				pOZWHardware->AddNodeToGroup((uint8_t) stoi(node), (uint8_t) stoi(group), (uint8_t)nodeId, (uint8_t)instance);
 				root["status"] = "OK";
 				root["title"] = "ZWaveAddGroupNode";
 			}
@@ -5850,9 +5850,9 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			int iHardwareID = atoi(idx.c_str());
+			int iHardwareID = stoi(idx);
 
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5870,8 +5870,8 @@ namespace http {
 
 					for (const auto &sd : result)
 					{
-						unsigned int homeID = static_cast<unsigned int>(std::stoul(sd[1]));
-						uint8_t nodeID = (uint8_t)atoi(sd[2].c_str());
+						unsigned int homeID = static_cast<unsigned int>(stoul(sd[1]));
+						uint8_t nodeID = (uint8_t) stoi(sd[2]);
 						COpenZWave::NodeInfo* pNode = pOZWHardware->GetNodeInfo(homeID, nodeID);
 						if (pNode == nullptr)
 							continue;
@@ -5916,7 +5916,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -5944,9 +5944,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID=='%q')", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -5970,9 +5970,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID==%q)", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -5995,9 +5995,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID==%q)", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6020,9 +6020,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID==%q)", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6045,9 +6045,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID==%q)", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6072,7 +6072,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -6095,7 +6095,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -6118,7 +6118,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -6135,7 +6135,7 @@ namespace http {
 			if (idx.empty())
 				return;
 
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -6192,7 +6192,7 @@ namespace http {
 			std::string sNode = request::findValue(&values, "node");
 			if (sNode.empty())
 				return;
-			int iNode = atoi(sNode.c_str());
+			int iNode = stoi(sNode);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(m_ZW_Hwidx);
 			if (pHardware != nullptr)
 			{
@@ -6212,7 +6212,7 @@ namespace http {
 			std::string sNode = request::findValue(&values, "node");
 			if (sNode.empty())
 				return;
-			int iNode = atoi(sNode.c_str());
+			int iNode = stoi(sNode);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(m_ZW_Hwidx);
 			if (pHardware != nullptr)
 			{
@@ -6279,7 +6279,7 @@ namespace http {
 					return;
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				std::lock_guard<std::mutex> l(pOZWHardware->m_NotificationMutex);
-				reply::set_content(&rep, pOZWHardware->m_ozwcp.DoAdminCommand(sFun, atoi(sNode.c_str()), atoi(sButton.c_str())));
+				reply::set_content(&rep, pOZWHardware->m_ozwcp.DoAdminCommand(sFun, stoi(sNode), stoi(sButton)));
 			}
 		}
 		void CWebServer::ZWaveCPNodeChange(WebEmSession& /*session*/, const request& req, reply& rep)
@@ -6302,7 +6302,7 @@ namespace http {
 					return;
 				COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 				std::lock_guard<std::mutex> l(pOZWHardware->m_NotificationMutex);
-				reply::set_content(&rep, pOZWHardware->m_ozwcp.DoNodeChange(sFun, atoi(sNode.c_str()), sValue));
+				reply::set_content(&rep, pOZWHardware->m_ozwcp.DoNodeChange(sFun, stoi(sNode), sValue));
 			}
 		}
 		void CWebServer::ZWaveCPSetGroup(WebEmSession& /*session*/, const request& req, reply& rep)
@@ -6326,7 +6326,7 @@ namespace http {
 				{
 					COpenZWave* pOZWHardware = (COpenZWave*)pHardware;
 					std::lock_guard<std::mutex> l(pOZWHardware->m_NotificationMutex);
-					reply::set_content(&rep, pOZWHardware->m_ozwcp.UpdateGroup(sFun, atoi(sNode.c_str()), atoi(sGroup.c_str()), glist));
+					reply::set_content(&rep, pOZWHardware->m_ozwcp.UpdateGroup(sFun, stoi(sNode), stoi(sGroup), glist));
 				}
 			}
 		}
@@ -6384,8 +6384,8 @@ namespace http {
 				std::string sNum = request::findValue(&values, "num");
 				std::string sArg = request::findValue(&values, "cnt");
 
-				int node = atoi(sNum.c_str());
-				int cnt = atoi(sArg.c_str());
+				int node = stoi(sNum);
+				int cnt = stoi(sArg);
 
 				reply::set_content(&rep, pOZWHardware->m_ozwcp.DoTestNetwork(node, cnt));
 				reply::add_header_attachment(&rep, "testheal.xml");
@@ -6395,7 +6395,7 @@ namespace http {
 				std::string sNum = request::findValue(&values, "num");
 				std::string sHealRRS = request::findValue(&values, "healrrs");
 
-				int node = atoi(sNum.c_str());
+				int node = stoi(sNum);
 				bool healrrs = !sHealRRS.empty();
 
 				reply::set_content(&rep, pOZWHardware->m_ozwcp.HealNetworkNode(node, healrrs));
@@ -6414,7 +6414,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)
@@ -6438,15 +6438,15 @@ namespace http {
 			std::string scodeindex = request::findValue(&req, "codeindex");
 			if (idx.empty() || scodeindex.empty())
 				return;
-			int iCodeIndex = atoi(scodeindex.c_str());
+			int iCodeIndex = stoi(scodeindex);
 
 			std::vector<std::vector<std::string> > result;
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID=='%q')", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6471,9 +6471,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID,HomeID,NodeID from ZWaveNodes WHERE (ID==%q)", idx.c_str());
 			if (!result.empty())
 			{
-				int hwid = atoi(result[0][0].c_str());
-				unsigned int homeID = static_cast<unsigned int>(std::stoul(result[0][1]));
-				uint8_t nodeID = (uint8_t)atoi(result[0][2].c_str());
+				int hwid = stoi(result[0][0]);
+				unsigned int homeID = static_cast<unsigned int>(stoul(result[0][1]));
+				uint8_t nodeID = (uint8_t) stoi(result[0][2]);
 				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(hwid);
 				if (pHardware != nullptr)
 				{
@@ -6494,7 +6494,7 @@ namespace http {
 			if (idx.empty())
 				return;
 
-			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 			if (pHardware != nullptr)
 			{
 				if (pHardware->HwdType != HTYPE_OpenZWave)

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -1512,8 +1512,8 @@ bool COpenZWave::SwitchColor(const uint8_t nodeID, const uint8_t instanceID, con
 							//Zipato Bulb2 does not support cold white and warm white at the same time
 							std::stringstream sstr;
 							std::string RGB = OutColorStr.substr(0, 7);
-							unsigned wWhite = strtoul(OutColorStr.substr(7, 2).c_str(), nullptr, 16);
-							unsigned cWhite = strtoul(OutColorStr.substr(9, 2).c_str(), nullptr, 16);
+							unsigned wWhite = stoul(OutColorStr.substr(7, 2), nullptr, 16);
+							unsigned cWhite = stoul(OutColorStr.substr(9, 2), nullptr, 16);
 							if (wWhite > cWhite)
 							{
 								wWhite = wWhite + cWhite;

--- a/hardware/OpenZWave.cpp
+++ b/hardware/OpenZWave.cpp
@@ -1681,7 +1681,7 @@ void COpenZWave::AddValue(NodeInfo* pNode, const OpenZWave::ValueID& vID)
 				std::string strValue;
 				if (m_pManager->GetValueAsString(vID, &strValue) == true)
 				{
-					pNode->Application_version = (int)(stof(strValue) * 100.0F);
+					pNode->Application_version = static_cast<int>(stod(strValue) * 100.0);
 				}
 			}
 			else
@@ -5051,7 +5051,7 @@ bool COpenZWave::ApplyNodeConfig(const unsigned int homeID, const uint8_t nodeID
 						}
 						else if (vType == OpenZWave::ValueID::ValueType_Decimal)
 						{
-							bRet = m_pManager->SetValue(vID, stof(ValueVal));
+							bRet = m_pManager->SetValue(vID, stod(ValueVal));
 						}
 						else
 						{

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -1017,7 +1017,7 @@ bool P1MeterBase::CheckCRC()
 	char crc_str[5];
 	strncpy(crc_str, l_buffer + 1, 4);
 	crc_str[4] = 0;
-	uint16_t m_crc16 = (uint16_t)strtoul(crc_str, nullptr, 16);
+	uint16_t m_crc16 = (uint16_t) strtoul(crc_str, nullptr, 16);
 
 	// calculate CRC
 	uint16_t crc = 0;

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -720,14 +720,14 @@ bool P1MeterBase::MatchLine()
 					* Electricity meter 02h
 					* Gas meter 03h
 					* Heat meter 04h
-					* Warm water meter (30�C ... 90�C) 06h
+					* Warm water meter (30°C ... 90°C) 06h
 					* Water meter 07h
 					* Heat Cost Allocator 08h
 					* Cooling meter (Volume measured at return temperature: outlet) 0Ah
 					* Cooling meter (Volume measured at flow temperature: inlet) 0Bh
 					* Heat meter (Volume measured at flow temperature: inlet) 0Ch
 					* Combined Heat / Cooling meter 0Dh
-					* Hot water meter (= 90�C) 15h
+					* Hot water meter (= 90°C) 15h
 					* Cold water meter a 16h
 					* Breaker (electricity) 20h
 					* Valve (gas or water) 21h

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -766,7 +766,7 @@ bool P1MeterBase::MatchLine()
 					m_p1_mbus_channel = l_buffer[2];
 					break;
 				case P1TYPE_POWERUSAGE:
-					temp_usage = (unsigned long)(stof(sValue) * 1000.0F);
+					temp_usage = static_cast<unsigned long>(stod(sValue) * 1000.0);
 					if ((l_buffer[8] & 0xFE) == 0x30)
 					{
 						// map tariff IDs 0 (Lux) and 1 (Bel, Nld) both to powerusage1
@@ -784,7 +784,7 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_POWERDELIV:
-					temp_usage = (unsigned long)(stof(sValue) * 1000.0F);
+					temp_usage = static_cast<unsigned long>(stod(sValue) * 1000.0);
 					if ((l_buffer[8] & 0xFE) == 0x30)
 					{
 						// map tariff IDs 0 (Lux) and 1 (Bel, Nld) both to powerdeliv1
@@ -802,12 +802,12 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_USAGECURRENT:
-					temp_usage = (unsigned long)(stof(sValue) * 1000.0F); // Watt
+					temp_usage = static_cast<unsigned long>(stod(sValue) * 1000.0); // Watt
 					if (temp_usage < P1MAXTOTALPOWER)
 						m_power.usagecurrent = temp_usage;
 					break;
 				case P1TYPE_DELIVCURRENT:
-					temp_usage = (unsigned long)(stof(sValue) * 1000.0F); // Watt;
+					temp_usage = static_cast<unsigned long>(stod(sValue) * 1000.0); // Watt;
 					if (temp_usage < P1MAXTOTALPOWER)
 						m_power.delivcurrent = temp_usage;
 					break;
@@ -875,32 +875,32 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_POWERUSEL1:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel1 = temp_power; //Power Used L1;
 					break;
 				case P1TYPE_POWERUSEL2:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel2 = temp_power; //Power Used L2;
 					break;
 				case P1TYPE_POWERUSEL3:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel3 = temp_power; //Power Used L3;
 					break;
 				case P1TYPE_POWERDELL1:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell1 = temp_power; //Power Used L1;
 					break;
 				case P1TYPE_POWERDELL2:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell2 = temp_power; //Power Used L2;
 					break;
 				case P1TYPE_POWERDELL3:
-					temp_power = stof(sValue) * 1000.0F;
+					temp_power = static_cast<float>(stod(sValue) * 1000.0);
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell3 = temp_power; //Power Used L3;
 					break;

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -249,31 +249,31 @@ void P1MeterBase::Init()
 	std::string tmpval;
 	tmpval = GetTextSensorText(0, 7, bExists);
 	if (bExists)
-		m_last_nbr_pwr_failures = std::stoi(tmpval);
+		m_last_nbr_pwr_failures = stoi(tmpval);
 
 	tmpval = GetTextSensorText(0, 8, bExists);
 	if (bExists)
-		m_last_nbr_long_pwr_failures = std::stoi(tmpval);
+		m_last_nbr_long_pwr_failures = stoi(tmpval);
 
 	tmpval = GetTextSensorText(0, 9, bExists);
 	if (bExists)
-		m_last_nbr_volt_sags_l1 = std::stoi(tmpval);
+		m_last_nbr_volt_sags_l1 = stoi(tmpval);
 	tmpval = GetTextSensorText(0, 10, bExists);
 	if (bExists)
-		m_last_nbr_volt_sags_l2 = std::stoi(tmpval);
+		m_last_nbr_volt_sags_l2 = stoi(tmpval);
 	tmpval = GetTextSensorText(0, 11, bExists);
 	if (bExists)
-		m_last_nbr_volt_sags_l3 = std::stoi(tmpval);
+		m_last_nbr_volt_sags_l3 = stoi(tmpval);
 
 	tmpval = GetTextSensorText(0, 12, bExists);
 	if (bExists)
-		m_last_nbr_volt_swells_l1 = std::stoi(tmpval);
+		m_last_nbr_volt_swells_l1 = stoi(tmpval);
 	tmpval = GetTextSensorText(0, 13, bExists);
 	if (bExists)
-		m_last_nbr_volt_swells_l2 = std::stoi(tmpval);
+		m_last_nbr_volt_swells_l2 = stoi(tmpval);
 	tmpval = GetTextSensorText(0, 14, bExists);
 	if (bExists)
-		m_last_nbr_volt_swells_l3 = std::stoi(tmpval);
+		m_last_nbr_volt_swells_l3 = stoi(tmpval);
 
 	m_voltagel1 = -1;
 	m_voltagel2 = -1;
@@ -596,12 +596,12 @@ bool P1MeterBase::MatchLine()
 							else // gas clock is ahead
 							{
 								struct tm gastm;
-								gastm.tm_year = atoi(m_gastimestamp.substr(0, 2).c_str()) + 100;
-								gastm.tm_mon = atoi(m_gastimestamp.substr(2, 2).c_str()) - 1;
-								gastm.tm_mday = atoi(m_gastimestamp.substr(4, 2).c_str());
-								gastm.tm_hour = atoi(m_gastimestamp.substr(6, 2).c_str());
-								gastm.tm_min = atoi(m_gastimestamp.substr(8, 2).c_str());
-								gastm.tm_sec = atoi(m_gastimestamp.substr(10, 2).c_str());
+								gastm.tm_year = stoi(m_gastimestamp.substr(0, 2)) + 100;
+								gastm.tm_mon = stoi(m_gastimestamp.substr(2, 2)) - 1;
+								gastm.tm_mday = stoi(m_gastimestamp.substr(4, 2));
+								gastm.tm_hour = stoi(m_gastimestamp.substr(6, 2));
+								gastm.tm_min = stoi(m_gastimestamp.substr(8, 2));
+								gastm.tm_sec = stoi(m_gastimestamp.substr(10, 2));
 								if (m_gastimestamp.length() == 12)
 									gastm.tm_isdst = -1;
 								else if (m_gastimestamp[12] == 'W')
@@ -713,21 +713,21 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_MBUSDEVICETYPE:
-					mbus_type = (P1MBusType)std::stoul(sValue);
+					mbus_type = (P1MBusType) stoul(sValue);
 					mbus_channel = l_buffer[2];
 					//Open Metering System Specification 4.3.3 table 2 (Device Types of OMS-Meter)
 					/*
 					* Electricity meter 02h
 					* Gas meter 03h
 					* Heat meter 04h
-					* Warm water meter (30°C ... 90°C) 06h
+					* Warm water meter (30ï¿½C ... 90ï¿½C) 06h
 					* Water meter 07h
 					* Heat Cost Allocator 08h
 					* Cooling meter (Volume measured at return temperature: outlet) 0Ah
 					* Cooling meter (Volume measured at flow temperature: inlet) 0Bh
 					* Heat meter (Volume measured at flow temperature: inlet) 0Ch
 					* Combined Heat / Cooling meter 0Dh
-					* Hot water meter (= 90°C) 15h
+					* Hot water meter (= 90ï¿½C) 15h
 					* Cold water meter a 16h
 					* Breaker (electricity) 20h
 					* Valve (gas or water) 21h
@@ -766,7 +766,7 @@ bool P1MeterBase::MatchLine()
 					m_p1_mbus_channel = l_buffer[2];
 					break;
 				case P1TYPE_POWERUSAGE:
-					temp_usage = (unsigned long)(std::stof(sValue) * 1000.0F);
+					temp_usage = (unsigned long)(stof(sValue) * 1000.0F);
 					if ((l_buffer[8] & 0xFE) == 0x30)
 					{
 						// map tariff IDs 0 (Lux) and 1 (Bel, Nld) both to powerusage1
@@ -784,7 +784,7 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_POWERDELIV:
-					temp_usage = (unsigned long)(std::stof(sValue) * 1000.0F);
+					temp_usage = (unsigned long)(stof(sValue) * 1000.0F);
 					if ((l_buffer[8] & 0xFE) == 0x30)
 					{
 						// map tariff IDs 0 (Lux) and 1 (Bel, Nld) both to powerdeliv1
@@ -802,56 +802,56 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_USAGECURRENT:
-					temp_usage = (unsigned long)(std::stof(sValue) * 1000.0F); // Watt
+					temp_usage = (unsigned long)(stof(sValue) * 1000.0F); // Watt
 					if (temp_usage < P1MAXTOTALPOWER)
 						m_power.usagecurrent = temp_usage;
 					break;
 				case P1TYPE_DELIVCURRENT:
-					temp_usage = (unsigned long)(std::stof(sValue) * 1000.0F); // Watt;
+					temp_usage = (unsigned long)(stof(sValue) * 1000.0F); // Watt;
 					if (temp_usage < P1MAXTOTALPOWER)
 						m_power.delivcurrent = temp_usage;
 					break;
 				case P1TYPE_NUMPWRFAIL:
-					m_nbr_pwr_failures = std::stoi(sValue);
+					m_nbr_pwr_failures = stoi(sValue);
 					break;
 				case P1TYPE_NUMLONGPWRFAIL:
-					m_nbr_long_pwr_failures = std::stoi(sValue);
+					m_nbr_long_pwr_failures = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSAGSL1:
-					m_nbr_volt_sags_l1 = std::stoi(sValue);
+					m_nbr_volt_sags_l1 = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSAGSL2:
-					m_nbr_volt_sags_l2 = std::stoi(sValue);
+					m_nbr_volt_sags_l2 = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSAGSL3:
-					m_nbr_volt_sags_l3 = std::stoi(sValue);
+					m_nbr_volt_sags_l3 = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSWELLSL1:
-					m_nbr_volt_swells_l1 = std::stoi(sValue);
+					m_nbr_volt_swells_l1 = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSWELLSL2:
-					m_nbr_volt_swells_l2 = std::stoi(sValue);
+					m_nbr_volt_swells_l2 = stoi(sValue);
 					break;
 				case P1TYPE_NUMVOLTSWELLSL3:
-					m_nbr_volt_swells_l3 = std::stoi(sValue);
+					m_nbr_volt_swells_l3 = stoi(sValue);
 					break;
 				case P1TYPE_VOLTAGEL1:
-					temp_volt = std::stof(sValue);
+					temp_volt = stof(sValue);
 					if (temp_volt < 300)
 						m_voltagel1 = temp_volt; //Voltage L1;
 					break;
 				case P1TYPE_VOLTAGEL2:
-					temp_volt = std::stof(sValue);
+					temp_volt = stof(sValue);
 					if (temp_volt < 300)
 						m_voltagel2 = temp_volt; //Voltage L2;
 					break;
 				case P1TYPE_VOLTAGEL3:
-					temp_volt = std::stof(sValue);
+					temp_volt = stof(sValue);
 					if (temp_volt < 300)
 						m_voltagel3 = temp_volt; //Voltage L3;
 					break;
 				case P1TYPE_AMPERAGEL1:
-					temp_ampere = std::stof(sValue);
+					temp_ampere = stof(sValue);
 					if (temp_ampere < 100)
 					{
 						m_amperagel1 = temp_ampere; //Amperage L1;
@@ -859,7 +859,7 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_AMPERAGEL2:
-					temp_ampere = std::stof(sValue);
+					temp_ampere = stof(sValue);
 					if (temp_ampere < 100)
 					{
 						m_amperagel2 = temp_ampere; //Amperage L2;
@@ -867,7 +867,7 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_AMPERAGEL3:
-					temp_ampere = std::stof(sValue);
+					temp_ampere = stof(sValue);
 					if (temp_ampere < 100)
 					{
 						m_amperagel3 = temp_ampere; //Amperage L3;
@@ -875,32 +875,32 @@ bool P1MeterBase::MatchLine()
 					}
 					break;
 				case P1TYPE_POWERUSEL1:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel1 = temp_power; //Power Used L1;
 					break;
 				case P1TYPE_POWERUSEL2:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel2 = temp_power; //Power Used L2;
 					break;
 				case P1TYPE_POWERUSEL3:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerusel3 = temp_power; //Power Used L3;
 					break;
 				case P1TYPE_POWERDELL1:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell1 = temp_power; //Power Used L1;
 					break;
 				case P1TYPE_POWERDELL2:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell2 = temp_power; //Power Used L2;
 					break;
 				case P1TYPE_POWERDELL3:
-					temp_power = std::stof(sValue) * 1000.0F;
+					temp_power = stof(sValue) * 1000.0F;
 					if (temp_power < P1MAXPHASEPOWER)
 						m_powerdell3 = temp_power; //Power Used L3;
 					break;
@@ -909,7 +909,7 @@ bool P1MeterBase::MatchLine()
 					break;
 				case P1TYPE_GASUSAGE:
 				case P1TYPE_MBUSUSAGEDSMR4:
-					temp_float = std::stof(sValue);
+					temp_float = stof(sValue);
 					temp_usage = (unsigned long)(temp_float * 1000.0F);
 
 					if (

--- a/hardware/PVOutput_Input.cpp
+++ b/hardware/PVOutput_Input.cpp
@@ -132,7 +132,7 @@ void CPVOutputInput::GetMeterDetails()
 	double Usage = 0;
 	if (splitresult[3] != "NaN")
 	{
-		Usage = atof(splitresult[3].c_str());
+		Usage = stod(splitresult[3]);
 	}
 	if (Usage < 0)
 		Usage = 0;
@@ -140,7 +140,7 @@ void CPVOutputInput::GetMeterDetails()
 	double Consumption = 0;
 	if (splitresult[5] != "NaN")
 	{
-		Consumption = atof(splitresult[5].c_str());
+		Consumption = stod(splitresult[5]);
 		if (Consumption < 0)
 			Consumption = 0;
 		m_bHadConsumption = true;
@@ -148,19 +148,19 @@ void CPVOutputInput::GetMeterDetails()
 
 	if (splitresult[6] != "NaN")
 	{
-		double Efficiency = atof(splitresult[6].c_str()) * 100.0;
+		double Efficiency = stod(splitresult[6]) * 100.0;
 		if (Efficiency > 100.0)
 			Efficiency = 100.0;
 		SendPercentageSensor(1, 0, 255, float(Efficiency), "Efficiency");
 	}
 	if (splitresult[7] != "NaN")
 	{
-		double Temperature = atof(splitresult[7].c_str());
+		double Temperature = stod(splitresult[7]);
 		SendTempSensor(1, 255, float(Temperature), "Temperature");
 	}
 	if (splitresult[8] != "NaN")
 	{
-		double Voltage = atof(splitresult[8].c_str());
+		double Voltage = stod(splitresult[8]);
 		if (Voltage >= 0)
 			SendVoltageSensor(0, 1, 255, float(Voltage), "Voltage");
 	}
@@ -206,7 +206,7 @@ void CPVOutputInput::GetMeterDetails()
 	double kWhCounterUsage = 0;
 	if (splitresult[0] != "NaN")
 	{
-		kWhCounterUsage = atof(splitresult[0].c_str());
+		kWhCounterUsage = stod(splitresult[0]);
 	}
 	SendKwhMeter(0, 1, 255, Usage, kWhCounterUsage / 1000.0, "SolarMain");
 
@@ -217,7 +217,7 @@ void CPVOutputInput::GetMeterDetails()
 			double kWhCounterConsumed = 0;
 			if (splitresult[11] != "NaN")
 			{
-				kWhCounterConsumed = atof(splitresult[11].c_str());
+				kWhCounterConsumed = stod(splitresult[11]);
 			}
 			
 			if (kWhCounterConsumed != 0)

--- a/hardware/PanasonicTV.cpp
+++ b/hardware/PanasonicTV.cpp
@@ -250,7 +250,7 @@ CPanasonicNode::CPanasonicNode(const int pHwdID, const int PollIntervalsec, cons
 	m_PowerOnSupported = false;
 
 	m_HwdID = pHwdID;
-	m_DevID = atoi(pID.c_str());
+	m_DevID = stoi(pID);
 	sprintf(m_szDevID, "%X%02X%02X%02X", 0, 0, (m_DevID & 0xFF00) >> 8, m_DevID & 0xFF);
 	m_Name = pName;
 	m_IP = pIP;
@@ -263,8 +263,8 @@ CPanasonicNode::CPanasonicNode(const int pHwdID, const int PollIntervalsec, cons
 	result2 = m_sql.safe_query("SELECT ID,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == 1)", m_HwdID, m_szDevID);
 	if (result2.size() == 1)
 	{
-		m_ID = atoi(result2[0][0].c_str());
-		m_PreviousStatus.Status((_eMediaStatus)atoi(result2[0][1].c_str()));
+		m_ID = stoi(result2[0][0]);
+		m_PreviousStatus.Status((_eMediaStatus) stoi(result2[0][1]));
 		m_PreviousStatus.Status(result2[0][2]);
 	}
 	m_CurrentStatus = m_PreviousStatus;
@@ -456,7 +456,7 @@ int CPanasonicNode::handleMessage(const std::string& pMessage)
 			std::string sFound = pMessage.substr(iPosBegin + 1, ((iPosEnd - iPosBegin) - 1));
 			if (is_number(sFound))
 			{
-				return atoi(sFound.c_str());
+				return stoi(sFound);
 			}
 		}
 		iPosBegin++;
@@ -1002,7 +1002,7 @@ void CPanasonic::AddNode(const std::string& Name, const std::string& IPAddress, 
 	if (result.empty())
 		return;
 
-	int ID = atoi(result[0][0].c_str());
+	int ID = stoi(result[0][0]);
 
 	char szID[40];
 	sprintf(szID, "%X%02X%02X%02X", 0, 0, (ID & 0xFF00) >> 8, ID & 0xFF);
@@ -1149,7 +1149,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -1169,7 +1169,7 @@ namespace http {
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["IP"] = sd[2];
-					root["result"][ii]["Port"] = atoi(sd[3].c_str());
+					root["result"][ii]["Port"] = stoi(sd[3]);
 					ii++;
 				}
 			}
@@ -1190,7 +1190,7 @@ namespace http {
 			std::string extra = request::findValue(&req, "extra");
 			if ((hwid.empty()) || (mode1.empty()) || (mode2.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1201,9 +1201,9 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "PanasonicSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
-			int iMode3 = atoi(mode3.c_str());
+			int iMode1 = stoi(mode1);
+			int iMode2 = stoi(mode2);
+			int iMode3 = stoi(mode3);
 
 			m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d, Mode3=%d, Extra='%s' WHERE (ID == '%q')", iMode1, iMode2, iMode3, extra.c_str(), hwid.c_str());
 
@@ -1223,10 +1223,10 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Port = atoi(request::findValue(&req, "port").c_str());
+			int Port = stoi(request::findValue(&req, "port"));
 			if ((hwid.empty()) || (name.empty()) || (ip.empty()) || (Port == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1251,10 +1251,10 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Port = atoi(request::findValue(&req, "port").c_str());
+			int Port = stoi(request::findValue(&req, "port"));
 			if ((hwid.empty()) || (nodeid.empty()) || (name.empty()) || (ip.empty()) || (Port == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1262,7 +1262,7 @@ namespace http {
 				return;
 			CPanasonic* pHardware = dynamic_cast<CPanasonic*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "PanasonicUpdateNode";
 			pHardware->UpdateNode(NodeID, name, ip, Port);
@@ -1280,7 +1280,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1288,7 +1288,7 @@ namespace http {
 				return;
 			CPanasonic* pHardware = dynamic_cast<CPanasonic*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "PanasonicRemoveNode";
 			pHardware->RemoveNode(NodeID);
@@ -1305,7 +1305,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -1324,7 +1324,7 @@ namespace http {
 			std::string sAction = request::findValue(&req, "action");
 			if (sIdx.empty())
 				return;
-			int idx = atoi(sIdx.c_str());
+			int idx = stoi(sIdx);
 			root["status"] = "OK";
 			root["title"] = "PanasonicMediaCommand";
 
@@ -1332,9 +1332,9 @@ namespace http {
 			result = m_sql.safe_query("SELECT DS.SwitchType, H.Type, H.ID FROM DeviceStatus DS, Hardware H WHERE (DS.ID=='%q') AND (DS.HardwareID == H.ID)", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				_eSwitchType	sType = (_eSwitchType)atoi(result[0][0].c_str());
-				_eHardwareTypes	hType = (_eHardwareTypes)atoi(result[0][1].c_str());
-				int HwID = atoi(result[0][2].c_str());
+				_eSwitchType	sType = (_eSwitchType) stoi(result[0][0]);
+				_eHardwareTypes	hType = (_eHardwareTypes) stoi(result[0][1]);
+				int HwID = stoi(result[0][2]);
 				// Is the device a media Player?
 				if (sType == STYPE_Media)
 				{

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -526,10 +526,10 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		{
 			//Already in the system
 			//Update state
-			int nvalue = atoi(result[0][0].c_str());
-			unsigned sTypeOld = atoi(result[0][3].c_str());
+			int nvalue = stoi(result[0][0]);
+			unsigned sTypeOld = (unsigned) stoul(result[0][3]);
 			std::string sID = result[0][4];
-			bool bUsed = std::stoi(result[0][5]) != 0;
+			bool bUsed = stoi(result[0][5]) != 0;
 			std::string curName = result[0][6];
 			if (!bUsed)
 			{
@@ -614,9 +614,9 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 		if (!result.empty())
 		{
 			//Already in the system
-			int nvalue = atoi(result[0][0].c_str());
+			int nvalue = stoi(result[0][0]);
 			std::string sID = result[0][1];
-			bool bUsed = std::stoi(result[0][2]) != 0;
+			bool bUsed = stoi(result[0][2]) != 0;
 			std::string curName = result[0][3];
 			if (!bUsed)
 			{
@@ -669,7 +669,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 			//Already in the system
 
 			std::string sID = result[0][2];
-			bool bUsed = std::stoi(result[0][3]) != 0;
+			bool bUsed = stoi(result[0][3]) != 0;
 			std::string curName = result[0][4];
 
 			if (!bUsed)
@@ -683,7 +683,7 @@ void CPhilipsHue::InsertUpdateLamp(const int NodeID, const _eHueLightType LType,
 			}
 
 			//Update state
-			int nvalue = atoi(result[0][0].c_str());
+			int nvalue = stoi(result[0][0]);
 		}
 		else
 		{
@@ -861,7 +861,7 @@ bool CPhilipsHue::GetLights(const Json::Value& root)
 		Json::Value light = *iLight;
 		if (light.isObject())
 		{
-			int lID = atoi(iLight.key().asString().c_str());
+			int lID = stoi(iLight.key().asString());
 
 			_tHueLightState tlight;
 			_eHueLightType LType;
@@ -899,7 +899,7 @@ bool CPhilipsHue::GetGroups(const Json::Value& root)
 		Json::Value group = *iGroup;
 		if (group.isObject())
 		{
-			int gID = atoi(iGroup.key().asString().c_str());
+			int gID = stoi(iGroup.key().asString());
 
 			_tHueLightState tstate;
 			_eHueLightType LType;
@@ -1044,7 +1044,7 @@ bool CPhilipsHue::GetScenes(const Json::Value& root)
 				if (!result.empty())
 				{
 					//existing scene
-					sID = atoi(result[0][0].c_str());
+					sID = stoi(result[0][0]);
 				}
 				else
 				{
@@ -1056,7 +1056,7 @@ bool CPhilipsHue::GetScenes(const Json::Value& root)
 						Log(LOG_ERROR, "Problem adding new Scene!!");
 						return false;
 					}
-					sID = atoi(result[0][0].c_str());
+					sID = stoi(result[0][0]);
 				}
 				std::string Name = "Scene " + hscene.name;
 				_tHueLightState tstate;
@@ -1086,7 +1086,7 @@ bool CPhilipsHue::GetSensors(const Json::Value& root)
 		if (sensor.isObject())
 		{
 			bool bNewSensor = false;
-			int sID = atoi(iSensor.key().asString().c_str());
+			int sID = stoi(iSensor.key().asString());
 
 			CPHSensor current_sensor(sensor);
 			CPHSensor previous_sensor;
@@ -1239,7 +1239,7 @@ void CPhilipsHue::SetSwitchOptions(const int NodeID, const uint8_t Unitcode, con
 	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%08X') AND (Unit == '%d')", m_HwdID, NodeID, Unitcode);
 	if (!result.empty())
 	{
-		int sIdx = std::stoi(result[0][0]);
+		int sIdx = stoi(result[0][0]);
 		m_sql.SetDeviceOptions(sIdx, options);
 	}
 }
@@ -1263,7 +1263,7 @@ namespace http {
 			if ((sipaddress.empty()) || (sport.empty()))
 				return;
 
-			std::string sresult = CPhilipsHue::RegisterUser(sipaddress, (unsigned short)atoi(sport.c_str()), susername);
+			std::string sresult = CPhilipsHue::RegisterUser(sipaddress, (unsigned short) stoi(sport), susername);
 			std::vector<std::string> strarray;
 			StringSplit(sresult, ";", strarray);
 			if (strarray.size() != 2)

--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -207,7 +207,7 @@ int CPiFace::LoadConfig()
 				EndPos = GetParameterString(Line, ".", StartPos, Parameter);
 				if (EndPos >= 0)
 				{
-					Address = (unsigned char)(strtol(Parameter.c_str(), nullptr, 0) & 0xFF); // data can be restricted further but as we check later on keep it wide for
+					Address = (unsigned char) (stol(Parameter, nullptr, 0) & 0xFF); // data can be restricted further but as we check later on keep it wide for
 					// future use.
 					StartPos = EndPos;
 				}
@@ -234,7 +234,7 @@ int CPiFace::LoadConfig()
 				EndPos = GetParameterString(Line, ".", StartPos, Parameter);
 				if (EndPos >= 0)
 				{
-					PinNumber = (unsigned char)(strtol(Parameter.c_str(), nullptr, 0) & 0xFF); // data can be restricted further but as we check later on keep it wide for
+					PinNumber = (unsigned char) (stol(Parameter, nullptr, 0) & 0xFF); // data can be restricted further but as we check later on keep it wide for
 					// future use.
 					StartPos = EndPos;
 				}
@@ -351,7 +351,7 @@ int CPiFace::LoadConfig()
 						// count_update_interval(_s)(ec)
 						unsigned long UpdateInterval;
 
-						UpdateInterval = strtol(Parametervalue.c_str(), nullptr, 0);
+						UpdateInterval = stoul(Parametervalue, nullptr, 0);
 						IOport->Pin[PinNumber].Count.SetUpdateInterval(UpdateInterval * 1000);
 						result++;
 						break;
@@ -360,7 +360,7 @@ int CPiFace::LoadConfig()
 						// count_update_interval_diff_perc
 						unsigned long UpdateIntervalPerc;
 
-						UpdateIntervalPerc = strtol(Parametervalue.c_str(), nullptr, 0);
+						UpdateIntervalPerc = stoul(Parametervalue, nullptr, 0);
 						if (UpdateIntervalPerc < 1 || UpdateIntervalPerc > 1000)
 						{
 							Log(LOG_ERROR, "Error config file: invalid value %s found", Parametervalue.c_str());
@@ -375,7 +375,7 @@ int CPiFace::LoadConfig()
 						//count_initial_value
 						unsigned long StartValue;
 
-						StartValue = strtol(Parametervalue.c_str(), nullptr, 0);
+						StartValue = stoul(Parametervalue, nullptr, 0);
 						IOport->Pin[PinNumber].Count.SetTotal(StartValue);
 						result++;
 						Regenerate_Config = true;
@@ -385,7 +385,7 @@ int CPiFace::LoadConfig()
 						//count_minimum_pulse_period_msec
 						unsigned long Min_Pulse_Period;
 
-						Min_Pulse_Period = strtol(Parametervalue.c_str(), nullptr, 0); // results in 0 if str is invalid
+						Min_Pulse_Period = stoul(Parametervalue, nullptr, 0); // results in 0 if str is invalid
 						IOport->Pin[PinNumber].Count.SetRateLimit(Min_Pulse_Period);
 						result++;
 						break;
@@ -416,7 +416,7 @@ int CPiFace::LoadConfig()
 
 					case 12:
 						// count_divider
-						IOport->Pin[PinNumber].Count.SetDivider(strtol(Parametervalue.c_str(), nullptr, 0));
+						IOport->Pin[PinNumber].Count.SetDivider(stoul(Parametervalue, nullptr, 0));
 						result++;
 						break;
 					}

--- a/hardware/PiFace.cpp
+++ b/hardware/PiFace.cpp
@@ -1357,7 +1357,7 @@ void CIOPort::Init(bool Available, int hwdId, int devId /* 0 - 4 */, unsigned ch
 			result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID=%d AND Type=%d AND DeviceID='%d')", hwdId, int(pTypeRFXMeter), meterid);
 			if (result.size() == 1)
 			{
-				value = atol(result[0][0].c_str());
+				value = stoul(result[0][0]);
 				found = true;
 			}
 			break;
@@ -1378,12 +1378,14 @@ void CIOPort::Init(bool Available, int hwdId, int devId /* 0 - 4 */, unsigned ch
 				double dValue = 0;
 				if (resultparts.size() == 1)
 				{
-					dValue = atol(resultparts[0].c_str()) / (1000. / Pin[PinNr].Count.GetDivider());
+					// FIXME: use stod instead of stol ?
+					dValue = stol(resultparts[0]) / (1000.0 / Pin[PinNr].Count.GetDivider());
 					found = true;
 				}
 				else if (resultparts.size() == 2)
 				{
-					dValue = atol(resultparts[1].c_str()) / (1000. / Pin[PinNr].Count.GetDivider());
+					// FIXME: use stod instead of stol ?
+					dValue = stol(resultparts[1]) / (1000.0 / Pin[PinNr].Count.GetDivider());
 					found = true;
 				}
 				value = (unsigned long)dValue;

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -244,7 +244,7 @@ void CPinger::AddNode(const std::string &Name, const std::string &IPAddress, con
 	if (result.empty())
 		return;
 
-	int ID = atoi(result[0][0].c_str());
+	int ID = stoi(result[0][0]);
 
 	char szID[40];
 	sprintf(szID, "%X%02X%02X%02X", 0, 0, (ID & 0xFF00) >> 8, ID & 0xFF);
@@ -317,12 +317,12 @@ void CPinger::ReloadNodes()
 		for (const auto &sd : result)
 		{
 			PingNode pnode;
-			pnode.ID = atoi(sd[0].c_str());
+			pnode.ID = stoi(sd[0]);
 			pnode.Name = sd[1];
 			pnode.IP = sd[2];
 			pnode.LastOK = mytime(nullptr);
 
-			int SensorTimeoutSec = atoi(sd[3].c_str());
+			int SensorTimeoutSec = stoi(sd[3]);
 			pnode.SensorTimeoutSec = (SensorTimeoutSec > 0) ? SensorTimeoutSec : 5;
 			m_nodes.push_back(pnode);
 		}
@@ -459,7 +459,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -480,7 +480,7 @@ namespace http {
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["IP"] = sd[2];
-					root["result"][ii]["Timeout"] = atoi(sd[3].c_str());
+					root["result"][ii]["Timeout"] = stoi(sd[3]);
 					ii++;
 				}
 			}
@@ -498,7 +498,7 @@ namespace http {
 			std::string mode2 = request::findValue(&req, "mode2");
 			if ((hwid.empty()) || (mode1.empty()) || (mode2.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -509,8 +509,8 @@ namespace http {
 			root["status"] = "OK";
 			root["title"] = "PingerSetMode";
 
-			int iMode1 = atoi(mode1.c_str());
-			int iMode2 = atoi(mode2.c_str());
+			int iMode1 = stoi(mode1);
+			int iMode2 = stoi(mode2);
 
 			m_sql.safe_query(
 				"UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == '%q')",
@@ -533,10 +533,10 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Timeout = atoi(request::findValue(&req, "timeout").c_str());
+			int Timeout = stoi(request::findValue(&req, "timeout"));
 			if ((hwid.empty()) || (name.empty()) || (ip.empty()) || (Timeout == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -561,10 +561,10 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			std::string name = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			std::string ip = HTMLSanitizer::Sanitize(request::findValue(&req, "ip"));
-			int Timeout = atoi(request::findValue(&req, "timeout").c_str());
+			int Timeout = stoi(request::findValue(&req, "timeout"));
 			if ((hwid.empty()) || (nodeid.empty()) || (name.empty()) || (ip.empty()) || (Timeout == 0))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -572,7 +572,7 @@ namespace http {
 				return;
 			CPinger *pHardware = dynamic_cast<CPinger*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "PingerUpdateNode";
 			pHardware->UpdateNode(NodeID, name, ip, Timeout);
@@ -590,7 +590,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -598,7 +598,7 @@ namespace http {
 				return;
 			CPinger *pHardware = dynamic_cast<CPinger*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "PingerRemoveNode";
 			pHardware->RemoveNode(NodeID);
@@ -615,7 +615,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;

--- a/hardware/RFLinkBase.cpp
+++ b/hardware/RFLinkBase.cpp
@@ -258,7 +258,7 @@ void GetSwitchType(const char* ID, const unsigned char unit, const unsigned char
 	result = m_sql.safe_query("SELECT SwitchType FROM DeviceStatus WHERE (DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		switchType = atoi(result[0][0].c_str());
+		switchType = stoi(result[0][0]);
 	}
 }
 
@@ -587,7 +587,7 @@ bool CRFLinkBase::SendSwitchInt(const int ID, const int switchunit, const int Ba
 		if (switchcmd.compare(0, 10, "SET_LEVEL=") == 0 ){
 			cmnd=gswitch_sSetLevel;
 			std::string str2 = switchcmd.substr(10);
-			svalue=atoi(str2.c_str());
+			svalue = stoi(str2);
 	  		Log(LOG_STATUS, "%d level: %d", cmnd, svalue);
 		}
 	}
@@ -669,7 +669,7 @@ bool CRFLinkBase::ParseLine(const std::string &sLine)
 		(sLine.find("PING") != std::string::npos)
 		);
 
-	int RFLink_ID = atoi(results[0].c_str());
+	int RFLink_ID = stoi(results[0]);
 	if (RFLink_ID != 20)
 	{
 		return false; //only accept RFLink->Master messages
@@ -1182,7 +1182,7 @@ namespace http {
 			#endif
 
 			bool bCreated = false;						// flag to know if the command was a success
-			CRFLinkBase *pRFLINK = dynamic_cast<CRFLinkBase*>(m_mainworker.GetHardware(atoi(idx.c_str())));
+			CRFLinkBase *pRFLINK = dynamic_cast<CRFLinkBase*>(m_mainworker.GetHardware(stoi(idx)));
 			if (pRFLINK == nullptr)
 				return;
 

--- a/hardware/RFXComSerial.cpp
+++ b/hardware/RFXComSerial.cpp
@@ -212,14 +212,14 @@ namespace http {
 			if (result.empty())
 				return;
 
-			unsigned char Mode1 = atoi(result[0][0].c_str());
-			unsigned char Mode2 = atoi(result[0][1].c_str());
-			unsigned char Mode3 = atoi(result[0][2].c_str());
-			unsigned char Mode4 = atoi(result[0][3].c_str());
-			unsigned char Mode5 = atoi(result[0][4].c_str());
-			unsigned char Mode6 = atoi(result[0][5].c_str());
+			unsigned char Mode1 = stoi(result[0][0]);
+			unsigned char Mode2 = stoi(result[0][1]);
+			unsigned char Mode3 = stoi(result[0][2]);
+			unsigned char Mode4 = stoi(result[0][3]);
+			unsigned char Mode5 = stoi(result[0][4]);
+			unsigned char Mode6 = stoi(result[0][5]);
 
-			_eHardwareTypes HWType = (_eHardwareTypes)atoi(result[0][6].c_str());
+			_eHardwareTypes HWType = (_eHardwareTypes) stoi(result[0][6]);
 
 			tRBUF Response;
 			Response.ICMND.freqsel = Mode1;
@@ -258,7 +258,7 @@ namespace http {
 				Response.IRESPONSE.KEELOQenabled = (request::findValue(&req, "Keeloq") == "on") ? 1 : 0;
 				Response.IRESPONSE.HCEnabled = (request::findValue(&req, "HC") == "on") ? 1 : 0;
 
-				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(idx.c_str()));
+				CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(idx));
 				if (pHardware)
 				{
 					CRFXBase* pBase = dynamic_cast<CRFXBase*>(pHardware);
@@ -270,7 +270,7 @@ namespace http {
 						if (AsyncMode.empty())
 							AsyncMode = "0";
 						result = m_sql.safe_query("UPDATE Hardware SET Extra='%q' WHERE (ID='%q')", AsyncMode.c_str(), idx.c_str());
-						pBase->SetAsyncType((CRFXBase::_eRFXAsyncType)atoi(AsyncMode.c_str()));
+						pBase->SetAsyncType((CRFXBase::_eRFXAsyncType) stoi(AsyncMode));
 					}
 				}
 			}

--- a/hardware/Rego6XXSerial.cpp
+++ b/hardware/Rego6XXSerial.cpp
@@ -447,14 +447,14 @@ namespace http {
 			if (result.empty())
 				return;
 
-			unsigned char currentMode1 = atoi(result[0][0].c_str());
+			unsigned char currentMode1 = (unsigned char) stoi(result[0][0]);
 
 			std::string sRego6XXType = request::findValue(&req, "Rego6XXType");
-			unsigned char newMode1 = atoi(sRego6XXType.c_str());
+			unsigned char newMode1 = (unsigned char) stoi(sRego6XXType);
 
 			if (currentMode1 != newMode1)
 			{
-				m_sql.UpdateRFXCOMHardwareDetails(atoi(idx.c_str()), newMode1, 0, 0, 0, 0, 0);
+				m_sql.UpdateRFXCOMHardwareDetails(stoi(idx), newMode1, 0, 0, 0, 0, 0);
 			}
 		}
 	} // namespace server

--- a/hardware/RelayNet.cpp
+++ b/hardware/RelayNet.cpp
@@ -443,7 +443,7 @@ void RelayNet::UpdateDomoticzInput(int InputNumber, bool State)
 		std::vector<std::string> sd=result[0];
 		bool dbState = true;
 
-		if (atoi(sd[1].c_str()) == 0)
+		if (stoi(sd[1]) == 0)
 		{
 			dbState = false;
 		}
@@ -495,7 +495,7 @@ void RelayNet::UpdateDomoticzRelay(int RelayNumber, bool State)
 		std::vector<std::string> sd = result[0];
 		bool dbState = true;
 
-		if (atoi(sd[1].c_str()) == 0)
+		if (stoi(sd[1]) == 0)
 		{
 			dbState = false;
 		}

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -226,7 +226,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "pressure_kPa"))
 	{
-		pressure = stof(data["pressure_kPa"]) * 10.0F; // convert to hPA
+		pressure = static_cast<float>(stod(data["pressure_kPa"]) * 10.0); // convert to hPA
 		havePressure = true;
 	}
 	if (FindField(data, "rain_mm"))
@@ -241,7 +241,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "wind_avg_km_h")) // wind speed average (converting into m/s note that internal storage if 10.0f*m/s) 
 	{
-		wind_speed = (stof(data["wind_avg_km_h"])) / 3.6F;
+		wind_speed = static_cast<float>(stod(data["wind_avg_km_h"]) / 3.6);
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_avg_m_s")) // wind speed average
@@ -256,7 +256,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "wind_max_km_h")) // idem, converting to m/s
 	{
-		wind_gust = (stof(data["wind_max_km_h"])) / 3.6F;
+		wind_gust = static_cast<float>(stod(data["wind_max_km_h"]) / 3.6);
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "wind_max_m_s"))
@@ -291,7 +291,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "light_klx"))
 	{
-		lux = (stof(data["light_klx"])) * 1000.0F;
+		lux = static_cast<float>(stod(data["light_klx"]) * 1000.0);
 		haveLux = true;
 	}
 	if (FindField(data, "light_lux"))

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -318,7 +318,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "code"))
 	{
-		code = strtoul(data["code"].c_str(), nullptr, 16);
+		code = stoul(data["code"], nullptr, 16);
 	}
 
 	std::string model = data["model"]; // new model format normalized from the 201 different devices presently supported by rtl_433
@@ -563,7 +563,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 			break;
 		}
 		if (bHandled)
-			SendSecurity1Sensor(strtoul(data["id"].c_str(), nullptr, 16), x10_device, batterylevel, x10_status, model, m_Name, snr);
+			SendSecurity1Sensor(stoul(data["id"], nullptr, 16), x10_device, batterylevel, x10_status, model, m_Name, snr);
 	} // End of X10-Security section
 
 	return bHandled; //not handled (Yet!)

--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -168,16 +168,16 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 
 	if (FindField(data, "id"))
 	{
-		id = atoi(data["id"].c_str());
+		id = stoi(data["id"]);
 	}
 	if (FindField(data, "unit"))
 	{
-		unit = atoi(data["unit"].c_str());
+		unit = stoi(data["unit"]);
 		haveUnit = true;
 	}
 	if (FindField(data, "channel"))
 	{
-		channel = atoi(data["channel"].c_str());
+		channel = stoi(data["channel"]);
 		haveChannel = true;
 	}
 	if (FindField(data, "battery_ok"))
@@ -193,7 +193,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 	}
 	if (FindField(data, "temperature_C"))
 	{
-		tempC = (float)atof(data["temperature_C"].c_str());
+		tempC = stof(data["temperature_C"]);
 		haveTemp = true;
 	}
 	if (FindField(data, "humidity"))
@@ -210,98 +210,98 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		}
 		else
 		{
-			humidity = atoi(data["humidity"].c_str());
+			humidity = stoi(data["humidity"]);
 			haveHumidity = true;
 		}
 	}
 	if (FindField(data, "pressure_hPa"))
 	{
-		pressure = (float)atof(data["pressure_hPa"].c_str());
+		pressure = stof(data["pressure_hPa"]);
 		havePressure = true;
 	}
 	if (FindField(data, "pressure_PSI"))
 	{
-		pressure_PSI = (float)atof(data["pressure_PSI"].c_str());
+		pressure_PSI = stof(data["pressure_PSI"]);
 		havePressure_PSI = true;
 	}
 	if (FindField(data, "pressure_kPa"))
 	{
-		pressure = 10.0F * (float)atof(data["pressure_kPa"].c_str()); // convert to hPA
+		pressure = stof(data["pressure_kPa"]) * 10.0F; // convert to hPA
 		havePressure = true;
 	}
 	if (FindField(data, "rain_mm"))
 	{
-		rain = (float)atof(data["rain_mm"].c_str());
+		rain = stof(data["rain_mm"]);
 		haveRain = true;
 	}
 	if (FindField(data, "depth_cm"))
 	{
-		depth = (float)atof(data["depth_cm"].c_str());
+		depth = stof(data["depth_cm"]);
 		haveDepth = true;
 	}
 	if (FindField(data, "wind_avg_km_h")) // wind speed average (converting into m/s note that internal storage if 10.0f*m/s) 
 	{
-		wind_speed = ((float)atof(data["wind_avg_km_h"].c_str())) / 3.6F;
+		wind_speed = (stof(data["wind_avg_km_h"])) / 3.6F;
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_avg_m_s")) // wind speed average
 	{
-		wind_speed = (float)atof(data["wind_avg_m_s"].c_str());
+		wind_speed = stof(data["wind_avg_m_s"]);
 		haveWind_Speed = true;
 	}
 	if (FindField(data, "wind_dir_deg"))
 	{
-		wind_dir = atoi(data["wind_dir_deg"].c_str()); // does domoticz assume it is degree ? (and not rad or something else)
+		wind_dir = stoi(data["wind_dir_deg"]); // does domoticz assume it is degree ? (and not rad or something else)
 		haveWind_Dir = true;
 	}
 	if (FindField(data, "wind_max_km_h")) // idem, converting to m/s
 	{
-		wind_gust = ((float)atof(data["wind_max_km_h"].c_str())) / 3.6F;
+		wind_gust = (stof(data["wind_max_km_h"])) / 3.6F;
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "wind_max_m_s"))
 	{
-		wind_gust = (float)atof(data["wind_max_m_s"].c_str());
+		wind_gust = stof(data["wind_max_m_s"]);
 		haveWind_Gust = true;
 	}
 	if (FindField(data, "moisture"))
 	{
-		moisture = atoi(data["moisture"].c_str());
+		moisture = stoi(data["moisture"]);
 		haveMoisture = true;
 	}
 	if (FindField(data, "power_W")) // -- power_W,energy_kWh,radio_clock,sequence,
 	{
-		power = (float)atof(data["power_W"].c_str());
+		power = stof(data["power_W"]);
 		havePower = true;
 	}
 	if (FindField(data, "energy_kWh")) // sensor type general subtype electric counter
 	{
-		energy = (float)atof(data["energy_kWh"].c_str());
+		energy = stof(data["energy_kWh"]);
 		haveEnergy = true;
 	}
 	if (FindField(data, "sequence")) // please do not remove : to be added in future PR for data in sensor (for fiability reporting)
 	{
-		sequence = atoi(data["sequence"].c_str());
+		sequence = stoi(data["sequence"]);
 		haveSequence = true;
 	}
 	if (FindField(data, "uv"))
 	{
-		uvi = (float)atof(data["uv"].c_str());
+		uvi = stof(data["uv"]);
 		haveUV = true;
 	}
 	if (FindField(data, "light_klx"))
 	{
-		lux = ((float)atof(data["light_klx"].c_str())) * 1000;
+		lux = (stof(data["light_klx"])) * 1000.0F;
 		haveLux = true;
 	}
 	if (FindField(data, "light_lux"))
 	{
-		lux = (float)atof(data["light_lux"].c_str());
+		lux = stof(data["light_lux"]);
 		haveLux = true;
 	}
 	if (FindField(data, "volume_m3"))
 	{
-		meter = (float)atof(data["volume_m3"].c_str());
+		meter = stof(data["volume_m3"]);
 		haveMeter = true;
 	}
 	if (FindField(data, "snr"))
@@ -310,7 +310,7 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		   rtl_433 will not be able to decode a signal with less snr than 4dB or so, why we map snr<5dB to rssi=0 .
 		   We use better resolution at low snr. snr=5-10dB map to rssi=1-6, snr=11-20dB map to rssi=6-11, snr>20dB map to rssi=11
 		*/
-		snr = std::stoi(data["snr"]) - 4;
+		snr = stoi(data["snr"]) - 4;
 
 		if (snr > 5) snr -= (int)(snr - 5) / 2;
 		if (snr > 11) snr = 11; // Domoticz RSSI field can only be 0-11, 12 is used for non-RF received devices

--- a/hardware/S0MeterBase.cpp
+++ b/hardware/S0MeterBase.cpp
@@ -63,16 +63,16 @@ void S0MeterBase::InitBase()
 	StringSplit(Settings, ";", splitresults);
 	if (splitresults.size() == 10)
 	{
-		m_meters[0].m_type = atoi(splitresults[0].c_str());
-		m_meters[0].m_pulse_per_unit = atof(splitresults[1].c_str());
-		m_meters[1].m_type = atoi(splitresults[2].c_str());
-		m_meters[1].m_pulse_per_unit = atof(splitresults[3].c_str());
-		m_meters[2].m_type = atoi(splitresults[4].c_str());
-		m_meters[2].m_pulse_per_unit = atof(splitresults[5].c_str());
-		m_meters[3].m_type = atoi(splitresults[6].c_str());
-		m_meters[3].m_pulse_per_unit = atof(splitresults[7].c_str());
-		m_meters[4].m_type = atoi(splitresults[8].c_str());
-		m_meters[4].m_pulse_per_unit = atof(splitresults[9].c_str());
+		m_meters[0].m_type = stoi(splitresults[0]);
+		m_meters[0].m_pulse_per_unit = stod(splitresults[1]);
+		m_meters[1].m_type = stoi(splitresults[2]);
+		m_meters[1].m_pulse_per_unit = stod(splitresults[3]);
+		m_meters[2].m_type = stoi(splitresults[4]);
+		m_meters[2].m_pulse_per_unit = stod(splitresults[5]);
+		m_meters[3].m_type = stoi(splitresults[6]);
+		m_meters[3].m_pulse_per_unit = stod(splitresults[7]);
+		m_meters[4].m_type = stoi(splitresults[8]);
+		m_meters[4].m_pulse_per_unit = stod(splitresults[9]);
 	}
 }
 
@@ -106,7 +106,7 @@ void S0MeterBase::ReloadLastTotals()
 			StringSplit(result[0][0],";",results);
 			if (results.size()==2)
 			{
-				m_meters[ii].m_counter_start=atof(results[1].c_str())/1000.0;
+				m_meters[ii].m_counter_start = stod(results[1]) / 1000.0;
 			}
 		}
 		*/
@@ -134,11 +134,11 @@ void S0MeterBase::ReloadLastTotals()
 			m_meters[ii].m_firstTime = false;
 			if (results.size() == 1)
 			{
-				m_meters[ii].m_counter_start = atof(results[0].c_str()) / 1000.0;
+				m_meters[ii].m_counter_start = stod(results[0]) / 1000.0;
 			}
 			else if (results.size() == 2)
 			{
-				m_meters[ii].m_counter_start = atof(results[1].c_str()) / 1000.0;
+				m_meters[ii].m_counter_start = stod(results[1]) / 1000.0;
 			}
 		}
 	}
@@ -281,7 +281,7 @@ void S0MeterBase::ParseLine()
 		totmeters = max_s0_meters;
 	// ID:0001:I:99:M1:123:456:M2:234:567 = ID(1)/Pulse Interval(3)/M1Actual(5)/M1Total(7)/M2Actual(8)/M2Total(9)
 	// std::string MeterID=results[1];
-	double s0_pulse_interval = atof(results[3].c_str());
+	double s0_pulse_interval = stod(results[3]);
 
 	int roffset = 4;
 	if (results[0] == "ID")
@@ -290,10 +290,10 @@ void S0MeterBase::ParseLine()
 		{
 			m_meters[ii].m_PacketsSinceLastPulseChange++;
 
-			double s0_pulse = atof(results[roffset + 1].c_str());
+			double s0_pulse = stod(results[roffset + 1]);
 
 			unsigned long LastTotalPulses = m_meters[ii].total_pulses;
-			m_meters[ii].total_pulses = (unsigned long)atol(results[roffset + 2].c_str());
+			m_meters[ii].total_pulses = stoul(results[roffset + 2]);
 			if (m_meters[ii].total_pulses < LastTotalPulses)
 			{
 				// counter has looped
@@ -355,7 +355,7 @@ void S0MeterBase::ParseLine()
 		roffset = 2;
 		for (int ii = 0; ii < totmeters; ii++)
 		{
-			double s0_counter = atof(results[roffset + 1].c_str());
+			double s0_counter = stod(results[roffset + 1]);
 			if (s0_counter != 0)
 			{
 				if (m_meters[ii].m_firstTime)
@@ -369,7 +369,7 @@ void S0MeterBase::ParseLine()
 					m_meters[ii].m_counter_start += m_meters[ii].m_current_counter;
 				}
 				m_meters[ii].m_current_counter = s0_counter;
-				m_meters[ii].m_CurrentUsage = atof(results[roffset + 2].c_str());
+				m_meters[ii].m_CurrentUsage = stod(results[roffset + 2]);
 
 				// double counter_value = m_meters[ii].m_counter_start + s0_counter;
 				SendMeter(ii + 1, m_meters[ii].m_CurrentUsage / 1000.0F, m_meters[ii].m_current_counter);

--- a/hardware/SBFSpot.cpp
+++ b/hardware/SBFSpot.cpp
@@ -208,8 +208,8 @@ bool CSBFSpot::GetMeter(const unsigned char ID1,const unsigned char ID2, double 
 	StringSplit(result[0][1],";",splitresult);
 	if (splitresult.size()!=2)
 		return false;
-	musage=atof(splitresult[0].c_str());
-	mtotal=atof(splitresult[1].c_str())/1000.0;
+	musage = stod(splitresult[0]);
+	mtotal = stod(splitresult[1])/1000.0;
 	return true;
 }
 
@@ -233,7 +233,7 @@ void CSBFSpot::ImportOldMonthData()
 			return;
 		}
 	}
-	uint64_t ulID = std::stoull(result[0][0]);
+	uint64_t ulID = stoull(result[0][0]);
 
 	//Try actual year, and previous year
 	time_t atime = time(nullptr);
@@ -293,9 +293,9 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 		{
 			if (bIsSMAWebExport)
 			{
-				int day = atoi(sLine.substr(dayPos, 2).c_str());
-				int month = atoi(sLine.substr(monthPos, 2).c_str());
-				int year = atoi(sLine.substr(yearPos, 4).c_str());
+				int day = stoi(sLine.substr(dayPos, 2));
+				int month = stoi(sLine.substr(monthPos, 2));
+				int year = stoi(sLine.substr(yearPos, 4));
 
 				std::string szKwhCounter = sLine.substr(18);
 				size_t pPos = szKwhCounter.find('.');
@@ -306,7 +306,7 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 				if (pPos == std::string::npos)
 					szKwhCounter = "0," + szKwhCounter;
 				stdreplace(szKwhCounter, ",", ".");
-				double kWhCounter = atof(szKwhCounter.c_str()) * 1000;
+				double kWhCounter = stod(szKwhCounter) * 1000.0;
 				uint64_t ulCounter = (uint64_t)kWhCounter;
 
 				//check if this day record does not exists in the database, and insert it
@@ -366,13 +366,13 @@ void CSBFSpot::ImportOldMonthData(const uint64_t DevID, const int Year, const in
 					}
 					else
 					{
-						int day = atoi(results[0].substr(dayPos, 2).c_str());
-						int month = atoi(results[0].substr(monthPos, 2).c_str());
-						int year = atoi(results[0].substr(yearPos, 4).c_str());
+						int day = stoi(results[0].substr(dayPos, 2));
+						int month = stoi(results[0].substr(monthPos, 2));
+						int year = stoi(results[0].substr(yearPos, 4));
 
 						std::string szKwhCounter = results[iInvOff + 1];
 						stdreplace(szKwhCounter, ",", ".");
-						double kWhCounter = atof(szKwhCounter.c_str()) * 1000;
+						double kWhCounter = stod(szKwhCounter) * 1000.0;
 						uint64_t ulCounter = (uint64_t)kWhCounter;
 
 						//check if this day record does not exists in the database, and insert it
@@ -419,8 +419,8 @@ int CSBFSpot::getSunRiseSunSetMinutes(const bool bGetSunRise)
 		StringSplit(strarray[0], ":", sunRisearray);
 		StringSplit(strarray[1], ":", sunSetarray);
 
-		int sunRiseInMinutes = (atoi(sunRisearray[0].c_str()) * 60) + atoi(sunRisearray[1].c_str());
-		int sunSetInMinutes = (atoi(sunSetarray[0].c_str()) * 60) + atoi(sunSetarray[1].c_str());
+		int sunRiseInMinutes = (stoi(sunRisearray[0]) * 60) + stoi(sunRisearray[1]);
+		int sunSetInMinutes = (stoi(sunSetarray[0]) * 60) + stoi(sunSetarray[1]);
 
 		if (bGetSunRise) {
 			return sunRiseInMinutes;
@@ -561,25 +561,25 @@ void CSBFSpot::GetMeterDetails()
 
 		std::string szKwhCounter = results[23];
 		stdreplace(szKwhCounter, ",", ".");
-		kWhCounter += atof(szKwhCounter.c_str());
+		kWhCounter += stod(szKwhCounter);
 		std::string szPacActual = results[20];
 		stdreplace(szPacActual, ",", ".");
-		Pac += atof(szPacActual.c_str());
+		Pac += stod(szPacActual);
 
 		float voltage;
 		tmpString = results[16];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = stof(tmpString);
 		SendVoltageSensor(0, (InvIdx * 10) + 1, 255, voltage, "Volt uac1");
 		tmpString = results[17];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = stof(tmpString);
 		if (voltage != 0) {
 			SendVoltageSensor(0, (InvIdx * 10) + 2, 255, voltage, "Volt uac2");
 		}
 		tmpString = results[18];
 		stdreplace(tmpString, ",", ".");
-		voltage = static_cast<float>(atof(tmpString.c_str()));
+		voltage = stof(tmpString);
 		if (voltage != 0) {
 			SendVoltageSensor(0, (InvIdx * 10) + 3, 255, voltage, "Volt uac3");
 		}
@@ -587,23 +587,23 @@ void CSBFSpot::GetMeterDetails()
 		float percentage;
 		tmpString = results[21];
 		stdreplace(tmpString, ",", ".");
-		percentage = static_cast<float>(atof(tmpString.c_str()));
+		percentage = stof(tmpString);
 		SendPercentageSensor((InvIdx * 10) + 1, 0, 255, percentage, "Efficiency");
 		tmpString = results[24];
 		stdreplace(tmpString, ",", ".");	
-		float frequency = static_cast<float>(atof(tmpString.c_str()));
+		float frequency = stof(tmpString);
 //		SendPercentageSensor((InvIdx * 10) + 2, 0, 255, percentage, "Hz");
 		SendCustomSensor((InvIdx * 10) + 2, 0, 255, frequency, "Hz", "Hz");
 		tmpString = results[27];
 		stdreplace(tmpString, ",", ".");
-		percentage = static_cast<float>(atof(tmpString.c_str()));
+		percentage = stof(tmpString);
 		SendPercentageSensor((InvIdx * 10) + 3, 0, 255, percentage, "BT_Signal");
 
 		if (results.size() >= 31)
 		{
 			tmpString = results[30];
 			stdreplace(tmpString, ",", ".");
-			float temperature = static_cast<float>(atof(tmpString.c_str()));
+			float temperature = stof(tmpString);
 			SendTempSensor((InvIdx * 10) + 1, 255, temperature, "Temperature");
 		}
 		InvIdx++;
@@ -642,7 +642,7 @@ namespace http {
 			{
 				return;
 			}
-			int hardwareID = atoi(idx.c_str());
+			int hardwareID = stoi(idx);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(hardwareID);
 			if (pHardware != nullptr)
 			{

--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -129,8 +129,8 @@ int SolarEdgeAPI::getSunRiseSunSetMinutes(const bool bGetSunRise)
 		StringSplit(strarray[0], ":", sunRisearray);
 		StringSplit(strarray[1], ":", sunSetarray);
 
-		int sunRiseInMinutes = (atoi(sunRisearray[0].c_str()) * 60) + atoi(sunRisearray[1].c_str());
-		int sunSetInMinutes = (atoi(sunSetarray[0].c_str()) * 60) + atoi(sunSetarray[1].c_str());
+		int sunRiseInMinutes = (stoi(sunRisearray[0]) * 60) + stoi(sunRisearray[1]);
+		int sunSetInMinutes = (stoi(sunSetarray[0]) * 60) + stoi(sunSetarray[1]);
 
 		if (bGetSunRise) {
 			return sunRiseInMinutes;

--- a/hardware/Sterbox.cpp
+++ b/hardware/Sterbox.cpp
@@ -140,13 +140,13 @@ void CSterbox::UpdateSwitch(const unsigned char Idx, const int SubUnit, const bo
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
 		{
 			//Check Level
-			int slevel = atoi(result[0][2].c_str());
+			int slevel = stoi(result[0][2]);
 			if (slevel == level)
 				return;
 		}
@@ -326,7 +326,7 @@ void CSterbox::GetMeterDetails()
 					tmpinp = analog[jj];
 					tmpstr2 = tmpstr2.substr(1, 10);
 
-					float lValue = (float)atof(tmpstr2.c_str());
+					float lValue = stof(tmpstr2);
 					std::stringstream sstr;
 					sstr << "Analog " << jj;
 					pos1 = tmpinp.find('t');
@@ -354,12 +354,12 @@ void CSterbox::GetMeterDetails()
 					//Log(LOG_ERROR,"OU Status: %s", tmpstr2.c_str());
 
 				}
-				//int Idx = atoi(tmpstr.substr(0, pos1).c_str());
+				//int Idx = stoi(tmpstr.substr(0, pos1));
 				//tmpstr = tmpstr.substr(pos1 + 1);
 				//pos1 = tmpstr.find("<");
 				//if (pos1 != std::string::npos)
 				//{
-				//	int lValue = atoi(tmpstr.substr(0, pos1).c_str());
+				//	int lValue = stoi(tmpstr.substr(0, pos1));
 				//	float voltage = (float)(5.0f / 1023.0f)*lValue;
 				//	if (voltage > 5.0f)
 				//		voltage = 5.0f;

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -563,7 +563,7 @@ void CSysfsGpio::CreateDomoticzDevices()
 					}
 					else
 					{
-						if (atoi(sd[1].c_str()) != GPIO_IN) /* device was not an input, delete it */
+						if (stoi(sd[1]) != GPIO_IN) // device was not an input, delete it
 						{
 							m_sql.safe_query("DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)", m_HwdID, s.pin_number);
 
@@ -606,7 +606,7 @@ void CSysfsGpio::CreateDomoticzDevices()
 					}
 					else
 					{
-						if ((atoi(sd[1].c_str()) != GPIO_OUT)) /* device was not an output, delete it */
+						if ((stoi(sd[1]) != GPIO_OUT)) // device was not an output, delete it
 						{
 							m_sql.safe_query("DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)", m_HwdID, s.pin_number);
 
@@ -614,7 +614,7 @@ void CSysfsGpio::CreateDomoticzDevices()
 						}
 						else
 						{
-							GpioWrite(s.pin_number, atoi(sd[0].c_str()));
+							GpioWrite(s.pin_number, stoi(sd[0]));
 						}
 					}
 				}
@@ -689,11 +689,11 @@ void CSysfsGpio::UpdateDomoticzInputs(bool forceUpdate)
 				{
 					std::vector<std::string> sd = result[0];
 
-					if (atoi(sd[1].c_str()) == 1) /* Check if device is used */
+					if (stoi(sd[1]) == 1) // Check if device is used
 					{
 						int db_state = GPIO_HIGH;
 
-						if (atoi(sd[0].c_str()) == GPIO_LOW) /* determine database state*/
+						if (stoi(sd[0]) == GPIO_LOW) // determine database stat
 						{
 							db_state = GPIO_LOW;
 						}
@@ -806,9 +806,9 @@ void CSysfsGpio::UpdateGpioOutputs()
 			if ((!result.empty()) && (!result.empty()))
 			{
 				std::vector<std::string> sd = result[0];
-				s.db_state = atoi(sd[0].c_str());
+				s.db_state = (int8_t) stoi(sd[0]);
 
-				if (atoi(sd[1].c_str()))
+				if (stoi(sd[1]))
 				{
 					/* device is used, update gpio output pin */
 					GpioWrite(s.pin_number, s.db_state);

--- a/hardware/SysfsGpio.cpp
+++ b/hardware/SysfsGpio.cpp
@@ -778,10 +778,10 @@ void CSysfsGpio::UpdateDeviceID(int pin)
 			}
 
 			/* extract hex device sub-id's */
-			m_saved_state[index].id1 = strtol(sdeviceid.substr(0, 1).c_str(), nullptr, 16) & 0xFF;
-			m_saved_state[index].id2 = strtol(sdeviceid.substr(1, 2).c_str(), nullptr, 16) & 0xFF;
-			m_saved_state[index].id3 = strtol(sdeviceid.substr(3, 2).c_str(), nullptr, 16) & 0xFF;
-			m_saved_state[index].id4 = strtol(sdeviceid.substr(5, 2).c_str(), nullptr, 16) & 0xFF;
+			m_saved_state[index].id1 = stol(sdeviceid.substr(0, 1), nullptr, 16) & 0xFF;
+			m_saved_state[index].id2 = stol(sdeviceid.substr(1, 2), nullptr, 16) & 0xFF;
+			m_saved_state[index].id3 = stol(sdeviceid.substr(3, 2), nullptr, 16) & 0xFF;
+			m_saved_state[index].id4 = stol(sdeviceid.substr(5, 2), nullptr, 16) & 0xFF;
 			m_saved_state[index].id_valid = 1;
 		}
 

--- a/hardware/TCPProxy/tcpproxy_server.cpp
+++ b/hardware/TCPProxy/tcpproxy_server.cpp
@@ -52,7 +52,7 @@ namespace tcp_proxy
 		{
 			end=boost::asio::ip::tcp::endpoint(
 				boost::asio::ip::address::from_string(upstream_host),
-				(unsigned short)atoi(upstream_port.c_str()));
+				(unsigned short) stoi(upstream_port));
 		}
 		else
 			end=*i;

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -499,19 +499,19 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	if (IsSensorTypeOrAlias(sType, "temp")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "temp";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "humidity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "humidity";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "baro")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "baro";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "gps")) {
@@ -524,7 +524,7 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 			payload[index]["type"] = "gps";
 			payload[index]["lat"] = stod(strarray[0]);
 			payload[index]["lon"] = stod(strarray[1]);
-			payload[index]["alt"] = stod(strarray[2]);
+			payload[index]["alt"] = stof(strarray[2]);
 			ret = true;
 		}
 	}
@@ -543,25 +543,25 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	else if (IsSensorTypeOrAlias(sType, "analog_input")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_input";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "analog_output")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_output";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "presence")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "presence";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "luminosity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "luminosity";
-		payload[index]["value"] = stod(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -499,19 +499,19 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	if (IsSensorTypeOrAlias(sType, "temp")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "temp";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "humidity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "humidity";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "baro")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "baro";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "gps")) {
@@ -524,7 +524,7 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 			payload[index]["type"] = "gps";
 			payload[index]["lat"] = stod(strarray[0]);
 			payload[index]["lon"] = stod(strarray[1]);
-			payload[index]["alt"] = stof(strarray[2]);
+			payload[index]["alt"] = stod(strarray[2]);
 			ret = true;
 		}
 	}
@@ -543,25 +543,25 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	else if (IsSensorTypeOrAlias(sType, "analog_input")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_input";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "analog_output")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_output";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "presence")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "presence";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "luminosity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "luminosity";
-		payload[index]["value"] = stof(sValue);
+		payload[index]["value"] = stod(sValue);
 		ret = true;
 	}
 

--- a/hardware/TTNMQTT.cpp
+++ b/hardware/TTNMQTT.cpp
@@ -101,8 +101,8 @@ bool CTTNMQTT::StartHardware()
 
 			if (!((Latitude == "1") && (Longitude == "1")))
 			{
-				m_DomLat = std::stod(Latitude);
-				m_DomLon = std::stod(Longitude);
+				m_DomLat = stod(Latitude);
+				m_DomLon = stod(Longitude);
 			}
 			else
 			{
@@ -422,11 +422,11 @@ void CTTNMQTT::UpdateUserVariable(const std::string &varName, const std::string 
 		result = m_sql.safe_query("SELECT ID FROM UserVariables WHERE (Name=='%q')", varName.c_str());
 		if (result.empty())
 			return;
-		ID = atoi(result[0][0].c_str());
+		ID = stoi(result[0][0]);
 	}
 	else
 	{
-		ID = atoi(result[0][0].c_str());
+		ID = stoi(result[0][0]);
 		m_sql.safe_query("UPDATE UserVariables SET Value='%q', LastUpdate='%q' WHERE (ID==%d)", varValue.c_str(), sLastUpdate.c_str(), ID);
 	}
 
@@ -456,7 +456,7 @@ int CTTNMQTT::GetAddDeviceAndSensor(const int m_HwdID, const std::string &Device
 
 	if (!result.empty())
 	{
-		DeviceID = atoi(result[0][0].c_str());
+		DeviceID = stoi(result[0][0]);
 		//Add last received in database ?
 	}
 
@@ -499,19 +499,19 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	if (IsSensorTypeOrAlias(sType, "temp")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "temp";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "humidity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "humidity";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "baro")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "baro";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "gps")) {
@@ -522,46 +522,46 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 		{
 			payload[index]["channel"] = channel;
 			payload[index]["type"] = "gps";
-			payload[index]["lat"] = std::stod(strarray[0]);
-			payload[index]["lon"] = std::stod(strarray[1]);
-			payload[index]["alt"] = std::stof(strarray[2]);
+			payload[index]["lat"] = stod(strarray[0]);
+			payload[index]["lon"] = stod(strarray[1]);
+			payload[index]["alt"] = stof(strarray[2]);
 			ret = true;
 		}
 	}
 	else if (IsSensorTypeOrAlias(sType, "digital_input")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "digital_input";
-		payload[index]["value"] = std::stoi(sValue);
+		payload[index]["value"] = stoi(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "digital_output")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "digital_output";
-		payload[index]["value"] = std::stoi(sValue);
+		payload[index]["value"] = stoi(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "analog_input")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_input";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "analog_output")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "analog_output";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "presence")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "presence";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 	else if (IsSensorTypeOrAlias(sType, "luminosity")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "luminosity";
-		payload[index]["value"] = std::stof(sValue);
+		payload[index]["value"] = stof(sValue);
 		ret = true;
 	}
 
@@ -571,7 +571,7 @@ bool CTTNMQTT::ConvertField2Payload(const std::string &sType, const std::string 
 	if (IsSensorTypeOrAlias(sType, "batterylevel")) {
 		payload[index]["channel"] = channel;
 		payload[index]["type"] = "batterylevel";
-		payload[index]["value"] = std::stoi(sValue);
+		payload[index]["value"] = stoi(sValue);
 		ret = true;
 	}
 

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -445,7 +445,7 @@ void CTado::UpdateSwitch(const int Idx, const bool bOn, const std::string &defau
 	if (!result.empty())
 	{
 		//check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -543,7 +543,7 @@ void CTeleinfoBase::MatchLine()
 
 	label = splitresults[0];
 	vString = splitresults[1];
-	value = atoi(splitresults[1].c_str());
+	value = stoul(splitresults[1]);
 
 	// Historic mode
 	if (label == "ADCO" || label == "ADSC") 

--- a/hardware/TeleinfoBase.cpp
+++ b/hardware/TeleinfoBase.cpp
@@ -672,7 +672,7 @@ void CTeleinfoBase::MatchLine()
 	else if (label == "SINSTI") m_teleinfo.SINSTI = value;
 	else if (label == "STGE")
 	{  // Status register, hexadecimal string (without 0x)
-		m_teleinfo.STGE = strtoul(splitresults[1].c_str(), nullptr, 16);
+		m_teleinfo.STGE = stoul(splitresults[1], nullptr, 16);
 
 		// Color of tomorow
 		int tomorow = ( m_teleinfo.STGE & 0x0C000000 ) >> 26;

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -66,13 +66,13 @@ void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *mod
     switch (dataType)
     {
     case TELLSTICK_TEMPERATURE:
-        SendTempSensor(deviceId, 255, atof(value), "Temp");
+        SendTempSensor(deviceId, 255, (float) atof(value), "Temp");
         break;
     case TELLSTICK_HUMIDITY:
         SendHumiditySensor(deviceId, 255, atoi(value), "Humidity");
         break;
     case TELLSTICK_RAINRATE:
-        SendRainSensor(deviceId, 255, atof(value), "Rain");
+        SendRainSensor(deviceId, 255, (float) atof(value), "Rain");
         break;
     case TELLSTICK_RAINTOTAL:
     case TELLSTICK_WINDDIRECTION:

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -66,13 +66,13 @@ void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *mod
     switch (dataType)
     {
     case TELLSTICK_TEMPERATURE:
-        SendTempSensor(deviceId, 255, (float) atof(value), "Temp");
+        SendTempSensor(deviceId, 255, static_cast<float>(atof(value)), "Temp");
         break;
     case TELLSTICK_HUMIDITY:
         SendHumiditySensor(deviceId, 255, atoi(value), "Humidity");
         break;
     case TELLSTICK_RAINRATE:
-        SendRainSensor(deviceId, 255, (float) atof(value), "Rain");
+        SendRainSensor(deviceId, 255, static_cast<float>(atof(value)), "Rain");
         break;
     case TELLSTICK_RAINTOTAL:
     case TELLSTICK_WINDDIRECTION:
@@ -105,6 +105,7 @@ void CTellstick::deviceEvent(int deviceId, int method, const char *data)
 	break;
     case TELLSTICK_DIM:
         gswitch.cmnd = gswitch_sSetLevel;
+        // FIXME: compute next line as double and ground to int ?
         gswitch.level = atoi(data) * 99 / 255;
 	    sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, 255, m_Name.c_str());
 	break;

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -157,7 +157,7 @@ void CTellstick::rawDeviceEvent(int controllerId, const char *data)
 	pos = message.find(';', pos + 1);
     }
     if (!deviceId.empty() && !winddirection.empty() && ! windaverage.empty() && ! windgust.empty()) {
-        SendWind(stoi(deviceId), 255, stoi(winddirection), stof(windaverage), stof(windgust), 0, 0, false, false, "Wind");
+        SendWind(stoi(deviceId), 255, stoi(winddirection), stof(windaverage), stof(windgust), 0.0F, 0.0F, false, false, "Wind");
     }
 }
 

--- a/hardware/Tellstick.cpp
+++ b/hardware/Tellstick.cpp
@@ -66,13 +66,13 @@ void CTellstick::sensorEvent(int deviceId, const char *protocol, const char *mod
     switch (dataType)
     {
     case TELLSTICK_TEMPERATURE:
-        SendTempSensor(deviceId, 255, static_cast<float>(atof(value)), "Temp");
+        SendTempSensor(deviceId, 255, atof(value), "Temp");
         break;
     case TELLSTICK_HUMIDITY:
         SendHumiditySensor(deviceId, 255, atoi(value), "Humidity");
         break;
     case TELLSTICK_RAINRATE:
-        SendRainSensor(deviceId, 255, static_cast<float>(atof(value)), "Rain");
+        SendRainSensor(deviceId, 255, atof(value), "Rain");
         break;
     case TELLSTICK_RAINTOTAL:
     case TELLSTICK_WINDDIRECTION:
@@ -105,7 +105,7 @@ void CTellstick::deviceEvent(int deviceId, int method, const char *data)
 	break;
     case TELLSTICK_DIM:
         gswitch.cmnd = gswitch_sSetLevel;
-        gswitch.level = atoi(data)*99/255;
+        gswitch.level = atoi(data) * 99 / 255;
 	    sDecodeRXMessage(this, (const unsigned char *)&gswitch, nullptr, 255, m_Name.c_str());
 	break;
     default:
@@ -157,7 +157,7 @@ void CTellstick::rawDeviceEvent(int controllerId, const char *data)
 	pos = message.find(';', pos + 1);
     }
     if (!deviceId.empty() && !winddirection.empty() && ! windaverage.empty() && ! windgust.empty()) {
-        SendWind(atoi(deviceId.c_str()), 255, atoi(winddirection.c_str()), static_cast<float>(atof(windaverage.c_str())), static_cast<float>(atof(windgust.c_str())), 0, 0, false, false, "Wind");
+        SendWind(stoi(deviceId), 255, stoi(winddirection), stof(windaverage), stof(windgust), 0, 0, false, false, "Wind");
     }
 }
 
@@ -333,9 +333,9 @@ namespace http {
             if (hwIdStr.empty() || repeatsStr.empty() || repeatIntervalStr.empty())
                 return;
 
-            int hwID = atoi(hwIdStr.c_str());
-            int repeats = atoi(repeatsStr.c_str());
-            int repeatInterval = atoi(repeatIntervalStr.c_str());
+            int hwID = stoi(hwIdStr);
+            int repeats = stoi(repeatsStr);
+            int repeatInterval = stoi(repeatIntervalStr);
 
             m_sql.safe_query("UPDATE Hardware SET Mode1=%d, Mode2=%d WHERE (ID == %d)",
                              repeats, repeatInterval, hwID);

--- a/hardware/ToonThermostat.cpp
+++ b/hardware/ToonThermostat.cpp
@@ -149,15 +149,15 @@ void CToonThermostat::Init()
 	result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID==1) AND ([Type]==%d) AND (SubType==%d)", m_HwdID, pTypeP1Power, sTypeP1Power);
 	if (!result.empty())
 	{
-		unsigned long devID = (unsigned long)atol(result[0][0].c_str());
+		unsigned long devID = stoul(result[0][0]);
 		result = m_sql.safe_query("SELECT MAX(Counter1), MAX(Counter2), MAX(Counter3), MAX(Counter4) FROM Multimeter_Calendar WHERE (DeviceRowID==%ld)", devID);
 		if (!result.empty())
 		{
 			std::vector<std::string> sd = *result.begin();
-			m_OffsetUsage1 = (unsigned long)atol(sd[0].c_str());
-			m_OffsetDeliv1 = (unsigned long)atol(sd[1].c_str());
-			m_OffsetUsage2 = (unsigned long)atol(sd[2].c_str());
-			m_OffsetDeliv2 = (unsigned long)atol(sd[3].c_str());
+			m_OffsetUsage1 = stoul(sd[0]);
+			m_OffsetDeliv1 = stoul(sd[1]);
+			m_OffsetUsage2 = stoul(sd[2]);
+			m_OffsetDeliv2 = stoul(sd[3]);
 		}
 	}
 	m_bDoLogin = true;
@@ -241,7 +241,7 @@ void CToonThermostat::UpdateSwitch(const unsigned char Idx, const bool bOn, cons
 	if (!result.empty())
 	{
 		// check if we have a change, if not do not update it
-		int nvalue = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][1]);
 		if ((!bOn) && (nvalue == 0))
 			return;
 		if ((bOn && (nvalue != 0)))
@@ -418,7 +418,7 @@ bool CToonThermostat::GetUUIDIdx(const std::string &UUID, int &idx)
 	if (result.empty())
 		return false;
 	std::vector<std::string> sd = result[0];
-	idx = atoi(sd[0].c_str());
+	idx = stoi(sd[0]);
 	return true;
 }
 
@@ -804,7 +804,7 @@ bool CToonThermostat::ParseThermostatData(const Json::Value &root)
 
 		if (root["thermostatInfo"]["burnerInfo"].isString())
 		{
-			burnerInfo = atoi(root["thermostatInfo"]["burnerInfo"].asString().c_str());
+			burnerInfo = stoi(root["thermostatInfo"]["burnerInfo"].asString());
 		}
 		else if (root["thermostatInfo"]["burnerInfo"].isInt())
 		{

--- a/hardware/USBtin_MultiblocV8.cpp
+++ b/hardware/USBtin_MultiblocV8.cpp
@@ -1819,7 +1819,7 @@ float USBtin_MultiblocV8::TimeLeftInMinutes(float current, int DischargeableAh, 
 
 float USBtin_MultiblocV8::GetInformationFromId(int NodeId, int sType)
 {
-	float value = 0;
+	float value = 0.0F;
 	_tGeneralDevice gDevice;
 	gDevice.subtype = sType; // sTypeCustom;
 	gDevice.id = NodeId;

--- a/hardware/USBtin_MultiblocV8.cpp
+++ b/hardware/USBtin_MultiblocV8.cpp
@@ -895,8 +895,8 @@ bool USBtin_MultiblocV8::CheckOutputChange(unsigned long sID, int OutputNumber, 
 		if (!ForceUpdate)
 		{
 			// check if we have a change, if not do not update it
-			nvalue = atoi(result[0][1].c_str());
-			slevel = atoi(result[0][2].c_str());
+			nvalue = stoi(result[0][1]);
+			slevel = stoi(result[0][2]);
 			// Log(LOG_NORM,"MultiblocV8: Output 1 nvalue : %d ",nvalue);
 			if ((!CdeReceive) && (nvalue == 0))
 				returnvalue = false; // still off, nothing to do
@@ -1832,7 +1832,7 @@ float USBtin_MultiblocV8::GetInformationFromId(int NodeId, int sType)
 
 	if (!result.empty())
 	{
-		value = static_cast<float>(atof(result[0][2].c_str()));
+		value = stof(result[0][2]);
 	}
 	return value;
 }

--- a/hardware/VisualCrossing.cpp
+++ b/hardware/VisualCrossing.cpp
@@ -173,7 +173,7 @@ void CVisualCrossing::GetMeterDetails()
 	}
 	if (root["currentConditions"]["pressure"].empty() == false)
 	{
-		barometric = atoi(root["currentConditions"]["pressure"].asString().c_str());
+		barometric = stoi(root["currentConditions"]["pressure"].asString());
 		if (barometric<1000)
 			barometric_forcast = baroForecastRain;
 		else if (barometric<1020)
@@ -232,13 +232,13 @@ void CVisualCrossing::GetMeterDetails()
 
 	if (root["currentConditions"]["winddir"].empty() == false)
 	{
-		wind_degrees = atoi(root["currentConditions"]["winddir"].asString().c_str());
+		wind_degrees = stoi(root["currentConditions"]["winddir"].asString());
 	}
 	if (root["currentConditions"]["windspeed"].empty() == false)
 	{
 		if ((root["currentConditions"]["windspeed"] != "N/A") && (root["currentConditions"]["windspeed"] != "--"))
 		{
-			float temp_wind_kph = static_cast<float>(atof(root["currentConditions"]["windspeed"].asString().c_str()));
+			float temp_wind_kph = stof(root["currentConditions"]["windspeed"].asString());
 			if (temp_wind_kph != -9999.00F)
 			{
 				//convert to m/s
@@ -250,7 +250,7 @@ void CVisualCrossing::GetMeterDetails()
 	{
 		if ((root["currentConditions"]["windgust"] != "N/A") && (root["currentConditions"]["windgust"] != "--"))
 		{
-			float temp_wind_gust_kph = static_cast<float>(atof(root["currentConditions"]["windgust"].asString().c_str()));
+			float temp_wind_gust_kph = stof(root["currentConditions"]["windgust"].asString());
 			if (temp_wind_gust_kph != -9999.00F)
 			{
 				//convert to m/s
@@ -262,7 +262,7 @@ void CVisualCrossing::GetMeterDetails()
 	{
 		if ((root["currentConditions"]["feelslike"] != "N/A") && (root["currentConditions"]["feelslike"] != "--"))
 		{
-			wind_chill = static_cast<float>(atof(root["currentConditions"]["feelslike"].asString().c_str()));
+			wind_chill = stof(root["currentConditions"]["feelslike"].asString());
 		}
 	}
 	if (wind_degrees != -1)

--- a/hardware/WOL.cpp
+++ b/hardware/WOL.cpp
@@ -186,7 +186,7 @@ void CWOL::AddNode(const std::string &Name, const std::string &MACAddress)
 	if (result.empty())
 		return;
 
-	int ID = atoi(result[0][0].c_str());
+	int ID = stoi(result[0][0]);
 
 	char szID[40];
 	sprintf(szID, "%X%02X%02X%02X", 0, 0, (ID & 0xFF00) >> 8, ID & 0xFF);
@@ -254,7 +254,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pHardware == nullptr)
 				return;
@@ -293,7 +293,7 @@ namespace http {
 			std::string mac = HTMLSanitizer::Sanitize(request::findValue(&req, "mac"));
 			if ((hwid.empty()) || (name.empty()) || (mac.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -320,7 +320,7 @@ namespace http {
 			std::string mac = HTMLSanitizer::Sanitize(request::findValue(&req, "mac"));
 			if ((hwid.empty()) || (nodeid.empty()) || (name.empty()) || (mac.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -328,7 +328,7 @@ namespace http {
 				return;
 			CWOL *pHardware = dynamic_cast<CWOL*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "WOLUpdateNode";
 			pHardware->UpdateNode(NodeID, name, mac);
@@ -346,7 +346,7 @@ namespace http {
 			std::string nodeid = request::findValue(&req, "nodeid");
 			if ((hwid.empty()) || (nodeid.empty()))
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;
@@ -354,7 +354,7 @@ namespace http {
 				return;
 			CWOL *pHardware = dynamic_cast<CWOL*>(pBaseHardware);
 
-			int NodeID = atoi(nodeid.c_str());
+			int NodeID = stoi(nodeid);
 			root["status"] = "OK";
 			root["title"] = "WOLRemoveNode";
 			pHardware->RemoveNode(NodeID);
@@ -371,7 +371,7 @@ namespace http {
 			std::string hwid = request::findValue(&req, "idx");
 			if (hwid.empty())
 				return;
-			int iHardwareID = atoi(hwid.c_str());
+			int iHardwareID = stoi(hwid);
 			CDomoticzHardwareBase *pBaseHardware = m_mainworker.GetHardware(iHardwareID);
 			if (pBaseHardware == nullptr)
 				return;

--- a/hardware/Wunderground.cpp
+++ b/hardware/Wunderground.cpp
@@ -275,7 +275,7 @@ void CWunderground::GetMeterDetails()
 	}
 	if (root["metric_si"]["pressure"].empty()==false)
 	{
-		barometric=atoi(root["metric_si"]["pressure"].asString().c_str());
+		barometric = stoi(root["metric_si"]["pressure"].asString());
 		if (barometric<1000)
 			barometric_forcast=baroForecastRain;
 		else if (barometric<1020)
@@ -313,27 +313,27 @@ void CWunderground::GetMeterDetails()
 
 	if (root["winddir"].empty()==false)
 	{
-		wind_degrees=atoi(root["winddir"].asString().c_str());
+		wind_degrees = stoi(root["winddir"].asString());
 	}
 	if (root["metric_si"]["windSpeed"].empty()==false)
 	{
 		if ((root["metric_si"]["windSpeed"] != "N/A") && (root["metric_si"]["windSpeed"] != "--"))
 		{
-			windspeed_ms = static_cast<float>(atof(root["metric_si"]["windSpeed"].asString().c_str()));
+			windspeed_ms = stof(root["metric_si"]["windSpeed"].asString());
 		}
 	}
 	if (root["metric_si"]["windGust"].empty()==false)
 	{
 		if ((root["metric_si"]["windGust"] != "N/A") && (root["metric_si"]["windGust"] != "--"))
 		{
-			windgust_ms = static_cast<float>(atof(root["metric_si"]["windGust"].asString().c_str()));
+			windgust_ms = stof(root["metric_si"]["windGust"].asString());
 		}
 	}
 	if (root["metric_si"]["windChill"].empty()==false)
 	{
 		if ((root["metric_si"]["windChill"] != "N/A") && (root["metric_si"]["windChill"] != "--"))
 		{
-			wind_chill = static_cast<float>(atof(root["metric_si"]["windChill"].asString().c_str()));
+			wind_chill = stof(root["metric_si"]["windChill"].asString());
 		}
 	}
 	if (wind_degrees!=-1)
@@ -394,7 +394,7 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["uv"] != "N/A") && (root["uv"] != "--"))
 		{
-			float UV = static_cast<float>(atof(root["uv"].asString().c_str()));
+			float UV = stof(root["uv"].asString());
 			if ((UV < 16) && (UV >= 0))
 			{
 				SendUVSensor(0, 1, 255, UV, "UV");
@@ -407,7 +407,7 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["metric_si"]["precipTotal"] != "N/A") && (root["metric_si"]["precipTotal"] != "--"))
 		{
-			float RainCount = static_cast<float>(atof(root["metric_si"]["precipTotal"].asString().c_str()));
+			float RainCount = stof(root["metric_si"]["precipTotal"].asString());
 			if ((RainCount != -9999.00F) && (RainCount >= 0.00F))
 			{
 				RBUF tsen;
@@ -427,7 +427,7 @@ void CWunderground::GetMeterDetails()
 				{
 					if ((root["metric_si"]["precipRate"] != "N/A") && (root["metric_si"]["precipRate"] != "--"))
 					{
-						float rainrateph = static_cast<float>(atof(root["metric_si"]["precipRate"].asString().c_str()));
+						float rainrateph = stof(root["metric_si"]["precipRate"].asString());
 						if (rainrateph != -9999.00F)
 						{
 							int at10 = ground(std::abs(rainrateph * 100.0F));
@@ -454,7 +454,7 @@ void CWunderground::GetMeterDetails()
 	{
 		if ((root["visibility"] != "N/A") && (root["visibility"] != "--"))
 		{
-			float visibility = static_cast<float>(atof(root["visibility"].asString().c_str()));
+			float visibility = stof(root["visibility"].asString());
 			if (visibility >= 0)
 			{
 				_tGeneralDevice gdevice;
@@ -468,7 +468,7 @@ void CWunderground::GetMeterDetails()
 	//Solar Radiation
 	if (root["solarRadiation"].empty() == false)
 	{
-		float radiation = static_cast<float>(atof(root["solarRadiation"].asString().c_str()));
+		float radiation = stof(root["solarRadiation"].asString());
 		if (radiation >= 0.0F)
 		{
 			_tGeneralDevice gdevice;

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -666,8 +666,8 @@ void XiaomiGateway::InsertUpdateRGBGateway(const std::string &nodeid, const std:
 	if (result.empty())
 	{
 		Log(LOG_STATUS, "New Gateway Found (%s/%s)", str.c_str(), Name.c_str());
-		// int value = atoi(brightness.c_str());
-		// int value = hue; // atoi(hue.c_str());
+		// int value = stoi(brightness);
+		// int value = hue; // stoi(hue);
 		int cmd = Color_LedOn;
 		if (!bIsOn)
 		{
@@ -685,10 +685,10 @@ void XiaomiGateway::InsertUpdateRGBGateway(const std::string &nodeid, const std:
 	}
 	else
 	{
-		nvalue = atoi(result[0][0].c_str());
+		nvalue = stoi(result[0][0]);
 		tIsOn = (nvalue != 0);
-		lastLevel = atoi(result[0][1].c_str());
-		// int value = atoi(brightness.c_str());
+		lastLevel = stoi(result[0][1]);
+		// int value = stoi(brightness);
 		if ((bIsOn != tIsOn) || (brightness != lastLevel))
 		{
 			int cmd = Color_LedOn;
@@ -799,64 +799,64 @@ void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::str
 				std::string Idx = result[0][0];
 				if (Name == NAME_SELECTOR_WIRELESS_SINGLE)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click|Long Click|Long Click Release", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click|Long Click|Long Click Release", false));
 				}
 				else if (Name == NAME_SELECTOR_WIRELESS_SINGLE_SQUARE)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click", false));
 				}
 				else if (Name == NAME_SELECTOR_WIRELESS_SINGLE_SMART_PUSH)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Shake", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Shake", false));
 				}
 				else if (Name == NAME_SELECTOR_CUBE_V1)
 				{
 					m_sql.SetDeviceOptions(
-						atoi(Idx.c_str()),
+						stoi(Idx),
 						m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|flip90|flip180|move|tap_twice|shake_air|swing|alert|free_fall|clock_wise|anti_clock_wise",
 									 false));
 				}
 				else if (Name == NAME_SELECTOR_CUBE_AQARA)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()),
+					m_sql.SetDeviceOptions(stoi(Idx),
 							       m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|flip90|flip180|move|tap_twice|shake_air|swing|alert|free_fall|rotate", false));
 				}
 				else if (Name == NAME_SENSOR_VIBRATION)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Tilt|Vibrate|Free Fall", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Tilt|Vibrate|Free Fall", false));
 				}
 				else if (Name == NAME_SELECTOR_WIRELESS_WALL_DUAL)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Switch 1|Switch 2|Both Click|Switch 1 Double Click|Switch 2 "
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Switch 1|Switch 2|Both Click|Switch 1 Double Click|Switch 2 "
 													   "Double Click|Both Double Click|Switch 1 Long Click|Switch 2 Long Click|Both Long Click",
 													   false));
 				}
 				else if (Name == NAME_SELECTOR_WIRED_WALL_SINGLE)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Switch1 On|Switch1 Off", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Switch1 On|Switch1 Off", false));
 				}
 				else if (Name == NAME_SELECTOR_WIRELESS_WALL_SINGLE)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click|Long Click", false));
+					m_sql.SetDeviceOptions(stoi(Idx), m_sql.BuildDeviceOptions("SelectorStyle:0;LevelNames:Off|Click|Double Click|Long Click", false));
 				}
 				else if (Name == NAME_GATEWAY_SOUND_ALARM_RINGTONE)
 				{
 					m_sql.SetDeviceOptions(
-						atoi(Idx.c_str()),
+						stoi(Idx),
 						m_sql.BuildDeviceOptions(
 							"SelectorStyle:1;LevelNames:Off|Police siren 1|Police siren 2|Accident tone|Missle countdown|Ghost|Sniper|War|Air Strike|Barking dogs", false));
 				}
 				else if (Name == NAME_GATEWAY_SOUND_ALARM_CLOCK)
 				{
 					m_sql.SetDeviceOptions(
-						atoi(Idx.c_str()),
+						stoi(Idx),
 						m_sql.BuildDeviceOptions(
 							"SelectorStyle:1;LevelNames:Off|MiMix|Enthusiastic|GuitarClassic|IceWorldPiano|LeisureTime|Childhood|MorningStreamlet|MusicBox|Orange|Thinker",
 							false));
 				}
 				else if (Name == NAME_GATEWAY_SOUND_DOORBELL)
 				{
-					m_sql.SetDeviceOptions(atoi(Idx.c_str()),
+					m_sql.SetDeviceOptions(stoi(Idx),
 							       m_sql.BuildDeviceOptions("SelectorStyle:1;LevelNames:Off|Doorbell ring tone|Knock on door|Hilarious|Alarm clock", false));
 				}
 			}
@@ -869,8 +869,8 @@ void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::str
 	}
 	else
 	{
-		int nvalue = atoi(result[0][0].c_str());
-		int BatteryLevel = atoi(result[0][1].c_str());
+		int nvalue = stoi(result[0][0]);
+		int BatteryLevel = stoi(result[0][1]);
 
 		if (messagetype == "heartbeat")
 		{
@@ -893,8 +893,8 @@ void XiaomiGateway::InsertUpdateSwitch(const std::string &nodeid, const std::str
 		{
 			if (!load_power.empty() && !power_consumed.empty())
 			{
-				int power = atoi(load_power.c_str());
-				int consumed = atoi(power_consumed.c_str()) / 1000;
+				int power = stoi(load_power);
+				int consumed = stoi(power_consumed) / 1000;
 				SendKwhMeter(sID, 1, 255, power, consumed, "Xiaomi Smart Plug Usage");
 			}
 		}
@@ -1411,7 +1411,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 				int battery = 255;
 				if (!voltage.empty() && voltage != "3600")
 				{
-					battery = ((atoi(voltage.c_str()) - 2200) / 10);
+					battery = ((stoi(voltage) - 2200) / 10);
 				}
 				if (type != STYPE_END)
 				{
@@ -1454,7 +1454,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 							level = 0;
 						}
 						if (!density.empty())
-							level = atoi(density.c_str());
+							level = stoi(density);
 					}
 					if ((status == STATE_MOTION_YES) || (status == STATE_OPEN) || (status == "no_close") || (status == STATE_ON) || (!no_close.empty()))
 					{
@@ -1516,7 +1516,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					std::string rotate = root2["rotate"].asString();
 					if (!rotate.empty())
 					{
-						int amount = atoi(rotate.c_str());
+						int amount = stoi(rotate);
 						if (amount > 0)
 						{
 							level = 90;
@@ -1562,7 +1562,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 						}
 						else if ((model == MODEL_ACT_BLINDS_CURTAIN) && (!curtain.empty()))
 						{
-							level = atoi(curtain.c_str());
+							level = stoi(curtain);
 							TrueGateway->InsertUpdateSwitch(sid, name, on, type, unitcode, level, cmd, "", "", battery);
 						}
 						else
@@ -1573,11 +1573,11 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 							}
 							if (!lux.empty())
 							{
-								TrueGateway->InsertUpdateLux(sid, name, atoi(lux.c_str()), battery);
+								TrueGateway->InsertUpdateLux(sid, name, stoi(lux), battery);
 							}
 							if (!voltage.empty() && m_IncludeVoltage)
 							{
-								TrueGateway->InsertUpdateVoltage(sid, name, atoi(voltage.c_str()));
+								TrueGateway->InsertUpdateVoltage(sid, name, stoi(voltage));
 							}
 						}
 					}
@@ -1620,26 +1620,26 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					if (name == NAME_SENSOR_TEMP_HUM_AQARA)
 					{
 						std::string szPressure = root2["pressure"].asString();
-						pressure = static_cast<float>(atof(szPressure.c_str())) / 100.0F;
+						pressure = stof(szPressure) / 100.0F;
 					}
 
 					if ((!temperature.empty()) && (!humidity.empty()) && (pressure != 0))
 					{
 						// Temp+Hum+Baro
-						float temp = std::stof(temperature) / 100.0F;
-						int hum = static_cast<int>((std::stof(humidity) / 100));
+						float temp = stof(temperature) / 100.0F;
+						int hum = static_cast<int>(stof(humidity) / 100.0F);
 						TrueGateway->InsertUpdateTempHumPressure(sid, "Xiaomi TempHumBaro", temp, hum, pressure, battery);
 					}
 					else if ((!temperature.empty()) && (!humidity.empty()))
 					{
 						// Temp+Hum
-						float temp = std::stof(temperature) / 100.0F;
-						int hum = static_cast<int>((std::stof(humidity) / 100));
+						float temp = stof(temperature) / 100.0F;
+						int hum = static_cast<int>(stof(humidity) / 100.0F);
 						TrueGateway->InsertUpdateTempHum(sid, "Xiaomi TempHum", temp, hum, battery);
 					}
 					else if (!temperature.empty())
 					{
-						float temp = std::stof(temperature) / 100.0F;
+						float temp = stof(temperature) / 100.0F;
 						if (temp < 99)
 						{
 							TrueGateway->InsertUpdateTemperature(sid, "Xiaomi Temperature", temp, battery);
@@ -1647,7 +1647,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					}
 					else if (!humidity.empty())
 					{
-						int hum = static_cast<int>((std::stof(humidity) / 100));
+						int hum = static_cast<int>(stof(humidity) / 100.0F);
 						if (hum > 1)
 						{
 							TrueGateway->InsertUpdateHumidity(sid, "Xiaomi Humidity", hum, battery);
@@ -1664,7 +1664,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 						if (TrueGateway->GetGatewaySid() == sid)
 						{
 							std::stringstream ss;
-							ss << std::hex << atoi(rgb.c_str());
+							ss << std::hex << stoi(rgb);
 							std::string hexstring(ss.str());
 							if (hexstring.length() == 7)
 							{
@@ -1680,7 +1680,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 								on = true;
 							}
 							TrueGateway->InsertUpdateRGBGateway(sid, name + " (" + TrueGateway->GetGatewayIp() + ")", on, brightness, 0);
-							TrueGateway->InsertUpdateLux(sid, NAME_GATEWAY_LUX, atoi(illumination.c_str()), 255);
+							TrueGateway->InsertUpdateLux(sid, NAME_GATEWAY_LUX, stoi(illumination), 255);
 							TrueGateway->InsertUpdateSwitch(sid, NAME_GATEWAY_SOUND_ALARM_RINGTONE, false, STYPE_Selector, 3, 0, cmd, "", "", 255);
 							TrueGateway->InsertUpdateSwitch(sid, NAME_GATEWAY_SOUND_ALARM_CLOCK, false, STYPE_Selector, 4, 0, cmd, "", "", 255);
 							TrueGateway->InsertUpdateSwitch(sid, NAME_GATEWAY_SOUND_DOORBELL, false, STYPE_Selector, 5, 0, cmd, "", "", 255);

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -1620,26 +1620,26 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					if (name == NAME_SENSOR_TEMP_HUM_AQARA)
 					{
 						std::string szPressure = root2["pressure"].asString();
-						pressure = stof(szPressure) / 100.0F;
+						pressure = static_cast<float>(stod(szPressure) / 100.0);
 					}
 
 					if ((!temperature.empty()) && (!humidity.empty()) && (pressure != 0))
 					{
 						// Temp+Hum+Baro
-						float temp = stof(temperature) / 100.0F;
-						int hum = static_cast<int>(stof(humidity) / 100.0F);
+						float temp = static_cast<float>(stod(temperature) / 100.0);
+						int hum = static_cast<int>(stod(humidity) / 100.0);
 						TrueGateway->InsertUpdateTempHumPressure(sid, "Xiaomi TempHumBaro", temp, hum, pressure, battery);
 					}
 					else if ((!temperature.empty()) && (!humidity.empty()))
 					{
 						// Temp+Hum
-						float temp = stof(temperature) / 100.0F;
-						int hum = static_cast<int>(stof(humidity) / 100.0F);
+						float temp = static_cast<float>(stod(temperature) / 100.0);
+						int hum = static_cast<int>(stod(humidity) / 100.0);
 						TrueGateway->InsertUpdateTempHum(sid, "Xiaomi TempHum", temp, hum, battery);
 					}
 					else if (!temperature.empty())
 					{
-						float temp = stof(temperature) / 100.0F;
+						float temp = static_cast<float>(stod(temperature) / 100.0);
 						if (temp < 99)
 						{
 							TrueGateway->InsertUpdateTemperature(sid, "Xiaomi Temperature", temp, battery);
@@ -1647,7 +1647,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 					}
 					else if (!humidity.empty())
 					{
-						int hum = static_cast<int>(stof(humidity) / 100.0F);
+						int hum = static_cast<int>(stod(humidity) / 100.0);
 						if (hum > 1)
 						{
 							TrueGateway->InsertUpdateHumidity(sid, "Xiaomi Humidity", hum, battery);

--- a/hardware/XiaomiGateway.cpp
+++ b/hardware/XiaomiGateway.cpp
@@ -1673,7 +1673,7 @@ void XiaomiGateway::xiaomi_udp_server::handle_receive(const boost::system::error
 							std::string bright_hex = hexstring.substr(0, 2);
 							std::stringstream ss2;
 							ss2 << std::hex << bright_hex.c_str();
-							int brightness = strtoul(bright_hex.c_str(), nullptr, 16);
+							int brightness = stoul(bright_hex, nullptr, 16);
 							bool on = false;
 							if (rgb != "0")
 							{

--- a/hardware/Yeelight.cpp
+++ b/hardware/Yeelight.cpp
@@ -128,7 +128,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 		Log(LOG_STATUS, "Invalid location received! (No IP Address)");
 		return;
 	}
-	uint32_t sID = (uint32_t)(atoi(ipaddress[0].c_str()) << 24) | (uint32_t)(atoi(ipaddress[1].c_str()) << 16) | (atoi(ipaddress[2].c_str()) << 8) | atoi(ipaddress[3].c_str());
+	uint32_t sID = ((uint32_t) stoi(ipaddress[0]) << 24) | ((uint32_t) stoi(ipaddress[1]) << 16) | ((uint32_t) stoi(ipaddress[2]) << 8) | ((uint32_t) stoi(ipaddress[3]));
 	char szDeviceID[20];
 	if (sID == 1)
 		sprintf(szDeviceID, "%d", 1);
@@ -137,14 +137,14 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 
 	std::vector<std::vector<std::string> > result;
 	result = m_sql.safe_query("SELECT nValue, LastLevel, SubType, ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d)", m_HwdID, szDeviceID, pTypeColorSwitch);
-	int yeelightColorMode = atoi(syeelightColorMode.c_str());
+	int yeelightColorMode = stoi(syeelightColorMode);
 	if (yeelightColorMode > 0) {
 		Debug(DEBUG_HARDWARE, "Yeelight::InsertUpdateSwitch colorMode: %u, Bri: %s, Hue: %s, Sat: %s, RGB: %s, CT: %s", yeelightColorMode, yeelightBright.c_str(), syeelightHue.c_str(), syeelightSat.c_str(), syeelightRGB.c_str(), syeelightCT.c_str());
 	}
 	if (result.empty())
 	{
 		Log(LOG_STATUS, "New Light Found (%s/%s)", Location.c_str(), lightName.c_str());
-		int value = atoi(yeelightBright.c_str());
+		int value = stoi(yeelightBright);
 		int cmd = Color_LedOn;
 		int level = 100;
 		if (!bIsOn) {
@@ -163,7 +163,7 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 	}
 	else {
 		// Make sure subtype is correct
-		unsigned sTypeOld = atoi(result[0][2].c_str());
+		unsigned sTypeOld = (unsigned) stoul(result[0][2]);
 		std::string sIdx = result[0][3];
 		if (sTypeOld != YeeType)
 		{
@@ -171,10 +171,10 @@ void Yeelight::InsertUpdateSwitch(const std::string &nodeID, const std::string &
 			m_sql.UpdateDeviceValue("SubType", (int)YeeType, sIdx);
 		}
 
-		int nvalue = atoi(result[0][0].c_str());
+		int nvalue = stoi(result[0][0]);
 		bool tIsOn = (nvalue != 0);
-		int lastLevel = atoi(result[0][1].c_str());
-		int value = atoi(yeelightBright.c_str());
+		int lastLevel = stoi(result[0][1]);
+		int value = stoi(yeelightBright);
 		if ((bIsOn != tIsOn) || (value != lastLevel))
 		{
 			int cmd = Color_LedOn;
@@ -609,7 +609,7 @@ namespace http {
 				return;
 			root["status"] = "OK";
 
-			int HwdID = atoi(idx.c_str());
+			int HwdID = stoi(idx);
 
 			Yeelight yeelight(HwdID);
 			//TODO: Add support for other bulb types to WebUI (WW, RGB, RGBWW)

--- a/hardware/YouLess.cpp
+++ b/hardware/YouLess.cpp
@@ -215,8 +215,8 @@ void CYouLess::GetMeterDetails()
 		pcurrent=pcurrent.substr(0,fpos);
 	stdreplace(pcurrent,",","");
 
-	unsigned long lpusage = atol(pusage.c_str());
-	unsigned long lpcurrent = atol(pcurrent.c_str());
+	unsigned long lpusage = stoul(pusage);
+	unsigned long lpcurrent = stoul(pcurrent);
 	if (lpusage)
 	{
 		m_meter.powerusage = lpusage;

--- a/hardware/ZiBlueBase.cpp
+++ b/hardware/ZiBlueBase.cpp
@@ -301,7 +301,7 @@ void CZiBlueBase::GetManualSwitchParameters(const std::multimap<std::string, std
 	auto it = Parameters.find("housecode");
 	if (it != Parameters.end())
 	{
-		int ID = atoi(it->second.c_str());
+		int ID = stoi(it->second);
 		std::stringstream s_strid;
 		s_strid << std::hex << std::setfill('0') << std::setw(8) << ID;
 		devIDOut = s_strid.str();
@@ -316,7 +316,7 @@ void CZiBlueBase::GetManualSwitchParameters(const std::multimap<std::string, std
 		it = Parameters.find("qualifier");
 		if (it != Parameters.end())
 		{
-			int id = atoi(devIDOut.c_str());
+			int id = stoi(devIDOut);
 			int qualifier = it->second == "true" ? 1 : 0; 
 			id |= qualifier << 16;
 			std::stringstream temp;
@@ -572,7 +572,7 @@ bool CZiBlueBase::SendSwitchInt(const int ID, const int switchunit, const int Ba
 		{
 			cmnd = gswitch_sSetLevel;
 			std::string str2 = switchcmd.substr(10);
-			svalue = atoi(str2.c_str());
+			svalue = stoi(str2);
 			Log(LOG_STATUS, "%d level: %d", cmnd, svalue);
 		}
 	}

--- a/hardware/eHouseTCP.cpp
+++ b/hardware/eHouseTCP.cpp
@@ -269,7 +269,7 @@ int eHouseTCP::UpdateSQLState(int devh, const uint8_t devl, int devtype, const u
 		// add Plan for each controllers
 		if (!result.empty())
 		{
-			i = atoi(result[0][0].c_str());
+			i = stoi(result[0][0]);
 			result = m_sql.safe_query("SELECT ID FROM DeviceToPlansMap WHERE (DeviceRowID==%d)", i);
 			if (result.empty())
 			{
@@ -287,7 +287,7 @@ int eHouseTCP::UpdateSQLState(int devh, const uint8_t devl, int devtype, const u
 	}
 	else
 	{
-		return atoi(result[0][0].c_str());
+		return stoi(result[0][0]);
 	}
 	return -1;
 }
@@ -320,7 +320,7 @@ int eHouseTCP::UpdateSQLPlan(int /*devh*/, int /*devl*/, int /*devtype*/, const 
 	}
 	else
 	{
-		i = atoi(result[0][0].c_str());
+		i = stoi(result[0][0]);
 		return i;
 	}
 	return -1;
@@ -1071,9 +1071,9 @@ bool eHouseTCP::WriteToHardware(const char *pdata, const unsigned char /*length*
 				result = m_sql.safe_query("SELECT nValue, sValue, LastLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)", m_HwdID, IDX, AddrL);
 				if (!result.empty())
 				{
-					int nvalue = atoi(result[0][0].c_str());
-					int svalue = atoi(result[0][1].c_str());
-					// int lastLevel = atoi(result[0][2].c_str());
+					int nvalue = stoi(result[0][0]);
+					int svalue = stoi(result[0][1]);
+					// int lastLevel = stoi(result[0][2]);
 					if (nvalue == 0)
 					{
 						proev[4] = ev[4] = 2;

--- a/hardware/eVehicles/MercApi.cpp
+++ b/hardware/eVehicles/MercApi.cpp
@@ -89,7 +89,7 @@ CMercApi::CMercApi(const std::string &username, const std::string &password, con
 			return;
 	}
 
-	m_uservar_refreshtoken_idx = atoi(result[0][0].c_str());
+	m_uservar_refreshtoken_idx = (uint32_t) stoul(result[0][0]);
 	m_refreshtoken = result[0][1];
 }
 
@@ -190,8 +190,8 @@ void CMercApi::GetLocationData(Json::Value& jsondata, tLocationData& data)
 	std::string CarLongitude = jsondata["longitude"].asString();
 	data.speed = jsondata["speed"].asInt();
 	data.is_driving = data.speed > 0;
-	data.latitude = std::stod(CarLatitude);
-	data.longitude = std::stod(CarLongitude);
+	data.latitude = stod(CarLatitude);
+	data.longitude = stod(CarLongitude);
 	*/
 }
 
@@ -253,7 +253,7 @@ void CMercApi::GetChargeData(Json::Value& jsondata, CVehicleApi::tChargeData& da
 					if(!iter2["value"].empty())
 					{
 						m_pBase->Debug(DEBUG_NORM, "SoC has value %s", iter2["value"].asString().c_str());
-						data.battery_level = static_cast<float>(atof(iter2["value"].asString().c_str()));
+						data.battery_level = stof(iter2["value"].asString());
 					}
 				}
 				if (id == "rangeelectric")
@@ -457,7 +457,7 @@ void CMercApi::GetVehicleData(Json::Value& jsondata, tVehicleData& data)
 					if(!iter2["value"].empty())
 					{
 						m_pBase->Debug(DEBUG_NORM, "Odo has value %s", iter2["value"].asString().c_str());
-						data.odo = static_cast<float>(atof(iter2["value"].asString().c_str()));
+						data.odo = stof(iter2["value"].asString());
 					}
 				}
 			}
@@ -952,7 +952,7 @@ uint16_t CMercApi::ExtractHTTPResultCode(const std::string& sResponseHeaderLine0
 			{
 				iHttpCodeStartPos = (uint8_t)sResponseHeaderLine0.find_first_of(' ') + 1;	// So look for a SPACE as the seperator (RFC2616)
 
-				iHttpCode = (uint16_t)std::stoi(sResponseHeaderLine0.substr(iHttpCodeStartPos, 3));
+				iHttpCode = (uint16_t) stoi(sResponseHeaderLine0.substr(iHttpCodeStartPos, 3));
 				if (iHttpCode < 100 || iHttpCode > 599)		// Check valid resultcode range
 				{
 					m_pBase->Log(LOG_STATUS, "Found non-standard resultcode (%d) in HTTP response statusline: %s", iHttpCode, sResponseHeaderLine0.c_str());

--- a/hardware/eVehicles/TeslaApi.cpp
+++ b/hardware/eVehicles/TeslaApi.cpp
@@ -145,8 +145,8 @@ void CTeslaApi::GetLocationData(Json::Value &jsondata, tLocationData &data)
 	std::string CarLongitude = jsondata["longitude"].asString();
 	data.speed = jsondata["speed"].asInt();
 	data.is_driving = data.speed > 0;
-	data.latitude = std::stod(CarLatitude);
-	data.longitude = std::stod(CarLongitude);
+	data.latitude = stod(CarLatitude);
+	data.longitude = stod(CarLongitude);
 	if (m_config.home_latitude != 0 && m_config.home_latitude != 0)
 	{
 		if ((std::fabs(m_config.home_latitude - data.latitude) < 2E-4) && (std::fabs(m_config.home_longitude - data.longitude) < 2E-3) && !data.is_driving)

--- a/hardware/eVehicles/eVehicle.cpp
+++ b/hardware/eVehicles/eVehicle.cpp
@@ -289,8 +289,8 @@ bool CeVehicle::StartHardware()
 	{
 		std::string Latitude = strarray[0];
 		std::string Longitude = strarray[1];
-		m_api->m_config.home_latitude = std::stod(Latitude);
-		m_api->m_config.home_longitude = std::stod(Longitude);
+		m_api->m_config.home_latitude = stod(Latitude);
+		m_api->m_config.home_longitude = stod(Longitude);
 
 		Log(LOG_STATUS, "Using Domoticz home location (Lat %s, Lon %s) as car's home location.", Latitude.c_str(), Longitude.c_str());
 	}
@@ -886,7 +886,7 @@ void CeVehicle::UpdateCustomVehicleData(CVehicleApi::tCustomData& data)
 
 						if (is_number(sValue))
 						{
-							float fValue = static_cast<float>(std::atof(sValue.c_str()));
+							float fValue = stof(sValue);
 							SendCustom(VEHICLE_CUSTOM, iChildID, fValue, sLabel);
 						}
 						else if (isBool)

--- a/hardware/openwebnet/bt_openwebnet.cpp
+++ b/hardware/openwebnet/bt_openwebnet.cpp
@@ -1127,7 +1127,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 {
 	if (who == "0") {
 		// "Scenario"
-		int scenNumber = atoi(what.c_str());
+		int scenNumber = stoi(what);
 		if (scenNumber >= 1 && scenNumber <= 32) {
 			std::stringstream sstr;
 			sstr << "Scenario ";
@@ -1465,7 +1465,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 		{
 			return "Release of sensor local adjustment";
 		}
-		int iWhat = atoi(what.c_str());
+		int iWhat = stoi(what);
 		if (iWhat >= 1100 && iWhat <= 1199) {
 			//Weekly Heating program x(x = 1...3)
 			std::stringstream sstr;
@@ -1696,7 +1696,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 		{
 			return "decreases image quality";
 		}
-		int iWhat = atoi(what.c_str());
+		int iWhat = stoi(what);
 		if (iWhat >= 311 && iWhat <= 344)
 		{
 			int iFirstDial = (iWhat - 300) / 10;
@@ -1775,7 +1775,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 			}
 		}
 
-		int iWhat = atoi(what.c_str());
+		int iWhat = stoi(what);
 		if (iWhat >= 0 && iWhat <= 31) {
 			//int iFirstDial = (iWhat - 300) / 10;
 			//int iSecondDial = iWhat - 300 - 10 * iFirstDial;
@@ -1851,7 +1851,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 			return "find the first free frequency less than the selected one";
 		}
 
-		int iWhat = atoi(what.c_str());
+		int iWhat = stoi(what);
 		if (iWhat >= 1001 && iWhat <= 1015) {
 			std::stringstream sstr;
 			int iDeltaVolume = iWhat - 1000;
@@ -2089,7 +2089,7 @@ std::string bt_openwebnet::getWhatDescription(const std::string& who, const std:
 			sstr << "profile id ";
 			if (!whatParameters.empty())
 			{
-				int profileID = atoi(whatParameters[0].c_str());
+				int profileID = stoi(whatParameters[0]);
 				sstr << profileID;
 			}
 		}
@@ -2188,13 +2188,13 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 		}
 
 		if (!macAddr.empty()) {
-			long lMacAddr = atol(macAddr.c_str());
+			long lMacAddr = stol(macAddr);
 			desc << "mac address ";
 			desc << std::hex << lMacAddr;
 		}
 
 		if (!unit.empty()) {
-			if (atoi(unit.c_str()) == 0) {
+			if (stoi(unit) == 0) {
 				desc << "all units";
 			}
 			else {
@@ -2246,7 +2246,7 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 		}
 		else if (int len1 = str1.length()) 
 		{
-			int iWhere = atoi(str1.c_str());
+			int iWhere = stoi(str1);
 			if (len1 <= 2)
 			{
 				// 0 : General probes (all probes)
@@ -2282,7 +2282,7 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 			//#0 : Central Unit
 			//#1 : Zone 1 via Central Unit...
 			//#99 : Zone 99 via Central Unit
-			int iWhere = atoi(str2.c_str());
+			int iWhere = stoi(str2);
 			if (iWhere == 0)
 				return "Central Unit";
 			else if ((iWhere >= 1) && (iWhere <= 99))
@@ -2290,18 +2290,19 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 		}
 	}
 	else if (who == "5") {
-        
-        if (atoi(what.c_str()) == 11 ){
+        int iWhat = stoi(what);
+
+        if (iWhat == 11 ){
             return "zone " + whereParameters[0];
         }
-	if (atoi(what.c_str()) >= 0 && atoi(what.c_str()) <= 10)
-	{
-		return "";
-	}
-	if (atoi(what.c_str()) == 18)
-	{
-		return "zone " + whereParameters[0];
-	}
+		if (iWhat >= 0 && iWhat <= 10)
+		{
+			return "";
+		}
+		if (iWhat == 18)
+		{
+			return "zone " + whereParameters[0];
+		}
 
 		// "Burglar alarm" : TODO
 		//1 : CONTROL PANEL
@@ -2378,7 +2379,7 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 		// "Dry contact";
 		if (where.length() >= 2 && where[0] == '3') {
 			std::string whereRight = where.substr(1);
-			int iWhere = atoi(whereRight.c_str());
+			int iWhere = stoi(whereRight);
 			if (iWhere > 10 && iWhere < 100) {
 				int iZ = iWhere / 10;
 				int iN = iWhere - 10 * iZ;
@@ -2405,7 +2406,7 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 
 
 	if (translateAmbPL) {
-		if (atoi(where.c_str()) == 0) {
+		if (stoi(where) == 0) {
 			if (!whereParameters.empty())
 			{
 				//group from 1 to 255
@@ -2459,7 +2460,7 @@ std::string bt_openwebnet::getWhereDescription(const std::string& who, const std
 				pointOfLight = end;
 			}
 			else {
-				int amb = atoi(begin.c_str());
+				int amb = stoi(begin);
 				if (amb >= 1 && amb <= 10) {
 					//A = [01 - 09], PL = [10 - 15]
 					//A = 10 , PL = [01 - 15];
@@ -2524,7 +2525,7 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 		//12 Complete probe status
 		//13 Local set offset : 00  knob on 0 // 01  knob on + 1 (degree) //11  knob on - 1 (degree)//02  knob on + 2 (degree)//12  knob on - 2 (degree)//03  knob on + 3 (degree)//13  knob on - 3 (degree)//4  knob on Local OFF
 		//14 Set Point temperature
-		//14 et 0 : values T et M : T = Zone operation temperature not ad just by local offset.The T field is composed from 4 digits: c1c2c3c4, included between "0050"(5° temperature) and "0400"(40° temperature). c1 is always equal to 0, it indicates a positive temperature.The c2c3 couple indicates the temperature values between[05° - 40°].c4 indicates the decimal Celsius degree by 0.5° step. M = operation mode1  heating mode2  conditional mode3  generic mode
+		//14 et 0 : values T et M : T = Zone operation temperature not ad just by local offset.The T field is composed from 4 digits: c1c2c3c4, included between "0050"(5ï¿½ temperature) and "0400"(40ï¿½ temperature). c1 is always equal to 0, it indicates a positive temperature.The c2c3 couple indicates the temperature values between[05ï¿½ - 40ï¿½].c4 indicates the decimal Celsius degree by 0.5ï¿½ step. M = operation mode1  heating mode2  conditional mode3  generic mode
 		//19 Valves status 		CV, HV = Valves' status, CV: Conditioning Valve and HV : Heating Valve
 		//			CV, HV = 0  OFF
 		//		CV, HV = 1  ON
@@ -2655,7 +2656,7 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 		//	71			Actuators info
 		//	72			Totalizers
 		//	73			Differential current level
-		//	250			Status Stop&Go(Général)
+		//	250			Status Stop&Go(Gï¿½nï¿½ral)
 		//	251			Status Stop&Go(open / close)
 		//	252			Status Stop&Go(failure / no failure)
 		//	253			Status Stop&Go(block / not block)

--- a/hardware/openwebnet/bt_openwebnet.cpp
+++ b/hardware/openwebnet/bt_openwebnet.cpp
@@ -2523,12 +2523,26 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 		//0 Measures Temperature
 		//11 Fan coil Speed 0 = Auto 1 = vel 1 2 = vel2 3 = vel3 15 = OFF
 		//12 Complete probe status
-		//13 Local set offset : 00  knob on 0 // 01  knob on + 1 (degree) //11  knob on - 1 (degree)//02  knob on + 2 (degree)//12  knob on - 2 (degree)//03  knob on + 3 (degree)//13  knob on - 3 (degree)//4  knob on Local OFF
+		//13 Local set offset :
+		//	00  knob on 0
+		//	01  knob on + 1 (degree)
+		//	11  knob on - 1 (degree)
+		//	02  knob on + 2 (degree)
+		//	12  knob on - 2 (degree)
+		//	03  knob on + 3 (degree)
+		//	13  knob on - 3 (degree)
+		//	04  knob on Local OFF
 		//14 Set Point temperature
-		//14 et 0 : values T et M : T = Zone operation temperature not ad just by local offset.The T field is composed from 4 digits: c1c2c3c4, included between "0050"(5� temperature) and "0400"(40� temperature). c1 is always equal to 0, it indicates a positive temperature.The c2c3 couple indicates the temperature values between[05� - 40�].c4 indicates the decimal Celsius degree by 0.5� step. M = operation mode1  heating mode2  conditional mode3  generic mode
+		//14 et 0 : values T et M :
+		//	T = Zone operation temperature not ad just by local offset.
+		//	The T field is composed from 4 digits: c1c2c3c4, included between "0050"(5° temperature) and "0400"(40° temperature).
+		//	c1 is always equal to 0, it indicates a positive temperature.
+		//	The c2c3 couple indicates the temperature values between[05° - 40°].
+		//	c4 indicates the decimal Celsius degree by 0.5° step.
+		//	M = operation mode1  heating mode2  conditional mode3  generic mode
 		//19 Valves status 		CV, HV = Valves' status, CV: Conditioning Valve and HV : Heating Valve
-		//			CV, HV = 0  OFF
-		//		CV, HV = 1  ON
+		//	CV, HV = 0  OFF
+		//	CV, HV = 1  ON
 		//	CV, HV = 2  Opened
 		//	CV, HV = 3  Closed
 		//	CV, HV = 4  Stop
@@ -2553,7 +2567,7 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 		//	Day = [01 - 31]
 		//	Month = [01 - 12]
 		//	Year = [2000 - 2099]
-		//	Example: 12 June 2007 is holiday end date			*#4 * #0 * #30 * 12 * 06 * 2007##
+		//	Example: 12 June 2007 is holiday end date	*#4 * #0 * #30 * 12 * 06 * 2007##
 		//31 Holiday deadline hour
 		//	Hour*Minutes
 		//	Hour = [00 - 23]
@@ -2647,8 +2661,8 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 	}
 	else if (who == "18") {
 		// "Energy management"
-		//113			Active Power
-		//	1200			End Automatic Update size
+		//	113			Active Power
+		//	1200		End Automatic Update size
 		//	51			Energy / Unit Totalizer
 		//	52			Energy / Unit pe month
 		//	53			Partial totalizer for current month
@@ -2656,7 +2670,7 @@ std::string bt_openwebnet::getDimensionsDescription(const std::string& who, cons
 		//	71			Actuators info
 		//	72			Totalizers
 		//	73			Differential current level
-		//	250			Status Stop&Go(G�n�ral)
+		//	250			Status Stop&Go(General)
 		//	251			Status Stop&Go(open / close)
 		//	252			Status Stop&Go(failure / no failure)
 		//	253			Status Stop&Go(block / not block)

--- a/hardware/openzwave/control_panel/ozwcp.cpp
+++ b/hardware/openzwave/control_panel/ozwcp.cpp
@@ -420,7 +420,7 @@ MyValue *MyNode::lookup(const std::string &data)
 	size_t pos1, pos2;
 	std::string str;
 
-	node = (uint8)strtol(data.c_str(), nullptr, 10);
+	node = (uint8) stol(data);
 	if (node == 0)
 		return nullptr;
 	pos1 = data.find('-', 0);
@@ -450,10 +450,10 @@ MyValue *MyNode::lookup(const std::string &data)
 	if (pos2 == std::string::npos)
 		return nullptr;
 	str = data.substr(pos1, pos2 - pos1);
-	inst = (uint8)strtol(str.c_str(), nullptr, 10);
+	inst = (uint8) stol(str);
 	pos1 = pos2 + 1;
 	str = data.substr(pos1);
-	ind = (uint8)strtol(str.c_str(), nullptr, 10);
+	ind = (uint8) stol(str);
 	OpenZWave::ValueID id(homeId, node, vg, cls, inst, ind, typ);
 	MyNode* n = nodes[node];
 	if (n == nullptr)

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -108,14 +108,14 @@ namespace Plugins {
 			std::string sVersion = szPyVersion.substr(0, szPyVersion.find_first_of(' '));
 
 			std::string sMajorVersion = sVersion.substr(0, sVersion.find_first_of('.'));
-			if (std::stoi(sMajorVersion) < MINIMUM_MAJOR_VERSION)
+			if (stoi(sMajorVersion) < MINIMUM_MAJOR_VERSION)
 			{
 				_log.Log(LOG_STATUS, "PluginSystem: Invalid Python version '%s' found, Major version '%d' or above required.", sVersion.c_str(), MINIMUM_MAJOR_VERSION);
 				return false;
 			}
 
 			std::string sMinorVersion = sVersion.substr(sMajorVersion.length()+1);
-			if (std::stoi(sMinorVersion) < MINIMUM_MINOR_VERSION)
+			if (stoi(sMinorVersion) < MINIMUM_MINOR_VERSION)
 			{
 				_log.Log(LOG_STATUS, "PluginSystem: Invalid Python version '%s' found, Minor version '%d.%d' or above required.", sVersion.c_str(), MINIMUM_MAJOR_VERSION, MINIMUM_MINOR_VERSION);
 				return false;
@@ -348,9 +348,9 @@ namespace Plugins {
 			return;
 		//std::vector<std::string> sd = result[0];
 		//GizMoCuz: Why does this work with UNIT ? Why not use the device idx which is always unique ?
-		_log.Debug(DEBUG_NORM, "CPluginSystem::DeviceModified: Notifying plugin %u about modification of device %u", atoi(sHwdID.c_str()), atoi(Unit.c_str()));
+		_log.Debug(DEBUG_NORM, "CPluginSystem::DeviceModified: Notifying plugin %d about modification of device %d", stoi(sHwdID), stoi(Unit));
 		Plugins::CPlugin *pPlugin = (Plugins::CPlugin*)pHardware;
-		pPlugin->DeviceModified(sd[1], atoi(Unit.c_str()));
+		pPlugin->DeviceModified(sd[1], stoi(Unit));
 	}
 } // namespace Plugins
 
@@ -526,8 +526,8 @@ namespace http {
 			result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit FROM DeviceStatus WHERE (ID=='%q') ", sIdx.c_str());
 			if (result.size() == 1)
 			{
-				int HwID = atoi(result[0][0].c_str());
-				int Unit = atoi(result[0][2].c_str());
+				int HwID = stoi(result[0][0]);
+				int Unit = stoi(result[0][2]);
 				Plugins::CPluginSystem Plugins;
 				std::map<int, CDomoticzHardwareBase*>*	PluginHwd = Plugins.GetHardware();
 				Plugins::CPlugin*	pPlugin = (Plugins::CPlugin*)(*PluginHwd)[HwID];

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -476,7 +476,7 @@ namespace Plugins {
 			std::string		sHeaderText = sHeaderLine.substr(sHeaderName.length() + 2);
 			if (uHeaderName == "CONTENT-LENGTH")
 			{
-				m_ContentLength = atoi(sHeaderText.c_str());
+				m_ContentLength = stoi(sHeaderText);
 			}
 			if (uHeaderName == "TRANSFER-ENCODING")
 			{
@@ -1356,7 +1356,7 @@ namespace Plugins {
 					if (iWillPropLen)
 					{
 						const char* cWill = (const char*)&*it;
-						AddIntToDict(pMqttDict, "WillDelayInterval", atoi(std::string(cWill, iWillPropLen).c_str()));
+						AddIntToDict(pMqttDict, "WillDelayInterval", stoi(std::string(cWill, iWillPropLen)));
 					}
 					else
 					{
@@ -1376,7 +1376,7 @@ namespace Plugins {
 					if (iTopicLen)
 					{
 						const char* cTopic = (const char*)&*it;
-						AddIntToDict(pMqttDict, "WillTopic", atoi(std::string(cTopic, iTopicLen).c_str()));
+						AddIntToDict(pMqttDict, "WillTopic", stoi(std::string(cTopic, iTopicLen)));
 					}
 					it += iTopicLen;
 				}
@@ -2521,7 +2521,7 @@ namespace Plugins {
 				else if (pMask.IsString())
 				{
 					std::string sMask = PyUnicode_AsUTF8(pMask);
-					llMaskingKey = atoi(sMask.c_str());
+					llMaskingKey = stoll(sMask);
 					bMaskBit = 0x80; // Set mask bit in header
 				}
 				else

--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -204,7 +204,7 @@ namespace Plugins {
 			{
 				if (!m_Acceptor)
 				{
-					m_Acceptor = new boost::asio::ip::tcp::acceptor(ios, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), atoi(m_Port.c_str())));
+					m_Acceptor = new boost::asio::ip::tcp::acceptor(ios, boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), stoi(m_Port)));
 				}
 				boost::system::error_code ec;
 
@@ -632,7 +632,7 @@ namespace Plugins {
 			if (!m_Socket)
 			{
 				boost::system::error_code ec;
-				int	iPort = atoi(m_Port.c_str());
+				int	iPort = stoi(m_Port);
 
 				// Handle broadcast messages
 				if (m_IP == "255.255.255.255")
@@ -759,12 +759,12 @@ namespace Plugins {
 			if (((m_IP.substr(0, 4) >= "224.") && (m_IP.substr(0, 4) <= "239.")) || (m_IP.substr(0, 4) == "255."))
 			{
 				m_Socket->set_option(boost::asio::socket_base::broadcast(true));
-				boost::asio::ip::udp::endpoint destination(boost::asio::ip::address_v4::broadcast(), atoi(m_Port.c_str()));
+				boost::asio::ip::udp::endpoint destination(boost::asio::ip::address_v4::broadcast(), stoi(m_Port));
 				int bytes_transferred = m_Socket->send_to(boost::asio::buffer(pMessage, pMessage.size()), destination);
 			}
 			else
 			{
-				boost::asio::ip::udp::endpoint destination(boost::asio::ip::address::from_string(m_IP.c_str()), atoi(m_Port.c_str()));
+				boost::asio::ip::udp::endpoint destination(boost::asio::ip::address::from_string(m_IP.c_str()), stoi(m_Port));
 				int bytes_transferred = m_Socket->send_to(boost::asio::buffer(pMessage, pMessage.size()), destination);
 			}
 		}

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -1427,7 +1427,7 @@ namespace Plugins
 				for (const auto &sd : result)
 				{
 					// Build argument list
-					PyNewRef nrArgList = Py_BuildValue(tupleStr.c_str(), sd[0].c_str(), atoi(sd[1].c_str()));
+					PyNewRef nrArgList = Py_BuildValue(tupleStr.c_str(), sd[0].c_str(), stoi(sd[1]));
 					if (!nrArgList)
 					{
 						Log(LOG_ERROR, "Building device argument list failed for key %s/%s.", sd[0].c_str(), sd[1].c_str());
@@ -1486,7 +1486,7 @@ namespace Plugins
 						Log(LOG_ERROR, "(%s) failed to add ID '%s' to image dictionary.", m_PluginKey.c_str(), sd[0].c_str());
 						goto Error;
 					}
-					pImage->ImageID = atoi(sd[0].c_str()) + 100;
+					pImage->ImageID = stoi(sd[0]) + 100;
 					pImage->Base = PyUnicode_FromString(sd[1].c_str());
 					pImage->Name = PyUnicode_FromString(sd[2].c_str());
 					pImage->Description = PyUnicode_FromString(sd[3].c_str());
@@ -2541,7 +2541,7 @@ namespace Plugins
 
 	std::string CPluginNotifier::GetCustomIcon(std::string &szCustom)
 	{
-		int iIconLine = atoi(szCustom.c_str());
+		int iIconLine = stoi(szCustom);
 		std::string szRetVal = "Light48";
 		if (iIconLine < 100) // default set of custom icons
 		{
@@ -2620,7 +2620,7 @@ namespace Plugins
 		{
 			posCustom += 13;
 			std::string szCustom = ExtraData.substr(posCustom, ExtraData.find('|', posCustom) - posCustom);
-			int iCustom = atoi(szCustom.c_str());
+			int iCustom = stoi(szCustom);
 			if (iCustom)
 			{
 				szImageFile = szImageFolder + GetCustomIcon(szCustom) + "_" + szStatus + ".png";
@@ -2648,7 +2648,7 @@ namespace Plugins
 			posType += 12;
 			std::string szType = ExtraData.substr(posType, ExtraData.find('|', posType) - posType);
 			std::string szTypeImage;
-			_eSwitchType switchtype = (_eSwitchType)atoi(szType.c_str());
+			_eSwitchType switchtype = (_eSwitchType) stoi(szType);
 			switch (switchtype)
 			{
 				case STYPE_OnOff:

--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -151,7 +151,7 @@ namespace Plugins {
 			{
 				std::vector<std::string> sd = *itt;
 
-				PyNewRef nrArgList = Py_BuildValue("(ssi)", sd[0].c_str(), DeviceID.c_str(), atoi(sd[1].c_str()));
+				PyNewRef nrArgList = Py_BuildValue("(ssi)", sd[0].c_str(), DeviceID.c_str(), stoi(sd[1]));
 				if (!nrArgList)
 				{
 					pModState->pPlugin->Log(LOG_ERROR, "Building device argument list failed for key %s/%s.", sd[0].c_str(), sd[1].c_str());
@@ -160,12 +160,12 @@ namespace Plugins {
 				PyNewRef pUnit = PyObject_CallObject((PyObject *)pModState->pUnitClass, nrArgList);
 				if (!pUnit)
 				{
-					pModState->pPlugin->Log(LOG_ERROR, "Unit object creation failed for key %d.", atoi(sd[0].c_str()));
+					pModState->pPlugin->Log(LOG_ERROR, "Unit object creation failed for key %d.", stoi(sd[0]));
 					goto Error;
 				}
 
 				// Add the object to the dictionary
-				PyNewRef pKey = PyLong_FromLong(atoi(sd[1].c_str()));
+				PyNewRef pKey = PyLong_FromLong(stol(sd[1]));
 				if (PyDict_SetItem((PyObject *)self->m_UnitDict, pKey, pUnit) == -1)
 				{
 					pModState->pPlugin->Log(LOG_ERROR, "Failed to add key '%s' to Unit dictionary.", std::string(pKey).c_str());
@@ -488,20 +488,20 @@ namespace Plugins {
 			{
 				for (const auto &sd : result)
 				{
-					self->Unit = atoi(sd[0].c_str());
-					self->ID = atoi(sd[1].c_str());
+					self->Unit = stoi(sd[0]);
+					self->ID = stoi(sd[1]);
 					Py_XDECREF(self->Name);
 					self->Name = PyUnicode_FromString(sd[2].c_str());
-					self->nValue = atoi(sd[3].c_str());
+					self->nValue = stoi(sd[3]);
 					Py_XDECREF(self->sValue);
 					self->sValue = PyUnicode_FromString(sd[4].c_str());
-					self->Type = atoi(sd[5].c_str());
-					self->SubType = atoi(sd[6].c_str());
-					self->SwitchType = atoi(sd[7].c_str());
-					self->LastLevel = atoi(sd[8].c_str());
-					self->Image = atoi(sd[9].c_str());
-					self->SignalLevel = atoi(sd[10].c_str());
-					self->BatteryLevel = atoi(sd[11].c_str());
+					self->Type = stoi(sd[5]);
+					self->SubType = stoi(sd[6]);
+					self->SwitchType = stoi(sd[7]);
+					self->LastLevel = stoi(sd[8]);
+					self->Image = stoi(sd[9]);
+					self->SignalLevel = stoi(sd[10]);
+					self->BatteryLevel = stoi(sd[11]);
 					Py_XDECREF(self->LastUpdate);
 					self->LastUpdate = PyUnicode_FromString(sd[12].c_str());
 					PyDict_Clear(self->Options);
@@ -532,9 +532,9 @@ namespace Plugins {
 					self->Description = PyUnicode_FromString(sd[14].c_str());
 					Py_XDECREF(self->Color);
 					self->Color = PyUnicode_FromString(_tColor(std::string(sd[15])).toJSONString().c_str()); // Parse the color to detect incorrectly formatted color data
-					self->Used = atoi(sd[16].c_str());
-					self->Adjustment = static_cast<float>(atof(sd[17].c_str()));
-					self->Multiplier = static_cast<float>(atof(sd[18].c_str()));
+					self->Used = stoi(sd[16]);
+					self->Adjustment = stof(sd[17]);
+					self->Multiplier = stof(sd[18]);
 				}
 			}
 		}
@@ -645,7 +645,7 @@ namespace Plugins {
 						result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (OrgHardwareID==0) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
 						if (!result.empty())
 						{
-							self->ID = atoi(result[0][0].c_str());
+							self->ID = stoi(result[0][0]);
 
 							// Check the parent device is in the plugin dictionary (can happen if this Unit has just been created)
 							if (!PyDict_Contains((PyObject *)pModState->pPlugin->m_DeviceDict, pDevice->DeviceID))

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -195,7 +195,7 @@ namespace Plugins {
 									_log.Log(LOG_ERROR, "(%s) failed to add ID '%s' to image dictionary.", self->pPlugin->m_PluginKey.c_str(), sd[0].c_str());
 									break;
 								}
-								pImage->ImageID = atoi(sd[0].c_str()) + 100;
+								pImage->ImageID = stoi(sd[0]) + 100;
 								pImage->Base = PyUnicode_FromString(sd[1].c_str());
 								pImage->Name = PyUnicode_FromString(sd[2].c_str());
 								pImage->Description = PyUnicode_FromString(sd[3].c_str());
@@ -682,22 +682,22 @@ namespace Plugins {
 			{
 				for (const auto &sd : result)
 				{
-					self->Unit = atoi(sd[0].c_str());
-					self->ID = atoi(sd[1].c_str());
+					self->Unit = stoi(sd[0]);
+					self->ID = stoi(sd[1]);
 					Py_XDECREF(self->Name);
 					self->Name = PyUnicode_FromString(sd[2].c_str());
-					self->nValue = atoi(sd[3].c_str());
+					self->nValue = stoi(sd[3]);
 					Py_XDECREF(self->sValue);
 					self->sValue = PyUnicode_FromString(sd[4].c_str());
 					Py_XDECREF(self->DeviceID);
 					self->DeviceID = PyUnicode_FromString(sd[5].c_str());
-					self->Type = atoi(sd[6].c_str());
-					self->SubType = atoi(sd[7].c_str());
-					self->SwitchType = atoi(sd[8].c_str());
-					self->LastLevel = atoi(sd[9].c_str());
-					self->Image = atoi(sd[10].c_str());
-					self->SignalLevel = atoi(sd[11].c_str());
-					self->BatteryLevel = atoi(sd[12].c_str());
+					self->Type = stoi(sd[6]);
+					self->SubType = stoi(sd[7]);
+					self->SwitchType = stoi(sd[8]);
+					self->LastLevel = stoi(sd[9]);
+					self->Image = stoi(sd[10]);
+					self->SignalLevel = stoi(sd[11]);
+					self->BatteryLevel = stoi(sd[12]);
 					Py_XDECREF(self->LastUpdate);
 					self->LastUpdate = PyUnicode_FromString(sd[13].c_str());
 					PyDict_Clear(self->Options);
@@ -729,7 +729,7 @@ namespace Plugins {
 					self->Description = PyUnicode_FromString(sd[15].c_str());
 					Py_XDECREF(self->Color);
 					self->Color = PyUnicode_FromString(_tColor(std::string(sd[16])).toJSONString().c_str()); //Parse the color to detect incorrectly formatted color data
-					self->Used = atoi(sd[17].c_str());
+					self->Used = stoi(sd[17]);
 				}
 			}
 		}
@@ -793,7 +793,7 @@ namespace Plugins {
 						result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (Unit==%d)", self->HwdID, self->Unit);
 						if (!result.empty())
 						{
-							self->ID = atoi(result[0][0].c_str());
+							self->ID = stoi(result[0][0]);
 
 							PyNewRef	pKey = PyLong_FromLong(self->Unit);
 							if (PyDict_SetItem((PyObject*)self->pPlugin->m_DeviceDict, pKey, (PyObject*)self) == -1)

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -451,8 +451,8 @@ namespace http
 								StringSplit(usernamefromtoken,";", strarray);
 								if(strarray.size() == 2)
 								{
-									int iClient = std::atoi(strarray[0].c_str());
-									int iUser = std::atoi(strarray[1].c_str());
+									int iClient = stoi(strarray[0]);
+									int iUser = stoi(strarray[1]);
 									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found valid Refresh token (%s) (c:%d,u:%d)!", refresh_token.c_str(), iClient, iUser);
 
 									Json::Value jwtpayload;

--- a/main/Camera.cpp
+++ b/main/Camera.cpp
@@ -36,15 +36,15 @@ void CCameraHandler::ReloadCameras()
 		for (const auto &sd : result)
 		{
 			cameraDevice citem;
-			citem.ID = std::stoull(sd[0]);
+			citem.ID = stoull(sd[0]);
 			citem.Name = sd[1];
 			citem.Address = sd[2];
-			citem.Port = atoi(sd[3].c_str());
+			citem.Port = stoi(sd[3]);
 			citem.Username = base64_decode(sd[4]);
 			citem.Password = base64_decode(sd[5]);
 			citem.ImageURL = sd[6];
-			citem.Protocol = (eCameraProtocol)atoi(sd[7].c_str());
-			citem.AspectRatio = (uint8_t)atoi(sd[8].c_str());
+			citem.Protocol = (eCameraProtocol) stoi(sd[7]);
+			citem.AspectRatio = (uint8_t) stoi(sd[8]);
 			m_cameradevices.push_back(citem);
 			_AddedCameras.push_back(sd[0]);
 		}
@@ -70,10 +70,10 @@ void CCameraHandler::ReloadCameraActiveDevices(const std::string &CamID)
 		for (const auto &sd : result)
 		{
 			cameraActiveDevice aDevice;
-			aDevice.ID = std::stoull(sd[0]);
-			aDevice.DevSceneType = (unsigned char)atoi(sd[1].c_str());
-			aDevice.DevSceneRowID = std::stoull(sd[2]);
-			aDevice.AspectRatio = std::stoi(sd[3]);
+			aDevice.ID = stoull(sd[0]);
+			aDevice.DevSceneType = (unsigned char) stoi(sd[1]);
+			aDevice.DevSceneRowID = stoull(sd[2]);
+			aDevice.AspectRatio = (uint8_t) stoi(sd[3]);
 			pCamera->mActiveDevices.push_back(aDevice);
 		}
 	}
@@ -82,7 +82,7 @@ void CCameraHandler::ReloadCameraActiveDevices(const std::string &CamID)
 //Return 0 if NO, otherwise Cam IDX
 uint64_t CCameraHandler::IsDevSceneInCamera(const unsigned char DevSceneType, const std::string &DevSceneID)
 {
-	return IsDevSceneInCamera(DevSceneType, std::stoull(DevSceneID));
+	return IsDevSceneInCamera(DevSceneType, stoull(DevSceneID));
 }
 
 uint64_t CCameraHandler::IsDevSceneInCamera(const unsigned char DevSceneType, const uint64_t DevSceneID)
@@ -134,7 +134,7 @@ std::string CCameraHandler::GetCameraURL(cameraDevice *pCamera)
 
 CCameraHandler::cameraDevice* CCameraHandler::GetCamera(const std::string &CamID)
 {
-	return GetCamera(std::stoull(CamID));
+	return GetCamera(stoull(CamID));
 }
 
 CCameraHandler::cameraDevice* CCameraHandler::GetCamera(const uint64_t CamID)
@@ -149,7 +149,7 @@ CCameraHandler::cameraDevice* CCameraHandler::GetCamera(const uint64_t CamID)
 
 int CCameraHandler::GetCameraAspectRatio(const std::string& CamIdx)
 {
-	return GetCameraAspectRatio(std::stoull(CamIdx));
+	return GetCameraAspectRatio(stoull(CamIdx));
 }
 
 int CCameraHandler::GetCameraAspectRatio(const uint64_t &CamID)
@@ -165,7 +165,7 @@ int CCameraHandler::GetCameraAspectRatio(const uint64_t &CamID)
 bool CCameraHandler::TakeSnapshot(const std::string &CamID, std::vector<unsigned char> &camimage)
 {
 	if (is_number(CamID))
-		return TakeSnapshot(std::stoull(CamID), camimage);
+		return TakeSnapshot(stoull(CamID), camimage);
 	else
 		return TakeSnapshot(CamID, camimage);
 }
@@ -412,12 +412,12 @@ namespace http {
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["Enabled"] = (sd[2] == "1") ? "true" : "false";
 					root["result"][ii]["Address"] = sd[3];
-					root["result"][ii]["Port"] = atoi(sd[4].c_str());
+					root["result"][ii]["Port"] = stoi(sd[4]);
 					root["result"][ii]["Username"] = base64_decode(sd[5]);
 					root["result"][ii]["Password"] = base64_decode(sd[6]);
 					root["result"][ii]["ImageURL"] = sd[7];
-					root["result"][ii]["Protocol"] = atoi(sd[8].c_str());
-					root["result"][ii]["AspectRatio"] = atoi(sd[9].c_str());
+					root["result"][ii]["Protocol"] = stoi(sd[8]);
+					root["result"][ii]["AspectRatio"] = stoi(sd[9]);
 					ii++;
 				}
 			}
@@ -492,8 +492,8 @@ namespace http {
 			std::string username = HTMLSanitizer::Sanitize(request::findValue(&req, "username"));
 			std::string password = request::findValue(&req, "password");
 			std::string timageurl = HTMLSanitizer::Sanitize(request::findValue(&req, "imageurl"));
-			int cprotocol = atoi(request::findValue(&req, "protocol").c_str());
-			int aspectratio = atoi(request::findValue(&req, "aspectratio").c_str());
+			int cprotocol = stoi(request::findValue(&req, "protocol"));
+			int aspectratio = stoi(request::findValue(&req, "aspectratio"));
 			if ((name.empty()) || (address.empty()) || (timageurl.empty()))
 				return;
 
@@ -502,7 +502,7 @@ namespace http {
 			{
 				imageurl = base64_decode(imageurl);
 
-				int port = atoi(sport.c_str());
+				int port = stoi(sport);
 				root["status"] = "OK";
 				root["title"] = "AddCamera";
 				m_sql.safe_query(
@@ -539,8 +539,8 @@ namespace http {
 			std::string username = HTMLSanitizer::Sanitize(request::findValue(&req, "username"));
 			std::string password = request::findValue(&req, "password");
 			std::string timageurl = HTMLSanitizer::Sanitize(request::findValue(&req, "imageurl"));
-			int cprotocol = atoi(request::findValue(&req, "protocol").c_str());
-			int aspectratio = atoi(request::findValue(&req, "aspectratio").c_str());
+			int cprotocol = stoi(request::findValue(&req, "protocol"));
+			int aspectratio = stoi(request::findValue(&req, "aspectratio"));
 			if ((name.empty()) || (senabled.empty()) || (address.empty()) || (timageurl.empty()))
 				return;
 
@@ -549,7 +549,7 @@ namespace http {
 			{
 				imageurl = base64_decode(imageurl);
 
-				int port = atoi(sport.c_str());
+				int port = stoi(sport);
 
 				root["status"] = "OK";
 				root["title"] = "UpdateCamera";

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -693,7 +693,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			if (splitresults.size() > 1)
 			{
 				temp = stof(splitresults[0]);
-				humidity = ground(stof(splitresults[1]));
+				humidity = static_cast<int>(ground(stod(splitresults[1])));
 				dewpoint = (float)CalculateDewPoint(temp, humidity);
 				isTemp = true;
 				isHum = true;
@@ -706,7 +706,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 				continue;
 			}
 			temp = stof(splitresults[0]);
-			humidity = ground(stof(splitresults[1]));
+			humidity = static_cast<int>(ground(stod(splitresults[1])));
 			barometer = stof(splitresults[3]);
 			dewpoint = (float)CalculateDewPoint(temp, humidity);
 			isTemp = true;
@@ -921,7 +921,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			if (splitresults.size() == 2)
 			{
 				rainmm = 0;
-				rainmmlasthour = stof(splitresults[0]) / 100.0F;
+				rainmmlasthour = static_cast<float>(stod(splitresults[0]) / 100.0);
 				isRain = true;
 				weatherval = rainmmlasthour;
 				isWeather = true;
@@ -1701,7 +1701,7 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 		}
 		else if (uvitem.variableType == 1)
 		{ //Float
-			luaTable.AddNumber(uvitem.ID, stof(uvitem.variableValue));
+			luaTable.AddNumber(uvitem.ID, stold(uvitem.variableValue));
 		}
 		else { //String,Date,Time
 			luaTable.AddString(uvitem.ID, uvitem.variableValue);
@@ -2490,19 +2490,19 @@ void CEventSystem::ParseActionString(const std::string &oAction_, _tActionParseR
 				oResults_.sCommand.append(sToken);
 				break;
 			case 1:
-				oResults_.fForSec = 60.0F * stof(sToken);
+				oResults_.fForSec = static_cast<float>(stod(sToken) * 60.0);
 				break;
 			case 2:
-				oResults_.fAfterSec = 1.0F * stof(sToken);
+				oResults_.fAfterSec = static_cast<float>(stod(sToken));
 				break;
 			case 3:
-				oResults_.fRandomSec = 60.0F * stof(sToken);
+				oResults_.fRandomSec = static_cast<float>(stod(sToken) * 60.0);
 				break;
 			case 4:
-				oResults_.iRepeat = stoi(sToken);
+				oResults_.iRepeat = static_cast<float>(stod(sToken));
 				break;
 			case 5:
-				oResults_.fRepeatSec = 1.0F * stof(sToken);
+				oResults_.fRepeatSec = static_cast<float>(stod(sToken));
 				break;
 			}
 		}
@@ -2898,12 +2898,12 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	{
 		_tUserVariable uvitem = uservar.second;
 		if (uvitem.variableType == 0)
-		{ //Integer
+		{ // Integer
 			luaTable.AddInteger(uvitem.variableName, stoi(uvitem.variableValue));
 		}
 		else if (uvitem.variableType == 1)
-		{ //Float
-			luaTable.AddNumber(uvitem.variableName, stof(uvitem.variableValue));
+		{ // Float
+			luaTable.AddNumber(uvitem.variableName, stold(uvitem.variableValue));
 		} else { //String,Date,Time
 			luaTable.AddString(uvitem.variableName, uvitem.variableValue);
 		}

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -2499,7 +2499,7 @@ void CEventSystem::ParseActionString(const std::string &oAction_, _tActionParseR
 				oResults_.fRandomSec = static_cast<float>(stod(sToken) * 60.0);
 				break;
 			case 4:
-				oResults_.iRepeat = static_cast<float>(stod(sToken));
+				oResults_.iRepeat = stoi(sToken);
 				break;
 			case 5:
 				oResults_.fRepeatSec = static_cast<float>(stod(sToken));

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -242,15 +242,15 @@ void CEventSystem::LoadEvents()
 		for (auto &sd : result)
 		{
 			_tEventItem eitem;
-			eitem.ID = std::stoull(sd[0]);
+			eitem.ID = stoull(sd[0]);
 			eitem.Name = sd[1] + "_" + sd[5];
 			eitem.Interpreter = sd[6];
 			std::transform(sd[7].begin(), sd[7].end(), sd[7].begin(), ::tolower);
 			eitem.Type = sd[7];
 			eitem.Conditions = sd[2];
 			eitem.Actions = sd[3];
-			eitem.EventStatus = atoi(sd[4].c_str());
-			eitem.SequenceNo = atoi(sd[5].c_str());
+			eitem.EventStatus = stoi(sd[4]);
+			eitem.SequenceNo = stoi(sd[5]);
 			m_events.push_back(eitem);
 		}
 	}
@@ -274,12 +274,12 @@ void CEventSystem::LoadEvents()
 		for (auto &sd : result)
 		{
 			CEventSystem::_tEventItem eitem;
-			eitem.ID = std::stoull(sd[0]);
+			eitem.ID = stoull(sd[0]);
 			eitem.Name = sd[1];
 			eitem.Interpreter = sd[2];
 			std::transform(sd[3].begin(), sd[3].end(), sd[3].begin(), ::tolower);
 			eitem.Type = sd[3];
-			eitem.EventStatus = atoi(sd[4].c_str());
+			eitem.EventStatus = stoi(sd[4]);
 			eitem.Actions = sd[5];
 			eitem.SequenceNo = 0;
 			m_events.push_back(eitem);
@@ -410,10 +410,10 @@ void CEventSystem::UpdateJsonMap(_tDeviceStatus &item, const uint64_t ulDevID)
 					item.JsonMapString[index] = l_JsonValueString.assign(value);
 					break;
 				case JTYPE_FLOAT:
-					item.JsonMapFloat[index] = (float)atof(value.c_str());
+					item.JsonMapFloat[index] = stof(value);
 					break;
 				case JTYPE_INT:
-					item.JsonMapInt[index] = atoi(value.c_str());
+					item.JsonMapInt[index] = stoi(value);
 					break;
 				case JTYPE_BOOL:
 					if (value == "true")
@@ -458,12 +458,12 @@ void CEventSystem::GetCurrentStates()
 			std::string l_description;		l_description.reserve(200);
 			std::string l_deviceID;			l_deviceID.reserve(25);
 
-			sitem.hardwareID = atoi(sd[0].c_str());
-			sitem.ID = std::stoull(sd[1]);
+			sitem.hardwareID = stoi(sd[0]);
+			sitem.ID = stoull(sd[1]);
 			sitem.deviceName = l_deviceName.assign(sd[2]);
 
-			sitem.devType = atoi(sd[5].c_str());
-			sitem.subType = atoi(sd[6].c_str());
+			sitem.devType = (uint8_t) stoi(sd[5]);
+			sitem.subType = (uint8_t) stoi(sd[6]);
 
 			if ((sitem.devType == pTypeGeneral) && (sitem.subType == sTypeCounterIncremental))
 			{
@@ -472,39 +472,39 @@ void CEventSystem::GetCurrentStates()
 				std::vector<std::vector<std::string> > result2;
 
 				result2 = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (ID=%" PRIu64 ")", sitem.ID);
-				uint64_t total_max = std::stoull(result2[0][0]);
+				uint64_t total_max = stoull(result2[0][0]);
 
 				//get value of today
 				std::string szDate = TimeToString(nullptr, TF_Date);
 				result2 = m_sql.safe_query("SELECT MIN(Value) FROM Meter WHERE (DeviceRowID=%" PRIu64 " AND Date>='%q')", sitem.ID, szDate.c_str());
 				if (!result2.empty())
 				{
-					uint64_t total_min = std::stoull(result2[0][0]);
+					uint64_t total_min = stoull(result2[0][0]);
 					uint64_t total_real = total_max - total_min;
 
 					sd[4] = std::to_string(total_real); //sitem.sValue = l_sValue.assign(sd[4]);
 				}
 			}
 
-			sitem.nValue = atoi(sd[3].c_str());
+			sitem.nValue = stoi(sd[3]);
 			sitem.sValue = l_sValue.assign(sd[4]);
 
-			sitem.switchtype = atoi(sd[7].c_str());
+			sitem.switchtype = (uint8_t) stoi(sd[7]);
 			_eSwitchType switchtype = (_eSwitchType)sitem.switchtype;
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[10]);
 			sitem.nValueWording = l_nValueWording.assign(nValueToWording(sitem.devType, sitem.subType, switchtype, sitem.nValue, sitem.sValue, options));
 			sitem.lastUpdate = l_lastUpdate.assign(sd[8]);
-			sitem.lastLevel = atoi(sd[9].c_str());
+			sitem.lastLevel = (uint8_t) stoi(sd[9]);
 			sitem.description = l_description.assign(sd[11]);
-			sitem.batteryLevel = atoi(sd[12].c_str());
-			sitem.signalLevel = atoi(sd[13].c_str());
-			sitem.unit = atoi(sd[14].c_str());
+			sitem.batteryLevel = stoi(sd[12]);
+			sitem.signalLevel = stoi(sd[13]);
+			sitem.unit = stoi(sd[14]);
 			sitem.deviceID = l_deviceID.assign(sd[15]);
-			sitem.protection = atoi(sd[16].c_str());
-			sitem.AddjValue = std::stof(sd[17]);
-			sitem.AddjMulti = std::stof(sd[18]);
-			sitem.AddjValue2 = std::stof(sd[19]);
-			sitem.AddjMulti2 = std::stof(sd[20]);
+			sitem.protection = stoi(sd[16]);
+			sitem.AddjValue = stof(sd[17]);
+			sitem.AddjMulti = stof(sd[18]);
+			sitem.AddjValue2 = stof(sd[19]);
+			sitem.AddjMulti2 = stof(sd[20]);
 
 			if (!m_sql.m_bDisableDzVentsSystem)
 			{
@@ -531,10 +531,10 @@ void CEventSystem::GetCurrentUserVariables()
 		for (const auto &sd : result)
 		{
 			_tUserVariable uvitem;
-			uvitem.ID = std::stoull(sd[0]);
+			uvitem.ID = stoull(sd[0]);
 			uvitem.variableName = sd[1];
 			uvitem.variableValue = sd[2];
-			uvitem.variableType = atoi(sd[3].c_str());
+			uvitem.variableType = stoi(sd[3]);
 			uvitem.lastUpdate = sd[4];
 			m_uservariables[uvitem.ID] = uvitem;
 		}
@@ -556,8 +556,8 @@ void CEventSystem::GetCurrentScenesGroups()
 			std::vector<std::vector<std::string> > result2;
 
 			_tScenesGroups sgitem;
-			sgitem.ID = std::stoull(sd[0]);
-			unsigned char nValue = atoi(sd[2].c_str());
+			sgitem.ID = stoull(sd[0]);
+			unsigned char nValue = stoi(sd[2]);
 
 			if (nValue == 0)
 				sgitem.scenesgroupValue = "Off";
@@ -566,16 +566,16 @@ void CEventSystem::GetCurrentScenesGroups()
 			else
 				sgitem.scenesgroupValue = "Mixed";
 			sgitem.scenesgroupName = sd[1];
-			sgitem.scenesgroupType = atoi(sd[3].c_str());
+			sgitem.scenesgroupType = stoi(sd[3]);
 			sgitem.lastUpdate = sd[4];
-			sgitem.protection = atoi(sd[5].c_str());
+			sgitem.protection = stoi(sd[5]);
 			sgitem.description = sd[6];
 			result2 = m_sql.safe_query("SELECT DISTINCT A.DeviceRowID FROM SceneDevices AS A, DeviceStatus AS B WHERE (A.SceneRowID == %" PRIu64 ") AND (A.DeviceRowID == B.ID)", sgitem.ID);
 			if (!result2.empty())
 			{
 				for (const auto &sd2 : result2)
 				{
-					sgitem.memberID.push_back(std::stoull(sd2[0]));
+					sgitem.memberID.push_back(stoull(sd2[0]));
 				}
 			}
 			m_scenesgroups[sgitem.ID] = sgitem;
@@ -656,7 +656,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP:
 			if (!splitresults.empty())
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				isTemp = true;
 			}
 			break;
@@ -665,7 +665,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = stof(splitresults[0]);
 					isTemp = true;
 				}
 			}
@@ -673,7 +673,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = stof(splitresults[0]);
 					isUtility = true;
 				}
 			}
@@ -681,7 +681,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeThermostat1:
 			if (!splitresults.empty())
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				isTemp = true;
 			}
 			break;
@@ -692,8 +692,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP_HUM:
 			if (splitresults.size() > 1)
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
-				humidity = ground(atof(splitresults[1].c_str()));
+				temp = stof(splitresults[0]);
+				humidity = ground(stof(splitresults[1]));
 				dewpoint = (float)CalculateDewPoint(temp, humidity);
 				isTemp = true;
 				isHum = true;
@@ -705,9 +705,9 @@ void CEventSystem::GetCurrentMeasurementStates()
 				_log.Log(LOG_ERROR, "EventSystem: TEMP_HUM_BARO missing values : ID=%" PRIu64 ", sValue=%s", sitem.ID, sitem.sValue.c_str());
 				continue;
 			}
-			temp = static_cast<float>(atof(splitresults[0].c_str()));
-			humidity = ground(atof(splitresults[1].c_str()));
-			barometer = static_cast<float>(atof(splitresults[3].c_str()));
+			temp = stof(splitresults[0]);
+			humidity = ground(stof(splitresults[1]));
+			barometer = stof(splitresults[3]);
 			dewpoint = (float)CalculateDewPoint(temp, humidity);
 			isTemp = true;
 			isHum = true;
@@ -717,34 +717,34 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeTEMP_BARO:
 			if (splitresults.size() > 1)
 			{
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
-				barometer = static_cast<float>(atof(splitresults[1].c_str()));
+				temp = stof(splitresults[0]);
+				barometer = stof(splitresults[1]);
 				isTemp = true;
 				isBaro = true;
 			}
 			break;
 		case pTypeBARO:
-			barometer = static_cast<float>(atof(splitresults[0].c_str()));
+			barometer = stof(splitresults[0]);
 			isBaro = true;
 			break;
 		case pTypeRadiator1:
 			if (sitem.subType == sTypeSmartwares)
 			{
-				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
+				utilityval = stof(sitem.sValue);
 				isUtility = true;
 			}
 			break;
 		case pTypeUV:
 			if (splitresults.size() == 2)
 			{
-				uv = static_cast<float>(atof(splitresults[0].c_str()));
+				uv = stof(splitresults[0]);
 				isUV = true;
 				weatherval = uv;
 				isWeather = true;
 
 				if (sitem.subType == sTypeUV3)
 				{
-					temp = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = stof(splitresults[1]);
 					isTemp = true;
 				}
 			}
@@ -752,17 +752,17 @@ void CEventSystem::GetCurrentMeasurementStates()
 		case pTypeWIND:
 			if (splitresults.size() == 6)
 			{
-				winddir = static_cast<float>(atof(splitresults[0].c_str()));
+				winddir = stof(splitresults[0]);
 				isWindDir = true;
 
 				if (sitem.subType != sTypeWIND5)
 				{
-					int intSpeed = atoi(splitresults[2].c_str());
+					int intSpeed = stoi(splitresults[2]);
 					windspeed = float(intSpeed) * 0.1F; // m/s
 					isWindSpeed = true;
 				}
 
-				int intGust = atoi(splitresults[3].c_str());
+				int intGust = stoi(splitresults[3]);
 				windgust = float(intGust) * 0.1F; // m/s
 				isWindGust = true;
 				if ((windgust == 0) && (windspeed != 0))
@@ -777,8 +777,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 				}
 				if ((sitem.subType == sTypeWIND4) || (sitem.subType == sTypeWINDNoTemp))
 				{
-					temp = static_cast<float>(atof(splitresults[4].c_str()));
-					//chill = static_cast<float>(atof(splitresults[5].c_str()));
+					temp = stof(splitresults[4]);
+					//chill = stof(splitresults[5]);
 					isTemp = true;
 				}
 			}
@@ -788,13 +788,13 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if (!splitresults.empty())
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = stof(splitresults[0]);
 					isTemp = true;
 				}
 			}
 			else if ((sitem.subType == sTypeRFXSensorVolt) || (sitem.subType == sTypeRFXSensorAD))
 			{
-				utilityval = static_cast<float>(atof(sitem.sValue.c_str()));
+				utilityval = stof(sitem.sValue);
 				isUtility = true;
 			}
 			break;
@@ -806,37 +806,37 @@ void CEventSystem::GetCurrentMeasurementStates()
 			if (!splitresults.empty())
 			{
 				if (splitresults.size() == 2)
-					utilityval = static_cast<float>(atof(splitresults[1].c_str()));
+					utilityval = stof(splitresults[1]);
 				else
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = stof(splitresults[0]);
 				isUtility = true;
 			}
 			break;
 		case pTypePOWER:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = stof(splitresults[0]);
 				isUtility = true;
 			}
 			break;
 		case pTypeUsage:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = stof(splitresults[0]);
 				isUtility = true;
 			}
 			break;
 		case pTypeP1Power:
 			if (splitresults.size() == 6)
 			{
-				utilityval = static_cast<float>(atof(splitresults[4].c_str()));
+				utilityval = stof(splitresults[4]);
 				isUtility = true;
 			}
 			break;
 		case pTypeLux:
 			if (!splitresults.empty())
 			{
-				utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+				utilityval = stof(splitresults[0]);
 				isUtility = true;
 			}
 			break;
@@ -846,14 +846,14 @@ void CEventSystem::GetCurrentMeasurementStates()
 			{
 				if ((sitem.subType == sTypeVisibility) || (sitem.subType == sTypeSolarRadiation))
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = stof(splitresults[0]);
 					isUtility = true;
 					weatherval = utilityval;
 					isWeather = true;
 				}
 				else if (sitem.subType == sTypeBaro)
 				{
-					barometer = static_cast<float>(atof(splitresults[0].c_str()));
+					barometer = stof(splitresults[0]);
 					isBaro = true;
 				}
 				else if ((sitem.subType == sTypeAlert)
@@ -868,7 +868,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 					|| (sitem.subType == sTypeSoundLevel)
 					)
 				{
-					utilityval = static_cast<float>(atof(splitresults[0].c_str()));
+					utilityval = stof(splitresults[0]);
 					isUtility = true;
 				}
 			}
@@ -883,7 +883,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 					std::vector<std::vector<std::string> > result2;
 
 					result2 = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (ID=%" PRIu64 ")", sitem.ID);
-					uint64_t total_max = std::stoull(result2[0][0]);
+					uint64_t total_max = stoull(result2[0][0]);
 
 					//get value of today
 					std::string szDate = TimeToString(nullptr, TF_Date);
@@ -891,7 +891,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 						sitem.ID, szDate.c_str());
 					if (!result2.empty())
 					{
-						uint64_t total_min = std::stoull(result2[0][0]);
+						uint64_t total_min = stoull(result2[0][0]);
 						uint64_t total_real = total_max - total_min;
 
 						utilityval = float(total_real) / divider;
@@ -905,7 +905,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 					float divider = m_sql.GetCounterDivider(int(metertype), int(sitem.devType), float(sitem.AddjValue2));
 
 					if (splitresults.size() > 1) {
-						float usage = std::stof(splitresults[1]);
+						float usage = stof(splitresults[1]);
 						if (usage < 0.0) {
 							usage = 0.0;
 						}
@@ -921,7 +921,7 @@ void CEventSystem::GetCurrentMeasurementStates()
 			if (splitresults.size() == 2)
 			{
 				rainmm = 0;
-				rainmmlasthour = static_cast<float>(atof(splitresults[0].c_str())) / 100.0F;
+				rainmmlasthour = stof(splitresults[0]) / 100.0F;
 				isRain = true;
 				weatherval = rainmmlasthour;
 				isWeather = true;
@@ -949,12 +949,12 @@ void CEventSystem::GetCurrentMeasurementStates()
 					std::vector<std::string> sd2 = result2[0];
 					if (sitem.subType == sTypeRAINWU || sitem.subType == sTypeRAINByRate)
 					{
-						total_real = atof(sd2[1].c_str());
+						total_real = stod(sd2[1]);
 					}
 					else
 					{
-						float total_min = static_cast<float>(atof(sd2[0].c_str()));
-						float total_max = static_cast<float>(atof(splitresults[1].c_str()));
+						float total_min = stof(sd2[0]);
+						float total_max = stof(splitresults[1]);
 						total_real = total_max - total_min;
 					}
 					rainmm = float(total_real);
@@ -976,8 +976,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 				uint64_t total_min_gas, total_real_gas;
 				uint64_t gasactual;
 
-				total_min_gas = std::stoull(sd2[0]);
-				gasactual = std::stoull(sitem.sValue);
+				total_min_gas = stoull(sd2[0]);
+				gasactual = stoull(sitem.sValue);
 				total_real_gas = gasactual - total_min_gas;
 				utilityval = float(total_real_gas) / GasDivider;
 				isUtility = true;
@@ -1001,8 +1001,8 @@ void CEventSystem::GetCurrentMeasurementStates()
 
 					uint64_t total_min, total_max, total_real;
 
-					total_min = std::stoull(sd2[0]);
-					total_max = std::stoull(sd2[1]);
+					total_min = stoull(sd2[0]);
+					total_max = stoull(sd2[1]);
 					total_real = total_max - total_min;
 
 					utilityval = float(total_real) / divider;
@@ -1455,9 +1455,9 @@ void CEventSystem::ProcessDevice(
 
 	std::vector<std::string> sd = result[0];
 
-	_eSwitchType switchType = (_eSwitchType)std::stoi(sd[0]);
+	_eSwitchType switchType = (_eSwitchType) stoi(sd[0]);
 	std::string lastUpdate = sd[1];
-	uint8_t lastLevel = (uint8_t)std::stoi(sd[2]);
+	uint8_t lastLevel = (uint8_t) stoi(sd[2]);
 	std::string dev_options = sd[3];
 	std::string devname = sd[4];
 
@@ -1470,14 +1470,14 @@ void CEventSystem::ProcessDevice(
 		//special case for incremental counter, need to calculate the actual count value
 
 		//get value of today
-		uint64_t total_max = std::stoull(osValue);
+		uint64_t total_max = stoull(osValue);
 
 		std::string szDate = TimeToString(nullptr, TF_Date);
 		std::vector<std::vector<std::string> > result2;
 		result2 = m_sql.safe_query("SELECT MIN(Value) FROM Meter WHERE (DeviceRowID=%" PRIu64 " AND Date>='%q')", ulDevID, szDate.c_str());
 		if (!result2.empty())
 		{
-			uint64_t total_min = std::stoull(result2[0][0]);
+			uint64_t total_min = stoull(result2[0][0]);
 			uint64_t total_real = total_max - total_min;
 
 			osValue = std::to_string(total_real); //sitem.sValue = l_sValue.assign(dev_options);
@@ -1640,9 +1640,9 @@ void CEventSystem::EvaluateEvent(const std::vector<_tEventQueue> &items)
 			if (!result.empty())
 			{
 				std::vector<std::string> sd = result[0];
-				Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)m_mainworker.GetHardware(atoi(sd[0].c_str()));
+				Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)m_mainworker.GetHardware(stoi(sd[0]));
 				if (pPlugin)
-					pPlugin->MessagePlugin(new Plugins::onSecurityEventCallback(sd[2].c_str(), atoi(sd[3].c_str()), item.nValue, m_szSecStatus[item.nValue]));
+					pPlugin->MessagePlugin(new Plugins::onSecurityEventCallback(sd[2].c_str(), stoi(sd[3]), item.nValue, m_szSecStatus[item.nValue]));
 			}
 		}
 #endif
@@ -1695,16 +1695,15 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	for (const auto &variable : m_uservariables)
 	{
 		_tUserVariable uvitem = variable.second;
-		if (uvitem.variableType == 0) {
-			//Integer
-			luaTable.AddInteger(uvitem.ID, atoi(uvitem.variableValue.c_str()));
+		if (uvitem.variableType == 0)
+		{ //Integer
+			luaTable.AddInteger(uvitem.ID, stoi(uvitem.variableValue));
 		}
-		else if (uvitem.variableType == 1) {
-			//Float
-			luaTable.AddNumber(uvitem.ID, atof(uvitem.variableValue.c_str()));
+		else if (uvitem.variableType == 1)
+		{ //Float
+			luaTable.AddNumber(uvitem.ID, stof(uvitem.variableValue));
 		}
-		else {
-			//String,Date,Time
+		else { //String,Date,Time
 			luaTable.AddString(uvitem.ID, uvitem.variableValue);
 		}
 	}
@@ -1948,7 +1947,7 @@ static inline int64_t GetIndexFromDevice(std::string devline)
 	if (fpos == std::string::npos)
 		return -1;
 	devline = devline.substr(0, fpos);
-	return atoll(devline.c_str());
+	return stoll(devline);
 }
 
 std::string CEventSystem::ProcessVariableArgument(const std::string &Argument)
@@ -2161,7 +2160,7 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 			break;
 		}
 
-		int deviceNo = atoi(deviceName.c_str());
+		int deviceNo = stoi(deviceName);
 		if (deviceNo)
 		{
 			boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
@@ -2184,7 +2183,7 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 			{
 				sceneType = 2;
 			}
-			deviceNo = atoi(deviceName.substr(6).c_str());
+			deviceNo = stoi(deviceName.substr(6));
 			if (deviceNo)
 			{
 				if (ScheduleEvent(deviceNo, doWhat, true, item.Name, sceneType))
@@ -2211,14 +2210,14 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 				{
 					std::vector<std::string> sd = result[0];
 					std::string errorMessage;
-					if (!m_sql.UpdateUserVariable(variableNo, sd[0], (const _eUsrVariableType)atoi(sd[1].c_str()), doWhat, false, errorMessage))
+					if (!m_sql.UpdateUserVariable(variableNo, sd[0], (const _eUsrVariableType) stoi(sd[1]), doWhat, false, errorMessage))
 					{
 						_log.Log(LOG_ERROR, "EventSystem: Error updating variable %s: %s", sd[0].c_str(), errorMessage.c_str());
 					}
 				}
 			}
 			else
-				m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, (const uint64_t)atol(variableNo.c_str()), doWhat, false));
+				m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, (const uint64_t) stoull(variableNo), doWhat, false));
 
 			actionsDone = true;
 			continue;
@@ -2232,16 +2231,16 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 			StripQuotes(parseResult.sCommand);
 
 			if (parseResult.fAfterSec < (1. / timer_resolution_hz / 2))
-				m_mainworker.UpdateDevice(std::stoi(variableName), 0, parseResult.sCommand, "EventSystem/" + item.Name,
+				m_mainworker.UpdateDevice(stoi(variableName), 0, parseResult.sCommand, "EventSystem/" + item.Name,
 					12, 255, false);
 			else
-				m_sql.AddTaskItem(_tTaskItem::UpdateDevice(parseResult.fAfterSec, std::stoull(variableName), 0, parseResult.sCommand, false, false, item.Name));
+				m_sql.AddTaskItem(_tTaskItem::UpdateDevice(parseResult.fAfterSec, stoull(variableName), 0, parseResult.sCommand, false, false, item.Name));
 
 			actionsDone = true;
 		}
 		else if (deviceName.find("SendCamera:") == 0)
 		{
-			if (!atoi(deviceName.substr(11).c_str()))
+			if (!stoi(deviceName.substr(11)))
 				continue;
 			ScheduleEvent(deviceName, doWhat, item.Name);
 			actionsDone = true;
@@ -2249,7 +2248,7 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 		}
 		else if (deviceName.find("SetSetpoint:") == 0)
 		{
-			int idx = atoi(deviceName.substr(12).c_str());
+			int idx = stoi(deviceName.substr(12));
 			std::string temp, mode, until;
 			std::vector<std::string> aParam;
 			StringSplit(doWhat, "#", aParam);
@@ -2399,13 +2398,13 @@ bool CEventSystem::parseBlocklyActions(const _tEventItem &item)
 				sound = aParam[3];
 				subsystem = aParam[4];
 			}
-			m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, std::string(""), atoi(priority.c_str()), sound, subsystem));
+			m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, std::string(""), stoi(priority), sound, subsystem));
 			actionsDone = true;
 			continue;
 		}
 		else if (deviceName.find("CustomCommand:") == 0)
 		{
-			int idx = atoi(deviceName.substr(14).c_str());
+			int idx = stoi(deviceName.substr(14));
 			_tActionParseResults parseResult;
 			parseResult.fAfterSec = 0;
 			ParseActionString(doWhat, parseResult);
@@ -2491,19 +2490,19 @@ void CEventSystem::ParseActionString(const std::string &oAction_, _tActionParseR
 				oResults_.sCommand.append(sToken);
 				break;
 			case 1:
-				oResults_.fForSec = 60.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fForSec = 60.0F * stof(sToken);
 				break;
 			case 2:
-				oResults_.fAfterSec = 1.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fAfterSec = 1.0F * stof(sToken);
 				break;
 			case 3:
-				oResults_.fRandomSec = 60.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fRandomSec = 60.0F * stof(sToken);
 				break;
 			case 4:
-				oResults_.iRepeat = atoi(sToken.c_str());
+				oResults_.iRepeat = stoi(sToken);
 				break;
 			case 5:
-				oResults_.fRepeatSec = 1.F * static_cast<float>(atof(sToken.c_str()));
+				oResults_.fRepeatSec = 1.0F * stof(sToken);
 				break;
 			}
 		}
@@ -2544,14 +2543,14 @@ bool CEventSystem::PythonScheduleEvent(const std::string &ID, const std::string 
 
 		doWhat = ProcessVariableArgument(parseResult.sCommand);
 
-		uint64_t idx = atol(sd[0].c_str());
+		uint64_t idx = stoull(sd[0]);
 		m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, idx, doWhat, false));
 
 		return true;
 	}
 	if (ID.find("SetSetpoint:") == 0)
 	{
-		int idx = atoi(ID.substr(12).c_str());
+		int idx = stoi(ID.substr(12));
 		std::string doWhat = std::string(Action);
 		std::string temp, mode, until;
 		std::vector<std::string> aParam;
@@ -2576,7 +2575,7 @@ bool CEventSystem::PythonScheduleEvent(const std::string &ID, const std::string 
 	}
 	if (ID.find("CustomCommand:") == 0)
 	{
-		int idx = atoi(ID.substr(14).c_str());
+		int idx = stoi(ID.substr(14));
 		std::string doWhat = std::string(Action);
 		_tActionParseResults parseResult;
 		parseResult.fAfterSec = 0;
@@ -2898,16 +2897,14 @@ void CEventSystem::EvaluateLuaClassic(lua_State *lua_state, const _tEventQueue &
 	for (const auto &uservar : m_uservariables)
 	{
 		_tUserVariable uvitem = uservar.second;
-		if (uvitem.variableType == 0) {
-			//Integer
-			luaTable.AddInteger(uvitem.variableName, atoi(uvitem.variableValue.c_str()));
+		if (uvitem.variableType == 0)
+		{ //Integer
+			luaTable.AddInteger(uvitem.variableName, stoi(uvitem.variableValue));
 		}
-		else if (uvitem.variableType == 1) {
-			//Float
-			luaTable.AddNumber(uvitem.variableName, atof(uvitem.variableValue.c_str()));
-		}
-		else {
-			//String,Date,Time
+		else if (uvitem.variableType == 1)
+		{ //Float
+			luaTable.AddNumber(uvitem.variableName, stof(uvitem.variableValue));
+		} else { //String,Date,Time
 			luaTable.AddString(uvitem.variableName, uvitem.variableValue);
 		}
 	}
@@ -3236,7 +3233,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			subsystem = aParam[5];
 		}
 
-		m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, extraData, atoi(priority.c_str()), sound, subsystem));
+		m_sql.AddTaskItem(_tTaskItem::SendNotification(0, subject, body, extraData, stoi(priority), sound, subsystem));
 		scriptTrue = true;
 	}
 	else if (lCommand == "SendEmail") {
@@ -3310,13 +3307,13 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 		}
 		int nValue = 0;
 		std::string sValue;
-		int idx = std::stoi(strarray[0]);
+		int idx = stoi(strarray[0]);
 		if (strarray.size() > 1 && !strarray[1].empty())
-			nValue = atoi(strarray[1].c_str());
+			nValue = stoi(strarray[1]);
 		if (strarray.size() > 2 && !strarray[2].empty())
 			sValue = strarray[2];
 		//if (strarray.size() > 3 && !strarray[3].empty())
-			//Protected = atoi(strarray[3].c_str()); //GizMoCuz: this should not be able to be changed via events!
+			//Protected = stoi(strarray[3]); //GizMoCuz: this should not be able to be changed via events!
 
 		m_mainworker.UpdateDevice(idx, nValue, sValue, "EventSystem/" + filename, 12, 255, false);
 		scriptTrue = true;
@@ -3341,14 +3338,14 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 			if (parseResult.fAfterSec < (1. / timer_resolution_hz / 2))
 			{
 				std::string errorMessage;
-				if (!m_sql.UpdateUserVariable(sd[0], variableName, (const _eUsrVariableType)atoi(sd[1].c_str()), variableValue, false, errorMessage))
+				if (!m_sql.UpdateUserVariable(sd[0], variableName, (const _eUsrVariableType) stoi(sd[1]), variableValue, false, errorMessage))
 				{
 					_log.Log(LOG_ERROR, "EventSystem: Error updating variable %s: %s", variableName.c_str(), errorMessage.c_str());
 				}
 			}
 			else
 			{
-				uint64_t idx = std::stoull(sd[0]);
+				uint64_t idx = stoull(sd[0]);
 				m_sql.AddTaskItem(_tTaskItem::SetVariable(parseResult.fAfterSec, idx, variableValue, false));
 			}
 			scriptTrue = true;
@@ -3368,7 +3365,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 		case 2:
 			mode = aParam[1];
 		case 1:
-			idx = atoi(SetPointIdx.c_str());
+			idx = stoi(SetPointIdx);
 			temp = aParam[0];
 			m_sql.AddTaskItem(_tTaskItem::SetSetPoint(0.5F, idx, temp, mode, until));
 			break;
@@ -3381,7 +3378,7 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 	}
 	else if (lCommand.find("CustomCommand:") == 0)
 	{
-		int idx = atoi(lCommand.substr(14).c_str());
+		int idx = stoi(lCommand.substr(14));
 		std::string luaString = lua_tostring(lua_state, -1);
 		_tActionParseResults parseResult;
 		parseResult.fAfterSec = 0;
@@ -3412,7 +3409,7 @@ bool CEventSystem::CustomCommand(const uint64_t idx, const std::string &sCommand
 	if (result.size() != 1)
 		return false;
 
-	int HardwareID = atoi(result[0][0].c_str());
+	int HardwareID = stoi(result[0][0]);
 	CDomoticzHardwareBase *pHardware = m_mainworker.GetHardware(HardwareID);
 	if (!pHardware)
 		return false;
@@ -3449,12 +3446,12 @@ void CEventSystem::WriteToLog(const std::string &devNameNoQuotes, const std::str
 	}
 	else if (devNameNoQuotes == "WriteToLogUserVariable")
 	{
-		_log.Log(LOG_STATUS, "%s", m_uservariables[atoi(doWhat.c_str())].variableValue.c_str());
+		_log.Log(LOG_STATUS, "%s", m_uservariables[stoi(doWhat)].variableValue.c_str());
 	}
 	else if (devNameNoQuotes == "WriteToLogDeviceVariable")
 	{
 		boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
-		int devIdx = atoi(doWhat.c_str());
+		int devIdx = stoi(doWhat);
 		if (m_devicestates[devIdx].devType == pTypeHUM)
 		{
 			//nValue devices
@@ -3468,7 +3465,7 @@ void CEventSystem::WriteToLog(const std::string &devNameNoQuotes, const std::str
 	else if (devNameNoQuotes == "WriteToLogSwitch")
 	{
 		boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
-		_log.Log(LOG_STATUS, "%s", m_devicestates[atoi(doWhat.c_str())].nValueWording.c_str());
+		_log.Log(LOG_STATUS, "%s", m_devicestates[stoi(doWhat)].nValueWording.c_str());
 	}
 }
 
@@ -3520,7 +3517,7 @@ bool CEventSystem::ScheduleEvent(std::string deviceName, const std::string &Acti
 	if (!result.empty())
 	{
 		std::vector<std::string> sd = result[0];
-		int idx = atoi(sd[0].c_str());
+		int idx = stoi(sd[0]);
 		return (ScheduleEvent(idx, Action, isScene, eventName, sceneType));
 	}
 
@@ -3546,7 +3543,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 			_log.Log(LOG_ERROR, "EventSystem: Missing command arguments! '%s'", oParseResults.sCommand.c_str());
 			return false;
 		}
-		level = calculateDimLevel(deviceID, atoi(oParseResults.sCommand.substr(10).c_str()));
+		level = calculateDimLevel(deviceID, stoi(oParseResults.sCommand.substr(10)));
 		oParseResults.sCommand = oParseResults.sCommand.substr(0, 9);
 	}
 	else if (oParseResults.sCommand.substr(0, 10) == "Set Volume") {
@@ -3555,7 +3552,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 			_log.Log(LOG_ERROR, "EventSystem: Missing command arguments! '%s'", oParseResults.sCommand.c_str());
 			return false;
 		}
-		level = atoi(oParseResults.sCommand.substr(11).c_str());
+		level = stoi(oParseResults.sCommand.substr(11));
 		oParseResults.sCommand = oParseResults.sCommand.substr(0, 10);
 	}
 	else if (oParseResults.sCommand.substr(0, 13) == "Play Playlist") {
@@ -3576,7 +3573,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 			if (iLastSpace != std::string::npos)
 			{
 				sPlayList = sParams.substr(0, iLastSpace);
-				level = atoi(sParams.substr(iLastSpace).c_str());
+				level = stoi(sParams.substr(iLastSpace));
 			}
 			if (!pHardware->SetPlaylist(deviceID, sPlayList))
 			{
@@ -3611,7 +3608,7 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 			//CKodi			*pHardware = dynamic_cast<CKodi*>(pBaseHardware);
 			if (sParams.length() > 0)
 			{
-				level = atoi(sParams.c_str());
+				level = stoi(sParams);
 			}
 		}
 		oParseResults.sCommand = oParseResults.sCommand.substr(0, 14);
@@ -3654,8 +3651,8 @@ bool CEventSystem::ScheduleEvent(int deviceID, const std::string &Action, bool i
 		}
 
 		std::vector<std::string> sd = result[0];
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[0].c_str());
-		int iOnDelay = atoi(sd[1].c_str());
+		_eSwitchType switchtype = (_eSwitchType) stoi(sd[0]);
+		int iOnDelay = stoi(sd[1]);
 
 		bool bIsOn = IsLightSwitchOn(oParseResults.sCommand);
 		if (switchtype == STYPE_Selector) {
@@ -3997,9 +3994,9 @@ int CEventSystem::calculateDimLevel(int deviceID, int percentageLevel)
 	{
 		std::vector<std::string> sd = result[0];
 
-		unsigned char dType = atoi(sd[0].c_str());
-		unsigned char dSubType = atoi(sd[1].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[2].c_str());
+		unsigned char dType = (unsigned char) stoi(sd[0]);
+		unsigned char dSubType = (unsigned char) stoi(sd[1]);
+		_eSwitchType switchtype = (_eSwitchType) stoi(sd[2]);
 		std::string lstatus;
 		int llevel = 0;
 		bool bHaveDimmer = false;
@@ -4160,7 +4157,7 @@ namespace http {
 						std::string Name = sd[1];
 						std::string XMLStatement = sd[2];
 						std::string eventStatus = sd[3];
-						//int Status=atoi(sd[3].c_str());
+						//int Status = stoi(sd[3]);
 
 						root["result"][ii]["id"] = ID;
 						root["result"][ii]["name"] = Name;
@@ -4183,7 +4180,7 @@ namespace http {
 				if (eventid.empty())
 					return;
 
-				m_sql.safe_query("UPDATE EventMaster SET Status ='%d' WHERE (ID == '%q')", atoi(eventactive.c_str()), eventid.c_str());
+				m_sql.safe_query("UPDATE EventMaster SET Status ='%d' WHERE (ID == '%q')", stoi(eventactive), eventid.c_str());
 				m_mainworker.m_eventsystem.LoadEvents();
 				root["status"] = "OK";
 
@@ -4220,7 +4217,7 @@ namespace http {
 				if ((interpreter == "Blockly") && (eventlogic.empty()))
 					return;
 
-				int eventStatus = atoi(eventactive.c_str());
+				int eventStatus = stoi(eventactive);
 
 				bool parsingSuccessful = eventxml.length() > 0;
 				Json::Value jsonRoot;

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1562,7 +1562,7 @@ double round_digits(double dIn, const int totDigits)
 {
 	std::stringstream sstr;
 	sstr << std::setprecision(totDigits) << std::fixed << dIn;
-	return std::stod(sstr.str());
+	return stod(sstr.str());
 }
 
 const std::string std_format(const char* szFormat, ...)

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -180,7 +180,7 @@ std::vector<char> HexToBytes(const std::string& hex) {
 
 	for (unsigned int i = 0; i < hex.length(); i += 2) {
 		std::string byteString = hex.substr(i, 2);
-		char byte = (char)strtol(byteString.c_str(), nullptr, 16);
+		char byte = (char) stol(byteString, nullptr, 16);
 		bytes.push_back(byte);
 	}
 

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -62,7 +62,7 @@ bool CLogger::SetLogFlags(const std::string &sFlags)
 		if (is_number(wflag))
 		{
 			// Flags are set provided (bitwise)
-			iFlags = strtoul(wflag.c_str(), nullptr, 10);
+			iFlags = stoul(wflag);
 			break;
 		}
 		if (wflag == "all")
@@ -105,7 +105,7 @@ bool CLogger::SetDebugFlags(const std::string &sFlags)
 		if (is_number(wflag))
 		{
 			// Flags are set provided (bitwise)
-			iFlags = strtoul(wflag.c_str(), nullptr, 10);
+			iFlags = stoul(wflag);
 			break;
 		}
 		if (wflag == "all")

--- a/main/LuaHandler.cpp
+++ b/main/LuaHandler.cpp
@@ -41,7 +41,7 @@ int CLuaHandler::l_domoticz_updateDevice(lua_State* lua_state)
 			}
 
 			// Parse
-			int invalue = (!nvalue.empty()) ? atoi(nvalue.c_str()) : 0;
+			int invalue = (!nvalue.empty()) ? stoi(nvalue) : 0;
 			int signallevel = 12;
 			if (nargs >= 4 && lua_isnumber(lua_state, 4))
 			{

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1064,7 +1064,7 @@ void GetLightStatus(
 
 		if (switchtype != STYPE_Media) {
 			// Calculate % that the light is currently on, taking the maxdimlevel into account.
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 		}
 
 		// Fill in other parameters
@@ -1098,7 +1098,7 @@ void GetLightStatus(
 				lstatus = "Group On";
 				break;
 			case light2_sSetGroupLevel:
-				sprintf(szTmp, "Set Group Level: %d %%", atoi(sValue.c_str()));
+				sprintf(szTmp, "Set Group Level: %d %%", stoi(sValue));
 				if (sValue != "0")
 					lstatus = szTmp;
 				else
@@ -1124,16 +1124,16 @@ void GetLightStatus(
 		break;
 	case pTypeLighting5:
 		if (dSubType == sTypeLivolo)
-			llevel = int((100.0F / 7.0F) * atof(sValue.c_str()));
+			llevel = int((100.0F / 7.0F) * stof(sValue));
 		else
-			llevel = int((100.0F / 31.0F) * atof(sValue.c_str()));
+			llevel = int((100.0F / 31.0F) * stof(sValue));
 		switch (dSubType)
 		{
 		case sTypeLightwaveRF:
 			bHaveGroupCmd = true;
 			bHaveDimmer = true;
 			maxDimLevel = 32;
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1321,7 +1321,7 @@ void GetLightStatus(
 			break;
 		case sTypeIT:
 			maxDimLevel = 9;
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1396,7 +1396,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 
 		// Fill in other parameters
 		switch (dSubType)
@@ -1434,7 +1434,7 @@ void GetLightStatus(
 			lstatus = "Group On";
 			break;
 		case gswitch_sSetGroupLevel:
-			sprintf(szTmp, "Set Group Level: %d %%", atoi(sValue.c_str()));
+			sprintf(szTmp, "Set Group Level: %d %%", stoi(sValue));
 			if (sValue != "0")
 				lstatus = szTmp;
 			else
@@ -1552,7 +1552,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 
 		switch (nValue)
 		{
@@ -1739,7 +1739,7 @@ void GetLightStatus(
 			maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-			llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 		}
 
 		switch (nValue)
@@ -1909,7 +1909,7 @@ void GetLightStatus(
 	case pTypeEvohomeRelay:
 		bHaveDimmer = true;
 		maxDimLevel = 200;
-		llevel = int(0.5F * atof(sValue.c_str()));
+		llevel = int(0.5F * stof(sValue));
 		switch (nValue)
 		{
 		case light1_sOff:
@@ -2223,7 +2223,7 @@ void GetLightStatus(
 	case pTypeDDxxxx:
 		bHaveDimmer = true;
 		maxDimLevel = 100;
-		llevel = (int)float((100.0F / float(maxDimLevel)) * atof(sValue.c_str()));
+		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
 
 		switch (nValue)
 		{
@@ -3989,7 +3989,7 @@ void ConvertToGeneralSwitchType(std::string& devid, int& dtype, int& subtype)
 		if (subtype == sTypeAB400D) subtype = sSwitchTypeAB400D;
 		if (subtype == sTypeIMPULS) subtype = sSwitchTypeTriState;
 		std::stringstream s_strid;
-		s_strid << std::hex << atoi(devid.c_str());
+		s_strid << std::hex << stoi(devid);
 		devid = s_strid.str();
 		devid = "000000" + devid;
 	}

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -4045,7 +4045,7 @@ void ConvertToGeneralSwitchType(std::string& devid, int& dtype, int& subtype)
 		else if (subtype == sTypeBlindsT9) subtype = sSwitchTypeBrel;
 		else if (subtype == sTypeBlindsT10) subtype = sSwitchTypeDooya;
 		std::stringstream s_strid;
-		s_strid << std::hex << strtoul(devid.c_str(), nullptr, 16);
+		s_strid << std::hex << stoul(devid, nullptr, 16);
 		unsigned long deviceid = 0;
 		s_strid >> deviceid;
 		deviceid = (unsigned long)((deviceid & 0xffffff00) >> 8);

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -1064,7 +1064,7 @@ void GetLightStatus(
 
 		if (switchtype != STYPE_Media) {
 			// Calculate % that the light is currently on, taking the maxdimlevel into account.
-			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+			llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 		}
 
 		// Fill in other parameters
@@ -1124,16 +1124,16 @@ void GetLightStatus(
 		break;
 	case pTypeLighting5:
 		if (dSubType == sTypeLivolo)
-			llevel = int((100.0F / 7.0F) * stof(sValue));
+			llevel = int((100.0 / 7.0) * stod(sValue));
 		else
-			llevel = int((100.0F / 31.0F) * stof(sValue));
+			llevel = int((100.0 / 31.0) * stod(sValue));
 		switch (dSubType)
 		{
 		case sTypeLightwaveRF:
 			bHaveGroupCmd = true;
 			bHaveDimmer = true;
 			maxDimLevel = 32;
-			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+			llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1321,7 +1321,7 @@ void GetLightStatus(
 			break;
 		case sTypeIT:
 			maxDimLevel = 9;
-			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+			llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 			switch (nValue)
 			{
 			case light5_sOff:
@@ -1396,7 +1396,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+		llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 
 		// Fill in other parameters
 		switch (dSubType)
@@ -1552,7 +1552,7 @@ void GetLightStatus(
 		maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+		llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 
 		switch (nValue)
 		{
@@ -1739,7 +1739,7 @@ void GetLightStatus(
 			maxDimLevel = 100;
 
 		// Calculate % that the light is currently on, taking the maxdimlevel into account.
-			llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+			llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 		}
 
 		switch (nValue)
@@ -1909,7 +1909,7 @@ void GetLightStatus(
 	case pTypeEvohomeRelay:
 		bHaveDimmer = true;
 		maxDimLevel = 200;
-		llevel = int(0.5F * stof(sValue));
+		llevel = int(0.5 * stod(sValue));
 		switch (nValue)
 		{
 		case light1_sOff:
@@ -2223,7 +2223,7 @@ void GetLightStatus(
 	case pTypeDDxxxx:
 		bHaveDimmer = true;
 		maxDimLevel = 100;
-		llevel = int((100.0F / float(maxDimLevel)) * stof(sValue));
+		llevel = int((100.0 / double(maxDimLevel)) * stod(sValue));
 
 		switch (nValue)
 		{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -951,7 +951,7 @@ bool CSQLHelper::OpenDatabase()
 				sqlite3_exec(m_dbase, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
 				for (const auto &sd : result)
 				{
-					safe_query("UPDATE Temperature_Calendar SET Temp_Avg=%.1f WHERE RowID='%q'", atof(sd[1].c_str()), sd[0].c_str());
+					safe_query("UPDATE Temperature_Calendar SET Temp_Avg=%.1f WHERE RowID='%q'", stof(sd[1]), sd[0].c_str());
 				}
 				sqlite3_exec(m_dbase, "END TRANSACTION;", nullptr, nullptr, nullptr);
 			}
@@ -1147,7 +1147,7 @@ bool CSQLHelper::OpenDatabase()
 			result = safe_query("SELECT ID FROM Hardware WHERE (Type==%d) AND (Name=='Motherboard') LIMIT 1", HTYPE_System);
 			if (!result.empty())
 			{
-				int hwId = atoi(result[0][0].c_str());
+				int hwId = stoi(result[0][0]);
 				safe_query("UPDATE DeviceStatus SET HardwareID=%d WHERE (HardwareID=1000)", hwId);
 			}
 		}
@@ -1314,7 +1314,7 @@ bool CSQLHelper::OpenDatabase()
 			result = query("SELECT ID FROM Hardware WHERE ([Type] = 19)");
 			if (!result.empty())
 			{
-				int TeleInfoHWID = atoi(result[0][0].c_str());
+				int TeleInfoHWID = stoi(result[0][0]);
 				szQuery2 << "UPDATE DeviceStatus SET HardwareID=" << TeleInfoHWID << " WHERE ([HardwareID]=0)";
 				query(szQuery2.str());
 			}
@@ -1338,7 +1338,7 @@ bool CSQLHelper::OpenDatabase()
 			result = query(szQuery.str());
 			for (const auto &sd : result)
 			{
-				int hwid = atoi(sd[0].c_str());
+				int hwid = stoi(sd[0]);
 
 				szQuery.clear();
 				szQuery.str("");
@@ -1411,9 +1411,9 @@ bool CSQLHelper::OpenDatabase()
 			{
 				for (const auto &sd : result)
 				{
-					int hwId = atoi(sd[0].c_str());
-					_eHardwareTypes hwtype = (_eHardwareTypes)atoi(sd[1].c_str());
-					size_t Port = (size_t)atoi(sd[2].c_str());
+					int hwId = stoi(sd[0]);
+					_eHardwareTypes hwtype = (_eHardwareTypes) stoi(sd[1]);
+					size_t Port = (size_t) stoull(sd[2]);
 
 					if (IsSerialDevice(hwtype))
 					{
@@ -1541,7 +1541,7 @@ bool CSQLHelper::OpenDatabase()
 				for (const auto &sd : result)
 				{
 					std::string idx = sd[0];
-					int lid = atoi(sd[1].c_str());
+					int lid = stoi(sd[1]);
 					char szTmp[20];
 					sprintf(szTmp, "%08X", lid);
 					safe_query("UPDATE DeviceStatus SET DeviceID='%q' WHERE (ID='%q')", szTmp, idx.c_str());
@@ -1568,7 +1568,7 @@ bool CSQLHelper::OpenDatabase()
 			for (const auto &sd2 : result2)
 			{
 				//Change type to new sensor, and update ID
-				int oldID = atoi(sd2[1].c_str());
+				int oldID = stoi(sd2[1]);
 				char szTmp[20];
 				sprintf(szTmp, "%08X", oldID);
 				safe_query("UPDATE DeviceStatus SET [DeviceID]='%s', [Type]=%d, [SubType]=%d, [Unit]=1 WHERE (ID==%s)", szTmp, pTypeGeneral, sTypeKwh, sd2[0].c_str());
@@ -1609,9 +1609,9 @@ bool CSQLHelper::OpenDatabase()
 			result = query(szQuery.str());
 			for (const auto &sd : result)
 			{
-				int hwid = atoi(sd[0].c_str());
-				int nodeid = atoi(sd[1].c_str());
-				//int childid = atoi(sd[2].c_str());
+				int hwid = stoi(sd[0]);
+				int nodeid = stoi(sd[1]);
+				//int childid = stoi(sd[2]);
 
 				szQuery.clear();
 				szQuery.str("");
@@ -1658,7 +1658,7 @@ bool CSQLHelper::OpenDatabase()
 			}
 			if (!result.empty())
 			{
-				hwdID = atoi(result[0][0].c_str());
+				hwdID = stoi(result[0][0]);
 			}
 			if (hwdID > 0)
 			{
@@ -1834,8 +1834,8 @@ bool CSQLHelper::OpenDatabase()
 					{
 						for (const auto &sd : result1)
 						{
-							uint64_t devidx = atoi(sd[0].c_str());
-							_eMeterType switchType = (_eMeterType)atoi(sd[2].c_str());
+							uint64_t devidx = stoull(sd[0]);
+							_eMeterType switchType = (_eMeterType) stoi(sd[2]);
 
 							if (switchType == MTYPE_COUNTER)
 							{
@@ -2283,7 +2283,7 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << (float)atof(sd3[0].c_str()) / 10.0F << ", '"
+							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << stof(sd3[0]) / 10.0F << ", '"
 								 << sd3[1] << "')";
 							query(szQuery2.str());
 						}
@@ -2301,9 +2301,9 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							float percentage_min = (float)atof(sd3[0].c_str()) / 10.0F;
-							float percentage_max = (float)atof(sd3[1].c_str()) / 10.0F;
-							float percentage_avg = (float)atof(sd3[2].c_str()) / 10.0F;
+							float percentage_min = stof(sd3[0]) / 10.0F;
+							float percentage_max = stof(sd3[1]) / 10.0F;
+							float percentage_avg = stof(sd3[2]) / 10.0F;
 							szQuery2 << "INSERT INTO Percentage_Calendar (DeviceRowID, Percentage_Min, Percentage_Max, Percentage_Avg, Date) VALUES (" << sd[0] << ", " << percentage_min << ", " << percentage_max << ", " << percentage_avg << ", '" << sd3[3] << "')";
 							query(szQuery2.str());
 						}
@@ -2334,7 +2334,7 @@ bool CSQLHelper::OpenDatabase()
 					int r, g, b;
 
 					//convert hue to RGB
-					float iHue = float(atof(sd[1].c_str()));
+					float iHue = stof(sd[1]);
 					hsb2rgb(iHue, 1.0F, 1.0F, r, g, b, 255);
 
 					_tColor color = _tColor(r, g, b, 0, 0, ColorModeRGB);
@@ -2354,7 +2354,7 @@ bool CSQLHelper::OpenDatabase()
 					int r, g, b;
 
 					//convert hue to RGB
-					float iHue = float(atof(sd[1].c_str()));
+					float iHue = stof(sd[1]);
 					hsb2rgb(iHue, 1.0F, 1.0F, r, g, b, 255);
 
 					_tColor color = _tColor(r, g, b, 0, 0, ColorModeRGB);
@@ -2407,7 +2407,7 @@ bool CSQLHelper::OpenDatabase()
 						if (laLower.find("http%3a//") != std::string::npos || laLower.find("https%3a//") != std::string::npos)
 						{
 							options["LevelActions"] = CURLEncode::URLDecode(levelActions);
-							uint64_t ullidx = std::stoull(idx);
+							uint64_t ullidx = stoull(idx);
 							SetDeviceOptions(ullidx, options);
 						}
 					}
@@ -2498,7 +2498,7 @@ bool CSQLHelper::OpenDatabase()
 					std::string EnergyMeterMode = sd[1];
 					if (EnergyMeterMode == "1")
 					{
-						uint64_t ullidx = std::stoull(idx);
+						uint64_t ullidx = stoull(idx);
 						SetDeviceOptions(ullidx, BuildDeviceOptions("EnergyMeterMode:" + EnergyMeterMode, false));
 					}
 				}
@@ -2569,7 +2569,7 @@ bool CSQLHelper::OpenDatabase()
 					{
 						for (const auto &sd : dsResult)
 						{
-							int id = atoi(sd[1].c_str());
+							int id = stoi(sd[1]);
 							char szTmp[20];
 							sprintf(szTmp, "%06X01", id);
 
@@ -2602,7 +2602,7 @@ bool CSQLHelper::OpenDatabase()
 					{
 						for (const auto &sd : result2)
 						{
-							int sub_type = atoi(sd[2].c_str());
+							int sub_type = stoi(sd[2]);
 							uint32_t NodeID;
 							std::stringstream s_strid;
 							s_strid << std::hex << sd[1];
@@ -2871,7 +2871,7 @@ bool CSQLHelper::OpenDatabase()
 				for (const auto &sdn : result)
 				{
 					safe_query("INSERT INTO EnOceanNodes (ID, HardwareID, NodeID, ManufacturerID, Func, Type) VALUES ('%q','%q',%u,'%q','%q','%q')",
-						sdn[0].c_str(), sdn[1].c_str(), static_cast<uint32_t>(std::stoul(sdn[2], 0, 16)), sdn[3].c_str(), sdn[4].c_str(), sdn[5].c_str());
+						sdn[0].c_str(), sdn[1].c_str(), static_cast<uint32_t>(stoul(sdn[2], 0, 16)), sdn[3].c_str(), sdn[4].c_str(), sdn[5].c_str());
 				}
 			}
 			query("DROP TABLE EnoceanSensors");
@@ -2959,10 +2959,10 @@ bool CSQLHelper::OpenDatabase()
 						}
 						else
 						{
-							nValue = atoi(result[0][0].c_str());	// RowID
-							int iActive = atoi(result[0][1].c_str());
-							int iRights = atoi(result[0][2].c_str());
-							int iTabsEnabled = atoi(result[0][3].c_str());
+							nValue = stoi(result[0][0]);	// RowID
+							int iActive = stoi(result[0][1]);
+							int iRights = stoi(result[0][2]);
+							int iTabsEnabled = stoi(result[0][3]);
 							if (iActive != 1 || iTabsEnabled == 0 || iRights != http::server::URIGHTS_ADMIN)
 							{
 								// Although there already is a User with the same Username as the WebUserName
@@ -2984,14 +2984,14 @@ bool CSQLHelper::OpenDatabase()
 			result = safe_query("SELECT COUNT(*) FROM Users WHERE Active=1 AND Rights=%d", http::server::URIGHTS_ADMIN);
 			if(!result.empty())
 			{
-				nValue = atoi(result[0][0].c_str());
+				nValue = stoi(result[0][0]);
 				if (nValue == 0)
 				{
 					result = safe_query("SELECT ROWID FROM Users WHERE Username='%s'", base64_encode(DEFAULT_ADMINUSER).c_str());
 					if (!result.empty())
 					{
 						// There is already a User called Admin but apparently either not Active and/or with Admin privileges
-						nValue = atoi(result[0][0].c_str());
+						nValue = stoi(result[0][0]);
 						std::string oldUserName = DEFAULT_ADMINUSER;
 						oldUserName.append("_old");
 						safe_query("UPDATE Users SET Username='%s' WHERE ROWID='%d'", base64_encode(oldUserName).c_str(), nValue);
@@ -3100,12 +3100,12 @@ bool CSQLHelper::OpenDatabase()
 			result = m_sql.safe_query("SELECT ID FROM HARDWARE WHERE ([Type]==%d)", HTYPE_EnphaseAPI);
 			if (!result.empty())
 			{
-				int hwID = atoi(result[0][0].c_str());
+				int hwID = stoi(result[0][0]);
 				std::string szOldName = "EnphaseOffset_Production";
 				result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='%q')", szOldName.c_str());
 				if (!result.empty())
 				{
-					int vID = atoi(result[0][0].c_str());
+					int vID = stoi(result[0][0]);
 					std::string szValue = result[0][1];
 					std::string szNewName = szOldName + "_" + std::to_string(hwID);
 					m_sql.safe_query("INSERT INTO UserVariables (Name, ValueType, Value) VALUES ('%q',%d,'%q')", szNewName.c_str(), USERVARTYPE_STRING, szValue.c_str());
@@ -3251,9 +3251,9 @@ bool CSQLHelper::OpenDatabase()
 			result = query(szQuery.str());
 			if (!result.empty())
 			{
-				if (atoi(result[0][1].c_str()) != nValue)
+				if (stoi(result[0][1]) != nValue)
 				{
-					UpdateRFXCOMHardwareDetails(atoi(result[0][0].c_str()), nValue, 0, 0, 0, 0, 0);
+					UpdateRFXCOMHardwareDetails(stoi(result[0][0]), nValue, 0, 0, 0, 0, 0);
 				}
 			}
 			UpdatePreferencesVar("Rego6XXType", 0); // Set to zero to avoid another copy
@@ -3615,7 +3615,7 @@ bool CSQLHelper::StartThread()
 bool CSQLHelper::SwitchLightFromTasker(const std::string& idx, const std::string& switchcmd, const std::string& level, const std::string& color, const std::string& User)
 {
 	_tColor ocolor(color);
-	return SwitchLightFromTasker(std::stoull(idx), switchcmd, atoi(level.c_str()), ocolor, User);
+	return SwitchLightFromTasker(stoull(idx), switchcmd, stoi(level), ocolor, User);
 }
 
 bool CSQLHelper::SwitchLightFromTasker(uint64_t idx, const std::string& switchcmd, int level, _tColor color, const std::string& User)
@@ -3627,7 +3627,7 @@ bool CSQLHelper::SwitchLightFromTasker(uint64_t idx, const std::string& switchcm
 		return false;
 
 	std::vector<std::string> sd = result[0];
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 
 	int hindex = m_mainworker.FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
@@ -3645,7 +3645,7 @@ bool CSQLHelper::SwitchLightFromTasker(uint64_t idx, const std::string& switchcm
 		return (bret) ? MainWorker::SL_OK : MainWorker::SL_ERROR;
 	}
 
-	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 
 	std::string switchCommand = switchcmd;
 	bool bret = m_mainworker.SwitchLightInt(sd, switchCommand, level, color, false, User);
@@ -4177,7 +4177,7 @@ void CSQLHelper::Do_Work()
 					s_str.str("");
 					s_str << itt._idx;
 					std::string errorMessage;
-					if (!UpdateUserVariable(s_str.str(), sd[0], (const _eUsrVariableType)atoi(sd[1].c_str()), itt._sValue, (itt._nValue == 0) ? false : true, errorMessage))
+					if (!UpdateUserVariable(s_str.str(), sd[0], (const _eUsrVariableType) stoi(sd[1]), itt._sValue, (itt._nValue == 0) ? false : true, errorMessage))
 					{
 						_log.Log(LOG_ERROR, "Error updating variable %s: %s", sd[0].c_str(), errorMessage.c_str());
 					}
@@ -4196,12 +4196,12 @@ void CSQLHelper::Do_Work()
 				std::stringstream sstr;
 				sstr << itt._idx;
 				std::string idx = sstr.str();
-				float fValue = (float)atof(itt._sValue.c_str());
+				float fValue = stof(itt._sValue);
 
 				auto result = safe_query("SELECT a.[Type] FROM Hardware as a, DeviceStatus as b WHERE (b.ID == %" PRIu64 ") AND (a.ID == b.HardwareID)", itt._idx);
 				if (!result.empty())
 				{
-					_eHardwareTypes HwdType = (_eHardwareTypes)atoi(result[0][0].c_str());
+					_eHardwareTypes HwdType = (_eHardwareTypes) stoi(result[0][0]);
 					if (HwdType == HTYPE_EVOHOME_SCRIPT || HwdType == HTYPE_EVOHOME_SERIAL || HwdType == HTYPE_EVOHOME_WEB || HwdType == HTYPE_EVOHOME_TCP)
 						m_mainworker.SetSetPointEvo(idx, fValue, itt._command, itt._sUntil);
 					else
@@ -4510,7 +4510,7 @@ uint64_t CSQLHelper::CreateDevice(const int HardwareID, const int SensorType, co
 		if (!result.empty())
 		{
 			std::vector<std::string> sd = result[0];
-			_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[0].c_str());
+			_eHardwareTypes Type = (_eHardwareTypes) stoi(sd[0]);
 			if (Type == HTYPE_PythonPlugin)
 			{
 				// Not allowed to add device to plugin HW (plugin framework does not use key column "ID" but instead uses column "unit" as key)
@@ -4816,15 +4816,15 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, int OrgHardwareID, const 
 			);
 
 			//Call the EventSystem for the main switch
-			uint64_t ParentID = (uint64_t)atoll(sd[0].c_str());
+			uint64_t ParentID = stoull(sd[0]);
 			std::string ParentName = sd[1];
-			int ParentHardwareID = atoi(sd[2].c_str());
-			unsigned char ParentType = (unsigned char)atoi(sd[3].c_str());
-			unsigned char ParentSubType = (unsigned char)atoi(sd[4].c_str());
-			unsigned char ParentUnit = (unsigned char)atoi(sd[5].c_str());
+			int ParentHardwareID = stoi(sd[2]);
+			unsigned char ParentType = (unsigned char) stoi(sd[3]);
+			unsigned char ParentSubType = (unsigned char) stoi(sd[4]);
+			unsigned char ParentUnit = (unsigned char) stoi(sd[5]);
 			m_mainworker.m_eventsystem.ProcessDevice(ParentHardwareID, ParentID, ParentUnit, ParentType, ParentSubType, signallevel, batterylevel, nValue, sValue);
 
-			m_mainworker.sOnDeviceUpdate(std::stoi(sd[2]), std::stoll(sd[0]));
+			m_mainworker.sOnDeviceUpdate(stoi(sd[2]), stoull(sd[0]));
 
 			//Set the status of all slave devices from this device (except the one we just received) to off
 			//Check if this switch was a Sub/Slave device for other devices, if so adjust the state of those other devices
@@ -4837,7 +4837,7 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, int OrgHardwareID, const 
 			{
 				for (const auto &sd : result2)
 				{
-					int oDevType = atoi(sd[1].c_str());
+					int oDevType = stoi(sd[1]);
 					int newnValue = 0;
 					switch (oDevType)
 					{
@@ -4911,7 +4911,7 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, int OrgHardwareID, const 
 						sLastUpdate.c_str(),
 						sd[0].c_str()
 					);
-					m_mainworker.sOnDeviceUpdate(std::stoi(sd[2]), std::stoll(sd[0]));
+					m_mainworker.sOnDeviceUpdate(stoi(sd[2]), stoull(sd[0]));
 				}
 			}
 			// TODO: Should plugin be notified?
@@ -4929,7 +4929,7 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, int OrgHardwareID, const 
 		//set the status to off
 		for (const auto &sd : result)
 		{
-			int oDevType = atoi(sd[1].c_str());
+			int oDevType = stoi(sd[1]);
 			int newnValue = 0;
 			switch (oDevType)
 			{
@@ -5003,7 +5003,7 @@ uint64_t CSQLHelper::UpdateValue(const int HardwareID, int OrgHardwareID, const 
 				sLastUpdate.c_str(),
 				sd[0].c_str()
 			);
-			m_mainworker.sOnDeviceUpdate(std::stoi(sd[2]), std::stoll(sd[0]));
+			m_mainworker.sOnDeviceUpdate(stoi(sd[2]), stoull(sd[0]));
 		}
 		// TODO: Should plugin be notified?
 	}
@@ -5047,7 +5047,7 @@ uint64_t CSQLHelper::InsertDevice(const int HardwareID, const int OrgHardwareID,
 		_log.Log(LOG_ERROR, "Serious database error, problem getting ID from DeviceStatus!");
 		return -1;
 	}
-	ulID = std::stoull(result[0][0]);
+	ulID = stoull(result[0][0]);
 
 	return ulID;
 }
@@ -5058,7 +5058,7 @@ uint64_t CSQLHelper::GetDeviceIndex(const int HardwareID, const int OrgHardwareI
 	if (result.empty())
 		return -1;
 	devname = result[0].at(1);
-	return std::stoull(result[0].at(0));
+	return stoull(result[0].at(0));
 }
 
 uint64_t CSQLHelper::UpdateManagedValueInt(
@@ -5085,9 +5085,9 @@ uint64_t CSQLHelper::UpdateManagedValueInt(
 	}
 	else
 	{
-		ulID = std::stoull(result[0][0]);
+		ulID = stoull(result[0][0]);
 		devname = result[0][1];
-		bDeviceUsed = atoi(result[0][2].c_str()) != 0;
+		bDeviceUsed = stoi(result[0][2]) != 0;
 	}
 
 	std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
@@ -5111,16 +5111,16 @@ uint64_t CSQLHelper::UpdateManagedValueInt(
 			shortLog,
 			true,
 			parts[10].c_str(),
-			std::stoll(parts[0]),
-			std::stoll(parts[2]),
-			std::stoll(parts[4]),
-			std::stoll(parts[5]),
-			std::stoll(parts[1]),
-			std::stoll(parts[3]),
-			std::stoll(parts[6]),
-			std::stoll(parts[7]),
-			std::stoll(parts[8]),
-			std::stoll(parts[9])
+			stoll(parts[0]),
+			stoll(parts[2]),
+			stoll(parts[4]),
+			stoll(parts[5]),
+			stoll(parts[1]),
+			stoll(parts[3]),
+			stoll(parts[6]),
+			stoll(parts[7]),
+			stoll(parts[8]),
+			stoll(parts[9])
 		);
 		return ulID;
 	}
@@ -5140,12 +5140,12 @@ uint64_t CSQLHelper::UpdateManagedValueInt(
 			shortLog,
 			true,
 			parts[6].c_str(),
-			std::stoll(parts[0]),
-			std::stoll(parts[2]),
-			std::stoll(parts[4]),
-			std::stoll(parts[5]),
-			std::stoll(parts[1]),
-			std::stoll(parts[3])
+			stoll(parts[0]),
+			stoll(parts[2]),
+			stoll(parts[4]),
+			stoll(parts[5]),
+			stoll(parts[1]),
+			stoll(parts[3])
 		);
 		return ulID;
 	}
@@ -5162,8 +5162,8 @@ uint64_t CSQLHelper::UpdateManagedValueInt(
 			shortLog,
 			false,
 			parts[2].c_str(),
-			std::stoll(parts[0]),
-			std::stoll(parts[1])
+			stoll(parts[0]),
+			stoll(parts[1])
 		);
 		return ulID;
 	}
@@ -5251,11 +5251,11 @@ uint64_t CSQLHelper::UpdateValueInt(
 	else
 	{
 		//Update
-		ulID = std::stoull(result[0][0]);
+		ulID = stoull(result[0][0]);
 		devname = result[0][1];
-		bDeviceUsed = atoi(result[0][2].c_str()) != 0;
-		stype = (_eSwitchType)atoi(result[0][3].c_str());
-		nValueBeforeUpdate = atoi(result[0][4].c_str());
+		bDeviceUsed = stoi(result[0][2]) != 0;
+		stype = (_eSwitchType) stoi(result[0][3]);
+		nValueBeforeUpdate = stoi(result[0][4]);
 		sValueBeforeUpdate = result[0][5];
 
 		std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
@@ -5280,9 +5280,9 @@ uint64_t CSQLHelper::UpdateValueInt(
 			StringSplit(sValueBeforeUpdate, ";", powerAndEnergyBeforeUpdate);
 			if (powerAndEnergyBeforeUpdate.size() == 2)
 			{
-				//we need to use atof here because some users seem to have a illegal sValue in the database that causes std::stof to crash
-				double powerDuringInterval = atof(powerAndEnergyBeforeUpdate[0].c_str());
-				double energyUpToInterval = atof(powerAndEnergyBeforeUpdate[1].c_str());
+				//we need to use atof here because some users seem to have a illegal sValue in the database that causes stof to crash
+				double powerDuringInterval = stod(powerAndEnergyBeforeUpdate[0]);
+				double energyUpToInterval = stod(powerAndEnergyBeforeUpdate[1]);
 				double energyDuringInterval = powerDuringInterval * intervalSeconds / 3600;
 				double energyAfterInterval = energyUpToInterval + energyDuringInterval;
 				std::vector<std::string> powerAndEnergyUpdate;
@@ -5423,8 +5423,8 @@ uint64_t CSQLHelper::UpdateValueInt(
 			bool bHaveDimmer = false;
 			std::vector<std::string> sd = result[0];
 			std::string Name = sd[0];
-			_eSwitchType switchtype = (_eSwitchType)atoi(sd[1].c_str());
-			float AddjValue = static_cast<float>(atof(sd[2].c_str()));
+			_eSwitchType switchtype = (_eSwitchType) stoi(sd[1]);
+			float AddjValue = stof(sd[2]);
 			GetLightStatus(devType, subType, switchtype, nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 
 			bool bIsLightSwitchOn = IsLightSwitchOn(lstatus);
@@ -5501,7 +5501,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 						for (const auto &sd : result)
 						{
 							std::string camidx = sd[0];
-							float delay = static_cast<float>(atof(sd[1].c_str()));
+							float delay = stof(sd[1]);
 							std::string subject = Name + " Status: " + lstatus;
 							AddTaskItem(_tTaskItem::EmailCameraSnapshot(delay + 1, camidx, subject));
 						}
@@ -5672,7 +5672,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 
 bool CSQLHelper::UpdateLastUpdate(const std::string& sidx)
 {
-	return UpdateLastUpdate(std::stoull(sidx));
+	return UpdateLastUpdate(stoll(sidx));
 }
 
 bool CSQLHelper::UpdateLastUpdate(const int64_t idx)
@@ -5701,7 +5701,7 @@ bool CSQLHelper::GetLastValue(const int HardwareID, const char* DeviceID, const 
 
 	if (!sqlresult.empty())
 	{
-		nValue = (int)atoi(sqlresult[0][0].c_str());
+		nValue = stoi(sqlresult[0][0]);
 		sValue = sqlresult[0][1];
 		sLastUpdate = sqlresult[0][2];
 
@@ -5724,8 +5724,8 @@ void CSQLHelper::GetAddjustment(const int HardwareID, const char* ID, const unsi
 		HardwareID, ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		AddjValue = static_cast<float>(atof(result[0][0].c_str()));
-		AddjMulti = static_cast<float>(atof(result[0][1].c_str()));
+		AddjValue = stof(result[0][0]);
+		AddjMulti = stof(result[0][1]);
 	}
 }
 
@@ -5738,7 +5738,7 @@ void CSQLHelper::GetMeterType(const int HardwareID, const char* ID, const unsign
 		HardwareID, ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		meterType = atoi(result[0][0].c_str());
+		meterType = stoi(result[0][0]);
 	}
 }
 
@@ -5752,8 +5752,8 @@ void CSQLHelper::GetAddjustment2(const int HardwareID, const char* ID, const uns
 		HardwareID, ID, unit, devType, subType);
 	if (!result.empty())
 	{
-		AddjValue = static_cast<float>(atof(result[0][0].c_str()));
-		AddjMulti = static_cast<float>(atof(result[0][1].c_str()));
+		AddjValue = stof(result[0][0]);
+		AddjMulti = stof(result[0][1]);
 	}
 }
 
@@ -5817,7 +5817,7 @@ bool CSQLHelper::GetPreferencesVar(const std::string& Key, double& Value)
 	bool res = GetPreferencesVar(Key, nValue, sValue);
 	if (!res)
 		return false;
-	Value = atof(sValue.c_str());
+	Value = stod(sValue);
 	return true;
 }
 bool CSQLHelper::GetPreferencesVar(const std::string& Key, int& nValue, std::string& sValue)
@@ -5831,7 +5831,7 @@ bool CSQLHelper::GetPreferencesVar(const std::string& Key, int& nValue, std::str
 	if (result.empty())
 		return false;
 	std::vector<std::string> sd = result[0];
-	nValue = atoi(sd[0].c_str());
+	nValue = stoi(sd[0]);
 	sValue = sd[1];
 	return true;
 }
@@ -5865,7 +5865,7 @@ int CSQLHelper::GetLastBackupNo(const char* Key, int& nValue)
 	if (result.empty())
 		return -1;
 	std::vector<std::string> sd = result[0];
-	nValue = atoi(sd[0].c_str());
+	nValue = stoi(sd[0]);
 	return nValue;
 }
 
@@ -5888,7 +5888,7 @@ void CSQLHelper::SetLastBackupNo(const char* Key, const int nValue)
 	else
 	{
 		//Update
-		uint64_t ID = std::stoull(result[0][0]);
+		uint64_t ID = stoull(result[0][0]);
 
 		safe_query(
 			"UPDATE BackupLog SET Key='%q', nValue=%d "
@@ -5916,7 +5916,7 @@ bool CSQLHelper::HasTimers(const uint64_t Idx)
 	if (!result.empty())
 	{
 		std::vector<std::string> sd = result[0];
-		int totaltimers = atoi(sd[0].c_str());
+		int totaltimers = stoi(sd[0]);
 		if (totaltimers > 0)
 			return true;
 	}
@@ -5924,7 +5924,7 @@ bool CSQLHelper::HasTimers(const uint64_t Idx)
 	if (!result.empty())
 	{
 		std::vector<std::string> sd = result[0];
-		int totaltimers = atoi(sd[0].c_str());
+		int totaltimers = stoi(sd[0]);
 		return (totaltimers > 0);
 	}
 	return false;
@@ -5932,7 +5932,7 @@ bool CSQLHelper::HasTimers(const uint64_t Idx)
 
 bool CSQLHelper::HasTimers(const std::string& Idx)
 {
-	uint64_t idxll = std::stoull(Idx);
+	uint64_t idxll = stoull(Idx);
 	return HasTimers(idxll);
 }
 
@@ -5947,13 +5947,13 @@ bool CSQLHelper::HasSceneTimers(const uint64_t Idx)
 	if (result.empty())
 		return false;
 	std::vector<std::string> sd = result[0];
-	int totaltimers = atoi(sd[0].c_str());
+	int totaltimers = stoi(sd[0]);
 	return (totaltimers > 0);
 }
 
 bool CSQLHelper::HasSceneTimers(const std::string& Idx)
 {
-	uint64_t idxll = std::stoull(Idx);
+	uint64_t idxll = stoull(Idx);
 	return HasSceneTimers(idxll);
 }
 
@@ -6060,10 +6060,10 @@ void CSQLHelper::UpdateTemperatureLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
-			unsigned char dType = atoi(sd[1].c_str());
-			unsigned char dSubType = atoi(sd[2].c_str());
-			int nValue = atoi(sd[3].c_str());
+			uint64_t ID = stoull(sd[0]);
+			unsigned char dType = (unsigned char) stoi(sd[1]);
+			unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			int nValue = stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			if (dType != pTypeRadiator1)
@@ -6100,31 +6100,31 @@ void CSQLHelper::UpdateTemperatureLog()
 			case pTypeRego6XXTemp:
 			case pTypeTEMP:
 			case pTypeSetpoint:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				break;
 			case pTypeThermostat1:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				break;
 			case pTypeRadiator1:
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				break;
 			case pTypeEvohomeWater:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = stof(splitresults[0]);
 					if (splitresults[1] == "On")
-						setpoint = 60;
+						setpoint = 60.0F;
 					else if (splitresults[1] == "Off")
-						setpoint = 0;
+						setpoint = 0.0F;
 					else
-						setpoint = static_cast<float>(atof(splitresults[1].c_str()));
+						setpoint = stof(splitresults[1]);
 				}
 				break;
 			case pTypeEvohomeZone:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
-					setpoint = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = stof(splitresults[0]);
+					setpoint = stof(splitresults[1]);
 				}
 				break;
 			case pTypeHUM:
@@ -6133,28 +6133,28 @@ void CSQLHelper::UpdateTemperatureLog()
 			case pTypeTEMP_HUM:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
-					humidity = ground(atof(splitresults[1].c_str()));
+					temp = stof(splitresults[0]);
+					humidity = ground(stof(splitresults[1]));
 					dewpoint = (float)CalculateDewPoint(temp, humidity);
 				}
 				break;
 			case pTypeTEMP_HUM_BARO:
 				if (splitresults.size() == 5)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
-					humidity = ground(atof(splitresults[1].c_str()));
+					temp = stof(splitresults[0]);
+					humidity = ground(stof(splitresults[1]));
 					if (dSubType == sTypeTHBFloat)
-						barometer = int(atof(splitresults[3].c_str()) * 10.0F);
+						barometer = int(stof(splitresults[3]) * 10.0F);
 					else
-						barometer = atoi(splitresults[3].c_str());
+						barometer = stoi(splitresults[3]);
 					dewpoint = (float)CalculateDewPoint(temp, humidity);
 				}
 				break;
 			case pTypeTEMP_BARO:
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
-					barometer = int(atof(splitresults[1].c_str()) * 10.0F);
+					temp = stof(splitresults[0]);
+					barometer = int(stof(splitresults[1]) * 10.0F);
 				}
 				break;
 			case pTypeUV:
@@ -6162,7 +6162,7 @@ void CSQLHelper::UpdateTemperatureLog()
 					continue;
 				if (splitresults.size() >= 2)
 				{
-					temp = static_cast<float>(atof(splitresults[1].c_str()));
+					temp = stof(splitresults[1]);
 				}
 				break;
 			case pTypeWIND:
@@ -6172,26 +6172,26 @@ void CSQLHelper::UpdateTemperatureLog()
 				{
 					if (dSubType != sTypeWINDNoTemp)
 					{
-						temp = static_cast<float>(atof(splitresults[4].c_str()));
+						temp = stof(splitresults[4]);
 					}
-					chill = static_cast<float>(atof(splitresults[5].c_str()));
+					chill = stof(splitresults[5]);
 				}
 				break;
 			case pTypeRFXSensor:
 				if (dSubType != sTypeRFXSensorTemp)
 					continue;
-				temp = static_cast<float>(atof(splitresults[0].c_str()));
+				temp = stof(splitresults[0]);
 				break;
 			case pTypeGeneral:
 				if (dSubType == sTypeSystemTemp)
 				{
-					temp = static_cast<float>(atof(splitresults[0].c_str()));
+					temp = stof(splitresults[0]);
 				}
 				else if (dSubType == sTypeBaro)
 				{
 					if (splitresults.size() != 2)
 						continue;
-					barometer = int(atof(splitresults[0].c_str()) * 10.0F);
+					barometer = int(stof(splitresults[0]) * 10.0F);
 				}
 				break;
 			}
@@ -6228,10 +6228,10 @@ void CSQLHelper::UpdateRainLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
-			//unsigned char dType=atoi(sd[1].c_str());
-			//unsigned char dSubType=atoi(sd[2].c_str());
-			//int nValue=atoi(sd[3].c_str());
+			uint64_t ID = stoull(sd[0]);
+			//unsigned char dType = (unsigned char) stoi(sd[1]);
+			//unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			//int nValue = stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			//do not include sensors that have no reading within an hour
@@ -6253,8 +6253,8 @@ void CSQLHelper::UpdateRainLog()
 			if (splitresults.size() < 2)
 				continue; //impossible
 
-			int rate = atoi(splitresults[0].c_str());
-			float total = static_cast<float>(atof(splitresults[1].c_str()));
+			int rate = stoi(splitresults[0]);
+			float total = stof(splitresults[1]);
 
 			//insert record
 			safe_query(
@@ -6285,15 +6285,15 @@ void CSQLHelper::UpdateWindLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
+			uint64_t ID = stoull(sd[0]);
 
 			unsigned short DeviceID;
 			std::stringstream s_str2(sd[1]);
 			s_str2 >> DeviceID;
 
-			//unsigned char dType=atoi(sd[2].c_str());
-			//unsigned char dSubType=atoi(sd[3].c_str());
-			//int nValue=atoi(sd[4].c_str());
+			//unsigned char dType = (unsigned char) stoi(sd[2]);
+			//unsigned char dSubType = (unsigned char) stoi(sd[3]);
+			//int nValue = stoi(sd[4]);
 			std::string sValue = sd[5];
 
 			//do not include sensors that have no reading within an hour
@@ -6315,10 +6315,10 @@ void CSQLHelper::UpdateWindLog()
 			if (splitresults.size() < 4)
 				continue; //impossible
 
-			float direction = static_cast<float>(atof(splitresults[0].c_str()));
+			float direction = stof(splitresults[0]);
 
-			int speed = atoi(splitresults[2].c_str());
-			int gust = atoi(splitresults[3].c_str());
+			int speed = stoi(splitresults[2]);
+			int gust = stoi(splitresults[3]);
 
 			auto ittWC = m_mainworker.m_wind_calculator.find(DeviceID);
 			if (ittWC != m_mainworker.m_wind_calculator.end())
@@ -6364,10 +6364,10 @@ void CSQLHelper::UpdateUVLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
-			//unsigned char dType=atoi(sd[1].c_str());
-			//unsigned char dSubType=atoi(sd[2].c_str());
-			//int nValue=atoi(sd[3].c_str());
+			uint64_t ID = stoull(sd[0]);
+			//unsigned char dType = (unsigned char) stoi(sd[1]);
+			//unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			//int nValue = stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			//do not include sensors that have no reading within an hour
@@ -6389,7 +6389,7 @@ void CSQLHelper::UpdateUVLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			float level = static_cast<float>(atof(splitresults[0].c_str()));
+			float level = stof(splitresults[0]);
 
 			//insert record
 			safe_query(
@@ -6443,9 +6443,9 @@ bool CSQLHelper::UpdateCalendarMeter(
 	}
 
 	std::vector<std::string> sd = result[0];
-	uint64_t DeviceRowID = std::stoull(sd[0]);
+	uint64_t DeviceRowID = stoull(sd[0]);
 	//std::string devname = sd[1];
-	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[2].c_str());
+	//_eSwitchType switchtype = (_eSwitchType) stoi(sd[2]);
 
 	if (shortLog)
 	{
@@ -6674,15 +6674,15 @@ void CSQLHelper::UpdateMeter()
 				continue;
 			}
 
-			uint64_t ID = std::stoull(sd[0]);
+			uint64_t ID = stoull(sd[0]);
 			std::string devname = sd[1];
-			int hardwareID = atoi(sd[2].c_str());
+			int hardwareID = stoi(sd[2]);
 			std::string DeviceID = sd[3];
-			unsigned char Unit = atoi(sd[4].c_str());
+			unsigned char Unit = (unsigned char) stoi(sd[4]);
 
-			unsigned char dType = atoi(sd[5].c_str());
-			unsigned char dSubType = atoi(sd[6].c_str());
-			int nValue = atoi(sd[7].c_str());
+			unsigned char dType = (unsigned char) stoi(sd[5]);
+			unsigned char dSubType = (unsigned char) stoi(sd[6]);
+			int nValue = stoi(sd[7]);
 			std::string sValue = sd[8];
 			std::string sLastUpdate = sd[9];
 
@@ -6727,7 +6727,7 @@ void CSQLHelper::UpdateMeter()
 				if (splitresults.size() < 2)
 					continue;
 				sUsage = splitresults[0];
-				double fValue = atof(splitresults[1].c_str()) * 100;
+				double fValue = stod(splitresults[1]) * 100.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
@@ -6738,7 +6738,7 @@ void CSQLHelper::UpdateMeter()
 				if (splitresults.size() < 2)
 					continue;
 				sUsage = splitresults[0];
-				double fValue = atof(splitresults[1].c_str()) * 100;
+				double fValue = stod(splitresults[1]) * 100.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
@@ -6755,25 +6755,25 @@ void CSQLHelper::UpdateMeter()
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeVisibility))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeDistance))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeSolarRadiation))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeSoundLevel))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
@@ -6784,59 +6784,59 @@ void CSQLHelper::UpdateMeter()
 				if (splitresults.size() < 2)
 					continue;
 
-				double fValue = atof(splitresults[0].c_str()) * 10.0F;
+				double fValue = stod(splitresults[0]) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sUsage = szTmp;
 
-				fValue = atof(splitresults[1].c_str());
+				fValue = stod(splitresults[1]);
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeLux)
 			{
-				double fValue = atof(sValue.c_str());
+				double fValue = stod(sValue);
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeWEIGHT)
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeRFXSensor)
 			{
-				double fValue = atof(sValue.c_str());
+				double fValue = stod(sValue);
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeCounterIncremental))
 			{
-				double fValue = atof(sValue.c_str());
+				double fValue = stod(sValue);
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeVoltage))
 			{
-				double fValue = atof(sValue.c_str()) * 1000.0F;
+				double fValue = stod(sValue) * 1000.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypeCurrent))
 			{
-				double fValue = atof(sValue.c_str()) * 1000.0F;
+				double fValue = stod(sValue) * 1000.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeUsage)
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
+				double fValue = stod(sValue) * 10.0;
 				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
@@ -6847,9 +6847,9 @@ void CSQLHelper::UpdateMeter()
 			try
 			{
 				if (!sUsage.empty())
-					MeterUsage = std::stoll(sUsage);
+					MeterUsage = stoll(sUsage);
 				if (!sValue.empty())
-					MeterValue = std::stoll(sValue);
+					MeterValue = stoll(sValue);
 			}
 			catch (const std::exception&)
 			{
@@ -6898,10 +6898,10 @@ void CSQLHelper::UpdateMultiMeter()
 				continue;
 			}
 
-			uint64_t ID = std::stoull(sd[0]);
-			unsigned char dType = atoi(sd[1].c_str());
-			unsigned char dSubType = atoi(sd[2].c_str());
-			//int nValue=atoi(sd[3].c_str());
+			uint64_t ID = stoull(sd[0]);
+			unsigned char dType = (unsigned char) stoi(sd[1]);
+			unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			//int nValue = stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			//do not include sensors that have no reading within an hour
@@ -6942,12 +6942,12 @@ void CSQLHelper::UpdateMultiMeter()
 
 				try
 				{
-					powerusage1 = std::stoull(splitresults[0]);
-					powerusage2 = std::stoull(splitresults[1]);
-					powerdeliv1 = std::stoull(splitresults[2]);
-					powerdeliv2 = std::stoull(splitresults[3]);
-					usagecurrent = std::stoull(splitresults[4]);
-					delivcurrent = std::stoull(splitresults[5]);
+					powerusage1 = stoull(splitresults[0]);
+					powerusage2 = stoull(splitresults[1]);
+					powerdeliv1 = stoull(splitresults[2]);
+					powerdeliv2 = stoull(splitresults[3]);
+					usagecurrent = stoull(splitresults[4]);
+					delivcurrent = stoull(splitresults[5]);
 				}
 				catch (const std::exception &)
 				{
@@ -6967,19 +6967,19 @@ void CSQLHelper::UpdateMultiMeter()
 				if (splitresults.size() != 3)
 					continue; //impossible
 
-				value1 = (unsigned long)(atof(splitresults[0].c_str()) * 10.0F);
-				value2 = (unsigned long)(atof(splitresults[1].c_str()) * 10.0F);
-				value3 = (unsigned long)(atof(splitresults[2].c_str()) * 10.0F);
+				value1 = (uint64_t) (stof(splitresults[0]) * 10.0F);
+				value2 = (uint64_t) (stof(splitresults[1]) * 10.0F);
+				value3 = (uint64_t) (stof(splitresults[2]) * 10.0F);
 			}
 			else if ((dType == pTypeCURRENTENERGY) && (dSubType == sTypeELEC4))
 			{
 				if (splitresults.size() != 4)
 					continue; //impossible
 
-				value1 = (unsigned long)(atof(splitresults[0].c_str()) * 10.0F);
-				value2 = (unsigned long)(atof(splitresults[1].c_str()) * 10.0F);
-				value3 = (unsigned long)(atof(splitresults[2].c_str()) * 10.0F);
-				value4 = (uint64_t)(atof(splitresults[3].c_str()) * 1000.0F);
+				value1 = (uint64_t) (stof(splitresults[0]) * 10.0F);
+				value2 = (uint64_t) (stof(splitresults[1]) * 10.0F);
+				value3 = (uint64_t) (stof(splitresults[2]) * 10.0F);
+				value4 = (uint64_t) (stof(splitresults[3]) * 1000.0F);
 			}
 			else
 				continue;//don't know you (yet)
@@ -7021,11 +7021,11 @@ void CSQLHelper::UpdatePercentageLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
+			uint64_t ID = stoull(sd[0]);
 
-			//unsigned char dType=atoi(sd[1].c_str());
-			//unsigned char dSubType=atoi(sd[2].c_str());
-			//int nValue=atoi(sd[3].c_str());
+			//unsigned char dType = (unsigned char) stoi(sd[1]);
+			//unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			//int nValue = stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			//do not include sensors that have no reading within an hour
@@ -7047,7 +7047,7 @@ void CSQLHelper::UpdatePercentageLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			float percentage = static_cast<float>(atof(sValue.c_str()));
+			float percentage = stof(sValue);
 
 			//insert record
 			safe_query(
@@ -7079,11 +7079,11 @@ void CSQLHelper::UpdateFanLog()
 	{
 		for (const auto &sd : result)
 		{
-			uint64_t ID = std::stoull(sd[0]);
+			uint64_t ID = stoull(sd[0]);
 
-			//unsigned char dType=atoi(sd[1].c_str());
-			//unsigned char dSubType=atoi(sd[2].c_str());
-			//int nValue=atoi(sd[3].c_str());
+			//unsigned char dType = (unsigned char) stoi(sd[1]);
+			//unsigned char dSubType = (unsigned char) stoi(sd[2]);
+			//int nValu e= stoi(sd[3]);
 			std::string sValue = sd[4];
 
 			//do not include sensors that have no reading within an hour
@@ -7105,7 +7105,7 @@ void CSQLHelper::UpdateFanLog()
 			if (splitresults.empty())
 				continue; //impossible
 
-			int speed = (int)atoi(sValue.c_str());
+			int speed = stoi(sValue);
 
 			//insert record
 			safe_query(
@@ -7143,7 +7143,7 @@ void CSQLHelper::AddCalendarTemperature()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		result = safe_query("SELECT MIN(Temperature), MAX(Temperature), AVG(Temperature), MIN(Chill), MAX(Chill), AVG(Humidity), AVG(Barometer), MIN(DewPoint), MIN(SetPoint), MAX(SetPoint), AVG(SetPoint) FROM Temperature WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
@@ -7154,17 +7154,17 @@ void CSQLHelper::AddCalendarTemperature()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float temp_min = static_cast<float>(atof(sd[0].c_str()));
-			float temp_max = static_cast<float>(atof(sd[1].c_str()));
-			float temp_avg = static_cast<float>(atof(sd[2].c_str()));
-			float chill_min = static_cast<float>(atof(sd[3].c_str()));
-			float chill_max = static_cast<float>(atof(sd[4].c_str()));
-			int humidity = atoi(sd[5].c_str());
-			int barometer = atoi(sd[6].c_str());
-			float dewpoint = static_cast<float>(atof(sd[7].c_str()));
-			float setpoint_min = static_cast<float>(atof(sd[8].c_str()));
-			float setpoint_max = static_cast<float>(atof(sd[9].c_str()));
-			float setpoint_avg = static_cast<float>(atof(sd[10].c_str()));
+			float temp_min = stof(sd[0]);
+			float temp_max = stof(sd[1]);
+			float temp_avg = stof(sd[2]);
+			float chill_min = stof(sd[3]);
+			float chill_max = stof(sd[4]);
+			int humidity = stoi(sd[5]);
+			int barometer = stoi(sd[6]);
+			float dewpoint = stof(sd[7]);
+			float setpoint_min = stof(sd[8]);
+			float setpoint_max = stof(sd[9]);
+			float setpoint_avg = stof(sd[10]);
 			result = safe_query(
 				"INSERT INTO Temperature_Calendar (DeviceRowID, Temp_Min, Temp_Max, Temp_Avg, Chill_Min, Chill_Max, Humidity, Barometer, DewPoint, SetPoint_Min, SetPoint_Max, SetPoint_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%.2f', '%.2f', '%.2f', '%.2f', '%.2f', '%d', '%d', '%.2f', '%.2f', '%.2f', '%.2f', '%q')",
@@ -7211,7 +7211,7 @@ void CSQLHelper::AddCalendarUpdateRain()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		//Get Device Information
 		result = safe_query("SELECT SubType FROM DeviceStatus WHERE (ID='%" PRIu64 "')", ID);
@@ -7219,7 +7219,7 @@ void CSQLHelper::AddCalendarUpdateRain()
 			continue;
 		std::vector<std::string> sd = result[0];
 
-		unsigned char subType = atoi(sd[0].c_str());
+		unsigned char subType = (unsigned char) stoi(sd[0]);
 
 		if (subType == sTypeRAINWU || subType == sTypeRAINByRate)
 		{
@@ -7242,9 +7242,9 @@ void CSQLHelper::AddCalendarUpdateRain()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float total_min = static_cast<float>(atof(sd[0].c_str()));
-			float total_max = static_cast<float>(atof(sd[1].c_str()));
-			int rate = atoi(sd[2].c_str());
+			float total_min = stof(sd[0]);
+			float total_max = stof(sd[1]);
+			int rate = stoi(sd[2]);
 
 			float total_real = 0;
 			if (subType == sTypeRAINWU || subType == sTypeRAINByRate)
@@ -7314,7 +7314,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		//Get Device Information
 		result = safe_query("SELECT Name, HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Options FROM DeviceStatus WHERE (ID='%" PRIu64 "')", ID);
@@ -7323,12 +7323,12 @@ void CSQLHelper::AddCalendarUpdateMeter()
 		std::vector<std::string> sd = result[0];
 
 		std::string devname = sd[0];
-		//int hardwareID= atoi(sd[1].c_str());
+		//int hardwareID = stoi(sd[1]);
 		//std::string DeviceID=sd[2];
-		//unsigned char Unit = atoi(sd[3].c_str());
-		unsigned char devType = atoi(sd[4].c_str());
-		unsigned char subType = atoi(sd[5].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[6].c_str());
+		//unsigned char Unit = (unsigned char) stoi(sd[3]);
+		unsigned char devType = (unsigned char) stoi(sd[4]);
+		unsigned char subType = (unsigned char) stoi(sd[5]);
+		_eSwitchType switchtype = (_eSwitchType) stoi(sd[6]);
 		_eMeterType metertype = (_eMeterType)switchtype;
 		std::string sOptions = sd[7];
 		std::map<std::string, std::string> options = BuildDeviceOptions(sOptions);
@@ -7370,9 +7370,9 @@ void CSQLHelper::AddCalendarUpdateMeter()
 		{
 			std::vector<std::string> sd = result[0];
 
-			double total_min = (double)atof(sd[0].c_str());
-			double total_max = (double)atof(sd[1].c_str());
-			double avg_value = (double)atof(sd[2].c_str());
+			double total_min = stod(sd[0]);
+			double total_max = stod(sd[1]);
+			double avg_value = stod(sd[2]);
 
 			// if kwh counter => total_min = first value of the day, and total_max = last value of the day
 			// because last value can be lower than first value when consumed energy is negative (e.g. photovoltaic produces more than building usage)
@@ -7383,7 +7383,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
-					total_min = (double)atof(sd[0].c_str());
+					total_min = stod(sd[0]);
 					total_max = total_min;
 				}
 				result = safe_query("SELECT Value FROM Meter WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00') ORDER BY Date DESC LIMIT 1",
@@ -7391,7 +7391,7 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				if (!result.empty())
 				{
 					std::vector<std::string> sd = result[0];
-					total_max = (double)atof(sd[0].c_str());
+					total_max = stod(sd[0]);
 				}
 			}
 
@@ -7532,7 +7532,7 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		//Get Device Information
 		result = safe_query("SELECT Name, HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Options FROM DeviceStatus WHERE (ID='%" PRIu64 "')", ID);
@@ -7541,13 +7541,13 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 		std::vector<std::string> sd = result[0];
 
 		std::string devname = sd[0];
-		//int hardwareID= atoi(sd[1].c_str());
-		//std::string DeviceID=sd[2];
-		//unsigned char Unit = atoi(sd[3].c_str());
-		unsigned char devType = atoi(sd[4].c_str());
-		unsigned char subType = atoi(sd[5].c_str());
-		//_eSwitchType switchtype=(_eSwitchType) atoi(sd[6].c_str());
-		//_eMeterType metertype=(_eMeterType)switchtype;
+		//int hardwareID = stoi(sd[1]);
+		//std::string DeviceID = sd[2];
+		//unsigned char Unit = (unsigned char) stoi(sd[3]);
+		unsigned char devType = (unsigned char) stoi(sd[4]);
+		unsigned char subType = (unsigned char) stoi(sd[5]);
+		//_eSwitchType switchtype = (_eSwitchType) stoi(sd[6]);
+		//_eMeterType metertyp e= (_eMeterType) switchtype;
 
 		std::string sOptions = sd[7];
 		std::map<std::string, std::string> options = BuildDeviceOptions(sOptions);
@@ -7582,20 +7582,20 @@ void CSQLHelper::AddCalendarUpdateMultiMeter()
 			{
 				for (int ii = 0; ii < 6; ii++)
 				{
-					float total_min = static_cast<float>(atof(sd[(ii * 2) + 0].c_str()));
-					float total_max = static_cast<float>(atof(sd[(ii * 2) + 1].c_str()));
+					float total_min = stof(sd[(ii * 2) + 0]);
+					float total_max = stof(sd[(ii * 2) + 1]);
 					total_real[ii] = total_max - total_min;
 				}
-				counter1 = static_cast<float>(atof(sd[1].c_str()));
-				counter2 = static_cast<float>(atof(sd[3].c_str()));
-				counter3 = static_cast<float>(atof(sd[9].c_str()));
-				counter4 = static_cast<float>(atof(sd[11].c_str()));
+				counter1 = stof(sd[1]);
+				counter2 = stof(sd[3]);
+				counter3 = stof(sd[9]);
+				counter4 = stof(sd[11]);
 			}
 			else
 			{
 				for (int ii = 0; ii < 6; ii++)
 				{
-					float fvalue = static_cast<float>(atof(sd[ii].c_str()));
+					float fvalue = stof(sd[ii]);
 					total_real[ii] = fvalue;
 				}
 			}
@@ -7668,7 +7668,7 @@ void CSQLHelper::AddCalendarUpdateWind()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		result = safe_query("SELECT AVG(Direction), MIN(Speed), MAX(Speed), MIN(Gust), MAX(Gust) FROM Wind WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
@@ -7679,11 +7679,11 @@ void CSQLHelper::AddCalendarUpdateWind()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float Direction = static_cast<float>(atof(sd[0].c_str()));
-			int speed_min = atoi(sd[1].c_str());
-			int speed_max = atoi(sd[2].c_str());
-			int gust_min = atoi(sd[3].c_str());
-			int gust_max = atoi(sd[4].c_str());
+			float Direction = stof(sd[0]);
+			int speed_min = stoi(sd[1]);
+			int speed_max = stoi(sd[2]);
+			int gust_min = stoi(sd[3]);
+			int gust_max = stoi(sd[4]);
 
 			result = safe_query(
 				"INSERT INTO Wind_Calendar (DeviceRowID, Direction, Speed_Min, Speed_Max, Gust_Min, Gust_Max, Date) "
@@ -7725,7 +7725,7 @@ void CSQLHelper::AddCalendarUpdateUV()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		result = safe_query("SELECT MAX(Level) FROM UV WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
@@ -7736,7 +7736,7 @@ void CSQLHelper::AddCalendarUpdateUV()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float level = static_cast<float>(atof(sd[0].c_str()));
+			float level = stof(sd[0]);
 
 			result = safe_query(
 				"INSERT INTO UV_Calendar (DeviceRowID, Level, Date) "
@@ -7774,7 +7774,7 @@ void CSQLHelper::AddCalendarUpdatePercentage()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		result = safe_query("SELECT MIN(Percentage), MAX(Percentage), AVG(Percentage) FROM Percentage WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
@@ -7785,9 +7785,9 @@ void CSQLHelper::AddCalendarUpdatePercentage()
 		{
 			std::vector<std::string> sd = result[0];
 
-			float percentage_min = static_cast<float>(atof(sd[0].c_str()));
-			float percentage_max = static_cast<float>(atof(sd[1].c_str()));
-			float percentage_avg = static_cast<float>(atof(sd[2].c_str()));
+			float percentage_min = stof(sd[0]);
+			float percentage_max = stof(sd[1]);
+			float percentage_avg = stof(sd[2]);
 			result = safe_query(
 				"INSERT INTO Percentage_Calendar (DeviceRowID, Percentage_Min, Percentage_Max, Percentage_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%g', '%g', '%g','%q')",
@@ -7826,7 +7826,7 @@ void CSQLHelper::AddCalendarUpdateFan()
 
 	for (const auto &sddev : resultdevices)
 	{
-		uint64_t ID = std::stoull(sddev[0]);
+		uint64_t ID = stoull(sddev[0]);
 
 		result = safe_query("SELECT MIN(Speed), MAX(Speed), AVG(Speed) FROM Fan WHERE (DeviceRowID='%" PRIu64 "' AND Date>='%q' AND Date<='%q 00:00:00')",
 			ID,
@@ -7837,9 +7837,9 @@ void CSQLHelper::AddCalendarUpdateFan()
 		{
 			std::vector<std::string> sd = result[0];
 
-			int speed_min = (int)atoi(sd[0].c_str());
-			int speed_max = (int)atoi(sd[1].c_str());
-			int speed_avg = (int)atoi(sd[2].c_str());
+			int speed_min = stoi(sd[0]);
+			int speed_max = stoi(sd[1]);
+			int speed_avg = stoi(sd[2]);
 			result = safe_query(
 				"INSERT INTO Fan_Calendar (DeviceRowID, Speed_Min, Speed_Max, Speed_Avg, Date) "
 				"VALUES ('%" PRIu64 "', '%d', '%d', '%d','%q')",
@@ -8034,7 +8034,7 @@ void CSQLHelper::DeleteDevices(const std::string& idx)
 			safe_exec_no_return("DELETE FROM SharedDevices WHERE (DeviceRowID== '%q')", str.c_str());
 			safe_exec_no_return("DELETE FROM PushLink WHERE (DeviceRowID== '%q')", str.c_str());
 			//notify eventsystem device is no longer present
-			uint64_t ullidx = std::stoull(str);
+			uint64_t ullidx = stoull(str);
 			m_mainworker.m_eventsystem.RemoveSingleState(ullidx, m_mainworker.m_eventsystem.REASON_DEVICE);
 			//and now delete all records in the DeviceStatus table itself
 			safe_exec_no_return("DELETE FROM DeviceStatus WHERE (ID == '%q')", str.c_str());
@@ -8044,9 +8044,9 @@ void CSQLHelper::DeleteDevices(const std::string& idx)
 #ifdef ENABLE_PYTHON
 	for (const auto& it : removeddevices)
 	{
-		int HwID = atoi(std::get<0>(it).c_str());
+		int HwID = stoi(std::get<0>(it));
 		std::string DeviceID = std::get<1>(it);
-		int Unit = atoi(std::get<2>(it).c_str());
+		int Unit = stoi(std::get<2>(it));
 		// Notify plugin to sync plugins' device list
 		CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(HwID);
 		if (pHardware != nullptr && pHardware->HwdType == HTYPE_PythonPlugin)
@@ -8081,7 +8081,7 @@ void CSQLHelper::DeleteScenes(const std::string& idx)
 			safe_exec_no_return("DELETE FROM SceneDevices WHERE (SceneRowID == '%q')", str.c_str());
 			safe_exec_no_return("DELETE FROM SceneTimers WHERE (SceneRowID == '%q')", str.c_str());
 			safe_exec_no_return("DELETE FROM SceneLog WHERE (SceneRowID=='%q')", str.c_str());
-			uint64_t ullidx = std::stoull(str);
+			uint64_t ullidx = stoull(str);
 			m_mainworker.m_eventsystem.RemoveSingleState(ullidx, m_mainworker.m_eventsystem.REASON_SCENEGROUP);
 		}
 
@@ -8171,7 +8171,7 @@ void CSQLHelper::CheckSceneStatusWithDevice(const uint64_t DevIdx)
 
 void CSQLHelper::CheckSceneStatus(const std::string& Idx)
 {
-	uint64_t idxll = std::stoull(Idx);
+	uint64_t idxll = stoull(Idx);
 	return CheckSceneStatus(idxll);
 }
 
@@ -8183,7 +8183,7 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 	if (result.empty())
 		return; //not found
 
-	unsigned char orgValue = (unsigned char)atoi(result[0][0].c_str());
+	unsigned char orgValue = (unsigned char) stoi(result[0][0]);
 	unsigned char newValue = orgValue;
 
 	result = safe_query("SELECT a.ID, a.DeviceID, a.Unit, a.Type, a.SubType, a.SwitchType, a.nValue, a.sValue FROM DeviceStatus AS a, SceneDevices as b WHERE (a.ID == b.DeviceRowID) AND (b.SceneRowID == %" PRIu64 ")",
@@ -8195,12 +8195,12 @@ void CSQLHelper::CheckSceneStatus(const uint64_t Idx)
 
 	for (const auto &sd : result)
 	{
-		int nValue = atoi(sd[6].c_str());
+		int nValue = stoi(sd[6]);
 		std::string sValue = sd[7];
-		//unsigned char Unit=atoi(sd[2].c_str());
-		unsigned char dType = atoi(sd[3].c_str());
-		unsigned char dSubType = atoi(sd[4].c_str());
-		_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+		//unsigned char Unit = (unsigned char) stoi(sd[2]);
+		unsigned char dType = (unsigned char) stoi(sd[3]);
+		unsigned char dSubType = (unsigned char) stoi(sd[4]);
+		_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 
 		std::string lstatus;
 		int llevel = 0;
@@ -8504,7 +8504,7 @@ uint64_t CSQLHelper::UpdateValueLighting2GroupCmd(const int HardwareID, const ch
 
 	for (const auto &unit : result)
 	{
-		unsigned char theUnit = atoi(unit[0].c_str()); // get the unit value
+		unsigned char theUnit = (unsigned char) stoi(unit[0]); // get the unit value
 		devRowIndex = UpdateValue(HardwareID, 0, ID, theUnit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction, User);
 	}
 	return devRowIndex;
@@ -8545,7 +8545,7 @@ uint64_t CSQLHelper::UpdateValueHomeConfortGroupCmd(const int HardwareID, const 
 
 	for (const auto &unit : result)
 	{
-		unsigned char theUnit = atoi(unit[0].c_str()); // get the unit value
+		unsigned char theUnit = (unsigned char) stoi(unit[0]); // get the unit value
 		devRowIndex = UpdateValue(HardwareID, 0, ID, theUnit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction, User);
 	}
 	return devRowIndex;
@@ -8727,7 +8727,7 @@ void CSQLHelper::CheckBatteryLow()
 	//check if last batterylow_notification is not sent today and if true, send notification
 	for (const auto &sd : result)
 	{
-		uint64_t ulID = std::stoull(sd[0]);
+		uint64_t ulID = stoull(sd[0]);
 		bool bDoSend = true;
 		auto sitt = m_batterylowlastsend.find(ulID);
 		if (sitt != m_batterylowlastsend.end())
@@ -8737,7 +8737,7 @@ void CSQLHelper::CheckBatteryLow()
 		if (bDoSend)
 		{
 			char szTmp[300];
-			int batlevel = atoi(sd[2].c_str());
+			int batlevel = stoi(sd[2]);
 			if (batlevel == 0)
 				sprintf(szTmp, "Battery Low: %s (Level: Low)", sd[1].c_str());
 			else
@@ -8807,7 +8807,7 @@ void CSQLHelper::CheckDeviceTimeout()
 	//check if last timeout_notification is not sent today and if true, send notification
 	for (const auto &sd : result)
 	{
-		uint64_t ulID = std::stoull(sd[0]);
+		uint64_t ulID = stoull(sd[0]);
 		bool bDoSend = true;
 		auto sitt = m_timeoutlastsend.find(ulID);
 		if (sitt != m_timeoutlastsend.end())
@@ -9148,7 +9148,7 @@ bool CSQLHelper::AddUserVariableEx(const std::string& varname, const _eUsrVariab
 	result = safe_query("SELECT ID FROM UserVariables WHERE (Name=='%q')", varname.c_str());
 	if (!result.empty())
 	{
-		uint64_t vId = std::stoull(result[0][0]);
+		uint64_t vId = stoull(result[0][0]);
 		if (eventtrigger)
 			m_mainworker.m_eventsystem.SetEventTrigger(vId, m_mainworker.m_eventsystem.REASON_USERVARIABLE, 0);
 		if (m_bEnableEventSystem)
@@ -9175,7 +9175,7 @@ bool CSQLHelper::UpdateUserVariable(const std::string& idx, const std::string& v
 	);
 	if (m_bEnableEventSystem)
 	{
-		uint64_t vId = std::stoull(idx);
+		uint64_t vId = stoull(idx);
 		if (eventtrigger)
 			m_mainworker.m_eventsystem.SetEventTrigger(vId, m_mainworker.m_eventsystem.REASON_USERVARIABLE, 0);
 		m_mainworker.m_eventsystem.UpdateUserVariable(vId, varname, (int)eVartype, szVarValue, sLastUpdate);
@@ -9203,7 +9203,7 @@ bool CSQLHelper::UpdateUserVariable(const std::string& varname, const _eUsrVaria
 	);
 	if (m_bEnableEventSystem)
 	{
-		uint64_t vId = std::stoull(result[0][0]);
+		uint64_t vId = stoull(result[0][0]);
 		if (eventtrigger)
 			m_mainworker.m_eventsystem.SetEventTrigger(vId, m_mainworker.m_eventsystem.REASON_USERVARIABLE, 0);
 		m_mainworker.m_eventsystem.UpdateUserVariable(vId, varname, (int)eVartype, szVarValue, sLastUpdate);
@@ -9352,13 +9352,17 @@ bool CSQLHelper::CheckDateTimeSQL(const std::string& sDateTime)
 	return false;
 }
 
-bool CSQLHelper::CheckTime(const std::string& sTime)
+bool CSQLHelper::CheckTime(const std::string &sTime)
 {
 	size_t iSemiColon = sTime.find(':');
-	if ((iSemiColon == std::string::npos) || (iSemiColon < 1) || (iSemiColon > 2) || (iSemiColon == sTime.length() - 1)) return false;
-	if ((sTime.length() < 3) || (sTime.length() > 5)) return false;
-	if (atoi(sTime.substr(0, iSemiColon).c_str()) >= 24) return false;
-	if (atoi(sTime.substr(iSemiColon + 1).c_str()) >= 60) return false;
+	if ((iSemiColon == std::string::npos) || (iSemiColon < 1) || (iSemiColon > 2) || (iSemiColon == sTime.length() - 1))
+		return false;
+	if ((sTime.length() < 3) || (sTime.length() > 5))
+		return false;
+	if (stoi(sTime.substr(0, iSemiColon)) >= 24)
+		return false;
+	if (stoi(sTime.substr(iSemiColon + 1)) >= 60)
+		return false;
 	return true;
 }
 
@@ -9390,7 +9394,7 @@ void CSQLHelper::SendUpdateInt(const std::string& Idx)
 	auto result = safe_query("SELECT HardwareID, Name From DeviceStatus WHERE (ID == %s )", Idx.c_str());
 	if (result.empty())
 		return;
-	m_mainworker.sOnDeviceReceived(atoi(result[0][0].c_str()), atoll(Idx.c_str()), result[0][1], nullptr);
+	m_mainworker.sOnDeviceReceived(stoi(result[0][0]), stoull(Idx), result[0][1], nullptr);
 }
 
 void CSQLHelper::UpdateDeviceValue(const char* FieldName, const std::string& Value, const std::string& Idx)
@@ -9496,7 +9500,7 @@ bool CSQLHelper::InsertCustomIconFromZipFile(const std::string& szZipFile, std::
 					int RowID = 0;
 					if (bIsDuplicate)
 					{
-						RowID = atoi(result[0][0].c_str());
+						RowID = stoi(result[0][0]);
 					}
 
 					//Locate the files in the zip, if not present back out
@@ -9542,7 +9546,7 @@ bool CSQLHelper::InsertCustomIconFromZipFile(const std::string& szZipFile, std::
 							}
 							return false;
 						}
-						RowID = atoi(result[0][0].c_str());
+						RowID = stoi(result[0][0]);
 					}
 					else
 					{
@@ -9671,7 +9675,7 @@ std::map<std::string, std::string> CSQLHelper::GetDeviceOptions(const std::strin
 		return optionsMap;
 	}
 
-	uint64_t ulID = std::stoull(idx);
+	uint64_t ulID = stoull(idx);
 	std::vector<std::vector<std::string> > result;
 	result = safe_query("SELECT Options FROM DeviceStatus WHERE (ID==%" PRIu64 ")", ulID);
 	if (!result.empty()) {

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5280,9 +5280,9 @@ uint64_t CSQLHelper::UpdateValueInt(
 			StringSplit(sValueBeforeUpdate, ";", powerAndEnergyBeforeUpdate);
 			if (powerAndEnergyBeforeUpdate.size() == 2)
 			{
-				//we need to use atof here because some users seem to have a illegal sValue in the database that causes stof to crash
-				double powerDuringInterval = stod(powerAndEnergyBeforeUpdate[0]);
-				double energyUpToInterval = stod(powerAndEnergyBeforeUpdate[1]);
+				// We need to use atof here because some users seem to have a illegal sValue in the database that causes stof to crash
+				double powerDuringInterval = atof(powerAndEnergyBeforeUpdate[0].c_str());
+				double energyUpToInterval = atof(powerAndEnergyBeforeUpdate[1].c_str());
 				double energyDuringInterval = powerDuringInterval * intervalSeconds / 3600;
 				double energyAfterInterval = energyUpToInterval + energyDuringInterval;
 				std::vector<std::string> powerAndEnergyUpdate;

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -951,7 +951,7 @@ bool CSQLHelper::OpenDatabase()
 				sqlite3_exec(m_dbase, "BEGIN TRANSACTION;", nullptr, nullptr, nullptr);
 				for (const auto &sd : result)
 				{
-					safe_query("UPDATE Temperature_Calendar SET Temp_Avg=%.1f WHERE RowID='%q'", stof(sd[1]), sd[0].c_str());
+					safe_query("UPDATE Temperature_Calendar SET Temp_Avg=%.1f WHERE RowID='%q'", stod(sd[1]), sd[0].c_str());
 				}
 				sqlite3_exec(m_dbase, "END TRANSACTION;", nullptr, nullptr, nullptr);
 			}
@@ -2283,7 +2283,7 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << stof(sd3[0]) / 10.0F << ", '"
+							szQuery2 << "INSERT INTO Percentage (DeviceRowID, Percentage, Date) VALUES (" << sd[0] << ", " << (stod(sd3[0]) / 10.0) << ", '"
 								 << sd3[1] << "')";
 							query(szQuery2.str());
 						}
@@ -2301,9 +2301,9 @@ bool CSQLHelper::OpenDatabase()
 						{
 							szQuery2.clear();
 							szQuery2.str("");
-							float percentage_min = stof(sd3[0]) / 10.0F;
-							float percentage_max = stof(sd3[1]) / 10.0F;
-							float percentage_avg = stof(sd3[2]) / 10.0F;
+							float percentage_min = static_cast<float>(stod(sd3[0]) / 10.0);
+							float percentage_max = static_cast<float>(stod(sd3[1]) / 10.0);
+							float percentage_avg = static_cast<float>(stod(sd3[2]) / 10.0);
 							szQuery2 << "INSERT INTO Percentage_Calendar (DeviceRowID, Percentage_Min, Percentage_Max, Percentage_Avg, Date) VALUES (" << sd[0] << ", " << percentage_min << ", " << percentage_max << ", " << percentage_avg << ", '" << sd3[3] << "')";
 							query(szQuery2.str());
 						}
@@ -6134,7 +6134,7 @@ void CSQLHelper::UpdateTemperatureLog()
 				if (splitresults.size() >= 2)
 				{
 					temp = stof(splitresults[0]);
-					humidity = ground(stof(splitresults[1]));
+					humidity = static_cast<unsigned char>(ground(stod(splitresults[1])));
 					dewpoint = (float)CalculateDewPoint(temp, humidity);
 				}
 				break;
@@ -6142,9 +6142,9 @@ void CSQLHelper::UpdateTemperatureLog()
 				if (splitresults.size() == 5)
 				{
 					temp = stof(splitresults[0]);
-					humidity = ground(stof(splitresults[1]));
+					humidity = static_cast<unsigned char>(ground(stod(splitresults[1])));
 					if (dSubType == sTypeTHBFloat)
-						barometer = int(stof(splitresults[3]) * 10.0F);
+						barometer = static_cast<int>(stod(splitresults[3]) * 10.0);
 					else
 						barometer = stoi(splitresults[3]);
 					dewpoint = (float)CalculateDewPoint(temp, humidity);
@@ -6154,7 +6154,7 @@ void CSQLHelper::UpdateTemperatureLog()
 				if (splitresults.size() >= 2)
 				{
 					temp = stof(splitresults[0]);
-					barometer = int(stof(splitresults[1]) * 10.0F);
+					barometer = static_cast<int>(stod(splitresults[1]) * 10.0);
 				}
 				break;
 			case pTypeUV:
@@ -6191,7 +6191,7 @@ void CSQLHelper::UpdateTemperatureLog()
 				{
 					if (splitresults.size() != 2)
 						continue;
-					barometer = int(stof(splitresults[0]) * 10.0F);
+					barometer = static_cast<int>(stod(splitresults[0]) * 10.0);
 				}
 				break;
 			}
@@ -6967,19 +6967,19 @@ void CSQLHelper::UpdateMultiMeter()
 				if (splitresults.size() != 3)
 					continue; //impossible
 
-				value1 = (uint64_t) (stof(splitresults[0]) * 10.0F);
-				value2 = (uint64_t) (stof(splitresults[1]) * 10.0F);
-				value3 = (uint64_t) (stof(splitresults[2]) * 10.0F);
+				value1 = static_cast<uint64_t>(stod(splitresults[0]) * 10.0);
+				value2 = static_cast<uint64_t>(stod(splitresults[1]) * 10.0);
+				value3 = static_cast<uint64_t>(stod(splitresults[2]) * 10.0);
 			}
 			else if ((dType == pTypeCURRENTENERGY) && (dSubType == sTypeELEC4))
 			{
 				if (splitresults.size() != 4)
 					continue; //impossible
 
-				value1 = (uint64_t) (stof(splitresults[0]) * 10.0F);
-				value2 = (uint64_t) (stof(splitresults[1]) * 10.0F);
-				value3 = (uint64_t) (stof(splitresults[2]) * 10.0F);
-				value4 = (uint64_t) (stof(splitresults[3]) * 1000.0F);
+				value1 = static_cast<uint64_t>(stod(splitresults[0]) * 10.0);
+				value2 = static_cast<uint64_t>(stod(splitresults[1]) * 10.0);
+				value3 = static_cast<uint64_t>(stod(splitresults[2]) * 10.0);
+				value4 = static_cast<uint64_t>(stod(splitresults[3]) * 1000.0);
 			}
 			else
 				continue;//don't know you (yet)

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -1413,7 +1413,7 @@ bool CSQLHelper::OpenDatabase()
 				{
 					int hwId = stoi(sd[0]);
 					_eHardwareTypes hwtype = (_eHardwareTypes) stoi(sd[1]);
-					size_t Port = (size_t) stoull(sd[2]);
+					size_t Port = (size_t) stoul(sd[2]);
 
 					if (IsSerialDevice(hwtype))
 					{
@@ -5280,7 +5280,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 			StringSplit(sValueBeforeUpdate, ";", powerAndEnergyBeforeUpdate);
 			if (powerAndEnergyBeforeUpdate.size() == 2)
 			{
-				// We need to use atof here because some users seem to have a illegal sValue in the database that causes stof to crash
+				// FIXME: We need to use atof here because some users seem to have a illegal sValue in the database that causes stof to crash
 				double powerDuringInterval = atof(powerAndEnergyBeforeUpdate[0].c_str());
 				double energyUpToInterval = atof(powerAndEnergyBeforeUpdate[1].c_str());
 				double energyDuringInterval = powerDuringInterval * intervalSeconds / 3600;

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -72,7 +72,7 @@ void CScheduler::ReloadSchedules()
 	{
 		for (const auto& sd : result)
 		{
-			bool bDUsed = (atoi(sd[7].c_str()) != 0);
+			bool bDUsed = (stoi(sd[7]) != 0);
 
 			if (bDUsed == true)
 			{
@@ -82,16 +82,16 @@ void CScheduler::ReloadSchedules()
 				titem.bIsScene = false;
 				titem.bIsThermostat = false;
 
-				_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
-				titem.RowID = std::stoull(sd[0]);
-				titem.TimerID = std::stoull(sd[14]);
-				titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-				titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+				_eTimerType timerType = (_eTimerType) stoi(sd[2]);
+				titem.RowID = stoull(sd[0]);
+				titem.TimerID = stoull(sd[14]);
+				titem.startHour = (unsigned char) stoi(sd[1].substr(0, 2));
+				titem.startMin = (unsigned char) stoi(sd[1].substr(3, 2));
 				titem.startTime = 0;
 				titem.timerType = timerType;
-				titem.timerCmd = (_eTimerCommand)atoi(sd[3].c_str());
-				titem.Level = (unsigned char)atoi(sd[4].c_str());
-				titem.bUseRandomness = (atoi(sd[8].c_str()) != 0);
+				titem.timerCmd = (_eTimerCommand) stoi(sd[3]);
+				titem.Level = stoi(sd[4]);
+				titem.bUseRandomness = (stoi(sd[8]) != 0);
 				titem.Color = _tColor(sd[9]);
 				titem.MDay = 0;
 				titem.Month = 0;
@@ -102,23 +102,23 @@ void CScheduler::ReloadSchedules()
 					std::string sdate = sd[10];
 					if (sdate.size() != 10)
 						continue; //invalid
-					titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-					titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-					titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+					titem.startYear = (unsigned short) stoi(sdate.substr(0, 4));
+					titem.startMonth = (unsigned char) stoi(sdate.substr(5, 2));
+					titem.startDay = (unsigned char) stoi(sdate.substr(8, 2));
 				}
 				else if (timerType == TTYPE_MONTHLY)
 				{
 					std::string smday = sd[11];
 					if (smday == "0")
 						continue; //invalid
-					titem.MDay = atoi(smday.c_str());
+					titem.MDay = stoi(smday);
 				}
 				else if (timerType == TTYPE_MONTHLY_WD)
 				{
 					std::string socc = sd[13];
 					if (socc == "0")
 						continue; //invalid
-					titem.Occurence = atoi(socc.c_str());
+					titem.Occurence = stoi(socc);
 				}
 				else if (timerType == TTYPE_YEARLY)
 				{
@@ -126,8 +126,8 @@ void CScheduler::ReloadSchedules()
 					std::string smonth = sd[12];
 					if ((smday == "0") || (smonth == "0"))
 						continue; //invalid
-					titem.MDay = atoi(smday.c_str());
-					titem.Month = atoi(smonth.c_str());
+					titem.MDay = stoi(smday);
+					titem.Month = stoi(smonth);
 				}
 				else if (timerType == TTYPE_YEARLY_WD)
 				{
@@ -135,15 +135,15 @@ void CScheduler::ReloadSchedules()
 					std::string socc = sd[13];
 					if ((smonth == "0") || (socc == "0"))
 						continue; //invalid
-					titem.Month = atoi(smonth.c_str());
-					titem.Occurence = atoi(socc.c_str());
+					titem.Month = stoi(smonth);
+					titem.Occurence = stoi(socc);
 				}
 
 				if ((titem.timerCmd == TCMD_ON) && (titem.Level == 0))
 				{
 					titem.Level = 100;
 				}
-				titem.Days = atoi(sd[5].c_str());
+				titem.Days = stoi(sd[5]);
 				titem.DeviceName = sd[6];
 
 				if (AdjustScheduleItem(&titem, false) == true)
@@ -186,30 +186,30 @@ void CScheduler::ReloadSchedules()
 				std::stringstream s_str(sd[12]);
 				s_str >> titem.TimerID; }
 
-			_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
+			_eTimerType timerType = (_eTimerType) stoi(sd[2]);
 
 			if (timerType == TTYPE_FIXEDDATETIME)
 			{
 				std::string sdate = sd[8];
 				if (sdate.size() != 10)
 					continue; //invalid
-				titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-				titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-				titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+				titem.startYear = (unsigned short) stoi(sdate.substr(0, 4));
+				titem.startMonth = (unsigned char) stoi(sdate.substr(5, 2));
+				titem.startDay = (unsigned char) stoi(sdate.substr(8, 2));
 			}
 			else if (timerType == TTYPE_MONTHLY)
 			{
 				std::string smday = sd[9];
 				if (smday == "0")
 					continue; //invalid
-				titem.MDay = atoi(smday.c_str());
+				titem.MDay = stoi(smday);
 			}
 			else if (timerType == TTYPE_MONTHLY_WD)
 			{
 				std::string socc = sd[11];
 				if (socc == "0")
 					continue; //invalid
-				titem.Occurence = atoi(socc.c_str());
+				titem.Occurence = stoi(socc);
 			}
 			else if (timerType == TTYPE_YEARLY)
 			{
@@ -217,8 +217,8 @@ void CScheduler::ReloadSchedules()
 				std::string smonth = sd[10];
 				if ((smday == "0") || (smonth == "0"))
 					continue; //invalid
-				titem.MDay = atoi(smday.c_str());
-				titem.Month = atoi(smonth.c_str());
+				titem.MDay = stoi(smday);
+				titem.Month = stoi(smonth);
 			}
 			else if (timerType == TTYPE_YEARLY_WD)
 			{
@@ -226,22 +226,22 @@ void CScheduler::ReloadSchedules()
 				std::string socc = sd[11];
 				if ((smonth == "0") || (socc == "0"))
 					continue; //invalid
-				titem.Month = atoi(smonth.c_str());
-				titem.Occurence = atoi(socc.c_str());
+				titem.Month = stoi(smonth);
+				titem.Occurence = stoi(socc);
 			}
 
-			titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-			titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+			titem.startHour = (unsigned char) stoi(sd[1].substr(0, 2));
+			titem.startMin = (unsigned char) stoi(sd[1].substr(3, 2));
 			titem.startTime = 0;
 			titem.timerType = timerType;
-			titem.timerCmd = (_eTimerCommand)atoi(sd[3].c_str());
-			titem.Level = (unsigned char)atoi(sd[4].c_str());
-			titem.bUseRandomness = (atoi(sd[7].c_str()) != 0);
+			titem.timerCmd = (_eTimerCommand) stoi(sd[3]);
+			titem.Level = stoi(sd[4]);
+			titem.bUseRandomness = (stoi(sd[7]) != 0);
 			if ((titem.timerCmd == TCMD_ON) && (titem.Level == 0))
 			{
 				titem.Level = 100;
 			}
-			titem.Days = atoi(sd[5].c_str());
+			titem.Days = stoi(sd[5]);
 			titem.DeviceName = sd[6];
 			if (AdjustScheduleItem(&titem, false) == true)
 				m_scheduleitems.push_back(titem);
@@ -268,33 +268,33 @@ void CScheduler::ReloadSchedules()
 			titem.MDay = 0;
 			titem.Month = 0;
 			titem.Occurence = 0;
-			titem.RowID = std::stoull(sd[0]);
-			titem.TimerID = std::stoull(sd[10]);
+			titem.RowID = stoull(sd[0]);
+			titem.TimerID = stoull(sd[10]);
 
-			_eTimerType timerType = (_eTimerType)atoi(sd[2].c_str());
+			_eTimerType timerType = (_eTimerType) stoi(sd[2]);
 
 			if (timerType == TTYPE_FIXEDDATETIME)
 			{
 				std::string sdate = sd[6];
 				if (sdate.size() != 10)
 					continue; //invalid
-				titem.startYear = (unsigned short)atoi(sdate.substr(0, 4).c_str());
-				titem.startMonth = (unsigned char)atoi(sdate.substr(5, 2).c_str());
-				titem.startDay = (unsigned char)atoi(sdate.substr(8, 2).c_str());
+				titem.startYear = (unsigned short) stoi(sdate.substr(0, 4));
+				titem.startMonth = (unsigned char) stoi(sdate.substr(5, 2));
+				titem.startDay = (unsigned char) stoi(sdate.substr(8, 2));
 			}
 			else if (timerType == TTYPE_MONTHLY)
 			{
 				std::string smday = sd[7];
 				if (smday == "0")
 					continue; //invalid
-				titem.MDay = atoi(smday.c_str());
+				titem.MDay = stoi(smday);
 			}
 			else if (timerType == TTYPE_MONTHLY_WD)
 			{
 				std::string socc = sd[9];
 				if (socc == "0")
 					continue; //invalid
-				titem.Occurence = atoi(socc.c_str());
+				titem.Occurence = stoi(socc);
 			}
 			else if (timerType == TTYPE_YEARLY)
 			{
@@ -302,8 +302,8 @@ void CScheduler::ReloadSchedules()
 				std::string smonth = sd[8];
 				if ((smday == "0") || (smonth == "0"))
 					continue; //invalid
-				titem.MDay = atoi(smday.c_str());
-				titem.Month = atoi(smonth.c_str());
+				titem.MDay = stoi(smday);
+				titem.Month = stoi(smonth);
 			}
 			else if (timerType == TTYPE_YEARLY_WD)
 			{
@@ -311,19 +311,19 @@ void CScheduler::ReloadSchedules()
 				std::string socc = sd[9];
 				if ((smonth == "0") || (socc == "0"))
 					continue; //invalid
-				titem.Month = atoi(smonth.c_str());
-				titem.Occurence = atoi(socc.c_str());
+				titem.Month = stoi(smonth);
+				titem.Occurence = stoi(socc);
 			}
 
-			titem.startHour = (unsigned char)atoi(sd[1].substr(0, 2).c_str());
-			titem.startMin = (unsigned char)atoi(sd[1].substr(3, 2).c_str());
+			titem.startHour = (unsigned char) stoi(sd[1].substr(0, 2));
+			titem.startMin = (unsigned char) stoi(sd[1].substr(3, 2));
 			titem.startTime = 0;
 			titem.timerType = timerType;
 			titem.timerCmd = TCMD_ON;
-			titem.Temperature = static_cast<float>(atof(sd[3].c_str()));
+			titem.Temperature = stof(sd[3]);
 			titem.Level = 100;
 			titem.bUseRandomness = false;
-			titem.Days = atoi(sd[4].c_str());
+			titem.Days = stoi(sd[4]);
 			titem.DeviceName = sd[5];
 			if (AdjustScheduleItem(&titem, false) == true)
 				m_scheduleitems.push_back(titem);
@@ -350,9 +350,9 @@ void CScheduler::SetSunRiseSetTimes(const std::string& sSunRise, const std::stri
 		for (size_t a = 0; a < allSchedules.size(); a = a + 1)
 		{
 			//std::cout << allSchedules[a].c_str() << ' ';
-			int hour = atoi(allSchedules[a].substr(0, 2).c_str());
-			int min = atoi(allSchedules[a].substr(3, 2).c_str());
-			int sec = atoi(allSchedules[a].substr(6, 2).c_str());
+			int hour = stoi(allSchedules[a].substr(0, 2));
+			int min = stoi(allSchedules[a].substr(3, 2));
+			int sec = stoi(allSchedules[a].substr(6, 2));
 
 			constructTime(temptime, tm1, ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, hour, min, sec, ltime.tm_isdst);
 			if ((*allTimes[a] != temptime) && (temptime != 0))
@@ -874,9 +874,9 @@ void CScheduler::CheckSchedules()
 						{
 							std::vector<std::string> sd = result[0];
 
-							unsigned char dType = atoi(sd[0].c_str());
-							unsigned char dSubType = atoi(sd[1].c_str());
-							_eSwitchType switchtype = (_eSwitchType)atoi(sd[2].c_str());
+							unsigned char dType = (unsigned char) stoi(sd[0]);
+							unsigned char dSubType = (unsigned char) stoi(sd[1]);
+							_eSwitchType switchtype = (_eSwitchType) stoi(sd[2]);
 							std::string lstatus;
 							int llevel = 0;
 							bool bHaveDimmer = false;
@@ -1103,11 +1103,11 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : tot_result)
 				{
-					int iTimerIdx = atoi(sd[0].c_str());
-					bool bActive = atoi(sd[1].c_str()) != 0;
-					bool bIsScene = atoi(sd[4].c_str()) != 0;
-					bool bIsThermostat = atoi(sd[5].c_str()) != 0;
-					int iDays = atoi(sd[13].c_str());
+					int iTimerIdx = stoi(sd[0]);
+					bool bActive = stoi(sd[1]) != 0;
+					bool bIsScene = stoi(sd[4]) != 0;
+					bool bIsThermostat = stoi(sd[5]) != 0;
+					int iDays = stoi(sd[13]);
 					char ltimeBuf[30] = "";
 
 					if (bActive)
@@ -1125,18 +1125,18 @@ namespace http {
 						}
 					}
 
-					unsigned char iLevel = atoi(sd[10].c_str());
+					unsigned char iLevel = (unsigned char) stoi(sd[10]);
 					if (iLevel == 0)
 						iLevel = 100;
 
-					int iTimerType = atoi(sd[8].c_str());
+					int iTimerType = stoi(sd[8]);
 					std::string sdate = sd[6];
 					if ((iTimerType == TTYPE_FIXEDDATETIME) && (sdate.size() == 10))
 					{
 						char szTmp[30];
-						int Year = atoi(sdate.substr(0, 4).c_str());
-						int Month = atoi(sdate.substr(5, 2).c_str());
-						int Day = atoi(sdate.substr(8, 2).c_str());
+						int Year = stoi(sdate.substr(0, 4));
+						int Month = stoi(sdate.substr(5, 2));
+						int Day = stoi(sdate.substr(8, 2));
 						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
@@ -1148,15 +1148,15 @@ namespace http {
 					root["result"][ii]["Type"] = bIsScene ? "Scene" : "Device";
 					root["result"][ii]["IsThermostat"] = bIsThermostat ? "true" : "false";
 					root["result"][ii]["DevName"] = sd[2];
-					root["result"][ii]["DeviceRowID"] = atoi(sd[3].c_str()); //TODO: Isn't this a 64 bit device index?
+					root["result"][ii]["DeviceRowID"] = stoi(sd[3]); //TODO: Isn't this a 64 bit device index?
 					root["result"][ii]["Date"] = sdate;
 					root["result"][ii]["Time"] = sd[7];
 					root["result"][ii]["TimerType"] = iTimerType;
 					root["result"][ii]["TimerTypeStr"] = Timer_Type_Desc(iTimerType);
 					root["result"][ii]["Days"] = iDays;
-					root["result"][ii]["MDay"] = atoi(sd[15].c_str());
-					root["result"][ii]["Month"] = atoi(sd[16].c_str());
-					root["result"][ii]["Occurence"] = atoi(sd[17].c_str());
+					root["result"][ii]["MDay"] = stoi(sd[15]);
+					root["result"][ii]["Month"] = stoi(sd[16]);
+					root["result"][ii]["Occurence"] = stoi(sd[17]);
 					root["result"][ii]["ScheduleDate"] = ltimeBuf;
 					if (bIsThermostat)
 					{
@@ -1164,10 +1164,10 @@ namespace http {
 					}
 					else
 					{
-						root["result"][ii]["TimerCmd"] = atoi(sd[9].c_str());
+						root["result"][ii]["TimerCmd"] = stoi(sd[9]);
 						root["result"][ii]["Level"] = iLevel;
 						root["result"][ii]["Color"] = sd[11];
-						root["result"][ii]["Randomness"] = (atoi(sd[14].c_str()) != 0) ? "true" : "false";
+						root["result"][ii]["Randomness"] = (stoi(sd[14]) != 0) ? "true" : "false";
 					}
 					ii++;
 				}
@@ -1178,7 +1178,7 @@ namespace http {
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			if (idx == 0)
 				return;
@@ -1191,7 +1191,7 @@ namespace http {
 			if (result.empty())
 				return;
 
-			_eSwitchType switchtype = (_eSwitchType)std::stoi(result[0][0]);
+			_eSwitchType switchtype = (_eSwitchType) stoi(result[0][0]);
 			const bool bIsBlinds = (
 				switchtype == STYPE_Blinds
 				|| switchtype == STYPE_BlindsPercentage
@@ -1208,36 +1208,36 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					unsigned char iLevel = atoi(sd[6].c_str());
+					unsigned char iLevel = (unsigned char) stoi(sd[6]);
 					if ((iLevel == 0) && (!bIsBlinds))
 						iLevel = 100;
 
-					int iTimerType = atoi(sd[4].c_str());
+					int iTimerType = stoi(sd[4]);
 					std::string sdate = sd[2];
 					if ((iTimerType == TTYPE_FIXEDDATETIME) && (sdate.size() == 10))
 					{
-						int Year = atoi(sdate.substr(0, 4).c_str());
-						int Month = atoi(sdate.substr(5, 2).c_str());
-						int Day = atoi(sdate.substr(8, 2).c_str());
+						int Year = stoi(sdate.substr(0, 4));
+						int Month = stoi(sdate.substr(5, 2));
+						int Day = stoi(sdate.substr(8, 2));
 						sdate = std_format("%04d-%02d-%02d", Year, Month, Day);
 					}
 					else
 						sdate = "";
 
 					root["result"][ii]["idx"] = sd[0];
-					root["result"][ii]["Active"] = (atoi(sd[1].c_str()) == 0) ? "false" : "true";
+					root["result"][ii]["Active"] = (stoi(sd[1]) == 0) ? "false" : "true";
 					root["result"][ii]["Date"] = sdate;
 					root["result"][ii]["Time"] = sd[3].substr(0, 5);
 					root["result"][ii]["Type"] = iTimerType;
-					root["result"][ii]["Cmd"] = atoi(sd[5].c_str());
+					root["result"][ii]["Cmd"] = stoi(sd[5]);
 					root["result"][ii]["Level"] = iLevel;
 					root["result"][ii]["Color"] = sd[7];
-					root["result"][ii]["Days"] = atoi(sd[8].c_str());
-					root["result"][ii]["Randomness"] = (atoi(sd[9].c_str()) == 0) ? "false" : "true";
-					root["result"][ii]["MDay"] = atoi(sd[10].c_str());
-					root["result"][ii]["Month"] = atoi(sd[11].c_str());
-					root["result"][ii]["Occurence"] = atoi(sd[12].c_str());
-					root["result"][ii]["Persistent"] = (atoi(sd[13].c_str()) == 9999) ? "true" : "false";
+					root["result"][ii]["Days"] = stoi(sd[8]);
+					root["result"][ii]["Randomness"] = (stoi(sd[9]) == 0) ? "false" : "true";
+					root["result"][ii]["MDay"] = stoi(sd[10]);
+					root["result"][ii]["Month"] = stoi(sd[11]);
+					root["result"][ii]["Occurence"] = stoi(sd[12]);
+					root["result"][ii]["Persistent"] = (stoi(sd[13]) == 9999) ? "true" : "false";
 					ii++;
 				}
 			}
@@ -1256,7 +1256,7 @@ namespace http {
 			int rnvalue = 0;
 			std::string sValue = request::findValue(&req, "ActiveTimerPlan");
 			m_sql.GetPreferencesVar("ActiveTimerPlan", rnOldvalue);
-			rnvalue = (!sValue.empty() ? atoi(sValue.c_str()) : rnOldvalue);
+			rnvalue = (!sValue.empty() ? stoi(sValue) : rnOldvalue);
 			if (rnOldvalue != rnvalue)
 			{
 				std::vector<std::vector<std::string> > result;
@@ -1299,7 +1299,7 @@ namespace http {
 			std::string persistent = request::findValue(&req, "persistent");
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (randomness.empty()) || (scmd.empty()) || (sdays.empty()))
 				return;
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
@@ -1314,9 +1314,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1346,15 +1346,15 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			unsigned char icmd = atoi(scmd.c_str());
-			int days = atoi(sdays.c_str());
-			unsigned char level = atoi(slevel.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			unsigned char icmd = (unsigned char) stoi(scmd);
+			int days = stoi(sdays);
+			unsigned char level = (unsigned char) stoi(slevel);
 			_tColor color = _tColor(scolor);
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "AddTimer";
 			m_sql.safe_query(
@@ -1403,7 +1403,7 @@ namespace http {
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (randomness.empty()) || (scmd.empty()) || (sdays.empty()))
 				return;
 
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
@@ -1418,9 +1418,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1450,15 +1450,15 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			unsigned char icmd = atoi(scmd.c_str());
-			int days = atoi(sdays.c_str());
-			unsigned char level = atoi(slevel.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			unsigned char icmd = (unsigned char) stoi(scmd);
+			int days = stoi(sdays);
+			unsigned char level = (unsigned char) stoi(slevel);
 			_tColor color = _tColor(scolor);
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "UpdateTimer";
 			m_sql.safe_query(
@@ -1567,7 +1567,7 @@ namespace http {
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			if (idx == 0)
 				return;
@@ -1583,13 +1583,13 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					int iTimerType = atoi(sd[4].c_str());
+					int iTimerType = stoi(sd[4]);
 					std::string sdate = sd[2];
 					if ((iTimerType == TTYPE_FIXEDDATETIME) && (sdate.size() == 10))
 					{
-						int Year = atoi(sdate.substr(0, 4).c_str());
-						int Month = atoi(sdate.substr(5, 2).c_str());
-						int Day = atoi(sdate.substr(8, 2).c_str());
+						int Year = stoi(sdate.substr(0, 4));
+						int Month = stoi(sdate.substr(5, 2));
+						int Day = stoi(sdate.substr(8, 2));
 						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
@@ -1597,16 +1597,16 @@ namespace http {
 						sdate = "";
 
 					root["result"][ii]["idx"] = sd[0];
-					root["result"][ii]["Active"] = (atoi(sd[1].c_str()) == 0) ? "false" : "true";
+					root["result"][ii]["Active"] = (stoi(sd[1]) == 0) ? "false" : "true";
 					root["result"][ii]["Date"] = sdate;
 					root["result"][ii]["Time"] = sd[3].substr(0, 5);
 					root["result"][ii]["Type"] = iTimerType;
-					root["result"][ii]["Temperature"] = atof(sd[5].c_str());
-					root["result"][ii]["Days"] = atoi(sd[6].c_str());
-					root["result"][ii]["MDay"] = atoi(sd[7].c_str());
-					root["result"][ii]["Month"] = atoi(sd[8].c_str());
-					root["result"][ii]["Occurence"] = atoi(sd[9].c_str());
-					root["result"][ii]["Persistent"] = (atoi(sd[10].c_str()) == 9999) ? "true" : "false";
+					root["result"][ii]["Temperature"] = stof(sd[5]);
+					root["result"][ii]["Days"] = stoi(sd[6]);
+					root["result"][ii]["MDay"] = stoi(sd[7]);
+					root["result"][ii]["Month"] = stoi(sd[8]);
+					root["result"][ii]["Occurence"] = stoi(sd[9]);
+					root["result"][ii]["Persistent"] = (stoi(sd[10]) == 9999) ? "true" : "false";
 					ii++;
 				}
 			}
@@ -1635,7 +1635,7 @@ namespace http {
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (stvalue.empty()) || (sdays.empty()))
 				return;
 
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
 			time_t now = mytime(nullptr);
@@ -1649,9 +1649,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1681,13 +1681,13 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			int days = atoi(sdays.c_str());
-			float temperature = static_cast<float>(atof(stvalue.c_str()));
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			int days = stoi(sdays);
+			float temperature = stof(stvalue);
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "AddSetpointTimer";
 
@@ -1745,7 +1745,7 @@ namespace http {
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (stvalue.empty()) || (sdays.empty()))
 				return;
 
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
 			time_t now = mytime(nullptr);
@@ -1759,9 +1759,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -1791,13 +1791,13 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			int days = atoi(sdays.c_str());
-			float tempvalue = static_cast<float>(atof(stvalue.c_str()));
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			int days = stoi(sdays);
+			float tempvalue = stof(stvalue);
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "UpdateSetpointTimer";
 			m_sql.safe_query(
@@ -1906,7 +1906,7 @@ namespace http {
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			if (idx == 0)
 				return;
@@ -1923,17 +1923,17 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					unsigned char iLevel = atoi(sd[6].c_str());
+					unsigned char iLevel = (unsigned char) stoi(sd[6]);
 					if (iLevel == 0)
 						iLevel = 100;
 
-					int iTimerType = atoi(sd[4].c_str());
+					int iTimerType = stoi(sd[4]);
 					std::string sdate = sd[2];
 					if ((iTimerType == TTYPE_FIXEDDATETIME) && (sdate.size() == 10))
 					{
-						int Year = atoi(sdate.substr(0, 4).c_str());
-						int Month = atoi(sdate.substr(5, 2).c_str());
-						int Day = atoi(sdate.substr(8, 2).c_str());
+						int Year = stoi(sdate.substr(0, 4));
+						int Month = stoi(sdate.substr(5, 2));
+						int Day = stoi(sdate.substr(8, 2));
 						sprintf(szTmp, "%04d-%02d-%02d", Year, Month, Day);
 						sdate = szTmp;
 					}
@@ -1941,18 +1941,18 @@ namespace http {
 						sdate = "";
 
 					root["result"][ii]["idx"] = sd[0];
-					root["result"][ii]["Active"] = (atoi(sd[1].c_str()) == 0) ? "false" : "true";
+					root["result"][ii]["Active"] = (stoi(sd[1]) == 0) ? "false" : "true";
 					root["result"][ii]["Date"] = sdate;
 					root["result"][ii]["Time"] = sd[3].substr(0, 5);
 					root["result"][ii]["Type"] = iTimerType;
-					root["result"][ii]["Cmd"] = atoi(sd[5].c_str());
+					root["result"][ii]["Cmd"] = stoi(sd[5]);
 					root["result"][ii]["Level"] = iLevel;
-					root["result"][ii]["Days"] = atoi(sd[7].c_str());
-					root["result"][ii]["Randomness"] = (atoi(sd[8].c_str()) == 0) ? "false" : "true";
-					root["result"][ii]["MDay"] = atoi(sd[9].c_str());
-					root["result"][ii]["Month"] = atoi(sd[10].c_str());
-					root["result"][ii]["Occurence"] = atoi(sd[11].c_str());
-					root["result"][ii]["Persistent"] = (atoi(sd[12].c_str()) == 9999) ? "true" : "false";
+					root["result"][ii]["Days"] = stoi(sd[7]);
+					root["result"][ii]["Randomness"] = (stoi(sd[8]) == 0) ? "false" : "true";
+					root["result"][ii]["MDay"] = stoi(sd[9]);
+					root["result"][ii]["Month"] = stoi(sd[10]);
+					root["result"][ii]["Occurence"] = stoi(sd[11]);
+					root["result"][ii]["Persistent"] = (stoi(sd[12]) == 9999) ? "true" : "false";
 					ii++;
 				}
 			}
@@ -1984,7 +1984,7 @@ namespace http {
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (randomness.empty()) || (scmd.empty()) || (sdays.empty()))
 				return;
 
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
 			time_t now = mytime(nullptr);
@@ -1998,9 +1998,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -2030,14 +2030,14 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			unsigned char icmd = atoi(scmd.c_str());
-			int days = atoi(sdays.c_str());
-			unsigned char level = atoi(slevel.c_str());
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			unsigned char icmd = (unsigned char) stoi(scmd);
+			int days = stoi(sdays);
+			unsigned char level = (unsigned char) stoi(slevel);
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "AddSceneTimer";
 			m_sql.safe_query(
@@ -2084,7 +2084,7 @@ namespace http {
 			if ((idx.empty()) || (active.empty()) || (stimertype.empty()) || (shour.empty()) || (smin.empty()) || (randomness.empty()) || (scmd.empty()) || (sdays.empty()))
 				return;
 
-			unsigned char iTimerType = atoi(stimertype.c_str());
+			unsigned char iTimerType = (unsigned char) stoi(stimertype);
 			int timer_plan = (persistent == "true") ? 9999 : m_sql.m_ActiveTimerPlan;
 
 			time_t now = mytime(nullptr);
@@ -2098,9 +2098,9 @@ namespace http {
 			{
 				if (sdate.size() == 10)
 				{
-					Year = atoi(sdate.substr(0, 4).c_str());
-					Month = atoi(sdate.substr(5, 2).c_str());
-					Day = atoi(sdate.substr(8, 2).c_str());
+					Year = stoi(sdate.substr(0, 4));
+					Month = stoi(sdate.substr(5, 2));
+					Day = stoi(sdate.substr(8, 2));
 				}
 			}
 			else if (iTimerType == TTYPE_MONTHLY)
@@ -2130,14 +2130,14 @@ namespace http {
 					return;
 			}
 
-			unsigned char hour = atoi(shour.c_str());
-			unsigned char min = atoi(smin.c_str());
-			unsigned char icmd = atoi(scmd.c_str());
-			int days = atoi(sdays.c_str());
-			unsigned char level = atoi(slevel.c_str());
-			int mday = atoi(smday.c_str());
-			int month = atoi(smonth.c_str());
-			int occurence = atoi(soccurence.c_str());
+			unsigned char hour = (unsigned char) stoi(shour);
+			unsigned char min = (unsigned char) stoi(smin);
+			unsigned char icmd = (unsigned char) stoi(scmd);
+			int days = stoi(sdays);
+			unsigned char level = (unsigned char) stoi(slevel);
+			int mday = stoi(smday);
+			int month = stoi(smonth);
+			int occurence = stoi(soccurence);
 			root["status"] = "OK";
 			root["title"] = "UpdateSceneTimer";
 			m_sql.safe_query(
@@ -2258,7 +2258,7 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					root["result"][ii]["idx"] = atoi(sd[0].c_str());
+					root["result"][ii]["idx"] = stoi(sd[0]);
 					root["result"][ii]["Name"] = sd[1];
 					root["result"][ii]["Active"] = (sd[0] == sd[2]);
 					ii++;
@@ -2320,7 +2320,7 @@ namespace http {
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			int iPlan = atoi(idx.c_str());
+			int iPlan = stoi(idx);
 			if (iPlan < 1)
 				return;
 

--- a/main/Scheduler.cpp
+++ b/main/Scheduler.cpp
@@ -1601,7 +1601,7 @@ namespace http {
 					root["result"][ii]["Date"] = sdate;
 					root["result"][ii]["Time"] = sd[3].substr(0, 5);
 					root["result"][ii]["Type"] = iTimerType;
-					root["result"][ii]["Temperature"] = stof(sd[5]);
+					root["result"][ii]["Temperature"] = stod(sd[5]);
 					root["result"][ii]["Days"] = stoi(sd[6]);
 					root["result"][ii]["MDay"] = stoi(sd[7]);
 					root["result"][ii]["Month"] = stoi(sd[8]);

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2239,7 +2239,8 @@ namespace http
 						{
 							double tempCelcius = stod(strarray[0]);
 							double temp = ConvertTemperature(tempCelcius, tempsign);
-							double humidity = stod(strarray[1]);
+							// FIXME: use stod instead of stoi ?
+							double humidity = stoi(strarray[1]);
 
 							root["result"][ii]["Temp"] = temp;
 							root["result"][ii]["Humidity"] = humidity;

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2282,7 +2282,7 @@ namespace http
 
 							if (dSubType == sTypeTHBFloat)
 							{
-								root["result"][ii]["Barometer"] = stof(strarray[3]);
+								root["result"][ii]["Barometer"] = stod(strarray[3]);
 								root["result"][ii]["ForecastStr"] = RFX_WSForecast_Desc((unsigned char) stoi(strarray[4]));
 							}
 							else
@@ -2292,7 +2292,7 @@ namespace http
 							}
 							if (dSubType == sTypeTHBFloat)
 							{
-								sprintf(szData, "%.1f %c, %d %%, %.1f hPa", temp, tempsign, stoi(strarray[1]), stof(strarray[3]));
+								sprintf(szData, "%.1f %c, %d %%, %.1f hPa", temp, tempsign, stoi(strarray[1]), stod(strarray[3]));
 							}
 							else
 							{
@@ -2321,9 +2321,9 @@ namespace http
 							int forecast = stoi(strarray[2]);
 							root["result"][ii]["Forecast"] = forecast;
 							root["result"][ii]["ForecastStr"] = BMP_Forecast_Desc(forecast);
-							root["result"][ii]["Barometer"] = stof(strarray[1]);
+							root["result"][ii]["Barometer"] = stod(strarray[1]);
 
-							sprintf(szData, "%.1f %c, %.1f hPa", tvalue, tempsign, stof(strarray[1]));
+							sprintf(szData, "%.1f %c, %.1f hPa", tvalue, tempsign, stod(strarray[1]));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
@@ -2373,7 +2373,7 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 6)
 						{
-							root["result"][ii]["Direction"] = stof(strarray[0]);
+							root["result"][ii]["Direction"] = stod(strarray[0]);
 							root["result"][ii]["DirectionStr"] = strarray[1];
 
 							if (dSubType != sTypeWIND5)
@@ -2471,13 +2471,9 @@ namespace http
 
 								total_real *= AddjMulti;
 								if (dSubType == sTypeRAINByRate)
-								{
-									rate = stof(sd2[1]) / 10000.0F;
-								}
+									rate = static_cast<float>(stod(sd2[1]) / 10000.0);
 								else
-								{
-									rate = stof(strarray[0]) * float(AddjMulti) / 100.0F;
-								}
+									rate = static_cast<float>(stod(strarray[0]) * double(AddjMulti) / 100.0);
 
 								sprintf(szTmp, "%.1f", total_real);
 								root["result"][ii]["Rain"] = szTmp;
@@ -2900,7 +2896,7 @@ namespace http
 							sprintf(szTmp, "%.03f m3", musage);
 							root["result"][ii]["CounterToday"] = szTmp;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							sprintf(szTmp, "%.03f", stof(sValue) / divider);
+							sprintf(szTmp, "%.03f", stod(sValue) / divider);
 							root["result"][ii]["Data"] = szTmp;
 						}
 						else
@@ -2909,7 +2905,7 @@ namespace http
 							root["result"][ii]["Counter"] = szTmp;
 							sprintf(szTmp, "%.03f m3", 0.0F);
 							root["result"][ii]["CounterToday"] = szTmp;
-							sprintf(szTmp, "%.03f", stof(sValue) / divider);
+							sprintf(szTmp, "%.03f", stod(sValue) / divider);
 							root["result"][ii]["Data"] = szTmp;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						}
@@ -2964,11 +2960,14 @@ namespace http
 							double total = stod(strarray[3]);
 							if (displaytype == 0)
 							{
-								sprintf(szData, "%.1f A, %.1f A, %.1f A", stof(strarray[0]), stof(strarray[1]), stof(strarray[2]));
+								sprintf(szData, "%.1f A, %.1f A, %.1f A", stod(strarray[0]), stod(strarray[1]), stod(strarray[2]));
 							}
 							else
 							{
-								sprintf(szData, "%d Watt, %d Watt, %d Watt", int(stof(strarray[0]) * voltage), int(stof(strarray[1]) * voltage), int(stof(strarray[2]) * voltage));
+								sprintf(szData, "%d Watt, %d Watt, %d Watt",
+										static_cast<int>(stod(strarray[0]) * voltage),
+										static_cast<int>(stod(strarray[1]) * voltage),
+										static_cast<int>(stod(strarray[2]) * voltage));
 							}
 							if (total > 0)
 							{
@@ -3014,7 +3013,7 @@ namespace http
 								}
 								else
 								{
-									sprintf(szData, "%g Watt", stof(strarray[0]));
+									sprintf(szData, "%g Watt", stod(strarray[0]));
 								}
 								root["result"][ii]["Usage"] = szData;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -3031,7 +3030,7 @@ namespace http
 								}
 								else
 								{
-									sprintf(szData, "%g Watt", stof(strarray[0]));
+									sprintf(szData, "%g Watt", stod(strarray[0]));
 								}
 								root["result"][ii]["Usage"] = szData;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -3142,7 +3141,7 @@ namespace http
 								sprintf(szTmp, "%.1f mi", vis * 0.6214F);
 							}
 							root["result"][ii]["Data"] = szTmp;
-							root["result"][ii]["Visibility"] = stof(sValue);
+							root["result"][ii]["Visibility"] = stod(sValue);
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "visibility";
 							root["result"][ii]["SwitchTypeVal"] = metertype;
@@ -3170,7 +3169,7 @@ namespace http
 							float radiation = stof(sValue);
 							sprintf(szTmp, "%.1f Watt/m2", radiation);
 							root["result"][ii]["Data"] = szTmp;
-							root["result"][ii]["Radiation"] = stof(sValue);
+							root["result"][ii]["Radiation"] = stod(sValue);
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "radiation";
 							root["result"][ii]["SwitchTypeVal"] = metertype;
@@ -3213,14 +3212,14 @@ namespace http
 						}
 						else if (dSubType == sTypePercentage)
 						{
-							sprintf(szData, "%g%%", stof(sValue));
+							sprintf(szData, "%g%%", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "hardware";
 						}
 						else if (dSubType == sTypeWaterflow)
 						{
-							sprintf(szData, "%g l/min", stof(sValue));
+							sprintf(szData, "%g l/min", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							if (!CustomImage)
@@ -3239,7 +3238,7 @@ namespace http
 								SensorType = stoi(sResults[0]);
 								szAxesLabel = sResults[1];
 							}
-							sprintf(szData, "%g %s", stof(sValue), szAxesLabel.c_str());
+							sprintf(szData, "%g %s", stod(sValue), szAxesLabel.c_str());
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["SensorType"] = SensorType;
 							root["result"][ii]["SensorUnit"] = szAxesLabel;
@@ -3267,19 +3266,19 @@ namespace http
 						}
 						else if (dSubType == sTypeVoltage)
 						{
-							sprintf(szData, "%g V", stof(sValue));
+							sprintf(szData, "%g V", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "current";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Voltage"] = stof(sValue);
+							root["result"][ii]["Voltage"] = stod(sValue);
 						}
 						else if (dSubType == sTypeCurrent)
 						{
-							sprintf(szData, "%g A", stof(sValue));
+							sprintf(szData, "%g A", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "current";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Current"] = stof(sValue);
+							root["result"][ii]["Current"] = stod(sValue);
 						}
 						else if (dSubType == sTypeTextStatus)
 						{
@@ -3304,11 +3303,11 @@ namespace http
 						}
 						else if (dSubType == sTypePressure)
 						{
-							sprintf(szData, "%.1f Bar", stof(sValue));
+							sprintf(szData, "%.1f Bar", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "gauge";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Pressure"] = stof(sValue);
+							root["result"][ii]["Pressure"] = stod(sValue);
 						}
 						else if (dSubType == sTypeBaro)
 						{
@@ -3316,13 +3315,13 @@ namespace http
 							StringSplit(sValue, ";", tstrarray);
 							if (tstrarray.empty())
 								continue;
-							sprintf(szData, "%g hPa", stof(tstrarray[0]));
+							sprintf(szData, "%g hPa", stod(tstrarray[0]));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "gauge";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							if (tstrarray.size() > 1)
 							{
-								root["result"][ii]["Barometer"] = stof(tstrarray[0]);
+								root["result"][ii]["Barometer"] = stod(tstrarray[0]);
 								int forecast = stoi(tstrarray[1]);
 								root["result"][ii]["Forecast"] = forecast;
 								root["result"][ii]["ForecastStr"] = BMP_Forecast_Desc(forecast);
@@ -3610,13 +3609,13 @@ namespace http
 					}
 					else if (dType == pTypeLux)
 					{
-						sprintf(szTmp, "%.0f Lux", stof(sValue));
+						sprintf(szTmp, "%.0f Lux", stod(sValue));
 						root["result"][ii]["Data"] = szTmp;
 						root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 					}
 					else if (dType == pTypeWEIGHT)
 					{
-						sprintf(szTmp, "%g %s", m_sql.m_weightscale * stof(sValue), m_sql.m_weightsign.c_str());
+						sprintf(szTmp, "%g %s", m_sql.m_weightscale * stod(sValue), m_sql.m_weightsign.c_str());
 						root["result"][ii]["Data"] = szTmp;
 						root["result"][ii]["HaveTimeout"] = false;
 						root["result"][ii]["SwitchTypeVal"] = (m_sql.m_weightsign == "kg") ? 0 : 1;
@@ -3625,7 +3624,7 @@ namespace http
 					{
 						if (dSubType == sTypeElectric)
 						{
-							sprintf(szData, "%g Watt", stof(sValue));
+							sprintf(szData, "%g Watt", stod(sValue));
 							root["result"][ii]["Data"] = szData;
 						}
 						else

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -174,7 +174,7 @@ namespace http
 					case 2:
 						_log.Log(LOG_ERROR, "WebServer(%s) startup failed on address %s with port: %s: %s", m_server_alias.c_str(), settings.listening_address.c_str(),
 							settings.listening_port.c_str(), e.what());
-						if (atoi(settings.listening_port.c_str()) < 1024)
+						if (stoi(settings.listening_port) < 1024)
 							_log.Log(LOG_ERROR, "WebServer(%s) check privileges for opening ports below 1024", m_server_alias.c_str());
 						else
 							_log.Log(LOG_ERROR, "WebServer(%s) check if no other application is using port: %s", m_server_alias.c_str(),
@@ -720,17 +720,17 @@ namespace http
 			{
 				for (const auto& sd : result)
 				{
-					int bIsActive = static_cast<int>(atoi(sd[1].c_str()));
+					int bIsActive = stoi(sd[1]);
 					if (bIsActive)
 					{
-						unsigned long ID = (unsigned long)atol(sd[0].c_str());
+						unsigned long ID = stoul(sd[0]);
 
 						std::string username = base64_decode(sd[2]);
 						std::string password = sd[3];
 						std::string mfatoken = sd[4];
 
-						_eUserRights rights = (_eUserRights)atoi(sd[5].c_str());
-						int activetabs = atoi(sd[6].c_str());
+						_eUserRights rights = (_eUserRights) stoi(sd[5]);
+						int activetabs = stoi(sd[6]);
 
 						AddUser(ID, username, password, mfatoken, rights, activetabs);
 					}
@@ -743,11 +743,11 @@ namespace http
 			{
 				for (const auto& sd : result)
 				{
-					int bIsActive = static_cast<int>(atoi(sd[1].c_str()));
+					int bIsActive = stoi(sd[1]);
 					if (bIsActive)
 					{
-						unsigned long ID = (unsigned long)m_iamsettings.getUserIdxOffset() + (unsigned long)atol(sd[0].c_str());
-						int bPublic = static_cast<int>(atoi(sd[2].c_str()));
+						unsigned long ID = ((unsigned long) m_iamsettings.getUserIdxOffset()) + stoul(sd[0]);
+						int bPublic = stoi(sd[2]);
 						std::string applicationname = sd[3];
 						std::string secret = sd[4];
 						std::string pemfile = sd[5];
@@ -843,7 +843,7 @@ namespace http
 			wtmp.PubKey = pubkey;
 			wtmp.userrights = (_eUserRights)userrights;
 			wtmp.ActiveTabs = activetabs;
-			wtmp.TotSensors = atoi(result[0][0].c_str());
+			wtmp.TotSensors = stoi(result[0][0]);
 			m_users.push_back(wtmp);
 
 			_tUserAccessCode utmp;
@@ -932,10 +932,10 @@ namespace http
 				for (const auto& sd : result)
 				{
 					_tHardwareListInt tlist;
-					int ID = atoi(sd[0].c_str());
+					int ID = stoi(sd[0]);
 					tlist.Name = sd[1];
-					tlist.Enabled = (atoi(sd[2].c_str()) != 0);
-					tlist.HardwareTypeVal = atoi(sd[3].c_str());
+					tlist.Enabled = (stoi(sd[2]) != 0);
+					tlist.HardwareTypeVal = stoi(sd[3]);
 #ifndef ENABLE_PYTHON
 					tlist.HardwareType = Hardware_Type_Desc(tlist.HardwareTypeVal);
 #else
@@ -1025,7 +1025,7 @@ namespace http
 							result = m_sql.safe_query("SELECT COUNT(*) FROM SharedDevices WHERE (SharedUserID == %lu)", m_users[iUser].ID);
 							if (!result.empty())
 							{
-								totUserDevices = (unsigned int)std::stoi(result[0][0]);
+								totUserDevices = (unsigned int) stoul(result[0][0]);
 							}
 						}
 					}
@@ -1077,7 +1077,7 @@ namespace http
 					{
 						for (const auto& sd : result)
 						{
-							unsigned char favorite = atoi(sd[4].c_str());
+							unsigned char favorite = (unsigned char) stoi(sd[4]);
 							// Check if we only want favorite devices
 							if ((bFetchFavorites) && (!favorite))
 								continue;
@@ -1092,10 +1092,10 @@ namespace http
 									continue;
 							}
 
-							int nValue = atoi(sd[2].c_str());
+							int nValue = stoi(sd[2]);
 
-							unsigned char scenetype = atoi(sd[5].c_str());
-							int iProtected = atoi(sd[6].c_str());
+							unsigned char scenetype = (unsigned char) stoi(sd[5]);
+							int iProtected = stoi(sd[6]);
 
 							std::string sSceneName = sd[1];
 							if (!bDisplayHidden && sSceneName[0] == '$')
@@ -1125,7 +1125,7 @@ namespace http
 								std::string typeOfThisOne = root["result"][ii]["Type"].asString();
 								if (typeOfThisOne == root["result"][ii - 1]["Type"].asString())
 								{
-									root["result"][ii - 1]["PlanIDs"].append(atoi(sd[9].c_str()));
+									root["result"][ii - 1]["PlanIDs"].append(stoi(sd[9]));
 									continue;
 								}
 							}
@@ -1138,7 +1138,7 @@ namespace http
 							root["result"][ii]["LastUpdate"] = sLastUpdate;
 							root["result"][ii]["PlanID"] = sd[9].c_str();
 							Json::Value jsonArray;
-							jsonArray.append(atoi(sd[9].c_str()));
+							jsonArray.append(stoi(sd[9]));
 							root["result"][ii]["PlanIDs"] = jsonArray;
 
 							if (nValue == 0)
@@ -1157,8 +1157,8 @@ namespace http
 								root["result"][ii]["CameraIdx"] = scidx.str();
 								root["result"][ii]["CameraAspect"] = m_mainworker.m_cameras.GetCameraAspectRatio(scidx.str());
 							}
-							root["result"][ii]["XOffset"] = atoi(sd[7].c_str());
-							root["result"][ii]["YOffset"] = atoi(sd[8].c_str());
+							root["result"][ii]["XOffset"] = stoi(sd[7]);
+							root["result"][ii]["YOffset"] = stoi(sd[8]);
 							ii++;
 						}
 					}
@@ -1385,7 +1385,7 @@ namespace http
 			{
 				try
 				{
-					unsigned char favorite = atoi(sd[12].c_str());
+					unsigned char favorite = (unsigned char) stoi(sd[12]);
 					bool bIsInPlan = !planID.empty() && (planID != "0");
 
 					// Check if we only want favorite devices
@@ -1409,7 +1409,7 @@ namespace http
 								sDeviceName = sDeviceName.substr(1);
 						}
 					}
-					int hardwareID = atoi(sd[14].c_str());
+					int hardwareID = stoi(sd[14]);
 					auto hItt = _hardwareNames.find(hardwareID);
 					bool bIsHardwareDisabled = true;
 					if (hItt != _hardwareNames.end())
@@ -1420,10 +1420,10 @@ namespace http
 						bIsHardwareDisabled = !(*hItt).second.Enabled;
 					}
 
-					unsigned int dType = atoi(sd[5].c_str());
-					unsigned int dSubType = atoi(sd[6].c_str());
-					unsigned int used = atoi(sd[4].c_str());
-					int nValue = atoi(sd[9].c_str());
+					unsigned int dType = (unsigned int) stoul(sd[5]);
+					unsigned int dSubType = (unsigned int) stoul(sd[6]);
+					unsigned int used = (unsigned int) stoul(sd[4]);
+					int nValue = stoi(sd[9]);
 					std::string sValue = sd[10];
 					std::string sLastUpdate = sd[11];
 					if (sLastUpdate.size() > 19)
@@ -1437,17 +1437,17 @@ namespace http
 							continue;
 					}
 
-					_eSwitchType switchtype = (_eSwitchType)atoi(sd[13].c_str());
+					_eSwitchType switchtype = (_eSwitchType) stoi(sd[13]);
 					_eMeterType metertype = (_eMeterType)switchtype;
-					double AddjValue = atof(sd[15].c_str());
-					double AddjMulti = atof(sd[16].c_str());
-					double AddjValue2 = atof(sd[17].c_str());
-					double AddjMulti2 = atof(sd[18].c_str());
-					int LastLevel = atoi(sd[19].c_str());
-					int CustomImage = atoi(sd[20].c_str());
+					double AddjValue = stod(sd[15]);
+					double AddjMulti = stod(sd[16]);
+					double AddjValue2 = stod(sd[17]);
+					double AddjMulti2 = stod(sd[18]);
+					int LastLevel = stoi(sd[19]);
+					int CustomImage = stoi(sd[20]);
 					std::string strParam1 = base64_encode(sd[21]);
 					std::string strParam2 = base64_encode(sd[22]);
-					int iProtected = atoi(sd[23].c_str());
+					int iProtected = stoi(sd[23]);
 
 					std::string Description = sd[27];
 					std::string sOptions = sd[28];
@@ -1522,14 +1522,14 @@ namespace http
 					// assume results are ordered such that same device is adjacent
 					// if the idx and the Type are equal (type to prevent matching against Scene with same idx)
 					std::string thisIdx = sd[0];
-					const int devIdx = atoi(thisIdx.c_str());
+					const int devIdx = stoi(thisIdx);
 
 					if ((ii > 0) && thisIdx == root["result"][ii - 1]["idx"].asString())
 					{
 						std::string typeOfThisOne = RFX_Type_Desc(dType, 1);
 						if (typeOfThisOne == root["result"][ii - 1]["Type"].asString())
 						{
-							root["result"][ii - 1]["PlanIDs"].append(atoi(sd[26].c_str()));
+							root["result"][ii - 1]["PlanIDs"].append(stoi(sd[26]));
 							continue;
 						}
 					}
@@ -1637,7 +1637,7 @@ namespace http
 							(dType == pTypeCURRENTENERGY) || (dType == pTypeENERGY) || (dType == pTypeRFXMeter) || (dType == pTypeAirQuality) || (dType == pTypeRFXSensor) ||
 							(dType == pTypeP1Power) || (dType == pTypeP1Gas))
 						{
-							root["result"][ii]["ID"] = is_number(sd[1]) ? std_format("%04X", (unsigned int)atoi(sd[1].c_str())) : sd[1];
+							root["result"][ii]["ID"] = is_number(sd[1]) ? std_format("%04X", (unsigned int) stoul(sd[1])) : sd[1];
 						}
 						else
 						{
@@ -1645,7 +1645,7 @@ namespace http
 						}
 					}
 
-					root["result"][ii]["Unit"] = atoi(sd[2].c_str());
+					root["result"][ii]["Unit"] = stoi(sd[2]);
 					root["result"][ii]["Type"] = RFX_Type_Desc(dType, 1);
 					root["result"][ii]["SubType"] = RFX_Type_SubType_Desc(dType, dSubType);
 					root["result"][ii]["TypeImg"] = RFX_Type_Desc(dType, 2);
@@ -1654,12 +1654,12 @@ namespace http
 					root["result"][ii]["Used"] = used;
 					root["result"][ii]["Favorite"] = favorite;
 
-					int iSignalLevel = atoi(sd[7].c_str());
+					int iSignalLevel = stoi(sd[7]);
 					if (iSignalLevel < 12)
 						root["result"][ii]["SignalLevel"] = iSignalLevel;
 					else
 						root["result"][ii]["SignalLevel"] = "-";
-					root["result"][ii]["BatteryLevel"] = atoi(sd[8].c_str());
+					root["result"][ii]["BatteryLevel"] = stoi(sd[8]);
 					root["result"][ii]["LastUpdate"] = sLastUpdate;
 
 					root["result"][ii]["CustomImage"] = CustomImage;
@@ -1683,7 +1683,7 @@ namespace http
 					root["result"][ii]["YOffset"] = sd[25].c_str();
 					root["result"][ii]["PlanID"] = sd[26].c_str();
 					Json::Value jsonArray;
-					jsonArray.append(atoi(sd[26].c_str()));
+					jsonArray.append(stoi(sd[26]));
 					root["result"][ii]["PlanIDs"] = jsonArray;
 					root["result"][ii]["AddjValue"] = AddjValue;
 					root["result"][ii]["AddjMulti"] = AddjMulti;
@@ -1784,7 +1784,7 @@ namespace http
 						else
 						{
 							root["result"][ii]["Level"] = llevel;
-							root["result"][ii]["LevelInt"] = atoi(sValue.c_str());
+							root["result"][ii]["LevelInt"] = stoi(sValue);
 						}
 						root["result"][ii]["HaveDimmer"] = bHaveDimmer;
 						std::string DimmerType = "none";
@@ -1795,10 +1795,10 @@ namespace http
 							{
 								// Milight V4/V5 bridges do not support absolute dimming for RGB or CW_WW lights
 								if (_hardwareNames[hardwareID].HardwareTypeVal == HTYPE_LimitlessLights &&
-									atoi(_hardwareNames[hardwareID].Mode2.c_str()) != CLimitLess::LBTYPE_V6 &&
-									(atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_RGB ||
-										atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_White ||
-										atoi(_hardwareNames[hardwareID].Mode1.c_str()) == sTypeColor_CW_WW))
+									stoi(_hardwareNames[hardwareID].Mode2) != CLimitLess::LBTYPE_V6 &&
+									(stoi(_hardwareNames[hardwareID].Mode1) == sTypeColor_RGB ||
+										stoi(_hardwareNames[hardwareID].Mode1) == sTypeColor_White ||
+										stoi(_hardwareNames[hardwareID].Mode1) == sTypeColor_CW_WW))
 								{
 									DimmerType = "rel";
 								}
@@ -2031,7 +2031,7 @@ namespace http
 								levelNames.assign("Off"); // default is Off only
 							}
 							root["result"][ii]["TypeImg"] = "Light";
-							root["result"][ii]["SelectorStyle"] = atoi(selectorStyle.c_str());
+							root["result"][ii]["SelectorStyle"] = stoi(selectorStyle);
 							root["result"][ii]["LevelOffHidden"] = (levelOffHidden == "true");
 							root["result"][ii]["LevelNames"] = base64_encode(levelNames);
 							root["result"][ii]["LevelActions"] = base64_encode(levelActions);
@@ -2119,11 +2119,11 @@ namespace http
 						{
 							root["result"][ii]["SwitchType"] = "TPI";
 							root["result"][ii]["Level"] = llevel;
-							root["result"][ii]["LevelInt"] = atoi(sValue.c_str());
+							root["result"][ii]["LevelInt"] = stoi(sValue);
 							if (root["result"][ii]["Unit"].asInt() > 100)
 								root["result"][ii]["Protected"] = true;
 
-							sprintf(szData, "%s: %d", lstatus.c_str(), atoi(sValue.c_str()));
+							sprintf(szData, "%s: %d", lstatus.c_str(), stoi(sValue));
 							root["result"][ii]["Data"] = szData;
 						}
 					}
@@ -2137,7 +2137,7 @@ namespace http
 						if (strarray.size() >= 3)
 						{
 							int i = 0;
-							double tempCelcius = atof(strarray[i++].c_str());
+							double tempCelcius = stod(strarray[i++]);
 							double temp = ConvertTemperature(tempCelcius, tempsign);
 							double tempSetPoint;
 							root["result"][ii]["Temp"] = temp;
@@ -2147,7 +2147,7 @@ namespace http
 							}
 							else
 							{
-								tempCelcius = atof(strarray[i++].c_str());
+								tempCelcius = stod(strarray[i++]);
 								tempSetPoint = ConvertTemperature(tempCelcius, tempsign);
 								root["result"][ii]["SetPoint"] = tempSetPoint;
 							}
@@ -2180,7 +2180,7 @@ namespace http
 					}
 					else if ((dType == pTypeTEMP) || (dType == pTypeRego6XXTemp))
 					{
-						double tvalue = ConvertTemperature(atof(sValue.c_str()), tempsign);
+						double tvalue = ConvertTemperature(stod(sValue), tempsign);
 						root["result"][ii]["Temp"] = tvalue;
 						sprintf(szData, "%.1f %c", tvalue, tempsign);
 						root["result"][ii]["Data"] = szData;
@@ -2200,7 +2200,7 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 4)
 						{
-							double tvalue = ConvertTemperature(atof(strarray[0].c_str()), tempsign);
+							double tvalue = ConvertTemperature(stod(strarray[0]), tempsign);
 							root["result"][ii]["Temp"] = tvalue;
 							sprintf(szData, "%.1f %c", tvalue, tempsign);
 							root["result"][ii]["Data"] = szData;
@@ -2209,7 +2209,7 @@ namespace http
 					}
 					else if ((dType == pTypeRFXSensor) && (dSubType == sTypeRFXSensorTemp))
 					{
-						double tvalue = ConvertTemperature(atof(sValue.c_str()), tempsign);
+						double tvalue = ConvertTemperature(stod(sValue), tempsign);
 						root["result"][ii]["Temp"] = tvalue;
 						sprintf(szData, "%.1f %c", tvalue, tempsign);
 						root["result"][ii]["Data"] = szData;
@@ -2226,7 +2226,7 @@ namespace http
 					else if (dType == pTypeHUM)
 					{
 						root["result"][ii]["Humidity"] = nValue;
-						root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc(atoi(sValue.c_str()));
+						root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc((unsigned char) stoi(sValue));
 						sprintf(szData, "Humidity %d %%", nValue);
 						root["result"][ii]["Data"] = szData;
 						root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -2237,14 +2237,14 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 3)
 						{
-							double tempCelcius = atof(strarray[0].c_str());
+							double tempCelcius = stod(strarray[0]);
 							double temp = ConvertTemperature(tempCelcius, tempsign);
-							double humidity = atoi(strarray[1].c_str());
+							double humidity = stod(strarray[1]);
 
 							root["result"][ii]["Temp"] = temp;
 							root["result"][ii]["Humidity"] = humidity;
-							root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc(atoi(strarray[2].c_str()));
-							sprintf(szData, "%.1f %c, %d %%", temp, tempsign, atoi(strarray[1].c_str()));
+							root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc(stoi(strarray[2]));
+							sprintf(szData, "%.1f %c, %d %%", temp, tempsign, stoi(strarray[1]));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
@@ -2268,35 +2268,35 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 5)
 						{
-							double tempCelcius = atof(strarray[0].c_str());
+							double tempCelcius = stod(strarray[0]);
 							double temp = ConvertTemperature(tempCelcius, tempsign);
-							double humidity = atof(strarray[1].c_str());
+							double humidity = stod(strarray[1]);
 
 							root["result"][ii]["Temp"] = temp;
 							root["result"][ii]["Humidity"] = humidity;
-							root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc(atoi(strarray[2].c_str()));
-							root["result"][ii]["Forecast"] = atoi(strarray[4].c_str());
+							root["result"][ii]["HumidityStatus"] = RFX_Humidity_Status_Desc((unsigned char) stoi(strarray[2]));
+							root["result"][ii]["Forecast"] = stoi(strarray[4]);
 
 							sprintf(szTmp, "%.2f", ConvertTemperature(CalculateDewPoint(tempCelcius, ground(humidity)), tempsign));
 							root["result"][ii]["DewPoint"] = szTmp;
 
 							if (dSubType == sTypeTHBFloat)
 							{
-								root["result"][ii]["Barometer"] = atof(strarray[3].c_str());
-								root["result"][ii]["ForecastStr"] = RFX_WSForecast_Desc(atoi(strarray[4].c_str()));
+								root["result"][ii]["Barometer"] = stof(strarray[3]);
+								root["result"][ii]["ForecastStr"] = RFX_WSForecast_Desc((unsigned char) stoi(strarray[4]));
 							}
 							else
 							{
-								root["result"][ii]["Barometer"] = atoi(strarray[3].c_str());
-								root["result"][ii]["ForecastStr"] = RFX_Forecast_Desc(atoi(strarray[4].c_str()));
+								root["result"][ii]["Barometer"] = stoi(strarray[3]);
+								root["result"][ii]["ForecastStr"] = RFX_Forecast_Desc((unsigned char) stoi(strarray[4]));
 							}
 							if (dSubType == sTypeTHBFloat)
 							{
-								sprintf(szData, "%.1f %c, %d %%, %.1f hPa", temp, tempsign, atoi(strarray[1].c_str()), atof(strarray[3].c_str()));
+								sprintf(szData, "%.1f %c, %d %%, %.1f hPa", temp, tempsign, stoi(strarray[1]), stof(strarray[3]));
 							}
 							else
 							{
-								sprintf(szData, "%.1f %c, %d %%, %d hPa", temp, tempsign, atoi(strarray[1].c_str()), atoi(strarray[3].c_str()));
+								sprintf(szData, "%.1f %c, %d %%, %d hPa", temp, tempsign, stoi(strarray[1]), stoi(strarray[3]));
 							}
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -2316,14 +2316,14 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() >= 3)
 						{
-							double tvalue = ConvertTemperature(atof(strarray[0].c_str()), tempsign);
+							double tvalue = ConvertTemperature(stod(strarray[0]), tempsign);
 							root["result"][ii]["Temp"] = tvalue;
-							int forecast = atoi(strarray[2].c_str());
+							int forecast = stoi(strarray[2]);
 							root["result"][ii]["Forecast"] = forecast;
 							root["result"][ii]["ForecastStr"] = BMP_Forecast_Desc(forecast);
-							root["result"][ii]["Barometer"] = atof(strarray[1].c_str());
+							root["result"][ii]["Barometer"] = stof(strarray[1]);
 
-							sprintf(szData, "%.1f %c, %.1f hPa", tvalue, tempsign, atof(strarray[1].c_str()));
+							sprintf(szData, "%.1f %c, %.1f hPa", tvalue, tempsign, stof(strarray[1]));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 
@@ -2342,11 +2342,11 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 2)
 						{
-							float UVI = static_cast<float>(atof(strarray[0].c_str()));
+							float UVI = stof(strarray[0]);
 							root["result"][ii]["UVI"] = strarray[0];
 							if (dSubType == sTypeUV3)
 							{
-								double tvalue = ConvertTemperature(atof(strarray[1].c_str()), tempsign);
+								double tvalue = ConvertTemperature(stod(strarray[1]), tempsign);
 
 								root["result"][ii]["Temp"] = tvalue;
 								sprintf(szData, "%.1f UVI, %.1f&deg; %c", UVI, tvalue, tempsign);
@@ -2373,12 +2373,12 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 6)
 						{
-							root["result"][ii]["Direction"] = atof(strarray[0].c_str());
+							root["result"][ii]["Direction"] = stof(strarray[0]);
 							root["result"][ii]["DirectionStr"] = strarray[1];
 
 							if (dSubType != sTypeWIND5)
 							{
-								int intSpeed = atoi(strarray[2].c_str());
+								int intSpeed = stoi(strarray[2]);
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -2393,7 +2393,7 @@ namespace http
 
 							// if (dSubType!=sTypeWIND6) //problem in RFXCOM firmware? gust=speed?
 							{
-								int intGust = atoi(strarray[3].c_str());
+								int intGust = stoi(strarray[3]);
 								if (m_sql.m_windunit != WINDUNIT_Beaufort)
 								{
 									sprintf(szTmp, "%.1f", float(intGust) * m_sql.m_windscale);
@@ -2409,10 +2409,10 @@ namespace http
 							{
 								if (dSubType == sTypeWIND4)
 								{
-									double tvalue = ConvertTemperature(atof(strarray[4].c_str()), tempsign);
+									double tvalue = ConvertTemperature(stod(strarray[4]), tempsign);
 									root["result"][ii]["Temp"] = tvalue;
 								}
-								double tvalue = ConvertTemperature(atof(strarray[5].c_str()), tempsign);
+								double tvalue = ConvertTemperature(stod(strarray[5]), tempsign);
 								root["result"][ii]["Chill"] = tvalue;
 
 								_tTrendCalculator::_eTendencyType tstate = _tTrendCalculator::_eTendencyType::TENDENCY_UNKNOWN;
@@ -2460,23 +2460,23 @@ namespace http
 
 								if (dSubType == sTypeRAINWU || dSubType == sTypeRAINByRate)
 								{
-									total_real = atof(sd2[0].c_str());
+									total_real = stod(sd2[0]);
 								}
 								else
 								{
-									double total_min = atof(sd2[0].c_str());
-									double total_max = atof(strarray[1].c_str());
+									double total_min = stod(sd2[0]);
+									double total_max = stod(strarray[1]);
 									total_real = total_max - total_min;
 								}
 
 								total_real *= AddjMulti;
 								if (dSubType == sTypeRAINByRate)
 								{
-									rate = static_cast<float>(atof(sd2[1].c_str()) / 10000.0F);
+									rate = stof(sd2[1]) / 10000.0F;
 								}
 								else
 								{
-									rate = (static_cast<float>(atof(strarray[0].c_str())) / 100.0F) * float(AddjMulti);
+									rate = stof(strarray[0]) * float(AddjMulti) / 100.0F;
 								}
 
 								sprintf(szTmp, "%.1f", total_real);
@@ -2520,8 +2520,8 @@ namespace http
 						{
 							std::vector<std::string> sd2 = result2[0];
 
-							int64_t total_first = std::stoll(sd2[0]);
-							int64_t total_last = std::stoll(sValue);
+							int64_t total_first = stoll(sd2[0]);
+							int64_t total_last = stoll(sValue);
 							int64_t total_real = total_last - total_first;
 
 							sprintf(szTmp, "%" PRId64, total_real);
@@ -2566,7 +2566,7 @@ namespace http
 
 						double meteroffset = AddjValue;
 
-						double dvalue = static_cast<double>(atof(sValue.c_str()));
+						double dvalue = stod(sValue);
 
 						switch (metertype)
 						{
@@ -2628,8 +2628,8 @@ namespace http
 						{
 							std::vector<std::string> sd2 = result2[0];
 
-							uint64_t total_min = std::stoull(sd2[0]);
-							uint64_t total_max = std::stoull(sd2[1]);
+							uint64_t total_min = stoull(sd2[0]);
+							uint64_t total_max = stoull(sd2[1]);
 							uint64_t total_real = total_max - total_min;
 
 							sprintf(szTmp, "%" PRIu64, total_real);
@@ -2670,7 +2670,7 @@ namespace http
 						if (splitresults.size() < 2)
 							continue;
 
-						uint64_t total_actual = std::stoull(splitresults[0]);
+						uint64_t total_actual = stoull(splitresults[0]);
 						musage = 0;
 						switch (metertype)
 						{
@@ -2695,7 +2695,7 @@ namespace http
 
 						root["result"][ii]["SwitchTypeVal"] = metertype;
 
-						uint64_t acounter = std::stoull(sValue);
+						uint64_t acounter = stoull(sValue);
 						musage = 0;
 						switch (metertype)
 						{
@@ -2777,12 +2777,12 @@ namespace http
 								EnergyDivider = float(tValue);
 							}
 
-							uint64_t powerusage1 = std::stoull(splitresults[0]);
-							uint64_t powerusage2 = std::stoull(splitresults[1]);
-							uint64_t powerdeliv1 = std::stoull(splitresults[2]);
-							uint64_t powerdeliv2 = std::stoull(splitresults[3]);
-							uint64_t usagecurrent = std::stoull(splitresults[4]);
-							uint64_t delivcurrent = std::stoull(splitresults[5]);
+							uint64_t powerusage1 = stoull(splitresults[0]);
+							uint64_t powerusage2 = stoull(splitresults[1]);
+							uint64_t powerdeliv1 = stoull(splitresults[2]);
+							uint64_t powerdeliv2 = stoull(splitresults[3]);
+							uint64_t usagecurrent = stoull(splitresults[4]);
+							uint64_t delivcurrent = stoull(splitresults[5]);
 
 							powerdeliv1 = (powerdeliv1 < 10) ? 0 : powerdeliv1;
 							powerdeliv2 = (powerdeliv2 < 10) ? 0 : powerdeliv2;
@@ -2829,10 +2829,10 @@ namespace http
 							{
 								std::vector<std::string> sd2 = result2[0];
 
-								uint64_t total_min_usage_1 = std::stoull(sd2[0]);
-								uint64_t total_min_deliv_1 = std::stoull(sd2[1]);
-								uint64_t total_min_usage_2 = std::stoull(sd2[2]);
-								uint64_t total_min_deliv_2 = std::stoull(sd2[3]);
+								uint64_t total_min_usage_1 = stoull(sd2[0]);
+								uint64_t total_min_deliv_1 = stoull(sd2[1]);
+								uint64_t total_min_usage_2 = stoull(sd2[2]);
+								uint64_t total_min_deliv_2 = stoull(sd2[3]);
 								uint64_t total_real_usage, total_real_deliv;
 
 								total_min_deliv_1 = (total_min_deliv_1 < 10) ? 0 : total_min_deliv_1;
@@ -2880,11 +2880,11 @@ namespace http
 						{
 							std::vector<std::string> sd2 = result2[0];
 
-							uint64_t total_min_gas = std::stoull(sd2[0]);
+							uint64_t total_min_gas = stoull(sd2[0]);
 							uint64_t gasactual;
 							try
 							{
-								gasactual = std::stoull(sValue);
+								gasactual = stoull(sValue);
 							}
 							catch (std::invalid_argument e)
 							{
@@ -2900,7 +2900,7 @@ namespace http
 							sprintf(szTmp, "%.03f m3", musage);
 							root["result"][ii]["CounterToday"] = szTmp;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							sprintf(szTmp, "%.03f", atof(sValue.c_str()) / divider);
+							sprintf(szTmp, "%.03f", stof(sValue) / divider);
 							root["result"][ii]["Data"] = szTmp;
 						}
 						else
@@ -2909,7 +2909,7 @@ namespace http
 							root["result"][ii]["Counter"] = szTmp;
 							sprintf(szTmp, "%.03f m3", 0.0F);
 							root["result"][ii]["CounterToday"] = szTmp;
-							sprintf(szTmp, "%.03f", atof(sValue.c_str()) / divider);
+							sprintf(szTmp, "%.03f", stof(sValue) / divider);
 							root["result"][ii]["Data"] = szTmp;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						}
@@ -2926,9 +2926,9 @@ namespace http
 							m_sql.GetPreferencesVar("CM113DisplayType", displaytype);
 							m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
-							double val1 = atof(strarray[0].c_str());
-							double val2 = atof(strarray[1].c_str());
-							double val3 = atof(strarray[2].c_str());
+							double val1 = stod(strarray[0]);
+							double val2 = stod(strarray[1]);
+							double val3 = stod(strarray[2]);
 
 							if (displaytype == 0)
 							{
@@ -2961,15 +2961,15 @@ namespace http
 							m_sql.GetPreferencesVar("CM113DisplayType", displaytype);
 							m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
-							double total = atof(strarray[3].c_str());
+							double total = stod(strarray[3]);
 							if (displaytype == 0)
 							{
-								sprintf(szData, "%.1f A, %.1f A, %.1f A", atof(strarray[0].c_str()), atof(strarray[1].c_str()), atof(strarray[2].c_str()));
+								sprintf(szData, "%.1f A, %.1f A, %.1f A", stof(strarray[0]), stof(strarray[1]), stof(strarray[2]));
 							}
 							else
 							{
-								sprintf(szData, "%d Watt, %d Watt, %d Watt", int(atof(strarray[0].c_str()) * voltage), int(atof(strarray[1].c_str()) * voltage),
-									int(atof(strarray[2].c_str()) * voltage));
+								sprintf(szData, "%d Watt, %d Watt, %d Watt", int(stof(strarray[0]) * voltage), int(stof(strarray[1]) * voltage),
+									int(stof(strarray[2]) * voltage));
 							}
 							if (total > 0)
 							{
@@ -2987,7 +2987,7 @@ namespace http
 						StringSplit(sValue, ";", strarray);
 						if (strarray.size() == 2)
 						{
-							double total = atof(strarray[1].c_str()) / 1000;
+							double total = stod(strarray[1]) / 1000;
 
 							time_t now = mytime(nullptr);
 							struct tm ltime;
@@ -3005,17 +3005,17 @@ namespace http
 								float divider = m_sql.GetCounterDivider(int(metertype), int(dType), float(AddjValue2));
 
 								std::vector<std::string> sd2 = result2[0];
-								double minimum = atof(sd2[0].c_str()) / divider;
+								double minimum = stod(sd2[0]) / divider;
 
 								sprintf(szData, "%.3f kWh", total);
 								root["result"][ii]["Data"] = szData;
 								if ((dType == pTypeENERGY) || (dType == pTypePOWER))
 								{
-									sprintf(szData, "%ld Watt", atol(strarray[0].c_str()));
+									sprintf(szData, "%ld Watt", stol(strarray[0]));
 								}
 								else
 								{
-									sprintf(szData, "%g Watt", atof(strarray[0].c_str()));
+									sprintf(szData, "%g Watt", stof(strarray[0]));
 								}
 								root["result"][ii]["Usage"] = szData;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -3028,11 +3028,11 @@ namespace http
 								root["result"][ii]["Data"] = szData;
 								if ((dType == pTypeENERGY) || (dType == pTypePOWER))
 								{
-									sprintf(szData, "%ld Watt", atol(strarray[0].c_str()));
+									sprintf(szData, "%ld Watt", stol(strarray[0]));
 								}
 								else
 								{
-									sprintf(szData, "%g Watt", atof(strarray[0].c_str()));
+									sprintf(szData, "%g Watt", stof(strarray[0]));
 								}
 								root["result"][ii]["Usage"] = szData;
 								root["result"][ii]["HaveTimeout"] = bHaveTimeout;
@@ -3074,11 +3074,11 @@ namespace http
 							std::string value_max = options["ValueMax"];
 							std::string value_unit = options["ValueUnit"];
 
-							double valuestep = (!value_step.empty()) ? atof(value_step.c_str()) : 0.5;
-							double valuemin = (!value_min.empty()) ? atof(value_min.c_str()) : -200.0;
-							double valuemax = (!value_max.empty()) ? atof(value_max.c_str()) : 200.0;
+							double valuestep = (!value_step.empty()) ? stod(value_step) : 0.5;
+							double valuemin = (!value_min.empty()) ? stod(value_min) : -200.0;
+							double valuemax = (!value_max.empty()) ? stod(value_max) : 200.0;
 
-							double value = atof(sValue.c_str());
+							double value = stod(sValue);
 
 							if (
 								(value_unit.empty())
@@ -3117,7 +3117,7 @@ namespace http
 						{
 							bHasTimers = m_sql.HasTimers(sd[0]);
 
-							double tempCelcius = atof(sValue.c_str());
+							double tempCelcius = stod(sValue);
 							double temp = ConvertTemperature(tempCelcius, tempsign);
 
 							sprintf(szTmp, "%.1f", temp);
@@ -3131,7 +3131,7 @@ namespace http
 					{
 						if (dSubType == sTypeVisibility)
 						{
-							float vis = static_cast<float>(atof(sValue.c_str()));
+							float vis = stof(sValue);
 							if (metertype == 0)
 							{
 								// km
@@ -3143,14 +3143,14 @@ namespace http
 								sprintf(szTmp, "%.1f mi", vis * 0.6214F);
 							}
 							root["result"][ii]["Data"] = szTmp;
-							root["result"][ii]["Visibility"] = atof(sValue.c_str());
+							root["result"][ii]["Visibility"] = stof(sValue);
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "visibility";
 							root["result"][ii]["SwitchTypeVal"] = metertype;
 						}
 						else if (dSubType == sTypeDistance)
 						{
-							float vis = static_cast<float>(atof(sValue.c_str()));
+							float vis = stof(sValue);
 							if (metertype == 0)
 							{
 								// Metric
@@ -3168,10 +3168,10 @@ namespace http
 						}
 						else if (dSubType == sTypeSolarRadiation)
 						{
-							float radiation = static_cast<float>(atof(sValue.c_str()));
+							float radiation = stof(sValue);
 							sprintf(szTmp, "%.1f Watt/m2", radiation);
 							root["result"][ii]["Data"] = szTmp;
-							root["result"][ii]["Radiation"] = atof(sValue.c_str());
+							root["result"][ii]["Radiation"] = stof(sValue);
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "radiation";
 							root["result"][ii]["SwitchTypeVal"] = metertype;
@@ -3195,7 +3195,7 @@ namespace http
 						}
 						else if (dSubType == sTypeSystemTemp)
 						{
-							double tvalue = ConvertTemperature(atof(sValue.c_str()), tempsign);
+							double tvalue = ConvertTemperature(stod(sValue), tempsign);
 							root["result"][ii]["Temp"] = tvalue;
 							sprintf(szData, "%.1f %c", tvalue, tempsign);
 							root["result"][ii]["Data"] = szData;
@@ -3214,14 +3214,14 @@ namespace http
 						}
 						else if (dSubType == sTypePercentage)
 						{
-							sprintf(szData, "%g%%", atof(sValue.c_str()));
+							sprintf(szData, "%g%%", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["TypeImg"] = "hardware";
 						}
 						else if (dSubType == sTypeWaterflow)
 						{
-							sprintf(szData, "%g l/min", atof(sValue.c_str()));
+							sprintf(szData, "%g l/min", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							if (!CustomImage)
@@ -3237,10 +3237,10 @@ namespace http
 
 							if (sResults.size() == 2)
 							{
-								SensorType = atoi(sResults[0].c_str());
+								SensorType = stoi(sResults[0]);
 								szAxesLabel = sResults[1];
 							}
-							sprintf(szData, "%g %s", atof(sValue.c_str()), szAxesLabel.c_str());
+							sprintf(szData, "%g %s", stof(sValue), szAxesLabel.c_str());
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["SensorType"] = SensorType;
 							root["result"][ii]["SensorUnit"] = szAxesLabel;
@@ -3252,7 +3252,7 @@ namespace http
 						}
 						else if (dSubType == sTypeFan)
 						{
-							sprintf(szData, "%d RPM", atoi(sValue.c_str()));
+							sprintf(szData, "%d RPM", stoi(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							if (!CustomImage)
@@ -3261,26 +3261,26 @@ namespace http
 						}
 						else if (dSubType == sTypeSoundLevel)
 						{
-							sprintf(szData, "%d dB", atoi(sValue.c_str()));
+							sprintf(szData, "%d dB", stoi(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "Speaker";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						}
 						else if (dSubType == sTypeVoltage)
 						{
-							sprintf(szData, "%g V", atof(sValue.c_str()));
+							sprintf(szData, "%g V", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "current";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Voltage"] = atof(sValue.c_str());
+							root["result"][ii]["Voltage"] = stof(sValue);
 						}
 						else if (dSubType == sTypeCurrent)
 						{
-							sprintf(szData, "%g A", atof(sValue.c_str()));
+							sprintf(szData, "%g A", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "current";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Current"] = atof(sValue.c_str());
+							root["result"][ii]["Current"] = stof(sValue);
 						}
 						else if (dSubType == sTypeTextStatus)
 						{
@@ -3305,11 +3305,11 @@ namespace http
 						}
 						else if (dSubType == sTypePressure)
 						{
-							sprintf(szData, "%.1f Bar", atof(sValue.c_str()));
+							sprintf(szData, "%.1f Bar", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "gauge";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
-							root["result"][ii]["Pressure"] = atof(sValue.c_str());
+							root["result"][ii]["Pressure"] = stof(sValue);
 						}
 						else if (dSubType == sTypeBaro)
 						{
@@ -3317,14 +3317,14 @@ namespace http
 							StringSplit(sValue, ";", tstrarray);
 							if (tstrarray.empty())
 								continue;
-							sprintf(szData, "%g hPa", atof(tstrarray[0].c_str()));
+							sprintf(szData, "%g hPa", stof(tstrarray[0]));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "gauge";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							if (tstrarray.size() > 1)
 							{
-								root["result"][ii]["Barometer"] = atof(tstrarray[0].c_str());
-								int forecast = atoi(tstrarray[1].c_str());
+								root["result"][ii]["Barometer"] = stof(tstrarray[0]);
+								int forecast = stoi(tstrarray[1]);
 								root["result"][ii]["Forecast"] = forecast;
 								root["result"][ii]["ForecastStr"] = BMP_Forecast_Desc(forecast);
 							}
@@ -3460,8 +3460,8 @@ namespace http
 							{
 								std::vector<std::string> sd2 = result2[0];
 
-								int64_t total_first = std::stoll(sd2[0]);
-								int64_t total_last = std::stoll(sValue);
+								int64_t total_first = stoll(sd2[0]);
+								int64_t total_last = stoll(sValue);
 								int64_t total_real = total_last - total_first;
 
 								double musage = 0;
@@ -3502,7 +3502,7 @@ namespace http
 							root["result"][ii]["ValueUnits"] = ValueUnits;
 							root["result"][ii]["Divider"] = divider;
 
-							double dvalue = static_cast<double>(atof(sValue.c_str()));
+							double dvalue = stod(sValue);
 							double meteroffset = AddjValue;
 
 							switch (metertype)
@@ -3555,14 +3555,14 @@ namespace http
 							double dvalue;
 							if (splitresults.size() < 2)
 							{
-								dvalue = static_cast<double>(atof(sValue.c_str()));
+								dvalue = stod(sValue);
 							}
 							else
 							{
-								dvalue = static_cast<double>(atof(splitresults[1].c_str()));
+								dvalue = stod(splitresults[1]);
 								if (dvalue < 0.0)
 								{
-									dvalue = static_cast<double>(atof(splitresults[0].c_str()));
+									dvalue = stod(splitresults[0]);
 								}
 							}
 							root["result"][ii]["SwitchTypeVal"] = metertype;
@@ -3611,13 +3611,13 @@ namespace http
 					}
 					else if (dType == pTypeLux)
 					{
-						sprintf(szTmp, "%.0f Lux", atof(sValue.c_str()));
+						sprintf(szTmp, "%.0f Lux", stof(sValue));
 						root["result"][ii]["Data"] = szTmp;
 						root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 					}
 					else if (dType == pTypeWEIGHT)
 					{
-						sprintf(szTmp, "%g %s", m_sql.m_weightscale * atof(sValue.c_str()), m_sql.m_weightsign.c_str());
+						sprintf(szTmp, "%g %s", m_sql.m_weightscale * stof(sValue), m_sql.m_weightsign.c_str());
 						root["result"][ii]["Data"] = szTmp;
 						root["result"][ii]["HaveTimeout"] = false;
 						root["result"][ii]["SwitchTypeVal"] = (m_sql.m_weightsign == "kg") ? 0 : 1;
@@ -3626,7 +3626,7 @@ namespace http
 					{
 						if (dSubType == sTypeElectric)
 						{
-							sprintf(szData, "%g Watt", atof(sValue.c_str()));
+							sprintf(szData, "%g Watt", stof(sValue));
 							root["result"][ii]["Data"] = szData;
 						}
 						else
@@ -3640,11 +3640,11 @@ namespace http
 						switch (dSubType)
 						{
 						case sTypeRFXSensorAD:
-							sprintf(szData, "%d mV", atoi(sValue.c_str()));
+							sprintf(szData, "%d mV", stoi(sValue));
 							root["result"][ii]["TypeImg"] = "current";
 							break;
 						case sTypeRFXSensorVolt:
-							sprintf(szData, "%d mV", atoi(sValue.c_str()));
+							sprintf(szData, "%d mV", stoi(sValue));
 							root["result"][ii]["TypeImg"] = "current";
 							break;
 						}
@@ -3659,7 +3659,7 @@ namespace http
 						{
 							std::string lstatus = "On";
 
-							if (atoi(sValue.c_str()) == 0)
+							if (stoi(sValue) == 0)
 							{
 								lstatus = "Off";
 							}
@@ -3669,7 +3669,7 @@ namespace http
 							root["result"][ii]["HaveGroupCmd"] = false;
 							root["result"][ii]["SwitchTypeVal"] = STYPE_OnOff;
 							root["result"][ii]["SwitchType"] = Switch_Type_Desc(STYPE_OnOff);
-							sprintf(szData, "%d", atoi(sValue.c_str()));
+							sprintf(szData, "%d", stoi(sValue));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 							root["result"][ii]["StrParam1"] = strParam1;
@@ -3691,7 +3691,7 @@ namespace http
 							}
 
 							root["result"][ii]["Level"] = 0;
-							root["result"][ii]["LevelInt"] = atoi(sValue.c_str());
+							root["result"][ii]["LevelInt"] = stoi(sValue);
 						}
 						break;
 						case sTypeRego6XXCounter:
@@ -3710,8 +3710,8 @@ namespace http
 							{
 								std::vector<std::string> sd2 = result2[0];
 
-								uint64_t total_min = std::stoull(sd2[0]);
-								uint64_t total_max = std::stoull(sd2[1]);
+								uint64_t total_min = stoull(sd2[0]);
+								uint64_t total_max = stoull(sd2[1]);
 								uint64_t total_real = total_max - total_min;
 
 								sprintf(szTmp, "%" PRIu64, total_real);
@@ -3731,7 +3731,7 @@ namespace http
 						if (pHardware->HwdType == HTYPE_PythonPlugin)
 						{
 							Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)pHardware;
-							bHaveTimeout = pPlugin->HasNodeFailed(sd[1].c_str(), atoi(sd[2].c_str()));
+							bHaveTimeout = pPlugin->HasNodeFailed(sd[1].c_str(), stoi(sd[2]));
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;
 						}
 					}
@@ -3775,10 +3775,9 @@ namespace http
 
 			for (const auto& sd : result)
 			{
-				const int year = atoi(sd[0].c_str());
-				const double value = atof(sd[2].c_str());
-
-				const int previousIndex = sgroupby == "year" ? 0 : sgroupby == "quarter" ? sd[1][1] - '0' - 1 : atoi(sd[1].c_str()) - 1;
+				const int year = stoi(sd[0]);
+				const double value = stod(sd[2]);
+				const int previousIndex = sgroupby == "year" ? 0 : sgroupby == "quarter" ? sd[1][1] - '0' - 1 : stoi(sd[1]) - 1;
 				const double* sumPrevious = year - 1 != yearPrevious[previousIndex] ? NULL : &yearSumPrevious[previousIndex];
 				const char* trend = !sumPrevious ? "" : *sumPrevious < value ? "up" : *sumPrevious > value ? "down" : "equal";
 				const int ii = root["result"].size();
@@ -3825,7 +3824,7 @@ namespace http
 			{
 				queryString = "select count(*) from " + dbasetable + " where DeviceRowID = " + std::to_string(idx) + " and " + counter("") + " != 0 ";
 				result = m_sql.safe_query(queryString.c_str(), idx, idx, idx, idx, idx);
-				if (atoi(result[0][0].c_str()) == 0)
+				if (stoi(result[0][0]) == 0)
 				{
 					bUseValues = true;
 				}
@@ -3920,9 +3919,9 @@ namespace http
 				int yearPrevious[12];
 				for (const auto& sd : result)
 				{
-					const int year = atoi(sd[0].c_str());
-					const double fsum = atof(sd[1].c_str());
-					const int previousIndex = sgroupby == "year" ? 0 : sgroupby == "quarter" ? sd[2][1] - '0' - 1 : atoi(sd[2].c_str()) - 1;
+					const int year = stoi(sd[0]);
+					const double fsum = stod(sd[1]);
+					const int previousIndex = sgroupby == "year" ? 0 : sgroupby == "quarter" ? sd[2][1] - '0' - 1 : stoi(sd[2]) - 1;
 					const double* sumPrevious = year - 1 != yearPrevious[previousIndex] ? NULL : &yearSumPrevious[previousIndex];
 					const char* trend = !sumPrevious ? "" : *sumPrevious < fsum ? "up" : *sumPrevious > fsum ? "down" : "equal";
 					const int ii = root["result"].size();
@@ -3951,7 +3950,7 @@ namespace http
 			std::string todayCategory;
 			if (sgroupby == "quarter")
 			{
-				int todayMonth = atoi(today.substr(5, 2).c_str());
+				int todayMonth = stoi(today.substr(5, 2));
 				if (todayMonth < 4)
 					todayCategory = "Q1";
 				else if (todayMonth < 7)
@@ -3989,7 +3988,7 @@ namespace http
 			}
 			else
 			{
-				resultPlusTodayValue = atof(root["result"][todayResultIndex]["s"].asString().c_str()) + todayValue;
+				resultPlusTodayValue = stod(root["result"][todayResultIndex]["s"].asString()) + todayValue;
 			}
 			char szTmp[30];
 			sprintf(szTmp, formatString.c_str(), resultPlusTodayValue);
@@ -4042,7 +4041,7 @@ namespace http
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					int ID = atoi(sd[0].c_str());
+					int ID = stoi(sd[0]);
 
 					_tCustomIcon cImage;
 					cImage.idx = 100 + ID;
@@ -4295,7 +4294,7 @@ namespace http
 				return;
 			}
 			std::vector<std::vector<std::string>> result;
-			result = m_sql.safe_queryBlob("SELECT Image FROM Floorplans WHERE ID=%d", atol(idx.c_str()));
+			result = m_sql.safe_queryBlob("SELECT Image FROM Floorplans WHERE ID=%d", stol(idx));
 			if (result.empty())
 				return;
 			reply::set_content(&rep, result[0][0].begin(), result[0][0].end());

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -2968,8 +2968,7 @@ namespace http
 							}
 							else
 							{
-								sprintf(szData, "%d Watt, %d Watt, %d Watt", int(stof(strarray[0]) * voltage), int(stof(strarray[1]) * voltage),
-									int(stof(strarray[2]) * voltage));
+								sprintf(szData, "%d Watt, %d Watt, %d Watt", int(stof(strarray[0]) * voltage), int(stof(strarray[1]) * voltage), int(stof(strarray[2]) * voltage));
 							}
 							if (total > 0)
 							{

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -1678,7 +1678,7 @@ namespace http
 			}
 			if (m_sql.GetPreferencesVar("DegreeDaysBaseTemperature", sValue))
 			{
-				root["DegreeDaysBaseTemperature"] = stof(sValue);
+				root["DegreeDaysBaseTemperature"] = stod(sValue);
 			}
 			m_sql.GetPreferencesVar("DashboardType", iDashboardType);
 			root["DashboardType"] = iDashboardType;

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -341,12 +341,12 @@ namespace http
 									const std::string &smode1, const std::string &smode2, const std::string &smode3, const std::string &smode4, const std::string &smode5, const std::string &smode6,
 									const std::string &extra, const std::string idx = "")
 		{
-			int mode1 = !smode1.empty() ? atoi(smode1.c_str()) : -1;
-			int mode2 = !smode2.empty() ? atoi(smode2.c_str()) : -1;
-			int mode3 = !smode3.empty() ? atoi(smode3.c_str()) : -1;
-			int mode4 = !smode4.empty() ? atoi(smode4.c_str()) : -1;
-			int mode5 = !smode5.empty() ? atoi(smode5.c_str()) : -1;
-			int mode6 = !smode6.empty() ? atoi(smode6.c_str()) : -1;
+			int mode1 = !smode1.empty() ? stoi(smode1) : -1;
+			int mode2 = !smode2.empty() ? stoi(smode2) : -1;
+			int mode3 = !smode3.empty() ? stoi(smode3) : -1;
+			int mode4 = !smode4.empty() ? stoi(smode4) : -1;
+			int mode5 = !smode5.empty() ? stoi(smode5) : -1;
+			int mode6 = !smode6.empty() ? stoi(smode6) : -1;
 
 			if (htype == HTYPE_DomoticzInternal)
 			{
@@ -477,48 +477,48 @@ namespace http
 			std::string sdatatimeout = request::findValue(&req, "datatimeout");
 			if ((name.empty()) || (senabled.empty()) || (shtype.empty()))
 				return;
-			_eHardwareTypes htype = (_eHardwareTypes)atoi(shtype.c_str());
+			_eHardwareTypes htype = (_eHardwareTypes) stoi(shtype);
 
 			stdstring_trim(username);
 			stdstring_trim(password);
-			int iDataTimeout = atoi(sdatatimeout.c_str());
+			int iDataTimeout = stoi(sdatatimeout);
 			int mode1 = 0;
 			int mode2 = 0;
 			int mode3 = 0;
 			int mode4 = 0;
 			int mode5 = 0;
 			int mode6 = 0;
-			int port = atoi(sport.c_str());
-			uint32_t iLogLevelEnabled = (uint32_t)atoi(loglevel.c_str());
+			int port = stoi(sport);
+			uint32_t iLogLevelEnabled = (uint32_t) stoul(loglevel);
 			std::string mode1Str = request::findValue(&req, "Mode1");
 			if (!mode1Str.empty())
 			{
-				mode1 = atoi(mode1Str.c_str());
+				mode1 = stoi(mode1Str);
 			}
 			std::string mode2Str = request::findValue(&req, "Mode2");
 			if (!mode2Str.empty())
 			{
-				mode2 = atoi(mode2Str.c_str());
+				mode2 = stoi(mode2Str);
 			}
 			std::string mode3Str = request::findValue(&req, "Mode3");
 			if (!mode3Str.empty())
 			{
-				mode3 = atoi(mode3Str.c_str());
+				mode3 = stoi(mode3Str);
 			}
 			std::string mode4Str = request::findValue(&req, "Mode4");
 			if (!mode4Str.empty())
 			{
-				mode4 = atoi(mode4Str.c_str());
+				mode4 = stoi(mode4Str);
 			}
 			std::string mode5Str = request::findValue(&req, "Mode5");
 			if (!mode5Str.empty())
 			{
-				mode5 = atoi(mode5Str.c_str());
+				mode5 = stoi(mode5Str);
 			}
 			std::string mode6Str = request::findValue(&req, "Mode6");
 			if (!mode6Str.empty())
 			{
-				mode6 = atoi(mode6Str.c_str());
+				mode6 = stoi(mode6Str);
 			}
 
 			if (!ValidateHardware(htype, sport, address, port, username, password, mode1Str, mode2Str, mode3Str, mode4Str, mode5Str, mode6Str, extra))
@@ -608,7 +608,7 @@ namespace http
 			if (!result.empty())
 			{
 				std::vector<std::string> sd = result[0];
-				int ID = atoi(sd[0].c_str());
+				int ID = stoi(sd[0]);
 
 				root["idx"] = sd[0].c_str(); // OTO output the created ID for easier management on the caller side (if automated)
 
@@ -652,20 +652,20 @@ namespace http
 			std::string mode5Str = request::findValue(&req, "Mode5");
 			std::string mode6Str = request::findValue(&req, "Mode6");
 
-			int mode1 = atoi(mode1Str.c_str());
-			int mode2 = atoi(mode2Str.c_str());
-			int mode3 = atoi(mode3Str.c_str());
-			int mode4 = atoi(mode4Str.c_str());
-			int mode5 = atoi(mode5Str.c_str());
-			int mode6 = atoi(mode6Str.c_str());
+			int mode1 = stoi(mode1Str);
+			int mode2 = stoi(mode2Str);
+			int mode3 = stoi(mode3Str);
+			int mode4 = stoi(mode4Str);
+			int mode5 = stoi(mode5Str);
+			int mode6 = stoi(mode6Str);
 
 			bool bEnabled = (senabled == "true") ? true : false;
 
-			_eHardwareTypes htype = (_eHardwareTypes)atoi(shtype.c_str());
-			int iDataTimeout = atoi(sdatatimeout.c_str());
+			_eHardwareTypes htype = (_eHardwareTypes) stoi(shtype);
+			int iDataTimeout = stoi(sdatatimeout);
 
-			int port = atoi(sport.c_str());
-			uint32_t iLogLevelEnabled = (uint32_t)atoi(loglevel.c_str());
+			int port = stoi(sport);
+			uint32_t iLogLevelEnabled = (uint32_t) stoul(loglevel);
 
 			bool bIsSerial = false;
 
@@ -728,7 +728,7 @@ namespace http
 			}
 
 			// re-add the device in our system
-			int ID = atoi(idx.c_str());
+			int ID = stoi(idx);
 			m_mainworker.AddHardwareFromParams(ID, name, bEnabled, htype, iLogLevelEnabled, address, port, sport, username, password, extra, mode1, mode2, mode3, mode4, mode5, mode6,
 				iDataTimeout, true);
 		}
@@ -747,8 +747,8 @@ namespace http
 			devresult = m_sql.safe_query("SELECT Type, SubType FROM DeviceStatus WHERE (ID=='%q')", idx.c_str());
 			if (!devresult.empty())
 			{
-				int devType = std::stoi(devresult[0][0]);
-				int devSubType = std::stoi(devresult[0][1]);
+				int devType = stoi(devresult[0][0]);
+				int devSubType = stoi(devresult[0][1]);
 				std::vector<std::string> result;
 				result = CBasePush::DropdownOptions(devType, devSubType);
 				int ii = 0;
@@ -779,9 +779,9 @@ namespace http
 			devresult = m_sql.safe_query("SELECT Type, SubType FROM DeviceStatus WHERE (ID=='%q')", idx.c_str());
 			if (!devresult.empty())
 			{
-				int devType = std::stoi(devresult[0][0]);
-				int devSubType = std::stoi(devresult[0][1]);
-				wording = CBasePush::DropdownOptionsValue(devType, devSubType, std::stoi(pos));
+				int devType = stoi(devresult[0][0]);
+				int devSubType = stoi(devresult[0][1]);
+				wording = CBasePush::DropdownOptionsValue(devType, devSubType, stoi(pos));
 			}
 			root["wording"] = wording;
 			root["status"] = "OK";
@@ -832,7 +832,7 @@ namespace http
 			}
 
 			std::string errorMessage;
-			if (!m_sql.AddUserVariable(variablename, (const _eUsrVariableType)atoi(variabletype.c_str()), variablevalue, errorMessage))
+			if (!m_sql.AddUserVariable(variablename, (const _eUsrVariableType) stoi(variabletype), variablevalue, errorMessage))
 			{
 				root["message"] = errorMessage;
 			}
@@ -930,7 +930,7 @@ namespace http
 				bTypeNameChanged = true; // new type
 
 			std::string errorMessage;
-			if (!m_sql.UpdateUserVariable(idx, variablename, (const _eUsrVariableType)atoi(variabletype.c_str()), variablevalue, !bTypeNameChanged, errorMessage))
+			if (!m_sql.UpdateUserVariable(idx, variablename, (const _eUsrVariableType) stoi(variabletype), variablevalue, !bTypeNameChanged, errorMessage))
 			{
 				root["message"] = errorMessage;
 			}
@@ -969,7 +969,7 @@ namespace http
 			if (idx.empty())
 				return;
 
-			int iVarID = atoi(idx.c_str());
+			int iVarID = stoi(idx);
 
 			std::vector<std::vector<std::string>> result;
 			result = m_sql.safe_query("SELECT ID, Name, ValueType, Value, LastUpdate FROM UserVariables WHERE (ID==%d)", iVarID);
@@ -1000,7 +1000,7 @@ namespace http
 			root["status"] = "OK";
 			root["title"] = "AllowNewHardware";
 
-			m_sql.AllowNewHardwareTimer(atoi(sTimeout.c_str()));
+			m_sql.AllowNewHardwareTimer(stoi(sTimeout));
 		}
 
 		void CWebServer::Cmd_DeleteHardware(WebEmSession& session, const request& req, Json::Value& root)
@@ -1014,7 +1014,7 @@ namespace http
 			std::string idx = request::findValue(&req, "idx");
 			if (idx.empty())
 				return;
-			int hwID = atoi(idx.c_str());
+			int hwID = stoi(idx);
 
 			CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(hwID);
 			if ((pBaseHardware != nullptr) && (pBaseHardware->HwdType == HTYPE_DomoticzInternal))
@@ -1047,7 +1047,7 @@ namespace http
 			std::string sloglevel = request::findValue(&req, "loglevel");
 			if (!sloglevel.empty())
 			{
-				lLevel = (_eLogLevel)atoi(sloglevel.c_str());
+				lLevel = (_eLogLevel) stoi(sloglevel);
 			}
 
 			std::list<CLogger::_tLogLineStruct> logmessages = _log.GetLog(lLevel);
@@ -1096,7 +1096,7 @@ namespace http
 			if (!result.empty())
 			{
 				std::vector<std::string> sd = result[0];
-				int ID = atoi(sd[0].c_str());
+				int ID = stoi(sd[0]);
 
 				root["idx"] = ID; // OTO output the created ID for easier management on the caller side (if automated)
 			}
@@ -1154,7 +1154,7 @@ namespace http
 				|| sactplan.empty()
 				)
 				return;
-			const int iActPlan = atoi(sactplan.c_str());
+			const int iActPlan = stoi(sactplan);
 			const bool iUnique = (sunique == "true") ? true : false;
 			int ii = 0;
 
@@ -1174,8 +1174,8 @@ namespace http
 					}
 					if (bDoAdd)
 					{
-						int _dtype = atoi(sd[2].c_str());
-						std::string Name = "[" + sd[4] + "] " + sd[1] + " (" + RFX_Type_Desc(_dtype, 1) + "/" + RFX_Type_SubType_Desc(_dtype, atoi(sd[3].c_str())) + ")";
+						int _dtype = stoi(sd[2]);
+						std::string Name = "[" + sd[4] + "] " + sd[1] + " (" + RFX_Type_Desc(_dtype, 1) + "/" + RFX_Type_SubType_Desc(_dtype, (unsigned char) stoi(sd[3])) + ")";
 						root["result"][ii]["type"] = 0;
 						root["result"][ii]["idx"] = sd[0];
 						root["result"][ii]["Name"] = Name;
@@ -1223,7 +1223,7 @@ namespace http
 			root["status"] = "OK";
 			root["title"] = "AddPlanActiveDevice";
 
-			int activetype = atoi(sactivetype.c_str());
+			int activetype = stoi(sactivetype);
 
 			// check if it is not already there
 			std::vector<std::vector<std::string>> result;
@@ -1250,7 +1250,7 @@ namespace http
 				for (const auto& sd : result)
 				{
 					std::string ID = sd[0];
-					int DevSceneType = atoi(sd[1].c_str());
+					int DevSceneType = stoi(sd[1]);
 					std::string DevSceneRowID = sd[2];
 
 					std::string Name;
@@ -1678,7 +1678,7 @@ namespace http
 			}
 			if (m_sql.GetPreferencesVar("DegreeDaysBaseTemperature", sValue))
 			{
-				root["DegreeDaysBaseTemperature"] = atof(sValue.c_str());
+				root["DegreeDaysBaseTemperature"] = stof(sValue);
 			}
 			m_sql.GetPreferencesVar("DashboardType", iDashboardType);
 			root["DashboardType"] = iDashboardType;
@@ -1719,7 +1719,7 @@ namespace http
 				result = m_sql.safe_query("SELECT TabsEnabled FROM Users WHERE (ID==%lu)", UserID);
 				if (!result.empty())
 				{
-					int TabsEnabled = atoi(result[0][0].c_str());
+					int TabsEnabled = stoi(result[0][0]);
 					bEnableTabLight = (TabsEnabled & (1 << 0));
 					bEnableTabScenes = (TabsEnabled & (1 << 1));
 					bEnableTabTemp = (TabsEnabled & (1 << 2));
@@ -1976,7 +1976,7 @@ namespace http
 
 			std::string idx = request::findValue(&req, "idx");
 
-			if (!IsIdxForUser(&session, atoi(idx.c_str())))
+			if (!IsIdxForUser(&session, stoi(idx)))
 			{
 				_log.Log(LOG_ERROR, "User: %s tried to update an Unauthorized device!", session.username.c_str());
 				session.reply_status = reply::forbidden;
@@ -2025,26 +2025,26 @@ namespace http
 				dsubtype = result[0][5];
 			}
 
-			int HardwareID = atoi(hid.c_str());
-			int OrgHardwareID = atoi(ohid.c_str());
+			int HardwareID = stoi(hid);
+			int OrgHardwareID = stoi(ohid);
 			std::string DeviceID = did;
-			int unit = atoi(dunit.c_str());
-			int devType = atoi(dtype.c_str());
-			int subType = atoi(dsubtype.c_str());
+			int unit = stoi(dunit);
+			int devType = stoi(dtype);
+			int subType = stoi(dsubtype);
 
-			// uint64_t ulIdx = std::stoull(idx);
+			// uint64_t ulIdx = stoull(idx);
 
-			int invalue = atoi(nvalue.c_str());
+			int invalue = stoi(nvalue);
 
 			std::string sSignalLevel = request::findValue(&req, "rssi");
 			if (!sSignalLevel.empty())
 			{
-				signallevel = atoi(sSignalLevel.c_str());
+				signallevel = stoi(sSignalLevel);
 			}
 			std::string sBatteryLevel = request::findValue(&req, "battery");
 			if (!sBatteryLevel.empty())
 			{
-				batterylevel = atoi(sBatteryLevel.c_str());
+				batterylevel = stoi(sBatteryLevel);
 			}
 			std::string szUpdateUser = Username + " (IP: " + session.remote_host + ")";
 			if (m_mainworker.UpdateDevice(HardwareID, OrgHardwareID, DeviceID, unit, devType, subType, invalue, svalue, szUpdateUser, signallevel, batterylevel, parseTrigger))
@@ -2116,7 +2116,7 @@ namespace http
 
 			if ((idx.empty()) || (sstate.empty()))
 				return;
-			int iState = atoi(sstate.c_str());
+			int iState = stoi(sstate);
 
 			int urights = 3;
 			bool bHaveUser = (!session.username.empty());
@@ -2300,9 +2300,9 @@ namespace http
 				root["title"] = "GetCosts";
 
 				std::vector<std::string> sd = result[0];
-				unsigned char dType = atoi(sd[0].c_str());
-				// unsigned char subType = atoi(sd[1].c_str());
-				// nValue = (unsigned char)atoi(sd[2].c_str());
+				unsigned char dType = (unsigned char) stoi(sd[0]);
+				// unsigned char subType = (unsigned char) stoi(sd[1]);
+				// nValue = (unsigned char) stoi(sd[2]);
 				std::string sValue = sd[3];
 
 				if (dType == pTypeP1Power)
@@ -2314,12 +2314,12 @@ namespace http
 					if (splitresults.size() != 6)
 						return;
 
-					uint64_t powerusage1 = std::stoull(splitresults[0]);
-					uint64_t powerusage2 = std::stoull(splitresults[1]);
-					uint64_t powerdeliv1 = std::stoull(splitresults[2]);
-					uint64_t powerdeliv2 = std::stoull(splitresults[3]);
-					// uint64_t usagecurrent = std::stoull(splitresults[4]);
-					// uint64_t delivcurrent = std::stoull(splitresults[5]);
+					uint64_t powerusage1 = stoull(splitresults[0]);
+					uint64_t powerusage2 = stoull(splitresults[1]);
+					uint64_t powerdeliv1 = stoull(splitresults[2]);
+					uint64_t powerdeliv2 = stoull(splitresults[3]);
+					// uint64_t usagecurrent = stoull(splitresults[4]);
+					// uint64_t delivcurrent = stoull(splitresults[5]);
 
 					powerdeliv1 = (powerdeliv1 < 10) ? 0 : powerdeliv1;
 					powerdeliv2 = (powerdeliv2 < 10) ? 0 : powerdeliv2;
@@ -2448,22 +2448,22 @@ namespace http
 				/* Start processing the simple ones */
 				/* -------------------------------- */
 
-				m_sql.UpdatePreferencesVar("DashboardType", atoi(request::findValue(&req, "DashboardType").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("MobileType", atoi(request::findValue(&req, "MobileType").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("ReleaseChannel", atoi(request::findValue(&req, "ReleaseChannel").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("LightHistoryDays", atoi(request::findValue(&req, "LightHistoryDays").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("5MinuteHistoryDays", atoi(request::findValue(&req, "ShortLogDays").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("ElectricVoltage", atoi(request::findValue(&req, "ElectricVoltage").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("CM113DisplayType", atoi(request::findValue(&req, "CM113DisplayType").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("MaxElectricPower", atoi(request::findValue(&req, "MaxElectricPower").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("DoorbellCommand", atoi(request::findValue(&req, "DoorbellCommand").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("SmartMeterType", atoi(request::findValue(&req, "SmartMeterType").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("SecOnDelay", atoi(request::findValue(&req, "SecOnDelay").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("FloorplanPopupDelay", atoi(request::findValue(&req, "FloorplanPopupDelay").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("FloorplanActiveOpacity", atoi(request::findValue(&req, "FloorplanActiveOpacity").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("FloorplanInactiveOpacity", atoi(request::findValue(&req, "FloorplanInactiveOpacity").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("OneWireSensorPollPeriod", atoi(request::findValue(&req, "OneWireSensorPollPeriod").c_str())); cntSettings++;
-				m_sql.UpdatePreferencesVar("OneWireSwitchPollPeriod", atoi(request::findValue(&req, "OneWireSwitchPollPeriod").c_str())); cntSettings++;
+				m_sql.UpdatePreferencesVar("DashboardType", stoi(request::findValue(&req, "DashboardType"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("MobileType", stoi(request::findValue(&req, "MobileType"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("ReleaseChannel", stoi(request::findValue(&req, "ReleaseChannel"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("LightHistoryDays", stoi(request::findValue(&req, "LightHistoryDays"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("5MinuteHistoryDays", stoi(request::findValue(&req, "ShortLogDays"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("ElectricVoltage", stoi(request::findValue(&req, "ElectricVoltage"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("CM113DisplayType", stoi(request::findValue(&req, "CM113DisplayType"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("MaxElectricPower", stoi(request::findValue(&req, "MaxElectricPower"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("DoorbellCommand", stoi(request::findValue(&req, "DoorbellCommand"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("SmartMeterType", stoi(request::findValue(&req, "SmartMeterType"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("SecOnDelay", stoi(request::findValue(&req, "SecOnDelay"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("FloorplanPopupDelay", stoi(request::findValue(&req, "FloorplanPopupDelay"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("FloorplanActiveOpacity", stoi(request::findValue(&req, "FloorplanActiveOpacity"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("FloorplanInactiveOpacity", stoi(request::findValue(&req, "FloorplanInactiveOpacity"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("OneWireSensorPollPeriod", stoi(request::findValue(&req, "OneWireSensorPollPeriod"))); cntSettings++;
+				m_sql.UpdatePreferencesVar("OneWireSwitchPollPeriod", stoi(request::findValue(&req, "OneWireSwitchPollPeriod"))); cntSettings++;
 
 				m_sql.UpdatePreferencesVar("UseAutoUpdate", (request::findValue(&req, "checkforupdates") == "on" ? 1 : 0)); cntSettings++;
 				m_sql.UpdatePreferencesVar("UseAutoBackup", (request::findValue(&req, "enableautobackup") == "on" ? 1 : 0)); cntSettings++;
@@ -2487,33 +2487,33 @@ namespace http
 				/* More complex ones that need additional processing */
 				/* ------------------------------------------------- */
 
-				float CostEnergy = static_cast<float>(atof(request::findValue(&req, "CostEnergy").c_str()));
+				float CostEnergy = stof(request::findValue(&req, "CostEnergy"));
 				m_sql.UpdatePreferencesVar("CostEnergy", int(CostEnergy * 10000.0F)); cntSettings++;
-				float CostEnergyT2 = static_cast<float>(atof(request::findValue(&req, "CostEnergyT2").c_str()));
+				float CostEnergyT2 = stof(request::findValue(&req, "CostEnergyT2"));
 				m_sql.UpdatePreferencesVar("CostEnergyT2", int(CostEnergyT2 * 10000.0F)); cntSettings++;
-				float CostEnergyR1 = static_cast<float>(atof(request::findValue(&req, "CostEnergyR1").c_str()));
+				float CostEnergyR1 = stof(request::findValue(&req, "CostEnergyR1"));
 				m_sql.UpdatePreferencesVar("CostEnergyR1", int(CostEnergyR1 * 10000.0F)); cntSettings++;
-				float CostEnergyR2 = static_cast<float>(atof(request::findValue(&req, "CostEnergyR2").c_str()));
+				float CostEnergyR2 = stof(request::findValue(&req, "CostEnergyR2"));
 				m_sql.UpdatePreferencesVar("CostEnergyR2", int(CostEnergyR2 * 10000.0F)); cntSettings++;
-				float CostGas = static_cast<float>(atof(request::findValue(&req, "CostGas").c_str()));
+				float CostGas = stof(request::findValue(&req, "CostGas"));
 				m_sql.UpdatePreferencesVar("CostGas", int(CostGas * 10000.0F)); cntSettings++;
-				float CostWater = static_cast<float>(atof(request::findValue(&req, "CostWater").c_str()));
+				float CostWater = stof(request::findValue(&req, "CostWater"));
 				m_sql.UpdatePreferencesVar("CostWater", int(CostWater * 10000.0F)); cntSettings++;
 
-				int EnergyDivider = atoi(request::findValue(&req, "EnergyDivider").c_str());
+				int EnergyDivider = stoi(request::findValue(&req, "EnergyDivider"));
 				if (EnergyDivider < 1)
 					EnergyDivider = 1000;
 				m_sql.UpdatePreferencesVar("MeterDividerEnergy", EnergyDivider); cntSettings++;
-				int GasDivider = atoi(request::findValue(&req, "GasDivider").c_str());
+				int GasDivider = stoi(request::findValue(&req, "GasDivider"));
 				if (GasDivider < 1)
 					GasDivider = 100;
 				m_sql.UpdatePreferencesVar("MeterDividerGas", GasDivider); cntSettings++;
-				int WaterDivider = atoi(request::findValue(&req, "WaterDivider").c_str());
+				int WaterDivider = stoi(request::findValue(&req, "WaterDivider"));
 				if (WaterDivider < 1)
 					WaterDivider = 100;
 				m_sql.UpdatePreferencesVar("MeterDividerWater", WaterDivider); cntSettings++;
 
-				int sensortimeout = atoi(request::findValue(&req, "SensorTimeout").c_str());
+				int sensortimeout = stoi(request::findValue(&req, "SensorTimeout"));
 				if (sensortimeout < 10)
 					sensortimeout = 10;
 				m_sql.UpdatePreferencesVar("SensorTimeout", sensortimeout); cntSettings++;
@@ -2531,7 +2531,7 @@ namespace http
 				/* Also update m_sql.variables */
 				/* --------------------------- */
 
-				int iShortLogInterval = atoi(request::findValue(&req, "ShortLogInterval").c_str());
+				int iShortLogInterval = stoi(request::findValue(&req, "ShortLogInterval"));
 				if (iShortLogInterval < 1)
 					iShortLogInterval = 5;
 				m_sql.m_ShortLogInterval = iShortLogInterval;
@@ -2550,15 +2550,15 @@ namespace http
 				m_sql.m_bAcceptNewHardware = (iEnableNewHardware == 1);
 				m_sql.UpdatePreferencesVar("AcceptNewHardware", m_sql.m_bAcceptNewHardware); cntSettings++;
 
-				int nUnit = atoi(request::findValue(&req, "WindUnit").c_str());
+				int nUnit = stoi(request::findValue(&req, "WindUnit"));
 				m_sql.m_windunit = (_eWindUnit)nUnit;
 				m_sql.UpdatePreferencesVar("WindUnit", m_sql.m_windunit); cntSettings++;
 
-				nUnit = atoi(request::findValue(&req, "TempUnit").c_str());
+				nUnit = stoi(request::findValue(&req, "TempUnit"));
 				m_sql.m_tempunit = (_eTempUnit)nUnit;
 				m_sql.UpdatePreferencesVar("TempUnit", m_sql.m_tempunit); cntSettings++;
 
-				nUnit = atoi(request::findValue(&req, "WeightUnit").c_str());
+				nUnit = stoi(request::findValue(&req, "WeightUnit"));
 				m_sql.m_weightunit = (_eWeightUnit)nUnit;
 				m_sql.UpdatePreferencesVar("WeightUnit", m_sql.m_weightunit); cntSettings++;
 
@@ -2622,7 +2622,7 @@ namespace http
 				int rnvalue = 0;
 
 				m_sql.GetPreferencesVar("ActiveTimerPlan", rnOldvalue);
-				rnvalue = atoi(request::findValue(&req, "ActiveTimerPlan").c_str());
+				rnvalue = stoi(request::findValue(&req, "ActiveTimerPlan"));
 				if (rnOldvalue != rnvalue)
 				{
 					m_sql.UpdatePreferencesVar("ActiveTimerPlan", rnvalue);
@@ -2633,7 +2633,7 @@ namespace http
 
 				rnOldvalue = 0;
 				m_sql.GetPreferencesVar("NotificationSensorInterval", rnOldvalue);
-				rnvalue = atoi(request::findValue(&req, "NotificationSensorInterval").c_str());
+				rnvalue = stoi(request::findValue(&req, "NotificationSensorInterval"));
 				if (rnOldvalue != rnvalue)
 				{
 					m_sql.UpdatePreferencesVar("NotificationSensorInterval", rnvalue);
@@ -2643,7 +2643,7 @@ namespace http
 
 				rnOldvalue = 0;
 				m_sql.GetPreferencesVar("NotificationSwitchInterval", rnOldvalue);
-				rnvalue = atoi(request::findValue(&req, "NotificationSwitchInterval").c_str());
+				rnvalue = stoi(request::findValue(&req, "NotificationSwitchInterval"));
 				if (rnOldvalue != rnvalue)
 				{
 					m_sql.UpdatePreferencesVar("NotificationSwitchInterval", rnvalue);
@@ -2681,12 +2681,12 @@ namespace http
 					m_mainworker.m_eventsystem.GetCurrentStates();
 				}
 				cntSettings++;
-				m_sql.UpdatePreferencesVar("DzVentsLogLevel", atoi(request::findValue(&req, "DzVentsLogLevel").c_str()));
+				m_sql.UpdatePreferencesVar("DzVentsLogLevel", stoi(request::findValue(&req, "DzVentsLogLevel")));
 				cntSettings++;
 
 				rnOldvalue = 0;
 				m_sql.GetPreferencesVar("RemoteSharedPort", rnOldvalue);
-				m_sql.UpdatePreferencesVar("RemoteSharedPort", atoi(request::findValue(&req, "RemoteSharedPort").c_str()));
+				m_sql.UpdatePreferencesVar("RemoteSharedPort", stoi(request::findValue(&req, "RemoteSharedPort")));
 				m_sql.GetPreferencesVar("RemoteSharedPort", rnvalue);
 
 				if (rnvalue != rnOldvalue)
@@ -2704,7 +2704,7 @@ namespace http
 
 				rnOldvalue = 0;
 				m_sql.GetPreferencesVar("RandomTimerFrame", rnOldvalue);
-				rnvalue = atoi(request::findValue(&req, "RandomSpread").c_str());
+				rnvalue = stoi(request::findValue(&req, "RandomSpread"));
 				if (rnOldvalue != rnvalue)
 				{
 					m_sql.UpdatePreferencesVar("RandomTimerFrame", rnvalue);
@@ -2713,7 +2713,7 @@ namespace http
 				cntSettings++;
 
 				rnOldvalue = 0;
-				int batterylowlevel = atoi(request::findValue(&req, "BatterLowLevel").c_str());
+				int batterylowlevel = stoi(request::findValue(&req, "BatterLowLevel"));
 				if (batterylowlevel > 100)
 					batterylowlevel = 100;
 				m_sql.GetPreferencesVar("BatteryLowNotification", rnOldvalue);
@@ -2815,7 +2815,7 @@ namespace http
 			}
 			root["status"] = "OK";
 			root["title"] = "AddScene";
-			m_sql.safe_query("INSERT INTO Scenes (Name,SceneType) VALUES ('%q',%d)", name.c_str(), atoi(stype.c_str()));
+			m_sql.safe_query("INSERT INTO Scenes (Name,SceneType) VALUES ('%q',%d)", name.c_str(), stoi(stype));
 			if (m_sql.m_bEnableEventSystem)
 			{
 				m_mainworker.m_eventsystem.GetCurrentScenesGroups();
@@ -2871,8 +2871,8 @@ namespace http
 			root["status"] = "OK";
 			root["title"] = "UpdateScene";
 			m_sql.safe_query("UPDATE Scenes SET Name='%q', Description='%q', SceneType=%d, Protected=%d, OnAction='%q', OffAction='%q' WHERE (ID == '%q')", name.c_str(),
-				description.c_str(), atoi(stype.c_str()), iProtected, onaction.c_str(), offaction.c_str(), idx.c_str());
-			uint64_t ullidx = std::stoull(idx);
+				description.c_str(), stoi(stype), iProtected, onaction.c_str(), offaction.c_str(), idx.c_str());
+			uint64_t ullidx = stoull(idx);
 			m_mainworker.m_eventsystem.WWWUpdateSingleState(ullidx, name, m_mainworker.m_eventsystem.REASON_SCENEGROUP);
 		}
 
@@ -2931,7 +2931,7 @@ namespace http
 						result2 = m_sql.safe_query("SELECT COUNT(*) FROM DeviceToPlansMap WHERE (PlanID=='%q')", sd[0].c_str());
 						if (!result2.empty())
 						{
-							totDevices = (unsigned int)atoi(result2[0][0].c_str());
+							totDevices = (unsigned int) stoul(result2[0][0]);
 						}
 						root["result"][ii]["Devices"] = totDevices;
 
@@ -2955,7 +2955,7 @@ namespace http
 			for (const auto& sd : result)
 			{
 				std::string Key = sd[0];
-				int nValue = atoi(sd[1].c_str());
+				int nValue = stoi(sd[1]);
 				std::string sValue = sd[2];
 
 				if (Key == "FloorplanPopupDelay")
@@ -3014,7 +3014,7 @@ namespace http
 					result3 = m_sql.safe_query("SELECT COUNT(*) FROM Plans WHERE (FloorplanID=='%q')", sd[0].c_str());
 					if (!result3.empty())
 					{
-						totPlans = (unsigned int)atoi(result3[0][0].c_str());
+						totPlans = (unsigned int) stoul(result3[0][0]);
 					}
 					root["result"][ii]["Plans"] = totPlans;
 
@@ -3076,9 +3076,9 @@ namespace http
 							continue;
 					}
 
-					unsigned char nValue = atoi(sd[4].c_str());
-					unsigned char scenetype = atoi(sd[5].c_str());
-					int iProtected = atoi(sd[7].c_str());
+					unsigned char nValue = (unsigned char) stoi(sd[4]);
+					unsigned char scenetype = (unsigned char) stoi(sd[5]);
+					int iProtected = stoi(sd[7]);
 
 					std::string onaction = base64_encode(sd[8]);
 					std::string offaction = base64_encode(sd[9]);
@@ -3086,7 +3086,7 @@ namespace http
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["Name"] = sName;
 					root["result"][ii]["Description"] = sd[10];
-					root["result"][ii]["Favorite"] = atoi(sd[3].c_str());
+					root["result"][ii]["Favorite"] = stoi(sd[3]);
 					root["result"][ii]["Protected"] = (iProtected != 0);
 					root["result"][ii]["OnAction"] = onaction;
 					root["result"][ii]["OffAction"] = offaction;
@@ -3159,7 +3159,7 @@ namespace http
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					_eHardwareTypes hType = (_eHardwareTypes)atoi(sd[3].c_str());
+					_eHardwareTypes hType = (_eHardwareTypes) stoi(sd[3]);
 					if (hType == HTYPE_DomoticzInternal)
 						continue;
 					root["result"][ii]["idx"] = sd[0];
@@ -3167,7 +3167,7 @@ namespace http
 					root["result"][ii]["Enabled"] = (sd[2] == "1") ? "true" : "false";
 					root["result"][ii]["Type"] = hType;
 					root["result"][ii]["Address"] = sd[4];
-					root["result"][ii]["Port"] = atoi(sd[5].c_str());
+					root["result"][ii]["Port"] = stoi(sd[5]);
 					root["result"][ii]["SerialPort"] = sd[6];
 					root["result"][ii]["Username"] = sd[7];
 					root["result"][ii]["Password"] = sd[8];
@@ -3184,17 +3184,17 @@ namespace http
 					}
 					else
 					{
-						root["result"][ii]["Mode1"] = atoi(sd[10].c_str());
-						root["result"][ii]["Mode2"] = atoi(sd[11].c_str());
-						root["result"][ii]["Mode3"] = atoi(sd[12].c_str());
-						root["result"][ii]["Mode4"] = atoi(sd[13].c_str());
-						root["result"][ii]["Mode5"] = atoi(sd[14].c_str());
-						root["result"][ii]["Mode6"] = atoi(sd[15].c_str());
+						root["result"][ii]["Mode1"] = stoi(sd[10]);
+						root["result"][ii]["Mode2"] = stoi(sd[11]);
+						root["result"][ii]["Mode3"] = stoi(sd[12]);
+						root["result"][ii]["Mode4"] = stoi(sd[13]);
+						root["result"][ii]["Mode5"] = stoi(sd[14]);
+						root["result"][ii]["Mode6"] = stoi(sd[15]);
 					}
-					root["result"][ii]["DataTimeout"] = atoi(sd[16].c_str());
-					root["result"][ii]["LogLevel"] = atoi(sd[17].c_str());
+					root["result"][ii]["DataTimeout"] = stoi(sd[16]);
+					root["result"][ii]["LogLevel"] = stoi(sd[17]);
 
-					CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(atoi(sd[0].c_str()));
+					CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(stoi(sd[0]));
 					if (pHardware != nullptr)
 					{
 						if ((pHardware->HwdType == HTYPE_RFXtrx315) || (pHardware->HwdType == HTYPE_RFXtrx433) || (pHardware->HwdType == HTYPE_RFXtrx868) ||
@@ -3303,9 +3303,9 @@ namespace http
 					root["result"][ii]["Enabled"] = (sd[1] == "1") ? "true" : "false";
 					root["result"][ii]["Username"] = base64_decode(sd[2]);
 					root["result"][ii]["Password"] = sd[3];
-					root["result"][ii]["Rights"] = atoi(sd[4].c_str());
-					root["result"][ii]["RemoteSharing"] = atoi(sd[5].c_str());
-					root["result"][ii]["TabsEnabled"] = atoi(sd[6].c_str());
+					root["result"][ii]["Rights"] = stoi(sd[4]);
+					root["result"][ii]["RemoteSharing"] = stoi(sd[5]);
+					root["result"][ii]["TabsEnabled"] = stoi(sd[6]);
 					ii++;
 				}
 				root["status"] = "OK";
@@ -3528,7 +3528,7 @@ namespace http
 			{
 				_log.Log(LOG_STATUS, "User: %s initiated a SetPoint command", m_users[iUser].Username.c_str());
 			}
-			m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setpoint.c_str())));
+			m_mainworker.SetSetPoint(idx, stof(setpoint));
 		}
 
 		void CWebServer::Cmd_GetSceneActivations(WebEmSession& session, const request& req, Json::Value& root)
@@ -3552,7 +3552,7 @@ namespace http
 				return;
 			int ii = 0;
 			std::string Activators = result[0][0];
-			int SceneType = atoi(result[0][1].c_str());
+			int SceneType = stoi(result[0][1]);
 			if (!Activators.empty())
 			{
 				// Get Activator device names
@@ -3567,7 +3567,7 @@ namespace http
 					int sCode = 0;
 					if (arrayCode.size() == 2)
 					{
-						sCode = atoi(arrayCode[1].c_str());
+						sCode = stoi(arrayCode[1]);
 					}
 
 					result2 = m_sql.safe_query("SELECT Name, [Type], SubType, SwitchType FROM DeviceStatus WHERE (ID==%q)", sID.c_str());
@@ -3577,9 +3577,9 @@ namespace http
 						std::string lstatus = "-";
 						if ((SceneType == 0) && (arrayCode.size() == 2))
 						{
-							unsigned char devType = (unsigned char)atoi(sd[1].c_str());
-							unsigned char subType = (unsigned char)atoi(sd[2].c_str());
-							_eSwitchType switchtype = (_eSwitchType)atoi(sd[3].c_str());
+							unsigned char devType = (unsigned char) stoi(sd[1]);
+							unsigned char subType = (unsigned char) stoi(sd[2]);
+							_eSwitchType switchtype = (_eSwitchType) stoi(sd[3]);
 							int nValue = sCode;
 							std::string sValue;
 							int llevel = 0;
@@ -3588,7 +3588,7 @@ namespace http
 							int maxDimLevel = 0;
 							GetLightStatus(devType, subType, switchtype, nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 						}
-						uint64_t dID = std::stoull(sID);
+						uint64_t dID = stoull(sID);
 						root["result"][ii]["idx"] = Json::Value::UInt64(dID);
 						root["result"][ii]["name"] = sd[0];
 						root["result"][ii]["code"] = sCode;
@@ -3621,7 +3621,7 @@ namespace http
 			if (result.empty())
 				return;
 			std::string Activators = result[0][0];
-			unsigned char scenetype = atoi(result[0][1].c_str());
+			unsigned char scenetype = (unsigned char) stoi(result[0][1]);
 
 			if (!Activators.empty())
 			{
@@ -3680,7 +3680,7 @@ namespace http
 			if (result.empty())
 				return;
 			std::string Activators = result[0][0];
-			int SceneType = atoi(result[0][1].c_str());
+			int SceneType = stoi(result[0][1]);
 			if (!Activators.empty())
 			{
 				// Get Activator device names
@@ -3777,11 +3777,11 @@ namespace http
 					root["result"][ii]["name"] = sd[1];
 					root["result"][ii]["name_type"] = std_format("%s (%s/%s)",
 						sd[1].c_str(),
-						RFX_Type_Desc(std::stoi(sd[2]), 1),
-						RFX_Type_SubType_Desc(std::stoi(sd[2]), std::stoi(sd[3]))
+						RFX_Type_Desc((unsigned char) stoi(sd[2]), 1),
+						RFX_Type_SubType_Desc((unsigned char) stoi(sd[2]), (unsigned char) stoi(sd[3]))
 					);
-					//root["result"][ii]["Type"] = RFX_Type_Desc(std::stoi(sd[2]), 1);
-					//root["result"][ii]["SubType"] = RFX_Type_SubType_Desc(std::stoi(sd[2]), std::stoi(sd[3]));
+					//root["result"][ii]["Type"] = RFX_Type_Desc((unsigned char) stoi(sd[2]), 1);
+					//root["result"][ii]["SubType"] = RFX_Type_SubType_Desc((unsigned char) stoi(sd[2]), (unsigned char) stoi(sd[3]));
 					ii++;
 				}
 			}
@@ -3847,7 +3847,7 @@ namespace http
 			std::string sidx = request::findValue(&req, "idx");
 			if (sidx.empty())
 				return;
-			int idx = atoi(sidx.c_str());
+			int idx = stoi(sidx);
 			root["status"] = "OK";
 			root["title"] = "DeleteCustomIcon";
 
@@ -3884,7 +3884,7 @@ namespace http
 			if ((sidx.empty()) || (sname.empty()) || (sdescription.empty()))
 				return;
 
-			int idx = atoi(sidx.c_str());
+			int idx = stoi(sidx);
 			root["status"] = "OK";
 			root["title"] = "UpdateCustomIcon";
 
@@ -3904,12 +3904,12 @@ namespace http
 			std::string sname = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			if ((sidx.empty()) || (sname.empty()))
 				return;
-			int idx = atoi(sidx.c_str());
+			int idx = stoi(sidx);
 			root["status"] = "OK";
 			root["title"] = "RenameDevice";
 
 			m_sql.safe_query("UPDATE DeviceStatus SET Name='%q' WHERE (ID == %d)", sname.c_str(), idx);
-			uint64_t ullidx = std::stoull(sidx);
+			uint64_t ullidx = stoull(sidx);
 			m_mainworker.m_eventsystem.WWWUpdateSingleState(ullidx, sname, m_mainworker.m_eventsystem.REASON_DEVICE);
 
 #ifdef ENABLE_PYTHON
@@ -3930,12 +3930,12 @@ namespace http
 			std::string sname = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
 			if ((sidx.empty()) || (sname.empty()))
 				return;
-			int idx = atoi(sidx.c_str());
+			int idx = stoi(sidx);
 			root["status"] = "OK";
 			root["title"] = "RenameScene";
 
 			m_sql.safe_query("UPDATE Scenes SET Name='%q' WHERE (ID == %d)", sname.c_str(), idx);
-			uint64_t ullidx = std::stoull(sidx);
+			uint64_t ullidx = stoull(sidx);
 			m_mainworker.m_eventsystem.WWWUpdateSingleState(ullidx, sname, m_mainworker.m_eventsystem.REASON_SCENEGROUP);
 		}
 
@@ -3953,7 +3953,7 @@ namespace http
 			std::string sMainDeviceIdx = request::findValue(&req, "maindeviceidx");
 			if (sIdx.empty() || sUsed.empty())
 				return;
-			const int idx = atoi(sIdx.c_str());
+			const int idx = stoi(sIdx);
 			bool bIsUsed = (sUsed == "true");
 
 			if (!sName.empty())
@@ -4100,7 +4100,7 @@ namespace http
 
 			if ((sidx.empty()) || (enabled.empty()) || (name.empty()))
 				return;
-			uint64_t idx = std::stoull(sidx);
+			uint64_t idx = stoull(sidx);
 
 			m_sql.safe_query("UPDATE MobileDevices SET Name='%q', Active=%d WHERE (ID==%" PRIu64 ")", name.c_str(), (enabled == "true") ? 1 : 0, idx);
 
@@ -4135,14 +4135,14 @@ namespace http
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 
 			std::vector<std::vector<std::string>> result;
 			result = m_sql.safe_query("SELECT Type, SubType FROM DeviceStatus WHERE (ID==%" PRIu64 ")", idx);
 			if (!result.empty())
 			{
-				int dType = atoi(result[0][0].c_str());
+				int dType = stoi(result[0][0]);
 				if ((dType == pTypeTEMP) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO))
 				{
 					//Allow old Temp or Temp+Hum or Temp+Hum+Baro devices to be replaced by new Temp or Temp+Hum or Temp+Hum+Baro
@@ -4188,12 +4188,12 @@ namespace http
 			if (result.empty())
 				return;
 
-			int newHardwareID = std::stoi(result[0].at(0));
-			int newOrgHardwareID = std::stoi(result[0].at(1));
+			int newHardwareID = stoi(result[0].at(0));
+			int newOrgHardwareID = stoi(result[0].at(1));
 			std::string newDeviceID = result[0].at(2);
-			int newUnit = std::stoi(result[0].at(3));
-			int devType = std::stoi(result[0].at(4));
-			int subType = std::stoi(result[0].at(5));
+			int newUnit = stoi(result[0].at(3));
+			int devType = stoi(result[0].at(4));
+			int subType = stoi(result[0].at(5));
 
 			//get last update date from old device
 			result = m_sql.safe_query("SELECT LastUpdate FROM DeviceStatus WHERE (ID == '%q')", sidx.c_str());
@@ -4366,20 +4366,20 @@ namespace http
 
 			int switchtype = -1;
 			if (!sswitchtype.empty())
-				switchtype = atoi(sswitchtype.c_str());
+				switchtype = stoi(sswitchtype);
 
 			int used = (sused == "true") ? 1 : 0;
 			if (!maindeviceidx.empty())
 				used = 0;
 
 			std::vector<std::string> sd = result[0];
-			unsigned char dType = atoi(sd[0].c_str());
-			unsigned char dSubType = atoi(sd[1].c_str());
-			int HwdID = atoi(sd[2].c_str());
+			unsigned char dType = (unsigned char) stoi(sd[0]);
+			unsigned char dSubType = (unsigned char) stoi(sd[1]);
+			int HwdID = stoi(sd[2]);
 			std::string sHwdID = sd[2];
-			int OldCustomImage = atoi(sd[3].c_str());
+			int OldCustomImage = stoi(sd[3]);
 
-			int CustomImage = (!sCustomImage.empty()) ? std::stoi(sCustomImage) : OldCustomImage;
+			int CustomImage = (!sCustomImage.empty()) ? stoi(sCustomImage) : OldCustomImage;
 
 			// Strip trailing spaces in 'name'
 			name = stdstring_trim(name);
@@ -4389,7 +4389,7 @@ namespace http
 
 			if (!setPoint.empty() || !state.empty())
 			{
-				double tempcelcius = atof(setPoint.c_str());
+				double tempcelcius = stod(setPoint);
 				if (m_sql.m_tempunit == TEMPUNIT_F)
 				{
 					// Convert back to Celsius
@@ -4444,9 +4444,9 @@ namespace http
 				if (dType == pTypeEvohomeWater)
 					m_mainworker.SetSetPointEvo(idx, (state == "On") ? 1.0F : 0.0F, mode, until); // FIXME float not guaranteed precise?
 				else if (dType == pTypeEvohomeZone)
-					m_mainworker.SetSetPointEvo(idx, static_cast<float>(atof(setPoint.c_str())), mode, until);
+					m_mainworker.SetSetPointEvo(idx, stof(setPoint), mode, until);
 				else
-					m_mainworker.SetSetPoint(idx, static_cast<float>(atof(setPoint.c_str())));
+					m_mainworker.SetSetPoint(idx, stof(setPoint));
 			}
 
 			if (!strunit.empty())
@@ -4458,7 +4458,7 @@ namespace http
 				result = m_sql.safe_query("SELECT Type FROM Hardware WHERE (ID == %d)", HwdID);
 				if (!result.empty())
 				{
-					_eHardwareTypes Type = (_eHardwareTypes)std::stoi(result[0][0]);
+					_eHardwareTypes Type = (_eHardwareTypes) stoi(result[0][0]);
 					if (Type == HTYPE_PythonPlugin)
 					{
 						bUpdateUnit = false;
@@ -4478,24 +4478,24 @@ namespace http
 			}
 			if (!addjvalue.empty())
 			{
-				double faddjvalue = atof(addjvalue.c_str());
+				double faddjvalue = stod(addjvalue);
 				m_sql.safe_query("UPDATE DeviceStatus SET AddjValue=%f WHERE (ID == '%q')", faddjvalue, idx.c_str());
 			}
 			if (!addjmulti.empty())
 			{
-				double faddjmulti = atof(addjmulti.c_str());
+				double faddjmulti = stod(addjmulti);
 				if (faddjmulti == 0)
 					faddjmulti = 1;
 				m_sql.safe_query("UPDATE DeviceStatus SET AddjMulti=%f WHERE (ID == '%q')", faddjmulti, idx.c_str());
 			}
 			if (!addjvalue2.empty())
 			{
-				double faddjvalue2 = atof(addjvalue2.c_str());
+				double faddjvalue2 = stod(addjvalue2);
 				m_sql.safe_query("UPDATE DeviceStatus SET AddjValue2=%f WHERE (ID == '%q')", faddjvalue2, idx.c_str());
 			}
 			if (!addjmulti2.empty())
 			{
-				double faddjmulti2 = atof(addjmulti2.c_str());
+				double faddjmulti2 = stod(addjmulti2);
 				if (faddjmulti2 == 0)
 					faddjmulti2 = 1;
 				m_sql.safe_query("UPDATE DeviceStatus SET AddjMulti2=%f WHERE (ID == '%q')", faddjmulti2, idx.c_str());
@@ -4504,7 +4504,7 @@ namespace http
 			{
 				auto options = m_sql.GetDeviceOptions(idx);
 				options["EnergyMeterMode"] = EnergyMeterMode;
-				uint64_t ullidx = std::stoull(idx);
+				uint64_t ullidx = stoull(idx);
 				m_sql.SetDeviceOptions(ullidx, options);
 			}
 
@@ -4530,7 +4530,7 @@ namespace http
 			// Save device options
 			if (!sOptions.empty())
 			{
-				uint64_t ullidx = std::stoull(idx);
+				uint64_t ullidx = stoull(idx);
 				m_sql.SetDeviceOptions(ullidx, m_sql.BuildDeviceOptions(sOptions, false));
 			}
 
@@ -4557,7 +4557,7 @@ namespace http
 			{
 #ifdef ENABLE_PYTHON
 				// Notify plugin framework about the change
-				m_mainworker.m_pluginsystem.DeviceModified(atoi(idx.c_str()));
+				m_mainworker.m_pluginsystem.DeviceModified(stoull(idx));
 #endif
 			}
 			if (!result.empty())
@@ -4584,7 +4584,7 @@ namespace http
 			for (const auto& sd : result)
 			{
 				std::string Key = sd[0];
-				int nValue = atoi(sd[1].c_str());
+				int nValue = stoi(sd[1]);
 				std::string sValue = sd[2];
 
 				if (Key == "Location")
@@ -4932,7 +4932,7 @@ namespace http
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			std::vector<std::vector<std::string>> result;
 			// First get Device Type/SubType
@@ -4940,9 +4940,9 @@ namespace http
 			if (result.empty())
 				return;
 
-			unsigned char dType = atoi(result[0][0].c_str());
-			unsigned char dSubType = atoi(result[0][1].c_str());
-			_eSwitchType switchtype = (_eSwitchType)atoi(result[0][2].c_str());
+			unsigned char dType = (unsigned char) stoi(result[0][0]);
+			unsigned char dSubType = (unsigned char) stoi(result[0][1]);
+			_eSwitchType switchtype = (_eSwitchType) stoi(result[0][2]);
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][3]);
 
 			if (
@@ -4970,7 +4970,7 @@ namespace http
 				for (const auto& sd : result)
 				{
 					std::string lidx = sd.at(0);
-					int nValue = atoi(sd.at(1).c_str());
+					int nValue = stoi(sd.at(1));
 					std::string sValue = sd.at(2);
 					std::string sUser = sd.at(3);
 					std::string ldate = sd.at(4);
@@ -5004,7 +5004,7 @@ namespace http
 							std::string sLevel = selectorStatuses[sValue];
 							ldata = sLevel;
 							lstatus = "Set Level: " + sLevel;
-							llevel = atoi(sValue.c_str());
+							llevel = stoi(sValue);
 						}
 					}
 					else
@@ -5055,7 +5055,7 @@ namespace http
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			std::vector<std::vector<std::string>> result;
 
@@ -5082,7 +5082,7 @@ namespace http
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 			std::vector<std::vector<std::string>> result;
 
@@ -5096,7 +5096,7 @@ namespace http
 				for (const auto& sd : result)
 				{
 					root["result"][ii]["idx"] = sd[0];
-					int nValue = atoi(sd[1].c_str());
+					int nValue = stoi(sd[1]);
 					root["result"][ii]["Data"] = (nValue == 0) ? "Off" : "On";
 					root["result"][ii]["User"] = sd[2];
 					root["result"][ii]["Date"] = sd[3];

--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -123,13 +123,13 @@ namespace http
 						root["result"][ii]["Name"] = sd[1];
 						root["result"][ii]["DevID"] = sd[2];
 						root["result"][ii]["DevRealIdx"] = sd[9];
-						root["result"][ii]["Order"] = atoi(sd[10].c_str());
-						root["result"][ii]["OnDelay"] = atoi(sd[12].c_str());
-						root["result"][ii]["OffDelay"] = atoi(sd[13].c_str());
+						root["result"][ii]["Order"] = stoi(sd[10]);
+						root["result"][ii]["OnDelay"] = stoi(sd[12]);
+						root["result"][ii]["OffDelay"] = stoi(sd[13]);
 
-						_eSwitchType switchtype = (_eSwitchType)atoi(sd[14].c_str());
+						_eSwitchType switchtype = (_eSwitchType) stoi(sd[14]);
 
-						unsigned char devType = atoi(sd[3].c_str());
+						unsigned char devType = (unsigned char) stoi(sd[3]);
 
 						bool bIsBlinds = (
 							switchtype == STYPE_Blinds
@@ -144,11 +144,11 @@ namespace http
 						if (devType != pTypeRFY)
 							switchtype = STYPE_OnOff;
 
-						unsigned char subType = atoi(sd[4].c_str());
-						// unsigned char nValue = (unsigned char)atoi(sd[5].c_str());
+						unsigned char subType = (unsigned char) stoi(sd[4]);
+						// unsigned char nValue = (unsigned char) stoi(sd[5]);
 						std::string sValue = sd[6];
-						int command = atoi(sd[7].c_str());
-						int level = atoi(sd[8].c_str());
+						int command = stoi(sd[7]);
+						int level = stoi(sd[8]);
 
 						std::string lstatus;
 						int llevel = 0;
@@ -184,10 +184,10 @@ namespace http
 					int ii = 0;
 					for (const auto& sd : result)
 					{
-						int ID = atoi(sd[0].c_str());
+						int ID = stoi(sd[0]);
 						std::string Name = sd[1];
-						_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[2].c_str());
-						bool isEnabled = atoi(sd[3].c_str());
+						_eHardwareTypes Type = (_eHardwareTypes) stoi(sd[2]);
+						bool isEnabled = stoi(sd[3]) != 0;
 
 						bool supportsManual = ((Type == HTYPE_RFXLAN) || (Type == HTYPE_RFXtrx315) || (Type == HTYPE_RFXtrx433) || (Type == HTYPE_RFXtrx868) || (Type == HTYPE_EnOceanESP2) ||
 							(Type == HTYPE_EnOceanESP3) || (Type == HTYPE_Dummy) || (Type == HTYPE_Tellstick) || (Type == HTYPE_EVOHOME_SCRIPT) ||
@@ -296,10 +296,10 @@ namespace http
 					{
 						std::string ID = sd[0];
 						std::string Name = sd[1];
-						int Type = atoi(sd[2].c_str());
-						int SubType = atoi(sd[3].c_str());
-						int used = atoi(sd[4].c_str());
-						_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+						int Type = stoi(sd[2]);
+						int SubType = stoi(sd[3]);
+						int used = stoi(sd[4]);
+						_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 						std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sd[6]);
 						bool bdoAdd = false;
 						switch (Type)
@@ -344,7 +344,7 @@ namespace http
 								bdoAdd = false;
 							if (bdoAdd)
 							{
-								int idx = atoi(ID.c_str());
+								int idx = stoi(ID);
 								if (!IsIdxForUser(&session, idx))
 									continue;
 								root["result"][ii]["idx"] = ID;
@@ -429,9 +429,9 @@ namespace http
 					{
 						std::string ID = sd[0];
 						std::string Name = sd[1];
-						int Type = atoi(sd[2].c_str());
-						int SubType = atoi(sd[3].c_str());
-						int used = atoi(sd[4].c_str());
+						int Type = stoi(sd[2]);
+						int SubType = stoi(sd[3]);
+						int used = stoi(sd[4]);
 						if (used)
 						{
 							switch (Type)
@@ -512,10 +512,10 @@ namespace http
 					for (const auto& sd : result)
 					{
 						std::string ID = sd[0];
-						int DevSceneType = atoi(sd[1].c_str());
+						int DevSceneType = stoi(sd[1]);
 						std::string DevSceneRowID = sd[2];
-						int DevSceneWhen = atoi(sd[3].c_str());
-						int DevSceneDelay = atoi(sd[4].c_str());
+						int DevSceneWhen = stoi(sd[3]);
+						int DevSceneDelay = stoi(sd[4]);
 
 						std::string Name;
 						if (DevSceneType == 0)
@@ -680,7 +680,7 @@ namespace http
 					return false;
 				}
 				root["status"] = "OK";
-				int iSecStatus = atoi(ssecstatus.c_str());
+				int iSecStatus = stoi(ssecstatus);
 				m_mainworker.UpdateDomoticzSecurityStatus(iSecStatus, szSwitchUser);
 			}
 			else if (cparam == "getfloorplanimages")
@@ -688,7 +688,7 @@ namespace http
 				root["status"] = "OK";
 				root["title"] = "GetFloorplanImages";
 
-				bool bReturnUnused = atoi(request::findValue(&req, "unused").c_str()) != 0;
+				bool bReturnUnused = stoi(request::findValue(&req, "unused")) != 0;
 
 				if (!bReturnUnused)
 					result = m_sql.safe_query("SELECT ID, Name, ScaleFactor FROM Floorplans ORDER BY [Name]");
@@ -794,23 +794,23 @@ namespace http
 				std::string devidx = request::findValue(&req, "devidx");
 				std::string isscene = request::findValue(&req, "isscene");
 				std::string scommand = request::findValue(&req, "command");
-				int ondelay = atoi(request::findValue(&req, "ondelay").c_str());
-				int offdelay = atoi(request::findValue(&req, "offdelay").c_str());
+				int ondelay = stoi(request::findValue(&req, "ondelay"));
+				int offdelay = stoi(request::findValue(&req, "offdelay"));
 
 				if ((idx.empty()) || (devidx.empty()) || (isscene.empty()))
 					return false;
 				int level = -1;
 				if (request::hasValue(&req, "level"))
-					level = atoi(request::findValue(&req, "level").c_str());
+					level = stoi(request::findValue(&req, "level"));
 				std::string color = _tColor(request::findValue(&req, "color")).toJSONString(); // Parse the color to detect incorrectly formatted color data
 
 				unsigned char command = 0;
 				result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Options FROM DeviceStatus WHERE (ID=='%q')", devidx.c_str());
 				if (!result.empty())
 				{
-					int dType = atoi(result[0][3].c_str());
-					int sType = atoi(result[0][4].c_str());
-					_eSwitchType switchtype = (_eSwitchType)atoi(result[0][5].c_str());
+					int dType = stoi(result[0][3]);
+					int sType = stoi(result[0][4]);
+					_eSwitchType switchtype = (_eSwitchType) stoi(result[0][5]);
 					std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][6]);
 					GetLightCommand(dType, sType, switchtype, scommand, command, options);
 				}
@@ -819,7 +819,7 @@ namespace http
 				result = m_sql.safe_query("SELECT Activators, SceneType FROM Scenes WHERE (ID=='%q')", idx.c_str());
 				if (!result.empty())
 				{
-					// int SceneType = atoi(result[0][1].c_str());
+					// int SceneType = stoi(result[0][1]);
 
 					std::vector<std::string> arrayActivators;
 					StringSplit(result[0][0], ";", arrayActivators);
@@ -883,8 +883,8 @@ namespace http
 				std::string idx = request::findValue(&req, "idx");
 				std::string devidx = request::findValue(&req, "devidx");
 				std::string scommand = request::findValue(&req, "command");
-				int ondelay = atoi(request::findValue(&req, "ondelay").c_str());
-				int offdelay = atoi(request::findValue(&req, "offdelay").c_str());
+				int ondelay = stoi(request::findValue(&req, "ondelay"));
+				int offdelay = stoi(request::findValue(&req, "offdelay"));
 
 				if ((idx.empty()) || (devidx.empty()))
 					return false;
@@ -894,15 +894,15 @@ namespace http
 				result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType, SwitchType, Options FROM DeviceStatus WHERE (ID=='%q')", devidx.c_str());
 				if (!result.empty())
 				{
-					int dType = atoi(result[0][3].c_str());
-					int sType = atoi(result[0][4].c_str());
-					_eSwitchType switchtype = (_eSwitchType)atoi(result[0][5].c_str());
+					int dType = stoi(result[0][3]);
+					int sType = stoi(result[0][4]);
+					_eSwitchType switchtype = (_eSwitchType) stoi(result[0][5]);
 					std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][6]);
 					GetLightCommand(dType, sType, switchtype, scommand, command, options);
 				}
 				int level = -1;
 				if (request::hasValue(&req, "level"))
-					level = atoi(request::findValue(&req, "level").c_str());
+					level = stoi(request::findValue(&req, "level"));
 				std::string color = _tColor(request::findValue(&req, "color")).toJSONString(); // Parse the color to detect incorrectly formatted color data
 				root["status"] = "OK";
 				root["title"] = "UpdateSceneDevice";
@@ -1013,9 +1013,9 @@ namespace http
 					return false;
 				}
 
-				int activetype = atoi(sactivetype.c_str());
-				int activewhen = atoi(sactivewhen.c_str());
-				int activedelay = atoi(sactivedelay.c_str());
+				int activetype = stoi(sactivetype);
+				int activewhen = stoi(sactivewhen);
+				int activedelay = stoi(sactivedelay);
 
 				// first check if it is not already a Active Device
 				result = m_sql.safe_query("SELECT ID FROM CamerasActiveDevices WHERE (CameraRowID=='%q')"
@@ -1105,14 +1105,14 @@ namespace http
 
 				if ((hwdid.empty()) || (sswitchtype.empty()) || (slighttype.empty()))
 					return false;
-				_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
-				int lighttype = atoi(slighttype.c_str());
+				_eSwitchType switchtype = (_eSwitchType) stoi(sswitchtype);
+				int lighttype = stoi(slighttype);
 				int dtype;
 				int subtype = 0;
 				std::string sunitcode;
 				std::string devid;
 
-				CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
+				CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(stoi(hwdid));
 				if (pBaseHardware != nullptr && !pBaseHardware->GetManualSwitchesJsonConfiguration().empty())
 				{
 					pBaseHardware->GetManualSwitchParameters(req.parameters, switchtype, lighttype, dtype, subtype, devid, sunitcode);
@@ -1166,7 +1166,7 @@ namespace http
 						root["message"] = "No GPIO number given";
 						return false;
 					}
-					CGpio* pGpio = dynamic_cast<CGpio*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					CGpio* pGpio = dynamic_cast<CGpio*>(m_mainworker.GetHardware(stoi(hwdid)));
 					if (pGpio == nullptr)
 					{
 						root["status"] = "ERROR";
@@ -1179,7 +1179,7 @@ namespace http
 						root["message"] = "Given hardware is not GPIO";
 						return false;
 					}
-					CGpioPin* pPin = CGpio::GetPPinById(atoi(sunitcode.c_str()));
+					CGpioPin* pPin = CGpio::GetPPinById(stoi(sunitcode));
 					if (pPin == nullptr)
 					{
 						root["status"] = "ERROR";
@@ -1203,11 +1203,11 @@ namespace http
 #ifdef WITH_GPIO
 
 					sunitcode = request::findValue(&req, "unitcode"); // sysfs-gpio number
-					int unitcode = atoi(sunitcode.c_str());
+					int unitcode = stoi(sunitcode);
 					dtype = pTypeLighting2;
 					subtype = sTypeAC;
 					std::string sswitchtype = request::findValue(&req, "switchtype");
-					_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
+					_eSwitchType switchtype = (_eSwitchType) stoi(sswitchtype);
 
 					std::string id = request::findValue(&req, "id");
 					if ((id.empty()) || (sunitcode.empty()))
@@ -1223,7 +1223,7 @@ namespace http
 						return false;
 					}
 
-					CSysfsGpio* pSysfsGpio = dynamic_cast<CSysfsGpio*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					CSysfsGpio* pSysfsGpio = dynamic_cast<CSysfsGpio*>(m_mainworker.GetHardware(stoi(hwdid)));
 					if (pSysfsGpio == nullptr)
 					{
 						root["status"] = "ERROR";
@@ -1302,7 +1302,7 @@ namespace http
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return false;
-					int iUnitCode = atoi(sunitcode.c_str()) - 1;
+					int iUnitCode = stoi(sunitcode) - 1;
 					switch (iUnitCode)
 					{
 					case 0:
@@ -1446,7 +1446,7 @@ namespace http
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return false;
-					int iUnitCode = atoi(sunitcode.c_str());
+					int iUnitCode = stoi(sunitcode);
 					sprintf(szTmp, "%d", iUnitCode);
 					sunitcode = szTmp;
 					devid = id;
@@ -1474,10 +1474,10 @@ namespace http
 					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
 						return false;
 
-					int iUnitCode = atoi(sunitcode.c_str());
+					int iUnitCode = stoi(sunitcode);
 					sprintf(szTmp, "%d", iUnitCode);
 					sunitcode = szTmp;
-					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+					sprintf(szTmp, "%02X", stoi(shousecode));
 					shousecode = szTmp;
 					devid = id + shousecode;
 				}
@@ -1773,15 +1773,15 @@ namespace http
 
 				if ((hwdid.empty()) || (sswitchtype.empty()) || (slighttype.empty()) || (name.empty()))
 					return false;
-				_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
-				int lighttype = atoi(slighttype.c_str());
+				_eSwitchType switchtype = (_eSwitchType) stoi(sswitchtype);
+				int lighttype = stoi(slighttype);
 				int dtype = 0;
 				int subtype = 0;
 				std::string sunitcode;
 				std::string devid;
 				std::string StrParam1;
 
-				CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
+				CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(stoi(hwdid));
 				if ((pBaseHardware != nullptr) && (!pBaseHardware->GetManualSwitchesJsonConfiguration().empty()))
 				{
 					pBaseHardware->GetManualSwitchParameters(req.parameters, switchtype, lighttype, dtype, subtype, devid, sunitcode);
@@ -1797,7 +1797,7 @@ namespace http
 					bool bActEnabledState = m_sql.m_bAcceptNewHardware;
 					m_sql.m_bAcceptNewHardware = true;
 					std::string devname;
-					m_sql.UpdateValue(atoi(hwdid.c_str()), 0, devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, devname, true, szSwitchUser.c_str());
+					m_sql.UpdateValue(stoi(hwdid), 0, devid.c_str(), (unsigned char) stoi(sunitcode), dtype, subtype, 0, -1, 0, devname, true, szSwitchUser.c_str());
 					m_sql.m_bAcceptNewHardware = bActEnabledState;
 
 					// set name and switchtype
@@ -1821,7 +1821,7 @@ namespace http
 					m_mainworker.m_eventsystem.GetCurrentStates();
 
 					// Set device options
-					m_sql.SetDeviceOptions(atoi(ID.c_str()), m_sql.BuildDeviceOptions(deviceoptions, false));
+					m_sql.SetDeviceOptions(stoull(ID), m_sql.BuildDeviceOptions(deviceoptions, false));
 
 					if (!maindeviceidx.empty())
 					{
@@ -1849,11 +1849,11 @@ namespace http
 					if (!result.empty())
 					{
 						std::vector<std::string> sd = result[0];
-						_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[0].c_str());
+						_eHardwareTypes Type = (_eHardwareTypes) stoi(sd[0]);
 						if (Type == HTYPE_PythonPlugin)
 						{
 							// Not allowed to add device to plugin HW (plugin framework does not use key column "ID" but instead uses column "unit" as key)
-							_log.Log(LOG_ERROR, "CWebServer::HandleCommand addswitch: Not allowed to add device owned by plugin %u!", atoi(hwdid.c_str()));
+							_log.Log(LOG_ERROR, "CWebServer::HandleCommand addswitch: Not allowed to add device owned by plugin %d!", stoi(hwdid));
 							root["message"] = "Not allowed to add switch to plugin HW!";
 							return false;
 						}
@@ -1909,7 +1909,7 @@ namespace http
 					{
 						return false;
 					}
-					CGpio* pGpio = dynamic_cast<CGpio*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					CGpio* pGpio = dynamic_cast<CGpio*>(m_mainworker.GetHardware(stoi(hwdid)));
 					if (pGpio == nullptr)
 					{
 						return false;
@@ -1918,7 +1918,7 @@ namespace http
 					{
 						return false;
 					}
-					CGpioPin* pPin = CGpio::GetPPinById(atoi(sunitcode.c_str()));
+					CGpioPin* pPin = CGpio::GetPPinById(stoi(sunitcode));
 					if (pPin == nullptr)
 					{
 						return false;
@@ -1934,9 +1934,9 @@ namespace http
 					subtype = sTypeAC;
 					devid = "0";
 					sunitcode = request::findValue(&req, "unitcode"); // sysfs-gpio number
-					int unitcode = atoi(sunitcode.c_str());
+					int unitcode = stoi(sunitcode);
 					std::string sswitchtype = request::findValue(&req, "switchtype");
-					_eSwitchType switchtype = (_eSwitchType)atoi(sswitchtype.c_str());
+					_eSwitchType switchtype = (_eSwitchType) stoi(sswitchtype);
 					std::string id = request::findValue(&req, "id");
 					CSysfsGpio::RequestDbUpdate(unitcode);
 
@@ -1946,7 +1946,7 @@ namespace http
 					}
 					devid = id;
 
-					CSysfsGpio* pSysfsGpio = dynamic_cast<CSysfsGpio*>(m_mainworker.GetHardware(atoi(hwdid.c_str())));
+					CSysfsGpio* pSysfsGpio = dynamic_cast<CSysfsGpio*>(m_mainworker.GetHardware(stoi(hwdid)));
 					if ((pSysfsGpio == nullptr) || (pSysfsGpio->HwdType != HTYPE_SysfsGpio))
 					{
 						return false;
@@ -2029,7 +2029,7 @@ namespace http
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return false;
-					int iUnitCode = atoi(sunitcode.c_str()) - 1;
+					int iUnitCode = stoi(sunitcode) - 1;
 					switch (iUnitCode)
 					{
 					case 0:
@@ -2173,7 +2173,7 @@ namespace http
 					sunitcode = request::findValue(&req, "unitcode");
 					if ((id.empty()) || (sunitcode.empty()))
 						return false;
-					int iUnitCode = atoi(sunitcode.c_str());
+					int iUnitCode = stoi(sunitcode);
 					sprintf(szTmp, "%d", iUnitCode);
 					sunitcode = szTmp;
 					devid = id;
@@ -2202,7 +2202,7 @@ namespace http
 					bool bActEnabledState = m_sql.m_bAcceptNewHardware;
 					m_sql.m_bAcceptNewHardware = true;
 					std::string devname;
-					m_sql.UpdateValue(atoi(hwdid.c_str()), 0, devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, "20.5", devname, true, szSwitchUser.c_str());
+					m_sql.UpdateValue(stoi(hwdid), 0, devid.c_str(), (unsigned char) stoi(sunitcode), dtype, subtype, 0, -1, 0, "20.5", devname, true, szSwitchUser.c_str());
 					m_sql.m_bAcceptNewHardware = bActEnabledState;
 
 					// set name and switchtype
@@ -2233,10 +2233,10 @@ namespace http
 					if ((id.empty()) || (shousecode.empty()) || (sunitcode.empty()))
 						return false;
 
-					int iUnitCode = atoi(sunitcode.c_str());
+					int iUnitCode = stoi(sunitcode);
 					sprintf(szTmp, "%d", iUnitCode);
 					sunitcode = szTmp;
-					sprintf(szTmp, "%02X", atoi(shousecode.c_str()));
+					sprintf(szTmp, "%02X", stoi(shousecode));
 					shousecode = szTmp;
 					devid = id + shousecode;
 				}
@@ -2498,7 +2498,7 @@ namespace http
 				bool bActEnabledState = m_sql.m_bAcceptNewHardware;
 				m_sql.m_bAcceptNewHardware = true;
 				std::string devname;
-				m_sql.UpdateValue(atoi(hwdid.c_str()), 0, devid.c_str(), atoi(sunitcode.c_str()), dtype, subtype, 0, -1, 0, devname, true, szSwitchUser.c_str());
+				m_sql.UpdateValue(stoi(hwdid), 0, devid.c_str(), (unsigned char) stoi(sunitcode), dtype, subtype, 0, -1, 0, devname, true, szSwitchUser.c_str());
 				m_sql.m_bAcceptNewHardware = bActEnabledState;
 
 				// set name and switchtype
@@ -2522,7 +2522,7 @@ namespace http
 				m_mainworker.m_eventsystem.GetCurrentStates();
 
 				// Set device options
-				m_sql.SetDeviceOptions(atoi(ID.c_str()), m_sql.BuildDeviceOptions(deviceoptions, false));
+				m_sql.SetDeviceOptions(stoull(ID), m_sql.BuildDeviceOptions(deviceoptions, false));
 
 				if (!maindeviceidx.empty())
 				{
@@ -2560,9 +2560,9 @@ namespace http
 
 				root["status"] = "OK";
 				root["title"] = "GetNotificationTypes";
-				unsigned char dType = atoi(result[0][0].c_str());
-				unsigned char dSubType = atoi(result[0][1].c_str());
-				unsigned char switchtype = atoi(result[0][2].c_str());
+				unsigned char dType = (unsigned char) stoi(result[0][0]);
+				unsigned char dSubType = (unsigned char) stoi(result[0][1]);
+				unsigned char switchtype = (unsigned char) stoi(result[0][2]);
 
 				int ii = 0;
 				if (
@@ -2595,7 +2595,7 @@ namespace http
 						if (!result.empty())
 						{
 							std::string hdwid = result[0][0];
-							CDomoticzHardwareBase* pBaseHardware = dynamic_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(atoi(hdwid.c_str())));
+							CDomoticzHardwareBase* pBaseHardware = dynamic_cast<CDomoticzHardwareBase*>(m_mainworker.GetHardware(stoi(hdwid)));
 							if (pBaseHardware != nullptr)
 							{
 								_eHardwareTypes type = pBaseHardware->HwdType;
@@ -2974,7 +2974,7 @@ namespace http
 				if ((idx1.empty()) || (idx2.empty()))
 					return false;
 				std::string sroomid = request::findValue(&req, "roomid");
-				int roomid = atoi(sroomid.c_str());
+				int roomid = stoi(sroomid);
 
 				std::string Order1, Order2;
 				if (roomid == 0)
@@ -3017,7 +3017,7 @@ namespace http
 						root["status"] = "OK";
 						root["title"] = "SwitchDeviceOrder";
 
-						if (atoi(Order1.c_str()) < atoi(Order2.c_str()))
+						if (stoi(Order1) < stoi(Order2))
 						{
 							m_sql.safe_query("UPDATE SharedDevices SET [Order] = [Order]+1 WHERE ([Order] >= '%q' AND [Order] < '%q')", Order1.c_str(), Order2.c_str());
 						}
@@ -3044,7 +3044,7 @@ namespace http
 						root["status"] = "OK";
 						root["title"] = "SwitchDeviceOrder";
 
-						if (atoi(Order1.c_str()) < atoi(Order2.c_str()))
+						if (stoi(Order1) < stoi(Order2))
 						{
 							m_sql.safe_query("UPDATE DeviceStatus SET [Order] = [Order]+1 WHERE ([Order] >= '%q' AND [Order] < '%q')", Order1.c_str(), Order2.c_str());
 						}
@@ -3074,7 +3074,7 @@ namespace http
 					root["status"] = "OK";
 					root["title"] = "SwitchDeviceOrder";
 
-					if (atoi(Order1.c_str()) < atoi(Order2.c_str()))
+					if (stoi(Order1) < stoi(Order2))
 					{
 						m_sql.safe_query("UPDATE DeviceToPlansMap SET [Order] = [Order]+1 WHERE ([Order] >= '%q' AND [Order] < '%q') AND (PlanID==%d)", Order1.c_str(),
 							Order2.c_str(), roomid);
@@ -3117,7 +3117,7 @@ namespace http
 				root["status"] = "OK";
 				root["title"] = "SwitchSceneOrder";
 
-				if (atoi(Order1.c_str()) < atoi(Order2.c_str()))
+				if (stoi(Order1) < stoi(Order2))
 				{
 					m_sql.safe_query("UPDATE Scenes SET [Order] = [Order]+1 WHERE ([Order] >= '%q' AND [Order] < '%q')", Order1.c_str(), Order2.c_str());
 				}
@@ -3167,7 +3167,7 @@ namespace http
 				std::string srights = request::findValue(&req, "rights");
 				std::string sRemoteSharing = request::findValue(&req, "RemoteSharing");
 				std::string sTabsEnabled = request::findValue(&req, "TabsEnabled");
-				int rights = atoi(srights.c_str());
+				int rights = stoi(srights);
 
 				if (cparam != "deleteuser")
 				{
@@ -3204,7 +3204,7 @@ namespace http
 					root["title"] = "AddUser";
 					m_sql.safe_query("INSERT INTO Users (Active, Username, Password, Rights, RemoteSharing, TabsEnabled) VALUES (%d,'%q','%q','%d','%d','%d')",
 						(senabled == "true") ? 1 : 0, sHashedUsername.c_str(), password.c_str(), rights, (sRemoteSharing == "true") ? 1 : 0,
-						atoi(sTabsEnabled.c_str()));
+						stoi(sTabsEnabled));
 				}
 				else if (cparam == "updateuser")
 				{
@@ -3217,7 +3217,7 @@ namespace http
 						std::string sOldUsername = result[0][0];
 						std::string sOldPassword = result[0][1];
 						std::string sOldRights = result[0][2];
-						int oldrights = atoi(sOldRights.c_str());
+						int oldrights = stoi(sOldRights);
 						if ((oldrights == URIGHTS_ADMIN) && (rights != URIGHTS_ADMIN) && (CountAdminUsers() <= 1))
 						{
 							root["message"] = "Cannot change rights of last Admin user!";
@@ -3232,7 +3232,7 @@ namespace http
 							RemoveUsersSessions(sOldUsername, session);
 
 						m_sql.safe_query("UPDATE Users SET Active=%d, Username='%q', Password='%q', Rights=%d, RemoteSharing=%d, TabsEnabled=%d WHERE (ID == '%q')",
-							(senabled == "true") ? 1 : 0, sHashedUsername.c_str(), password.c_str(), rights, (sRemoteSharing == "true") ? 1 : 0, atoi(sTabsEnabled.c_str()),
+							(senabled == "true") ? 1 : 0, sHashedUsername.c_str(), password.c_str(), rights, (sRemoteSharing == "true") ? 1 : 0, stoi(sTabsEnabled),
 							idx.c_str());
 					}
 				}
@@ -3245,7 +3245,7 @@ namespace http
 					if (result.size() == 1)
 					{
 						srights = result[0][1];
-						rights = atoi(srights.c_str());
+						rights = stoi(srights);
 						if ((CountAdminUsers() <= 1) && (rights == URIGHTS_ADMIN))
 						{
 							root["message"] = "Cannot delete last Admin user!";
@@ -3277,8 +3277,8 @@ namespace http
 				if (result.empty())
 					return false;
 
-				unsigned char dType = atoi(result[0][0].c_str());
-				unsigned char dSubType = atoi(result[0][1].c_str());
+				unsigned char dType = (unsigned char) stoi(result[0][0]);
+				unsigned char dSubType = (unsigned char) stoi(result[0][1]);
 
 				if (
 					(dType != pTypeLighting1) && (dType != pTypeLighting2) && (dType != pTypeLighting3) && (dType != pTypeLighting4) && (dType != pTypeLighting5) &&
@@ -3345,8 +3345,8 @@ namespace http
 						root["ID"] = m_sql.m_LastSwitchID;
 						root["idx"] = Json::Value::UInt64(m_sql.m_LastSwitchRowID);
 						root["Name"] = result[0][0];
-						root["Used"] = atoi(result[0][1].c_str());
-						root["Cmd"] = atoi(result[0][2].c_str());
+						root["Used"] = stoi(result[0][1]);
+						root["Cmd"] = stoi(result[0][2]);
 					}
 				}
 			} // learnsw
@@ -3361,7 +3361,7 @@ namespace http
 				std::string sisfavorite = request::findValue(&req, "isfavorite");
 				if ((idx.empty()) || (sisfavorite.empty()))
 					return false;
-				int isfavorite = atoi(sisfavorite.c_str());
+				int isfavorite = stoi(sisfavorite);
 
 				root["status"] = "OK";
 				root["title"] = "MakeFavorite";
@@ -3395,7 +3395,7 @@ namespace http
 				std::string sisfavorite = request::findValue(&req, "isfavorite");
 				if ((idx.empty()) || (sisfavorite.empty()))
 					return false;
-				int isfavorite = atoi(sisfavorite.c_str());
+				int isfavorite = stoi(sisfavorite);
 				m_sql.safe_query("UPDATE Scenes SET Favorite=%d WHERE (ID == '%q')", isfavorite, idx.c_str());
 				root["status"] = "OK";
 				root["title"] = "MakeSceneFavorite";
@@ -3477,11 +3477,11 @@ namespace http
 					_log.Log(LOG_ERROR, "User: %s, switch not found (idx=%s)!", Username.c_str(), idx.c_str());
 					return false;
 				}
-				bool bIsProtected = atoi(result[0][0].c_str()) != 0;
+				bool bIsProtected = stoi(result[0][0]) != 0;
 				std::string sSwitchName = result[0][1];
 				if (session.rights == 1)
 				{
-					if (!IsIdxForUser(&session, atoi(idx.c_str())))
+					if (!IsIdxForUser(&session, stoi(idx)))
 					{
 						_log.Log(LOG_ERROR, "User: %s initiated a Unauthorized switch command!", Username.c_str());
 						session.reply_status = reply::forbidden;
@@ -3518,7 +3518,7 @@ namespace http
 
 				root["title"] = "SwitchLight";
 
-				const bool bIsOOC = atoi(onlyonchange.c_str()) != 0;
+				const bool bIsOOC = stoi(onlyonchange) != 0;
 
 				std::string szSwitchMsg = std_format("User: %s initiated a switch command (%s/%s/%s)", szSwitchUser.c_str(), idx.c_str(), sSwitchName.c_str(), switchcmd.c_str());
 
@@ -3570,7 +3570,7 @@ namespace http
 					_log.Log(LOG_ERROR, "User: %s, scene not found (idx=%s)!", szSwitchUser.c_str(), idx.c_str());
 					return false;
 				}
-				bool bIsProtected = atoi(result[0][0].c_str()) != 0;
+				bool bIsProtected = stoi(result[0][0]) != 0;
 				if (bIsProtected)
 				{
 					if (passcode.empty())
@@ -3620,7 +3620,7 @@ namespace http
 				{
 					return false;
 				}
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				_tColor color;
 
 				std::string json = request::findValue(&req, "color");
@@ -3705,10 +3705,10 @@ namespace http
 					int r, g, b;
 
 					// convert hue to RGB
-					float iHue = float(atof(hue.c_str()));
+					float iHue = stof(hue);
 					float iSat = 100.0F;
 					if (!sat.empty())
-						iSat = float(atof(sat.c_str()));
+						iSat = stof(sat);
 					hsb2rgb(iHue, iSat / 100.0F, 1.0F, r, g, b, 255);
 
 					color = _tColor(r, g, b, 0, 0, ColorModeRGB);
@@ -3723,7 +3723,7 @@ namespace http
 				}
 
 				if (!brightness.empty())
-					ival = atoi(brightness.c_str());
+					ival = stoi(brightness);
 				ival = int(ival * brightnessAdj);
 				ival = std::max(ival, 0);
 				ival = std::min(ival, 100);
@@ -3757,10 +3757,10 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 
 				std::string kelvin = request::findValue(&req, "kelvin");
-				double ival = atof(kelvin.c_str());
+				double ival = stod(kelvin);
 				ival = std::max(ival, 0.0);
 				ival = std::min(ival, 100.0);
 				_tColor color = _tColor((int)round(ival * 255.0F / 100.0F), ColorModeTemp);
@@ -3791,7 +3791,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Bright Up", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3817,7 +3817,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Bright Down", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3843,7 +3843,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Disco Mode", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3869,7 +3869,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				char szTmp[40];
 				sprintf(szTmp, "Disco Mode %s", cparam.substr(12).c_str());
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
@@ -3897,7 +3897,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Disco Up", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3923,7 +3923,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Disco Down", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3949,7 +3949,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Speed Up", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -3975,7 +3975,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Speed Up Long", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4001,7 +4001,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Speed Down", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4027,7 +4027,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Speed Minimal", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4053,7 +4053,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Speed Maximal", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4079,7 +4079,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Warmer", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4105,7 +4105,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Cooler", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4131,7 +4131,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Set Full", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4157,7 +4157,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Set Night", 0, NoColor, false, 0, szSwitchUser);
 			}
@@ -4183,7 +4183,7 @@ namespace http
 					return false;
 				}
 
-				uint64_t ID = std::stoull(idx);
+				uint64_t ID = stoull(idx);
 				// TODO: Change to color with mode=ColorModeWhite and level=100?
 				std::string szSwitchUser = Username + " (IP: " + session.remote_host + ")";
 				m_mainworker.SwitchLight(ID, "Set White", 0, NoColor, false, 0, szSwitchUser);

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -1720,19 +1720,19 @@ namespace http
 								{
 								case MTYPE_ENERGY:
 								case MTYPE_ENERGY_GENERATED:
-									sprintf(szTmp, "%.3f", stof(szValue) / divider);
+									sprintf(szTmp, "%.3f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_GAS:
-									sprintf(szTmp, "%.3f", stof(szValue) / divider);
+									sprintf(szTmp, "%.3f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_WATER:
-									sprintf(szTmp, "%.3f", stof(szValue) / divider);
+									sprintf(szTmp, "%.3f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_COUNTER:
-									sprintf(szTmp, "%.10g", stof(szValue) / divider);
+									sprintf(szTmp, "%.10g", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								default:
@@ -1779,22 +1779,22 @@ namespace http
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage_1);
 							std::string szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["v"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage_2);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["v2"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv_1);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["r1"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv_2);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["r2"] = szTmp;
 
 							ii++;
@@ -1832,19 +1832,19 @@ namespace http
 							{
 							case MTYPE_ENERGY:
 							case MTYPE_ENERGY_GENERATED:
-								sprintf(szTmp, "%.3f", stof(szValue) / divider);
+								sprintf(szTmp, "%.3f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_GAS:
-								sprintf(szTmp, "%.3f", stof(szValue) / divider);
+								sprintf(szTmp, "%.3f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_WATER:
-								sprintf(szTmp, "%.3f", stof(szValue) / divider);
+								sprintf(szTmp, "%.3f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_COUNTER:
-								sprintf(szTmp, "%.10g", stof(szValue) / divider);
+								sprintf(szTmp, "%.10g", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							default:
@@ -3229,37 +3229,37 @@ namespace http
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED:
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stof(szValue)) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stod(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", stof(szValue) / divider);
+										sprintf(szTmp, "%.2f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.2f", meteroffset + ((fcounter - stof(szValue)) / divider));
+											sprintf(szTmp, "%.2f", meteroffset + ((fcounter - stod(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stof(szValue)) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stod(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", stof(szValue) / divider);
+										sprintf(szTmp, "%.10g", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.10g", meteroffset + ((fcounter - stof(szValue)) / divider));
+											sprintf(szTmp, "%.10g", meteroffset + ((fcounter - stod(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
@@ -3284,19 +3284,19 @@ namespace http
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED:
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", stof(szValue) / divider);
+										sprintf(szTmp, "%.2f", stod(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", stof(szValue) / divider);
+										sprintf(szTmp, "%.10g", stod(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									}
@@ -3586,7 +3586,7 @@ namespace http
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED: {
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 
 										std::vector<std::string> mresults;
@@ -3596,28 +3596,28 @@ namespace http
 											sValue = mresults[1];
 										}
 										if (dType == pTypeENERGY)
-											sprintf(szTmp, "%.3f", meteroffset + (((stof(sValue) * 100.0F) - stof(szValue)) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + (((stod(sValue) * 100.0) - stod(szValue)) / divider));
 										else
-											sprintf(szTmp, "%.3f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((stod(sValue) - stod(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 									}
 															   break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", stof(szValue) / divider);
+										sprintf(szTmp, "%.2f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.2f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
+										sprintf(szTmp, "%.2f", meteroffset + ((stod(sValue) - stod(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", stof(szValue) / divider);
+										sprintf(szTmp, "%.3f", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.3f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
+										sprintf(szTmp, "%.3f", meteroffset + ((stod(sValue) - stod(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", stof(szValue) / divider);
+										sprintf(szTmp, "%.10g", stod(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.10g", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
+										sprintf(szTmp, "%.10g", meteroffset + ((stod(sValue) - stod(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									}
@@ -4159,19 +4159,19 @@ namespace http
 								{
 								case MTYPE_ENERGY:
 								case MTYPE_ENERGY_GENERATED:
-									sprintf(szTmp, "%.3f", stof(szValue) / divider);
+									sprintf(szTmp, "%.3f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_GAS:
-									sprintf(szTmp, "%.2f", stof(szValue) / divider);
+									sprintf(szTmp, "%.2f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_WATER:
-									sprintf(szTmp, "%.3f", stof(szValue) / divider);
+									sprintf(szTmp, "%.3f", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_COUNTER:
-									sprintf(szTmp, "%.10g", stof(szValue) / divider);
+									sprintf(szTmp, "%.10g", stod(szValue) / divider);
 									szValue = szTmp;
 									break;
 
@@ -4217,12 +4217,12 @@ namespace http
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage);
 							std::string szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["v"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", stof(szValue) / divider);
+							sprintf(szTmp, "%.3f", stod(szValue) / divider);
 							root["result"][ii]["v2"] = szTmp;
 							
 							ii++;
@@ -4260,19 +4260,19 @@ namespace http
 							{
 							case MTYPE_ENERGY:
 							case MTYPE_ENERGY_GENERATED:
-								sprintf(szTmp, "%.3f", stof(szValue) / divider);
+								sprintf(szTmp, "%.3f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_GAS:
-								sprintf(szTmp, "%.2f", stof(szValue) / divider);
+								sprintf(szTmp, "%.2f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_WATER:
-								sprintf(szTmp, "%.3f", stof(szValue) / divider);
+								sprintf(szTmp, "%.3f", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_COUNTER:
-								sprintf(szTmp, "%.10g", stof(szValue) / divider);
+								sprintf(szTmp, "%.10g", stod(szValue) / divider);
 								szValue = szTmp;
 								break;
 							}

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -216,7 +216,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -224,12 +224,12 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
@@ -253,7 +253,7 @@ namespace http
 									root["result"][ii]["te"] = se;
 								}
 								else
-									root["result"][ii]["te"] = stof(sd[0]);
+									root["result"][ii]["te"] = stod(sd[0]);
 							}
 							ii++;
 						}
@@ -586,7 +586,7 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[1].substr(0, 16);
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[0]) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stod(sd[0]) / 10.0);
 								root["result"][ii]["v"] = szTmp;
 								ii++;
 							}
@@ -604,7 +604,7 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[1].substr(0, 16);
-								root["result"][ii]["u"] = stof(sd[0]) / 10.0F;
+								root["result"][ii]["u"] = stod(sd[0]) / 10.0;
 								ii++;
 							}
 						}
@@ -633,9 +633,9 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = stof(sd[0]) / 10.0F;
-								float fval2 = stof(sd[1]) / 10.0F;
-								float fval3 = stof(sd[2]) / 10.0F;
+								float fval1 = static_cast<float>(stod(sd[0]) / 10.0);
+								float fval2 = static_cast<float>(stod(sd[1]) / 10.0);
+								float fval3 = static_cast<float>(stod(sd[2]) / 10.0);
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -703,9 +703,9 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = stof(sd[0]) / 10.0F;
-								float fval2 = stof(sd[1]) / 10.0F;
-								float fval3 = stof(sd[2]) / 10.0F;
+								float fval1 = static_cast<float>(stod(sd[0]) / 10.0);
+								float fval2 = static_cast<float>(stod(sd[1]) / 10.0);
+								float fval3 = static_cast<float>(stod(sd[2]) / 10.0);
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -2001,7 +2001,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -2009,12 +2009,12 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
@@ -2047,9 +2047,9 @@ namespace http
 								}
 								else
 								{
-									root["result"][ii]["te"] = stof(sd[1]);
-									root["result"][ii]["tm"] = stof(sd[0]);
-									root["result"][ii]["ta"] = stof(sd[6]);
+									root["result"][ii]["te"] = stod(sd[1]);
+									root["result"][ii]["tm"] = stod(sd[0]);
+									root["result"][ii]["ta"] = stod(sd[6]);
 								}
 							}
 
@@ -2108,7 +2108,7 @@ namespace http
 							{
 								if (dSubType == sTypeTHBFloat)
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else
@@ -2116,12 +2116,12 @@ namespace http
 							}
 							else if (dType == pTypeTEMP_BARO)
 							{
-								sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+								sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 								root["result"][ii]["ba"] = szTmp;
 							}
 							else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 							{
-								sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+								sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 								root["result"][ii]["ba"] = szTmp;
 							}
 						}
@@ -2154,9 +2154,9 @@ namespace http
 							}
 							else
 							{
-								root["result"][ii]["te"] = stof(sd[1]);
-								root["result"][ii]["tm"] = stof(sd[0]);
-								root["result"][ii]["ta"] = stof(sd[6]);
+								root["result"][ii]["te"] = stod(sd[1]);
+								root["result"][ii]["tm"] = stod(sd[0]);
+								root["result"][ii]["ta"] = stod(sd[6]);
 							}
 						}
 						ii++;
@@ -2223,7 +2223,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 										root["resultprev"][iPrev]["ba"] = szTmp;
 									}
 									else
@@ -2231,12 +2231,12 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["resultprev"][iPrev]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["resultprev"][iPrev]["ba"] = szTmp;
 								}
 							}
@@ -2269,9 +2269,9 @@ namespace http
 								}
 								else
 								{
-									root["resultprev"][iPrev]["te"] = stof(sd[1]);
-									root["resultprev"][iPrev]["tm"] = stof(sd[0]);
-									root["resultprev"][iPrev]["ta"] = stof(sd[6]);
+									root["resultprev"][iPrev]["te"] = stod(sd[1]);
+									root["resultprev"][iPrev]["tm"] = stod(sd[0]);
+									root["resultprev"][iPrev]["ta"] = stod(sd[6]);
 								}
 							}
 
@@ -2865,9 +2865,9 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[2].substr(0, 16);
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[0]) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stod(sd[0]) / 10.0);
 								root["result"][ii]["v_min"] = szTmp;
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[1]) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stod(sd[1]) / 10.0);
 								root["result"][ii]["v_max"] = szTmp;
 								ii++;
 							}
@@ -2892,8 +2892,8 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[2].substr(0, 16);
-								root["result"][ii]["u_min"] = stof(sd[0]) / 10.0F;
-								root["result"][ii]["u_max"] = stof(sd[1]) / 10.0F;
+								root["result"][ii]["u_min"] = stod(sd[0]) / 10.0;
+								root["result"][ii]["u_max"] = stod(sd[1]) / 10.0;
 								ii++;
 							}
 						}
@@ -2920,12 +2920,12 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = stof(sd[0]) / 10.0F;
-								float fval2 = stof(sd[1]) / 10.0F;
-								float fval3 = stof(sd[2]) / 10.0F;
-								float fval4 = stof(sd[3]) / 10.0F;
-								float fval5 = stof(sd[4]) / 10.0F;
-								float fval6 = stof(sd[5]) / 10.0F;
+								float fval1 = static_cast<float>(stod(sd[0]) / 10.0);
+								float fval2 = static_cast<float>(stod(sd[1]) / 10.0);
+								float fval3 = static_cast<float>(stod(sd[2]) / 10.0);
+								float fval4 = static_cast<float>(stod(sd[3]) / 10.0);
+								float fval5 = static_cast<float>(stod(sd[4]) / 10.0);
+								float fval6 = static_cast<float>(stod(sd[5]) / 10.0);
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -3004,12 +3004,12 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = stof(sd[0]) / 10.0F;
-								float fval2 = stof(sd[1]) / 10.0F;
-								float fval3 = stof(sd[2]) / 10.0F;
-								float fval4 = stof(sd[3]) / 10.0F;
-								float fval5 = stof(sd[4]) / 10.0F;
-								float fval6 = stof(sd[5]) / 10.0F;
+								float fval1 = static_cast<float>(stod(sd[0]) / 10.0);
+								float fval2 = static_cast<float>(stod(sd[1]) / 10.0);
+								float fval3 = static_cast<float>(stod(sd[2]) / 10.0);
+								float fval4 = static_cast<float>(stod(sd[3]) / 10.0);
+								float fval5 = static_cast<float>(stod(sd[4]) / 10.0);
+								float fval6 = static_cast<float>(stod(sd[5]) / 10.0);
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -3071,7 +3071,7 @@ namespace http
 						if (dType == pTypeP1Gas)
 						{
 							// Add last counter value
-							sprintf(szTmp, "%.3f", stof(sValue) / 1000.0F);
+							sprintf(szTmp, "%.3f", stod(sValue) / 1000.0);
 							root["counter"] = szTmp;
 						}
 						else if (dType == pTypeENERGY)
@@ -3508,9 +3508,9 @@ namespace http
 						if (!result.empty())
 						{
 							root["result"][ii]["d"] = szDateEnd;
-							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(result[0][0]) / 10.0F);
+							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stod(result[0][0]) / 10.0);
 							root["result"][ii]["v_min"] = szTmp;
-							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(result[0][1]) / 10.0F);
+							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stod(result[0][1]) / 10.0);
 							root["result"][ii]["v_max"] = szTmp;
 							ii++;
 						}
@@ -3521,8 +3521,8 @@ namespace http
 						if (!result.empty())
 						{
 							root["result"][ii]["d"] = szDateEnd;
-							root["result"][ii]["u_min"] = stof(result[0][0]) / 10.0F;
-							root["result"][ii]["u_max"] = stof(result[0][1]) / 10.0F;
+							root["result"][ii]["u_min"] = stod(result[0][0]) / 10.0;
+							root["result"][ii]["u_max"] = stod(result[0][1]) / 10.0;
 							ii++;
 						}
 					}
@@ -3835,7 +3835,7 @@ namespace http
 									{
 										if (dSubType == sTypeTHBFloat)
 										{
-											sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+											sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 											root["result"][ii]["ba"] = szTmp;
 										}
 										else
@@ -3843,12 +3843,12 @@ namespace http
 									}
 									else if (dType == pTypeTEMP_BARO)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 									{
-										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[3]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 								}
@@ -3909,7 +3909,7 @@ namespace http
 									{
 										if (dSubType == sTypeTHBFloat)
 										{
-											sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+											sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 											root["result"][ii]["ba"] = szTmp;
 										}
 										else
@@ -3917,12 +3917,12 @@ namespace http
 									}
 									else if (dType == pTypeTEMP_BARO)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 									{
-										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 								}
@@ -3986,7 +3986,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+										sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -3994,12 +3994,12 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
+									sprintf(szTmp, "%.1f", stod(sd[5]) / 10.0);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -36,7 +36,7 @@ namespace http
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 
 			std::vector<std::vector<std::string>> result;
@@ -59,9 +59,9 @@ namespace http
 			if (result.empty())
 				return;
 
-			unsigned char dType = atoi(result[0][0].c_str());
-			unsigned char dSubType = atoi(result[0][1].c_str());
-			_eMeterType metertype = (_eMeterType)atoi(result[0][2].c_str());
+			unsigned char dType = (unsigned char) stoi(result[0][0]);
+			unsigned char dSubType = (unsigned char) stoi(result[0][1]);
+			_eMeterType metertype = (_eMeterType) stoi(result[0][2]);
 			_log.Debug(DEBUG_WEBSERVER, "CWebServer::Cmd_HandleGraph() : dType:%02X  dSubType:%02X  metertype:%d", dType, dSubType, int(metertype));
 			if ((dType == pTypeP1Power) || (dType == pTypeENERGY) || (dType == pTypePOWER) || (dType == pTypeCURRENTENERGY) || ((dType == pTypeGeneral) && (dSubType == sTypeKwh)))
 			{
@@ -75,9 +75,9 @@ namespace http
 			// Special case of managed counter: Usage instead of Value in Meter table, and we don't want to calculate last value
 			bool bIsManagedCounter = (dType == pTypeGeneral) && (dSubType == sTypeManagedCounter);
 
-			double AddjValue = atof(result[0][3].c_str());
-			double AddjMulti = atof(result[0][4].c_str());
-			double AddjValue2 = atof(result[0][5].c_str());
+			double AddjValue = stod(result[0][3]);
+			double AddjMulti = stod(result[0][4]);
+			double AddjValue2 = stod(result[0][5]);
 			std::string sOptions = result[0][6];
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sOptions);
 
@@ -198,12 +198,12 @@ namespace http
 								|| dType == pTypeEvohomeWater
 								)
 							{
-								double tvalue = ConvertTemperature(atof(sd[0].c_str()), tempsign);
+								double tvalue = ConvertTemperature(stod(sd[0]), tempsign);
 								root["result"][ii]["te"] = tvalue;
 							}
 							if (((dType == pTypeWIND) && (dSubType == sTypeWIND4)) || ((dType == pTypeWIND) && (dSubType == sTypeWINDNoTemp)))
 							{
-								double tvalue = ConvertTemperature(atof(sd[1].c_str()), tempsign);
+								double tvalue = ConvertTemperature(stod(sd[1]), tempsign);
 								root["result"][ii]["ch"] = tvalue;
 							}
 							if ((dType == pTypeHUM) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO))
@@ -216,7 +216,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -224,18 +224,18 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
 							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
 							{
-								double se = ConvertTemperature(atof(sd[5].c_str()), tempsign);
+								double se = ConvertTemperature(stod(sd[5]), tempsign);
 								root["result"][ii]["se"] = se;
 							}
 							if (dType == pTypeSetpoint && dSubType == sTypeSetpoint)
@@ -249,11 +249,11 @@ namespace http
 									|| (value_unit == "F")
 									)
 								{
-									double se = ConvertTemperature(atof(sd[0].c_str()), tempsign);
+									double se = ConvertTemperature(stod(sd[0]), tempsign);
 									root["result"][ii]["te"] = se;
 								}
 								else
-									root["result"][ii]["te"] = atof(sd[0].c_str());
+									root["result"][ii]["te"] = stof(sd[0]);
 							}
 							ii++;
 						}
@@ -324,10 +324,10 @@ namespace http
 							{
 								if (nMeterType == 0)
 								{
-									int64_t actUsage1 = std::stoll(sd[0]);
-									int64_t actUsage2 = std::stoll(sd[4]);
-									int64_t actDeliv1 = std::stoll(sd[1]);
-									int64_t actDeliv2 = std::stoll(sd[5]);
+									int64_t actUsage1 = stoll(sd[0]);
+									int64_t actUsage2 = stoll(sd[4]);
+									int64_t actDeliv1 = stoll(sd[1]);
+									int64_t actDeliv2 = stoll(sd[5]);
 									actDeliv1 = (actDeliv1 < 10) ? 0 : actDeliv1;
 									actDeliv2 = (actDeliv2 < 10) ? 0 : actDeliv2;
 
@@ -436,10 +436,10 @@ namespace http
 											if (!result2.empty())
 											{
 												std::vector<std::string> sd = result2[0];
-												firstUsage1 = std::stoll(sd[0]);
-												firstDeliv1 = std::stoll(sd[1]);
-												firstUsage2 = std::stoll(sd[2]);
-												firstDeliv2 = std::stoll(sd[3]);
+												firstUsage1 = stoll(sd[0]);
+												firstDeliv1 = stoll(sd[1]);
+												firstUsage2 = stoll(sd[2]);
+												firstDeliv2 = stoll(sd[3]);
 												lastDay = ntime.tm_mday;
 											}
 										}
@@ -521,7 +521,7 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[1].substr(0, 16);
-								float fValue = float(atof(sd[0].c_str())) / vdiv;
+								float fValue = stof(sd[0]) / vdiv;
 								if (metertype == 1)
 								{
 									if ((dType == pTypeGeneral) && (dSubType == sTypeDistance))
@@ -586,7 +586,7 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[1].substr(0, 16);
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * atof(sd[0].c_str()) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[0]) / 10.0F);
 								root["result"][ii]["v"] = szTmp;
 								ii++;
 							}
@@ -604,7 +604,7 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[1].substr(0, 16);
-								root["result"][ii]["u"] = atof(sd[0].c_str()) / 10.0F;
+								root["result"][ii]["u"] = stof(sd[0]) / 10.0F;
 								ii++;
 							}
 						}
@@ -633,9 +633,9 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
+								float fval1 = stof(sd[0]) / 10.0F;
+								float fval2 = stof(sd[1]) / 10.0F;
+								float fval3 = stof(sd[2]) / 10.0F;
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -703,9 +703,9 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
+								float fval1 = stof(sd[0]) / 10.0F;
+								float fval2 = stof(sd[1]) / 10.0F;
+								float fval3 = stof(sd[2]) / 10.0F;
 
 								if (fval1 != 0)
 									bHaveL1 = true;
@@ -762,8 +762,8 @@ namespace http
 						result = m_sql.safe_query("SELECT MIN([Usage]), MAX([Usage]) FROM %s WHERE (DeviceRowID==%" PRIu64 ")", dbasetable.c_str(), idx);
 						if (!result.empty())
 						{
-							int64_t minValue = std::stoll(result[0][0]);
-							int64_t maxValue = std::stoll(result[0][1]);
+							int64_t minValue = stoll(result[0][0]);
+							int64_t maxValue = stoll(result[0][1]);
 
 							if ((minValue == 0) && (maxValue == 0))
 							{
@@ -777,7 +777,7 @@ namespace http
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
 						if (!sMethod.empty())
-							method = atoi(sMethod.c_str());
+							method = stoi(sMethod);
 						if (bHaveUsage == false)
 							method = 0;
 
@@ -813,7 +813,7 @@ namespace http
 								{
 									// bars / hour
 									std::string actDateTimeHour = sd[2].substr(0, 13);
-									int64_t actValue = std::stoll(sd[0]); // actual energy value
+									int64_t actValue = stoll(sd[0]); // actual energy value
 
 									ulLastValue = actValue;
 
@@ -883,7 +883,7 @@ namespace http
 
 								if (method == 1)
 								{
-									int64_t actValue = std::stoll(sd[1]);
+									int64_t actValue = stoll(sd[1]);
 
 									root["result"][ii]["d"] = sd[2].substr(0, 16);
 
@@ -941,7 +941,7 @@ namespace http
 						int method = 0;
 						std::string sMethod = request::findValue(&req, "method");
 						if (!sMethod.empty())
-							method = atoi(sMethod.c_str());
+							method = stoi(sMethod);
 
 						if (bIsManagedCounter)
 						{
@@ -964,7 +964,7 @@ namespace http
 								if (method == 0)
 								{
 									// bars / hour
-									int64_t actValue = std::stoll(sd[0]);
+									int64_t actValue = stoll(sd[0]);
 									szlastDateTime = sd[1].substr(0, 16);
 									szActDateTimeHour = sd[1].substr(0, 13) + ":00";
 
@@ -1082,7 +1082,7 @@ namespace http
 											if (!result2.empty())
 											{
 												std::vector<std::string> sd = result2[0];
-												ulRealFirstValue = std::stoll(sd[0]);
+												ulRealFirstValue = stoll(sd[0]);
 												lastDay = ntime.tm_mday;
 											}
 										}
@@ -1094,7 +1094,7 @@ namespace http
 								else
 								{
 									// realtime graph
-									int64_t actValue = std::stoll(sd[0]);
+									int64_t actValue = stoll(sd[0]);
 
 									std::string stime = sd[1];
 									struct tm ntime;
@@ -1252,8 +1252,8 @@ namespace http
 						int ii = 0;
 						for (const auto& sd : result)
 						{
-							float ActTotal = static_cast<float>(atof(sd[0].c_str()));
-							int Hour = atoi(sd[1].substr(11, 2).c_str());
+							float ActTotal = stof(sd[0]);
+							int Hour = stoi(sd[1].substr(11, 2));
 							if (Hour != WorkingHour)
 							{
 								if (WorkingHour != -1)
@@ -1282,7 +1282,7 @@ namespace http
 							StringSplit(sValue, ";", results);
 							if (results.size() == 2)
 							{
-								float ActTotal = static_cast<float>(atof(results[1].c_str()));
+								float ActTotal = stof(results[1]);
 								if (ActTotal > LastValue)
 									LastValue = ActTotal;
 							}
@@ -1312,8 +1312,8 @@ namespace http
 							root["result"][ii]["d"] = sd[3].substr(0, 16);
 							root["result"][ii]["di"] = sd[0];
 
-							int intSpeed = atoi(sd[1].c_str());
-							int intGust = atoi(sd[2].c_str());
+							int intSpeed = stoi(sd[1]);
+							int intGust = stoi(sd[2]);
 
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{
@@ -1418,12 +1418,12 @@ namespace http
 
 						for (const auto& sd : result)
 						{
-							float fdirection = static_cast<float>(atof(sd[0].c_str()));
+							float fdirection = stof(sd[0]);
 							if (fdirection >= 360)
 								fdirection = 0;
 							int direction = int(fdirection);
-							float speedOrg = static_cast<float>(atof(sd[1].c_str()));
-							float gustOrg = static_cast<float>(atof(sd[2].c_str()));
+							float speedOrg = stof(sd[1]);
+							float gustOrg = stof(sd[2]);
 							if ((gustOrg == 0) && (speedOrg != 0))
 								gustOrg = speedOrg;
 							if (gustOrg == 0)
@@ -1604,7 +1604,7 @@ namespace http
 						for (const auto& sd : result)
 						{
 							root["result"][ii]["d"] = sd[2].substr(0, 16);
-							double mmval = atof(sd[0].c_str());
+							double mmval = stod(sd[0]);
 							mmval *= AddjMulti;
 							sprintf(szTmp, "%.1f", mmval);
 							root["result"][ii]["mm"] = szTmp;
@@ -1625,9 +1625,9 @@ namespace http
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
-						// int rate = atoi(sd[2].c_str());
+						float total_min = stof(sd[0]);
+						float total_max = stof(sd[1]);
+						// int rate = stoi(sd[2]);
 
 						double total_real = 0;
 						if (dSubType == sTypeRAINWU || dSubType == sTypeRAINByRate)
@@ -1680,10 +1680,10 @@ namespace http
 								std::string szValueUsage2 = sd[2];
 								std::string szValueDeliv2 = sd[3];
 
-								float fUsage1 = (float)(atof(szValueUsage1.c_str()));
-								float fUsage2 = (float)(atof(szValueUsage2.c_str()));
-								float fDeliv1 = (float)(atof(szValueDeliv1.c_str()));
-								float fDeliv2 = (float)(atof(szValueDeliv2.c_str()));
+								float fUsage1 = stof(szValueUsage1);
+								float fUsage2 = stof(szValueUsage2);
+								float fDeliv1 = stof(szValueDeliv1);
+								float fDeliv2 = stof(szValueDeliv2);
 
 								fDeliv1 = (fDeliv1 < 10) ? 0 : fDeliv1;
 								fDeliv2 = (fDeliv2 < 10) ? 0 : fDeliv2;
@@ -1720,19 +1720,19 @@ namespace http
 								{
 								case MTYPE_ENERGY:
 								case MTYPE_ENERGY_GENERATED:
-									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.3f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_GAS:
-									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.3f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_WATER:
-									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.3f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_COUNTER:
-									sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.10g", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								default:
@@ -1754,15 +1754,15 @@ namespace http
 						{
 							std::vector<std::string> sd = result[0];
 
-							uint64_t total_min_usage_1 = std::stoull(sd[0]);
-							uint64_t total_max_usage_1 = std::stoull(sd[1]);
-							uint64_t total_min_usage_2 = std::stoull(sd[4]);
-							uint64_t total_max_usage_2 = std::stoull(sd[5]);
+							uint64_t total_min_usage_1 = stoull(sd[0]);
+							uint64_t total_max_usage_1 = stoull(sd[1]);
+							uint64_t total_min_usage_2 = stoull(sd[4]);
+							uint64_t total_max_usage_2 = stoull(sd[5]);
 							uint64_t total_real_usage_1, total_real_usage_2;
-							uint64_t total_min_deliv_1 = std::stoull(sd[2]);
-							uint64_t total_max_deliv_1 = std::stoull(sd[3]);
-							uint64_t total_min_deliv_2 = std::stoull(sd[6]);
-							uint64_t total_max_deliv_2 = std::stoull(sd[7]);
+							uint64_t total_min_deliv_1 = stoull(sd[2]);
+							uint64_t total_max_deliv_1 = stoull(sd[3]);
+							uint64_t total_min_deliv_2 = stoull(sd[6]);
+							uint64_t total_max_deliv_2 = stoull(sd[7]);
 							uint64_t total_real_deliv_1, total_real_deliv_2;
 
 							bool bHaveDeliverd = false;
@@ -1779,22 +1779,22 @@ namespace http
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage_1);
 							std::string szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["v"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage_2);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["v2"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv_1);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["r1"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv_2);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["r2"] = szTmp;
 
 							ii++;
@@ -1812,7 +1812,7 @@ namespace http
 						{
 							std::vector<std::string> sd = result[0];
 
-							int64_t total_min = std::stoll(sd[0]);
+							int64_t total_min = stoll(sd[0]);
 							int64_t total_max = total_min;
 							int64_t total_real;
 
@@ -1821,7 +1821,7 @@ namespace http
 							if (!result.empty())
 							{
 								std::vector<std::string> sd = result[0];
-								total_max = std::stoull(sd[0].c_str());
+								total_max = stoll(sd[0]);
 							}
 
 							total_real = total_max - total_min;
@@ -1832,19 +1832,19 @@ namespace http
 							{
 							case MTYPE_ENERGY:
 							case MTYPE_ENERGY_GENERATED:
-								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.3f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_GAS:
-								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.3f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_WATER:
-								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.3f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_COUNTER:
-								sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.10g", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							default:
@@ -1869,8 +1869,8 @@ namespace http
 				std::string sactmonth = request::findValue(&req, "actmonth");
 				std::string sactyear = request::findValue(&req, "actyear");
 
-				int actMonth = atoi(sactmonth.c_str());
-				int actYear = atoi(sactyear.c_str());
+				int actMonth = stoi(sactmonth);
+				int actYear = stoi(sactyear);
 
 				if ((!sactmonth.empty()) && (!sactyear.empty()))
 				{
@@ -1976,9 +1976,9 @@ namespace http
 								}
 								if (bOK)
 								{
-									double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[1]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
+									double ta = ConvertTemperature(stod(sd[6]), tempsign);
 									root["result"][ii]["te"] = te;
 									root["result"][ii]["tm"] = tm;
 									root["result"][ii]["ta"] = ta;
@@ -1986,8 +1986,8 @@ namespace http
 							}
 							if (((dType == pTypeWIND) && (dSubType == sTypeWIND4)) || ((dType == pTypeWIND) && (dSubType == sTypeWINDNoTemp)))
 							{
-								double ch = ConvertTemperature(atof(sd[3].c_str()), tempsign);
-								double cm = ConvertTemperature(atof(sd[2].c_str()), tempsign);
+								double ch = ConvertTemperature(stod(sd[3]), tempsign);
+								double cm = ConvertTemperature(stod(sd[2]), tempsign);
 								root["result"][ii]["ch"] = ch;
 								root["result"][ii]["cm"] = cm;
 							}
@@ -2001,7 +2001,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -2009,20 +2009,20 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
 							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
 							{
-								double sm = ConvertTemperature(atof(sd[8].c_str()), tempsign);
-								double sx = ConvertTemperature(atof(sd[9].c_str()), tempsign);
-								double se = ConvertTemperature(atof(sd[10].c_str()), tempsign);
+								double sm = ConvertTemperature(stod(sd[8]), tempsign);
+								double sx = ConvertTemperature(stod(sd[9]), tempsign);
+								double se = ConvertTemperature(stod(sd[10]), tempsign);
 								root["result"][ii]["sm"] = sm;
 								root["result"][ii]["se"] = se;
 								root["result"][ii]["sx"] = sx;
@@ -2038,18 +2038,18 @@ namespace http
 									|| (value_unit == "F")
 									)
 								{
-									double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[1]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
+									double ta = ConvertTemperature(stod(sd[6]), tempsign);
 									root["result"][ii]["te"] = te;
 									root["result"][ii]["tm"] = tm;
 									root["result"][ii]["ta"] = ta;
 								}
 								else
 								{
-									root["result"][ii]["te"] = atof(sd[1].c_str());
-									root["result"][ii]["tm"] = atof(sd[0].c_str());
-									root["result"][ii]["ta"] = atof(sd[6].c_str());
+									root["result"][ii]["te"] = stof(sd[1]);
+									root["result"][ii]["tm"] = stof(sd[0]);
+									root["result"][ii]["ta"] = stof(sd[6]);
 								}
 							}
 
@@ -2084,17 +2084,17 @@ namespace http
 							|| (dType == pTypeEvohomeWater)
 							)
 						{
-							double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-							double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-							double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+							double te = ConvertTemperature(stod(sd[1]), tempsign);
+							double tm = ConvertTemperature(stod(sd[0]), tempsign);
+							double ta = ConvertTemperature(stod(sd[6]), tempsign);
 							root["result"][ii]["te"] = te;
 							root["result"][ii]["tm"] = tm;
 							root["result"][ii]["ta"] = ta;
 						}
 						if (((dType == pTypeWIND) && (dSubType == sTypeWIND4)) || ((dType == pTypeWIND) && (dSubType == sTypeWINDNoTemp)))
 						{
-							double ch = ConvertTemperature(atof(sd[3].c_str()), tempsign);
-							double cm = ConvertTemperature(atof(sd[2].c_str()), tempsign);
+							double ch = ConvertTemperature(stod(sd[3]), tempsign);
+							double cm = ConvertTemperature(stod(sd[2]), tempsign);
 							root["result"][ii]["ch"] = ch;
 							root["result"][ii]["cm"] = cm;
 						}
@@ -2108,7 +2108,7 @@ namespace http
 							{
 								if (dSubType == sTypeTHBFloat)
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else
@@ -2116,20 +2116,20 @@ namespace http
 							}
 							else if (dType == pTypeTEMP_BARO)
 							{
-								sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+								sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 								root["result"][ii]["ba"] = szTmp;
 							}
 							else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 							{
-								sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+								sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 								root["result"][ii]["ba"] = szTmp;
 							}
 						}
 						if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
 						{
-							double sx = ConvertTemperature(atof(sd[8].c_str()), tempsign);
-							double sm = ConvertTemperature(atof(sd[7].c_str()), tempsign);
-							double se = ConvertTemperature(atof(sd[9].c_str()), tempsign);
+							double sx = ConvertTemperature(stod(sd[8]), tempsign);
+							double sm = ConvertTemperature(stod(sd[7]), tempsign);
+							double se = ConvertTemperature(stod(sd[9]), tempsign);
 							root["result"][ii]["se"] = se;
 							root["result"][ii]["sm"] = sm;
 							root["result"][ii]["sx"] = sx;
@@ -2145,18 +2145,18 @@ namespace http
 								|| (value_unit == "F")
 								)
 							{
-								double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-								double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-								double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+								double te = ConvertTemperature(stod(sd[1]), tempsign);
+								double tm = ConvertTemperature(stod(sd[0]), tempsign);
+								double ta = ConvertTemperature(stod(sd[6]), tempsign);
 								root["result"][ii]["te"] = te;
 								root["result"][ii]["tm"] = tm;
 								root["result"][ii]["ta"] = ta;
 							}
 							else
 							{
-								root["result"][ii]["te"] = atof(sd[1].c_str());
-								root["result"][ii]["tm"] = atof(sd[0].c_str());
-								root["result"][ii]["ta"] = atof(sd[6].c_str());
+								root["result"][ii]["te"] = stof(sd[1]);
+								root["result"][ii]["tm"] = stof(sd[0]);
+								root["result"][ii]["ta"] = stof(sd[6]);
 							}
 						}
 						ii++;
@@ -2198,9 +2198,9 @@ namespace http
 								}
 								if (bOK)
 								{
-									double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[1]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
+									double ta = ConvertTemperature(stod(sd[6]), tempsign);
 									root["resultprev"][iPrev]["te"] = te;
 									root["resultprev"][iPrev]["tm"] = tm;
 									root["resultprev"][iPrev]["ta"] = ta;
@@ -2208,8 +2208,8 @@ namespace http
 							}
 							if (((dType == pTypeWIND) && (dSubType == sTypeWIND4)) || ((dType == pTypeWIND) && (dSubType == sTypeWINDNoTemp)))
 							{
-								double ch = ConvertTemperature(atof(sd[3].c_str()), tempsign);
-								double cm = ConvertTemperature(atof(sd[2].c_str()), tempsign);
+								double ch = ConvertTemperature(stod(sd[3]), tempsign);
+								double cm = ConvertTemperature(stod(sd[2]), tempsign);
 								root["resultprev"][iPrev]["ch"] = ch;
 								root["resultprev"][iPrev]["cm"] = cm;
 							}
@@ -2223,7 +2223,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 										root["resultprev"][iPrev]["ba"] = szTmp;
 									}
 									else
@@ -2231,20 +2231,20 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["resultprev"][iPrev]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["resultprev"][iPrev]["ba"] = szTmp;
 								}
 							}
 							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
 							{
-								double sx = ConvertTemperature(atof(sd[8].c_str()), tempsign);
-								double sm = ConvertTemperature(atof(sd[7].c_str()), tempsign);
-								double se = ConvertTemperature(atof(sd[9].c_str()), tempsign);
+								double sx = ConvertTemperature(stod(sd[8]), tempsign);
+								double sm = ConvertTemperature(stod(sd[7]), tempsign);
+								double se = ConvertTemperature(stod(sd[9]), tempsign);
 								root["resultprev"][iPrev]["se"] = se;
 								root["resultprev"][iPrev]["sm"] = sm;
 								root["resultprev"][iPrev]["sx"] = sx;
@@ -2260,18 +2260,18 @@ namespace http
 									|| (value_unit == "F")
 									)
 								{
-									double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double ta = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[1]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
+									double ta = ConvertTemperature(stod(sd[6]), tempsign);
 									root["resultprev"][iPrev]["te"] = te;
 									root["resultprev"][iPrev]["tm"] = tm;
 									root["resultprev"][iPrev]["ta"] = ta;
 								}
 								else
 								{
-									root["resultprev"][iPrev]["te"] = atof(sd[1].c_str());
-									root["resultprev"][iPrev]["tm"] = atof(sd[0].c_str());
-									root["resultprev"][iPrev]["ta"] = atof(sd[6].c_str());
+									root["resultprev"][iPrev]["te"] = stof(sd[1]);
+									root["resultprev"][iPrev]["tm"] = stof(sd[0]);
+									root["resultprev"][iPrev]["ta"] = stof(sd[6]);
 								}
 							}
 
@@ -2427,7 +2427,7 @@ namespace http
 						for (const auto& sd : result)
 						{
 							root["result"][ii]["d"] = sd[2].substr(0, 16);
-							double mmval = atof(sd[0].c_str());
+							double mmval = stod(sd[0]);
 							mmval *= AddjMulti;
 							sprintf(szTmp, "%.1f", mmval);
 							root["result"][ii]["mm"] = szTmp;
@@ -2448,9 +2448,9 @@ namespace http
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
-						// int rate = atoi(sd[2].c_str());
+						float total_min = stof(sd[0]);
+						float total_max = stof(sd[1]);
+						// int rate = stoi(sd[2]);
 
 						double total_real = 0;
 						if (dSubType == sTypeRAINWU || dSubType == sTypeRAINByRate)
@@ -2476,7 +2476,7 @@ namespace http
 						for (const auto& sd : result)
 						{
 							root["resultprev"][iPrev]["d"] = sd[2].substr(0, 16);
-							double mmval = atof(sd[0].c_str());
+							double mmval = stod(sd[0]);
 							mmval *= AddjMulti;
 							sprintf(szTmp, "%.1f", mmval);
 							root["resultprev"][iPrev]["mm"] = szTmp;
@@ -2563,15 +2563,15 @@ namespace http
 								{
 									root["result"][ii]["d"] = sd[4].substr(0, 16);
 
-									double counter_1 = std::stod(sd[5]);
-									double counter_2 = std::stod(sd[6]);
-									double counter_3 = std::stod(sd[7]);
-									double counter_4 = std::stod(sd[8]);
+									double counter_1 = stod(sd[5]);
+									double counter_2 = stod(sd[6]);
+									double counter_3 = stod(sd[7]);
+									double counter_4 = stod(sd[8]);
 
-									float fUsage_1 = std::stof(sd[0]);
-									float fUsage_2 = std::stof(sd[2]);
-									float fDeliv_1 = std::stof(sd[1]);
-									float fDeliv_2 = std::stof(sd[3]);
+									float fUsage_1 = stof(sd[0]);
+									float fUsage_2 = stof(sd[2]);
+									float fDeliv_1 = stof(sd[1]);
+									float fDeliv_2 = stof(sd[3]);
 
 									fDeliv_1 = (fDeliv_1 < 10) ? 0 : fDeliv_1;
 									fDeliv_2 = (fDeliv_2 < 10) ? 0 : fDeliv_2;
@@ -2648,10 +2648,10 @@ namespace http
 								{
 									root["resultprev"][iPrev]["d"] = sd[4].substr(0, 16);
 
-									float fUsage_1 = std::stof(sd[0]);
-									float fUsage_2 = std::stof(sd[2]);
-									float fDeliv_1 = std::stof(sd[1]);
-									float fDeliv_2 = std::stof(sd[3]);
+									float fUsage_1 = stof(sd[0]);
+									float fUsage_2 = stof(sd[2]);
+									float fDeliv_1 = stof(sd[1]);
+									float fDeliv_2 = stof(sd[3]);
 
 									if ((fDeliv_1 != 0) || (fDeliv_2 != 0))
 									{
@@ -2769,9 +2769,9 @@ namespace http
 						{
 							for (const auto& sd : result)
 							{
-								float fValue1 = float(atof(sd[0].c_str())) / vdiv;
-								float fValue2 = float(atof(sd[1].c_str())) / vdiv;
-								float fValue3 = float(atof(sd[2].c_str())) / vdiv;
+								float fValue1 = stof(sd[0]) / vdiv;
+								float fValue2 = stof(sd[1]) / vdiv;
+								float fValue3 = stof(sd[2]) / vdiv;
 								root["result"][ii]["d"] = sd[3].substr(0, 16);
 
 								if (metertype == 1)
@@ -2865,9 +2865,9 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[2].substr(0, 16);
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * atof(sd[0].c_str()) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[0]) / 10.0F);
 								root["result"][ii]["v_min"] = szTmp;
-								sprintf(szTmp, "%.1f", m_sql.m_weightscale * atof(sd[1].c_str()) / 10.0F);
+								sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(sd[1]) / 10.0F);
 								root["result"][ii]["v_max"] = szTmp;
 								ii++;
 							}
@@ -2892,8 +2892,8 @@ namespace http
 							for (const auto& sd : result)
 							{
 								root["result"][ii]["d"] = sd[2].substr(0, 16);
-								root["result"][ii]["u_min"] = atof(sd[0].c_str()) / 10.0F;
-								root["result"][ii]["u_max"] = atof(sd[1].c_str()) / 10.0F;
+								root["result"][ii]["u_min"] = stof(sd[0]) / 10.0F;
+								root["result"][ii]["u_max"] = stof(sd[1]) / 10.0F;
 								ii++;
 							}
 						}
@@ -2920,12 +2920,12 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
-								float fval4 = static_cast<float>(atof(sd[3].c_str()) / 10.0F);
-								float fval5 = static_cast<float>(atof(sd[4].c_str()) / 10.0F);
-								float fval6 = static_cast<float>(atof(sd[5].c_str()) / 10.0F);
+								float fval1 = stof(sd[0]) / 10.0F;
+								float fval2 = stof(sd[1]) / 10.0F;
+								float fval3 = stof(sd[2]) / 10.0F;
+								float fval4 = stof(sd[3]) / 10.0F;
+								float fval5 = stof(sd[4]) / 10.0F;
+								float fval6 = stof(sd[5]) / 10.0F;
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -3004,12 +3004,12 @@ namespace http
 							{
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 
-								float fval1 = static_cast<float>(atof(sd[0].c_str()) / 10.0F);
-								float fval2 = static_cast<float>(atof(sd[1].c_str()) / 10.0F);
-								float fval3 = static_cast<float>(atof(sd[2].c_str()) / 10.0F);
-								float fval4 = static_cast<float>(atof(sd[3].c_str()) / 10.0F);
-								float fval5 = static_cast<float>(atof(sd[4].c_str()) / 10.0F);
-								float fval6 = static_cast<float>(atof(sd[5].c_str()) / 10.0F);
+								float fval1 = stof(sd[0]) / 10.0F;
+								float fval2 = stof(sd[1]) / 10.0F;
+								float fval3 = stof(sd[2]) / 10.0F;
+								float fval4 = stof(sd[3]) / 10.0F;
+								float fval5 = stof(sd[4]) / 10.0F;
+								float fval6 = stof(sd[5]) / 10.0F;
 
 								if ((fval1 != 0) || (fval2 != 0))
 									bHaveL1 = true;
@@ -3071,7 +3071,7 @@ namespace http
 						if (dType == pTypeP1Gas)
 						{
 							// Add last counter value
-							sprintf(szTmp, "%.3f", atof(sValue.c_str()) / 1000.0);
+							sprintf(szTmp, "%.3f", stof(sValue) / 1000.0F);
 							root["counter"] = szTmp;
 						}
 						else if (dType == pTypeENERGY)
@@ -3079,7 +3079,7 @@ namespace http
 							size_t spos = sValue.find(';');
 							if (spos != std::string::npos)
 							{
-								float fvalue = static_cast<float>(atof(sValue.substr(spos + 1).c_str()));
+								float fvalue = stof(sValue.substr(spos + 1));
 								sprintf(szTmp, "%.3f", fvalue / (divider / 100.0F));
 								root["counter"] = szTmp;
 							}
@@ -3089,7 +3089,7 @@ namespace http
 							size_t spos = sValue.find(';');
 							if (spos != std::string::npos)
 							{
-								float fvalue = static_cast<float>(atof(sValue.substr(spos + 1).c_str()));
+								float fvalue = stof(sValue.substr(spos + 1));
 								sprintf(szTmp, "%.3f", fvalue / divider);
 								root["counter"] = szTmp;
 							}
@@ -3097,7 +3097,7 @@ namespace http
 						else if (dType == pTypeRFXMeter)
 						{
 							// Add last counter value
-							double fvalue = atof(sValue.c_str());
+							double fvalue = stod(sValue);
 							switch (metertype)
 							{
 							case MTYPE_ENERGY:
@@ -3126,7 +3126,7 @@ namespace http
 							if (results.size() == 2)
 							{
 								// Add last counter value
-								double fvalue = atof(results[0].c_str());
+								double fvalue = stod(results[0]);
 								switch (metertype)
 								{
 								case MTYPE_ENERGY:
@@ -3151,7 +3151,7 @@ namespace http
 						}
 						else if ((dType == pTypeGeneral) && (dSubType == sTypeCounterIncremental))
 						{
-							double dvalue = static_cast<double>(atof(sValue.c_str()));
+							double dvalue = stod(sValue);
 
 							switch (metertype)
 							{
@@ -3174,7 +3174,7 @@ namespace http
 						}
 						else if (!bIsManagedCounter)
 						{
-							double dvalue = static_cast<double>(atof(sValue.c_str()));
+							double dvalue = stod(sValue);
 							sprintf(szTmp, "%.10g", meteroffset + (dvalue / divider));
 							root["counter"] = szTmp;
 						}
@@ -3223,43 +3223,43 @@ namespace http
 
 									std::string szValue = sd[0];
 
-									double fcounter = atof(sd[2].c_str());
+									double fcounter = stod(sd[2]);
 
 									switch (metertype)
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED:
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stof(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.2f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.2f", meteroffset + ((fcounter - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.2f", meteroffset + ((fcounter - stof(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((fcounter - stof(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.10g", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 										if (fcounter != 0)
-											sprintf(szTmp, "%.10g", meteroffset + ((fcounter - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.10g", meteroffset + ((fcounter - stof(szValue)) / divider));
 										else
 											strcpy(szTmp, "0");
 										root["result"][ii]["c"] = szTmp;
@@ -3284,19 +3284,19 @@ namespace http
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED:
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.2f", stof(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.10g", stof(szValue) / divider);
 										root["resultprev"][iPrev]["v"] = szTmp;
 										break;
 									}
@@ -3313,7 +3313,7 @@ namespace http
 						localtime_r(&now, &loctime);
 						if ((!sactmonth.empty()) && (!sactyear.empty()))
 						{
-							bool bIsThisMonth = (atoi(sactyear.c_str()) == loctime.tm_year + 1900) && (atoi(sactmonth.c_str()) == loctime.tm_mon + 1);
+							bool bIsThisMonth = (stoi(sactyear) == loctime.tm_year + 1900) && (stoi(sactmonth) == loctime.tm_mon + 1);
 							if (bIsThisMonth)
 							{
 								sprintf(szDateEnd, "%04d-%02d-%02d", loctime.tm_year + 1900, loctime.tm_mon + 1, loctime.tm_mday);
@@ -3321,7 +3321,7 @@ namespace http
 						}
 						else if (!sactyear.empty())
 						{
-							bool bIsThisYear = (atoi(sactyear.c_str()) == loctime.tm_year + 1900);
+							bool bIsThisYear = (stoi(sactyear) == loctime.tm_year + 1900);
 							if (bIsThisYear)
 							{
 								sprintf(szDateEnd, "%04d-%02d-%02d", loctime.tm_year + 1900, loctime.tm_mon + 1, loctime.tm_mday);
@@ -3347,15 +3347,15 @@ namespace http
 						if (!result.empty())
 						{
 							std::vector<std::string> sd = result[0];
-							uint64_t total_min_usage_1 = std::stoull(sd[0]);
-							uint64_t total_max_usage_1 = std::stoull(sd[1]);
-							uint64_t total_min_usage_2 = std::stoull(sd[4]);
-							uint64_t total_max_usage_2 = std::stoull(sd[5]);
+							uint64_t total_min_usage_1 = stoull(sd[0]);
+							uint64_t total_max_usage_1 = stoull(sd[1]);
+							uint64_t total_min_usage_2 = stoull(sd[4]);
+							uint64_t total_max_usage_2 = stoull(sd[5]);
 							uint64_t total_real_usage_1, total_real_usage_2;
-							uint64_t total_min_deliv_1 = std::stoull(sd[2]);
-							uint64_t total_max_deliv_1 = std::stoull(sd[3]);
-							uint64_t total_min_deliv_2 = std::stoull(sd[6]);
-							uint64_t total_max_deliv_2 = std::stoull(sd[7]);
+							uint64_t total_min_deliv_1 = stoull(sd[2]);
+							uint64_t total_max_deliv_1 = stoull(sd[3]);
+							uint64_t total_min_deliv_2 = stoull(sd[6]);
+							uint64_t total_max_deliv_2 = stoull(sd[7]);
 							uint64_t total_real_deliv_1, total_real_deliv_2;
 
 							total_real_usage_1 = total_max_usage_1 - total_min_usage_1;
@@ -3455,8 +3455,8 @@ namespace http
 						if (!result.empty())
 						{
 							root["result"][ii]["d"] = szDateEnd;
-							float fValue1 = float(atof(result[0][0].c_str())) / vdiv;
-							float fValue2 = float(atof(result[0][1].c_str())) / vdiv;
+							float fValue1 = stof(result[0][0]) / vdiv;
+							float fValue2 = stof(result[0][1]) / vdiv;
 							if (metertype == 1)
 							{
 								if ((dType == pTypeGeneral) && (dSubType == sTypeDistance))
@@ -3508,9 +3508,9 @@ namespace http
 						if (!result.empty())
 						{
 							root["result"][ii]["d"] = szDateEnd;
-							sprintf(szTmp, "%.1f", m_sql.m_weightscale * atof(result[0][0].c_str()) / 10.0F);
+							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(result[0][0]) / 10.0F);
 							root["result"][ii]["v_min"] = szTmp;
-							sprintf(szTmp, "%.1f", m_sql.m_weightscale * atof(result[0][1].c_str()) / 10.0F);
+							sprintf(szTmp, "%.1f", m_sql.m_weightscale * stof(result[0][1]) / 10.0F);
 							root["result"][ii]["v_max"] = szTmp;
 							ii++;
 						}
@@ -3521,8 +3521,8 @@ namespace http
 						if (!result.empty())
 						{
 							root["result"][ii]["d"] = szDateEnd;
-							root["result"][ii]["u_min"] = atof(result[0][0].c_str()) / 10.0F;
-							root["result"][ii]["u_max"] = atof(result[0][1].c_str()) / 10.0F;
+							root["result"][ii]["u_min"] = stof(result[0][0]) / 10.0F;
+							root["result"][ii]["u_max"] = stof(result[0][1]) / 10.0F;
 							ii++;
 						}
 					}
@@ -3539,7 +3539,7 @@ namespace http
 							if (!result.empty())
 							{
 								std::vector<std::string> sd = result[0];
-								int64_t total_min = std::stoll(sd[0]);
+								int64_t total_min = stoll(sd[0]);
 								int64_t total_max = total_min;
 								int64_t total_real;
 
@@ -3549,7 +3549,7 @@ namespace http
 								if (!result.empty())
 								{
 									std::vector<std::string> sd = result[0];
-									total_max = std::stoull(sd[0]);
+									total_max = stoll(sd[0]);
 								}
 
 								total_real = total_max - total_min;
@@ -3586,7 +3586,7 @@ namespace http
 									{
 									case MTYPE_ENERGY:
 									case MTYPE_ENERGY_GENERATED: {
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
 
 										std::vector<std::string> mresults;
@@ -3596,28 +3596,28 @@ namespace http
 											sValue = mresults[1];
 										}
 										if (dType == pTypeENERGY)
-											sprintf(szTmp, "%.3f", meteroffset + (((atof(sValue.c_str()) * 100.0F) - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + (((stof(sValue) * 100.0F) - stof(szValue)) / divider));
 										else
-											sprintf(szTmp, "%.3f", meteroffset + ((atof(sValue.c_str()) - atof(szValue.c_str())) / divider));
+											sprintf(szTmp, "%.3f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 									}
 															   break;
 									case MTYPE_GAS:
-										sprintf(szTmp, "%.2f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.2f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.2f", meteroffset + ((atof(sValue.c_str()) - atof(szValue.c_str())) / divider));
+										sprintf(szTmp, "%.2f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_WATER:
-										sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.3f", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.3f", meteroffset + ((atof(sValue.c_str()) - atof(szValue.c_str())) / divider));
+										sprintf(szTmp, "%.3f", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									case MTYPE_COUNTER:
-										sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+										sprintf(szTmp, "%.10g", stof(szValue) / divider);
 										root["result"][ii]["v"] = szTmp;
-										sprintf(szTmp, "%.10g", meteroffset + ((atof(sValue.c_str()) - atof(szValue.c_str())) / divider));
+										sprintf(szTmp, "%.10g", meteroffset + ((stof(sValue) - stof(szValue)) / divider));
 										root["result"][ii]["c"] = szTmp;
 										break;
 									}
@@ -3654,8 +3654,8 @@ namespace http
 							root["result"][ii]["d"] = sd[5].substr(0, 16);
 							root["result"][ii]["di"] = sd[0];
 
-							int intSpeed = atoi(sd[2].c_str());
-							int intGust = atoi(sd[4].c_str());
+							int intSpeed = stoi(sd[2]);
+							int intGust = stoi(sd[4]);
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{
 								sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -3687,8 +3687,8 @@ namespace http
 						root["result"][ii]["d"] = szDateEnd;
 						root["result"][ii]["di"] = sd[0];
 
-						int intSpeed = atoi(sd[2].c_str());
-						int intGust = atoi(sd[4].c_str());
+						int intSpeed = stoi(sd[2]);
+						int intGust = stoi(sd[4]);
 						if (m_sql.m_windunit != WINDUNIT_Beaufort)
 						{
 							sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -3721,8 +3721,8 @@ namespace http
 							root["resultprev"][iPrev]["d"] = sd[5].substr(0, 16);
 							root["resultprev"][iPrev]["di"] = sd[0];
 
-							int intSpeed = atoi(sd[2].c_str());
-							int intGust = atoi(sd[4].c_str());
+							int intSpeed = stoi(sd[2]);
+							int intGust = stoi(sd[4]);
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{
 								sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -3813,15 +3813,15 @@ namespace http
 								root["result"][ii]["d"] = sd[4]; //.substr(0,16);
 								if (sendTemp)
 								{
-									double te = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[0]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
 									root["result"][ii]["te"] = te;
 									root["result"][ii]["tm"] = tm;
 								}
 								if (sendChill)
 								{
-									double ch = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double cm = ConvertTemperature(atof(sd[1].c_str()), tempsign);
+									double ch = ConvertTemperature(stod(sd[1]), tempsign);
+									double cm = ConvertTemperature(stod(sd[1]), tempsign);
 									root["result"][ii]["ch"] = ch;
 									root["result"][ii]["cm"] = cm;
 								}
@@ -3835,7 +3835,7 @@ namespace http
 									{
 										if (dSubType == sTypeTHBFloat)
 										{
-											sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+											sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 											root["result"][ii]["ba"] = szTmp;
 										}
 										else
@@ -3843,23 +3843,23 @@ namespace http
 									}
 									else if (dType == pTypeTEMP_BARO)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 									{
-										sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[3]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 								}
 								if (sendDew)
 								{
-									double dp = ConvertTemperature(atof(sd[5].c_str()), tempsign);
+									double dp = ConvertTemperature(stod(sd[5]), tempsign);
 									root["result"][ii]["dp"] = dp;
 								}
 								if (sendSet)
 								{
-									double se = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+									double se = ConvertTemperature(stod(sd[6]), tempsign);
 									root["result"][ii]["se"] = se;
 								}
 								ii++;
@@ -3883,9 +3883,9 @@ namespace http
 								root["result"][ii]["d"] = sd[6].substr(0, 16);
 								if (sendTemp)
 								{
-									double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-									double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-									double ta = ConvertTemperature(atof(sd[8].c_str()), tempsign);
+									double te = ConvertTemperature(stod(sd[1]), tempsign);
+									double tm = ConvertTemperature(stod(sd[0]), tempsign);
+									double ta = ConvertTemperature(stod(sd[8]), tempsign);
 
 									root["result"][ii]["te"] = te;
 									root["result"][ii]["tm"] = tm;
@@ -3893,8 +3893,8 @@ namespace http
 								}
 								if (sendChill)
 								{
-									double ch = ConvertTemperature(atof(sd[3].c_str()), tempsign);
-									double cm = ConvertTemperature(atof(sd[2].c_str()), tempsign);
+									double ch = ConvertTemperature(stod(sd[3]), tempsign);
+									double cm = ConvertTemperature(stod(sd[2]), tempsign);
 
 									root["result"][ii]["ch"] = ch;
 									root["result"][ii]["cm"] = cm;
@@ -3909,7 +3909,7 @@ namespace http
 									{
 										if (dSubType == sTypeTHBFloat)
 										{
-											sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+											sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 											root["result"][ii]["ba"] = szTmp;
 										}
 										else
@@ -3917,25 +3917,25 @@ namespace http
 									}
 									else if (dType == pTypeTEMP_BARO)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 									{
-										sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 								}
 								if (sendDew)
 								{
-									double dp = ConvertTemperature(atof(sd[7].c_str()), tempsign);
+									double dp = ConvertTemperature(stod(sd[7]), tempsign);
 									root["result"][ii]["dp"] = dp;
 								}
 								if (sendSet)
 								{
-									double sm = ConvertTemperature(atof(sd[9].c_str()), tempsign);
-									double sx = ConvertTemperature(atof(sd[10].c_str()), tempsign);
-									double se = ConvertTemperature(atof(sd[11].c_str()), tempsign);
+									double sm = ConvertTemperature(stod(sd[9]), tempsign);
+									double sx = ConvertTemperature(stod(sd[10]), tempsign);
+									double se = ConvertTemperature(stod(sd[11]), tempsign);
 									root["result"][ii]["sm"] = sm;
 									root["result"][ii]["se"] = se;
 									root["result"][ii]["sx"] = sx;
@@ -3961,9 +3961,9 @@ namespace http
 							root["result"][ii]["d"] = szDateEnd;
 							if (sendTemp)
 							{
-								double te = ConvertTemperature(atof(sd[1].c_str()), tempsign);
-								double tm = ConvertTemperature(atof(sd[0].c_str()), tempsign);
-								double ta = ConvertTemperature(atof(sd[7].c_str()), tempsign);
+								double te = ConvertTemperature(stod(sd[1]), tempsign);
+								double tm = ConvertTemperature(stod(sd[0]), tempsign);
+								double ta = ConvertTemperature(stod(sd[7]), tempsign);
 
 								root["result"][ii]["te"] = te;
 								root["result"][ii]["tm"] = tm;
@@ -3971,8 +3971,8 @@ namespace http
 							}
 							if (sendChill)
 							{
-								double ch = ConvertTemperature(atof(sd[3].c_str()), tempsign);
-								double cm = ConvertTemperature(atof(sd[2].c_str()), tempsign);
+								double ch = ConvertTemperature(stod(sd[3]), tempsign);
+								double cm = ConvertTemperature(stod(sd[2]), tempsign);
 								root["result"][ii]["ch"] = ch;
 								root["result"][ii]["cm"] = cm;
 							}
@@ -3986,7 +3986,7 @@ namespace http
 								{
 									if (dSubType == sTypeTHBFloat)
 									{
-										sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+										sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else
@@ -3994,25 +3994,25 @@ namespace http
 								}
 								else if (dType == pTypeTEMP_BARO)
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								{
-									sprintf(szTmp, "%.1f", atof(sd[5].c_str()) / 10.0F);
+									sprintf(szTmp, "%.1f", stof(sd[5]) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
 							if (sendDew)
 							{
-								double dp = ConvertTemperature(atof(sd[6].c_str()), tempsign);
+								double dp = ConvertTemperature(stod(sd[6]), tempsign);
 								root["result"][ii]["dp"] = dp;
 							}
 							if (sendSet)
 							{
-								double sm = ConvertTemperature(atof(sd[8].c_str()), tempsign);
-								double sx = ConvertTemperature(atof(sd[9].c_str()), tempsign);
-								double se = ConvertTemperature(atof(sd[10].c_str()), tempsign);
+								double sm = ConvertTemperature(stod(sd[8]), tempsign);
+								double sx = ConvertTemperature(stod(sd[9]), tempsign);
+								double se = ConvertTemperature(stod(sd[10]), tempsign);
 
 								root["result"][ii]["sm"] = sm;
 								root["result"][ii]["se"] = se;
@@ -4083,9 +4083,9 @@ namespace http
 					{
 						std::vector<std::string> sd = result[0];
 
-						float total_min = static_cast<float>(atof(sd[0].c_str()));
-						float total_max = static_cast<float>(atof(sd[1].c_str()));
-						// int rate = atoi(sd[2].c_str());
+						float total_min = stof(sd[0]);
+						float total_max = stof(sd[1]);
+						// int rate = stoi(sd[2]);
 
 						float total_real = 0;
 						if (dSubType == sTypeRAINWU || dSubType == sTypeRAINByRate)
@@ -4129,8 +4129,8 @@ namespace http
 								std::string szUsage2 = sd[2];
 								std::string szDeliv2 = sd[3];
 
-								float fUsage = (float)(atof(szUsage1.c_str()) + atof(szUsage2.c_str()));
-								float fDeliv = (float)(atof(szDeliv1.c_str()) + atof(szDeliv2.c_str()));
+								float fUsage = stof(szUsage1) + stof(szUsage2);
+								float fDeliv = stof(szDeliv1) + stof(szDeliv2);
 
 								if (fDeliv != 0)
 									bHaveDeliverd = true;
@@ -4159,19 +4159,19 @@ namespace http
 								{
 								case MTYPE_ENERGY:
 								case MTYPE_ENERGY_GENERATED:
-									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.3f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_GAS:
-									sprintf(szTmp, "%.2f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.2f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_WATER:
-									sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.3f", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 								case MTYPE_COUNTER:
-									sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+									sprintf(szTmp, "%.10g", stof(szValue) / divider);
 									szValue = szTmp;
 									break;
 
@@ -4195,16 +4195,16 @@ namespace http
 						{
 							std::vector<std::string> sd = result[0];
 
-							uint64_t total_min_usage_1 = std::stoull(sd[0]);
-							uint64_t total_max_usage_1 = std::stoull(sd[1]);
-							uint64_t total_min_usage_2 = std::stoull(sd[4]);
-							uint64_t total_max_usage_2 = std::stoull(sd[5]);
+							uint64_t total_min_usage_1 = stoull(sd[0]);
+							uint64_t total_max_usage_1 = stoull(sd[1]);
+							uint64_t total_min_usage_2 = stoull(sd[4]);
+							uint64_t total_max_usage_2 = stoull(sd[5]);
 							uint64_t total_real_usage;
 
-							uint64_t total_min_deliv_1 = std::stoull(sd[2]);
-							uint64_t total_max_deliv_1 = std::stoull(sd[3]);
-							uint64_t total_min_deliv_2 = std::stoull(sd[6]);
-							uint64_t total_max_deliv_2 = std::stoull(sd[7]);
+							uint64_t total_min_deliv_1 = stoull(sd[2]);
+							uint64_t total_max_deliv_1 = stoull(sd[3]);
+							uint64_t total_min_deliv_2 = stoull(sd[6]);
+							uint64_t total_max_deliv_2 = stoull(sd[7]);
 							uint64_t total_real_deliv;
 
 							total_real_usage = (total_max_usage_1 + total_max_usage_2) - (total_min_usage_1 + total_min_usage_2);
@@ -4217,12 +4217,12 @@ namespace http
 
 							sprintf(szTmp, "%" PRIu64, total_real_usage);
 							std::string szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["v"] = szTmp;
 
 							sprintf(szTmp, "%" PRIu64, total_real_deliv);
 							szValue = szTmp;
-							sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+							sprintf(szTmp, "%.3f", stof(szValue) / divider);
 							root["result"][ii]["v2"] = szTmp;
 							
 							ii++;
@@ -4240,7 +4240,7 @@ namespace http
 						if (!result.empty())
 						{
 							std::vector<std::string> sd = result[0];
-							int64_t total_min = std::stoll(sd[0]);
+							int64_t total_min = stoll(sd[0]);
 							int64_t total_max = total_min;
 							int64_t total_real;
 
@@ -4250,7 +4250,7 @@ namespace http
 							if (!result.empty())
 							{
 								std::vector<std::string> sd = result[0];
-								total_max = std::stoull(sd[0]);
+								total_max = stoll(sd[0]);
 							}
 
 							total_real = total_max - total_min;
@@ -4260,19 +4260,19 @@ namespace http
 							{
 							case MTYPE_ENERGY:
 							case MTYPE_ENERGY_GENERATED:
-								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.3f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_GAS:
-								sprintf(szTmp, "%.2f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.2f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_WATER:
-								sprintf(szTmp, "%.3f", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.3f", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							case MTYPE_COUNTER:
-								sprintf(szTmp, "%.10g", atof(szValue.c_str()) / divider);
+								sprintf(szTmp, "%.10g", stof(szValue) / divider);
 								szValue = szTmp;
 								break;
 							}
@@ -4302,8 +4302,8 @@ namespace http
 							root["result"][ii]["d"] = sd[5].substr(0, 16);
 							root["result"][ii]["di"] = sd[0];
 
-							int intSpeed = atoi(sd[2].c_str());
-							int intGust = atoi(sd[4].c_str());
+							int intSpeed = stoi(sd[2]);
+							int intGust = stoi(sd[4]);
 							if (m_sql.m_windunit != WINDUNIT_Beaufort)
 							{
 								sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);
@@ -4334,8 +4334,8 @@ namespace http
 						root["result"][ii]["d"] = szDateEnd;
 						root["result"][ii]["di"] = sd[0];
 
-						int intSpeed = atoi(sd[2].c_str());
-						int intGust = atoi(sd[4].c_str());
+						int intSpeed = stoi(sd[2]);
+						int intGust = stoi(sd[4]);
 						if (m_sql.m_windunit != WINDUNIT_Beaufort)
 						{
 							sprintf(szTmp, "%.1f", float(intSpeed) * m_sql.m_windscale);

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -572,7 +572,7 @@ bool ParseConfigFile(const std::string &szConfigFile)
 		}
 
 		else if (szFlag == "startup_delay") {
-			int DelaySeconds = atoi(sLine.c_str());
+			int DelaySeconds = stoi(sLine);
 			_log.Log(LOG_STATUS, "Startup delay... waiting %d seconds...", DelaySeconds);
 			sleep_seconds(DelaySeconds);
 		}
@@ -799,7 +799,7 @@ int main(int argc, char**argv)
 				_log.Log(LOG_ERROR, "Please specify a startupdelay");
 				return 1;
 			}
-			int DelaySeconds = atoi(cmdLine.GetSafeArgument("-startupdelay", 0, "").c_str());
+			int DelaySeconds = stoi(cmdLine.GetSafeArgument("-startupdelay", 0, ""));
 			_log.Log(LOG_STATUS, "Startup delay... waiting %d seconds...", DelaySeconds);
 			sleep_seconds(DelaySeconds);
 		}
@@ -820,7 +820,7 @@ int main(int argc, char**argv)
 				return 1;
 			}
 			std::string wwwport = cmdLine.GetSafeArgument("-www", 0, "");
-			int iPort = (int)atoi(wwwport.c_str());
+			int iPort = stoi(wwwport);
 			if ((iPort < 0) || (iPort > 49151))
 			{
 				_log.Log(LOG_ERROR, "Please specify a valid www port (1 - 49151, or 0 to disable)");
@@ -870,7 +870,7 @@ int main(int argc, char**argv)
 				return 1;
 			}
 			std::string wwwport = cmdLine.GetSafeArgument("-sslwww", 0, "");
-			int iPort = (int)atoi(wwwport.c_str());
+			int iPort = stoi(wwwport);
 			if ((iPort < 0) || (iPort > 49151))
 			{
 				_log.Log(LOG_ERROR, "Please specify a valid sslwww port (1 - 49151)");
@@ -1174,7 +1174,7 @@ int main(int argc, char**argv)
 #ifndef _DEBUG
 	RedirectIOToConsole();	//hide console
 #endif
-	InitWindowsHelper(hInstance, hPrevInstance, nShowCmd, m_mainworker.GetWebserverAddress(), atoi(m_mainworker.GetWebserverPort().c_str()), bStartWebBrowser);
+	InitWindowsHelper(hInstance, hPrevInstance, nShowCmd, m_mainworker.GetWebserverAddress(), stoi(m_mainworker.GetWebserverPort()), bStartWebBrowser);
 	MSG Msg;
 	while (!g_bStopApplication)
 	{

--- a/main/domoticz_tester.cpp
+++ b/main/domoticz_tester.cpp
@@ -185,7 +185,7 @@ bool helper_tester(const std::string szFunction, std::string &szInput, std::stri
 	{
 		if (svInputs.size() == 2)
 		{
-			double dTestOutput = CalculateDewPoint(stod(svInputs[0]), stoi(svInputs[1]));
+			double dTestOutput = CalculateDewPoint(stod(svInputs[0]), static_cast<double>(stoi(svInputs[1])));
 			szOutput = std_format("%.2f", dTestOutput);
 			bSuccess = true;
 		}

--- a/main/domoticz_tester.cpp
+++ b/main/domoticz_tester.cpp
@@ -175,7 +175,7 @@ bool helper_tester(const std::string szFunction, std::string &szInput, std::stri
 	{
 		if (svInputs.size() == 2)
 		{
-			double dTestOutput = round_digits(std::stod(svInputs[0]), std::stoi(svInputs[1]));
+			double dTestOutput = round_digits(stod(svInputs[0]), stoi(svInputs[1]));
 			szOutput = std_format("%f", dTestOutput);
 			bSuccess = true;
 		}
@@ -185,7 +185,7 @@ bool helper_tester(const std::string szFunction, std::string &szInput, std::stri
 	{
 		if (svInputs.size() == 2)
 		{
-			double dTestOutput = CalculateDewPoint(std::stod(svInputs[0]), std::stoi(svInputs[1]));
+			double dTestOutput = CalculateDewPoint(stod(svInputs[0]), stoi(svInputs[1]));
 			szOutput = std_format("%.2f", dTestOutput);
 			bSuccess = true;
 		}

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -1086,7 +1086,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		}
 		else if (uvitem.variableType == 1)
 		{ //Float
-			luaTable.AddNumber("value", stof(uvitem.variableValue));
+			luaTable.AddNumber("value", stold(uvitem.variableValue));
 			vtype = "float";
 		}
 		else

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -298,7 +298,7 @@ void CdzVents::ProcessHttpResponse(lua_State* lua_state, const std::vector<CEven
 							{
 								pos = header.find(results[0]);
 								protocol = header.substr(0, pos + results[0].size());
-								statusCode = atoi(results[1].c_str());
+								statusCode = stoi(results[1]);
 								if (results.size() >= 3)
 								{
 									statusText = header.substr(header.find(results[2]));
@@ -951,11 +951,11 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 			{
 				long double value = 0.0F;
 				if (strarray.size() > 1)
-					value = atof(strarray[1].c_str());
+					value = stold(strarray[1]);
 				luaTable.AddNumber("whTotal", value);
 				value = 0.0F;
 				if (!strarray.empty())
-					value = atof(strarray[0].c_str());
+					value = stold(strarray[0]);
 				luaTable.AddNumber("whActual", value);
 			}
 
@@ -1081,18 +1081,16 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 
 		if (uvitem.variableType == 0)
 		{
-			luaTable.AddInteger("value", atoi(uvitem.variableValue.c_str()));
+			luaTable.AddInteger("value", stoi(uvitem.variableValue));
 			vtype = "integer";
 		}
 		else if (uvitem.variableType == 1)
-		{
-			//Float
-			luaTable.AddNumber("value", atof(uvitem.variableValue.c_str()));
+		{ //Float
+			luaTable.AddNumber("value", stof(uvitem.variableValue));
 			vtype = "float";
 		}
 		else
-		{
-			//String,Date,Time
+		{ //String,Date,Time
 			luaTable.AddString("value", uvitem.variableValue);
 			if (uvitem.variableType == 2)
 				vtype = "string";
@@ -1121,7 +1119,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 		{
 			luaTable.OpenSubTableEntry(index, 1, 3);
 			luaTable.AddString("name", sd[1]);
-			luaTable.AddInteger("id", atoi(sd[0].c_str()));
+			luaTable.AddInteger("id", stoi(sd[0]));
 			luaTable.AddString("baseType", "camera");
 			luaTable.CloseSubTableEntry(); // end entry
 
@@ -1137,11 +1135,11 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 	{
 		for (const auto &sd : result)
 		{
-			HardwareTypeVal = atoi(sd[2].c_str());
+			HardwareTypeVal = stoi(sd[2]);
 
 			luaTable.OpenSubTableEntry(index, 1, 6);
 			luaTable.AddString("name", sd[1]);
-			luaTable.AddInteger("id", atoi(sd[0].c_str()));
+			luaTable.AddInteger("id", stoi(sd[0]));
 			luaTable.AddInteger("typeValue", HardwareTypeVal);
 			luaTable.AddString("baseType", "hardware");
 			if (HardwareTypeVal != HTYPE_PythonPlugin)

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -949,7 +949,7 @@ void CdzVents::ExportDomoticzDataToLua(lua_State *lua_state, const std::vector<C
 			luaTable.AddInteger("hardwareID", sitem.hardwareID);
 			if (sitem.devType == pTypeGeneral && sitem.subType == sTypeKwh)
 			{
-				long double value = 0.0F;
+				long double value = 0.0;
 				if (strarray.size() > 1)
 					value = stold(strarray[1]);
 				luaTable.AddNumber("whTotal", value);

--- a/main/localtime_r.cpp
+++ b/main/localtime_r.cpp
@@ -95,12 +95,12 @@ bool ParseSQLdatetime(time_t &time, struct tm &result, const std::string &szSQLd
 	bool goodtime = false;
 	while (!goodtime) {
 		result.tm_isdst = isdst;
-		result.tm_year = atoi(szSQLdate.substr(0, 4).c_str()) - 1900;
-		result.tm_mon = atoi(szSQLdate.substr(5, 2).c_str()) - 1;
-		result.tm_mday = atoi(szSQLdate.substr(8, 2).c_str());
-		result.tm_hour = atoi(szSQLdate.substr(11, 2).c_str());
-		result.tm_min = atoi(szSQLdate.substr(14, 2).c_str());
-		result.tm_sec = atoi(szSQLdate.substr(17, 2).c_str());
+		result.tm_year = stoi(szSQLdate.substr(0, 4)) - 1900;
+		result.tm_mon = stoi(szSQLdate.substr(5, 2)) - 1;
+		result.tm_mday = stoi(szSQLdate.substr(8, 2));
+		result.tm_hour = stoi(szSQLdate.substr(11, 2));
+		result.tm_min = stoi(szSQLdate.substr(14, 2));
+		result.tm_sec = stoi(szSQLdate.substr(17, 2));
 		if (i > 1)
 			result.tm_hour++; // required to make result consistent across platforms
 		time = mktime(&result);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12880,8 +12880,8 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 
 		if (
 			(value_unit.empty())
-			|| (value_unit == "�C")
-			|| (value_unit == "�F")
+			|| (value_unit == "°C")
+			|| (value_unit == "°F")
 			|| (value_unit == "C")
 			|| (value_unit == "F")
 			)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -2926,7 +2926,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 				for (const auto& sd : result)
 				{
-					float rate = stof(sd[0]) / 10000.0F;
+					float rate = static_cast<float>(stod(sd[0]) / 10000.0);
 					std::string date = sd[1];
 
 					time_t rowtime;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -276,25 +276,25 @@ void MainWorker::AddAllDomoticzHardware()
 	{
 		for (const auto& sd : result)
 		{
-			int ID = atoi(sd[0].c_str());
+			int ID = stoi(sd[0]);
 			std::string Name = sd[1];
 			std::string sEnabled = sd[2];
 			bool Enabled = (sEnabled == "1") ? true : false;
-			_eHardwareTypes Type = (_eHardwareTypes)atoi(sd[3].c_str());
-			uint32_t LogLevelEnabled = (uint32_t)atoi(sd[4].c_str());
+			_eHardwareTypes Type = (_eHardwareTypes) stoi(sd[3]);
+			uint32_t LogLevelEnabled = stoul(sd[4]);
 			std::string Address = sd[5];
-			uint16_t Port = (uint16_t)atoi(sd[6].c_str());
+			uint16_t Port = (uint16_t) stoi(sd[6]);
 			std::string SerialPort = sd[7];
 			std::string Username = sd[8];
 			std::string Password = sd[9];
 			std::string Extra = sd[10];
-			int mode1 = atoi(sd[11].c_str());
-			int mode2 = atoi(sd[12].c_str());
-			int mode3 = atoi(sd[13].c_str());
-			int mode4 = atoi(sd[14].c_str());
-			int mode5 = atoi(sd[15].c_str());
-			int mode6 = atoi(sd[16].c_str());
-			int DataTimeout = atoi(sd[17].c_str());
+			int mode1 = stoi(sd[11]);
+			int mode2 = stoi(sd[12]);
+			int mode3 = stoi(sd[13]);
+			int mode4 = stoi(sd[14]);
+			int mode5 = stoi(sd[15]);
+			int mode6 = stoi(sd[16]);
+			int DataTimeout = stoi(sd[17]);
 			AddHardwareFromParams(ID, Name, Enabled, Type, LogLevelEnabled, Address, Port, SerialPort, Username, Password, Extra, mode1, mode2, mode3, mode4, mode5, mode6, DataTimeout,
 				false);
 		}
@@ -445,7 +445,7 @@ CDomoticzHardwareBase* MainWorker::GetHardwareByIDType(const std::string& HwdId,
 {
 	if (HwdId.empty())
 		return nullptr;
-	int iHardwareID = atoi(HwdId.c_str());
+	int iHardwareID = stoi(HwdId);
 	CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(iHardwareID);
 	if (pHardware == nullptr)
 		return nullptr;
@@ -495,8 +495,8 @@ bool MainWorker::GetSunSettings()
 	int month = ltime.tm_mon + 1;
 	int day = ltime.tm_mday;
 
-	double dLatitude = atof(Latitude.c_str());
-	double dLongitude = atof(Longitude.c_str());
+	double dLatitude = stod(Latitude);
+	double dLongitude = stod(Longitude);
 
 	SunRiseSet::_tSubRiseSetResults sresult;
 	SunRiseSet::GetSunRiseSet(dLatitude, dLongitude, year, month, day, sresult);
@@ -532,7 +532,7 @@ bool MainWorker::GetSunSettings()
 		for (const auto& str : strarray)
 		{
 			StringSplit(str, ":", hourMinItem);
-			int intMins = (atoi(hourMinItem[0].c_str()) * 60) + atoi(hourMinItem[1].c_str());
+			int intMins = (stoi(hourMinItem[0]) * 60) + stoi(hourMinItem[1]);
 			m_SunRiseSetMins.push_back(intMins);
 		}
 
@@ -606,22 +606,22 @@ bool MainWorker::RestartHardware(const std::string& idx)
 	std::vector<std::string> sd = result[0];
 	std::string Name = sd[0];
 	std::string senabled = (sd[1] == "1") ? "true" : "false";
-	_eHardwareTypes htype = (_eHardwareTypes)atoi(sd[2].c_str());
-	uint32_t LogLevelEnabled = (uint32_t)atoi(sd[3].c_str());
+	_eHardwareTypes htype = (_eHardwareTypes) stoi(sd[2]);
+	uint32_t LogLevelEnabled = stoul(sd[3]);
 	std::string address = sd[4];
-	uint16_t port = (uint16_t)atoi(sd[5].c_str());
+	uint16_t port = (uint16_t) stoi(sd[5]);
 	std::string serialport = sd[6];
 	std::string username = sd[7];
 	std::string password = sd[8];
 	std::string extra = sd[9];
-	int Mode1 = atoi(sd[10].c_str());
-	int Mode2 = atoi(sd[11].c_str());
-	int Mode3 = atoi(sd[12].c_str());
-	int Mode4 = atoi(sd[13].c_str());
-	int Mode5 = atoi(sd[14].c_str());
-	int Mode6 = atoi(sd[15].c_str());
-	int DataTimeout = atoi(sd[16].c_str());
-	return AddHardwareFromParams(atoi(idx.c_str()), Name, (senabled == "true") ? true : false, htype, LogLevelEnabled, address, port, serialport, username, password, extra, Mode1, Mode2, Mode3,
+	int Mode1 = stoi(sd[10]);
+	int Mode2 = stoi(sd[11]);
+	int Mode3 = stoi(sd[12]);
+	int Mode4 = stoi(sd[13]);
+	int Mode5 = stoi(sd[14]);
+	int Mode6 = stoi(sd[15]);
+	int DataTimeout = stoi(sd[16]);
+	return AddHardwareFromParams(stoi(idx), Name, (senabled == "true") ? true : false, htype, LogLevelEnabled, address, port, serialport, username, password, extra, Mode1, Mode2, Mode3,
 		Mode4, Mode5, Mode6, DataTimeout, true);
 }
 
@@ -656,10 +656,10 @@ bool MainWorker::AddHardwareFromParams(
 	case HTYPE_RFXtrx315:
 	case HTYPE_RFXtrx433:
 	case HTYPE_RFXtrx868:
-		pHardware = new RFXComSerial(ID, SerialPort, 38400, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
+		pHardware = new RFXComSerial(ID, SerialPort, 38400, (CRFXBase::_eRFXAsyncType) stoi(Extra));
 		break;
 	case HTYPE_RFXLAN:
-		pHardware = new RFXComTCP(ID, Address, Port, (CRFXBase::_eRFXAsyncType)atoi(Extra.c_str()));
+		pHardware = new RFXComTCP(ID, Address, Port, (CRFXBase::_eRFXAsyncType) stoi(Extra));
 		break;
 	case HTYPE_P1SmartMeter:
 		pHardware = new P1MeterSerial(ID, SerialPort, (Mode1 == 1) ? 115200 : 9600, (Mode2 != 0), Mode3, Password);
@@ -1338,7 +1338,7 @@ bool MainWorker::IsUpdateAvailable(const bool bIsForced)
 	if (strarray.size() != 3)
 		return false;
 
-	m_iRevision = atoi(strarray[2].c_str());
+	m_iRevision = stoi(strarray[2]);
 #ifdef DEBUG_DOWNLOAD
 	m_bHaveUpdate = true;
 #else
@@ -2908,7 +2908,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 			"SELECT ID FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
 		if (!result.empty())
 		{
-			uint64_t ulID = std::stoull(result[0][0]);
+			uint64_t ulID = stoull(result[0][0]);
 
 			time_t now = mytime(nullptr);
 			struct tm ltime;
@@ -2926,7 +2926,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 
 				for (const auto& sd : result)
 				{
-					float rate = (float)atof(sd[0].c_str()) / 10000.0F;
+					float rate = stof(sd[0]) / 10000.0F;
 					std::string date = sd[1];
 
 					time_t rowtime;
@@ -2954,7 +2954,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 			"SELECT ID FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
 		if (!result.empty())
 		{
-			uint64_t ulID = std::stoull(result[0][0]);
+			uint64_t ulID = stoull(result[0][0]);
 
 			//Get Counter from one Hour ago
 			time_t now = mytime(nullptr);
@@ -2968,7 +2968,7 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 				ulID, ltime.tm_year + 1900, ltime.tm_mon + 1, ltime.tm_mday, ltime.tm_hour, ltime.tm_min, ltime.tm_sec);
 			if (result.size() == 1)
 			{
-				float totalRainFallLastHour = TotalRain - static_cast<float>(atof(result[0][0].c_str()));
+				float totalRainFallLastHour = TotalRain - stof(result[0][0]);
 				Rainrate = ground(totalRainFallLastHour * 100.0F);
 			}
 		}
@@ -3364,8 +3364,8 @@ void MainWorker::decode_Temp(const CDomoticzHardwareBase* pHardware, const tRBUF
 		{
 			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, AddjValue, AddjMulti);
 			temp += AddjValue;
-			humidity = atoi(result[0][0].c_str());
-			uint8_t humidity_status = atoi(result[0][1].c_str());
+			humidity = (uint8_t) stoi(result[0][0]);
+			uint8_t humidity_status = stoi(result[0][1]);
 			sprintf(szTmp, "%.1f;%d;%d", temp, humidity, humidity_status);
 			DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 			m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, pTypeTEMP_HUM, sTypeTH_LC_TC, szTmp);
@@ -3500,7 +3500,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 			pHardware->m_HwdID, ID.c_str(), 0, pTypeTEMP, sTypeTEMP5);
 		if (result.size() == 1)
 		{
-			temp = static_cast<float>(atof(result[0][0].c_str()));
+			temp = stof(result[0][0]);
 			float AddjValue = 0.0F;
 			float AddjMulti = 1.0F;
 			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, AddjValue, AddjMulti);
@@ -5859,7 +5859,7 @@ void MainWorker::decode_ColorSwitch(const CDomoticzHardwareBase* pHardware, cons
 		pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
 	if (!result.empty())
 	{
-		DevRowIdx = std::stoull(result[0][0]);
+		DevRowIdx = stoull(result[0][0]);
 	}
 	else
 	{
@@ -6547,7 +6547,7 @@ void MainWorker::decode_evohome1(const CDomoticzHardwareBase* pHardware, const t
 	if (!result.empty())
 	{
 		std::vector<std::string> sd = result[0];
-		if (atoi(sd[7].c_str()) == cmnd && sd[8] == szUntilDate)
+		if (stoi(sd[7]) == cmnd && sd[8] == szUntilDate)
 			return;
 	}
 	else
@@ -6654,11 +6654,11 @@ void MainWorker::decode_evohome2(const CDomoticzHardwareBase* pHardware, const t
 	{
 		std::vector<std::string> sd = result[0];
 		szDevID = sd[1];
-		Unit = atoi(sd[2].c_str());
-		dType = atoi(sd[3].c_str());
-		dSubType = atoi(sd[4].c_str());
+		Unit = (uint8_t) stoi(sd[2]);
+		dType = (uint8_t) stoi(sd[3]);
+		dSubType = (uint8_t) stoi(sd[4]);
 		szUpdateStat = sd[5];
-		BatteryLevel = atoi(sd[6].c_str());
+		BatteryLevel = (uint8_t) stoi(sd[6]);
 	}
 	else
 	{
@@ -6793,18 +6793,18 @@ void MainWorker::decode_evohome3(const CDomoticzHardwareBase* pHardware, const t
 	{
 		if (pEvo->demand == 0xFF)//we sometimes get a 0418 message after the initial device creation but it will mess up the logging as we don't have a demand
 			return;
-		uint8_t cur_cmnd = atoi(result[0][5].c_str());
-		BatteryLevel = atoi(result[0][7].c_str());
+		uint8_t cur_cmnd = (uint8_t) stoi(result[0][5]);
+		BatteryLevel = (uint8_t) stoi(result[0][7]);
 
 		if (pEvo->updatetype == CEvohomeBase::updBattery)
 		{
 			BatteryLevel = pEvo->battery_level;
 			szDemand = result[0][6];
-			cmnd = (atoi(szDemand.c_str()) > 0) ? light1_sOn : light1_sOff;
+			cmnd = (stoi(szDemand) > 0) ? light1_sOn : light1_sOff;
 		}
 		if (Unit == 0xFF)
 		{
-			Unit = atoi(result[0][2].c_str());
+			Unit = (uint8_t) stoi(result[0][2]);
 			szDemand = result[0][6];
 			if (cmnd == cur_cmnd)
 				return;
@@ -8886,7 +8886,7 @@ void MainWorker::decode_Energy(const CDomoticzHardwareBase* pHardware, const tRB
 			StringSplit(sValue, ";", strarray);
 			if (strarray.size() != 2)
 				return;
-			total = atof(strarray[1].c_str());
+			total = stod(strarray[1]);
 		}
 	}
 
@@ -9029,7 +9029,7 @@ void MainWorker::decode_Current_Energy(const CDomoticzHardwareBase* pHardware, c
 			StringSplit(result2[0][1], ";", strarray);
 			if (strarray.size() == 4)
 			{
-				usage = atof(strarray[3].c_str());
+				usage = stod(strarray[3]);
 			}
 		}
 	}
@@ -9058,7 +9058,7 @@ void MainWorker::decode_Current_Energy(const CDomoticzHardwareBase* pHardware, c
 				StringSplit(result2[0][1], ";", strarray);
 				if (strarray.size() == 4)
 				{
-					usage = atof(strarray[3].c_str());
+					usage = stod(strarray[3]);
 				}
 			}
 		}
@@ -11112,7 +11112,7 @@ void MainWorker::decode_LightningSensor(const CDomoticzHardwareBase* pHardware, 
 	result = m_sql.safe_query("SELECT Timeout, ID FROM WOLNodes WHERE (HardwareID==%d) AND (Name=='%q')", pHardware->m_HwdID, lookupName.c_str());
 	if (!result.empty())
 	{
-		int old_count = atoi(result[0][0].c_str());
+		int old_count = stoi(result[0][0]);
 		if (old_count <= new_count)
 		{
 			new_count = strike_count - old_count;
@@ -11254,11 +11254,11 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 	if (result.empty())
 		return false;
 	std::vector<std::string> sd = result[0];
-	int devType = atoi(sd[0].c_str());
-	int subType = atoi(sd[1].c_str());
-	nValue = atoi(sd[2].c_str());
+	int devType = stoi(sd[0]);
+	int subType = stoi(sd[1]);
+	nValue = stoi(sd[2]);
 	sValue = sd[3];
-	_eMeterType metertype = (_eMeterType)atoi(sd[4].c_str());
+	_eMeterType metertype = (_eMeterType) stoi(sd[4]);
 
 	//Special cases
 	if ((devType == pTypeP1Power) && (subType == sTypeP1Power))
@@ -11268,8 +11268,8 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 		if (results.size() < 6)
 			return false; //invalid data
 		//Return usage or delivery
-		long usagecurrent = atol(results[4].c_str());
-		long delivcurrent = atol(results[5].c_str());
+		long usagecurrent = stol(results[4]);
+		long delivcurrent = stol(results[5]);
 		std::stringstream ssvalue;
 		if (delivcurrent > 0)
 		{
@@ -11308,8 +11308,8 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 		if (!result2.empty())
 		{
 			std::vector<std::string> sd2 = result2[0];
-			uint64_t total_min_gas = std::stoull(sd2[0].c_str());
-			uint64_t gasactual = std::stoull(sValue);
+			uint64_t total_min_gas = stoull(sd2[0]);
+			uint64_t gasactual = stoull(sValue);
 			uint64_t total_real_gas = gasactual - total_min_gas;
 			float musage = float(total_real_gas) / GasDivider;
 			sprintf(szTmp, "%.03f", musage);
@@ -11364,8 +11364,8 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 		{
 			std::vector<std::string> sd2 = result2[0];
 
-			uint64_t total_min = std::stoull(sd2[0]);
-			uint64_t total_max = std::stoull(sd2[1]);
+			uint64_t total_min = stoull(sd2[0]);
+			uint64_t total_max = stoull(sd2[1]);
 			uint64_t total_real = total_max - total_min;
 			sprintf(szTmp, "%" PRIu64, total_real);
 
@@ -11402,7 +11402,7 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 
 MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string& User)
 {
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 	{
@@ -11427,17 +11427,17 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 
 
 	std::string deviceID = sd[1];
-	int Unit = atoi(sd[2].c_str());
-	int dType = atoi(sd[3].c_str());
-	int dSubType = atoi(sd[4].c_str());
-	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	int Unit = stoi(sd[2]);
+	int dType = stoi(sd[3]);
+	int dSubType = stoi(sd[4]);
+	_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 
 	std::string lstatus;
 	int llevel = 0;
 	bool bHaveDimmer = false;
 	bool bHaveGroupCmd = false;
 	int maxDimLevel = 0;
-	int nValue = atoi(sd[7].c_str());
+	int nValue = stoi(sd[7]);
 	std::string sValue = sd[8];
 	GetLightStatus(dType, dSubType, switchtype, nValue, sValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 
@@ -11486,7 +11486,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			"SELECT LastLevel FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", HardwareID, sd[1].c_str(), Unit, int(dType), int(dSubType));
 		if (result.size() == 1)
 		{
-			level = atoi(result[0][0].c_str());
+			level = stoi(result[0][0]);
 			if (
 				(switchcmd == "On")
 				&& (level > 0)
@@ -11594,7 +11594,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.LIGHTING1.packettype = dType;
 		lcmd.LIGHTING1.subtype = dSubType;
 		lcmd.LIGHTING1.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
-		lcmd.LIGHTING1.housecode = atoi(sd[1].c_str());
+		lcmd.LIGHTING1.housecode = (BYTE) stoi(sd[1]);
 		lcmd.LIGHTING1.unitcode = Unit;
 		lcmd.LIGHTING1.filler = 0;
 		lcmd.LIGHTING1.rssi = 12;
@@ -11721,7 +11721,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			"SELECT sValue FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)", HardwareID, sd[1].c_str(), Unit, int(dType), int(dSubType));
 		if (result.size() == 1)
 		{
-			int pulsetimeing = atoi(result[0][0].c_str());
+			int pulsetimeing = stoi(result[0][0]);
 			lcmd.LIGHTING4.pulseHigh = pulsetimeing / 256;
 			lcmd.LIGHTING4.pulseLow = pulsetimeing & 0xFF;
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING4)))
@@ -12135,7 +12135,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.CURTAIN1.packettype = dType;
 		lcmd.CURTAIN1.subtype = dSubType;
 		lcmd.CURTAIN1.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
-		lcmd.CURTAIN1.housecode = atoi(sd[1].c_str());
+		lcmd.CURTAIN1.housecode = (BYTE) stoi(sd[1]);
 		lcmd.CURTAIN1.unitcode = Unit;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.CURTAIN1.cmnd, options))
 			return SL_ERROR;
@@ -12570,15 +12570,15 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 
 	std::vector<std::string> sd = result[0];
 
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
 
-	//uint8_t Unit = atoi(sd[2].c_str());
-	//uint8_t dType = atoi(sd[3].c_str());
-	//uint8_t dSubType = atoi(sd[4].c_str());
-	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	//uint8_t Unit = (uint8_t) stoi(sd[2]);
+	//uint8_t dType = (uint8_t) stoi(sd[3]);
+	//uint8_t dSubType = (uint8_t) stoi(sd[4]);
+	//_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 
 	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
 	if (pHardware == nullptr)
@@ -12604,7 +12604,7 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 	else if (status == "HeatingOff")
 		nStatus = CEvohomeBase::cmEvoHeatingOff;
 
-	int nValue = atoi(sd[7].c_str());
+	int nValue = stoi(sd[7]);
 	if (ooc == "1" && nValue == nStatus)
 		return false;//FIXME not an error ... status = (already set)
 
@@ -12638,12 +12638,12 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 
 MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const std::string& idx, const std::string& switchcmd, const std::string& level, const std::string& color, const std::string& ooc, const int ExtraDelay, const std::string& User)
 {
-	uint64_t ID = std::stoull(idx);
+	uint64_t ID = stoull(idx);
 	int ilevel = -1;
 	if (!level.empty())
-		ilevel = atoi(level.c_str());
+		ilevel = stoi(level);
 
-	return SwitchLight(ID, switchcmd, ilevel, _tColor(color), atoi(ooc.c_str()) != 0, ExtraDelay, User);
+	return SwitchLight(ID, switchcmd, ilevel, _tColor(color), stoi(ooc) != 0, ExtraDelay, User);
 }
 
 MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, const int level, _tColor color, const bool ooc, const int ExtraDelay, const std::string& User)
@@ -12660,17 +12660,17 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 	std::vector<std::string> sd = result[0];
 	std::string hwdid = sd[0];
 	std::string devid = sd[1];
-	int dtype = atoi(sd[3].c_str());
-	int subtype = atoi(sd[4].c_str());
-	_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
-	int iOnDelay = atoi(sd[6].c_str());
-	int nValue = atoi(sd[7].c_str());
+	int dtype = stoi(sd[3]);
+	int subtype = stoi(sd[4]);
+	_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
+	int iOnDelay = stoi(sd[6]);
+	int nValue = stoi(sd[7]);
 	std::string sValue = sd[8];
 	std::string devName = sd[9];
 
 	//std::string sOptions = sd[10].c_str();
 	// ----------- If needed convert to GeneralSwitch type (for o.a. RFlink) -----------
-	CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(atoi(hwdid.c_str()));
+	CDomoticzHardwareBase* pBaseHardware = m_mainworker.GetHardware(stoi(hwdid));
 	if (pBaseHardware != nullptr)
 	{
 		if (pBaseHardware->HwdType == HTYPE_ZIBLUEUSB || pBaseHardware->HwdType == HTYPE_ZIBLUETCP)
@@ -12685,7 +12685,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 	if (ooc)//Only on change
 	{
 		int nNewVal = bIsOn ? 1 : 0;//Is that everything we need here
-		if ((switchtype == STYPE_Selector) && (nValue == nNewVal) && (level == atoi(sValue.c_str()))) {
+		if ((switchtype == STYPE_Selector) && (nValue == nNewVal) && (level == stoi(sValue))) {
 			return SL_OK_NO_ACTION;
 		}
 		if (nValue == nNewVal)
@@ -12704,7 +12704,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 		return SL_OK;
 	}
 
-	int HardwareID = atoi(hwdid.c_str());
+	int HardwareID = stoi(hwdid);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 	{
@@ -12736,7 +12736,7 @@ bool MainWorker::SetSetPointEvo(const std::string& idx, const float TempValue, c
 		return false;
 
 	std::vector<std::string> sd = result[0];
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -12771,10 +12771,10 @@ bool MainWorker::SetSetPointEvo(const std::string& idx, const float TempValue, c
 	s_strid >> ID;
 
 
-	uint8_t Unit = atoi(sd[2].c_str());
-	uint8_t dType = atoi(sd[3].c_str());
-	uint8_t dSubType = atoi(sd[4].c_str());
-	//_eSwitchType switchtype=(_eSwitchType)atoi(sd[5].c_str());
+	uint8_t Unit = (uint8_t) stoi(sd[2]);
+	uint8_t dType = (uint8_t) stoi(sd[3]);
+	uint8_t dSubType = (uint8_t) stoi(sd[4]);
+	//_eSwitchType switchtype=(_eSwitchType) stoi(sd[5]);
 
 	if (pHardware->HwdType == HTYPE_EVOHOME_SCRIPT || pHardware->HwdType == HTYPE_EVOHOME_SERIAL || pHardware->HwdType == HTYPE_EVOHOME_WEB || pHardware->HwdType == HTYPE_EVOHOME_TCP)
 	{
@@ -12799,7 +12799,7 @@ bool MainWorker::SetSetPointEvo(const std::string& idx, const float TempValue, c
 		if (!result.empty())
 		{
 			sd = result[0];
-			tsen.controllermode = atoi(sd[2].c_str());
+			tsen.controllermode = (uint8_t) stoi(sd[2]);
 		}
 		//the latency on the scripted solution is quite bad so it's good to see the update happening...ideally this would go to an 'updating' status (also useful to update database if we ever use this as a pure virtual device)
 		PushAndWaitRxMessage(pHardware, (const uint8_t*)&tsen, nullptr, -1, nullptr);
@@ -12819,7 +12819,7 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue)
 
 	std::vector<std::string> sd = result[0];
 
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -12839,7 +12839,7 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue)
 
 bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float TempValue)
 {
-	int HardwareID = atoi(sd[0].c_str());
+	int HardwareID = stoi(sd[0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -12859,10 +12859,10 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
 	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
 
-	uint8_t Unit = atoi(sd[2].c_str());
-	uint8_t dType = atoi(sd[3].c_str());
-	uint8_t dSubType = atoi(sd[4].c_str());
-	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+	uint8_t Unit = (uint8_t) stoi(sd[2]);
+	uint8_t dType = (uint8_t) stoi(sd[3]);
+	uint8_t dSubType = (uint8_t) stoi(sd[4]);
+	//_eSwitchType switchtype = (_eSwitchType) stoi(sd[5]);
 
 	_tSetpoint tmeter;
 	tmeter.subtype = sTypeSetpoint;
@@ -12880,8 +12880,8 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 
 		if (
 			(value_unit.empty())
-			|| (value_unit == "°C")
-			|| (value_unit == "°F")
+			|| (value_unit == "ï¿½C")
+			|| (value_unit == "ï¿½F")
 			|| (value_unit == "C")
 			|| (value_unit == "F")
 			)
@@ -13035,8 +13035,8 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 			sprintf(szTemp, "%.1f", TempValue);
 			std::vector<std::string> strarray;
 			StringSplit(szTemp, ".", strarray);
-			lcmd.RADIATOR1.temperature = (uint8_t)atoi(strarray[0].c_str());
-			lcmd.RADIATOR1.tempPoint5 = (uint8_t)atoi(strarray[1].c_str());
+			lcmd.RADIATOR1.temperature = (BYTE) stoi(strarray[0]);
+			lcmd.RADIATOR1.tempPoint5 = (BYTE) stoi(strarray[1]);
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
 				return false;
 			PushAndWaitRxMessage(pHardware, (const uint8_t*)&lcmd, nullptr, -1, nullptr);
@@ -13064,7 +13064,7 @@ bool MainWorker::SetThermostatState(const std::string& idx, const int newState)
 		idx.c_str());
 	if (result.empty())
 		return false;
-	int HardwareID = atoi(result[0][0].c_str());
+	int HardwareID = stoi(result[0][0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -13118,7 +13118,7 @@ bool MainWorker::SetThermostatState(const std::string& idx, const int newState)
 	if (pHardware->HwdType == HTYPE_Netatmo)
 	{
 		CNetatmo* pGateway = dynamic_cast<CNetatmo*>(pHardware);
-		int tIndex = atoi(idx.c_str());
+		int tIndex = stoi(idx);
 		pGateway->SetProgramState(tIndex, newState);
 		return true;
 	}
@@ -13142,7 +13142,7 @@ bool MainWorker::SetZWaveThermostatMode(const std::string& idx, const int tMode)
 	if (result.empty())
 		return false;
 
-	int HardwareID = atoi(result[0][0].c_str());
+	int HardwareID = stoi(result[0][0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -13180,7 +13180,7 @@ bool MainWorker::SetZWaveThermostatFanMode(const std::string& idx, const int fMo
 	if (result.empty())
 		return false;
 
-	int HardwareID = atoi(result[0][0].c_str());
+	int HardwareID = stoi(result[0][0]);
 	int hindex = FindDomoticzHardware(HardwareID);
 	if (hindex == -1)
 		return false;
@@ -13221,7 +13221,7 @@ bool MainWorker::DoesDeviceActiveAScene(const uint64_t DevRowIdx, const int Cmnd
 	{
 		for (const auto& sd : result)
 		{
-			int SceneType = atoi(sd[1].c_str());
+			int SceneType = stoi(sd[1]);
 
 			std::vector<std::string> arrayActivators;
 			StringSplit(sd[0], ";", arrayActivators);
@@ -13237,12 +13237,12 @@ bool MainWorker::DoesDeviceActiveAScene(const uint64_t DevRowIdx, const int Cmnd
 					sCode = arrayCode[1];
 				}
 
-				uint64_t aID = std::stoull(sID);
+				uint64_t aID = stoull(sID);
 				if (aID == DevRowIdx)
 				{
 					if ((SceneType == SGTYPE_GROUP) || (sCode.empty()))
 						return true;
-					int iCode = atoi(sCode.c_str());
+					int iCode = stoi(sCode);
 					if (iCode == Cmnd)
 						return true;
 				}
@@ -13254,7 +13254,7 @@ bool MainWorker::DoesDeviceActiveAScene(const uint64_t DevRowIdx, const int Cmnd
 
 bool MainWorker::SwitchScene(const std::string& idx, const std::string& switchcmd, const std::string& User)
 {
-	uint64_t ID = std::stoull(idx);
+	uint64_t ID = stoull(idx);
 
 	return SwitchScene(ID, switchcmd, User);
 }
@@ -13276,7 +13276,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 	{
 		std::vector<std::string> sds = result[0];
 		Name = sds[0];
-		scenetype = (_eSceneGroupType)atoi(sds[1].c_str());
+		scenetype = (_eSceneGroupType) stoi(sds[1]);
 		onaction = sds[2];
 		offaction = sds[3];
 		status = sds[4];
@@ -13288,7 +13288,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 				return false;
 			//when asking for Toggle, just switch to the opposite value
 			if (switchcmd == "Toggle") {
-				nValue = (atoi(status.c_str()) == 0 ? 1 : 0);
+				nValue = (stoi(status) == 0 ? 1 : 0);
 				switchcmd = (nValue == 1 ? "On" : "Off");
 			}
 		}
@@ -13325,7 +13325,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 				for (const auto& sd : result)
 				{
 					std::string camidx = sd[0];
-					int delay = atoi(sd[1].c_str());
+					int delay = stoi(sd[1]);
 					std::string subject;
 					if (scenetype == SGTYPE_SCENE)
 						subject = Name + " Activated";
@@ -13354,27 +13354,27 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 
 	for (const auto& sd : result)
 	{
-		int cmd = atoi(sd[1].c_str());
-		int level = atoi(sd[2].c_str());
+		int cmd = stoi(sd[1]);
+		int level = stoi(sd[2]);
 		_tColor color(sd[3]);
-		int ondelay = atoi(sd[4].c_str());
-		int offdelay = atoi(sd[5].c_str());
+		int ondelay = stoi(sd[4]);
+		int offdelay = stoi(sd[5]);
 		std::vector<std::vector<std::string> > result2;
 		result2 = m_sql.safe_query(
 			"SELECT HardwareID, DeviceID,Unit,Type,SubType,SwitchType, nValue, sValue, Name FROM DeviceStatus WHERE (ID == '%q')", sd[0].c_str());
 		if (!result2.empty())
 		{
 			std::vector<std::string> sd2 = result2[0];
-			//uint8_t rnValue = atoi(sd2[6].c_str());
+			//uint8_t rnValue = (uint8_t) stoi(sd2[6]);
 			std::string sValue = sd2[7];
-			//uint8_t Unit = atoi(sd2[2].c_str());
-			uint8_t dType = atoi(sd2[3].c_str());
-			uint8_t dSubType = atoi(sd2[4].c_str());
+			//uint8_t Unit = (uint8_t) stoi(sd2[2]);
+			uint8_t dType = (uint8_t) stoi(sd2[3]);
+			uint8_t dSubType = (uint8_t) stoi(sd2[4]);
 			std::string DeviceName = sd2[8];
-			_eSwitchType switchtype = (_eSwitchType)atoi(sd2[5].c_str());
+			_eSwitchType switchtype = (_eSwitchType) stoi(sd2[5]);
 
 			//Check if this device will not activate a scene
-			uint64_t dID = std::stoull(sd[0]);
+			uint64_t dID = stoull(sd[0]);
 			if (DoesDeviceActiveAScene(dID, cmd))
 			{
 				_log.Log(LOG_ERROR, "Skipping sensor '%s' because this triggers another scene!", DeviceName.c_str());
@@ -13427,7 +13427,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 				}
 			}
 
-			int idx = atoi(sd[0].c_str());
+			int idx = stoi(sd[0]);
 			if (switchtype != STYPE_PushOn)
 			{
 				int delay = (lstatus == "Off") ? offdelay : ondelay;
@@ -13481,17 +13481,17 @@ void MainWorker::CheckSceneCode(const uint64_t DevRowIdx, const uint8_t dType, c
 					sCode = arrayCode[1];
 				}
 
-				uint64_t aID = std::stoull(sID);
+				uint64_t aID = stoull(sID);
 				if (aID == DevRowIdx)
 				{
-					uint64_t ID = std::stoull(sd[0]);
-					int scenetype = atoi(sd[2].c_str());
+					uint64_t ID = stoull(sd[0]);
+					int scenetype = stoi(sd[2]);
 					int rnValue = nValue;
 
 					if ((scenetype == SGTYPE_SCENE) && (!sCode.empty()))
 					{
 						//Also check code
-						int iCode = atoi(sCode.c_str());
+						int iCode = stoi(sCode);
 						if (iCode != nValue)
 							continue;
 						rnValue = 1; //A Scene can only be activated (On)
@@ -13535,7 +13535,7 @@ void MainWorker::LoadSharedUsers()
 			{
 				for (const auto& sd2 : result2)
 				{
-					uint64_t ID = std::stoull(sd2[0]);
+					uint64_t ID = stoull(sd2[0]);
 					suser.Devices.push_back(ID);
 				}
 			}
@@ -13768,12 +13768,12 @@ bool MainWorker::UpdateDevice(const int DevIdx, const int nValue, const std::str
 	if (result.empty())
 		return false;
 
-	int HardwareID = std::stoi(result[0][0]);
-	int OrgHardwareID = std::stoi(result[0][1]);
+	int HardwareID = stoi(result[0][0]);
+	int OrgHardwareID = stoi(result[0][1]);
 	std::string DeviceID = result[0][2];
-	int unit = std::stoi(result[0][3]);
-	int devType = std::stoi(result[0][4]);
-	int subType = std::stoi(result[0][5]);
+	int unit = stoi(result[0][3]);
+	int devType = stoi(result[0][4]);
+	int subType = stoi(result[0][5]);
 
 	return UpdateDevice(HardwareID, OrgHardwareID, DeviceID, unit, devType, subType, nValue, sValue, userName, signallevel, batterylevel, parseTrigger);
 }
@@ -13799,7 +13799,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 			)
 		{
 			_log.Log(LOG_NORM, "Updating SetPoint device....");
-			SetSetPoint(sidx.str(), static_cast<float>(atof(sValue.c_str())));
+			SetSetPoint(sidx.str(), stof(sValue));
 
 #ifdef ENABLE_PYTHON
 			// notify plugin
@@ -13844,7 +13844,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 				lcmd.LIGHTING2.id4 = ID4;
 				lcmd.LIGHTING2.unitcode = (uint8_t)unit;
 				lcmd.LIGHTING2.cmnd = (uint8_t)nValue;
-				lcmd.LIGHTING2.level = (uint8_t)atoi(sValue.c_str());
+				lcmd.LIGHTING2.level = (BYTE) stoi(sValue);
 				lcmd.LIGHTING2.filler = 0;
 				lcmd.LIGHTING2.rssi = signallevel;
 				DecodeRXMessage(pHardware, (const uint8_t*)&lcmd.LIGHTING2, nullptr, batterylevel, userName.c_str());
@@ -13871,7 +13871,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 
 				if (devType == pTypeTEMP)
 				{
-					temp = static_cast<float>(atof(sValue.c_str()));
+					temp = stof(sValue);
 					temp += AddjValue;
 					sprintf(szTmp, "%.2f", temp);
 					sValue = szTmp;
@@ -13881,7 +13881,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 					StringSplit(sValue, ";", strarray);
 					if (strarray.size() == 3)
 					{
-						temp = static_cast<float>(atof(strarray[0].c_str()));
+						temp = stof(strarray[0]);
 						temp += AddjValue;
 						sprintf(szTmp, "%.2f;%s;%s", temp, strarray[1].c_str(), strarray[2].c_str());
 						sValue = szTmp;
@@ -13892,8 +13892,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 					StringSplit(sValue, ";", strarray);
 					if (strarray.size() == 5)
 					{
-						temp = static_cast<float>(atof(strarray[0].c_str()));
-						float fbarometer = static_cast<float>(atof(strarray[3].c_str()));
+						temp = stof(strarray[0]);
+						float fbarometer = stof(strarray[3]);
 						temp += AddjValue;
 
 						AddjValue = 0.0F;

--- a/notifications/NotificationBase.cpp
+++ b/notifications/NotificationBase.cpp
@@ -146,7 +146,7 @@ void CNotificationBase::SetConfigValue(const std::string &Key, const std::string
 	{
 		if (Key == iter2.first)
 		{
-			*(iter2.second) = atoi(Value.c_str());
+			*(iter2.second) = stoi(Value);
 		}
 	}
 	for (auto &iter3 : _configValuesBase64)
@@ -191,7 +191,7 @@ void CNotificationBase::ConfigFromGetvars(const request& req, const bool save)
 			else if (sValue == "off")
 				Value = 0;
 			else
-				Value=atoi(sValue.c_str());
+				Value = stoi(sValue);
 		}
 		*(iter2.second) = Value;
 		if (save) {

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -262,11 +262,11 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const std::string &sValue) {
-	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, 0, sValue, static_cast<float>(atof(sValue.c_str())));
+	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, 0, sValue, stof(sValue));
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const int nValue, const std::string &sValue) {
-	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, nValue, sValue, static_cast<float>(atof(sValue.c_str())));
+	return CheckAndHandleNotification(DevRowIdx, HardwareID, ID, sName, unit, cType, cSubType, nValue, sValue, stof(sValue));
 }
 
 bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, const int HardwareID, const std::string &ID, const std::string &sName, const unsigned char unit, const unsigned char cType, const unsigned char cSubType, const int nValue, const std::string &sValue, const float fValue) {
@@ -288,7 +288,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeP1Power:
 			nexpected = 5;
 			if (nsize >= nexpected) {
-				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, (float)atof(strarray[4].c_str()));
+				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, stof(strarray[4]));
 			}
 			break;
 		case pTypeRFXSensor:
@@ -317,8 +317,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeTEMP_HUM:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
-				int Hum = atoi(strarray[1].c_str());
+				float Temp = stof(strarray[0]);
+				int Hum = stoi(strarray[1]);
 				float dewpoint = (float)CalculateDewPoint(Temp, Hum);
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, Hum, true, true);
 				r2 = CheckAndHandleDewPointNotification(DevRowIdx, sName, Temp, dewpoint);
@@ -328,27 +328,27 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeTEMP_HUM_BARO:
 			nexpected = 4;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
-				int Hum = atoi(strarray[1].c_str());
+				float Temp = stof(strarray[0]);
+				int Hum = stoi(strarray[1]);
 				float dewpoint = (float)CalculateDewPoint(Temp, Hum);
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, Hum, true, true);
 				r2 = CheckAndHandleDewPointNotification(DevRowIdx, sName, Temp, dewpoint);
-				r3 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, (float)atof(strarray[3].c_str()));
+				r3 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, stof(strarray[3]));
 				return r1 && r2 && r3;
 			}
 			break;
 		case pTypeRAIN:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				fValue2 = (float)atof(strarray[1].c_str());
+				fValue2 = stof(strarray[1]);
 				return CheckAndHandleRainNotification(DevRowIdx, sName, cType, cSubType, NTYPE_RAIN, fValue2);
 			}
 			break;
 		case pTypeTEMP_BARO:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Temp = (float)atof(strarray[0].c_str());
-				float Baro = (float)atof(strarray[1].c_str());
+				float Temp = stof(strarray[0]);
+				float Baro = stof(strarray[1]);
 				r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, 0, true, false);
 				r2 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_BARO, Baro);
 				return r1 && r2;
@@ -357,8 +357,8 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeUV:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float Level = (float)atof(strarray[0].c_str());
-				float Temp = (float)atof(strarray[1].c_str());
+				float Level = stof(strarray[0]);
+				float Temp = stof(strarray[1]);
 				if (cSubType == sTypeUV3)
 				{
 					r1 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, Temp, 0, true, false);
@@ -372,26 +372,26 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeCURRENT:
 			nexpected = 3;
 			if (nsize >= nexpected) {
-				float CurrentChannel1 = (float)atof(strarray[0].c_str());
-				float CurrentChannel2 = (float)atof(strarray[1].c_str());
-				float CurrentChannel3 = (float)atof(strarray[2].c_str());
+				float CurrentChannel1 = stof(strarray[0]);
+				float CurrentChannel2 = stof(strarray[1]);
+				float CurrentChannel3 = stof(strarray[2]);
 				return CheckAndHandleAmpere123Notification(DevRowIdx, sName, CurrentChannel1, CurrentChannel2, CurrentChannel3);
 			}
 			break;
 		case pTypeCURRENTENERGY:
 			nexpected = 3;
 			if (nsize >= nexpected) {
-				float CurrentChannel1 = (float)atof(strarray[0].c_str());
-				float CurrentChannel2 = (float)atof(strarray[1].c_str());
-				float CurrentChannel3 = (float)atof(strarray[2].c_str());
+				float CurrentChannel1 = stof(strarray[0]);
+				float CurrentChannel2 = stof(strarray[1]);
+				float CurrentChannel3 = stof(strarray[2]);
 				return CheckAndHandleAmpere123Notification(DevRowIdx, sName, CurrentChannel1, CurrentChannel2, CurrentChannel3);
 			}
 			break;
 		case pTypeWIND:
 			nexpected = 5;
 			if (nsize >= nexpected) {
-				float wspeedms = (float)(atof(strarray[2].c_str()) / 10.0F);
-				float temp = (float)atof(strarray[4].c_str());
+				float wspeedms = stof(strarray[2]) / 10.0F;
+				float temp = stof(strarray[4]);
 				r1 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_WIND, wspeedms);
 				r2 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, temp, 0, true, false);
 				return r1 && r2;
@@ -400,7 +400,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeYouLess:
 			nexpected = 2;
 			if (nsize >= nexpected) {
-				float usagecurrent = (float)atof(strarray[1].c_str());
+				float usagecurrent = stof(strarray[1]);
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, usagecurrent);
 			}
 			break;
@@ -414,7 +414,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypePOWER:
 			nexpected = 1;
 			if (nsize >= nexpected) {
-				fValue2 = (float)atof(strarray[0].c_str());
+				fValue2 = stof(strarray[0]);
 				return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 			}
 			break;
@@ -454,7 +454,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 				case sTypeKwh:
 					nexpected = 1;
 					if (nsize >= nexpected) {
-						fValue2 = (float)atof(strarray[0].c_str());
+						fValue2 = stof(strarray[0]);
 						return CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_USAGE, fValue2);
 					}
 					break;
@@ -557,7 +557,7 @@ bool CNotificationHelper::CheckAndHandleTempHumidityNotification(
 				continue; //impossible
 			std::string ntype = splitresults[0];
 			std::string custommsg;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = stof(splitresults[2]);
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
 			bCustomMessage = CustomRecoveryMessage(n.ID, custommsg, false);
@@ -728,7 +728,7 @@ bool CNotificationHelper::CheckAndHandleValueNotification(
 			if (splitresults.size() < 2)
 				continue; //impossible
 			std::string ntype = splitresults[0];
-			int svalue = static_cast<int>(atoi(splitresults[1].c_str()));
+			int svalue = stoi(splitresults[1]);
 
 			if (ntype == signvalue)
 			{
@@ -797,7 +797,7 @@ bool CNotificationHelper::CheckAndHandleAmpere123Notification(
 			std::string ntype = splitresults[0];
 			std::string custommsg;
 			std::string ltype;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = stof(splitresults[2]);
 			float ampere = 0.0F;
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
@@ -957,7 +957,7 @@ bool CNotificationHelper::CheckAndHandleNotification(
 				continue; //impossible
 			std::string ntype = splitresults[0];
 			std::string custommsg;
-			float svalue = static_cast<float>(atof(splitresults[2].c_str()));
+			float svalue = stof(splitresults[2]);
 			bool bSendNotification = false;
 			bool bCustomMessage = false;
 			bCustomMessage = CustomRecoveryMessage(n.ID, custommsg, false);
@@ -1026,7 +1026,7 @@ bool CNotificationHelper::CheckAndHandleSwitchNotification(
 		Idx);
 	if (result.empty())
 		return false;
-	_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+	_eSwitchType switchtype = (_eSwitchType) stoi(result[0][0]);
 	std::string szExtraData = "|Name=" + devicename + "|SwitchType=" + result[0][0] + "|CustomImage=" + result[0][1] + "|";
 
 	std::string msg;
@@ -1138,7 +1138,7 @@ bool CNotificationHelper::CheckAndHandleSwitchNotification(
 		Idx);
 	if (result.empty())
 		return false;
-	_eSwitchType switchtype = (_eSwitchType)atoi(result[0][0].c_str());
+	_eSwitchType switchtype = (_eSwitchType) stoi(result[0][0]);
 	std::string szExtraData = "|Name=" + devicename + "|SwitchType=" + result[0][0] + "|CustomImage=" + result[0][1] + "|";
 	std::string sOptions = result[0][2];
 
@@ -1170,7 +1170,7 @@ bool CNotificationHelper::CheckAndHandleSwitchNotification(
 					if (splitresults.size() < 3)
 						continue; //impossible
 					bool bWhenEqual = (splitresults[1] == "=");
-					int iLevel = atoi(splitresults[2].c_str());
+					int iLevel = stoi(splitresults[2]);
 					if (!bWhenEqual || iLevel < 10 || iLevel > 100)
 						continue; //invalid
 
@@ -1230,8 +1230,8 @@ bool CNotificationHelper::CheckAndHandleRainNotification(
 		Idx);
 	if (result.empty())
 		return false;
-	//double AddjValue = atof(result[0][0].c_str());
-	double AddjMulti = atof(result[0][1].c_str());
+	//double AddjValue = stod(result[0][0]);
+	double AddjMulti = stod(result[0][1]);
 
 	char szDateEnd[40];
 
@@ -1264,7 +1264,7 @@ bool CNotificationHelper::CheckAndHandleRainNotification(
 		{
 			std::vector<std::string> sd = result[0];
 
-			float total_min = static_cast<float>(atof(sd[0].c_str()));
+			float total_min = stof(sd[0]);
 			float total_max = mvalue;
 			double total_real = total_max - total_min;
 			total_real *= AddjMulti;
@@ -1307,7 +1307,7 @@ void CNotificationHelper::CheckAndHandleLastUpdateNotification()
 					std::string szExtraData;
 					std::string custommsg;
 					uint64_t Idx = n.first;
-					uint32_t SensorTimeOut = static_cast<uint32_t>(atoi(splitresults[2].c_str()));  // minutes
+					uint32_t SensorTimeOut = static_cast<uint32_t>(stoull(splitresults[2]));  // minutes
 					uint32_t diff = static_cast<uint32_t>(round(difftime(btime, n2.LastUpdate)));
 					bool bStartTime = (difftime(btime, m_StartTime) < SensorTimeOut * 60);
 					bool bSendNotification = ApplyRule(splitresults[1], (diff == SensorTimeOut * 60), (diff < SensorTimeOut * 60));
@@ -1591,13 +1591,13 @@ void CNotificationHelper::ReloadNotifications()
 		sstr << sd[1];
 		sstr >> Idx;
 
-		notification.Active = atoi(sd[2].c_str()) != 0;
+		notification.Active = stoi(sd[2]) != 0;
 		notification.Params = sd[3];
 		notification.CustomMessage = sd[4];
 		notification.CustomAction = CURLEncode::URLDecode(sd[5]);
 		notification.ActiveSystems = sd[6];
-		notification.Priority = atoi(sd[7].c_str());
-		notification.SendAlways = (atoi(sd[8].c_str())!=0);
+		notification.Priority = stoi(sd[7]);
+		notification.SendAlways = stoi(sd[8]) != 0;
 
 		std::string stime = sd[9];
 		if (stime == "0")
@@ -1655,7 +1655,7 @@ namespace http {
 			uint64_t idx = 0;
 			if (!request::findValue(&req, "idx").empty())
 			{
-				idx = std::stoull(request::findValue(&req, "idx"));
+				idx = stoull(request::findValue(&req, "idx"));
 			}
 
 			std::vector<_tNotification> notifications = m_notifications.GetNotifications(idx, false);
@@ -1709,7 +1709,7 @@ namespace http {
 
 			std::string Param;
 
-			_eNotificationTypes ntype = (_eNotificationTypes)atoi(stype.c_str());
+			_eNotificationTypes ntype = (_eNotificationTypes) stoi(stype);
 			std::string ttype = Notification_Type_Desc(ntype, 1);
 			if ((ntype == NTYPE_SWITCH_ON) || (ntype == NTYPE_SWITCH_OFF) || (ntype == NTYPE_DEWPOINT))
 			{
@@ -1738,7 +1738,7 @@ namespace http {
 					twhen = "<";
 				Param = std_format("%s;%s;%s;%s", ttype.c_str(), twhen.c_str(), svalue.c_str(), srecovery.c_str());
 			}
-			int priority = atoi(spriority.c_str());
+			int priority = stoi(spriority);
 			bool bOK = m_notifications.AddNotification(idx, (sactive == "true") ? true : false, Param, scustommessage, scustomaction, sactivesystems, priority, (ssendalways == "true") ? true : false);
 			if (bOK)
 			{
@@ -1786,7 +1786,7 @@ namespace http {
 
 			std::string Param;
 
-			_eNotificationTypes ntype = (_eNotificationTypes)atoi(stype.c_str());
+			_eNotificationTypes ntype = (_eNotificationTypes) stoi(stype);
 			std::string ttype = Notification_Type_Desc(ntype, 1);
 			if ((ntype == NTYPE_SWITCH_ON) || (ntype == NTYPE_SWITCH_OFF) || (ntype == NTYPE_DEWPOINT))
 			{
@@ -1815,7 +1815,7 @@ namespace http {
 					twhen = "<";
 				Param = std_format("%s;%s;%s;%s", ttype.c_str(), twhen.c_str(), svalue.c_str(), srecovery.c_str());
 			}
-			int priority = atoi(spriority.c_str());
+			int priority = stoi(spriority);
 			m_notifications.AddNotification(devidx, (sactive == "true") ? true : false, Param, scustommessage, scustomaction, sactivesystems, priority, (ssendalways == "true") ? true : false);
 		}
 		void CWebServer::Cmd_DeleteNotification(WebEmSession& session, const request& req, Json::Value& root)

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -390,7 +390,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeWIND:
 			nexpected = 5;
 			if (nsize >= nexpected) {
-				float wspeedms = stof(strarray[2]) / 10.0F;
+				float wspeedms = static_cast<float>(stod(strarray[2]) / 10.0);
 				float temp = stof(strarray[4]);
 				r1 = CheckAndHandleNotification(DevRowIdx, sName, cType, cSubType, NTYPE_WIND, wspeedms);
 				r2 = CheckAndHandleTempHumidityNotification(DevRowIdx, sName, temp, 0, true, false);

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -1776,7 +1776,7 @@ namespace http {
 			root["title"] = "UpdateNotification";
 
 			std::string recoverymsg;
-			if ((srecovery == "1") && (m_notifications.CustomRecoveryMessage(strtoull(idx.c_str(), nullptr, 0), recoverymsg, true)))
+			if ((srecovery == "1") && (m_notifications.CustomRecoveryMessage(stoull(idx, nullptr, 0), recoverymsg, true)))
 			{
 				scustommessage.append(";;");
 				scustommessage.append(recoverymsg);

--- a/notifications/NotificationKodi.cpp
+++ b/notifications/NotificationKodi.cpp
@@ -18,7 +18,7 @@ CNotificationKodi::CNotificationKodi() : CNotificationBase(std::string("kodi"), 
 
 std::string CNotificationKodi::GetCustomIcon(std::string &szCustom)
 {
-	int	iIconLine = atoi(szCustom.c_str());
+	int	iIconLine = stoi(szCustom);
 	std::string szRetVal = "Light48";
 	if (iIconLine < 100)  // default set of custom icons
 	{
@@ -111,7 +111,7 @@ std::string CNotificationKodi::GetIconFile(const std::string &ExtraData)
 		posType+=12;
 		std::string szType = ExtraData.substr(posType, ExtraData.find('|', posType) - posType);
 		std::string	szTypeImage;
-		_eSwitchType switchtype=(_eSwitchType)atoi(szType.c_str());
+		_eSwitchType switchtype = (_eSwitchType) stoi(szType);
 		switch (switchtype)
 		{
 			case STYPE_OnOff:

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -633,7 +633,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Gas usage")
 		{
-			sprintf(szData, "%g", stof(rawsendValue) / 1000.0F);
+			sprintf(szData, "%g", stod(rawsendValue) / 1000.0);
 		}
 		else if (vType == "Weight")
 		{

--- a/push/BasePush.cpp
+++ b/push/BasePush.cpp
@@ -472,7 +472,7 @@ std::string CBasePush::ProcessSendValue(
 
 		if ((vType == "Temperature") || (vType == "Temperature 1") || (vType == "Temperature 2") || (vType == "Setpoint"))
 		{
-			sprintf(szData, "%g", ConvertTemperature(std::stod(rawsendValue), tempsign));
+			sprintf(szData, "%g", ConvertTemperature(stod(rawsendValue), tempsign));
 		}
 		else if (vType == "Concentration")
 		{
@@ -487,7 +487,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Humidity Status")
 		{
-			sprintf(szData, "%s", RFX_Humidity_Status_Desc(std::stoi(rawsendValue)));
+			sprintf(szData, "%s", RFX_Humidity_Status_Desc((unsigned char) stoi(rawsendValue)));
 		}
 		else if (vType == "Barometer")
 		{
@@ -495,7 +495,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Forecast")
 		{
-			int forecast = std::stoi(rawsendValue);
+			int forecast = stoi(rawsendValue);
 			if (forecast != baroForecastNoInfo)
 			{
 				sprintf(szData, "%s", RFX_Forecast_Desc(forecast));
@@ -522,7 +522,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Speed")
 		{
-			int intSpeed = std::stoi(rawsendValue);
+			int intSpeed = stoi(rawsendValue);
 			if (m_sql.m_windunit != WINDUNIT_Beaufort)
 			{
 				sprintf(szData, "%g", float(intSpeed) * m_sql.m_windscale);
@@ -535,7 +535,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Gust")
 		{
-			int intGust = std::stoi(rawsendValue);
+			int intGust = stoi(rawsendValue);
 			if (m_sql.m_windunit != WINDUNIT_Beaufort)
 			{
 				sprintf(szData, "%g", float(intGust) * m_sql.m_windscale);
@@ -548,7 +548,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Chill")
 		{
-			sprintf(szData, "%g", ConvertTemperature(std::stof(rawsendValue), tempsign));
+			sprintf(szData, "%g", ConvertTemperature(stod(rawsendValue), tempsign));
 		}
 		else if (vType == "Rain rate")
 		{
@@ -572,7 +572,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Distance")
 		{
-			float vis = std::stof(rawsendValue);
+			float vis = stof(rawsendValue);
 			if (metertype == 0)
 			{
 				//cm
@@ -597,7 +597,7 @@ std::string CBasePush::ProcessSendValue(
 			int maxDimLevel = 0;
 			GetLightStatus(devType, devSubType, static_cast<_eSwitchType>(metertypein), 1, rawsendValue, lstatus, llevel, bHaveDimmer, maxDimLevel, bHaveGroupCmd);
 
-			int level = atoi(rawsendValue.c_str());
+			int level = stoi(rawsendValue);
 
 			if (maxDimLevel != 0)
 				level = (int) float((100.0F / float(maxDimLevel)) * level);
@@ -633,7 +633,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Gas usage")
 		{
-			sprintf(szData, "%g", std::stof(rawsendValue) / 1000.0F);
+			sprintf(szData, "%g", stof(rawsendValue) / 1000.0F);
 		}
 		else if (vType == "Weight")
 		{
@@ -649,7 +649,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Visibility")
 		{
-			float vis = std::stof(rawsendValue);
+			float vis = stof(rawsendValue);
 			if (metertype == 0)
 			{
 				//km
@@ -679,7 +679,7 @@ std::string CBasePush::ProcessSendValue(
 		}
 		else if (vType == "Fanspeed")
 		{
-			sprintf(szData, "%d", std::stoi(rawsendValue));
+			sprintf(szData, "%d", stoi(rawsendValue));
 		}
 		else if (vType == "Pressure")
 		{
@@ -913,12 +913,12 @@ void CBasePush::ReloadPushLinks(const PushType PType)
 	for (const auto& sd : result)
 	{
 		_tPushLinks tlink;
-		tlink.DeviceRowIdx = std::stoull(sd[0]);
-		tlink.DelimiterPos = std::stoi(sd[1]);
+		tlink.DeviceRowIdx = stoull(sd[0]);
+		tlink.DelimiterPos = stoi(sd[1]);
 		tlink.DeviceName = sd[3];
-		tlink.devType = std::stoi(sd[4]);
-		tlink.devSubType = std::stoi(sd[5]);
-		tlink.metertype = std::stoi(sd[6]);
+		tlink.devType = stoi(sd[4]);
+		tlink.devSubType = stoi(sd[5]);
+		tlink.metertype = stoi(sd[6]);
 		m_pushlinks.push_back(tlink);
 	}
 }
@@ -959,8 +959,8 @@ namespace http {
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					int dType = atoi(sd[2].c_str());
-					int dSubType = atoi(sd[3].c_str());
+					int dType = stoi(sd[2]);
+					int dSubType = stoi(sd[3]);
 					std::string sOptions = RFX_Type_SubType_Values(dType, dSubType);
 					std::vector<std::string> tmpV;
 					StringSplit(sOptions, ",", tmpV);

--- a/push/FibaroPush.cpp
+++ b/push/FibaroPush.cpp
@@ -83,17 +83,17 @@ void CFibaroPush::DoFibaroPush(const uint64_t DeviceRowIdx)
 	for (const auto &sd : result)
 	{
 		std::string sendValue;
-		int delpos = atoi(sd[1].c_str());
-		int dType = atoi(sd[3].c_str());
-		int dSubType = atoi(sd[4].c_str());
-		int nValue = atoi(sd[5].c_str());
+		int delpos = stoi(sd[1]);
+		int dType = stoi(sd[3]);
+		int dSubType = stoi(sd[4]);
+		int nValue = stoi(sd[5]);
 		std::string sValue = sd[6];
-		int targetType = atoi(sd[7].c_str());
+		int targetType = stoi(sd[7]);
 		std::string targetVariable = sd[8];
-		int targetDeviceID = atoi(sd[9].c_str());
+		int targetDeviceID = stoi(sd[9]);
 		std::string targetProperty = sd[10];
-		int includeUnit = atoi(sd[11].c_str());
-		int metertype = atoi(sd[12].c_str());
+		int includeUnit = stoi(sd[11]);
+		int metertype = stoi(sd[12]);
 		std::string lstatus;
 
 		if ((targetType == 0) || (targetType == 1)) {
@@ -231,9 +231,9 @@ namespace http {
 			std::string debugenabled = request::findValue(&req, "debugenabled");
 			if ((remote.empty()) || (username.empty()) || (password.empty()) || (linkactive.empty()) || (isversion4.empty()) || (debugenabled.empty()))
 				return;
-			int ilinkactive = atoi(linkactive.c_str());
-			int iisversion4 = atoi(isversion4.c_str());
-			int idebugenabled = atoi(debugenabled.c_str());
+			int ilinkactive = stoi(linkactive);
+			int iisversion4 = stoi(isversion4);
+			int idebugenabled = stoi(debugenabled);
 			m_sql.UpdatePreferencesVar("FibaroIP", remote);
 			m_sql.UpdatePreferencesVar("FibaroUsername", username);
 			m_sql.UpdatePreferencesVar("FibaroPassword", password);
@@ -328,10 +328,10 @@ namespace http {
 			}
 			std::string idx = request::findValue(&req, "idx");
 			std::string deviceid = request::findValue(&req, "deviceid");
-			int deviceidi = atoi(deviceid.c_str());
+			int deviceidi = stoi(deviceid);
 			std::string valuetosend = request::findValue(&req, "valuetosend");
 			std::string targettype = request::findValue(&req, "targettype");
-			int targettypei = atoi(targettype.c_str());
+			int targettypei = stoi(targettype);
 			std::string targetvariable = request::findValue(&req, "targetvariable");
 			std::string targetdeviceid = request::findValue(&req, "targetdeviceid");
 			std::string targetproperty = request::findValue(&req, "targetproperty");
@@ -348,26 +348,26 @@ namespace http {
 					"INSERT INTO PushLink (PushType,DeviceRowID,DelimitedValue,TargetType,TargetVariable,TargetDeviceID,TargetProperty,IncludeUnit,Enabled) VALUES ('%d','%d','%d','%d','%q','%d','%q','%d','%d')",
 					CBasePush::PushType::PUSHTYPE_FIBARO,
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str())
+					stoi(includeunit),
+					stoi(linkactive)
 				);
 			}
 			else {
 				m_sql.safe_query(
 					"UPDATE PushLink SET DeviceRowID='%d', DelimitedValue=%d, TargetType=%d, TargetVariable='%q', TargetDeviceID=%d, TargetProperty='%q', IncludeUnit='%d', Enabled='%d' WHERE (ID == '%q')",
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str()),
+					stoi(includeunit),
+					stoi(linkactive),
 					idx.c_str()
 				);
 			}

--- a/push/GooglePubSubPush.cpp
+++ b/push/GooglePubSubPush.cpp
@@ -131,18 +131,18 @@ void CGooglePubSubPush::DoGooglePubSubPush(const uint64_t DeviceRowIdx)
 
 		std::string sdeviceId = sd[0];
 		std::string ldelpos = sd[1];
-		int delpos = atoi(sd[1].c_str());
-		int dType = atoi(sd[3].c_str());
-		int dSubType = atoi(sd[4].c_str());
-		int nValue = atoi(sd[5].c_str());
+		int delpos = stoi(sd[1]);
+		int dType = stoi(sd[3]);
+		int dSubType = stoi(sd[4]);
+		int nValue = stoi(sd[5]);
 		std::string sValue = sd[6];
-		//int targetType = atoi(sd[7].c_str());
+		//int targetType = stoi(sd[7]);
 		std::string targetVariable = sd[8];
-		//int targetDeviceID = atoi(sd[9].c_str());
+		//int targetDeviceID = stoi(sd[9]);
 		std::string targetProperty = sd[10];
-		int includeUnit = atoi(sd[11].c_str());
-		int metertype = atoi(sd[12].c_str());
-		int lastUpdate = atoi(sd[13].c_str());
+		int includeUnit = stoi(sd[11]);
+		int metertype = stoi(sd[12]);
+		int lastUpdate = stoi(sd[13]);
 		std::string ltargetVariable = sd[8];
 		std::string ltargetDeviceId = sd[9];
 		std::string lname = sd[14];
@@ -307,8 +307,8 @@ namespace http {
 			std::string debugenabled = request::findValue(&req, "debugenabled");
 			if ((data.empty()) || (linkactive.empty()) || (debugenabled.empty()))
 				return;
-			int ilinkactive = atoi(linkactive.c_str());
-			int idebugenabled = atoi(debugenabled.c_str());
+			int ilinkactive = stoi(linkactive);
+			int idebugenabled = stoi(debugenabled);
 			m_sql.UpdatePreferencesVar("GooglePubSubData", data);
 			m_sql.UpdatePreferencesVar("GooglePubSubActive", ilinkactive);
 			m_sql.UpdatePreferencesVar("GooglePubSubDebug", idebugenabled);
@@ -387,10 +387,10 @@ namespace http {
 			}
 			std::string idx = request::findValue(&req, "idx");
 			std::string deviceid = request::findValue(&req, "deviceid");
-			int deviceidi = atoi(deviceid.c_str());
+			int deviceidi = stoi(deviceid);
 			std::string valuetosend = request::findValue(&req, "valuetosend");
 			std::string targettype = request::findValue(&req, "targettype");
-			int targettypei = atoi(targettype.c_str());
+			int targettypei = stoi(targettype);
 			std::string targetvariable = request::findValue(&req, "targetvariable");
 			std::string targetdeviceid = request::findValue(&req, "targetdeviceid");
 			std::string targetproperty = request::findValue(&req, "targetproperty");
@@ -405,33 +405,33 @@ namespace http {
 			if (idx == "0") {
 				//check if we already have this link
 				auto result = m_sql.safe_query("SELECT ID FROM PushLink WHERE (PushType==%d AND DeviceRowID==%d AND DelimitedValue==%d AND TargetType==%d)",
-					CBasePush::PushType::PUSHTYPE_GOOGLE_PUB_SUB, deviceidi, atoi(valuetosend.c_str()), targettypei);
+					CBasePush::PushType::PUSHTYPE_GOOGLE_PUB_SUB, deviceidi, stoi(valuetosend), targettypei);
 				if (!result.empty())
 					return; //already have this
 				m_sql.safe_query(
 					"INSERT INTO PushLink (PushType, DeviceRowID,DelimitedValue,TargetType,TargetVariable,TargetDeviceID,TargetProperty,IncludeUnit,Enabled) VALUES ('%d','%d','%d','%d','%q','%d','%q','%d','%d')",
 					CBasePush::PushType::PUSHTYPE_GOOGLE_PUB_SUB,
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str())
+					stoi(includeunit),
+					stoi(linkactive)
 				);
 			}
 			else {
 				m_sql.safe_query(
 					"UPDATE PushLink SET DeviceRowID='%d', DelimitedValue=%d, TargetType=%d, TargetVariable='%q', TargetDeviceID=%d, TargetProperty='%q', IncludeUnit='%d', Enabled='%d' WHERE (ID == '%q')",
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str()),
+					stoi(includeunit),
+					stoi(linkactive),
 					idx.c_str()
 				);
 			}

--- a/push/HttpPush.cpp
+++ b/push/HttpPush.cpp
@@ -89,21 +89,21 @@ void CHttpPush::DoHttpPush(const uint64_t DeviceRowIdx)
 		if (httpUrl.empty())
 			return;
 
-		//unsigned int deviceId = atoi(sd[0].c_str());
+		//unsigned int deviceId = (unsigned int) stoi(sd[0]);
 		std::string sdeviceId = sd[0];
 		std::string ldelpos = sd[1];
-		int delpos = atoi(sd[1].c_str());
-		int dType = atoi(sd[3].c_str());
-		int dSubType = atoi(sd[4].c_str());
-		int nValue = atoi(sd[5].c_str());
+		int delpos = stoi(sd[1]);
+		int dType = stoi(sd[3]);
+		int dSubType = stoi(sd[4]);
+		int nValue = stoi(sd[5]);
 		std::string sValue = sd[6];
-		//int targetType = atoi(sd[7].c_str());
+		//int targetType = stoi(sd[7]);
 		std::string targetVariable = sd[8];
-		//int targetDeviceID = atoi(sd[9].c_str());
+		//int targetDeviceID = stoi(sd[9]);
 		//std::string targetProperty = sd[10].c_str();
-		int includeUnit = atoi(sd[11].c_str());
-		int metertype = atoi(sd[12].c_str());
-		int lastUpdate = atoi(sd[13].c_str());
+		int includeUnit = stoi(sd[11]);
+		int metertype = stoi(sd[12]);
+		int lastUpdate = stoi(sd[13]);
 		std::string ltargetVariable = sd[8];
 		std::string ltargetDeviceId = sd[9];
 		std::string lname = sd[14];
@@ -272,15 +272,15 @@ namespace http {
 				return;
 			if ((method != "0") && (data.empty())) //PUT/POST should have data
 				return;
-			int ilinkactive = atoi(linkactive.c_str());
-			int idebugenabled = atoi(debugenabled.c_str());
+			int ilinkactive = stoi(linkactive);
+			int idebugenabled = stoi(debugenabled);
 			m_sql.UpdatePreferencesVar("HttpUrl", url);
-			m_sql.UpdatePreferencesVar("HttpMethod", atoi(method.c_str()));
+			m_sql.UpdatePreferencesVar("HttpMethod", stoi(method));
 			m_sql.UpdatePreferencesVar("HttpData", data);
 			m_sql.UpdatePreferencesVar("HttpHeaders", headers);
 			m_sql.UpdatePreferencesVar("HttpActive", ilinkactive);
 			m_sql.UpdatePreferencesVar("HttpDebug", idebugenabled);
-			m_sql.UpdatePreferencesVar("HttpAuth", atoi(auth.c_str()));
+			m_sql.UpdatePreferencesVar("HttpAuth", stoi(auth));
 			m_sql.UpdatePreferencesVar("HttpAuthBasicLogin", authbasiclogin);
 			m_sql.UpdatePreferencesVar("HttpAuthBasicPassword", authbasicpassword);
 
@@ -388,10 +388,10 @@ namespace http {
 			}
 			std::string idx = request::findValue(&req, "idx");
 			std::string deviceid = request::findValue(&req, "deviceid");
-			int deviceidi = atoi(deviceid.c_str());
+			int deviceidi = stoi(deviceid);
 			std::string valuetosend = request::findValue(&req, "valuetosend");
 			std::string targettype = request::findValue(&req, "targettype");
-			int targettypei = atoi(targettype.c_str());
+			int targettypei = stoi(targettype);
 			std::string targetvariable = request::findValue(&req, "targetvariable");
 			std::string targetdeviceid = request::findValue(&req, "targetdeviceid");
 			std::string targetproperty = request::findValue(&req, "targetproperty");
@@ -408,26 +408,26 @@ namespace http {
 					"INSERT INTO PushLink (PushType, DeviceRowID,DelimitedValue,TargetType,TargetVariable,TargetDeviceID,TargetProperty,IncludeUnit,Enabled) VALUES ('%d','%d','%d','%d','%q','%d','%q','%d','%d')",
 					CBasePush::PushType::PUSHTYPE_HTTP,
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str())
+					stoi(includeunit),
+					stoi(linkactive)
 				);
 			}
 			else {
 				m_sql.safe_query(
 					"UPDATE PushLink SET DeviceRowID='%d', DelimitedValue=%d, TargetType=%d, TargetVariable='%q', TargetDeviceID=%d, TargetProperty='%q', IncludeUnit='%d', Enabled='%d' WHERE (ID == '%q')",
 					deviceidi,
-					atoi(valuetosend.c_str()),
+					stoi(valuetosend),
 					targettypei,
 					targetvariable.c_str(),
-					atoi(targetdeviceid.c_str()),
+					stoi(targetdeviceid),
 					targetproperty.c_str(),
-					atoi(includeunit.c_str()),
-					atoi(linkactive.c_str()),
+					stoi(includeunit),
+					stoi(linkactive),
 					idx.c_str()
 				);
 			}

--- a/push/InfluxPush.cpp
+++ b/push/InfluxPush.cpp
@@ -132,15 +132,15 @@ void CInfluxPush::DoInfluxPush(const uint64_t DeviceRowIdx, const bool bForced)
 	for (const auto &sd : result)
 	{
 		std::string sendValue;
-		int delpos = atoi(sd[1].c_str());
-		int dType = atoi(sd[3].c_str());
-		int dSubType = atoi(sd[4].c_str());
-		int nValue = atoi(sd[5].c_str());
+		int delpos = stoi(sd[1]);
+		int dType = stoi(sd[3]);
+		int dSubType = stoi(sd[4]);
+		int nValue = stoi(sd[5]);
 		std::string sValue = sd[6];
-		int targetType = atoi(sd[7].c_str());
-		int includeUnit = atoi(sd[8].c_str());
+		int targetType = stoi(sd[7]);
+		int includeUnit = stoi(sd[8]);
 		std::string name = sd[9];
-		int metertype = atoi(sd[10].c_str());
+		int metertype = stoi(sd[10]);
 
 		std::vector<std::string> strarray;
 		if (sValue.find(';') != std::string::npos)
@@ -292,12 +292,12 @@ namespace http
 			std::string debugenabled = request::findValue(&req, "debugenabled");
 			if ((linkactive.empty()) || (remote.empty()) || (port.empty()) || (database.empty()) || (debugenabled.empty()))
 				return;
-			int ilinkactive = atoi(linkactive.c_str());
-			int idebugenabled = atoi(debugenabled.c_str());
+			int ilinkactive = stoi(linkactive);
+			int idebugenabled = stoi(debugenabled);
 			m_sql.UpdatePreferencesVar("InfluxActive", ilinkactive);
-			m_sql.UpdatePreferencesVar("InfluxVersion2", atoi(isversion2.c_str()));
+			m_sql.UpdatePreferencesVar("InfluxVersion2", stoi(isversion2));
 			m_sql.UpdatePreferencesVar("InfluxIP", remote);
-			m_sql.UpdatePreferencesVar("InfluxPort", atoi(port.c_str()));
+			m_sql.UpdatePreferencesVar("InfluxPort", stoi(port));
 			m_sql.UpdatePreferencesVar("InfluxPath", path);
 			m_sql.UpdatePreferencesVar("InfluxDatabase", database);
 			m_sql.UpdatePreferencesVar("InfluxUsername", username);
@@ -385,9 +385,9 @@ namespace http
 				int ii = 0;
 				for (const auto &sd : result)
 				{
-					int Delimitedvalue = std::stoi(sd[2]);
-					int devType = std::stoi(sd[10]);
-					int devSubType = std::stoi(sd[11]);
+					int Delimitedvalue = stoi(sd[2]);
+					int devType = stoi(sd[10]);
+					int devSubType = stoi(sd[11]);
 
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["DeviceID"] = sd[1];
@@ -416,26 +416,26 @@ namespace http
 			}
 			std::string idx = request::findValue(&req, "idx");
 			std::string deviceid = request::findValue(&req, "deviceid");
-			int deviceidi = atoi(deviceid.c_str());
+			int deviceidi = stoi(deviceid);
 			std::string valuetosend = request::findValue(&req, "valuetosend");
 			std::string targettype = request::findValue(&req, "targettype");
-			int targettypei = atoi(targettype.c_str());
+			int targettypei = stoi(targettype);
 			std::string linkactive = request::findValue(&req, "linkactive");
 			if (idx == "0")
 			{
 				//check if we already have this link
 				auto result = m_sql.safe_query("SELECT ID FROM PushLink WHERE (PushType==%d AND DeviceRowID==%d AND DelimitedValue==%d AND TargetType==%d)",
-					CBasePush::PushType::PUSHTYPE_INFLUXDB, deviceidi, atoi(valuetosend.c_str()), targettypei);
+					CBasePush::PushType::PUSHTYPE_INFLUXDB, deviceidi, stoi(valuetosend), targettypei);
 				if (!result.empty())
 					return; //already have this
 				m_sql.safe_query("INSERT INTO PushLink (PushType,DeviceRowID,DelimitedValue,TargetType,TargetVariable,TargetDeviceID,TargetProperty,IncludeUnit,Enabled) VALUES "
 						 "(%d,'%d',%d,%d,'%q',%d,'%q',%d,%d)",
-						 CBasePush::PushType::PUSHTYPE_INFLUXDB, deviceidi, atoi(valuetosend.c_str()), targettypei, "-", 0, "-", 0, atoi(linkactive.c_str()));
+						 CBasePush::PushType::PUSHTYPE_INFLUXDB, deviceidi, stoi(valuetosend), targettypei, "-", 0, "-", 0, stoi(linkactive));
 			}
 			else
 			{
-				m_sql.safe_query("UPDATE PushLink SET DeviceRowID=%d, DelimitedValue=%d, TargetType=%d, Enabled=%d WHERE (ID == '%q')", deviceidi, atoi(valuetosend.c_str()),
-						 targettypei, atoi(linkactive.c_str()), idx.c_str());
+				m_sql.safe_query("UPDATE PushLink SET DeviceRowID=%d, DelimitedValue=%d, TargetType=%d, Enabled=%d WHERE (ID == '%q')", deviceidi, stoi(valuetosend),
+						 targettypei, stoi(linkactive), idx.c_str());
 			}
 			m_influxpush.ReloadPushLinks(CBasePush::PushType::PUSHTYPE_INFLUXDB);
 			root["status"] = "OK";

--- a/push/MQTTPush.cpp
+++ b/push/MQTTPush.cpp
@@ -174,19 +174,19 @@ void CMQTTPush::DoMQTTPush(const uint64_t DeviceRowIdx, const bool bForced)
 
 	time_t atime = mytime(nullptr);
 
-	int dType = atoi(result[0][3].c_str());
-	int dSubType = atoi(result[0][4].c_str());
-	int nValue = atoi(result[0][5].c_str());
+	int dType = stoi(result[0][3]);
+	int dSubType = stoi(result[0][4]);
+	int nValue = stoi(result[0][5]);
 	std::string sValue = result[0][6];
 	std::string name = result[0][9];
-	int metertype = atoi(result[0][10].c_str());
+	int metertype = stoi(result[0][10]);
 
 	for (const auto& sd : result)
 	{
 		std::string sendValue;
-		int delpos = atoi(sd[1].c_str());
-		int targetType = atoi(sd[7].c_str());
-		int includeUnit = atoi(sd[8].c_str());
+		int delpos = stoi(sd[1]);
+		int targetType = stoi(sd[7]);
+		int includeUnit = stoi(sd[8]);
 
 		std::vector<std::string> strarray;
 		if (sValue.find(';') != std::string::npos)
@@ -212,7 +212,7 @@ void CMQTTPush::DoMQTTPush(const uint64_t DeviceRowIdx, const bool bForced)
 		szKey = vType + ",idx=" + sd[0] + ",name=" + name;
 
 		if (is_number(sendValue))
-			root[vType] = atoi(sendValue.c_str());
+			root[vType] = stoi(sendValue);
 		else
 			root[vType] = sendValue;
 
@@ -297,13 +297,13 @@ namespace http
 			if ((linkactive.empty()) || (ipaddress.empty()) || (port.empty()) || (topic_out.empty()) || (tls_version.empty()))
 				return;
 
-			int ilinkactive = atoi(linkactive.c_str());
-			int iTLSVersion = atoi(tls_version.c_str());
+			int ilinkactive = stoi(linkactive);
+			int iTLSVersion = stoi(tls_version);
 			if (iTLSVersion == 0) iTLSVersion = 2;
 
 			m_sql.UpdatePreferencesVar("MQTTPushActive", ilinkactive);
 			m_sql.UpdatePreferencesVar("MQTTPushIP", ipaddress);
-			m_sql.UpdatePreferencesVar("MQTTPushPort", atoi(port.c_str()));
+			m_sql.UpdatePreferencesVar("MQTTPushPort", stoi(port));
 			m_sql.UpdatePreferencesVar("MQTTPushUsername", username);
 			m_sql.UpdatePreferencesVar("MQTTPushPassword", password);
 			m_sql.UpdatePreferencesVar("MQTTPushTopicOut", topic_out);
@@ -385,9 +385,9 @@ namespace http
 				int ii = 0;
 				for (const auto& sd : result)
 				{
-					int Delimitedvalue = std::stoi(sd[2]);
-					int devType = std::stoi(sd[10]);
-					int devSubType = std::stoi(sd[11]);
+					int Delimitedvalue = stoi(sd[2]);
+					int devType = stoi(sd[10]);
+					int devSubType = stoi(sd[11]);
 
 					root["result"][ii]["idx"] = sd[0];
 					root["result"][ii]["DeviceID"] = sd[1];
@@ -416,26 +416,26 @@ namespace http
 			}
 			std::string idx = request::findValue(&req, "idx");
 			std::string deviceid = request::findValue(&req, "deviceid");
-			int deviceidi = atoi(deviceid.c_str());
+			int deviceidi = stoi(deviceid);
 			std::string valuetosend = request::findValue(&req, "valuetosend");
 			std::string targettype = request::findValue(&req, "targettype");
-			int targettypei = atoi(targettype.c_str());
+			int targettypei = stoi(targettype);
 			std::string linkactive = request::findValue(&req, "linkactive");
 			if (idx == "0")
 			{
 				//check if we already have this link
 				auto result = m_sql.safe_query("SELECT ID FROM PushLink WHERE (PushType==%d AND DeviceRowID==%d AND DelimitedValue==%d AND TargetType==%d)",
-					CBasePush::PushType::PUSHTYPE_MQTT, deviceidi, atoi(valuetosend.c_str()), targettypei);
+					CBasePush::PushType::PUSHTYPE_MQTT, deviceidi, stoi(valuetosend), targettypei);
 				if (!result.empty())
 					return; //already have this
 				m_sql.safe_query("INSERT INTO PushLink (PushType,DeviceRowID,DelimitedValue,TargetType,TargetVariable,TargetDeviceID,TargetProperty,IncludeUnit,Enabled) VALUES "
 					"(%d,'%d',%d,%d,'%q',%d,'%q',%d,%d)",
-					CBasePush::PushType::PUSHTYPE_MQTT, deviceidi, atoi(valuetosend.c_str()), targettypei, "-", 0, "-", 0, atoi(linkactive.c_str()));
+					CBasePush::PushType::PUSHTYPE_MQTT, deviceidi, stoi(valuetosend), targettypei, "-", 0, "-", 0, stoi(linkactive));
 			}
 			else
 			{
-				m_sql.safe_query("UPDATE PushLink SET DeviceRowID=%d, DelimitedValue=%d, TargetType=%d, Enabled=%d WHERE (ID == '%q')", deviceidi, atoi(valuetosend.c_str()),
-					targettypei, atoi(linkactive.c_str()), idx.c_str());
+				m_sql.safe_query("UPDATE PushLink SET DeviceRowID=%d, DelimitedValue=%d, TargetType=%d, Enabled=%d WHERE (ID == '%q')", deviceidi, stoi(valuetosend),
+					targettypei, stoi(linkactive), idx.c_str());
 			}
 			m_mqttpush.ReloadPushLinks(CBasePush::PushType::PUSHTYPE_MQTT);
 			root["status"] = "OK";

--- a/tcpserver/TCPServer.cpp
+++ b/tcpserver/TCPServer.cpp
@@ -178,17 +178,17 @@ namespace tcp {
 
 			int iIndex = 0;
 			root["DeviceID"] = result[0][iIndex++];
-			root["Unit"] = atoi(result[0][iIndex++].c_str());
+			root["Unit"] = stoi(result[0][iIndex++]);
 			root["Name"] = result[0][iIndex++];
-			root["Type"] = atoi(result[0][iIndex++].c_str());
-			root["SubType"] = atoi(result[0][iIndex++].c_str());
-			root["SwitchType"] = atoi(result[0][iIndex++].c_str());
-			root["SignalLevel"] = atoi(result[0][iIndex++].c_str());
-			root["BatteryLevel"] = atoi(result[0][iIndex++].c_str());
-			root["nValue"] = atoi(result[0][iIndex++].c_str());
+			root["Type"] = stoi(result[0][iIndex++]);
+			root["SubType"] = stoi(result[0][iIndex++]);
+			root["SwitchType"] = stoi(result[0][iIndex++]);
+			root["SignalLevel"] = stoi(result[0][iIndex++]);
+			root["BatteryLevel"] = stoi(result[0][iIndex++]);
+			root["nValue"] = stoi(result[0][iIndex++]);
 			root["sValue"] = result[0][iIndex++];
 			root["LastUpdate"] = result[0][iIndex++];
-			root["LastLevel"] = atoi(result[0][iIndex++].c_str());
+			root["LastLevel"] = stoi(result[0][iIndex++]);
 			root["Options"] = result[0][iIndex++];
 			root["Color"] = result[0][iIndex++];
 
@@ -400,7 +400,7 @@ namespace tcp {
 			}
 
 			std::string szIdx = result[0][0];
-			uint64_t idx = std::stoull(szIdx);
+			uint64_t idx = stoull(szIdx);
 
 			if (szAction == "SwitchLight")
 			{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -818,7 +818,7 @@ namespace http {
 					if (inet_pton((!ipnetwork.bIsIPv6) ? AF_INET : AF_INET6, szNetwork.c_str(), &ipnetwork.Network) != 1)
 						return; //invalid address
 
-					uint8_t iBitcount = std::stoi(szMask);
+					uint8_t iBitcount = (uint8_t) stoi(szMask);
 
 					if (!ipnetwork.bIsIPv6)
 					{
@@ -1923,7 +1923,7 @@ namespace http {
 					session.isnew = false;
 					session.rememberme = false;
 					session.username = _ah.user;
-					session.rights = std::atoi(_ah.qop.c_str());
+					session.rights = stoi(_ah.qop);
 					return true;
 				}
 				else if (_ah.method == "BASIC")
@@ -1938,7 +1938,7 @@ namespace http {
 								session.isnew = false;
 								session.rememberme = false;
 								session.username = _ah.user;
-								session.rights = std::atoi(_ah.qop.c_str());
+								session.rights = stoi(_ah.qop);
 								return true;
 							}
 							else

--- a/webserver/fastcgi.cpp
+++ b/webserver/fastcgi.cpp
@@ -403,7 +403,7 @@ bool fastcgi_parser::handlePHP(const server_settings &settings, const std::strin
 				if (tpos == std::string::npos)
 					continue;
 				std::string errcode = theader.substr(0, tpos);
-				rep = reply::stock_reply((reply::status_type)atoi(errcode.c_str()));
+				rep = reply::stock_reply((reply::status_type) stoi(errcode));
 				return true;
 			}
 

--- a/webserver/request_parser.cpp
+++ b/webserver/request_parser.cpp
@@ -299,7 +299,7 @@ boost::tribool request_parser::consume(request& req, const char* &pInput, const 
 			  std::transform(hname.begin(), hname.end(), hname.begin(), ::tolower);
 			  if (hname == "content-length")
 			  {
-				  req.content_length = atoi(ph.value.c_str());
+				  req.content_length = stoi(ph.value);
 				  break;
 			  }
 		  }


### PR DESCRIPTION
Replaced C style string to number conversion functions by their C++ style equivalents:
e.g. atoi(sValue.c_str()) -> stoi(sValue), and same for other similar functions : atol, atof, strtol, strtoll, strtoul, strtoull, strtod.

Removed unnecessary cast specifiers:
e.g. (float) stof(str) -> stof(str) or static_cast<float>stof(str) -> stof(str)

Replaced stof by stod when appropriate.

Replaced signed functions by unsigned when appropriate.

Checked (and rechecked, and rechecked again) the changes made. 
