### PR TITLE
Change to improve token handling of the Netatmo hardware device

### DIFF
--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -221,7 +221,7 @@ bool CNetatmo::Login()
 		}
 	}
 
-	Log (LOG_STATUS, "Requesting new tokens using authorization code");
+	Log (LOG_NORM, "Requesting new tokens using authorization code");
 
 	//Loggin on the API
 	std::stringstream sstr;
@@ -302,7 +302,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 			return true; //no need to refresh the token yet
 	}
 
-	Log (LOG_STATUS, "Requesting refreshed tokens");
+	Log (LOG_NORM, "Requesting refreshed tokens");
 
 	// Time to refresh the token
 	std::stringstream sstr;

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -196,6 +196,7 @@ void CNetatmo::Do_Work()
 			}
 		}
 	}
+	RefreshToken(true);
 	Log(LOG_STATUS, "Worker stopped...");
 }
 
@@ -243,7 +244,7 @@ bool CNetatmo::Login()
 	//Check for returned data
 	if (!ret)
 	{
-		Log(LOG_ERROR, "Error connecting to Server...");
+		Log(LOG_ERROR, "Error connecting to Server (login)...");
 		return false;
 	}
 
@@ -252,14 +253,14 @@ bool CNetatmo::Login()
 	ret = ParseJSon(sResult, root);
 	if ((!ret) || (!root.isObject()))
 	{
-		Log(LOG_ERROR, "Invalid/no data received...");
+		Log(LOG_ERROR, "Invalid/no data received (login)...");
 		return false;
 	}
 	//Check if access was granted
 	if (root["access_token"].empty() || root["expires_in"].empty() || root["refresh_token"].empty())
 	{
-		Log(LOG_ERROR, "No access granted, check credentials...");
-		Debug(DEBUG_HARDWARE, "No access granted, check credentials...(%s)(%s)", httpData.c_str(), root.toStyledString().c_str());
+		Log(LOG_ERROR, "No access granted, check credentials (Login)...");
+		Debug(DEBUG_HARDWARE, "No access granted, check credentials (Login)...(%s)(%s)", httpData.c_str(), root.toStyledString().c_str());
 		return false;
 	}
 
@@ -320,7 +321,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 	//Check for returned data
 	if (!ret)
 	{
-		Log(LOG_ERROR, "Error connecting to Server...");
+		Log(LOG_ERROR, "Error connecting to Server (refresh tokens)...");
 		return false;
 	}
 
@@ -329,7 +330,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 	ret = ParseJSon(sResult, root);
 	if ((!ret) || (!root.isObject()))
 	{
-		Log(LOG_ERROR, "Invalid/no data received...");
+		Log(LOG_ERROR, "Invalid/no data received (refresh tokens)...");
 		//Force login next time
 		m_isLogged = false;
 		return false;
@@ -339,7 +340,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 	if (root["access_token"].empty() || root["expires_in"].empty() || root["refresh_token"].empty())
 	{
 		//Force login next time
-		Log(LOG_ERROR, "No access granted, forcing login again...");
+		Log(LOG_ERROR, "No access granted, forcing login again (Refresh tokens)...");
 		m_isLogged = false;
 		return false;
 	}
@@ -351,6 +352,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 	//Store the duration of validity of the token
 	m_nextRefreshTs = mytime(nullptr) + expires;
 
+	StoreRefreshToken();
 	return true;
 }
 
@@ -750,7 +752,7 @@ void CNetatmo::GetMeterDetails()
 		httpUrl = MakeRequestURL(NETYPE_ENERGY);
 		if (!HTTPClient::GET(httpUrl, ExtraHeaders, sResult))
 		{
-			Log(LOG_ERROR, "Error connecting to Server...");
+			Log(LOG_ERROR, "Error connecting to Server (GetMeterDetails)...");
 			return;
 		}
 
@@ -758,7 +760,7 @@ void CNetatmo::GetMeterDetails()
 		bRet = ParseJSon(sResult, root);
 		if ((!bRet) || (!root.isObject()))
 		{
-			Log(LOG_ERROR, "Invalid data received...");
+			Log(LOG_ERROR, "Invalid data received (GetMeterDetails)...");
 			return;
 		}
 		if (!root["error"].empty())
@@ -782,7 +784,7 @@ void CNetatmo::GetMeterDetails()
 	httpUrl = MakeRequestURL(m_weatherType);
 	if (!HTTPClient::GET(httpUrl, ExtraHeaders, sResult))
 	{
-		Log(LOG_ERROR, "Error connecting to Server...");
+		Log(LOG_ERROR, "Error connecting to Server (GetMeterDetails)...");
 		return;
 	}
 
