### PR TITLE
Fix MQTT AutoDiscover device names

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -736,6 +736,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 
 		pDevice->identifiers = device_identifiers;
 
+		// This is the name of the *device* to which this sensor happens to be attached
 		std::string dev_name("");
 		if (!root["device"]["name"].empty())
 		{
@@ -745,32 +746,35 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 		{
 			dev_name = root["dev"]["name"].asString();
 		}
+		else
+		{
+			dev_name = pDevice->identifiers;
+		}
+		if (pDevice->name.empty())
+			pDevice->name = dev_name;
 
+		std::string sensor_name("");
+		if (root["name"].empty())
+		{
+			root["name"] = sensor_unique_id;
+		}
 		if (!dev_name.empty())
 		{
-			if (root["name"].empty())
-			{
-				root["name"] = (dev_name.empty()) ? sensor_unique_id : dev_name;
-			}
 			std::string subname = root["name"].asString();
 			if (subname.find("0x") != 0)
 			{
-				pDevice->name = dev_name;
 				if (dev_name != subname)
-					pDevice->name += " (" + subname + ")";
+					sensor_name = dev_name + " (" + subname + ")";
 			}
 			else
 			{
-				pDevice->name = dev_name;
+				sensor_name = subname;
 			}
-		}
-		else if (!root["name"].empty())
+                }
+		else
 		{
-			pDevice->name = root["name"].asString();
+			sensor_name = root["name"].asString();
 		}
-
-		if (pDevice->name.empty())
-			pDevice->name = pDevice->identifiers;
 
 		if (!root["device"]["sw_version"].empty())
 			pDevice->sw_version = root["device"]["sw_version"].asString();
@@ -853,7 +857,7 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 		pSensor->config = qMessage;
 		pSensor->component_type = component;
 		pSensor->device_identifiers = device_identifiers;
-		pSensor->name = pDevice->name;
+		pSensor->name = sensor_name;
 
 		if (!root["enabled_by_default"].empty())
 			pSensor->bEnabled_by_default = root["enabled_by_default"].asBool();


### PR DESCRIPTION
In HA MQTT AutoDiscovery, many sensors can be attached to a single device. The device doesn't have an MQTT topic of its own; it is reported as a property of each sensor, e.g.:
```
   "dev" : {
      "cns" : [
         [
            "mac",
            "782184bb134c"
         ]
      ],
      "ids" : "782184bb134c",
      "mdl" : "esp32-gateway",
      "mf" : "Espressif",
      "name" : "bathroom",
      "sw" : "2024.9.0-dev (Sep  6 2024, 22:54:39)"
   },
```
During sensor discovery, we look for an existing device with the same 'ids' and use that if it exists, otherwise we create a new one. We keep track of which sensors are attached to which device, for matching up things like electricity power/usage and temp/hum/baro sensors.

However, as we discover each sensor, we currently *overwrite* the device name to include the sensor name, then blindly set the new sensor name to the current device name. Leaving the device with the name of whatever sensor happens to have been discovered last.

Clean that up, to set the device name using only information about the device itself, and then set the sensor name as before but using its own variable instead of messing with the device name.

Now my combined Temp/Hum sensors won't get such strange names.

Fixes: 6164