### PR TITLE
Netatmo with HardwareBase Sensors

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
           submodules: true

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -24,7 +24,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: true

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2126,7 +2126,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		y << ";";
 		y << Temp_outdoor;
 		y << ";";
-		y << WindChill_c;
+		y << wind_Chill;
 		std::string sValue = y.str().c_str();
 		// sValue: "<WindDirDegrees>;<WindDirText>;<WindAveMeterPerSecond*10>;<WindGustMeterPerSecond*10>;<Temp_c>;<WindChill_c>"
 		SendWind(ID, batValue, wind_angle, wind_strength, wind_gust, wind_Temp, wind_Chill, false, false, name, rssiLevel);

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2090,11 +2090,8 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		v << ";";
 		v << rain_24;
 		std::string sValue = v.str().c_str();
-		SendRainSensor(5, batValue, m_RainOffset[ID] + m_OldRainCounter[ID], name, rssiLevel);
-		std::string Name = name + "-updatevalueint";
                 ///Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
-		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, rssiLevel, batValue, '0', v.str().c_str(), Name, 0, m_Name);
-		SendRainSensor(ID, batValue, rain_24 + rain_1, name + "- rain", rssiLevel);
+		SendRainSensor(ID, batValue, rain_24 + rain_1, name, rssiLevel);
 		//SendRainSensorWU(ID, batValue, rain_24, rain_1, name + "- WU", rssiLevel);
 	}
 
@@ -2765,8 +2762,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 
 						//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), v.str().c_str(), m_Name.c_str(), mrf_status, batteryLevel);
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, mrf_status, batteryLevel, '0', v.str().c_str(), moduleName, 0, m_Name);
-						SendRainSensor(7, batteryLevel, m_RainOffset[crcId] + m_OldRainCounter[crcId], moduleName, mrf_status);
-						SendRainSensor(crcId, batteryLevel, rain_24 + rain_1, moduleName + "-rain", mrf_status);
+						SendRainSensor(crcId, batteryLevel, rain_24 + rain_1, moduleName, mrf_status);
 						//SendRainSensorWU(crcId, batteryLevel, rain_24, rain_1, moduleName + "-WU", mrf_status);
 					}
 					if (bHaveCO2)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2094,8 +2094,8 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		std::string Name = name + "-updatevalueint";
                 ///Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, rssiLevel, batValue, '0', v.str().c_str(), Name, 0, m_Name);
-		SendRainSensor(ID, batteryLevel, rain_1 + rain_24, moduleName, mrf_status);
-		//SendRainSensorWU(ID, batValue, rain_24, rain_1, name, rssiLevel);
+		SendRainSensor(ID, batValue, rain_1 + rain_24, name + "- rain", mrf_status);
+		//SendRainSensorWU(ID, batValue, rain_24, rain_1, name + "- WU", rssiLevel);
 	}
 
 	if (bHaveCO2)
@@ -2768,7 +2768,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, mrf_status, batteryLevel, '0', v.str().c_str(), moduleName, 0, m_Name);
 						SendRainSensor(crcId, batteryLevel, m_RainOffset[crcId] + m_OldRainCounter[crcId], moduleName, mrf_status);
 						SendRainSensor(crcId, batteryLevel, rain_1 + rain_24, moduleName + "-rain", mrf_status);
-						//SendRainSensorWU(crcId, batteryLevel, rain_24, rain_1, moduleName, mrf_status);
+						//SendRainSensorWU(crcId, batteryLevel, rain_24, rain_1, moduleName + "-WU", mrf_status);
 					}
 					if (bHaveCO2)
 					{
@@ -2852,8 +2852,9 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						{
 							//information switch for active Boiler only when we have a Thermostat
 							// Valves don't have Boiler status
-							UpdateValueInt(0, ID.c_str(), 9, pTypeGeneralSwitch, sSwitchGeneralSwitch, mrf_status, batteryLevel, bIsActive, sValue.c_str(), aName,  0, m_Name);
-							
+							std::string bName = moduleName + " - Boiler Status";
+							//UpdateValueInt(0, ID.c_str(), 9, pTypeGeneralSwitch, sSwitchGeneralSwitch, mrf_status, batteryLevel, bIsActive, sValue.c_str(), bName,  0, m_Name);
+							SendGeneralSwitch(crcId, 9, batteryLevel, bIsActive, bIsActive, bName, m_Name, mrf_status);
 						}
 
 						//Thermostat schedule switch (actively changing thermostat schedule)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2094,7 +2094,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		std::string Name = name + "-updatevalueint";
                 ///Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, rssiLevel, batValue, '0', v.str().c_str(), Name, 0, m_Name);
-		SendRainSensor(ID, batValue, rain_1 + rain_24, name + "- rain", mrf_status);
+		SendRainSensor(ID, batValue, rain_1 + rain_24, name + "- rain", rssiLevel);
 		//SendRainSensorWU(ID, batValue, rain_24, rain_1, name + "- WU", rssiLevel);
 	}
 

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -1989,8 +1989,9 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 	RF_level << rssiLevel;
 	RF_level >> sValue;
 	std::string module_name  = name + " RF. Lvl";
-	SendCustomSensor(ID, 3, batValue, rssiLevel, name + " - RF-level, ", "% ", rssiLevel);
-        SendPercentageSensor(ID, 3, batValue, batValue, name + " - Bat. Level");
+	SendCustomSensor(ID, 3, batValue, static_cast<float>(rssiLevel), name + " - RF-level, ", "% ", rssiLevel);
+	if (batValue != 255)
+		SendPercentageSensor(ID, 3, batValue, static_cast<float>(batValue), name + " - Bat. Level");
 	//UpdateValueInt(0, str_ID.c_str(), 2, pTypeGeneral, sTypePercentage, rssiLevel, batValue, '0', sValue.c_str(), module_name, 0, m_Name); // RF Percentage
 
 	//Temperature and humidity sensors
@@ -2015,7 +2016,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		// sValue is string with values separated by semicolon: Temperature;Humidity;Humidity Status;Barometer;Forecast
 		//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] Temp & Humidity & Baro %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeTEMP_HUM_BARO, sTypeTHBFloat, rssiLevel, batValue, '0', sValue.c_str(), name,  0, m_Name);
-		SendTempHumBaroSensorFloat(ID, batValue, Temp, hum, baro, (uint8_t)nforecast, name, rssiLevel);
+		SendTempHumBaroSensorFloat(ID, batValue, Temp, hum, static_cast<float>(baro), (uint8_t)nforecast, name, rssiLevel);
 	}
 	else if (bHaveTemp && bHaveHum)
 	{
@@ -2314,8 +2315,9 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 				float wind_strength = 0;
 				float wind_gust = 0;
 				float wind_gust_angle = 0;
+				float wind_Temp = 0;
+				float wind_Chill = 0;
 				std::string Temp_outdoor = "0";
-				int WindChill_c = 0;
 
 				//uint64_t DeviceRowIdx;
 				iModuleIndex ++;
@@ -2472,7 +2474,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					{
 						std::string bat_Name = " " + moduleName + " - Bat. Lvl";
 						//UpdateValueInt(0, ID.c_str(), 2, pTypeGeneral, sTypeCustom, mrf_status, batteryLevel, '0', bat_percentage.c_str(), batName,  0, m_Name); // Battery level
-						SendPercentageSensor(crcId, 3, batteryLevel, batteryLevel, bat_Name);
+						SendPercentageSensor(crcId, 3, batteryLevel, static_cast<float>(batteryLevel), bat_Name);
 					}
 					if (!module["ts"].empty())
 					{
@@ -2697,7 +2699,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						// sValue is string with values separated by semicolon: Temperature;Humidity;Humidity Status;Barometer;Forecast
 						//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] Temp & Humidity & Baro %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), r.str().c_str(), m_Name.c_str(), mrf_status, batteryLevel);
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeTEMP_HUM_BARO, sTypeTHBFloat, mrf_status, batteryLevel, '0', r.str().c_str(), moduleName,  0, m_Name);
-						SendTempHumBaroSensorFloat(crcId, batteryLevel, Temp, hum, baro, (uint8_t)nforecast, moduleName, mrf_status);
+						SendTempHumBaroSensorFloat(crcId, batteryLevel, Temp, hum, static_cast<float>(baro), (uint8_t)nforecast, moduleName, mrf_status);
 					}
 					else if (bHaveTemp && bHaveHum)
 					{
@@ -2784,12 +2786,12 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						y << ";";
 						y << Temp_outdoor;
 						y << ";";
-						y << WindChill_c;
+						y << wind_Chill;
 
 						// sValue: "<WindDirDegrees>;<WindDirText>;<WindAveMeterPerSecond*10>;<WindGustMeterPerSecond*10>;<Temp_c>;<WindChill_c>"
 						//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] wind %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), y.str().c_str(), m_Name.c_str(), mrf_status, batteryLevel);
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeWIND, sTypeWINDNoTempNoChill, mrf_status, batteryLevel, '0', y.str().c_str(), moduleName, 0, m_Name);
-						SendWind(crcId, batteryLevel, wind_angle, (wind_strength / 3.6), (wind_gust / 3.6), 0, 0, false, false, moduleName, mrf_status);
+						SendWind(crcId, batteryLevel, wind_angle, (wind_strength / 3.6), (wind_gust / 3.6), wind_Temp, wind_Chill, false, false, moduleName, mrf_status);
 					}
 
 					if ((type == "NATherm1") || (type == "NRV"))

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -492,7 +492,7 @@ uint64_t CNetatmo::convert_mac(std::string mac)
 /// Send sensors to Main worker
 /// This gives a long thread runtime on some occasions
 /// </summary>
-uint64_t CNetatmo::UpdateValueInt(int HardwareID, const char* ID, unsigned char unit, unsigned char devType, unsigned char subType, unsigned char signallevel, unsigned char batterylevel, int nValue,
+uint64_t CNetatmo::(int HardwareID, const char* ID, unsigned char unit, unsigned char devType, unsigned char subType, unsigned char signallevel, unsigned char batterylevel, int nValue,
         const char* sValue, std::string& devname, bool bUseOnOffAction, const std::string& user)
 {
         uint64_t DeviceRowIdx = m_sql.UpdateValue(m_HwdID, HardwareID, ID, unit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction, user.c_str());
@@ -1993,7 +1993,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 	RF_level << rssiLevel;
 	RF_level >> sValue;
 	std::string module_name  = name + " RF. Lvl";
-	SendCustomSensor(ID, 3, batValue, static_cast<float>(rssiLevel), name + " - RF-level, ", " ", rssiLevel);
+	SendCustomSensor(ID, 2, batValue, static_cast<float>(rssiLevel), name + " - RF-level, ", " ", rssiLevel); // RF Percentage
 	if (batValue != 255)
 		SendPercentageSensor(ID, 3, batValue, static_cast<float>(batValue), name + " - Bat. Level");
 	//UpdateValueInt(0, str_ID.c_str(), 2, pTypeGeneral, sTypePercentage, rssiLevel, batValue, '0', sValue.c_str(), module_name, 0, m_Name); // RF Percentage
@@ -2090,11 +2090,11 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		v << ";";
 		v << rain_24;
 		std::string sValue = v.str().c_str();
-		SendRainSensor(ID, batValue, m_RainOffset[ID] + m_OldRainCounter[ID], name, rssiLevel);
+		SendRainSensor(5, batValue, m_RainOffset[ID] + m_OldRainCounter[ID], name, rssiLevel);
 		std::string Name = name + "-updatevalueint";
                 ///Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, rssiLevel, batValue, '0', v.str().c_str(), Name, 0, m_Name);
-		SendRainSensor(ID, batValue, rain_1 + rain_24, name + "- rain", rssiLevel);
+		SendRainSensor(ID, batValue, rain_24 + rain_1, name + "- rain", rssiLevel);
 		//SendRainSensorWU(ID, batValue, rain_24, rain_1, name + "- WU", rssiLevel);
 	}
 
@@ -2453,11 +2453,10 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 							//Debug(DEBUG_HARDWARE, "mrf_status =  %s -  %d", pName.c_str(), mrf_status);
 							nDevice.SignalLevel = mrf_status;
 							nDevice.BatteryLevel = batteryLevel;
-							//SendPercentageSensor(int NodeID, uint8_t ChildID, int BatteryLevel, float Percentage, const std::string &defaultname);
-							//SendCustomSensor(int NodeID, uint8_t ChildID, int BatteryLevel, float CustomValue, const std::string &defaultname, const std::string &defaultLabel, int RssiLevel = 12);
-							SendCustomSensor(crcId, 3, batteryLevel, mrf_percentage, pName, "  ", mrf_status);   // RF-level
-							//SendPercentageSensor(crcId, 3, batteryLevel, mrf_percentage, pName);
-							//UpdateValueInt(0, ID.c_str(), 3, pTypeGeneral, sTypePercentage, mrf_status, batteryLevel, '0', sigValue.c_str(), pName,  0, m_Name);  // RF- level
+							
+							SendCustomSensor(crcId, 2, batteryLevel, mrf_percentage, pName, "  ", mrf_status);   // RF-level
+							//SendPercentageSensor(crcId, 3, batteryLevel, batteryLevel, pName);
+							//UpdateValueInt(0, ID.c_str(), 2, pTypeGeneral, sTypePercentage, mrf_status, batteryLevel, '0', sigValue.c_str(), pName,  0, m_Name);  // RF- level
 						}
 					}
 					if (!module["wifi_state"].empty())
@@ -2480,7 +2479,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					if (!module["battery_level"].empty())
 					{
 						std::string bat_Name = " " + moduleName + " - Bat. Lvl";
-						//UpdateValueInt(0, ID.c_str(), 2, pTypeGeneral, sTypeCustom, mrf_status, batteryLevel, '0', bat_percentage.c_str(), batName,  0, m_Name); // Battery level
+						//UpdateValueInt(0, ID.c_str(), 3, pTypeGeneral, sTypeCustom, mrf_status, batteryLevel, '0', bat_percentage.c_str(), batName,  0, m_Name); // Battery level
 						SendPercentageSensor(crcId, 3, batteryLevel, static_cast<float>(batteryLevel), bat_Name);
 					}
 					if (!module["ts"].empty())
@@ -2766,8 +2765,8 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 
 						//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] rain %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), v.str().c_str(), m_Name.c_str(), mrf_status, batteryLevel);
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeRAIN, sTypeRAINByRate, mrf_status, batteryLevel, '0', v.str().c_str(), moduleName, 0, m_Name);
-						SendRainSensor(crcId, batteryLevel, m_RainOffset[crcId] + m_OldRainCounter[crcId], moduleName, mrf_status);
-						SendRainSensor(crcId, batteryLevel, rain_1 + rain_24, moduleName + "-rain", mrf_status);
+						SendRainSensor(7, batteryLevel, m_RainOffset[crcId] + m_OldRainCounter[crcId], moduleName, mrf_status);
+						SendRainSensor(crcId, batteryLevel, rain_24 + rain_1, moduleName + "-rain", mrf_status);
 						//SendRainSensorWU(crcId, batteryLevel, rain_24, rain_1, moduleName + "-WU", mrf_status);
 					}
 					if (bHaveCO2)

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -492,7 +492,7 @@ uint64_t CNetatmo::convert_mac(std::string mac)
 /// Send sensors to Main worker
 /// This gives a long thread runtime on some occasions
 /// </summary>
