### PR TITLE
Switch FCM notifications to new Google Firebase v1 API  (Adresses #5921)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,6 @@
+Version 2024.xxxxx (xxxxx 2024)
+- Changed: Google Cloud Messaging (GCM) now uses the new v1 API of Google's Firebase Cloud Messaging (FCM)
+
 Version 2024.5 (July 7th 2024)
 - Implemented: Currency Symbol in Location Settings
 - Implemented: dzVents, Added historical data helper 'med' to calculate the median value

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -5,39 +5,47 @@
 #include "../main/SQLHelper.h"
 #include "../main/json_helper.h"
 
-#define GAPI_POST_URL "https://fcm.googleapis.com/v1/projects/##PROJECTID##/messages:send"
+#define GAPI_FCM_POST_URL_BASE "https://fcm.googleapis.com/v1/projects/##PROJECTID##/messages:send"
 
-constexpr const char *FCMMessage = R"FCM(
-{
-  "to": "<to>",
-  "message": {
-    "notification": {
-      "title": "<title>",
-      "body": "<body>"
-    },
-    "data": {
-      "param1": "<extradata>"
-    },
-    "apns": {
-      "headers": {
-        "apns-priority": "5"
-      },
-      "payload": {
-        "aps": {
-          "sound": "default"
-        }
-      }
-    },
-    "android": {
-      "priority": "medium",
-      "notification": {
-        "sound": "default"
-      }
-    }
-  }
-})FCM";
+// FCM v1 send message format
+//{
+//  "validate_only": boolean,
+//  "message": {
+//    object (Message)
+//  }
+//}
 
