### PR TITLE
Update EvohomeWeb.cpp

### DIFF
--- a/hardware/EvohomeWeb.cpp
+++ b/hardware/EvohomeWeb.cpp
@@ -848,7 +848,7 @@ std::string CEvohomeWeb::local_to_utc(const std::string& local_time)
   */
 
 
-#define EVOHOME_HOST "https://tccna.honeywell.com"
+#define EVOHOME_HOST "https://tccna.resideo.com"
 
 
   /************************************************************************


### PR DESCRIPTION
Honeywell endpoint has been replaced by Resideo endpoints.

Honeywell endpoint is still working, but SSL certificate doesn't contain the domain of honeywell.com anymore