-uint64_t CNetatmo::(int HardwareID, const char* ID, unsigned char unit, unsigned char devType, unsigned char subType, unsigned char signallevel, unsigned char batterylevel, int nValue,
+uint64_t CNetatmo::UpdateValueInt(int HardwareID, const char* ID, unsigned char unit, unsigned char devType, unsigned char subType, unsigned char signallevel, unsigned char batterylevel, int nValue,
         const char* sValue, std::string& devname, bool bUseOnOffAction, const std::string& user)
 {
         uint64_t DeviceRowIdx = m_sql.UpdateValue(m_HwdID, HardwareID, ID, unit, devType, subType, signallevel, batterylevel, nValue, sValue, devname, bUseOnOffAction, user.c_str());

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -1871,11 +1871,11 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 			m_bNetatmoRefreshed[ID] = true;
 		// Check when dashboard data was last updated
 		if (!root["time_utc"].empty())
-			tNetatmoLastUpdate = root["time_utc"].asUInt(); //["dashboard_data"]["time_utc"].asUInt();
-		Debug(DEBUG_HARDWARE, "Module [%s] last update = %s", name.c_str(), ctime(&tNetatmoLastUpdate));
+			tNetatmoLastUpdate = root["time_utc"].asUInt();
+		//Debug(DEBUG_HARDWARE, "Module [%s] last update = %s", name.c_str(), ctime(&tNetatmoLastUpdate));
 		// check if Netatmo data was updated in the past NETAMO_POLL_INTERVALL (+1 min for sync time lags)... if not means sensors failed to send to cloud
 		int Interval = NETAMO_POLL_INTERVALL + 60;
-		Debug(DEBUG_HARDWARE, "Module [%s] Interval = %d", name.c_str(), Interval);
+		//Debug(DEBUG_HARDWARE, "Module [%s] Interval = %d", name.c_str(), Interval);
 		if (tNetatmoLastUpdate > (tNow - Interval))
 		{
 			if (!m_bNetatmoRefreshed[ID])
@@ -2093,8 +2093,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 
 	if (bHaveCO2)
 	{
-		//SendAirQualitySensor(uint8_t NodeID, uint8_t ChildID, int BatteryLevel, int AirQuality, const std::string &defaultname);
-		Debug(DEBUG_HARDWARE, "(%d) %s (%d)", co2, name.c_str(), batValue);
+		//Debug(DEBUG_HARDWARE, "(%d) %s (%d)", co2, name.c_str(), batValue);
 		SendAirQualitySensor(ID, DevIdx, batValue, co2, name);  // No RF-level
 		//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] co2 rssiLevel %d batValue %d nValue %d sValue %s %s ", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), rssiLevel, batValue, co2, std::to_string(co2).c_str(), m_Name.c_str());
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeAirQuality, sTypeVoc, rssiLevel, batValue, co2, "", name, 0, m_Name);
@@ -2102,6 +2101,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 
 	if (bHaveSound)
 	{
+		//Debug(DEBUG_HARDWARE, "(%d) %s (%d)", sound, name.c_str(), batValue);
 		SendSoundSensor(ID, batValue, sound, name);  // No RF-level
 		//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] sound %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), std::to_string(sound).c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeGeneral, sTypeSoundLevel, rssiLevel, batValue, '0', std::to_string(sound).c_str(), name, 0, m_Name);
@@ -2125,7 +2125,7 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		y << WindChill_c;
 		std::string sValue = y.str().c_str();
 		// sValue: "<WindDirDegrees>;<WindDirText>;<WindAveMeterPerSecond*10>;<WindGustMeterPerSecond*10>;<Temp_c>;<WindChill_c>"
-		SendWind(ID, batValue, wind_angle, wind_strength, wind_gust, 0, 0, false, false, name, rssiLevel);   // Wind-angle as Text ?
+		SendWind(ID, batValue, wind_angle, wind_strength, wind_gust, 0, 0, false, false, name, rssiLevel);
 		//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] wind %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeWIND, sTypeWINDNoTempNoChill, rssiLevel, batValue, '0', sValue.c_str(), name, 0, m_Name);
 	}

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2890,7 +2890,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						m_bPollGetEvents = true;
 					}
 					Debug(DEBUG_HARDWARE, "Poll Get Events (%d)", m_bPollGetEvents);
-					//m_bPollGetEvents = false;  // Blocking GetEvents because off Error "User Usage"
+					m_bPollGetEvents = false;  // Blocking GetEvents because off Error "User Usage"
 				}
 			//m_tNetatmoDevice.push_back(nDevice);
 			m_netatmo_devices.push_back(nDevice);

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -1839,8 +1839,9 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 	int wind_angle = 0;
 	float wind_strength = 0;
 	float wind_gust = 0;
+	float wind_Temp = 0;
+	float wind_Chill = 0;
 	std::string Temp_outdoor = "0";
-	std::string WindChill_c = "0";
 
 	int batValue = battery_percent;
 	bool action = 0;
@@ -1972,8 +1973,10 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		{
 			bHaveWind = true;
 			wind_angle = root["WindAngle"].asInt();
-			wind_strength = root["WindStrength"].asFloat();
-			wind_gust = root["GustStrength"].asFloat();
+			float windstrength = root["WindStrength"].asFloat();
+			wind_strength = windstrength / 3.6F;
+			float windgust = root["GustStrength"].asFloat();
+			wind_gust = windgust / 3.6F;
 		}
 	}
 
@@ -2117,16 +2120,16 @@ bool CNetatmo::ParseDashboard(const Json::Value& root, const int DevIdx, const i
 		y << ";";
 		y << wind_direction;
 		y << ";";
-		y << wind_strength *10 / 3.6;
+		y << wind_strength *10;
 		y << ";";
-		y << wind_gust *10 / 3.6;
+		y << wind_gust *10;
 		y << ";";
 		y << Temp_outdoor;
 		y << ";";
 		y << WindChill_c;
 		std::string sValue = y.str().c_str();
 		// sValue: "<WindDirDegrees>;<WindDirText>;<WindAveMeterPerSecond*10>;<WindGustMeterPerSecond*10>;<Temp_c>;<WindChill_c>"
-		SendWind(ID, batValue, wind_angle, wind_strength, wind_gust, 0, 0, false, false, name, rssiLevel);
+		SendWind(ID, batValue, wind_angle, wind_strength, wind_gust, wind_Temp, wind_Chill, false, false, name, rssiLevel);
 		//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] wind %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), sValue.c_str(), m_Name.c_str(), rssiLevel, batValue);
 		//UpdateValueInt(0, str_ID.c_str(), 0, pTypeWIND, sTypeWINDNoTempNoChill, rssiLevel, batValue, '0', sValue.c_str(), name, 0, m_Name);
 	}
@@ -2657,8 +2660,9 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					if (!module["wind_strength"].empty())
 					{
 						bHaveWind = true;
-						wind_strength = module["wind_strength"].asFloat(); // / 3.6F;
-						//Debug(DEBUG_HARDWARE, "HomeStatus Module Wind strength [%f] km/h", wind_strength);
+						float windstrength = module["wind_strength"].asFloat();
+						wind_strength = windstrength / 3.6F;
+						//Debug(DEBUG_HARDWARE, "HomeStatus Module Wind strength [%f] km/h", windstrength);
 					}
 					if (!module["wind_angle"].empty())
 					{
@@ -2669,8 +2673,9 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					if (!module["wind_gust"].empty())
 					{
 						bHaveWind = true;
-						wind_gust = module["wind_gust"].asFloat(); // / 3.6F;
-						//Debug(DEBUG_HARDWARE, "HomeStatus Module Wind gust [%f] km/h", wind_gust);
+						float windgust = module["wind_gust"].asFloat();
+						wind_gust = windgust / 3.6F;
+						//Debug(DEBUG_HARDWARE, "HomeStatus Module Wind gust [%f] km/h", windgust);
 					}
 					if (!module["wind_gust_angle"].empty())
 					{
@@ -2780,9 +2785,9 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						y << ";";
 						y << wind_direction;
 						y << ";";
-						y << wind_strength *10 / 3.6;
+						y << wind_strength *10;
 						y << ";";
-						y << wind_gust *10 / 3.6;
+						y << wind_gust *10;
 						y << ";";
 						y << Temp_outdoor;
 						y << ";";
@@ -2791,7 +2796,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 						// sValue: "<WindDirDegrees>;<WindDirText>;<WindAveMeterPerSecond*10>;<WindGustMeterPerSecond*10>;<Temp_c>;<WindChill_c>"
 						//Debug(DEBUG_HARDWARE, "(%d) %s (%s) [%s] wind %s %s %d %d", Hardware_int, str_ID.c_str(), pchar_ID, name.c_str(), y.str().c_str(), m_Name.c_str(), mrf_status, batteryLevel);
 						//UpdateValueInt(0, ID.c_str(), 0, pTypeWIND, sTypeWINDNoTempNoChill, mrf_status, batteryLevel, '0', y.str().c_str(), moduleName, 0, m_Name);
-						SendWind(crcId, batteryLevel, wind_angle, (wind_strength / 3.6), (wind_gust / 3.6), wind_Temp, wind_Chill, false, false, moduleName, mrf_status);
+						SendWind(crcId, batteryLevel, wind_angle, wind_strength, wind_gust, wind_Temp, wind_Chill, false, false, moduleName, mrf_status);
 					}
 
 					if ((type == "NATherm1") || (type == "NRV"))

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -2407,7 +2407,7 @@ bool CNetatmo::ParseHomeStatus(const std::string& sResult, Json::Value& root, st
 					else
 					{
 						Log(LOG_ERROR, "cloud data for module [%s] no longer updated (module possibly disconnected) since %s", moduleName.c_str(), ctime(&tNetatmoLastUpdate));
-						//connected = false;
+						connected = false;  //Block update, create sensor if cloud data is older then Interval.
 					}
 				}
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12988,8 +12988,8 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 
 		if (
 			(value_unit.empty())
-			|| (value_unit == "Â°C")
-			|| (value_unit == "Â°F")
+			|| (value_unit == "°C")
+			|| (value_unit == "°F")
 			|| (value_unit == "C")
 			|| (value_unit == "F")
 			)
@@ -13809,7 +13809,7 @@ void MainWorker::HeartbeatCheck()
 				if (diff > 60)
 				{
 					_log.Log(LOG_ERROR, "%s hardware (%d) thread seems to have ended unexpectedly", pHardware->m_Name.c_str(), pHardware->m_HwdID);
-
+					
 				}
 			}
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -12988,8 +12988,8 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 
 		if (
 			(value_unit.empty())
-			|| (value_unit == "?C")
-			|| (value_unit == "?F")
+			|| (value_unit == "°C")
+			|| (value_unit == "°F")
 			|| (value_unit == "C")
 			|| (value_unit == "F")
 			)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -9,13 +9,13 @@
 #include "../push/HttpPush.h"
 #include "../push/InfluxPush.h"
 #include "../push/GooglePubSubPush.h"
-#include "../push/MQTTPush.h"
 
 #include "../httpclient/HTTPClient.h"
 #include "../webserver/Base64.h"
 #include <boost/algorithm/string/join.hpp>
 #include "../main/json_helper.h"
 
+#include <boost/crc.hpp>
 #include <algorithm>
 #include <set>
 
@@ -76,9 +76,6 @@
 #include "../hardware/MQTTAutoDiscover.h"
 #include "../hardware/FritzboxTCP.h"
 #include "../hardware/ETH8020.h"
-#ifdef WITH_OPENZWAVE
-#include "../hardware/OpenZWave.h"
-#endif
 #include "../hardware/RFLinkSerial.h"
 #include "../hardware/RFLinkTCP.h"
 #include "../hardware/RFLinkMQTT.h"
@@ -183,11 +180,12 @@
 #include <fstream>
 #endif
 
+#define round(a) ( int ) ( a + .5 )
+
 extern std::string szStartupFolder;
 extern std::string szUserDataFolder;
 extern std::string szWWWFolder;
 extern std::string szAppVersion;
-extern std::string szCertFile;
 extern int iAppRevision;
 extern std::string szWebRoot;
 extern bool g_bUseUpdater;
@@ -199,7 +197,6 @@ CFibaroPush m_fibaropush;
 CGooglePubSubPush m_googlepubsubpush;
 CHttpPush m_httppush;
 CInfluxPush m_influxpush;
-CMQTTPush m_mqttpush;
 
 
 namespace tcp {
@@ -222,7 +219,7 @@ MainWorker::MainWorker()
 	m_secure_webserver_settings.listening_address = "::"; // listen to all network interfaces
 	m_secure_webserver_settings.listening_port = "443";
 	m_secure_webserver_settings.ssl_method = "tls";
-	m_secure_webserver_settings.certificate_chain_file_path = szCertFile;
+	m_secure_webserver_settings.certificate_chain_file_path = "./server_cert.pem";
 	m_secure_webserver_settings.ca_cert_file_path = m_secure_webserver_settings.certificate_chain_file_path; // not used
 	m_secure_webserver_settings.cert_file_path = m_secure_webserver_settings.certificate_chain_file_path;
 	m_secure_webserver_settings.private_key_file_path = m_secure_webserver_settings.certificate_chain_file_path;
@@ -238,6 +235,13 @@ MainWorker::MainWorker()
 
 	time_t atime = mytime(nullptr);
 	m_LastHeartbeat = atime;
+	struct tm ltime;
+	localtime_r(&atime, &ltime);
+	m_ScheduleLastMinute = ltime.tm_min;
+	m_ScheduleLastHour = ltime.tm_hour;
+	m_ScheduleLastMinuteTime = 0;
+	m_ScheduleLastHourTime = 0;
+	m_ScheduleLastDayTime = 0;
 	m_LastSunriseSet = "";
 	m_DayLength = "";
 
@@ -418,7 +422,7 @@ int MainWorker::FindDomoticzHardwareByType(const _eHardwareTypes HWType)
 	for (const auto& device : m_hardwaredevices)
 	{
 		if (device->HwdType == HWType)
-			return device->m_HwdID;
+			return ii;
 		ii++;
 	}
 	return -1;
@@ -505,7 +509,7 @@ bool MainWorker::GetSunSettings()
 	std::string asttwstart = std_format("%02d:%02d:00", sresult.AstronomicalTwilightStartHour, sresult.AstronomicalTwilightStartMin);
 	std::string asttwend = std_format("%02d:%02d:00", sresult.AstronomicalTwilightEndHour, sresult.AstronomicalTwilightEndMin);
 
-	m_scheduler.SetSunRiseSetTimes(sunrise, sunset, sunatsouth, civtwstart, civtwend, nauttwstart, nauttwend, asttwstart, asttwend); // Do not change the order
+	m_scheduler.SetSunRiseSetTimers(sunrise, sunset, sunatsouth, civtwstart, civtwend, nauttwstart, nauttwend, asttwstart, asttwend); // Do not change the order
 
 	bool bFirstTime = m_LastSunriseSet.empty();
 
@@ -552,6 +556,9 @@ bool MainWorker::GetSunSettings()
 
 		if (!bFirstTime)
 			m_eventsystem.LoadEvents();
+
+		// FixMe: only reload schedules relative to sunset/sunrise to prevent race conditions
+		// m_scheduler.ReloadSchedules(); // force reload of all schedules to adjust for changed sunrise/sunset values
 	}
 	return true;
 }
@@ -684,11 +691,6 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_KMTronic433:
 		pHardware = new KMTronic433(ID, SerialPort);
-		break;
-	case HTYPE_OpenZWave:
-#ifdef WITH_OPENZWAVE
-		pHardware = new COpenZWave(ID, SerialPort);
-#endif
 		break;
 	case HTYPE_EnOceanESP2:
 		pHardware = new CEnOceanESP2(ID, SerialPort, Mode1);
@@ -966,13 +968,13 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CDummy(ID);
 		break;
 	case HTYPE_Tellstick:
-	{
-		CTellstick* tellstick;
-		if (CTellstick::Create(&tellstick, ID, Mode1, Mode2)) {
-			pHardware = tellstick;
+		{
+			CTellstick* tellstick;
+			if (CTellstick::Create(&tellstick, ID, Mode1, Mode2)) {
+				pHardware = tellstick;
+			}
 		}
-	}
-	break;
+		break;
 	case HTYPE_EVOHOME_SCRIPT:
 		pHardware = new CEvohomeScript(ID);
 		break;
@@ -1008,10 +1010,10 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new COpenWebNetTCP(ID, Address, Port, Password, Mode1, Mode2);
 		break;
 	case HTYPE_BleBox:
-		pHardware = new BleBox(ID, Mode1, Mode2);
+		pHardware = new BleBox(ID, Mode1);
 		break;
 	case HTYPE_OpenWeatherMap:
-		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5);
+		pHardware = new COpenWeatherMap(ID, Username, Password, Mode1, Mode2, Mode3, Mode4);
 		break;
 	case HTYPE_Ec3kMeterTCP:
 		pHardware = new Ec3kMeterTCP(ID, Address, Port);
@@ -1049,7 +1051,7 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new USBtin(ID, SerialPort, Mode1, Mode2);
 		break;
 	case HTYPE_EnphaseAPI:
-		pHardware = new EnphaseAPI(ID, Address, Port, Mode1, Mode2, Mode4, Mode3, Username, Password, Extra);
+		pHardware = new EnphaseAPI(ID, Address, Port, Mode1, Mode2, Username, Password, Extra);
 		break;
 	case HTYPE_Comm5SMTCP:
 		pHardware = new Comm5SMTCP(ID, Address, Port);
@@ -1134,7 +1136,6 @@ bool MainWorker::Start()
 	m_fibaropush.Start();
 	m_httppush.Start();
 	m_influxpush.Start();
-	m_mqttpush.Start();
 	m_googlepubsubpush.Start();
 #ifdef PARSE_RFXCOM_DEVICE_LOG
 	if (m_bStartHardware == false)
@@ -1191,14 +1192,13 @@ bool MainWorker::Start()
 		LoadSharedUsers();
 	}
 
-	HandleHourPrice();
-
 	m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
 	SetThreadName(m_thread->native_handle(), "MainWorker");
 	m_rxMessageThread = std::make_shared<std::thread>([this] { Do_Work_On_Rx_Messages(); });
 	SetThreadName(m_rxMessageThread->native_handle(), "MainWorkerRxMsg");
 	return (m_thread != nullptr) && (m_rxMessageThread != nullptr);
 }
