### PR TITLE
Fix to handle values instead of counter for managed P1 Smart Meter

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3872,7 +3872,7 @@ namespace http
 			}
 			else
 			{
-				queryString.append("  sum(Value) as Sum");
+				queryString.append("  sum(" + value("") + ") as Sum");
 			}
 
 			if (sgroupby == "quarter")

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -81,6 +81,11 @@ namespace http
 			std::string sOptions = result[0][6];
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sOptions);
 
+			if (options["AddDBLogEntry"] == "true")
+			{
+				bIsManagedCounter = true;
+			}
+
 			double divider = m_sql.GetCounterDivider(int(metertype), int(dType), float(AddjValue2));
 
 			double meteroffset = AddjValue;


### PR DESCRIPTION
This fix the "Comparing graph" when using a P1 smart meter which is externally managed and has no counter, only values, in MultiMeter_Calendar. This extends and makes more generic the PR #5808