### PR TITLE
Fix AVATTO dimmers not switching on

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -4626,6 +4626,7 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 				if (
 					(m_discovered_devices[pSensor->device_identifiers].manufacturer == "TuYa")
 					|| (m_discovered_devices[pSensor->device_identifiers].manufacturer == "Tuya")
+					|| (m_discovered_devices[pSensor->device_identifiers].manufacturer == "AVATTO")
 					)
 				{
 					root["state"] = (slevel > 0) ? pSensor->payload_on : pSensor->payload_off;


### PR DESCRIPTION
Some Tuya dimmers report different manufacturer names, like 'AVATTO' in this case. Tested with both single and double version.