+
 
 bool MainWorker::Stop()
 {
@@ -1226,7 +1226,6 @@ bool MainWorker::Stop()
 		m_fibaropush.Stop();
 		m_httppush.Stop();
 		m_influxpush.Stop();
-		m_mqttpush.Stop();
 		m_googlepubsubpush.Stop();
 #ifdef ENABLE_PYTHON
 		m_pluginsystem.StopPluginSystem();
@@ -1555,8 +1554,8 @@ void MainWorker::ParseRFXLogFile()
 	{
 		if (hexstring.size() % 2 != 0)
 			continue;//illegal
-		size_t totbytes = hexstring.size() / 2;
-		size_t ii = 0;
+		int totbytes = hexstring.size() / 2;
+		int ii = 0;
 		for (ii = 0; ii < totbytes; ii++)
 		{
 			std::string hbyte = hexstring.substr((ii * 2), 2);
@@ -1569,7 +1568,7 @@ void MainWorker::ParseRFXLogFile()
 			const char* q = std::lower_bound(lut, lut + 16, b);
 			if (*q != b) throw std::invalid_argument("not a hex digit");
 
-			unsigned char uchar = static_cast<unsigned char>(((p - lut) << 4) | (q - lut));
+			unsigned char uchar = ((p - lut) << 4) | (q - lut);
 			rxbuffer[ii] = uchar;
 		}
 		if (ii == 0)
@@ -1585,18 +1584,6 @@ void MainWorker::Do_Work()
 	int second_counter = 0;
 	int minute_counter = 0;
 	int heartbeat_counter = 0;
-
-	time_t atime = mytime(nullptr);
-	struct tm ltime;
-	localtime_r(&atime, &ltime);
-
-	int _ScheduleLastMinute = ltime.tm_min;
-	int _ScheduleLastHour = ltime.tm_hour;
-	time_t _ScheduleLastMinuteTime = 0;
-	time_t _ScheduleLastHourTime = 0;
-	time_t _ScheduleLastDayTime = 0;
-
-
 	while (!IsStopRequested(500))
 	{
 		if (m_bDoDownloadDomoticzUpdate)
@@ -1693,29 +1680,23 @@ void MainWorker::Do_Work()
 			}
 		}
 
-		atime = mytime(nullptr);
+		time_t atime = mytime(nullptr);
 		struct tm ltime;
 		localtime_r(&atime, &ltime);
 
-		if (ltime.tm_hour != _ScheduleLastHour)
-		{
-			HandleHourPrice();
-		}
-
-		if (ltime.tm_min != _ScheduleLastMinute)
+		if (ltime.tm_min != m_ScheduleLastMinute)
 		{
 			minute_counter++;
-			if (difftime(atime, _ScheduleLastMinuteTime) > 30) //avoid RTC/NTP clock drifts
+			if (difftime(atime, m_ScheduleLastMinuteTime) > 30) //avoid RTC/NTP clock drifts
 			{
-				_ScheduleLastMinuteTime = atime;
-				_ScheduleLastMinute = ltime.tm_min;
+				m_ScheduleLastMinuteTime = atime;
+				m_ScheduleLastMinute = ltime.tm_min;
 
 				tzset(); //this because localtime_r/localtime_s does not update for DST
 
 				//check for 5 minute schedule
 				if (ltime.tm_min % m_sql.m_ShortLogInterval == 0)
 				{
-					HandleHourPrice();
 					m_sql.ScheduleShortlog();
 				}
 				std::string szPwdResetFile = szStartupFolder + "resetpwd";
@@ -1739,43 +1720,28 @@ void MainWorker::Do_Work()
 			{
 				IsUpdateAvailable(true);
 			}
-			if (ltime.tm_hour != _ScheduleLastHour)
+		}
+		if (ltime.tm_hour != m_ScheduleLastHour)
+		{
+			if (difftime(atime, m_ScheduleLastHourTime) > 30 * 60) //avoid RTC/NTP clock drifts
 			{
-				if (difftime(atime, _ScheduleLastHourTime) > 30 * 60) //avoid RTC/NTP clock drifts
+				m_ScheduleLastHourTime = atime;
+				m_ScheduleLastHour = ltime.tm_hour;
+				GetSunSettings();
+
+				m_sql.CheckDeviceTimeout();
+				m_sql.CheckBatteryLow();
+
+				//check for daily schedule
+				if (ltime.tm_hour == 0)
 				{
-					_ScheduleLastHourTime = atime;
-					_ScheduleLastHour = ltime.tm_hour;
-					GetSunSettings();
-
-					m_sql.CheckDeviceTimeout();
-					m_sql.CheckBatteryLow();
-
-					//check for daily schedule
-					if (ltime.tm_hour == 0)
+					if (atime - m_ScheduleLastDayTime > 12 * 60 * 60)
 					{
-						if (atime - _ScheduleLastDayTime > 12 * 60 * 60)
-						{
-							_ScheduleLastDayTime = atime;
-							m_sql.ScheduleDay();
-						}
+						m_ScheduleLastDayTime = atime;
+						m_sql.ScheduleDay();
 					}
-#ifdef WITH_OPENZWAVE
-					if (ltime.tm_hour == 4)
-					{
-						//Heal the OpenZWave network
-						std::lock_guard<std::mutex> l(m_devicemutex);
-						for (const auto& pHardware : m_hardwaredevices)
-						{
-							if (pHardware->HwdType == HTYPE_OpenZWave)
-							{
-								COpenZWave* pZWave = dynamic_cast<COpenZWave*>(pHardware);
-								pZWave->NightlyNodeHeal();
-							}
-						}
-					}
-#endif
-					HandleAutomaticBackups();
 				}
+				HandleAutomaticBackups();
 			}
 		}
 		if (heartbeat_counter++ > 12)
@@ -1838,6 +1804,165 @@ void MainWorker::OnHardwareConnected(CDomoticzHardwareBase* pHardware)
 	pRFXBase->SendResetCommand();
 }
 
+uint64_t MainWorker::PerformRealActionFromDomoticzClient(const uint8_t* pRXCommand, CDomoticzHardwareBase** pOriginalHardware)
+{
+	*pOriginalHardware = nullptr;
+	uint8_t devType = pRXCommand[1];
+	uint8_t subType = pRXCommand[2];
+	std::string ID;
+	uint8_t Unit = 0;
+	const tRBUF* pResponse = reinterpret_cast<const tRBUF*>(pRXCommand);
+	char szTmp[300];
+	std::vector<std::vector<std::string> > result;
+
+	switch (devType) {
+	case pTypeLighting1:
+		ID = std_format("%d", pResponse->LIGHTING1.housecode);
+		Unit = pResponse->LIGHTING1.unitcode;
+		break;
+	case pTypeLighting2:
+		sprintf(szTmp, "%X%02X%02X%02X", pResponse->LIGHTING2.id1, pResponse->LIGHTING2.id2, pResponse->LIGHTING2.id3, pResponse->LIGHTING2.id4);
+		ID = szTmp;
+		Unit = pResponse->LIGHTING2.unitcode;
+		break;
+	case pTypeLighting5:
+		if (subType != sTypeEMW100)
+			sprintf(szTmp, "%02X%02X%02X", pResponse->LIGHTING5.id1, pResponse->LIGHTING5.id2, pResponse->LIGHTING5.id3);
+		else
+			sprintf(szTmp, "%02X%02X", pResponse->LIGHTING5.id2, pResponse->LIGHTING5.id3);
+		ID = szTmp;
+		Unit = pResponse->LIGHTING5.unitcode;
+		break;
+	case pTypeLighting6:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->LIGHTING6.id1, pResponse->LIGHTING6.id2, pResponse->LIGHTING6.groupcode);
+		ID = szTmp;
+		Unit = pResponse->LIGHTING6.unitcode;
+		break;
+	case pTypeHomeConfort:
+		sprintf(szTmp, "%02X%02X%02X%02X", pResponse->HOMECONFORT.id1, pResponse->HOMECONFORT.id2, pResponse->HOMECONFORT.id3, pResponse->HOMECONFORT.housecode);
+		ID = szTmp;
+		Unit = pResponse->HOMECONFORT.unitcode;
+		break;
+	case pTypeRadiator1:
+		if (subType == sTypeSmartwaresSwitchRadiator)
+		{
+			sprintf(szTmp, "%X%02X%02X%02X", pResponse->RADIATOR1.id1, pResponse->RADIATOR1.id2, pResponse->RADIATOR1.id3, pResponse->RADIATOR1.id4);
+			ID = szTmp;
+			Unit = pResponse->RADIATOR1.unitcode;
+		}
+		break;
+	case pTypeColorSwitch:
+	{
+		const _tColorSwitch* pLed = reinterpret_cast<const _tColorSwitch*>(pResponse);
+		ID = "1";
+		Unit = pLed->dunit;
+	}
+	break;
+	case pTypeFS20:
+		sprintf(szTmp, "%02X%02X", pResponse->FS20.hc1, pResponse->FS20.hc2);
+		ID = szTmp;
+		Unit = pResponse->FS20.addr;
+		break;
+	case pTypeCurtain:
+		sprintf(szTmp, "%d", pResponse->CURTAIN1.housecode);
+		ID = szTmp;
+		Unit = pResponse->CURTAIN1.unitcode;
+		break;
+	case pTypeBlinds:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->BLINDS1.id1, pResponse->BLINDS1.id2, pResponse->BLINDS1.id3);
+		ID = szTmp;
+		Unit = pResponse->BLINDS1.unitcode;
+		break;
+	case pTypeRFY:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->RFY.id1, pResponse->RFY.id2, pResponse->RFY.id3);
+		ID = szTmp;
+		Unit = pResponse->RFY.unitcode;
+		break;
+	case pTypeSecurity1:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->SECURITY1.id1, pResponse->SECURITY1.id2, pResponse->SECURITY1.id3);
+		ID = szTmp;
+		Unit = 0;
+		break;
+	case pTypeSecurity2:
+		sprintf(szTmp, "%02X%02X%02X%02X%02X%02X%02X%02X", pResponse->SECURITY2.id1, pResponse->SECURITY2.id2, pResponse->SECURITY2.id3, pResponse->SECURITY2.id4, pResponse->SECURITY2.id5, pResponse->SECURITY2.id6, pResponse->SECURITY2.id7, pResponse->SECURITY2.id8);
+		ID = szTmp;
+		Unit = 0;
+		break;
+	case pTypeChime:
+		sprintf(szTmp, "%02X%02X", pResponse->CHIME.id1, pResponse->CHIME.id2);
+		ID = szTmp;
+		Unit = pResponse->CHIME.sound;
+		break;
+	case pTypeSetpoint:
+	{
+		const _tSetpoint* pMeter = reinterpret_cast<const _tSetpoint*>(pResponse);
+		sprintf(szTmp, "%X%02X%02X%02X", pMeter->id1, pMeter->id2, pMeter->id3, pMeter->id4);
+		ID = szTmp;
+		Unit = pMeter->dunit;
+	}
+	break;
+	case pTypeThermostat2:
+		ID = "1";
+		Unit = pResponse->THERMOSTAT2.unitcode;
+		break;
+	case pTypeThermostat3:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->THERMOSTAT3.unitcode1, pResponse->THERMOSTAT3.unitcode2, pResponse->THERMOSTAT3.unitcode3);
+		ID = szTmp;
+		Unit = 0;
+		break;
+	case pTypeThermostat4:
+		sprintf(szTmp, "%02X%02X%02X", pResponse->THERMOSTAT4.unitcode1, pResponse->THERMOSTAT4.unitcode2, pResponse->THERMOSTAT4.unitcode3);
+		ID = szTmp;
+		Unit = 0;
+		break;
+	case pTypeGeneralSwitch:
+	{
+		const _tGeneralSwitch* pSwitch = reinterpret_cast<const _tGeneralSwitch*>(pResponse);
+		sprintf(szTmp, "%08X", pSwitch->id);
+		ID = szTmp;
+		Unit = pSwitch->unitcode;
+	}
+	break;
+	case pTypeDDxxxx:
+		sprintf(szTmp, "%02X%02X%02X%02X", pResponse->DDXXXX.id1, pResponse->DDXXXX.id2, pResponse->DDXXXX.id3, pResponse->DDXXXX.id4);
+		ID = szTmp;
+		Unit = pResponse->DDXXXX.unitcode;
+		break;
+	default:
+		return -1;
+	}
+
+	if (!ID.empty())
+	{
+		// find our original hardware
+		// if it is not a domoticz type, perform the actual command
+
+		result = m_sql.safe_query(
+			"SELECT HardwareID,ID,Name,StrParam1,StrParam2,nValue,sValue FROM DeviceStatus WHERE (DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
+			ID.c_str(), Unit, devType, subType);
+		if (result.size() == 1)
+		{
+			std::vector<std::string> sd = result[0];
+
+			CDomoticzHardwareBase* pHardware = GetHardware(atoi(sd[0].c_str()));
+			if (pHardware != nullptr)
+			{
+				if (pHardware->HwdType != HTYPE_Domoticz)
+				{
+					*pOriginalHardware = pHardware;
+					pHardware->WriteToHardware((const char*)pRXCommand, pRXCommand[0] + 1);
+					std::stringstream s_strid;
+					s_strid << std::dec << sd[1];
+					uint64_t ullID;
+					s_strid >> ullID;
+					return ullID;
+				}
+			}
+		}
+	}
+	return -1;
+}
+
 void MainWorker::DecodeRXMessage(const CDomoticzHardwareBase* pHardware, const uint8_t* pRXCommand, const char* defaultName, const int BatteryLevel, const char* userName)
 {
 	if ((pHardware == nullptr) || (pRXCommand == nullptr))
@@ -1895,11 +2020,14 @@ void MainWorker::CheckAndPushRxMessage(const CDomoticzHardwareBase* pHardware, c
 	rxMessage.rxMessageIdx = m_rxMessageIdx++;
 	rxMessage.hardwareId = pHardware->m_HwdID;
 	// defensive copy of the command
+	rxMessage.vrxCommand.resize(pRXCommand[0] + 1);
 	rxMessage.vrxCommand.insert(rxMessage.vrxCommand.begin(), pRXCommand, pRXCommand + pRXCommand[0] + 1);
 	rxMessage.crc = 0x0;
 #ifdef DEBUG_RXQUEUE
 	// CRC
-	rxMessage.crc = crc16ccitt(pRXCommand, pRXCommand[0] + 1);
+	boost::crc_optimal<16, 0x1021, 0xFFFF, 0, false, false> crc_ccitt2;
+	crc_ccitt2 = std::for_each(pRXCommand, pRXCommand + pRXCommand[0] + 1, crc_ccitt2);
+	rxMessage.crc = crc_ccitt2();
 #endif
 
 	if (m_TaskRXMessage.IsStopRequested(0)) {
@@ -1918,7 +2046,7 @@ void MainWorker::CheckAndPushRxMessage(const CDomoticzHardwareBase* pHardware, c
 		rxMessage.rxMessageIdx,
 		pHardware->m_HwdID,
 		pHardware->HwdType,
-		pHardware->m_Name.c_str(),
+		pHardware->Name.c_str(),
 		pRXCommand[1],
 		pRXCommand[2]);
 #endif
@@ -1941,7 +2069,7 @@ void MainWorker::CheckAndPushRxMessage(const CDomoticzHardwareBase* pHardware, c
 			}
 		}
 #ifdef DEBUG_RXQUEUE
-		if (wait) {
+		if (moreThanTimeout) {
 			_log.Log(LOG_STATUS, "RxQueue: rxMessage(%lu) processed", rxMessage.rxMessageIdx);
 		}
 #endif
@@ -2017,8 +2145,10 @@ void MainWorker::Do_Work_On_Rx_Messages()
 
 #ifdef DEBUG_RXQUEUE
 		// CRC
-		uint16_t crc = crc16ccitt(pRXCommand, rxQItem.vrxCommand.size());
-		if (rxQItem.crc != crc) {
+		boost::uint16_t crc = rxQItem.crc;
+		boost::crc_optimal<16, 0x1021, 0xFFFF, 0, false, false> crc_ccitt2;
+		crc_ccitt2 = std::for_each(pRXCommand, pRXCommand + rxQItem.vrxCommand.size(), crc_ccitt2);
+		if (crc != crc_ccitt2()) {
 			_log.Log(LOG_ERROR, "RxQueue: cannot process invalid rxMessage(%lu) from hardware with id=%d (type %d)",
 				rxQItem.rxMessageIdx,
 				rxQItem.hardwareId,
@@ -2031,7 +2161,7 @@ void MainWorker::Do_Work_On_Rx_Messages()
 			rxQItem.rxMessageIdx,
 			pHardware->m_HwdID,
 			pHardware->HwdType,
-			pHardware->m_Name.c_str(),
+			pHardware->Name.c_str(),
 			pRXCommand[1],
 			pRXCommand[2]);
 #endif
@@ -2050,11 +2180,67 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 	// current date/time based on current system
 	//size_t Len = pRXCommand[0] + 1;
 
+	const_cast<CDomoticzHardwareBase*>(pHardware)->SetHeartbeatReceived();
+
 	uint64_t DeviceRowIdx = (uint64_t)-1;
 	std::string DeviceName;
+	tcp::server::CTCPClient* pClient2Ignore = nullptr;
+
+	std::string szLastSwitchUser = userName;
+
+	if (pHardware->HwdType == HTYPE_Domoticz)
+	{
+		szLastSwitchUser = pHardware->m_Name;
+		if (pHardware->m_HwdID == 8765) // did we receive it from our master?
+		{
+			CDomoticzHardwareBase* pOrgHardware = nullptr;
+			switch (pRXCommand[1])
+			{
+			case pTypeLighting1:
+			case pTypeLighting2:
+			case pTypeLighting3:
+			case pTypeLighting4:
+			case pTypeLighting5:
+			case pTypeLighting6:
+			case pTypeColorSwitch:
+			case pTypeCurtain:
+			case pTypeBlinds:
+			case pTypeRFY:
+			case pTypeSecurity1:
+			case pTypeSecurity2:
+			case pTypeChime:
+			case pTypeSetpoint:
+			case pTypeThermostat2:
+			case pTypeThermostat3:
+			case pTypeThermostat4:
+			case pTypeRadiator1:
+			case pTypeGeneralSwitch:
+			case pTypeHomeConfort:
+			case pTypeFan:
+			case pTypeFS20:
+			case pTypeHunter:
+			case pTypeDDxxxx:
+				// we received a control message from a domoticz client,
+				// and should actually perform this command ourself switch
+				DeviceRowIdx = PerformRealActionFromDomoticzClient(pRXCommand, &pOrgHardware);
+				if (DeviceRowIdx != (uint64_t)-1)
+				{
+					if (pOrgHardware != nullptr)
+					{
+						DeviceRowIdx = -1;
+						pClient2Ignore = (tcp::server::CTCPClient*)pHardware->m_pUserData;
+						pHardware = pOrgHardware;
+					}
+					WriteMessage("Control Command, ", (pOrgHardware == nullptr));
+				}
+				break;
+			}
+		}
+	}
+
 
 	_tRxMessageProcessingResult procResult;
-	procResult.Username = userName;
+	procResult.Username = szLastSwitchUser;
 	if (DeviceRowIdx == (uint64_t)-1)
 	{
 		switch (pRXCommand[1])
@@ -2273,9 +2459,6 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 		case pTypeDDxxxx:
 			decode_DDxxxx(pHardware, reinterpret_cast<const tRBUF*>(pRXCommand), procResult);
 			break;
-		case pTypeHoneywell_AL:
-			decode_Honeywell(pHardware, reinterpret_cast<const tRBUF*>(pRXCommand), procResult);
-			break;
 		default:
 			_log.Log(LOG_ERROR, "UNHANDLED PACKET TYPE:      FS20 %02X", pRXCommand[1]);
 			return;
@@ -2313,6 +2496,11 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 		std::string szLogString = sdevicetype + " (" + DeviceName + ")";
 		const_cast<CDomoticzHardwareBase*>(pHardware)->Log(LOG_NORM, szLogString);
 	}
+
+	//TODO: Notify plugin?
+
+	//Send to connected Sharing Users
+	m_sharedserver.SendToAll(pHardware->m_HwdID, DeviceRowIdx, (const char*)pRXCommand, pRXCommand[0] + 1, pClient2Ignore);
 
 	sOnDeviceReceived(pHardware->m_HwdID, DeviceRowIdx, DeviceName, pRXCommand);
 }
@@ -2852,10 +3040,6 @@ void MainWorker::decode_BateryLevel(bool bIsInPercentage, uint8_t level)
 
 uint8_t MainWorker::get_BateryLevel(const _eHardwareTypes HwdType, bool bIsInPercentage, uint8_t level)
 {
-	if (HwdType == HTYPE_OpenZWave)
-	{
-		bIsInPercentage = true;
-	}
 	uint8_t ret = 0;
 	if (bIsInPercentage)
 	{
@@ -2979,13 +3163,13 @@ void MainWorker::decode_Rain(const CDomoticzHardwareBase* pHardware, const tRBUF
 			if (result.size() == 1)
 			{
 				float totalRainFallLastHour = TotalRain - static_cast<float>(atof(result[0][0].c_str()));
-				Rainrate = ground(totalRainFallLastHour * 100.0F);
+				Rainrate = round(totalRainFallLastHour * 100.0F);
 			}
 		}
 	}
 
 	sprintf(szTmp, "%d;%.1f", Rainrate, TotalRain);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -3132,7 +3316,7 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	else
 		strDirection = "---";
 
-	dDirection = ground(dDirection);
+	dDirection = round(dDirection);
 
 	int intSpeed = (pResponse->WIND.av_speedh * 256) + pResponse->WIND.av_speedl;
 	int intGust = (pResponse->WIND.gusth * 256) + pResponse->WIND.gustl;
@@ -3211,7 +3395,7 @@ void MainWorker::decode_Wind(const CDomoticzHardwareBase* pHardware, const tRBUF
 	}
 
 	sprintf(szTmp, "%.2f;%s;%d;%d;%.1f;%.1f", dDirection, strDirection.c_str(), intSpeed, intGust, temp, chill);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -3316,11 +3500,7 @@ void MainWorker::decode_Temp(const CDomoticzHardwareBase* pHardware, const tRBUF
 		BatteryLevel = 100;
 
 	//Override battery level if hardware supports it
-	if (pHardware->HwdType == HTYPE_OpenZWave)
-	{
-		BatteryLevel = pResponse->TEMP.battery_level * 10;
-	}
-	else if ((pHardware->HwdType == HTYPE_EnOceanESP2) || (pHardware->HwdType == HTYPE_EnOceanESP3))
+	if ((pHardware->HwdType == HTYPE_EnOceanESP2) || (pHardware->HwdType == HTYPE_EnOceanESP3))
 	{
 		// WARNING
 		// battery_level & rssi fields fields are used here to transmit ID_BYTE0 value from EnOcean device
@@ -3352,7 +3532,7 @@ void MainWorker::decode_Temp(const CDomoticzHardwareBase* pHardware, const tRBUF
 	temp += AddjValue;
 
 	sprintf(szTmp, "%.1f", temp);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -3377,7 +3557,7 @@ void MainWorker::decode_Temp(const CDomoticzHardwareBase* pHardware, const tRBUF
 			humidity = atoi(result[0][0].c_str());
 			uint8_t humidity_status = atoi(result[0][1].c_str());
 			sprintf(szTmp, "%.1f;%d;%d", temp, humidity, humidity_status);
-			DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 			m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, pTypeTEMP_HUM, sTypeTH_LC_TC, szTmp);
 
 			bHandledNotification = true;
@@ -3479,12 +3659,6 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	else
 		BatteryLevel = 100;
 
-	//Override battery level if hardware supports it
-	if (pHardware->HwdType == HTYPE_OpenZWave)
-	{
-		BatteryLevel = pResponse->TEMP.battery_level;
-	}
-
 	uint8_t humidity = pResponse->HUM.humidity;
 	if (humidity > 100)
 	{
@@ -3493,7 +3667,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	}
 
 	sprintf(szTmp, "%d", pResponse->HUM.humidity_status);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, humidity, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, humidity, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -3516,7 +3690,7 @@ void MainWorker::decode_Hum(const CDomoticzHardwareBase* pHardware, const tRBUF*
 			m_sql.GetAddjustment(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, AddjValue, AddjMulti);
 			temp += AddjValue;
 			sprintf(szTmp, "%.1f;%d;%d", temp, humidity, pResponse->HUM.humidity_status);
-			DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 2, pTypeTEMP_HUM, sTypeTH_LC_TC, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 			m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, pTypeTEMP_HUM, sTypeTH_LC_TC, subType, szTmp);
 			bHandledNotification = true;
 		}
@@ -3667,7 +3841,7 @@ void MainWorker::decode_TempHum(const CDomoticzHardwareBase* pHardware, const tR
 	Humidity=0;
 	*/
 	sprintf(szTmp, "%.1f;%d;%d", temp, Humidity, HumidityStatus);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -3815,12 +3989,6 @@ void MainWorker::decode_TempHumBaro(const CDomoticzHardwareBase* pHardware, cons
 	else
 		BatteryLevel = 100;
 
-	//Override battery level if hardware supports it
-	if (pHardware->HwdType == HTYPE_OpenZWave)
-	{
-		BatteryLevel = pResponse->TEMP.battery_level;
-	}
-
 	float temp;
 	if (!pResponse->TEMP_HUM_BARO.tempsign)
 	{
@@ -3878,7 +4046,7 @@ void MainWorker::decode_TempHumBaro(const CDomoticzHardwareBase* pHardware, cons
 		}
 		sprintf(szTmp, "%.1f;%d;%d;%d;%d", temp, Humidity, HumidityStatus, barometer, forcast);
 	}
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -4014,7 +4182,7 @@ void MainWorker::decode_TempBaro(const CDomoticzHardwareBase* pHardware, const t
 	fbarometer += AddjValue;
 
 	sprintf(szTmp, "%.1f;%.1f;%d;%.2f", temp, fbarometer, forcast, pTempBaro->altitude);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -4118,7 +4286,7 @@ void MainWorker::decode_TempRain(const CDomoticzHardwareBase* pHardware, const t
 	float TotalRain = float((pResponse->TEMP_RAIN.raintotal1 * 256) + pResponse->TEMP_RAIN.raintotal2) / 10.0F;
 
 	sprintf(szTmp, "%.1f;%.1f", temp, TotalRain);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -4126,11 +4294,11 @@ void MainWorker::decode_TempRain(const CDomoticzHardwareBase* pHardware, const t
 	m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
 
 	sprintf(szTmp, "%.1f", temp);
-	uint64_t DevRowIdxTemp = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, pTypeTEMP, sTypeTEMP3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdxTemp = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeTEMP, sTypeTEMP3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	m_notifications.CheckAndHandleNotification(DevRowIdxTemp, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, pTypeTEMP, sTypeTEMP3, temp);
 
 	sprintf(szTmp, "%d;%.1f", 0, TotalRain);
-	uint64_t DevRowIdxRain = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, pTypeRAIN, sTypeRAIN3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdxRain = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeRAIN, sTypeRAIN3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	m_notifications.CheckAndHandleNotification(DevRowIdxRain, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, pTypeRAIN, sTypeRAIN3, cmnd, szTmp);
 
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -4215,7 +4383,7 @@ void MainWorker::decode_UV(const CDomoticzHardwareBase* pHardware, const tRBUF* 
 	}
 
 	sprintf(szTmp, "%.1f;%.1f", Level, temp);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -4293,7 +4461,7 @@ void MainWorker::decode_FS20(const CDomoticzHardwareBase* pHardware, const tRBUF
 	uint8_t cmnd = pResponse->FS20.cmd1;
 	uint8_t SignalLevel = pResponse->FS20.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -4561,7 +4729,7 @@ void MainWorker::decode_Lighting1(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t cmnd = pResponse->LIGHTING1.cmnd;
 	uint8_t SignalLevel = pResponse->LIGHTING1.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -4758,7 +4926,7 @@ void MainWorker::decode_Lighting2(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t SignalLevel = pResponse->LIGHTING2.rssi;
 
 	sprintf(szTmp, "%d", level);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 	bool isGroupCommand = ((cmnd == light2_sGroupOff) || (cmnd == light2_sGroupOn));
 	uint8_t single_cmnd = cmnd;
@@ -4909,7 +5077,7 @@ void MainWorker::decode_Lighting4(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t cmnd = 1; //only 'On' supported
 	uint8_t SignalLevel = pResponse->LIGHTING4.rssi;
 	sprintf(szTmp, "%d", (pResponse->LIGHTING4.pulseHigh * 256) + pResponse->LIGHTING4.pulseLow);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -5105,7 +5273,7 @@ void MainWorker::decode_Lighting5(const CDomoticzHardwareBase* pHardware, const 
 	if (bDoUpdate)
 	{
 		sprintf(szTmp, "%d", pResponse->LIGHTING5.level);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 		CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -5572,7 +5740,7 @@ void MainWorker::decode_Lighting6(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t SignalLevel = pResponse->LIGHTING6.rssi;
 
 	sprintf(szTmp, "%d", rfu);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -5639,7 +5807,7 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	uint8_t cmnd = pResponse->FAN.cmnd;
 	uint8_t SignalLevel = pResponse->FAN.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -5775,7 +5943,7 @@ void MainWorker::decode_HomeConfort(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t cmnd = pResponse->HOMECONFORT.cmnd;
 	uint8_t SignalLevel = pResponse->HOMECONFORT.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 
 	bool isGroupCommand = ((cmnd == HomeConfort_sGroupOff) || (cmnd == HomeConfort_sGroupOn));
 	uint8_t single_cmnd = cmnd;
@@ -5861,46 +6029,49 @@ void MainWorker::decode_ColorSwitch(const CDomoticzHardwareBase* pHardware, cons
 	char szValueTmp[100];
 	sprintf(szValueTmp, "%u", value);
 	std::string sValue = szValueTmp;
-
-	uint64_t DevRowIdx = (uint64_t)-1;
-
-	auto result = m_sql.safe_query(
-		"SELECT ID FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
-		pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
-	if (!result.empty())
-	{
-		DevRowIdx = std::stoull(result[0][0]);
-	}
-	else
-	{
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, 12, -1, cmnd, sValue.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
-		if (DevRowIdx == (uint64_t)-1)
-			return;
-	}
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, 12, -1, cmnd, sValue.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
+	if (DevRowIdx == (uint64_t)-1)
+		return;
+	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
 
 	// TODO: Why don't we let database update be handled by CSQLHelper::UpdateValue?
 	if (cmnd == Color_SetBrightnessLevel || cmnd == Color_SetColor)
 	{
-		//store light level
-		m_sql.safe_query(
-			"UPDATE DeviceStatus SET LastLevel='%d' WHERE (ID = %" PRIu64 ")",
-			value,
-			DevRowIdx);
+		std::vector<std::vector<std::string> > result;
+		result = m_sql.safe_query(
+			"SELECT ID,Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
+			pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
+		if (!result.empty())
+		{
+			uint64_t ulID = std::stoull(result[0][0]);
+
+			//store light level
+			m_sql.safe_query(
+				"UPDATE DeviceStatus SET LastLevel='%d' WHERE (ID = %" PRIu64 ")",
+				value,
+				ulID);
+		}
+
 	}
 
 	if (cmnd == Color_SetColor)
 	{
-		//store color in database
-		m_sql.safe_query(
-			"UPDATE DeviceStatus SET Color='%q' WHERE (ID = %" PRIu64 ")",
-			color.toJSONString().c_str(),
-			DevRowIdx);
-	}
+		std::vector<std::vector<std::string> > result;
+		result = m_sql.safe_query(
+			"SELECT ID,Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID='%q' AND Unit=%d AND Type=%d AND SubType=%d)",
+			pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
+		if (!result.empty())
+		{
+			uint64_t ulID = std::stoull(result[0][0]);
 
-	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, 12, -1, cmnd, sValue.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
-	if (DevRowIdx == (uint64_t)-1)
-		return;
-	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
+			//store color in database
+			m_sql.safe_query(
+				"UPDATE DeviceStatus SET Color='%q' WHERE (ID = %" PRIu64 ")",
+				color.toJSONString().c_str(),
+				ulID);
+		}
+
+	}
 
 	procResult.DeviceRowIdx = DevRowIdx;
 }
@@ -5921,7 +6092,7 @@ void MainWorker::decode_Chime(const CDomoticzHardwareBase* pHardware, const tRBU
 	uint8_t cmnd = pResponse->CHIME.sound;
 	uint8_t SignalLevel = pResponse->CHIME.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -6178,7 +6349,7 @@ void MainWorker::decode_Curtain(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t cmnd = pResponse->CURTAIN1.cmnd;
 	uint8_t SignalLevel = 9;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -6241,7 +6412,7 @@ void MainWorker::decode_BLINDS1(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t cmnd = pResponse->BLINDS1.cmnd;
 	uint8_t SignalLevel = pResponse->BLINDS1.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -6358,7 +6529,7 @@ void MainWorker::decode_BLINDS1(const CDomoticzHardwareBase* pHardware, const tR
 			else
 				WriteMessage("Set Limit");
 			break;
-		case blinds_sLowerLimit:
+		case blinds_slowerLimit:
 			WriteMessage("Set Lower Limit");
 			break;
 		case blinds_sDeleteLimits:
@@ -6395,7 +6566,7 @@ void MainWorker::decode_RFY(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	uint8_t cmnd = pResponse->RFY.cmnd;
 	uint8_t SignalLevel = pResponse->RFY.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -6570,7 +6741,7 @@ void MainWorker::decode_evohome1(const CDomoticzHardwareBase* pHardware, const t
 			return;
 	}
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szUntilDate.c_str(), procResult.DeviceName, pEvo->action != 0, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szUntilDate.c_str(), procResult.DeviceName, pEvo->action != 0, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	if (bNewDev)
@@ -6755,7 +6926,7 @@ void MainWorker::decode_evohome2(const CDomoticzHardwareBase* pHardware, const t
 			szUpdateStat = boost::algorithm::join(strarray, ";");
 		}
 	}
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, szDevID.c_str(), Unit, dType, dSubType, SignalLevel, BatteryLevel, cmnd, szUpdateStat.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, szDevID.c_str(), Unit, dType, dSubType, SignalLevel, BatteryLevel, cmnd, szUpdateStat.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	if (bNewDev)
@@ -6835,7 +7006,7 @@ void MainWorker::decode_evohome3(const CDomoticzHardwareBase* pHardware, const t
 			BatteryLevel = pEvo->battery_level;
 	}
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szDemand.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szDemand.c_str(), procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -6887,7 +7058,7 @@ void MainWorker::decode_Security1(const CDomoticzHardwareBase* pHardware, const 
 		BatteryLevel = 255;
 	}
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -7064,7 +7235,7 @@ void MainWorker::decode_Security2(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t SignalLevel = pResponse->SECURITY2.rssi;
 	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, false, pResponse->SECURITY2.battery_level & 0x0F);
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -7196,7 +7367,7 @@ void MainWorker::decode_Remote(const CDomoticzHardwareBase* pHardware, const tRB
 	uint8_t cmnd = light2_sOn;
 	uint8_t SignalLevel = pResponse->REMOTE.rssi;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -8293,7 +8464,7 @@ void MainWorker::decode_Thermostat(const CDomoticzHardwareBase* pHardware, const
 		return;
 	}
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -8339,7 +8510,7 @@ void MainWorker::decode_Thermostat1(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t status = (pResponse->THERMOSTAT1.status & 0x03);
 
 	sprintf(szTmp, "%d;%d;%d;%d", temp, set_point, mode, status);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -8413,7 +8584,7 @@ void MainWorker::decode_Thermostat2(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t SignalLevel = pResponse->THERMOSTAT2.rssi;
 	uint8_t BatteryLevel = 255;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -8474,7 +8645,7 @@ void MainWorker::decode_Thermostat3(const CDomoticzHardwareBase* pHardware, cons
 	uint8_t SignalLevel = pResponse->THERMOSTAT3.rssi;
 	uint8_t BatteryLevel = 255;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, "", procResult.DeviceName);
@@ -8571,7 +8742,7 @@ void MainWorker::decode_Thermostat4(const CDomoticzHardwareBase* pHardware, cons
 		pResponse->THERMOSTAT4.mode
 	);
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -8667,7 +8838,7 @@ void MainWorker::decode_Radiator1(const CDomoticzHardwareBase* pHardware, const 
 	uint8_t BatteryLevel = 255;
 
 	sprintf(szTmp, "%d.%d", pResponse->RADIATOR1.temperature, pResponse->RADIATOR1.tempPoint5);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -8812,7 +8983,7 @@ void MainWorker::decode_Current(const CDomoticzHardwareBase* pHardware, const tR
 	float CurrentChannel2 = float((pResponse->CURRENT.ch2h * 256) + pResponse->CURRENT.ch2l) / 10.0F;
 	float CurrentChannel3 = float((pResponse->CURRENT.ch3h * 256) + pResponse->CURRENT.ch3l) / 10.0F;
 	sprintf(szTmp, "%.1f;%.1f;%.1f", CurrentChannel1, CurrentChannel2, CurrentChannel3);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -8942,8 +9113,8 @@ void MainWorker::decode_Power(const CDomoticzHardwareBase* pHardware, const tRBU
 	double powerfactor = pResponse->POWER.pf / 100.0;
 	float frequency = (float)pResponse->POWER.freq; //Hz
 
-	sprintf(szTmp, "%ld;%.2f", long(ground(instant)), usage * 1000.0);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	sprintf(szTmp, "%ld;%.2f", long(round(instant)), usage * 1000.0);
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -8951,21 +9122,21 @@ void MainWorker::decode_Power(const CDomoticzHardwareBase* pHardware, const tRBU
 	//Voltage
 	sprintf(szTmp, "%.3f", Voltage);
 	std::string tmpDevName;
-	uint64_t DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 1, pTypeGeneral, sTypeVoltage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
+	uint64_t DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, pTypeGeneral, sTypeVoltage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
 	if (DevRowIdxAlt == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 1, pTypeGeneral, sTypeVoltage, Voltage);
 
 	//Powerfactor
 	sprintf(szTmp, "%.2f", (float)powerfactor);
-	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 2, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
+	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 2, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
 	if (DevRowIdxAlt == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 2, pTypeGeneral, sTypePercentage, (float)powerfactor);
 
 	//Frequency
 	sprintf(szTmp, "%.2f", (float)frequency);
-	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 3, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
+	DevRowIdxAlt = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 3, pTypeGeneral, sTypePercentage, SignalLevel, BatteryLevel, cmnd, szTmp, tmpDevName, true, procResult.Username.c_str());
 	if (DevRowIdxAlt == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, tmpDevName, 3, pTypeGeneral, sTypePercentage, frequency);
@@ -9076,11 +9247,11 @@ void MainWorker::decode_Current_Energy(const CDomoticzHardwareBase* pHardware, c
 		int voltage = 230;
 		m_sql.GetPreferencesVar("ElectricVoltage", voltage);
 
-		sprintf(szTmp, "%ld;%.2f", (long)ground((CurrentChannel1 + CurrentChannel2 + CurrentChannel3) * voltage), usage);
-		m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, pTypeENERGY, sTypeELEC3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		sprintf(szTmp, "%ld;%.2f", (long)round((CurrentChannel1 + CurrentChannel2 + CurrentChannel3) * voltage), usage);
+		m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeENERGY, sTypeELEC3, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	}
 	sprintf(szTmp, "%.1f;%.1f;%.1f;%.3f", CurrentChannel1, CurrentChannel2, CurrentChannel3, usage);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9180,7 +9351,7 @@ void MainWorker::decode_Weight(const CDomoticzHardwareBase* pHardware, const tRB
 	weight += AddjValue;
 
 	sprintf(szTmp, "%.1f", weight);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9274,7 +9445,7 @@ void MainWorker::decode_RFXSensor(const CDomoticzHardwareBase* pHardware, const 
 	}
 	break;
 	}
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9398,7 +9569,7 @@ void MainWorker::decode_RFXMeter(const CDomoticzHardwareBase* pHardware, const t
 		//float RFXPwr = float(counter) / 1000.0f;
 
 		sprintf(szTmp, "%lu", counter);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
@@ -9635,7 +9806,7 @@ void MainWorker::decode_P1MeterPower(const CDomoticzHardwareBase* pHardware, con
 		p1Power->usagecurrent,
 		p1Power->delivcurrent
 	);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9692,7 +9863,7 @@ void MainWorker::decode_P1MeterGas(const CDomoticzHardwareBase* pHardware, const
 	uint8_t BatteryLevel = 255;
 
 	sprintf(szTmp, "%u", p1Gas->gasusage);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9734,7 +9905,7 @@ void MainWorker::decode_YouLessMeter(const CDomoticzHardwareBase* pHardware, con
 		pMeter->powerusage,
 		pMeter->usagecurrent
 	);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9778,7 +9949,7 @@ void MainWorker::decode_Rego6XXTemp(const CDomoticzHardwareBase* pHardware, cons
 	sprintf(szTmp, "%.1f",
 		pRego->temperature
 	);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, pRego->temperature);
@@ -9811,7 +9982,7 @@ void MainWorker::decode_Rego6XXValue(const CDomoticzHardwareBase* pHardware, con
 		pRego->value
 	);
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, numValue, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, numValue, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9849,7 +10020,7 @@ void MainWorker::decode_AirQuality(const CDomoticzHardwareBase* pHardware, const
 	uint8_t SignalLevel = 12;
 	uint8_t BatteryLevel = 255;
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, pMeter->airquality, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, pMeter->airquality, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9860,8 +10031,8 @@ void MainWorker::decode_AirQuality(const CDomoticzHardwareBase* pHardware, const
 		WriteMessageStart();
 		switch (pMeter->subtype)
 		{
-		case sTypeVoc:
-			WriteMessage("subtype       = Voc");
+		case sTypeVoltcraft:
+			WriteMessage("subtype       = Voltcraft CO-20");
 
 			sprintf(szTmp, "CO2 = %d ppm", pMeter->airquality);
 			WriteMessage(szTmp);
@@ -9902,7 +10073,7 @@ void MainWorker::decode_Usage(const CDomoticzHardwareBase* pHardware, const tRBU
 
 	sprintf(szTmp, "%.1f", pMeter->fusage);
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9944,7 +10115,7 @@ void MainWorker::decode_Lux(const CDomoticzHardwareBase* pHardware, const tRBUF*
 
 	sprintf(szTmp, "%.0f", pMeter->fLux);
 
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -9981,25 +10152,19 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t BatteryLevel = pMeter->battery_level;
 
 	if (
-		(subType == sTypeVoltage)
-		|| (subType == sTypeCurrent)
-		|| (subType == sTypePercentage)
-		|| (subType == sTypeWaterflow)
-		|| (subType == sTypePressure)
-#ifdef WITH_OPENZWAVE
-		|| (subType == sTypeZWaveThermostatMode)
-		|| (subType == sTypeZWaveThermostatFanMode)
-		|| (subType == sTypeZWaveThermostatOperatingState)
-		|| (subType == sTypeZWaveAlarm)
-#endif
-		|| (subType == sTypeFan)
-		|| (subType == sTypeTextStatus)
-		|| (subType == sTypeSoundLevel)
-		|| (subType == sTypeBaro)
-		|| (subType == sTypeDistance)
-		|| (subType == sTypeSoilMoisture)
-		|| (subType == sTypeCustom)
-		|| (subType == sTypeKwh)
+		(subType == sTypeVoltage) ||
+		(subType == sTypeCurrent) ||
+		(subType == sTypePercentage) ||
+		(subType == sTypeWaterflow) ||
+		(subType == sTypePressure) ||
+		(subType == sTypeFan) ||
+		(subType == sTypeTextStatus) ||
+		(subType == sTypeSoundLevel) ||
+		(subType == sTypeBaro) ||
+		(subType == sTypeDistance) ||
+		(subType == sTypeSoilMoisture) ||
+		(subType == sTypeCustom) ||
+		(subType == sTypeKwh)
 		)
 	{
 		sprintf(szTmp, "%08X", (unsigned int)pMeter->intval1);
@@ -10019,114 +10184,98 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 	if (subType == sTypeVisibility)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeDistance)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeSolarRadiation)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeSoilMoisture)
 	{
 		cmnd = pMeter->intval2;
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeLeafWetness)
 	{
 		cmnd = pMeter->intval1;
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeVoltage)
 	{
 		sprintf(szTmp, "%.3f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeCurrent)
 	{
 		sprintf(szTmp, "%.3f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeBaro)
 	{
 		sprintf(szTmp, "%.02f;%d", pMeter->floatval1, pMeter->intval2);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypePressure)
 	{
 		sprintf(szTmp, "%.1f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypePercentage)
 	{
 		sprintf(szTmp, "%.2f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeWaterflow)
 	{
 		sprintf(szTmp, "%.2f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeFan)
 	{
 		sprintf(szTmp, "%d", pMeter->intval2);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeSoundLevel)
 	{
 		sprintf(szTmp, "%d", pMeter->intval2);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
-#ifdef WITH_OPENZWAVE
-	else if ((subType == sTypeZWaveThermostatMode) || (subType == sTypeZWaveThermostatFanMode) || (subType == sTypeZWaveThermostatOperatingState))
-	{
-		cmnd = (uint8_t)pMeter->intval2;
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
-	}
-	else if (subType == sTypeZWaveAlarm)
-	{
-		Unit = pMeter->id;
-		cmnd = pMeter->intval2;
-		strcpy(szTmp, pMeter->text);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
-		if (DevRowIdx == (uint64_t)-1)
-			return;
-	}
-#endif
 	else if (subType == sTypeKwh)
 	{
 		sprintf(szTmp, "%.3f;%.3f", pMeter->floatval1, pMeter->floatval2);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	}
 	else if (subType == sTypeAlert)
 	{
@@ -10135,26 +10284,26 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 		else
 			sprintf(szTmp, "%d", pMeter->intval1);
 		cmnd = pMeter->intval1;
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeCustom)
 	{
 		sprintf(szTmp, "%.4f", pMeter->floatval1);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
 	}
 	else if (subType == sTypeTextStatus)
 	{
 		strcpy(szTmp, pMeter->text);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	}
 	else if (subType == sTypeCounterIncremental)
 	{
 		sprintf(szTmp, "%d", pMeter->intval2);
-		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	}
 
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, cmnd, szTmp);
@@ -10276,7 +10425,7 @@ void MainWorker::decode_GeneralSwitch(const CDomoticzHardwareBase* pHardware, co
 	uint8_t SignalLevel = pSwitch->rssi;
 
 	sprintf(szTmp, "%d", level);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	uint8_t check_cmnd = cmnd;
@@ -10322,7 +10471,7 @@ void MainWorker::decode_BBQ(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	temp2 = float((pResponse->BBQ.sensor2h * 256) + pResponse->BBQ.sensor2l);// / 10.0f;
 
 	sprintf(szTmp, "%.0f;%.0f", temp1, temp2);
-	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
@@ -10373,7 +10522,7 @@ void MainWorker::decode_BBQ(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	tsen.TEMP.id2 = 1;
 
 	tsen.TEMP.tempsign = (temp1 >= 0) ? 0 : 1;
-	int at10 = ground(std::abs(temp1 * 10.0F));
+	int at10 = round(std::abs(temp1 * 10.0F));
 	tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
 	tsen.TEMP.temperaturel = (BYTE)(at10);
@@ -10386,7 +10535,7 @@ void MainWorker::decode_BBQ(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	tsen.TEMP.id2 = 2;
 
 	tsen.TEMP.tempsign = (temp2 >= 0) ? 0 : 1;
-	at10 = ground(std::abs(temp2 * 10.0F));
+	at10 = round(std::abs(temp2 * 10.0F));
 	tsen.TEMP.temperatureh = (BYTE)(at10 / 256);
 	at10 -= (tsen.TEMP.temperatureh * 256);
 	tsen.TEMP.temperaturel = (BYTE)(at10);
@@ -10666,7 +10815,7 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			apparentPower = (pResponse->TIC.power_H << 8) + pResponse->TIC.power_L;
 
 			sprintf(szTmp, "%u", apparentPower);
-			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 1, pTypeUsage, sTypeElectric, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, pTypeUsage, sTypeElectric, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 			if (DevRowIdx == (uint64_t)-1)
 				return;
@@ -10704,7 +10853,7 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			counter2 = (pResponse->TIC.counter2_0 << 24) + (pResponse->TIC.counter2_1 << 16) + (pResponse->TIC.counter2_2 << 8) + (pResponse->TIC.counter2_3);
 			sprintf(szTmp, "%u;%d", counter2ApparentPower, counter2);
 
-			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 			if (DevRowIdx == (uint64_t)-1)
 				return;
@@ -10722,7 +10871,7 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			counter2 = (pResponse->TIC.counter2_0 << 24) + (pResponse->TIC.counter2_1 << 16) + (pResponse->TIC.counter2_2 << 8) + (pResponse->TIC.counter2_3);
 
 			sprintf(szTmp, "%u;%d", counter2ApparentPower, counter2);
-			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 			if (DevRowIdx == (uint64_t)-1)
 				return;
@@ -10782,7 +10931,7 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 			counter2 = (pResponse->TIC.counter2_0 << 24) + (pResponse->TIC.counter2_1 << 16) + (pResponse->TIC.counter2_2 << 8) + (pResponse->TIC.counter2_3);
 
 			sprintf(szTmp, "%u;%d", counter2ApparentPower, counter2);
-			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), unitCounter2, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+			uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), unitCounter2, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 			if (DevRowIdx == (uint64_t)-1)
 				return;
@@ -10799,7 +10948,7 @@ void MainWorker::decode_CartelectronicTIC(const CDomoticzHardwareBase* pHardware
 		counter1 = (pResponse->TIC.counter1_0 << 24) + (pResponse->TIC.counter1_1 << 16) + (pResponse->TIC.counter1_2 << 8) + (pResponse->TIC.counter1_3);
 
 		sprintf(szTmp, "%u;%d", counter1ApparentPower, counter1);
-		uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), unitCounter1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+		uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), unitCounter1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 
 		if (DevRowIdx == (uint64_t)-1)
 			return;
@@ -10838,7 +10987,7 @@ void MainWorker::decode_CartelectronicEncoder(const CDomoticzHardwareBase* pHard
 	counter1 = (pResponse->CEENCODER.counter1_0 << 24) + (pResponse->CEENCODER.counter1_1 << 16) + (pResponse->CEENCODER.counter1_2 << 8) + (pResponse->CEENCODER.counter1_3);
 
 	sprintf(szTmp, "%d", counter1);
-	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, Unit, devType, subType, (float)counter1);
@@ -10847,7 +10996,7 @@ void MainWorker::decode_CartelectronicEncoder(const CDomoticzHardwareBase* pHard
 	counter2 = (pResponse->CEENCODER.counter2_0 << 24) + (pResponse->CEENCODER.counter2_1 << 16) + (pResponse->CEENCODER.counter2_2 << 8) + (pResponse->CEENCODER.counter2_3);
 
 	sprintf(szTmp, "%d", counter2);
-	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), 1, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	m_notifications.CheckAndHandleNotification(DevRowIdx, pHardware->m_HwdID, ID, procResult.DeviceName, 1, devType, subType, (float)counter2);
@@ -10906,44 +11055,41 @@ void MainWorker::decode_Weather(const CDomoticzHardwareBase* pHardware, const tR
 	}
 	pRFXDevice->SendWind(windID, BatteryLevel, intDirection, intSpeed, intGust, temp, chill, true, bHaveChill, procResult.DeviceName, SignalLevel);
 
-	int Humidity = (int)pResponse->WEATHER.humidity;
-	pRFXDevice->SendTempHumSensor(windID, BatteryLevel, temp, Humidity, procResult.DeviceName, SignalLevel);
+	if (subType == sTypeWEATHER2)
+	{
+		int Humidity = (int)pResponse->WEATHER.humidity;
+		pRFXDevice->SendTempHumSensor(windID, BatteryLevel, temp, Humidity, procResult.DeviceName, SignalLevel);
+	}
 
 	//Rain
-	float TotalRain = 0;
-	switch (subType)
+	if ((subType == sTypeWEATHER1) || (subType == sTypeWEATHER2))
 	{
-	case sTypeWEATHER0:
-		TotalRain = float((pResponse->WEATHER.raintotal2 * 256) + (pResponse->WEATHER.raintotal3)) * 0.1F;
-		break;
-	case sTypeWEATHER1:
-		TotalRain = float((pResponse->WEATHER.raintotal2 * 256) + (pResponse->WEATHER.raintotal3)) * 0.3F;
-		break;
-	case sTypeWEATHER2:
-		TotalRain = float((pResponse->WEATHER.raintotal2 * 256) + (pResponse->WEATHER.raintotal3)) * 0.254F;
-		break;
+		float TotalRain = 0;
+
+		if (subType == sTypeWEATHER1)
+		{
+			TotalRain = float((pResponse->WEATHER.raintotal2 * 256) + (pResponse->WEATHER.raintotal3)) * 0.3F;
+		}
+		else if (subType == sTypeWEATHER2)
+		{
+			TotalRain = float((pResponse->WEATHER.raintotal2 * 256) + (pResponse->WEATHER.raintotal3)) * 0.254F;
+		}
+		pRFXDevice->SendRainSensor(windID, BatteryLevel, TotalRain, procResult.DeviceName, SignalLevel);
 	}
-	pRFXDevice->SendRainSensor(windID, BatteryLevel, TotalRain, procResult.DeviceName, SignalLevel);
 
 	//UV
-	float UV = (float)pResponse->WEATHER.uv;
-	switch (subType)
+	if (subType == sTypeWEATHER2)
 	{
-	case sTypeWEATHER0:
-	case sTypeWEATHER2:
-		UV = UV / 10.0F;
-		break;
+		float UV = (float)pResponse->WEATHER.uv;
+		pRFXDevice->SendUVSensor(windID, 1, BatteryLevel, UV, procResult.DeviceName, SignalLevel);
 	}
-	pRFXDevice->SendUVSensor(windID, 1, BatteryLevel, UV, procResult.DeviceName, SignalLevel);
 
 	//Solar
-	float radiation = -1;
-	if (subType == sTypeWEATHER0)
-		radiation = (float)((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow) * 0.078925F;
-	else if (subType == sTypeWEATHER2)
-		radiation = (float)((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow);
-	if (radiation != -1)
+	if (subType == sTypeWEATHER2)
+	{
+		float radiation = (float)((pResponse->WEATHER.solarhigh * 256) + pResponse->WEATHER.solarlow);
 		pRFXDevice->SendSolarRadiationSensor((const uint8_t)windID, BatteryLevel, radiation, procResult.DeviceName);
+	}
 }
 
 void MainWorker::decode_Solar(const CDomoticzHardwareBase* pHardware, const tRBUF* pResponse, _tRxMessageProcessingResult& procResult)
@@ -10982,7 +11128,7 @@ void MainWorker::decode_Hunter(const CDomoticzHardwareBase* pHardware, const tRB
 	sprintf(szTmp, "%02X%02X%02X%02X%02X%02X", pResponse->HUNTER.id1, pResponse->HUNTER.id2, pResponse->HUNTER.id3, pResponse->HUNTER.id4, pResponse->HUNTER.id5, pResponse->HUNTER.id6);
 	ID = szTmp;
 
-	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
+	DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -11073,7 +11219,7 @@ void MainWorker::decode_LevelSensor(const CDomoticzHardwareBase* pHardware, cons
 	temp += AddjValue;
 
 	sprintf(szTmp, "%.1f", temp);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, pTypeTEMP, sTypeTEMP1, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, pTypeTEMP, sTypeTEMP1, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 
@@ -11174,7 +11320,7 @@ void MainWorker::decode_DDxxxx(const CDomoticzHardwareBase* pHardware, const tRB
 	uint8_t SignalLevel = pResponse->DDXXXX.rssi;
 
 	sprintf(szTmp, "%d", pResponse->DDXXXX.percent);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)
 		return;
 	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
@@ -11258,81 +11404,6 @@ void MainWorker::decode_DDxxxx(const CDomoticzHardwareBase* pHardware, const tRB
 	procResult.DeviceRowIdx = DevRowIdx;
 }
 
-void MainWorker::decode_Honeywell(const CDomoticzHardwareBase* pHardware, const tRBUF* pResponse, _tRxMessageProcessingResult& procResult)
-{
-	char szTmp[100];
-	uint8_t devType = pResponse->HONEYWELL_AL.packettype;
-	uint8_t subType = pResponse->HONEYWELL_AL.subtype;
-
-	sprintf(szTmp, "%02X%02X%02X", pResponse->HONEYWELL_AL.id1, pResponse->HONEYWELL_AL.id2, pResponse->HONEYWELL_AL.id3);
-
-	std::string ID = szTmp;
-	uint8_t Unit = (pResponse->HONEYWELL_AL.knock << 4) | pResponse->HONEYWELL_AL.alert;
-	uint8_t cmnd = 1;
-	uint8_t SignalLevel = pResponse->HONEYWELL_AL.rssi;
-
-	sprintf(szTmp, "%d", 0);
-	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, -1, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
-	if (DevRowIdx == (uint64_t)-1)
-		return;
-	CheckSceneCode(DevRowIdx, devType, subType, cmnd, szTmp, procResult.DeviceName);
-
-	if (_log.IsDebugLevelEnabled(DEBUG_RECEIVED))
-	{
-		WriteMessageStart();
-		char szTmp[100];
-
-		switch (pResponse->HONEYWELL_AL.subtype)
-		{
-		case sTypeSeries5:
-			WriteMessage("subtype       = Series5");
-			break;
-		case sTypePIR:
-			WriteMessage("subtype       = PIR");
-			break;
-		default:
-			sprintf(szTmp, "ERROR: Unknown Sub type for Packet type= %02X:%02X:", pResponse->HONEYWELL_AL.packettype, pResponse->HONEYWELL_AL.subtype);
-			WriteMessage(szTmp);
-			break;
-		}
-		sprintf(szTmp, "Sequence nbr  = %d", pResponse->HONEYWELL_AL.seqnbr);
-		WriteMessage(szTmp);
-
-		sprintf(szTmp, "id1-3         = %02X%02X%02X", pResponse->HONEYWELL_AL.id1, pResponse->HONEYWELL_AL.id2, pResponse->HONEYWELL_AL.id3);
-		WriteMessage(szTmp);
-
-		switch (pResponse->HONEYWELL_AL.alert)
-		{
-		case 0:
-			WriteMessage("Alert       = Normal");
-			break;
-		case 1:
-			WriteMessage("Alert       = Right halo light pattern");
-			break;
-		case 2:
-			WriteMessage("Alert       = Left halo light pattern");
-			break;
-		case 3:
-			WriteMessage("Alert       = High volume alarm");
-			break;
-		}
-
-		switch (pResponse->HONEYWELL_AL.knock)
-		{
-		case 0:
-			WriteMessage("Knock       = Yes");
-			break;
-		case 1:
-			WriteMessage("Knock       = No");
-			break;
-		}
-
-		sprintf(szTmp, "Signal level  = %d", pResponse->HONEYWELL_AL.rssi);
-		WriteMessage(szTmp);
-		WriteMessageEnd();
-	}
-	procResult.DeviceRowIdx = DevRowIdx;
-}
 
 bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sValue)
 {
@@ -11488,19 +11559,8 @@ bool MainWorker::GetSensorData(const uint64_t idx, int& nValue, std::string& sVa
 	return true;
 }
 
-MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string& User)
+bool MainWorker::SwitchLightInt(const std::vector<std::string>& sd, std::string switchcmd, int level, const _tColor color, const bool IsTesting, const std::string& User)
 {
-	int HardwareID = atoi(sd[0].c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-	{
-		_log.Log(LOG_ERROR, "Switch command not send!, Hardware device disabled or not found!");
-		return SL_ERROR;
-	}
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return SL_ERROR;
-
 	unsigned long ID;
 	std::stringstream s_strid;
 	s_strid << std::hex << sd[1];
@@ -11510,9 +11570,20 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 	uint8_t ID3 = (uint8_t)((ID & 0x0000FF00) >> 8);
 	uint8_t ID4 = (uint8_t)((ID & 0x000000FF));
 
+	int HardwareID = atoi(sd[0].c_str());
+
 	_log.Debug(DEBUG_NORM, "MAIN SwitchLightInt : switchcmd:%s level:%d HWid:%d  sd:%s %s %s %s %s %s", switchcmd.c_str(), level, HardwareID,
 		sd[0].c_str(), sd[1].c_str(), sd[2].c_str(), sd[3].c_str(), sd[4].c_str(), sd[5].c_str());
 
+	int hindex = FindDomoticzHardware(HardwareID);
+	if (hindex == -1)
+	{
+		_log.Log(LOG_ERROR, "Switch command not send!, Hardware device disabled or not found!");
+		return false;
+	}
+	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
+	if (pHardware == nullptr)
+		return false;
 
 	std::string deviceID = sd[1];
 	int Unit = atoi(sd[2].c_str());
@@ -11542,9 +11613,9 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			else if (switchcmd == "Arm Away")
 				iSecStatus = 2;
 			else
-				return SL_ERROR;
+				return false;
 			UpdateDomoticzSecurityStatus(iSecStatus, User);
-			return SL_OK;
+			return true;
 		}
 	}
 
@@ -11591,7 +11662,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			float fLevel = (maxDimLevel / 100.0F) * level;
 			if (fLevel > 100)
 				fLevel = 100;
-			level = ground(fLevel);
+			level = round(fLevel);
 		}
 		_log.Debug(DEBUG_NORM, "MAIN SwitchLightInt : switchcmd==\"On\" || level < 0, new level:%d", level);
 	}
@@ -11660,7 +11731,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		}
 		((Plugins::CPlugin*)m_hardwaredevices[hindex])->SendCommand(sd[1], Unit, switchcmd, level, color);
 #endif
-		return SL_OK;
+		return true;
 	}
 	if (pHardware->HwdType == HTYPE_MQTTAutoDiscovery)
 	{
@@ -11669,8 +11740,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		{
 			switchcmd = "Set Color";
 		}
-		bool bret = ((MQTTAutoDiscover*)m_hardwaredevices[hindex])->SendSwitchCommand(sd[1], sd[9], Unit, switchcmd, level, color, User);
-		return (bret == true) ? SL_OK : SL_ERROR;
+		return ((MQTTAutoDiscover*)m_hardwaredevices[hindex])->SendSwitchCommand(sd[1], sd[9], Unit, switchcmd, level, color, User);
 	}
 
 	switch (dType)
@@ -11688,7 +11758,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.LIGHTING1.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.LIGHTING1.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (switchtype == STYPE_Doorbell)
 		{
 			int rnvalue = 0;
@@ -11700,12 +11770,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		}
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING1)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeLighting2:
@@ -11724,7 +11794,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.LIGHTING2.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.LIGHTING2.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (switchtype == STYPE_Doorbell) {
 			int rnvalue = 0;
 			m_sql.GetPreferencesVar("DoorbellCommand", rnvalue);
@@ -11774,14 +11844,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		else if (switchtype != STYPE_Motion)
 		{ // Don't send actual motion off command
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING2)))
-				return SL_ERROR;
+				return false;
 		}
 
 		if (!IsTesting)
 		{ //send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeLighting3:
@@ -11813,14 +11883,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			lcmd.LIGHTING4.pulseHigh = pulsetimeing / 256;
 			lcmd.LIGHTING4.pulseLow = pulsetimeing & 0xFF;
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING4)))
-				return SL_ERROR;
+				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
 				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 			}
-			return SL_OK;
+			return true;
 		}
-		return SL_ERROR;
+		return false;
 	}
 	break;
 	case pTypeLighting5:
@@ -11838,7 +11908,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.LIGHTING5.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.LIGHTING5.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (switchtype == STYPE_Doorbell)
 		{
 			int rnvalue = 0;
@@ -11869,7 +11939,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 				uint8_t oldCmd = lcmd.LIGHTING5.cmnd;
 				lcmd.LIGHTING5.cmnd = light5_sLivoloAllOff;
 				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-					return SL_ERROR;
+					return false;
 				lcmd.LIGHTING5.cmnd = oldCmd;
 			}
 			if (switchcmd == "Set Level")
@@ -11877,11 +11947,11 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 				//dim value we have to send multiple times
 				for (int iDim = 0; iDim < level; iDim++)
 					if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-						return SL_ERROR;
+						return false;
 			}
 			else
 				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-					return SL_ERROR;
+					return false;
 		}
 		else if ((dSubType == sTypeTRC02) || (dSubType == sTypeTRC02_2))
 		{
@@ -11900,7 +11970,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 				uint8_t oldCmd = lcmd.LIGHTING5.cmnd;
 				lcmd.LIGHTING5.cmnd = light5_sRGBoff;
 				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-					return SL_ERROR;
+					return false;
 				lcmd.LIGHTING5.cmnd = oldCmd;
 				sleep_milliseconds(100);
 			}
@@ -11909,7 +11979,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 				//turn on
 				lcmd.LIGHTING5.cmnd = light5_sRGBon;
 				if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-					return SL_ERROR;
+					return false;
 				sleep_milliseconds(100);
 
 				if (switchcmd == "Set Color")
@@ -11921,9 +11991,9 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 						switchcmd = "Set Color";
 
 						float dval = 126.0F * hsb[0]; // Color Range is 0x06..0x84
-						lcmd.LIGHTING5.cmnd = light5_sRGBcolormin + 1 + ground(dval);
+						lcmd.LIGHTING5.cmnd = light5_sRGBcolormin + 1 + round(dval);
 						if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-							return SL_ERROR;
+							return false;
 					}
 				}
 			}
@@ -11931,13 +12001,13 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		else
 		{
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING5)))
-				return SL_ERROR;
+				return false;
 		}
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeLighting6:
@@ -11957,14 +12027,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.LIGHTING6.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.LIGHTING6.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.LIGHTING6)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeFS20:
@@ -11981,7 +12051,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.FS20.rssi = 12;
 		lcmd.FS20.cmd2 = 0;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.FS20.cmd1, options))
-			return SL_ERROR;
+			return false;
 		level = (level > 15) ? 15 : level;
 
 		if (level > 0)
@@ -11992,14 +12062,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		if (switchtype != STYPE_Motion) //dont send actual motion off command
 		{
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.FS20)))
-				return SL_ERROR;
+				return false;
 		}
 
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeHomeConfort:
@@ -12018,14 +12088,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.HOMECONFORT.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.HOMECONFORT.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.HOMECONFORT)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeFan:
@@ -12042,14 +12112,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.FAN.rssi = 12;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.FAN.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.FAN)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeColorSwitch:
@@ -12072,14 +12142,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			}
 		}
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.command, options))
-			return SL_ERROR;
+			return false;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(_tColorSwitch)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeSecurity1:
@@ -12100,13 +12170,13 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		case sTypeSA30:
 		{
 			if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.SECURITY1.status, options))
-				return SL_ERROR;
+				return false;
 			//send it twice
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
-				return SL_ERROR;
+				return false;
 			sleep_milliseconds(500);
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
-				return SL_ERROR;
+				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
 				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
@@ -12119,9 +12189,9 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		case sTypeMeiantech:
 		{
 			if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.SECURITY1.status, options))
-				return SL_ERROR;
+				return false;
 			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY1)))
-				return SL_ERROR;
+				return false;
 			if (!IsTesting) {
 				//send to internal for now (later we use the ACK)
 				PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
@@ -12129,7 +12199,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		}
 		break;
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeSecurity2:
@@ -12137,7 +12207,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		BYTE kCodes[9];
 		if (sd[1].size() < 8 * 2)
 		{
-			return SL_ERROR;
+			return false;
 		}
 		for (int ii = 0; ii < 8; ii++)
 		{
@@ -12168,12 +12238,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.SECURITY2.rssi = 12;
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY2)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeHunter:
@@ -12181,7 +12251,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		BYTE kCodes[6];
 		if (sd[1].size() < 6 * 2)
 		{
-			return SL_ERROR;
+			return false;
 		}
 		for (int ii = 0; ii < 6; ii++)
 		{
@@ -12204,16 +12274,16 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.HUNTER.id5 = kCodes[4];
 		lcmd.HUNTER.id6 = kCodes[5];
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.HUNTER.cmnd, options))
-			return SL_ERROR;
+			return false;
 		lcmd.HUNTER.rssi = 12;
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.SECURITY2)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeCurtain:
@@ -12226,16 +12296,16 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.CURTAIN1.housecode = atoi(sd[1].c_str());
 		lcmd.CURTAIN1.unitcode = Unit;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.CURTAIN1.cmnd, options))
-			return SL_ERROR;
+			return false;
 		lcmd.CURTAIN1.filler = 0;
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.CURTAIN1)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeBlinds:
@@ -12275,17 +12345,17 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			lcmd.BLINDS1.unitcode = 0;
 		}
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.BLINDS1.cmnd, options))
-			return SL_ERROR;
+			return false;
 		level = 15;
 		lcmd.BLINDS1.filler = 0;
 		lcmd.BLINDS1.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.BLINDS1)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeRFY:
@@ -12307,7 +12377,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		else
 		{
 			if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.RFY.cmnd, options))
-				return SL_ERROR;
+				return false;
 		}
 
 		bool bIsRFY2 = (lcmd.RFY.subtype == sTypeRFY2);
@@ -12326,14 +12396,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.RFY.filler = 0;
 		lcmd.RFY.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RFY)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			if (bIsRFY2)
 				lcmd.RFY.subtype = sTypeRFY2;
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeDDxxxx:
@@ -12349,7 +12419,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.DDXXXX.id4 = ID4;
 		lcmd.DDXXXX.unitcode = Unit;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.DDXXXX.cmnd, options))
