### PR TITLE
Frank Energie missing as gas supplier

### DIFF
--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1390,6 +1390,7 @@
 						<option value="EN">Eneco</option>
 						<option value="EVO">Energie van Ons</option>
 						<option value="EZ">Energy Zero</option>
+						<option value="FR">Frank Energie</option>
 						<option value="GSL">Groenestroom Lokaal</option>
 						<option value="MDE">Mijndomein Energie</option>
 						<option value="NE">NextEnergy</option>


### PR DESCRIPTION
The Enever JSON output also lists Frank Energie as gas supplier. Add it so the users which use then as their supplier to use the correct data.