### PR TITLE
Enocean changes

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -502,7 +502,7 @@ bool CDomoticzHardwareBase::GetWindSensorValue(const int NodeID, int& WindDir, f
 	return bExists;
 }
 
-void CDomoticzHardwareBase::SendWattMeter(const uint8_t NodeID, const uint8_t ChildID, const int BatteryLevel, const float musage, const std::string& defaultname, const int RssiLevel /* =12 */)
+void CDomoticzHardwareBase::SendWattMeter(const int NodeID, const uint8_t ChildID, const int BatteryLevel, const float musage, const std::string& defaultname, const int RssiLevel /* =12 */)
 {
 	if ((musage < -m_sql.m_max_kwh_usage) || (musage > m_sql.m_max_kwh_usage))
 	{
@@ -511,10 +511,11 @@ void CDomoticzHardwareBase::SendWattMeter(const uint8_t NodeID, const uint8_t Ch
 		return;
 	}
 	_tUsageMeter umeter;
-	umeter.id1 = 0;
-	umeter.id2 = 0;
-	umeter.id3 = 0;
-	umeter.id4 = NodeID;
+
+	umeter.id1 = (uint8_t)((NodeID & 0xFF000000) >> 24);
+	umeter.id2 = (uint8_t)((NodeID & 0xFF0000) >> 16);
+	umeter.id3 = (uint8_t)((NodeID & 0xFF00) >> 8);
+	umeter.id4 = (uint8_t)NodeID & 0xFF;
 	umeter.dunit = ChildID;
 	umeter.rssi = RssiLevel;
 	umeter.fusage = musage;

--- a/hardware/DomoticzHardware.h
+++ b/hardware/DomoticzHardware.h
@@ -89,7 +89,7 @@ class CDomoticzHardwareBase : public StoppableTask
 	void SendSetPointSensor(const uint8_t ID1, const uint8_t ID2, const uint8_t ID3, const uint8_t ID4, const uint8_t Unit, const int BatteryLevel, const float Value, const std::string &defaultname);
 	void SendKwhMeterOldWay(int NodeID, int ChildID, int BatteryLevel, double musage, double mtotal, const std::string &defaultname, int RssiLevel = 12);
 	void SendKwhMeter(int NodeID, int ChildID, int BatteryLevel, double musage, double mtotal, const std::string &defaultname, int RssiLevel = 12);
-	void SendWattMeter(uint8_t NodeID, uint8_t ChildID, int BatteryLevel, float musage, const std::string &defaultname, int RssiLevel = 12);
+	void SendWattMeter(int NodeID, uint8_t ChildID, int BatteryLevel, float musage, const std::string &defaultname, int RssiLevel = 12);
 	double GetKwhMeter(int NodeID, int ChildID, bool &bExists);
 	void SendLuxSensor(uint8_t NodeID, uint8_t ChildID, uint8_t BatteryLevel, float Lux, const std::string &defaultname);
 	void SendAirQualitySensor(uint8_t NodeID, uint8_t ChildID, int BatteryLevel, int AirQuality, const std::string &defaultname);

--- a/hardware/EnOceanESP3.cpp
+++ b/hardware/EnOceanESP3.cpp
@@ -4035,7 +4035,7 @@ void CEnOceanESP3::ParseERP1Packet(uint8_t *data, uint16_t datalen, uint8_t *opt
 			return;
 
 		default:
-			Log(LOG_ERROR, "ERP1: Node %08X RORG %s (%s) not supported", senderID, GetRORGLabel(RORG), GetRORGDescription(RORG));
+			Log(LOG_ERROR, "ERP1: Node %08X RORG %02X:%s (%s) not supported", senderID, RORG, GetRORGLabel(RORG), GetRORGDescription(RORG));
 	}
 }
 


### PR DESCRIPTION
Current A5-12-00, Automated Meter Reading, Counter implem is a bit wrong : it does not take into account CH and DT fields, mixing unrelated measure (at least for my device that provides several measurement channels and data types).
Use CH field to distinguish devices, and also DT that indicate if we've got a counter (using SendMeterSensor) or instant value measurement (using SendWattMeter).

note : 
- A5-12-00 profile is not explicitly for electric measurements (see https://tools.enocean-alliance.org/EEPViewer/profiles/A5/12/00/A5-12-00.pdf), but i don't know how to deal with this.
- modification in SendWattMeter is probably discussable (don't know the impact on other part of code), but i find it strange to restrict the nodeID to uint8_t where other functions use int ?