-			return SL_ERROR;
+			return false;
 		lcmd.DDXXXX.filler = 0;
 		lcmd.DDXXXX.rssi = 12;
 
@@ -12368,12 +12438,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		}
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.DDXXXX)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeChime:
@@ -12399,12 +12469,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.CHIME.id4 = 0;
 		lcmd.CHIME.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.CHIME)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeThermostat2:
@@ -12418,17 +12488,17 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.THERMOSTAT2.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.THERMOSTAT2.cmnd, options))
-			return SL_ERROR;
+			return false;
 
 		lcmd.THERMOSTAT2.filler = 0;
 		lcmd.THERMOSTAT2.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.THERMOSTAT2)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeThermostat3:
@@ -12442,17 +12512,17 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.THERMOSTAT3.unitcode3 = ID4;
 		lcmd.THERMOSTAT3.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.THERMOSTAT3.cmnd, options))
-			return SL_ERROR;
+			return false;
 		level = 15;
 		lcmd.THERMOSTAT3.filler = 0;
 		lcmd.THERMOSTAT3.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.THERMOSTAT3)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeThermostat4:
@@ -12468,18 +12538,18 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.THERMOSTAT4.unitcode3 = ID4;
 		lcmd.THERMOSTAT4.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.THERMOSTAT4.mode, options))
