### PR TITLE
Fix for Meter computed summation

### DIFF
--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -979,137 +979,6 @@ namespace Plugins {
 
 			std::string sID = std::to_string(self->ID);
 
-			// Name change
-			if (Name)
-			{
-				sName = Name;
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("Name", sName, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Description change
-			if (Description)
-			{
-				std::string sDescription = Description;
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("Description", sDescription, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// TypeName change - actually derives new Type, SubType and SwitchType values
-			if (TypeName) {
-				std::string stdsValue;
-				maptypename(std::string(TypeName), iType, iSubType, iSwitchType, stdsValue, pOptionsDict, pOptionsDict);
-
-				// Reset nValue and sValue when changing device types
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("nValue", 0, sID);
-				m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Type change
-			if (iType != self->Type)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("Type", iType, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// SubType change
-			if (iSubType != self->SubType)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("SubType", iSubType, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// SwitchType change
-			if (iSwitchType != self->SwitchType)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("SwitchType", iSwitchType, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Image change
-			if (iImage != self->Image)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("CustomImage", iImage, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// BatteryLevel change
-			if (iBatteryLevel != self->BatteryLevel)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("BatteryLevel", iBatteryLevel, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// SignalLevel change
-			if (iSignalLevel != self->SignalLevel)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("SignalLevel", iSignalLevel, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Used change
-			if (iUsed != self->Used)
-			{
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("Used", iUsed, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Color change
-			if (Color)
-			{
-				std::string	sColor = _tColor(std::string(Color)).toJSONString(); //Parse the color to detect incorrectly formatted color data
-				Py_BEGIN_ALLOW_THREADS
-				m_sql.UpdateDeviceValue("Color", sColor, sID);
-				Py_END_ALLOW_THREADS
-			}
-
-			// Options provided, assume change
-			if (pOptionsDict && PyBorrowedRef(pOptionsDict).IsDict())
-			{
-				if (self->SubType != sTypeCustom)
-				{
-					PyBorrowedRef	pKeyDict, pValueDict;
-					Py_ssize_t pos = 0;
-					std::map<std::string, std::string> mpOptions;
-					while (PyDict_Next(pOptionsDict, &pos, &pKeyDict, &pValueDict))
-					{
-						std::string sOptionName = pKeyDict;
-						std::string sOptionValue = pValueDict;
-						mpOptions.insert(std::pair<std::string, std::string>(sOptionName, sOptionValue));
-					}
-					Py_BEGIN_ALLOW_THREADS
-					m_sql.SetDeviceOptions(self->ID, mpOptions);
-					Py_END_ALLOW_THREADS
-				}
-				else
-				{
-					std::string sOptionValue;
-					PyBorrowedRef	pValue = PyDict_GetItemString(pOptionsDict, "Custom");
-					if (pValue)
-					{
-						sOptionValue = PyUnicode_AsUTF8(pValue);
-					}
-
-					std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
-					Py_BEGIN_ALLOW_THREADS
-					m_sql.UpdateDeviceValue("Options", iUsed, sID);
-					m_sql.safe_query("UPDATE DeviceStatus SET Options='%q', LastUpdate='%q' WHERE (HardwareID==%d) and (Unit==%d)",
-						sOptionValue.c_str(), sLastUpdate.c_str(), self->HwdID, self->Unit);
-					Py_END_ALLOW_THREADS
-				}
-			}
-
 			// TimedOut change (not stored in database, webserver calls back directly to check)
 			if (iTimedOut != self->TimedOut)
 			{
@@ -1168,6 +1037,139 @@ namespace Plugins {
 				Py_END_ALLOW_THREADS
 
 			}
+
+                        // Name change
+                        if (Name)
+                        {
+                                sName = Name;
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Name", sName, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Description change
+                        if (Description)
+                        {
+                                std::string sDescription = Description;
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Description", sDescription, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // TypeName change - actually derives new Type, SubType and SwitchType values
+                        if (TypeName) {
+                                std::string stdsValue;
+                                maptypename(std::string(TypeName), iType, iSubType, iSwitchType, stdsValue, pOptionsDict, pOptionsDict);
+
+                                // Reset nValue and sValue when changing device types
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("nValue", 0, sID);
+                                m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Type change
+                        if (iType != self->Type)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Type", iType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // SubType change
+                        if (iSubType != self->SubType)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("SubType", iSubType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // SwitchType change
+                        if (iSwitchType != self->SwitchType)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("SwitchType", iSwitchType, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Image change
+                        if (iImage != self->Image)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("CustomImage", iImage, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // BatteryLevel change
+                        if (iBatteryLevel != self->BatteryLevel)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("BatteryLevel", iBatteryLevel, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // SignalLevel change
+                        if (iSignalLevel != self->SignalLevel)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("SignalLevel", iSignalLevel, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Used change
+                        if (iUsed != self->Used)
+                        {
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Used", iUsed, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Color change
+                        if (Color)
+                        {
+                                std::string     sColor = _tColor(std::string(Color)).toJSONString(); //Parse the color to detect incorrectly formatted color data
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("Color", sColor, sID);
+                                Py_END_ALLOW_THREADS
+                        }
+
+                        // Options provided, assume change
+                        if (pOptionsDict && PyBorrowedRef(pOptionsDict).IsDict())
+                        {
+                                if (self->SubType != sTypeCustom)
+                                {
+                                        PyBorrowedRef   pKeyDict, pValueDict;
+                                        Py_ssize_t pos = 0;
+                                        std::map<std::string, std::string> mpOptions;
+                                        while (PyDict_Next(pOptionsDict, &pos, &pKeyDict, &pValueDict))
+                                        {
+                                                std::string sOptionName = pKeyDict;
+                                                std::string sOptionValue = pValueDict;
+                                                mpOptions.insert(std::pair<std::string, std::string>(sOptionName, sOptionValue));
+                                        }
+                                        Py_BEGIN_ALLOW_THREADS
+                                        m_sql.SetDeviceOptions(self->ID, mpOptions);
+                                        Py_END_ALLOW_THREADS
+                                }
+                                else
+                                {
+                                        std::string sOptionValue;
+                                        PyBorrowedRef   pValue = PyDict_GetItemString(pOptionsDict, "Custom");
+                                        if (pValue)
+                                        {
+                                                sOptionValue = PyUnicode_AsUTF8(pValue);
+                                        }
+
+                                        std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
+                                        Py_BEGIN_ALLOW_THREADS
+                                        m_sql.UpdateDeviceValue("Options", iUsed, sID);
+                                        m_sql.safe_query("UPDATE DeviceStatus SET Options='%q', LastUpdate='%q' WHERE (HardwareID==%d) and (Unit==%d)",
+                                                sOptionValue.c_str(), sLastUpdate.c_str(), self->HwdID, self->Unit);
+                                        Py_END_ALLOW_THREADS
+                                }
+                        }
+
+
 
 			CDevice_refresh(self);
 		}


### PR DESCRIPTION
When we update a meter widget that is compute mode, domoticz does the computation based on the lastupdate of the widget However if some options of the widget are modified as well (eg: signallevel), then the widget will be updated before we update the meter widget, hence generating a wrong summation as the lastupdate has just been updated.
Hence this fix revert the logic to update the widget main value first then update the options.
I suppose the same fix is needed on the extended api but I have no way to test it thouroughly.
