### PR TITLE
Allow to optionally force lastUpdate for SendSwitch and use it for Enocean Smoke Detector

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -675,7 +675,7 @@ void CDomoticzHardwareBase::SendSwitchUnchecked(int NodeID, uint8_t ChildID, int
 
 
 void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const bool bOn, const double Level, const std::string &defaultname, const std::string &userName,
-				       const int RssiLevel /* =12 */, const bool bForceLastUpdate /* =false */)
+				       const int RssiLevel /* =12 */, const bool bForceDbUpdate /* =false */)
 {
 	double rlevel = (16.0 / 100.0) * Level;
 	int level = int(rlevel);
@@ -692,7 +692,7 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 				  int(pTypeLighting2), int(sTypeAC));
 	if (!result.empty())
 	{
-		//check if we have a change, if not only update the LastUpdate field if forceLastUpdate
+		//check if we have a change, and if not only update the BatteryLevel and LastUpdate fields if bForceDbUpdate
 		bool bNoChange = false;
 		int nvalue = atoi(result[0][1].c_str());
 		if ((!bOn) && (nvalue == light2_sOff))
@@ -706,8 +706,8 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 		}
 		if (bNoChange)
 		{
-			if (bForceLastUpdate)
-				m_sql.UpdateLastUpdate(result[0][0]);
+			if (bForceDbUpdate)
+				m_sql.UpdateDeviceValue("BatteryLevel", BatteryLevel, result[0][0]);
 			return;
 		}
 	}

--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -688,7 +688,7 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 
 	std::string sIdx = std_format("%X%02X%02X%02X", ID1, ID2, ID3, ID4);
 	std::vector<std::vector<std::string> > result;
-	result = m_sql.safe_query("SELECT Name,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d) AND (Type==%d) AND (Subtype==%d)", m_HwdID, sIdx.c_str(), ChildID,
+	result = m_sql.safe_query("SELECT ID,nValue,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d) AND (Type==%d) AND (Subtype==%d)", m_HwdID, sIdx.c_str(), ChildID,
 				  int(pTypeLighting2), int(sTypeAC));
 	if (!result.empty())
 	{
@@ -707,10 +707,7 @@ void CDomoticzHardwareBase::SendSwitch(const int NodeID, const uint8_t ChildID, 
 		if (bNoChange)
 		{
 			if (bForceLastUpdate)
-			{
-				std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
-				m_sql.safe_query("UPDATE DeviceStatus SET LastUpdate='%q' WHERE (HardwareID == %d) AND (DeviceID == '%q')", sLastUpdate.c_str(), m_HwdID, sIdx.c_str());
-			}
+				m_sql.UpdateLastUpdate(result[0][0]);
 			return;
 		}
 	}

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -94,7 +94,7 @@ class CDomoticzHardwareBase : public StoppableTask
 	void SendLuxSensor(uint8_t NodeID, uint8_t ChildID, uint8_t BatteryLevel, float Lux, const std::string &defaultname);
 	void SendAirQualitySensor(uint8_t NodeID, uint8_t ChildID, int BatteryLevel, int AirQuality, const std::string &defaultname);
 	void SendSwitchUnchecked(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12);
-	void SendSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12);
+	void SendSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12, bool bForceLastUpdate = false);
 	void SendSwitchIfNotExists(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &userName, const std::string &defaultname);
 	void SendRGBWSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, int Level, bool bIsRGBW, const std::string &defaultname, const std::string &userName);
 	void SendGeneralSwitch(int NodeID, int ChildID, int BatteryLevel, uint8_t SwitchState, uint8_t Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12);

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -94,7 +94,7 @@ class CDomoticzHardwareBase : public StoppableTask
 	void SendLuxSensor(uint8_t NodeID, uint8_t ChildID, uint8_t BatteryLevel, float Lux, const std::string &defaultname);
 	void SendAirQualitySensor(uint8_t NodeID, uint8_t ChildID, int BatteryLevel, int AirQuality, const std::string &defaultname);
 	void SendSwitchUnchecked(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12);
-	void SendSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12, bool bForceLastUpdate = false);
+	void SendSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12, bool bForceDbUpdate = false);
 	void SendSwitchIfNotExists(int NodeID, uint8_t ChildID, int BatteryLevel, bool bOn, double Level, const std::string &userName, const std::string &defaultname);
 	void SendRGBWSwitch(int NodeID, uint8_t ChildID, int BatteryLevel, int Level, bool bIsRGBW, const std::string &defaultname, const std::string &userName);
 	void SendGeneralSwitch(int NodeID, int ChildID, int BatteryLevel, uint8_t SwitchState, uint8_t Level, const std::string &defaultname, const std::string &userName, int RssiLevel = 12);

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -3558,7 +3558,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 					Debug(DEBUG_NORM, "RPS msg: Node %08X (%s) Smoke alarm %s Energy level %s",
 						senderID, pNode->name.c_str(), SMO ? "ON" : "OFF", (battery_level > 5) ? "OK" : "LOW");
 
-					SendSwitch(senderID, 1, battery_level, SMO, 0, pNode->name, m_Name, rssi);
+					SendSwitch(senderID, 1, battery_level, SMO, 0, pNode->name, m_Name, rssi, true);
 					return;
 				}
 				Log(LOG_ERROR, "RPS msg: Node %08X (%s) EEP %02X-%02X-%02X not supported",


### PR DESCRIPTION
Smoke Detector status nearly never change, but sends a periodic status as a freshness info (for enocean F6-05-02, During "Alarm OFF" state, the "Alarm OFF" message shall be repeated every 20 minutes). 
This allows to update the associated 'lastUpdate' field of the db to know that the detector is still alive.

note : revival of a part of pretty old PR (#5143) i never took time to update..