-		return SL_ERROR;
+		return false;
 		level = 15;
 		lcmd.THERMOSTAT4.filler = 0;
 		lcmd.THERMOSTAT4.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.THERMOSTAT4)))
-		return SL_ERROR;
+		return false;
 		if (!IsTesting) {
 		//send to internal for now (later we use the ACK)
 		PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t *)&lcmd, NULL, -1);
 		}
 		*/
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeRemote:
@@ -12495,12 +12565,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.REMOTE.toggle = 0;
 		lcmd.REMOTE.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.REMOTE)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeEvohomeRelay:
@@ -12518,12 +12588,12 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			lcmd.demand = level;
 
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(_tEVOHOME3)))
-			return SL_ERROR;
+			return false;
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
 	break;
 	case pTypeRadiator1:
@@ -12539,7 +12609,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.RADIATOR1.id4 = ID4;
 		lcmd.RADIATOR1.unitcode = Unit;
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, lcmd.RADIATOR1.cmnd, options))
-			return SL_ERROR;
+			return false;
 		if (level > 15)
 			level = 15;
 		lcmd.RADIATOR1.temperature = 0;
@@ -12547,36 +12617,15 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		lcmd.RADIATOR1.filler = 0;
 		lcmd.RADIATOR1.rssi = 12;
 		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
