### PR TITLE
fix STYPE_END value in RFXNames.h

### DIFF
--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -25,7 +25,7 @@ enum _eSwitchType
 	STYPE_DoorLockInverted = 20,
 	STYPE_BlindsPercentageWithStop = 21,
 
-	STYPE_END = 23 //always set this to highest numer + 1
+	STYPE_END = STYPE_BlindsPercentageWithStop + 1 //always set this to highest numer + 1
 };
 
 enum _eMeterType


### PR DESCRIPTION
set to 23, but should be 22 according to the comment
 => fixed to be STYPE_BlindsPercentageWithStop + 1

(could also just not be manually assigned if other enum values are in the ascending order)