@@ -790,7 +792,7 @@ void CNetatmo::GetMeterDetails()
 	bRet = ParseJSon(sResult, root);
 	if ((!bRet) || (!root.isObject()))
 	{
-		Log(LOG_ERROR, "Invalid data received...");
+		Log(LOG_ERROR, "Invalid data received(GetMeterDetails)...");
 		return;
 	}
 	if (!root["error"].empty())
@@ -812,7 +814,7 @@ void CNetatmo::GetMeterDetails()
 			httpUrl = MakeRequestURL(NETYPE_HOMECOACH);
 			if (!HTTPClient::GET(httpUrl, ExtraHeaders, sResult))
 			{
-				Log(LOG_ERROR, "Error connecting to Server...");
+				Log(LOG_ERROR, "Error connecting to Server (ParseStationData)...");
 				return;
 			}
 
@@ -820,7 +822,7 @@ void CNetatmo::GetMeterDetails()
 			bool bRet = ParseJSon(sResult, root);
 			if ((!bRet) || (!root.isObject()))
 			{
-				Log(LOG_ERROR, "Invalid data received...");
+				Log(LOG_ERROR, "Invalid data received (ParseStationData)...");
 				return;
 			}
 			if (!root["error"].empty())
@@ -875,7 +877,7 @@ void CNetatmo::GetThermostatDetails()
 
 	if (!ret)
 	{
-		Log(LOG_ERROR, "Error connecting to Server...");
+		Log(LOG_ERROR, "Error connecting to Server (GetThermostatDetails)...");
 		return;
 	}
 	if (m_energyType != NETYPE_ENERGY)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -12,6 +12,11 @@
 #define NETATMO_SCOPES "read_station read_thermostat write_thermostat read_homecoach read_smokedetector read_presence read_camera"
 #define NETATMO_REDIRECT_URI "http://localhost/netatmo"
 
+
+// 03/03/2022 - PP Changing the Weather polling from 600 to 900s. This has reduce the number of server errors, 
+// 08/05/2024 - Give the poll interfval a defined name:
+#define NETAMO_POLL_INTERVALL 900
+
 #ifdef _DEBUG
 //#define DEBUG_NetatmoWeatherStationR
 #endif
@@ -164,23 +169,17 @@ void CNetatmo::Do_Work()
 		{
 			if (RefreshToken())
 			{
-				//Weather / HomeCoach data is updated every 10 minutes
-				// 03/03/2022 - PP Changing the Weather polling from 600 to 900s. This has reduce the number of server errors, 
-				// but do not prevennt to have one time to time
-				if ((sec_counter % 900 == 0) || (bFirstTimeWS))
+				//Weather, HomeCoach, and Thernistat data is updated every  NETAMO_POLL_INTERVALL  seconds 
+				if ((sec_counter % NETAMO_POLL_INTERVALL == 0) || (bFirstTimeTH) || (bFirstTimeWS))
 				{
 					bFirstTimeWS = false;
-					if ((m_bPollWeatherData) || (sec_counter % 1200 == 0))
-						GetMeterDetails();
-				}
-
-				//Thermostat data is updated every 10 minutes
-				if ((sec_counter % 900 == 0) || (bFirstTimeTH))
-				{
 					bFirstTimeTH = false;
+					if (m_bPollWeatherData)
+						GetMeterDetails();
 					if (m_bPollThermostat)
 						GetThermostatDetails();
 				}
+
 				//Update Thermostat data when the
 				//manual set point reach its end
 				if (m_bForceSetpointUpdate)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -196,7 +196,6 @@ void CNetatmo::Do_Work()
 			}
 		}
 	}
-	RefreshToken(true);
 	Log(LOG_STATUS, "Worker stopped...");
 }
 
@@ -221,6 +220,8 @@ bool CNetatmo::Login()
 			return true;
 		}
 	}
+
+	Log (LOG_STATUS, "Requesting new tokens using authorization code");
 
 	//Loggin on the API
 	std::stringstream sstr;
@@ -269,7 +270,7 @@ bool CNetatmo::Login()
 	m_refreshToken = root["refresh_token"].asString();
 
 	int expires = root["expires_in"].asInt();
-	m_nextRefreshTs = mytime(nullptr) + expires;
+	m_nextRefreshTs = mytime(nullptr) + expires * 2 / 3;
 
 	//Store the token in database in case
 	//of domoticz restart
@@ -300,6 +301,8 @@ bool CNetatmo::RefreshToken(const bool bForce)
 		if ((mytime(nullptr) - 15) < m_nextRefreshTs)
 			return true; //no need to refresh the token yet
 	}