-			return SL_ERROR;
+			return false;
 
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			lcmd.RADIATOR1.subtype = sTypeSmartwaresSwitchRadiator;
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
+		return true;
 	}
-	break;
-	case pTypeHoneywell_AL:
-	{
-		level = 15;
-		tRBUF lcmd;
-		lcmd.HONEYWELL_AL.packetlength = sizeof(lcmd.HONEYWELL_AL) - 1;
-		lcmd.HONEYWELL_AL.packettype = dType;
-		lcmd.HONEYWELL_AL.subtype = dSubType;
-		lcmd.HONEYWELL_AL.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
-		lcmd.HONEYWELL_AL.knock = (Unit & 0xF0) >> 4;
-		lcmd.HONEYWELL_AL.alert = Unit & 0x0F;
-		lcmd.CHIME.rssi = 12;
-		if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.HONEYWELL_AL)))
-			return SL_ERROR;
-		if (!IsTesting) {
-			//send to internal for now (later we use the ACK)
-			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&lcmd, nullptr, -1, User.c_str());
-		}
-		return SL_OK;
-	}
-	break;
 	case pTypeGeneralSwitch:
 	{
 		tRBUF lcmd;
@@ -12588,7 +12637,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 		gswitch.unitcode = Unit;
 
 		if (!GetLightCommand(dType, dSubType, switchtype, switchcmd, gswitch.cmnd, options))
-			return SL_ERROR;
+			return false;
 
 		if ((switchtype != STYPE_Selector) && (dSubType != sSwitchGeneralSwitch))
 		{
@@ -12609,61 +12658,34 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLightInt(const std::vector<
 			if ((switchcmd == "Set Level") || (switchcmd == "Set Group Level")) {
 				std::map<std::string, std::string> statuses;
 				GetSelectorSwitchStatuses(options, statuses);
-				int maxLevel = static_cast<int>(statuses.size() - 1) * 10;
+				int maxLevel = static_cast<int>(statuses.size()) * 10;
 
-				if (
-					(level < 0)
-					|| (level > maxLevel)
-					)
-				{
+				level = (level < 0) ? 0 : level;
+				level = (level > maxLevel) ? maxLevel : level;
+
+				std::stringstream sslevel;
+				sslevel << level;
+				if (statuses[sslevel.str()].empty()) {
 					_log.Log(LOG_ERROR, "Setting a wrong level value %d to Selector device %lu", level, ID);
-					return SL_ERROR;
 				}
 			}
 		}
-#ifdef WITH_OPENZWAVE
-		else if (pHardware->HwdType == HTYPE_OpenZWave)
-		{
-			if (
-				(switchtype == STYPE_BlindsPercentage)
-				|| (switchtype == STYPE_BlindsPercentageWithStop)
-				|| (switchtype == STYPE_VenetianBlindsUS)
-				|| (switchtype == STYPE_VenetianBlindsEU)
-				)
-			{
-				if (
-					(gswitch.cmnd == gswitch_sSetLevel)
-					&& (level == 100)
-					)
-				{
-					//For Multilevel switches, 255 (0xFF) means Restore to most recent (non-zero) level,
-					//which is perfect for dimmers, but for blinds (and using the slider), we set it to 99%
-					//this should be done in the openzwave class, but it is deprecated and will be removed soon
-					level = 99;
-					if (gswitch.cmnd == gswitch_sOpen)
-					{
-						gswitch.cmnd = gswitch_sSetLevel;
-					}
-				}
-			}
-		}
-#endif
+
 		gswitch.level = (uint8_t)level;
 		gswitch.rssi = 12;
 		if (switchtype != STYPE_Motion) //dont send actual motion off command
 		{
 			if (!WriteToHardware(HardwareID, (const char*)&gswitch, sizeof(_tGeneralSwitch)))
-				return SL_ERROR;
+				return false;
 		}
 		if (!IsTesting) {
 			//send to internal for now (later we use the ACK)
 			PushAndWaitRxMessage(m_hardwaredevices[hindex], (const uint8_t*)&gswitch, nullptr, -1, User.c_str());
 		}
-		return SL_OK;
 	}
-	break;
+	return true;
 	}
-	return SL_ERROR;
+	return false;
 }
 
 bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& status, const std::string& action, const std::string& ooc, const std::string& until)
