### PR TITLE
MQTT: Support 'onoff' colour mode

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1126,6 +1126,15 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 					pSensor->supported_color_modes.clear();
 				}
 			}
+			if (pSensor->supported_color_modes.find("onoff") != pSensor->supported_color_modes.end())
+			{
+				if (pSensor->supported_color_modes.size() == 1)
+				{
+					//we only support onoff, so it is a normal switch and does not support setting a color
+					pSensor->bColor_mode = false;
+					pSensor->supported_color_modes.clear();
+				}
+			}
 		}
 		else
 		{


### PR DESCRIPTION
I have a simple switch in ESPHome which doesn't work in Domoticz.
```yaml
light:
  - platform: binary
    name: "Blue LED"
    id: blue_led
    output: led_output

```
It appears like this in MQTT autodiscovery:
```json
{
   "avty_t" : "bathroom/status",
   "clrm" : true,
   "cmd_t" : "bathroom/light/blue_led/command",
   "dev" : {
      "cns" : [
         [
            "mac",
            "782184bb134c"
         ]
      ],
      "ids" : "782184bb134c",
      "mdl" : "esp32-gateway",
      "mf" : "Espressif",
      "name" : "bathroom",
      "sw" : "2024.9.0-dev (Sep  6 2024, 22:54:39)"
   },
   "name" : "Blue LED",
   "obj_id" : "bathroom_blue_led",
   "schema" : "json",
   "stat_t" : "bathroom/light/blue_led/state",
   "supported_color_modes" : [
      "onoff"
   ],
   "uniq_id" : "782184bb134c-light-6a29e1c2"
}
```