### PR TITLE
Update VisualCrossing.cpp

### DIFF
--- a/hardware/VisualCrossing.cpp
+++ b/hardware/VisualCrossing.cpp
@@ -130,7 +130,7 @@ void CVisualCrossing::GetMeterDetails()
 	{
 		if (!HTTPClient::GET(sURL.str(), sResult))
 		{
-			Log(LOG_ERROR, "Error getting http data!.");
+			Log(LOG_ERROR, "Error getting http data for location `" + szLoc + "`!.");
 			if (!sResult.empty())
 				Log(LOG_ERROR, sResult);
 			return;


### PR DESCRIPTION
Made used location visible in log.

Still trying to fix https://github.com/domoticz/domoticz/issues/6176

I have made my own release build with newest code, there it is working.
But still not on latest official beta release...
I am cirious what URL encoded location is being used in the URL to request data from visualcrossing.
And it is nice to see what location is set if others need support because of incorrect syntax etc.