### PR TITLE
Fix MQTT AutoDiscovery electricity usage meter sensors

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1809,38 +1809,31 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 
 		if (fUsage < -1000000)
 		{
-			//Way to negative, probably a bug in the sensor
+			//Way too negative, probably a bug in the sensor
 			return false;
 		}
 
+		sValue = std_format("%.3f", fUsage);
+
 		float fkWh = 0.0F;
 		_tMQTTASensor* pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "kwh");
-		if (pkWhSensor)
-			fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) * 1000.0F;
-		else
-		{
+		if (!pkWhSensor)
 			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wh");
-			if (pkWhSensor)
-				fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str()));
-			else
-			{
-				pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
-				if (pkWhSensor)
-					fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) / 60.0F;
-			}
-		}
+		if (!pkWhSensor)
+			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
+
 		if (pkWhSensor)
 		{
 			if (pkWhSensor->last_received != 0)
 			{
-				pkWhSensor->sValue = std_format("%.3f;%.3f", fUsage, fkWh);
+				pkWhSensor->sValue = std_format("%.3f;%.3f", fUsage, pkWhSensor->prev_value);
+
 				mosquitto_message xmessage;
 				xmessage.retain = false;
 				// Trigger extra update for the kWh sensor with the new W value
 				handle_auto_discovery_sensor(pkWhSensor, &xmessage);
 			}
 		}
-		sValue = std_format("%.3f", fUsage);
 	}
 	else if (
 		(szUnit == "kwh")
@@ -1863,31 +1856,60 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 
 		if (fkWh < -1000000)
 		{
-			//Way to negative, probably a bug in the sensor
+			//Way too negative, probably a bug in the sensor
 			return false;
 		}
 
-		if (fkWh == 0)
+		// Zero could be the first ever value received.
+		// Or it could also be that the middleware sends 0 when it has not received it before
+		if (fkWh == 0 || pSensor->state_class == "total_increasing")
 		{
-			//could be the first every value received.
-			//could also be that this the middleware sends 0 when it has not received it before
-			auto result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
-				m_HwdID, pSensor->unique_id.c_str(), devType, subType);
-			if (!result.empty())
+			float fPrevkWh = pSensor->prev_value;
+
+			if (!pSensor->last_received != 0)
 			{
-				std::vector<std::string> strarray;
-				StringSplit(result[0][0], ";", strarray);
-				if (strarray.size() == 2)
-				{
-					fkWh = static_cast<float>(atof(strarray[1].c_str()));
+				auto result = m_sql.safe_query("SELECT sValue,StrParam1 FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
+					m_HwdID, pSensor->unique_id.c_str(), devType, subType);
+				if (!result.empty()) {
+					std::vector<std::string> strarray;
+					StringSplit(result[0][0], ";", strarray);
+					if (strarray.size() == 2)
+						fPrevkWh = static_cast<float>(atof(strarray[1].c_str()));
+
+					// For total_increasing sensors, the epoch is stored in StrParam1
+					if (!result[0][1].empty())
+						pSensor->epoch = static_cast<float>(atof(result[0][1].c_str()));
 				}
 			}
+
+			// GuessSensorTypeValue() is sometimes invoked with empty sValue to do
+			// only what its name implies, nothing more. Do not bump the epoch when
+			// when that happens; just use the previous value.
+			if (fkWh == 0)
+			{
+				fkWh = fPrevkWh;
+			}
+			else if (pSensor->state_class == "total_increasing")
+			{
+				// If the value resulting from this reading would be lower than the
+				// previous value, the sensor must have reset. Bump its epoch, which
+				// we store in StrParam1.
+				if (fkWh + pSensor->epoch < fPrevkWh)
+				{
+					pSensor->epoch = fPrevkWh;
+					m_sql.safe_query("UPDATE DeviceStatus SET StrParam1='%f' WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
+							 pSensor->epoch, m_HwdID, pSensor->unique_id.c_str(), devType, subType);
+				}
+
+				fkWh += pSensor->epoch;
+			}
 		}
+		pSensor->prev_value = fkWh;
 
 		_tMQTTASensor* pWattSensor = get_auto_discovery_sensor_WATT_unit(pSensor);
-		if (pWattSensor)
+		if (pWattSensor && pWattSensor->last_received != 0)
 		{
-			fUsage = static_cast<float>(atof(pWattSensor->last_value.c_str()));
+			fUsage = static_cast<float>(atof(pWattSensor->sValue.c_str()));
 		}
 		sValue = std_format("%.3f;%.3f", fUsage, fkWh);
 	}

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -132,6 +132,8 @@ class MQTTAutoDiscover : public MQTT
 
 		bool bOnline = false;
 		time_t last_received = 0;
+		float prev_value = 0;
+		float epoch = 0;
 		std::string last_value;
 		std::string last_topic;
 		bool bIsJSON = false;

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -132,8 +132,8 @@ class MQTTAutoDiscover : public MQTT
 
 		bool bOnline = false;
 		time_t last_received = 0;
-		float prev_value = 0;
-		float epoch = 0;
+		double prev_value = 0;
+		double epoch = 0;
 		std::string last_value;
 		std::string last_topic;
 		bool bIsJSON = false;


### PR DESCRIPTION
 • Fix the `total_increasing` support so that meter readings don't go backwards.
 • Support pairing of kW sensors.
 • Fix loss of precision in JSON/float conversions.

Tested with both ESPHome devices, and data from a smart electricity meter.