-constexpr const char* FCMKeyB64 = R"pKey(ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAiZG9tb3RpY3otMTE5MSIsCiAgInByaXZhdGVfa2V5X2lkIjogImYzMDgwYzQyZWMyMzQ0YTg2OWM5OWQ2OGQ1NGE5YmM2YWZkZmNjMjQiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1MvVHRGY3hLNHVvdzNcbjM3VDcvYnBhWSsyRDhLVTdiS2NENGhEbDRmeDVkRVhCZ0NIK3M5YzBsaWx5N1kyakV1V21aTEZ1bCtGNEpQY0hcbjdHYm45YXp2U0taV0RtVWo0d2lBNzliY3NsMW0zOGkxcVB0TlFaNWQwajZzR1UxUVhXYlk2S0lJQXpQRWZORFJcbkN3VlQzdFJyRWJwVW1IckY5bk9hMzdrdDFtbUM4aHdQZmd0NkEyaHRONklSQ2FmUUZhNjhURXBlTVVYTk1WRndcbnhIWHRWMjM5SHYwbDIxR3NjYnZhZmV1RnNSbGxYY0dHZTJKRG5EMGtaVkpIMGhsb245eHFMZG9QV3I2VFlTU3Vcbm9pRmRNdEx5b3ZPb3ZrM2VLR3pLam1qbk5SL1JzK0M1b2xuYnZxR3JnUVNCOGpJQTFrci83bkRQS0xUOFB3SlZcblJla2svUUJ6QWdNQkFBRUNnZ0VBTjFEOGR0RHRDVDhQR05Ia0F2ZEVJOU02WmU1d3lGSEY4c1NuVmxQN0Yxd0dcbkNtR2xxWHhWcjNFWmJTcHdKS0F1YzdXdVBuQURCcHRtcWdFeDR2YUdXOUNyNUhQclpSdUNMai9VVE44RkhudDJcblJjTXZ1NjNIb3doRjFLOTY5SlVKNlBSM1VldWVsa0hndGVMZllPWlphMmZUQnhZUkVpSUM5SlJnVkpzOXZ1eTdcblJSWGtROC9aVDNaYTBpdjBNdzBYaFBnNmpTNkhWcm1qS2hVTWhNa1p5RERUN1RwNjl0amtjS3ZTSHRXMSt5VUFcbmE4eEJ5NVVBKzV3R3ExSFM0bkFUQU1MbTRmb2RleHZsV1VTVUNRaHhaYmhRc29ZVkVoNlhKdlUzYnVRalQ5SytcbkIrU3FDVVBoYktTTFJqR04zcE1PUWUwN2tQaGhqZzBOdzY1ZHcrTHpFUUtCZ1FESVVtdnNsZTBIbUs4QzhHUmVcbmxsOFZaY1FJNXhwOHhBc1V1ZFdpdytxOExIRS95NmNBcysyaG1CMWlva0VYbDdCNEtNTUhWWCthZXNrVHdRdWlcbkw5RXRNZXhPYmthZDNtMUJwOUhDb1JHMFNSUHlsaVU2a1FhUGxTNTM4OWZWN08zYm1OUFlxcGo3eUdhVXlmcEFcblhHU0tmNkh0cXVRRWd2UXVZOHFqdjJFZThRS0JnUUM3MkFFa0dYYkIvYy9rRkdVTmN0bStjelYwNEhmYksvRkJcblROV2docTlmaHVkYk1OdVZWVlU0T1kvZm9VdG8vQVJ0dzc3alpOT2lYRUFRZDlWdnN2ZHpqYjZMK21xMGt1bm9cblBFdlJhS1ZGRU1tdWVrOGljWFdvSEU4ak9VRmxjUm40LzRCWFNqRzFEb3hCaUJsZHJhR1VCamZQWE92Y0NjUXdcbmZJR0tmZlVkb3dLQmdRQzNoRUtZNkRUUXU4REJPWWRKM0FwWnFQUXhqNzZGUkhnK1VZejA0dlQ5MU4wZks2dmdcbkNmWU9EelFFYzA2Y2xYdTJhT2xhbzZvVjFKeTNleWYwT2tnd1ZrYjlCeXVzWHVQS3ZUcCtTbDdVd2dvRE9DZjlcbkFuVjNQcHptaVQ1WEhnbytIa0VkZ2hSS3ZhbTBiMkRTYTVJMEMzOUdJME5uR3EwbWZvZGJBZTJ3a1FLQmdRQ0VcbjNlRFF2QUk0YldOakhObnRqVk5mVnZaMDJXRnQ4Y01RUVZ6SjB2cXhReWJhWmRDcjdGUC9GUmdqUWwrb3Zyb1Rcbk9lWUh5Z1c0VGpBeWRkRE8xWFFhbENRM3RzVkxQSytleVNlSDA5RXk3UkQ3RFNCMGFIU2ttSUdSbEtvaEtzTUlcblVSRmlyT1JFQVNwTUlBeHhLcU9qcEZKTnBwaGVaN29SNGI5dlNuRGFxUUtCZ0JRNGYyMVkrQklqVjZuSkhpaC9cbll0QUhqUVpNdyt1NjU5TXF0WTBiTzcxMGVaMzhMc3NoZ1M4SGllMTlBRnhVWkNpY2JrQ2FvWmlPcmF5R0VCMkhcbi9TM0lmZjR1MEZVSzJocXFtcEF2K1RvSWVOSURwbTVDUlg2Q2U1T2dLNVRMTWY5ZC9tYm1wR24yYm1xR1Uwamhcblc0eEVQeHFrQjk3bEhVbUFCbXM0T0NIVVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImZpcmViYXNlLWFkbWluc2RrLWhteGE5QGRvbW90aWN6LTExOTEuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAogICJjbGllbnRfaWQiOiAiMTAzNzY5NTQ0NzM3NzU5Mjg5MDI1IiwKICAiYXV0aF91cmkiOiAiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLAogICJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLAogICJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vb2F1dGgyL3YxL2NlcnRzIiwKICAiY2xpZW50X3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vcm9ib3QvdjEvbWV0YWRhdGEveDUwOS9maXJlYmFzZS1hZG1pbnNkay1obXhhOSU0MGRvbW90aWN6LTExOTEuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAogICJ1bml2ZXJzZV9kb21haW4iOiAiZ29vZ2xlYXBpcy5jb20iCn0=)pKey";
+// FCM v1 message format
+//{
+//  "name": string,				# Output only!
+//  "data": {
+//    string: string,			# An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+//    ...
+//  },
+//  "notification": {
+//  	"title": string,
+//  	"body": string,
+//  	"image": string
+//  },
+//  "android": {
+//    object (AndroidConfig)
+//  },
+//  "webpush": {
+//    object (WebpushConfig)
+//  },
+//  "apns": {
+//    object (ApnsConfig)
+//  },
+//  "fcm_options": {
+//    object (FcmOptions)
+//  },
+//
+//  // Union field target can be only one of the following:
+//  "token": string,			# Registration token to send a message to, either a single device or a devicegroup
+//  "topic": string,
+//  "condition": string
+//  // End of list of possible types for union field target.
+//}
 
 CNotificationFCM::CNotificationFCM() : CNotificationBase(std::string("fcm"), OPTIONS_NONE)
 {
@@ -46,6 +54,40 @@ CNotificationFCM::CNotificationFCM() : CNotificationBase(std::string("fcm"), OPT
 
 bool CNotificationFCM::IsConfigured()
 {
+	// Check if the FCM Project ID is set
+	if (GAPI_FCM_ProjectID.empty())
+	{
+		// Let's replace this later with something better... this beats at least hardcoding some values that should not be hardcoded
+		std::vector<std::vector<std::string> > result;
+		result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='GAPI_FCM_ProjectID')");
+		if (!result.empty())
+		{
+			GAPI_FCM_ProjectID = result[0][1];
+		}
+		else
+		{
+			_log.Log(LOG_ERROR, "FCM: No FCM ProjectID set!");
+			return false;
+		}
+	}
+	GAPI_FCM_PostURL = GAPI_FCM_POST_URL_BASE;
+	stdreplace(GAPI_FCM_PostURL, "##PROJECTID##", GAPI_FCM_ProjectID);
+	// Check if the FCM Bearer token is set
+	if (GAPI_FCM_bearer_token.empty())
+	{
+		// Let's replace this later with something better... this beats at least hardcoding some values that should not be hardcoded
+		std::vector<std::vector<std::string> > result;
+		result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='GAPI_FCM_bearer_token')");
+		if (!result.empty())
+		{
+			GAPI_FCM_bearer_token = result[0][1];
+		}
+		else
+		{
+			_log.Log(LOG_ERROR, "FCM: No FCM Bearer token found!");
+			return false;
+		}
+	}
 	return true;
 }
 
