### PR TITLE
#6196 Update TADO_API_ENVIRONMENT_URL

### DIFF
--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -23,7 +23,7 @@
 #include "Tado.h"
 
 #define TADO_POLL_INTERVAL 30		// The plugin should collect information from the API every n seconds.
-#define TADO_API_ENVIRONMENT_URL "https://my.tado.com/webapp/env.js"
+#define TADO_API_ENVIRONMENT_URL "https://app.tado.com/env.js"
 #define TADO_TOKEN_MAXLOOPS 12		// Default token validity is 600 seconds before it needs to be refreshed.
 									// Each cycle takes 30-35 seconds, so let's stay a bit on the safe side.
 


### PR DESCRIPTION
As discussed in issue #6196, the Tado env URL has been changed, breaking the plugin. This PR updates the url variable to the new target.