@@ -12675,28 +12697,7 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 		idx.c_str());
 	if (result.empty())
 		return false;
-
 	std::vector<std::string> sd = result[0];
-
-	int HardwareID = atoi(sd[0].c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-		return false;
-
-	//uint8_t Unit = atoi(sd[2].c_str());
-	//uint8_t dType = atoi(sd[3].c_str());
-	//uint8_t dSubType = atoi(sd[4].c_str());
-	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
-
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SwitchEvoModal(idx, status, action, ooc, until);
-	}
 
 	int nStatus = 0;
 	if (status == "Away")
@@ -12715,6 +12716,21 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 	int nValue = atoi(sd[7].c_str());
 	if (ooc == "1" && nValue == nStatus)
 		return false;//FIXME not an error ... status = (already set)
+
+	int HardwareID = atoi(sd[0].c_str());
+	int hindex = FindDomoticzHardware(HardwareID);
+	if (hindex == -1)
+		return false;
+
+	//uint8_t Unit = atoi(sd[2].c_str());
+	//uint8_t dType = atoi(sd[3].c_str());
+	//uint8_t dSubType = atoi(sd[4].c_str());
+	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
+
+	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
+	if (pHardware == nullptr)
+		return false;
+
 
 	unsigned long ID;
 	std::stringstream s_strid;
@@ -12744,7 +12760,7 @@ bool MainWorker::SwitchEvoModal(const std::string& idx, const std::string& statu
 	return true;
 }
 
-MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const std::string& idx, const std::string& switchcmd, const std::string& level, const std::string& color, const std::string& ooc, const int ExtraDelay, const std::string& User)
+bool MainWorker::SwitchLight(const std::string& idx, const std::string& switchcmd, const std::string& level, const std::string& color, const std::string& ooc, const int ExtraDelay, const std::string& User)
 {
 	uint64_t ID = std::stoull(idx);
 	int ilevel = -1;
@@ -12754,7 +12770,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const std::string& id
 	return SwitchLight(ID, switchcmd, ilevel, _tColor(color), atoi(ooc.c_str()) != 0, ExtraDelay, User);
 }
 
-MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, const int level, _tColor color, const bool ooc, const int ExtraDelay, const std::string& User)
+bool MainWorker::SwitchLight(const uint64_t idx, const std::string& switchcmd, const int level, _tColor color, const bool ooc, const int ExtraDelay, const std::string& User)
 {
 	//Get Device details
 	_log.Debug(DEBUG_NORM, "MAIN SwitchLight idx:%" PRIu64 " cmd:%s lvl:%d ", idx, switchcmd.c_str(), level);
@@ -12763,7 +12779,7 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 		"SELECT HardwareID,DeviceID,Unit,Type,SubType,SwitchType,AddjValue2,nValue,sValue,Name,Options FROM DeviceStatus WHERE (ID == %" PRIu64 ")",
 		idx);
 	if (result.empty())
-		return SL_ERROR;
+		return false;
 
 	std::vector<std::string> sd = result[0];
 	std::string hwdid = sd[0];
@@ -12794,11 +12810,11 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 	{
 		int nNewVal = bIsOn ? 1 : 0;//Is that everything we need here
 		if ((switchtype == STYPE_Selector) && (nValue == nNewVal) && (level == atoi(sValue.c_str()))) {
-			return SL_OK_NO_ACTION;
+			return true;
 		}
 		if (nValue == nNewVal)
 		{
-			return SL_OK_NO_ACTION;
+			return true;//FIXME no return code for already set
 		}
 	}
 	//Check if we have an On-Delay, if yes, add it to the tasker
@@ -12809,31 +12825,14 @@ MainWorker::eSwitchLightReturnCode MainWorker::SwitchLight(const uint64_t idx, c
 			_log.Log(LOG_NORM, "Delaying switch [%s] action (%s) for %d seconds", devName.c_str(), switchcmd.c_str(), iOnDelay + ExtraDelay);
 		}
 		m_sql.AddTaskItem(_tTaskItem::SwitchLightEvent(static_cast<float>(iOnDelay + ExtraDelay), idx, switchcmd, level, color, "Switch with Delay", User));
-		return SL_OK;
+		return true;
 	}
-
-	int HardwareID = atoi(hwdid.c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-	{
-		_log.Log(LOG_ERROR, "Switch command not send!, Hardware device disabled or not found!");
-		return SL_ERROR;
-	}
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return SL_ERROR;
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP *pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return (MainWorker::eSwitchLightReturnCode)pDomoticz->SwitchLight(idx, switchcmd, level, color, ooc, User);
-	}
-
 	return SwitchLightInt(sd, switchcmd, level, color, false, User);
 }
 
 //Seems this is only called for EvoHome, so this function needs to be moved to the EvoHome (base)class!
 //(and modify Scheduler scripts)
-bool MainWorker::SetSetPointEvo(const std::string& idx, const float TempValue, const std::string& newMode, const std::string& until)
+bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue, const std::string& newMode, const std::string& until)
 {
 	//Get Device details
 	std::vector<std::vector<std::string> > result;
@@ -12854,13 +12853,7 @@ bool MainWorker::SetSetPointEvo(const std::string& idx, const float TempValue, c
 		return false;
 
 	if (pHardware->HwdType != HTYPE_EVOHOME_SCRIPT && pHardware->HwdType != HTYPE_EVOHOME_SERIAL && pHardware->HwdType != HTYPE_EVOHOME_WEB && pHardware->HwdType != HTYPE_EVOHOME_TCP)
-		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SetSetPointEvo(idx, TempValue, newMode, until);
-	}
+		return SetSetPointInt(sd, TempValue);
 
 	int nEvoMode = 0;
 	if (newMode == "PermanentOverride" || newMode.empty())
@@ -12926,22 +12919,6 @@ bool MainWorker::SetSetPoint(const std::string& idx, const float TempValue)
 		return false;
 
 	std::vector<std::string> sd = result[0];
-
-	int HardwareID = atoi(sd[0].c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-		return false;
-
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SetSetPoint(idx, TempValue);
-	}
-
 	return SetSetPointInt(sd, TempValue);
 }
 
@@ -13098,7 +13075,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		}
 		else if (pHardware->HwdType == HTYPE_EVOHOME_SCRIPT || pHardware->HwdType == HTYPE_EVOHOME_SERIAL || pHardware->HwdType == HTYPE_EVOHOME_WEB || pHardware->HwdType == HTYPE_EVOHOME_TCP)
 		{
-			return SetSetPointEvo(sd[7], TempValue, "PermanentOverride", "");
+			return SetSetPoint(sd[7], TempValue, "PermanentOverride", "");
 		}
 		else if (pHardware->HwdType == HTYPE_IntergasInComfortLAN2RF)
 		{
@@ -13163,6 +13140,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	return true;
 }
 
+
 bool MainWorker::SetThermostatState(const std::string& idx, const int newState)
 {
 	//Get Device details
@@ -13180,13 +13158,6 @@ bool MainWorker::SetThermostatState(const std::string& idx, const int newState)
 	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
 	if (pHardware == nullptr)
 		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SetThermostatState(idx, newState);
-	}
-
 	if (pHardware->HwdType == HTYPE_TOONTHERMOSTAT)
 	{
 		CToonThermostat* pGateway = dynamic_cast<CToonThermostat*>(pHardware);
@@ -13239,84 +13210,6 @@ bool MainWorker::SetThermostatState(const std::string& idx, const int newState)
 	return false;
 }
 
