### PR TITLE
Ensure AllowPlainBasicAuth settings is set to both HTTP and HTTPS webserver (Fixes #6064)

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -2574,7 +2574,7 @@ namespace http
 				bool AllowPlainBasicAuth = (request::findValue(&req, "AllowPlainBasicAuth") == "on" ? 1 : 0);
 				m_sql.UpdatePreferencesVar("AllowPlainBasicAuth", AllowPlainBasicAuth);
 
-				m_pWebEm->SetAllowPlainBasicAuth(AllowPlainBasicAuth);
+				m_webservers.SetAllowPlainBasicAuth(AllowPlainBasicAuth);
 				cntSettings++;
 
 				std::string WebLocalNetworks = CURLEncode::URLDecode(request::findValue(&req, "WebLocalNetworks"));


### PR DESCRIPTION
PR _fixes_ issue #6064 .

When toggling the __API Protection__ (_Allow Basic-Auth authentication over plain HTTP (API only)._) on the _Settings/Security_ tab, the setting was only applied to the webserver process (Either HTTP or HTTPS) where the settings was changed instead of both.

Not really a big issue, but annoying when trying to secure your domoticz environment as currently it requires a restart of domoticz to make the setting active for both HTTP and HTTPS server.

So in case one was using a HTTPS connection to domoticz to toggle the setting and in parallel testing the API over HTTP, there was no noticeable effect until domoticz was restarted (to make the setting active on the HTTP server).

Now the setting is active immediately for both HTTP and HTTPS regardless if the setting is changed over a HTTP or HTTPS connection.

