### PR TITLE
Fix a typo on initial sValue for General/kWh typename

### DIFF
--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -415,7 +415,7 @@ namespace Plugins {
 		else if (sTypeName == "Leaf Wetness")			SubType = sTypeLeafWetness;
 		else if (sTypeName == "kWh")
 		{
-			sValue = "0; 0.0";
+			sValue = "0;0.0";
 			SubType = sTypeKwh;
 		}
 		else if (sTypeName == "Current (Single)")		SubType = sTypeCurrent;


### PR DESCRIPTION
Suppress a space after semi-column