-#ifdef WITH_OPENZWAVE
-bool MainWorker::SetZWaveThermostatMode(const std::string& idx, const int tMode)
-{
-	//Get Device details
-	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query(
-		"SELECT HardwareID, DeviceID,Unit,Type,SubType,SwitchType FROM DeviceStatus WHERE (ID == '%q')",
-		idx.c_str());
-	if (result.empty())
-		return false;
-
-	int HardwareID = atoi(result[0][0].c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-		return false;
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SetZWaveThermostatMode(idx, tMode);
-	}
-
-	unsigned long ID;
-	std::stringstream s_strid;
-	s_strid << std::hex << result[0][1];
-	s_strid >> ID;
-
-	if (pHardware->HwdType != HTYPE_OpenZWave)
-		return false;
-	_tGeneralDevice tmeter;
-	tmeter.subtype = sTypeZWaveThermostatMode;
-	tmeter.intval1 = ID;
-	tmeter.intval2 = tMode;
-	return WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tGeneralDevice));
-}
-
-bool MainWorker::SetZWaveThermostatFanMode(const std::string& idx, const int fMode)
-{
-	//Get Device details
-	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query(
-		"SELECT HardwareID, DeviceID,Unit,Type,SubType,SwitchType FROM DeviceStatus WHERE (ID == '%q')",
-		idx.c_str());
-	if (result.empty())
-		return false;
-
-	int HardwareID = atoi(result[0][0].c_str());
-	int hindex = FindDomoticzHardware(HardwareID);
-	if (hindex == -1)
-		return false;
-	CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
-	if (pHardware == nullptr)
-		return false;
-
-	if (pHardware->HwdType == HTYPE_Domoticz)
-	{
-		DomoticzTCP* pDomoticz = static_cast<DomoticzTCP*>(pHardware);
-		return pDomoticz->SetZWaveThermostatFanMode(idx, fMode);
-	}
-	if (pHardware->HwdType != HTYPE_OpenZWave)
-		return false;
-
-	unsigned long ID;
-	std::stringstream s_strid;
-	s_strid << std::hex << result[0][1];
-	s_strid >> ID;
-
-	_tGeneralDevice tmeter;
-	tmeter.subtype = sTypeZWaveThermostatFanMode;
-	tmeter.intval1 = ID;
-	tmeter.intval2 = fMode;
-	return WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tGeneralDevice));
-}
-
-#endif
 
 //returns if a device activates a scene
 bool MainWorker::DoesDeviceActiveAScene(const uint64_t DevRowIdx, const int Cmnd)
@@ -13391,7 +13284,7 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 
 		if (scenetype == SGTYPE_GROUP)
 		{
-			std::vector<std::string> validCmdArray{ "On", "Off", "Toggle", "Group On", "Chime", "All On" };
+			std::vector<std::string> validCmdArray {"On", "Off", "Toggle", "Group On", "Chime", "All On"};
 			if (std::find(validCmdArray.begin(), validCmdArray.end(), switchcmd) == validCmdArray.end())
 				return false;
 			//when asking for Toggle, just switch to the opposite value
@@ -13522,13 +13415,13 @@ bool MainWorker::SwitchScene(const uint64_t idx, std::string switchcmd, const st
 					float fLevel = (maxDimLevel / 100.0F) * level;
 					if (fLevel > 100)
 						fLevel = 100;
-					ilevel = ground(fLevel);
+					ilevel = round(fLevel);
 				}
 				if (switchtype == STYPE_Selector) {
 					if (lstatus != "Set Level") {
 						ilevel = 0;
 					}
-					ilevel = ground(ilevel / 10.0F) * 10; // select only multiples of 10
+					ilevel = round(ilevel / 10.0F) * 10; // select only multiples of 10
 					if (ilevel == 0) {
 						lstatus = "Off";
 					}
@@ -13800,10 +13693,11 @@ void MainWorker::HeartbeatCheck()
 	{
 		if (!pHardware->m_bSkipReceiveCheck)
 		{
-			//Check Thread Timeout
+			//Skip Dummy Hardware
 			bool bDoCheck = (pHardware->HwdType != HTYPE_Dummy) && (pHardware->HwdType != HTYPE_EVOHOME_SCRIPT);
 			if (bDoCheck)
 			{
+				//Check Thread Timeout
 				double diff = difftime(now, pHardware->m_LastHeartbeat);
 				//_log.Log(LOG_STATUS, "%d last checking  %.2lf seconds ago", iterator->first, dif);
 				if (diff > 60)
@@ -13818,12 +13712,28 @@ void MainWorker::HeartbeatCheck()
 				}
 			}
 
-			//Check received data timeout
 			if (pHardware->m_DataTimeout > 0)
 			{
 				//Check Receive Timeout
 				double diff = difftime(now, pHardware->m_LastHeartbeatReceive);
 				bool bHaveDataTimeout = (diff > pHardware->m_DataTimeout);
+				if (!bHaveDataTimeout)
+				{
+					if (
+						(pHardware->HwdType == HTYPE_RFXLAN)
+						|| (pHardware->HwdType == HTYPE_RFXtrx315)
+						|| (pHardware->HwdType == HTYPE_RFXtrx433)
+						|| (pHardware->HwdType == HTYPE_RFXtrx868)
+						)
+					{
+						const CRFXBase* pRFXBase = static_cast<CRFXBase*>(pHardware);
+						if (pRFXBase->m_LastP1Received != 0)
+						{
+							diff = difftime(now, pRFXBase->m_LastP1Received);
+							bHaveDataTimeout = (diff > pHardware->m_DataTimeout);
+						}
+					}
+				}
 				if (bHaveDataTimeout)
 				{
 					std::string sDataTimeout;
@@ -13864,6 +13774,7 @@ void MainWorker::HeartbeatCheck()
 					m_devicestorestart.push_back(pHardware->m_HwdID);
 				}
 			}
+
 		}
 	}
 }
@@ -13872,21 +13783,20 @@ bool MainWorker::UpdateDevice(const int DevIdx, const int nValue, const std::str
 {
 	// Get the raw device parameters
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT HardwareID, OrgHardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID==%d)", DevIdx);
+	result = m_sql.safe_query("SELECT HardwareID, DeviceID, Unit, Type, SubType FROM DeviceStatus WHERE (ID==%d)", DevIdx);
 	if (result.empty())
 		return false;
 
 	int HardwareID = std::stoi(result[0][0]);
-	int OrgHardwareID = std::stoi(result[0][1]);
-	std::string DeviceID = result[0][2];
-	int unit = std::stoi(result[0][3]);
-	int devType = std::stoi(result[0][4]);
-	int subType = std::stoi(result[0][5]);
+	std::string DeviceID = result[0][1];
+	int unit = std::stoi(result[0][2]);
+	int devType = std::stoi(result[0][3]);
+	int subType = std::stoi(result[0][4]);
 
-	return UpdateDevice(HardwareID, OrgHardwareID, DeviceID, unit, devType, subType, nValue, sValue, userName, signallevel, batterylevel, parseTrigger);
+	return UpdateDevice(HardwareID, DeviceID, unit, devType, subType, nValue, sValue, userName, signallevel, batterylevel, parseTrigger);
 }
 
-bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, const std::string& DeviceID, const int unit, const int devType, const int subType, const int nValue, std::string sValue,
+bool MainWorker::UpdateDevice(const int HardwareID, const std::string& DeviceID, const int unit, const int devType, const int subType, const int nValue, std::string sValue,
 	const std::string& userName, const int signallevel, const int batterylevel, const bool parseTrigger)
 {
 	g_bUseEventTrigger = parseTrigger;
@@ -13895,7 +13805,7 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 	{
 		// Prevent hazardous modification of DB from JSON calls
 		std::string devname = "Unknown";
-		uint64_t devidx = m_sql.GetDeviceIndex(HardwareID, OrgHardwareID, DeviceID, unit, devType, subType, devname);
+		uint64_t devidx = m_sql.GetDeviceIndex(HardwareID, DeviceID, unit, devType, subType, devname);
 		if (devidx == (uint64_t)-1)
 			return false;
 		std::stringstream sidx;
@@ -13925,6 +13835,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 		std::stringstream s_strid;
 		s_strid << std::hex << DeviceID;
 		s_strid >> ID;
+
+		float temp = 12345.0F;
 
 		CDomoticzHardwareBase* pHardware = GetHardware(HardwareID);
 		if (pHardware)
@@ -13960,15 +13872,8 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 				return true;
 			}
 
-			if (
-				(devType == pTypeTEMP)
-				|| (devType == pTypeTEMP_HUM)
-				|| (devType == pTypeTEMP_HUM_BARO)
-				|| (devType == pTypeBARO)
-				)
+			if ((devType == pTypeTEMP) || (devType == pTypeTEMP_HUM) || (devType == pTypeTEMP_HUM_BARO) || (devType == pTypeBARO))
 			{
-				float temp = 12345.0F;
-
 				// Adjustment value
 				float AddjValue = 0.0F;
 				float AddjMulti = 1.0F;
@@ -14020,16 +13925,10 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 						sValue = szTmp;
 					}
 				}
-				// Calculate temperature trend
-				if (temp != 12345.0F)
-				{
-					uint64_t tID = ((uint64_t)(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
-					m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
-				}
 			}
 		}
 
-		devidx = m_sql.UpdateValue(HardwareID, OrgHardwareID, DeviceID.c_str(), (const uint8_t)unit, (const uint8_t)devType, (const uint8_t)subType,
+		devidx = m_sql.UpdateValue(HardwareID, DeviceID.c_str(), (const uint8_t)unit, (const uint8_t)devType, (const uint8_t)subType,
 			signallevel,	 // signal level,
 			batterylevel, // battery level
 			nValue, sValue.c_str(), devname,
@@ -14057,27 +13956,22 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 			}
 		}
 
+		// Calculate temperature trend
+		if (temp != 12345.0F)
+		{
+			uint64_t tID = ((uint64_t)(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
+			m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+		}
+
 #ifdef ENABLE_PYTHON
 		// notify plugin
 		m_pluginsystem.DeviceModified(devidx);
 #endif
+
 		// signal connected devices (MQTT, fibaro, http push ... ) about the update
 		sOnDeviceReceived(HardwareID, devidx, devname, nullptr);
-#ifdef WITH_OPENZWAVE
-		if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatMode))
-		{
-			_log.Log(LOG_NORM, "Sending Thermostat Mode to device....");
-			SetZWaveThermostatMode(sidx.str(), nValue);
-		}
-		else if ((devType == pTypeGeneral) && (subType == sTypeZWaveThermostatFanMode))
-		{
-			_log.Log(LOG_NORM, "Sending Thermostat Fan Mode to device....");
-			SetZWaveThermostatFanMode(sidx.str(), nValue);
-		}
-		else if (pHardware)
-#else
+
 		if (pHardware)
-#endif
 		{
 			// Handle Notification
 			m_notifications.CheckAndHandleNotification(devidx, HardwareID, DeviceID, devname, unit, devType, subType, nValue, sValue);
@@ -14093,157 +13987,4 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 	}
 	g_bUseEventTrigger = true;
 	return false;
-}
-
-void MainWorker::HandleHourPrice()
-{
-	int iHP_E_Idx = 0;
-	int iHP_G_Idx = 0;
-	m_sql.GetPreferencesVar("HourIdxElectricityDevice", iHP_E_Idx);
-	m_sql.GetPreferencesVar("HourIdxGasDevice", iHP_G_Idx);
-
-	int SensorTimeOut = 60;
-	m_sql.GetPreferencesVar("SensorTimeout", SensorTimeOut);
-
-	time_t atime = mytime(nullptr);
-	struct tm tm1;
-	localtime_r(&atime, &tm1);
-
-	float fHourPriceE = 0.0f;
-	float fHourPriceG = 0.0f;
-
-	if (iHP_E_Idx != 0)
-	{
-		if (iHP_E_Idx == 0x98765)
-		{
-			int iP1Hardware = m_mainworker.FindDomoticzHardwareByType(HTYPE_P1SmartMeter);
-			if (iP1Hardware == -1)
-				iP1Hardware = m_mainworker.FindDomoticzHardwareByType(HTYPE_P1SmartMeterLAN);
-
-			int nValue = 0;
-			m_sql.GetPreferencesVar("CostEnergy", nValue);
-			float priceT1 = (float)(nValue) / 10000.0F;
-
-			m_sql.GetPreferencesVar("CostEnergyT2", nValue);
-			float priceT2 = (float)(nValue) / 10000.0F;
-
-			if (iP1Hardware != -1)
-			{
-				P1MeterBase* pP1Meter = dynamic_cast<P1MeterBase*>(m_mainworker.GetHardware(iP1Hardware));
-				if (pP1Meter != nullptr)
-				{
-					if (pP1Meter->m_current_tariff == 1)
-						fHourPriceE = priceT1;
-					else
-						fHourPriceE = priceT2;
-				}
-			}
-			else
-			{
-				fHourPriceE = priceT1;
-			}
-		}
-		else
-		{
-			auto result = m_sql.safe_query("SELECT HardwareID, Type, SubType, sValue, LastUpdate, AddjValue2 FROM DeviceStatus WHERE (ID==%d)", iHP_E_Idx);
-			if (!result.empty())
-			{
-				uint8_t hwdID = std::stoi(result[0][0]);
-				const CDomoticzHardwareBase* pHardware = GetHardware(hwdID);
-				if (pHardware != nullptr)
-				{
-					if (pHardware->HwdType == HTYPE_EneverPriceFeeds)
-					{
-						//Make sure the prices are actual
-						Enever* pEnever = dynamic_cast<Enever*>(const_cast<CDomoticzHardwareBase*>(pHardware));
-						pEnever->ActualizePrices();
-						result = m_sql.safe_query("SELECT HardwareID, Type, SubType, sValue, LastUpdate, AddjValue2 FROM DeviceStatus WHERE (ID==%d)", iHP_E_Idx);
-					}
-				}
-
-				uint8_t devType = std::stoi(result[0][1]);
-				uint8_t subType = std::stoi(result[0][2]);
-				std::string sValue = result[0][3];
-				std::string sLastUpdate = result[0][4];
-
-				struct tm ntime;
-				time_t checktime;
-				ParseSQLdatetime(checktime, ntime, sLastUpdate, tm1.tm_isdst);
-
-				if (difftime(atime, checktime) < SensorTimeOut * 60)
-				{
-					if ((devType == pTypeGeneral) && (subType == sTypeCustom))
-					{
-						fHourPriceE = static_cast<float>(atof(sValue.c_str()));
-					}
-					else if ((devType == pTypeGeneral) && (subType == sTypeManagedCounter))
-					{
-						std::vector<std::string> strarray;
-						StringSplit(sValue, ";", strarray);
-						if (strarray.size() == 2)
-						{
-							float AddjValue2 = std::stof(result[0][5]);
-							if (AddjValue2 == 0)
-								AddjValue2 = 1;
-							fHourPriceG = static_cast<float>(atof(strarray[1].c_str())) / AddjValue2;
-						}
-					}
-				}
-			}
-		}
-	}
-	if (iHP_G_Idx != 0)
-	{
-		if (iHP_G_Idx == 0x98765)
-		{
-			int nValue = 0;
-			m_sql.GetPreferencesVar("CostGas", nValue);
-			fHourPriceG = (float)(nValue) / 10000.0F;
-		}
-		else
-		{
-			auto result = m_sql.safe_query("SELECT Type, SubType, sValue, LastUpdate, AddjValue2 FROM DeviceStatus WHERE (ID==%d)", iHP_G_Idx);
-			if (!result.empty())
-			{
-				uint8_t devType = std::stoi(result[0][0]);
-				uint8_t subType = std::stoi(result[0][1]);
-				std::string sValue = result[0][2];
-				std::string sLastUpdate = result[0][3];
-
-				struct tm ntime;
-				time_t checktime;
-				ParseSQLdatetime(checktime, ntime, sLastUpdate, tm1.tm_isdst);
-
-				if (difftime(atime, checktime) < SensorTimeOut * 60)
-				{
-					if ((devType == pTypeGeneral) && (subType == sTypeCustom))
-					{
-						fHourPriceG = static_cast<float>(atof(sValue.c_str()));
-					}
-					else if ((devType == pTypeGeneral) && (subType == sTypeManagedCounter))
-					{
-						std::vector<std::string> strarray;
-						StringSplit(sValue, ";", strarray);
-						if (strarray.size() == 2)
-						{
-							float AddjValue2 = std::stof(result[0][4]);
-							if (AddjValue2 == 0)
-								AddjValue2 = 1;
-							fHourPriceG = static_cast<float>(atof(strarray[1].c_str())) / AddjValue2;
-						}
-					}
-				}
-			}
-		}
-	}
-	m_hourPriceElectricity.timestamp = atime;
-	m_hourPriceGas.timestamp = atime;
-	m_hourPriceWater.timestamp = atime;
-
-	m_hourPriceElectricity.price = fHourPriceE;
-	m_hourPriceGas.price = fHourPriceG;
-
-	int nWaterPrice = 0;
-	m_sql.GetPreferencesVar("CostWater", nWaterPrice);
-	m_hourPriceWater.price = static_cast<float>(nWaterPrice) / 10000.0F;
 }


### PR DESCRIPTION
I changed the sensors to use the HardwareBasesensors.

Only the MAC-adres identifiers and the Rain-sensor is still on Updatevalueint
The Rainsensor is just to verify the correct working of the data.

Also I enabled back the Events and for now the error 'User usage' is not happening anymore 
If this error comes back the events need to be block again.