@@ -61,12 +103,6 @@ bool CNotificationFCM::SendMessageImplementation(
 {
 	//send message to FCM
 	//ExtraData should be empty, is only filled currently when hitting the test button from the mobile devices setup page in the web gui
-
-	//std::string szPostData(FCMMessage);
-	//stdreplace(szPostData, "<to>", sTo);
-	//stdreplace(szPostData, "<title>", Subject);
-	//stdreplace(szPostData, "<body>", Text);
-	//stdreplace(szPostData, "<extradata>", ExtraData);
 
 	//Get All Devices
 	std::vector<std::vector<std::string> > result;
@@ -90,106 +126,45 @@ bool CNotificationFCM::SendMessageImplementation(
 	if (result.empty())
 		return true;
 
-	std::string sTo;
+	std::vector<std::string> mobileDevices;
+
 	for (const auto &r : result)
 	{
-		if (!sTo.empty())
-			sTo += ", ";
-		sTo += r[0];
+		mobileDevices.push_back(r[0]);	//Store the SenderID for later use
 	}
 
-	//We need to distinguish between Android and iOS devices for the following JSon notification call
+	// Build the message
+	std::stringstream sstr;
 
-	std::vector<std::string> androidDevices;
-	std::vector<std::string> iOSDevices;
+	sstr << "{ \"registration_ids\": [";
 
-	for (const auto &sd : result)
+	int ii = 0;
+
+	for (const auto &device : mobileDevices)
 	{
-		std::string sSenderID = sd[0];
-		std::string sDeviceType = sd[1];
-
-		if ((sDeviceType.empty()) || (sDeviceType.find("Android") == 0))
-			androidDevices.push_back(sSenderID);
-		else
-			iOSDevices.push_back(sSenderID);
+		if (ii != 0)
+			sstr << ", ";
+		sstr << "\"" << device << "\"";
+		ii++;
 	}
 
-	//Android Devices
-	if (!androidDevices.empty())
+	sstr << R"(], "data" : { "subject": ")" << Subject << R"(", "body": ")" << Text << R"(", "extradata": ")" << ExtraData << R"(", "priority": ")" << std::to_string(Priority) << "\", ";
+	sstr << R"("deviceid": ")" << std::to_string(Idx) << R"(", "message": ")" << Subject << "\" } }";
+	std::string szPostdata = sstr.str();
+	_log.Debug(DEBUG_EVENTSYSTEM, "FCM: Generated message for %d devices: .%s.", ii, szPostdata.c_str());
+
+	std::vector<std::string> ExtraHeaders;
+	std::stringstream sstr2;
+	std::string sResult;
+
+	ExtraHeaders.push_back("Content-Type: application/json");
+
+	sstr2 << "Authorization: Bearer " << GAPI_FCM_bearer_token;
+	ExtraHeaders.push_back(sstr2.str());
+
+	if (HTTPClient::POST(GAPI_FCM_PostURL, szPostdata, ExtraHeaders, sResult))
 	{
-		std::stringstream sstr, sstr2;
-		std::string sResult;
-		sstr << "{ \"registration_ids\": [";
-
-		int ii = 0;
-
-		for (const auto &device : androidDevices)
-		{
-			if (ii != 0)
-				sstr << ", ";
-			sstr << "\"" << device << "\"";
-			ii++;
-		}
-
-		sstr << R"(], "data" : { "subject": ")" << Subject << R"(", "body": ")" << Text << R"(", "extradata": ")" << ExtraData << R"(", "priority": ")" << std::to_string(Priority) << "\", ";
-		sstr << R"("deviceid": ")" << std::to_string(Idx) << R"(", "message": ")" << Subject << "\" } }";
-		std::string szPostdata = sstr.str();
-
-		std::vector<std::string> ExtraHeaders;
-		ExtraHeaders.push_back("Content-Type: application/json");
-
-		sstr2 << "Authorization: key=" << GAPI_bearer_token;
-		ExtraHeaders.push_back(sstr2.str());
-
-		if (!HTTPClient::POST(GAPI_POST_URL, szPostdata, ExtraHeaders, sResult))
-		{
-			_log.Log(LOG_ERROR, "FCM: Could not send message, HTTP Error");
-			return false;
-		}
-
-		Json::Value root;
-
-		bool ret = ParseJSon(sResult, root);
-		if (!ret)
-		{
-			_log.Log(LOG_ERROR, "FCM: Can not connect to FCM API URL");
-			return false;
-		}
-	}
-
-	//iOS Devices
-	if (!iOSDevices.empty())
-	{
-		std::stringstream sstr, sstr2;
-		std::string sResult;
-		sstr << "{ \"registration_ids\": [";
-
-		int ii = 0;
-
-		for (const auto &device : iOSDevices)
-		{
-			if (ii != 0)
-				sstr << ", ";
-			sstr << "\"" << device << "\"";
-			ii++;
-		}
-
-		sstr << R"(], "notification" : { "subject": ")" << Subject << R"(", "body": ")" << Text << R"(", "extradata": ")" << ExtraData << R"(", "priority": ")" << std::to_string(Priority)
-		     << R"(", "sound": "default", )";
-		sstr << R"("deviceid": ")" << std::to_string(Idx) << R"(", "message": ")" << Subject << R"(", "content_available": true } })";
-		std::string szPostdata = sstr.str();
-
-		std::vector<std::string> ExtraHeaders;
-		ExtraHeaders.push_back("Content-Type: application/json");
-
-		sstr2 << "Authorization: Bearer " << GAPI_bearer_token;
-		ExtraHeaders.push_back(sstr2.str());
-
-		if (!HTTPClient::POST(GAPI_POST_URL, szPostdata, ExtraHeaders, sResult))
-		{
-			_log.Log(LOG_ERROR, "FCM: Could not send message, HTTP Error");
-			return false;
-		}
+		_log.Debug(DEBUG_EVENTSYSTEM, "FCM: Message sent to %d devices (%s)", ii, sResult.c_str());
 
 		Json::Value root;
 
@@ -200,13 +175,18 @@ bool CNotificationFCM::SendMessageImplementation(
 			return false;
 		}
 
-		if (!root["failure"].empty())
+		if (!root["error"].empty())
 		{
-			int iFailure = root["failure"].asInt();
-			return (iFailure == 0);
+			Json::Value jsonError = root["error"];
+			_log.Log(LOG_ERROR, "FCM: Could not send message! Errorcode %d (%s)", jsonError["code"].asInt(), jsonError["message"].asCString());
+			return false;
 		}
-
-
 	}
