### PR TITLE
bugfix for typename in PythonObjects.cpp

### DIFF
--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -1060,12 +1060,6 @@ namespace Plugins {
                         if (TypeName) {
                                 std::string stdsValue;
                                 maptypename(std::string(TypeName), iType, iSubType, iSwitchType, stdsValue, pOptionsDict, pOptionsDict);
-
-                                // Reset nValue and sValue when changing device types
-                                Py_BEGIN_ALLOW_THREADS
-                                m_sql.UpdateDeviceValue("nValue", 0, sID);
-                                m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
-                                Py_END_ALLOW_THREADS
                         }
 
                         // Type change


### PR DESCRIPTION
in PR #6183 in PythonObjects.cpp the code blocks where moved around in the CDevice_update function.
This leads to default nValue/sValue (e.g. 0°C 50% for Temp+Hum Devices) being written to the database if the function is called with a TypeName value.
With this change the sValue and nValue from the function call are used.
Writing default values did not matter prior to PR #6183 because the nValue and sValue were written to the database later in the function.
Calling CDevice_update (from python) with a TypeName but no nValue and sValue results in an error message. Therefore it seems unnecessary to write default values to the database.