+
+	Log (LOG_STATUS, "Requesting refreshed tokens");
 
 	// Time to refresh the token
 	std::stringstream sstr;
@@ -350,7 +353,7 @@ bool CNetatmo::RefreshToken(const bool bForce)
 	m_refreshToken = root["refresh_token"].asString();
 	int expires = root["expires_in"].asInt();
 	//Store the duration of validity of the token
-	m_nextRefreshTs = mytime(nullptr) + expires;
+	m_nextRefreshTs = mytime(nullptr) + expires * 2 / 3;
 
 	StoreRefreshToken();
 	return true;

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -578,9 +578,9 @@ namespace http
 					name.c_str(), (senabled == "true") ? 1 : 0, htype, iLogLevelEnabled, address.c_str(), port, sport.c_str(), username.c_str(), password.c_str(),
 					extra.c_str(), mode1Str.c_str(), mode2Str.c_str(), mode3Str.c_str(), mode4Str.c_str(), mode5Str.c_str(), mode6Str.c_str(), iDataTimeout);
 			}
-			else if ((htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868))
+			else if ((htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868) || (htype == HTYPE_Netatmo))
 			{
-				// No Extra field here, handled in CWebServer::SetRFXCOMMode
+				// No Extra field here, handled in CWebServer::SetRFXCOMMode and in CNetatmo::CNetatmo for Netatmo devices
 				m_sql.safe_query("INSERT INTO Hardware (Name, Enabled, Type, LogLevel, Address, Port, SerialPort, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, "
 					"DataTimeout) VALUES ('%q',%d, %d, %d,'%q',%d,'%q','%q','%q',%d,%d,%d,%d,%d,%d,%d)",
 					name.c_str(), (senabled == "true") ? 1 : 0, htype, iLogLevelEnabled, address.c_str(), port, sport.c_str(), username.c_str(), password.c_str(), mode1,
@@ -664,6 +664,7 @@ namespace http
 			if (!ValidateHardware(htype, sport, address, port, username, password, mode1Str, mode2Str, mode3Str, mode4Str, mode5Str, mode6Str, extra, idx))
 				return;
 
+
 			root["status"] = "OK";
 			root["title"] = "UpdateHardware";
 
@@ -698,9 +699,9 @@ namespace http
 						extra.c_str(), mode1Str.c_str(), mode2Str.c_str(), mode3Str.c_str(), mode4Str.c_str(), mode5Str.c_str(), mode6Str.c_str(), iDataTimeout,
 						idx.c_str());
 				}
-				else if ((htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868))
+				else if ((htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868) || (htype == HTYPE_Netatmo))
 				{
-					// No Extra field here, handled in CWebServer::SetRFXCOMMode
+					// No Extra field here, handled in CWebServer::SetRFXCOMMode and CNetatmo::CNetatmo( for Netatmo
 					m_sql.safe_query("UPDATE Hardware SET Name='%q', Enabled=%d, Type=%d, LogLevel=%d, Address='%q', Port=%d, SerialPort='%q', Username='%q', Password='%q', "
 						"Mode1=%d, Mode2=%d, Mode3=%d, Mode4=%d, Mode5=%d, Mode6=%d, DataTimeout=%d WHERE (ID == '%q')",
 						name.c_str(), (bEnabled == true) ? 1 : 0, htype, iLogLevelEnabled, address.c_str(), port, sport.c_str(), username.c_str(), password.c_str(),


### PR DESCRIPTION
When the worker (in hardware/Netatmo.cpp) is restarted or stopped (by disabling the hardware device or stopping Domoticz), the worker will use an expired refresh token or tries to log in with an expired authorization code. In some cases, a valid refresh token is lost, caused by the web server, not supporting this field.

This is partly caused by a change in the authorization process since May 29, 2024:

'Starting May 29, 2024, this behaviour will change to comply with the [OAuth2 Authorization Framework RFC recommendations (section 10.4)] (https://www.rfc-editor.org/rfc/rfc6749) and improve the security of our users' data.
When refreshing the tokens, the Access Token and Refresh Token will be different from the previous ones and the old tokens will be invalidated.'

This requires that the refresh token needs to be updated in its storage, so the new code can be used after a restart of the worker.

This patch will include 3 functional changes and some additional text in log and debug messages:

1.  Store the new refresh token after each token refresh request (about every 3 hours).
2. Refresh the tokens before stopping or restarting the hardware device, so the user has 3 hours to fix the reason why the hardware device needed to be stopped or restarted.
3. Don't let the web server update the refresh token in its storage, because it has an uninitialized value (0).


I've tested this changes, and it all works as expected, so It's ready to review and/or merged
