### PR TITLE
Rtl433 prevent "Unhandled sensor reading" logging for Generic-Remote device

### DIFF
--- a/hardware/Rtl433.cpp
+++ b/hardware/Rtl433.cpp
@@ -364,6 +364,11 @@ bool CRtl433::ParseData(std::map<std::string, std::string>& data)
 		}
 	}
 
+	if (model == "Generic-Remote") {
+		// prevent "Unhandled sensor reading" logging
+		bDone = true; 
+	}
+
 	if (bDone)
 		return true;
 


### PR DESCRIPTION
Rtl433 Generic-Remote device is logging messages all the time in the Domoticz logfile like the one shown below. This change prevents them.

2025-03-12 10:00:24.652 Status: RTL433: Unhandled sensor reading, please report: ({"time" : "2025-03-12 10:00:23", "model" : "Generic-Remote", "id" : 37418, "cmd" : 14, "tristate" : "XZ0X0XXX001X", "mod" : "ASK", "freq" : 433.973, "rssi" : -0.108, "snr" : 16.670, "noise" : -16.779}