### PR TITLE
Enocean use baseid as senderid

### DIFF
--- a/hardware/EnOceanESP3.h
+++ b/hardware/EnOceanESP3.h
@@ -61,6 +61,7 @@ public:
 
 	uint32_t m_id_base;
 	uint32_t m_id_chip;
+	uint32_t m_id_src;
 
 private:
 	bool StartHardware() override;
@@ -147,7 +148,7 @@ private:
 	uint32_t m_last_blind_nodeID = 0;
 	uint8_t m_last_blind_position = 0xFF;
 	std::string GetDbValue(const char *tableName, const char *fieldName, const char *whereFieldName, const char *whereFielValue);
-	void sendVld(unsigned int sID, unsigned int destID, int channel, int value);
-	void sendVld(unsigned int sID, unsigned int destID, unsigned char *data, int DataLen);
-	uint32_t sendVld(unsigned int unitBaseAddr, unsigned int destID, enocean::T_DATAFIELD *OffsetDes, ...);
+	void sendVld(unsigned int destID, int channel, int value);
+	void sendVld(unsigned int destID, unsigned char *data, int DataLen);
+	uint32_t sendVld(unsigned int destID, enocean::T_DATAFIELD *OffsetDes, ...);
 };

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1657,6 +1657,15 @@
 			</tr>
 		</table>
 	</div>
+	<div id="divenocean">
+		<br>
+		<table class="display" id="hardwareparamusebaseid" border="0" cellpadding="0" cellspacing="20">
+		<tr>
+				<td align="right" style="width:110px"><label for="usebaseid"><span data-i18n="Use base id as source"></span>:</label></td>
+				<td><input type="checkbox" id="usebaseid" name="usebaseid"><label for="usebaseid"></label></td>
+		</tr>
+		</table>
+	</div>
 	<div>
 		<br>
 		<table border="0" cellpadding="0" cellspacing="14">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -483,6 +483,10 @@ define(['app'], function (app) {
 					Mode1 = $("#hardwarecontent #divmodeldenkoviusbdevices #combomodeldenkoviusbdevices option:selected").val();
 				}
 
+				if (text.indexOf("EnOcean") >= 0 && text.indexOf("(ESP3)") >= 0) {
+					Mode1 = $("#hardwarecontent #divenocean #usebaseid").prop("checked") ? 1 : 0;
+				}
+
 				if (text.indexOf("USBtin") >= 0) {
 					//var Typecan = $("#hardwarecontent #divusbtin #combotypecanusbtin option:selected").val();
 					var ActivateMultiblocV8 = $("#hardwarecontent #divusbtin #activateMultiblocV8").prop("checked") ? 1 : 0;
@@ -2108,6 +2112,10 @@ define(['app'], function (app) {
 
 				if (text.indexOf("Denkovi") >= 0) {
 					Mode1 = $("#hardwarecontent #divmodeldenkoviusbdevices #combomodeldenkoviusbdevices option:selected").val();
+				}
+
+				if (text.indexOf("EnOcean") >= 0 && text.indexOf("(ESP3)") >= 0) {
+					Mode1 = $("#hardwarecontent #divenocean #usebaseid").prop("checked") ? 1 : 0;
 				}
 
 				$.ajax({
@@ -4367,6 +4375,8 @@ define(['app'], function (app) {
 
 							} else if (data["Type"].indexOf("Denkovi") >= 0) {
 								$("#hardwarecontent #divmodeldenkoviusbdevices #combomodeldenkoviusbdevices").val(data["Mode1"]);
+							} else if (data["Type"].indexOf("EnOcean") >= 0 && data["Type"].indexOf("(ESP3)") >= 0) {
+								$("#hardwarecontent #divenocean #usebaseid").prop("checked", data["Mode1"] > 0 );
 							}
 						}
 						else if ((((data["Type"].indexOf("LAN") >= 0) || (data["Type"].indexOf("Eco Devices") >= 0) || data["Type"].indexOf("MySensors Gateway with MQTT") >= 0 || data["Type"].indexOf("RFLink Gateway MQTT") >= 0) &&
@@ -5060,6 +5070,7 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divremote").hide();
 			$("#hardwarecontent #divlogin").hide();
 			$("#hardwarecontent #divhttppoller").hide();
+			$("#hardwarecontent #divenocean").hide();
 
 			// Handle plugins 1st because all the text indexof logic below will have unpredictable impacts for plugins
 			// Python Plugins have the plugin name, not the hardware type id, as the value
@@ -5128,6 +5139,9 @@ define(['app'], function (app) {
 				}
 				if (text.indexOf("Denkovi") >= 0) {
 					$("#hardwarecontent #divmodeldenkoviusbdevices").show();
+				}
+				if (text.indexOf("EnOcean") >= 0 && text.indexOf("(ESP3)") >= 0) {
+					$("#hardwarecontent #divenocean").show();
 				}
 				$("#hardwarecontent #divserial").show();
 			}


### PR DESCRIPTION
With this change, one can optionally choose to use the base id of the enocean dongle as sender id, instead of the chip id.
This can be usefull for dongle replacement without the need to re-associate every controller (see https://www.enocean.com/en/faq-knowledge-base/what-is-difference-between-base-id-and-chip-id/).

Note :
- changing the base id of the dongle is out of scope (i did it only once using some python script, and it can be done only a limited number of times). 
- this allowed me to use domoticz along to an existing solution provided in my flat by the builder.
