### PR TITLE
Handle OpenWeatherMap API 2.5 and 3.0

### DIFF
--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -46,6 +46,7 @@ std::string ReadFile(std::string filename)
 #endif
 
 #define OWM_onecall_URL "https://api.openweathermap.org/data/2.5/onecall?"
+#define OWM_30_onecall_URL "https://api.openweathermap.org/data/3.0/onecall?"
 #define OWM_Get_City_Details "https://api.openweathermap.org/data/2.5/weather?"
 #define OWM_icon_URL "https://openweathermap.org/img/wn/"	// for example 10d@4x.png
 #define OWM_forecast_URL "https://openweathermap.org/city/"
@@ -60,6 +61,17 @@ COpenWeatherMap::COpenWeatherMap(const int ID, const std::string &APIKey, const 
 	m_use_owminforecastscreen(owmforecastscreen)
 {
 	m_HwdID=ID;
+
+        if ( m_APIKey.find("V3.0:" == 0) )
+        {
+               m_APIVersion = "3.0";
+               m_APIKey = m_APIKey.substr(5); // Remove the "V3.0:" prefix
+        }
+        else
+        {
+               m_APIVersion = "2.5";
+
+	}
 
 	std::string sValue;
 	if (m_sql.GetPreferencesVar("Language", sValue))
@@ -664,6 +676,15 @@ void COpenWeatherMap::GetMeterDetails()
 	std::stringstream sURL;
 
 	sURL << OWM_onecall_URL;
+        // Check API version to use the right onecall API
+        if (m_APIVersion.find("3.0") == 0)
+        {
+            sURL << OWM_30_onecall_URL;
+        }
+        else
+        {
+            sURL << OWM_onecall_URL;
+        }
 	sURL << "lat=" << m_Lat << "&lon=" << m_Lon;
 	sURL << "&exclude=minutely";
 	sURL << "&appid=" << m_APIKey;

--- a/hardware/OpenWeatherMap.h
+++ b/hardware/OpenWeatherMap.h
@@ -30,6 +30,7 @@ class COpenWeatherMap : public CDomoticzHardwareBase
 	bool ResolveOWMCityLonLat(const std::string sURL, double& latitude, double& longitude, uint32_t& cityid);
 
 	std::string m_APIKey;
+        std::string m_APIVersion;  // Track the API Versionto be use for onecall
 	std::string m_Location;
 	std::string m_ForecastURL;
 	std::string m_Language;


### PR DESCRIPTION
Address issues #5336 and propose an implementation which is backward compatible.

If you have an old/legacy OpenWeatherMap API based on 2.5 you don't have to change anything.
If you have a new API  Key based on 3.0, then you just have to prefix your key with "V3.0:" like

![Screenshot 2024-04-06 at 11 41 34](https://github.com/domoticz/domoticz/assets/8291674/4d378ced-c49b-49b1-8c82-af2225c042ec)