+	else
+	{
+		_log.Log(LOG_ERROR, "FCM: Could not send message, HTTP Error");
+		return false;
+	}
+
 	return true;
 }

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -154,6 +154,7 @@ bool CNotificationFCM::SendMessageImplementation(
 			_log.Debug(DEBUG_EVENTSYSTEM, "FCM: No SenderID for device %s", mobileDevice[2].c_str());
 			continue;
 		}
+
 		// Build the message
 		std::stringstream sstr;
 
@@ -161,7 +162,20 @@ bool CNotificationFCM::SendMessageImplementation(
 
 		if (!vExtraData.empty())
 		{
-			sstr << R"("data": { "ExtraData": ")" << ExtraData << R"("}, )";
+			uint8_t iKVs = 0;
+			sstr << R"("data": { )";
+			for (std::string &extraDataKV : vExtraData)
+			{
+				if (extraDataKV.find("=") == std::string::npos)
+					continue;
+				if (iKVs > 0)
+					sstr << R"(, )";
+				std::vector<std::string> aKV;
+				StringSplit(extraDataKV, "=", aKV);
+				sstr << R"(")" << aKV[0] << R"(": ")" << aKV[1] << R"(")";
+				iKVs++;
+			}
+			sstr << R"(}, )";
 		}
 
 		if (bFromNotification)

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -110,6 +110,18 @@ bool CNotificationFCM::SendMessageImplementation(
 		}
 	}
 
+	// Add the default 'data' fields we always want to send if available
+	vExtraData.push_back("deviceid=" + std::to_string(Idx));
+	vExtraData.push_back("priority=" + std::to_string(Priority));
+	if (!Name.empty())
+		vExtraData.push_back("message=" + Name);
+	if (!Subject.empty())
+		vExtraData.push_back("subject=" + Subject);
+	if (!Text.empty())
+		vExtraData.push_back("body=" + Text);
+	if (!Sound.empty())
+		vExtraData.push_back("sound=" + Sound);
+
 	//Get All Devices
 	std::vector<std::vector<std::string>> mobileDevices;
 	std::string szQuery("SELECT ID,Active,Name,DeviceType,SenderID FROM MobileDevices");
@@ -178,10 +190,13 @@ bool CNotificationFCM::SendMessageImplementation(
 			sstr << R"(}, )";
 		}
 
