### PR TITLE
add scene handling to DomoticzEx Python framework

### DIFF
--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -925,7 +925,6 @@ namespace Plugins {
 				}
 
 				m_mainworker.sOnDeviceReceived(pModState->pPlugin->m_HwdID, self->ID, pModState->pPlugin->m_Name, NULL);
-				m_mainworker.CheckSceneCode(DevRowIdx, (const unsigned char)self->Type, (const unsigned char)self->SubType, nValue, sValue.c_str(), "Python");
 
 				// Only trigger notifications if a used value is changed
 				if (self->Used)

--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -925,6 +925,7 @@ namespace Plugins {
 				}
 
 				m_mainworker.sOnDeviceReceived(pModState->pPlugin->m_HwdID, self->ID, pModState->pPlugin->m_Name, NULL);
+				m_mainworker.CheckSceneCode(DevRowIdx, (const unsigned char)self->Type, (const unsigned char)self->SubType, nValue, sValue.c_str(), "Python");
 
 				// Only trigger notifications if a used value is changed
 				if (self->Used)


### PR DESCRIPTION
When switching form the legacy Python framework to the extended framework I noticed that my scenes stopped working. Upon closer inspection I noticed that the CUnitEx_update function has no code for handling scenes. I copied the missing line from PythonObjects.cpp and with this change scenes work again.