### PR TITLE
Patch device discovery

### DIFF
--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2133,7 +2133,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 				std::string module_id = module["id"].asString();
 				std::string bat_percentage;
 				std::string batName;
-				int batteryLevel = 255;
+				int batteryLevel;
 				float mrf_percentage = 12;
 				int mrf_status;
 				float rf_strength = 0;
@@ -2191,6 +2191,8 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					bat_str << std::setprecision(2) << battery_Level;
 					bat_str >> bat_percentage;
 				}
+				else
+					batteryLevel = 255;
 				if (!module["rf_state"].empty())
 				{
 					std::string rf_state = module["rf_state"].asString();
@@ -2232,7 +2234,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					Log(LOG_ERROR, "cloud data for module [%s] no longer updated (module possibly disconnected)", moduleName.c_str());
 					connected = false;
 				}
-
+				
 				if (connected)
 				{
 					if (!module["rf_strength"].empty())

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2193,6 +2193,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 				}
 				else
 					batteryLevel = 255;
+				
 				if (!module["rf_state"].empty())
 				{
 					std::string rf_state = module["rf_state"].asString();
@@ -2232,7 +2233,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 				else
 				{
 					Log(LOG_ERROR, "cloud data for module [%s] no longer updated (module possibly disconnected)", moduleName.c_str());
-					connected = false;
+					//connected = false;
 				}
 				
 				if (connected)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2224,7 +2224,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 				Debug(DEBUG_HARDWARE, "Module [%s] last update = %s", moduleName.c_str(), ctime(&tNetatmoLastUpdate));
 				// check if Netatmo data was updated in the past NETAMO_POLL_INTERVALL (+1 min for sync time lags)... if not means sensors failed to send to cloud
 				int Interval = NETAMO_POLL_INTERVALL + 60;
-				Debug(DEBUG_HARDWARE, "Module [%s] Interval = %d %u", moduleName.c_str(), Interval, tNetatmoLastUpdate);
+				Debug(DEBUG_HARDWARE, "Module [%s] Interval = %d %lu", moduleName.c_str(), Interval, tNetatmoLastUpdate);
 				if (tNetatmoLastUpdate > (tNow - Interval))
 				{
 					Log(LOG_STATUS, "cloud data for module [%s] is now updated again", moduleName.c_str());


### PR DESCRIPTION
There was a check for live Cloud data but this does not function correctly for other setups
so I comment out the line `connected = false;`
`bool connected = true;` will continu be set so `if (connected)` will continu to run.

Sorry for this mistake.

kind regards