+		/* For now, we do NOT use this as a Notification is handled by the device OS itself
+		 * and the app itself is not aware of the notification
 		if (bFromNotification)
 		{
 			sstr << R"("notification": { "title": ")" << Subject << R"(", "body": ")" << Text << R"("}, )";
 		}
+		*/
 
 		sstr << R"("token": ")" << mobileDevice[4] << R"(")";		// Add where to send
 		sstr << R"(} })";											// Close Send Message struct

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -5,8 +5,7 @@
 #include "../main/SQLHelper.h"
 #include "../main/json_helper.h"
 
-#define GAPI_POST_URL "https://fcm.googleapis.com/fcm/send"
-#define GAPI "AIzaSyBnRMroiDaXCKbwPeOmoxkNiQfjWkGMre8"
+#define GAPI_POST_URL "https://fcm.googleapis.com/v1/projects/##PROJECTID##/messages:send"
 
 constexpr const char *FCMMessage = R"FCM(
 {
@@ -139,7 +138,7 @@ bool CNotificationFCM::SendMessageImplementation(
 		std::vector<std::string> ExtraHeaders;
 		ExtraHeaders.push_back("Content-Type: application/json");
 
-		sstr2 << "Authorization: key=" << GAPI;
+		sstr2 << "Authorization: key=" << GAPI_bearer_token;
 		ExtraHeaders.push_back(sstr2.str());
 
 		if (!HTTPClient::POST(GAPI_POST_URL, szPostdata, ExtraHeaders, sResult))
@@ -183,7 +182,7 @@ bool CNotificationFCM::SendMessageImplementation(
 		std::vector<std::string> ExtraHeaders;
 		ExtraHeaders.push_back("Content-Type: application/json");
 
-		sstr2 << "Authorization: key=" << GAPI;
+		sstr2 << "Authorization: Bearer " << GAPI_bearer_token;
 		ExtraHeaders.push_back(sstr2.str());
 
 		if (!HTTPClient::POST(GAPI_POST_URL, szPostdata, ExtraHeaders, sResult))
@@ -211,4 +210,3 @@ bool CNotificationFCM::SendMessageImplementation(
 	}
 	return true;
 }
-

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -96,11 +96,10 @@ bool CNotificationFCM::SendMessageImplementation(
 	//send message to FCM
 
 	std::string sMidx;
-	std::vector<std::string> vDevices;
 	std::vector<std::string> vExtraData;
 	if (ExtraData.find("midx_") != std::string::npos) {
 		sMidx = ExtraData.substr(5);
-		boost::split(vDevices, sMidx, boost::is_any_of(";"));
+		stdreplace(sMidx, ";", ",");
 	}
 	else if (ExtraData.find("|") != std::string::npos) {
 		std::string temp;
@@ -114,8 +113,8 @@ bool CNotificationFCM::SendMessageImplementation(
 	//Get All Devices
 	std::vector<std::vector<std::string>> mobileDevices;
 	std::string szQuery("SELECT ID,Active,Name,DeviceType,SenderID FROM MobileDevices");
-	if (!vDevices.empty()) {
-		szQuery += " WHERE (ID IN (" + boost::algorithm::join(vDevices, ",") + "))";
+	if (!sMidx.empty()) {
+		szQuery += " WHERE (ID IN (" + sMidx + "))";
 	}
 	else {
 		szQuery += " WHERE (Active == 1)";

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -60,57 +60,26 @@ CNotificationFCM::CNotificationFCM() : CNotificationBase(std::string("fcm"), OPT
 
 bool CNotificationFCM::IsConfigured()
 {
-	// Check if the FCM Project ID is set
-	if (GAPI_FCM_ProjectID.empty())
+	constexpr const char* FCMKeyB64 = R"pKey(ewogICJ0eXBlIjogInNlcnZpY2VfYWNjb3VudCIsCiAgInByb2plY3RfaWQiOiAiZG9tb3RpY3otMTE5MSIsCiAgInByaXZhdGVfa2V5X2lkIjogImYzMDgwYzQyZWMyMzQ0YTg2OWM5OWQ2OGQ1NGE5YmM2YWZkZmNjMjQiLAogICJwcml2YXRlX2tleSI6ICItLS0tLUJFR0lOIFBSSVZBVEUgS0VZLS0tLS1cbk1JSUV2Z0lCQURBTkJna3Foa2lHOXcwQkFRRUZBQVNDQktnd2dnU2tBZ0VBQW9JQkFRQ1MvVHRGY3hLNHVvdzNcbjM3VDcvYnBhWSsyRDhLVTdiS2NENGhEbDRmeDVkRVhCZ0NIK3M5YzBsaWx5N1kyakV1V21aTEZ1bCtGNEpQY0hcbjdHYm45YXp2U0taV0RtVWo0d2lBNzliY3NsMW0zOGkxcVB0TlFaNWQwajZzR1UxUVhXYlk2S0lJQXpQRWZORFJcbkN3VlQzdFJyRWJwVW1IckY5bk9hMzdrdDFtbUM4aHdQZmd0NkEyaHRONklSQ2FmUUZhNjhURXBlTVVYTk1WRndcbnhIWHRWMjM5SHYwbDIxR3NjYnZhZmV1RnNSbGxYY0dHZTJKRG5EMGtaVkpIMGhsb245eHFMZG9QV3I2VFlTU3Vcbm9pRmRNdEx5b3ZPb3ZrM2VLR3pLam1qbk5SL1JzK0M1b2xuYnZxR3JnUVNCOGpJQTFrci83bkRQS0xUOFB3SlZcblJla2svUUJ6QWdNQkFBRUNnZ0VBTjFEOGR0RHRDVDhQR05Ia0F2ZEVJOU02WmU1d3lGSEY4c1NuVmxQN0Yxd0dcbkNtR2xxWHhWcjNFWmJTcHdKS0F1YzdXdVBuQURCcHRtcWdFeDR2YUdXOUNyNUhQclpSdUNMai9VVE44RkhudDJcblJjTXZ1NjNIb3doRjFLOTY5SlVKNlBSM1VldWVsa0hndGVMZllPWlphMmZUQnhZUkVpSUM5SlJnVkpzOXZ1eTdcblJSWGtROC9aVDNaYTBpdjBNdzBYaFBnNmpTNkhWcm1qS2hVTWhNa1p5RERUN1RwNjl0amtjS3ZTSHRXMSt5VUFcbmE4eEJ5NVVBKzV3R3ExSFM0bkFUQU1MbTRmb2RleHZsV1VTVUNRaHhaYmhRc29ZVkVoNlhKdlUzYnVRalQ5SytcbkIrU3FDVVBoYktTTFJqR04zcE1PUWUwN2tQaGhqZzBOdzY1ZHcrTHpFUUtCZ1FESVVtdnNsZTBIbUs4QzhHUmVcbmxsOFZaY1FJNXhwOHhBc1V1ZFdpdytxOExIRS95NmNBcysyaG1CMWlva0VYbDdCNEtNTUhWWCthZXNrVHdRdWlcbkw5RXRNZXhPYmthZDNtMUJwOUhDb1JHMFNSUHlsaVU2a1FhUGxTNTM4OWZWN08zYm1OUFlxcGo3eUdhVXlmcEFcblhHU0tmNkh0cXVRRWd2UXVZOHFqdjJFZThRS0JnUUM3MkFFa0dYYkIvYy9rRkdVTmN0bStjelYwNEhmYksvRkJcblROV2docTlmaHVkYk1OdVZWVlU0T1kvZm9VdG8vQVJ0dzc3alpOT2lYRUFRZDlWdnN2ZHpqYjZMK21xMGt1bm9cblBFdlJhS1ZGRU1tdWVrOGljWFdvSEU4ak9VRmxjUm40LzRCWFNqRzFEb3hCaUJsZHJhR1VCamZQWE92Y0NjUXdcbmZJR0tmZlVkb3dLQmdRQzNoRUtZNkRUUXU4REJPWWRKM0FwWnFQUXhqNzZGUkhnK1VZejA0dlQ5MU4wZks2dmdcbkNmWU9EelFFYzA2Y2xYdTJhT2xhbzZvVjFKeTNleWYwT2tnd1ZrYjlCeXVzWHVQS3ZUcCtTbDdVd2dvRE9DZjlcbkFuVjNQcHptaVQ1WEhnbytIa0VkZ2hSS3ZhbTBiMkRTYTVJMEMzOUdJME5uR3EwbWZvZGJBZTJ3a1FLQmdRQ0VcbjNlRFF2QUk0YldOakhObnRqVk5mVnZaMDJXRnQ4Y01RUVZ6SjB2cXhReWJhWmRDcjdGUC9GUmdqUWwrb3Zyb1Rcbk9lWUh5Z1c0VGpBeWRkRE8xWFFhbENRM3RzVkxQSytleVNlSDA5RXk3UkQ3RFNCMGFIU2ttSUdSbEtvaEtzTUlcblVSRmlyT1JFQVNwTUlBeHhLcU9qcEZKTnBwaGVaN29SNGI5dlNuRGFxUUtCZ0JRNGYyMVkrQklqVjZuSkhpaC9cbll0QUhqUVpNdyt1NjU5TXF0WTBiTzcxMGVaMzhMc3NoZ1M4SGllMTlBRnhVWkNpY2JrQ2FvWmlPcmF5R0VCMkhcbi9TM0lmZjR1MEZVSzJocXFtcEF2K1RvSWVOSURwbTVDUlg2Q2U1T2dLNVRMTWY5ZC9tYm1wR24yYm1xR1Uwamhcblc0eEVQeHFrQjk3bEhVbUFCbXM0T0NIVVxuLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLVxuIiwKICAiY2xpZW50X2VtYWlsIjogImZpcmViYXNlLWFkbWluc2RrLWhteGE5QGRvbW90aWN6LTExOTEuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAogICJjbGllbnRfaWQiOiAiMTAzNzY5NTQ0NzM3NzU5Mjg5MDI1IiwKICAiYXV0aF91cmkiOiAiaHR0cHM6Ly9hY2NvdW50cy5nb29nbGUuY29tL28vb2F1dGgyL2F1dGgiLAogICJ0b2tlbl91cmkiOiAiaHR0cHM6Ly9vYXV0aDIuZ29vZ2xlYXBpcy5jb20vdG9rZW4iLAogICJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vb2F1dGgyL3YxL2NlcnRzIiwKICAiY2xpZW50X3g1MDlfY2VydF91cmwiOiAiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vcm9ib3QvdjEvbWV0YWRhdGEveDUwOS9maXJlYmFzZS1hZG1pbnNkay1obXhhOSU0MGRvbW90aWN6LTExOTEuaWFtLmdzZXJ2aWNlYWNjb3VudC5jb20iLAogICJ1bml2ZXJzZV9kb21haW4iOiAiZ29vZ2xlYXBpcy5jb20iCn0=)pKey";
+
+	Json::Value root;
+
+	if (ParseJSon(base64_decode(FCMKeyB64), root))
 	{
-		// Let's replace this later with something better... this beats at least hardcoding some values that should not be hardcoded
-		std::vector<std::vector<std::string> > result;
-		result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='GAPI_FCM_ProjectID')");
-		if (!result.empty())
-		{
-			GAPI_FCM_ProjectID = result[0][1];
-		}
-		else
-		{
-			_log.Log(LOG_ERROR, "FCM: No FCM ProjectID set!");
-			return false;
-		}
+		GAPI_FCM_privkey = root["private_key"].asString();
+		GAPI_FCM_ProjectID = root["project_id"].asString();
+		GAPI_FCM_issuer = root["client_email"].asString();
+
+		GAPI_FCM_PostURL = GAPI_FCM_POST_URL_BASE;
+		stdreplace(GAPI_FCM_PostURL, "##PROJECTID##", GAPI_FCM_ProjectID);
+
+		slAccessToken_exp_time = std::chrono::system_clock::now();
+
+		//_log.Debug(DEBUG_EVENTSYSTEM, "FCM: Parsed FCM project data (Project URL %s)!", GAPI_FCM_PostURL.c_str());
+		return true;
 	}
-	GAPI_FCM_PostURL = GAPI_FCM_POST_URL_BASE;
-	stdreplace(GAPI_FCM_PostURL, "##PROJECTID##", GAPI_FCM_ProjectID);
-	// Check if the FCM issuer is set
-	if (GAPI_FCM_issuer.empty())
-	{
-		// Let's replace this later with something better... this beats at least hardcoding some values that should not be hardcoded
-		std::vector<std::vector<std::string> > result;
-		result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='GAPI_FCM_issuer')");
-		if (!result.empty())
-		{
-			GAPI_FCM_issuer = result[0][1];
-		}
-		else
-		{
-			_log.Log(LOG_ERROR, "FCM: No FCM issuer found!");
-			return false;
-		}
-	}
-	// Check if the FCM private key is set
-	if (GAPI_FCM_privkey.empty())
-	{
-		// Let's replace this later with something better... this beats at least hardcoding some values that should not be hardcoded
-		std::vector<std::vector<std::string> > result;
-		result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='GAPI_FCM_privkey')");
-		if (!result.empty())
-		{
-			GAPI_FCM_privkey = base64_decode(result[0][1]);		// The Priv key should be base64 encoded to get stored correctly in the DB (newlines)
-		}
-		else
-		{
-			_log.Log(LOG_ERROR, "FCM: No FCM private key found!");
-			return false;
-		}
-	}
-	return true;
+
+	return false;
 }
 
 bool CNotificationFCM::SendMessageImplementation(
@@ -241,6 +210,17 @@ bool CNotificationFCM::SendMessageImplementation(
 
 bool CNotificationFCM::getSlAccessToken(const std::string &bearer_token, std::string &slAccessToken)
 {
+	if (!slAccesToken_cached.empty())
+	{
+		_log.Debug(DEBUG_EVENTSYSTEM, "FCM: Cached Token found! (%ld - %ld)", slAccessToken_exp_time.time_since_epoch().count(), std::chrono::system_clock::now().time_since_epoch().count());
+		if (std::chrono::system_clock::now() < slAccessToken_exp_time)
+		{
+			_log.Debug(DEBUG_EVENTSYSTEM, "FCM: Using Cached Token!");
+			slAccessToken = slAccesToken_cached;
+			return true;
+		}
+	}
+
 	std::vector<std::string> ExtraHeaders;
 	std::string sPostBody, sResult;
 
@@ -254,13 +234,19 @@ bool CNotificationFCM::getSlAccessToken(const std::string &bearer_token, std::st
 	{
 		Json::Value root;
 
-		bool ret = ParseJSon(sResult, root);
-		if (ret)
+		if (ParseJSon(sResult, root))
 		{
 			if (!root["access_token"].empty())
 			{
 				slAccessToken = root["access_token"].asString();
-				_log.Debug(DEBUG_EVENTSYSTEM, "FCM: AccessToken retrieved (%s...)", slAccessToken.substr(0,10).c_str());
+				uint64_t slAccessToken_exp_seconds = 0;
+				if (!root["expires_in"].empty())
+				{
+					slAccessToken_exp_seconds = (root["expires_in"].asInt() - 120) * 1000000;		// 2 minutes before expiration
+					slAccessToken_exp_time = std::chrono::system_clock::now() + std::chrono::seconds{slAccessToken_exp_seconds};
+					slAccesToken_cached = slAccessToken;
+				}
+				_log.Debug(DEBUG_EVENTSYSTEM, "FCM: AccessToken retrieved (%s...) expires in %ld seconds", slAccessToken.substr(0,10).c_str(), slAccessToken_exp_seconds);
 				return true;
 			}
 		}
@@ -275,9 +261,6 @@ bool CNotificationFCM::getSlAccessToken(const std::string &bearer_token, std::st
 
 bool CNotificationFCM::createFCMjwt(const std::string &FCMissuer, std::string &sFCMjwt)
 {
-	std::string sPrivKey;
-	sPrivKey = GAPI_FCM_privkey;
-
 	sFCMjwt.clear();
 
 	try
@@ -293,7 +276,7 @@ bool CNotificationFCM::createFCMjwt(const std::string &FCMissuer, std::string &s
 		//.set_key_id(std::to_string(keyID))
 		//.set_id(GenerateUUID())
 		.set_payload_claim("scope", jwt::claim(std::string{GAPI_FCM_SCOPE}));
-		sFCMjwt = JWT.sign(jwt::algorithm::rs256{"", sPrivKey, "", ""}, &base64url_encode);
+		sFCMjwt = JWT.sign(jwt::algorithm::rs256{"", GAPI_FCM_privkey, "", ""}, &base64url_encode);
 	}
 	catch(const std::exception& err)
 	{

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -16,6 +16,9 @@ public:
 	std::string GAPI_FCM_issuer;
 	std::string GAPI_FCM_privkey;
 
+	std::string slAccesToken_cached;
+	std::chrono::_V2::system_clock::time_point slAccessToken_exp_time;
+
 	bool getSlAccessToken(const std::string &bearer_token, std::string &slAccessToken);
 	bool createFCMjwt(const std::string &FCMissuer, std::string &sFCMjwt);
 };

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -11,13 +11,12 @@ public:
 	bool SendMessageImplementation(uint64_t Idx, const std::string &Name, const std::string &Subject, const std::string &Text, const std::string &ExtraData, int Priority, const std::string &Sound,
 				       bool bFromNotification) override;
 	  private:
-	std::string GAPI_FCM_ProjectID;
-	std::string GAPI_FCM_PostURL;
-	std::string GAPI_FCM_issuer;
-	std::string GAPI_FCM_privkey;
+	std::string m_GAPI_FCM_PostURL;
+	std::string m_GAPI_FCM_issuer;
+	std::string m_GAPI_FCM_privkey;
 
-	std::string slAccesToken_cached;
-	std::chrono::_V2::system_clock::time_point slAccessToken_exp_time;
+	std::string m_slAccesToken_cached;
+	uint64_t m_slAccessToken_exp_time;
 
 	bool getSlAccessToken(const std::string &bearer_token, std::string &slAccessToken);
 	bool createFCMjwt(const std::string &FCMissuer, std::string &sFCMjwt);

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -10,4 +10,6 @@ public:
       protected:
 	bool SendMessageImplementation(uint64_t Idx, const std::string &Name, const std::string &Subject, const std::string &Text, const std::string &ExtraData, int Priority, const std::string &Sound,
 				       bool bFromNotification) override;
+	  private:
+	std::string GAPI_bearer_token;
 };

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -13,5 +13,9 @@ public:
 	  private:
 	std::string GAPI_FCM_ProjectID;
 	std::string GAPI_FCM_PostURL;
-	std::string GAPI_FCM_bearer_token;
+	std::string GAPI_FCM_issuer;
+	std::string GAPI_FCM_privkey;
+
+	bool getSlAccessToken(const std::string &bearer_token, std::string &slAccessToken);
+	bool createFCMjwt(const std::string &FCMissuer, std::string &sFCMjwt);
 };

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -11,5 +11,7 @@ public:
 	bool SendMessageImplementation(uint64_t Idx, const std::string &Name, const std::string &Subject, const std::string &Text, const std::string &ExtraData, int Priority, const std::string &Sound,
 				       bool bFromNotification) override;
 	  private:
-	std::string GAPI_bearer_token;
+	std::string GAPI_FCM_ProjectID;
+	std::string GAPI_FCM_PostURL;
+	std::string GAPI_FCM_bearer_token;
 };


### PR DESCRIPTION
This PR is to address deprecation of Google legacy FCM and move to the new v1 API of Google's Firebase Cloud Messaging.

It now uses the new v1 API and requests an Access Token each time it sends out messages (unless it can get it from its cache and has not expired).

Info from Google can be found [here](https://firebase.google.com/docs/cloud-messaging/migrate-v1).



