### PR TITLE
bugfix for default values when updating typename

### DIFF
--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -1060,14 +1060,12 @@ namespace Plugins {
                         if (TypeName) {
                                 std::string stdsValue;
                                 maptypename(std::string(TypeName), iType, iSubType, iSwitchType, stdsValue, pOptionsDict, pOptionsDict);
-				if (SuppressTriggers)
-				{
-	                                // Reset nValue and sValue when changing device types
-        	                        Py_BEGIN_ALLOW_THREADS
-                	                m_sql.UpdateDeviceValue("nValue", 0, sID);
-                        	        m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
-                                	Py_END_ALLOW_THREADS
-				}
+
+                                // Reset nValue and sValue when changing device types
+                                Py_BEGIN_ALLOW_THREADS
+                                m_sql.UpdateDeviceValue("nValue", 0, sID);
+                                m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
+                                Py_END_ALLOW_THREADS
                         }
 
                         // Type change

--- a/hardware/plugins/PythonObjects.cpp
+++ b/hardware/plugins/PythonObjects.cpp
@@ -1060,12 +1060,14 @@ namespace Plugins {
                         if (TypeName) {
                                 std::string stdsValue;
                                 maptypename(std::string(TypeName), iType, iSubType, iSwitchType, stdsValue, pOptionsDict, pOptionsDict);
-
-                                // Reset nValue and sValue when changing device types
-                                Py_BEGIN_ALLOW_THREADS
-                                m_sql.UpdateDeviceValue("nValue", 0, sID);
-                                m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
-                                Py_END_ALLOW_THREADS
+				if (SuppressTriggers)
+				{
+	                                // Reset nValue and sValue when changing device types
+        	                        Py_BEGIN_ALLOW_THREADS
+                	                m_sql.UpdateDeviceValue("nValue", 0, sID);
+                        	        m_sql.UpdateDeviceValue("sValue", stdsValue, sID);
+                                	Py_END_ALLOW_THREADS
+				}
                         }
 
                         // Type change


### PR DESCRIPTION
in PR https://github.com/domoticz/domoticz/pull/6183 in PythonObjects.cpp the code blocks where moved around in the CDevice_update function.
This leads to default nValue/sValue (e.g. 0°C 50% for Temp+Hum Devices) being written to the database if the function is called with a TypeName value.
With this change the sValue and nValue from the function call are used.
Writing default values did not matter prior to PR https://github.com/domoticz/domoticz/pull/6183 because the nValue and sValue were written to the database later in the function.

Second try, this way it should be more safe to not break any existing plugins
If the Update function is called with SupressTriggers = false, the nValue and sValue from function call is written to the DB and the default values are not written. If called with SupressTriggers = true, the default nValue and sValue is written to the DB
