### PR TITLE
During the stop of Domoticz service or reboot of the system a SIGABRT signal is raised randomly causing a crash of domoticz #6310 #6311

### DIFF
--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -935,8 +935,53 @@ void CHardwareMonitor::FetchUnixDisk()
 				char szTmp[300];
 				sprintf(szTmp, "%.2f", UsagedPercentage);
 				std::string hddname = "HDD " + dusage.MountPoint;
+				dindex=0;
+				std::vector<std::vector<std::string> > listOfHdd;
+				listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
+				if (!listOfHdd.empty())
+				{
+					for (const auto& sd : listOfHdd)
+					{
+						std::string idx = sd[0];
+						std::string szDeviceId = sd[1];
+						std::string Name = sd[2];
+						int deviceId;
+						sscanf(szDeviceId.c_str(), "%x", &deviceId);
+						if (!strcmp(Name.c_str(),hddname.c_str()))
+						{	
+							dindex=deviceId;
+							break;
+						}	
+					}
+				}
+				if (dindex==0)					
+				{
+					// new HDD
+					std::vector<std::vector<std::string> > listOfHdd;
+					listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
+					int firstFreedeviceId=1102;
+					if (!listOfHdd.empty())
+					{
+						for (int i=0; i<listOfHdd.size() ; i++)
+						{
+							for (const auto& sd : listOfHdd)
+							{
+								std::string szDeviceId = sd[1];
+								int deviceId;
+								sscanf(szDeviceId.c_str(), "%x", &deviceId);
+								if (firstFreedeviceId==deviceId)
+								{	
+									firstFreedeviceId++;
+									break;
+								}	
+							}
+						}
+					}
+					dindex=firstFreedeviceId;
+				}
+				dindex-=1102;	
+
 				UpdateSystemSensor("Load", 2 + dindex, hddname, szTmp);
-				dindex++;
 			}
 		}
 	}


### PR DESCRIPTION
Hello

1 - Context
Version: 2025.1 (build 16627)
Build Hash: https://github.com/domoticz/domoticz/commit/1eb2e944f05b745c1815062681be3ea5d2352e60-modified
Compile Date: 2025-04-09 08:37:45
dzVents Version: 3.1.8
Python Version: 3.9.2 (default, Dec 1 2024, 12:12:57) [GCC 10.2.1 20210110]

2 - Description of the issue
When stopping Domoticz service either with "sudo service domoticz stop" or "reboot" a SIGABRT signal is raised randomly causing a dump of the stack of the main thread prior to the completion of the stopping process of the domoticz hardwares and finally the end of the "mainworker" thread.

See below an extract of domoticz.log showing the issue
2025-04-17 09:06:32.773 Status: Closing application!...
2025-04-17 09:06:32.773 Status: Stopping worker...
2025-04-17 09:06:32.774 Status: RxQueue: queue worker stopped...
2025-04-17 09:06:33.274 Status: WebServer(HTTP) stopped
2025-04-17 09:06:33.776 Status: WebServer(SSL) stopped
2025-04-17 09:06:33.778 Status: TCPServer: shared server stopped
2025-04-17 09:06:33.778 Status: Stopping all hardware...
2025-04-17 09:06:33.782 Status: RFXCOM: Worker stopped...
2025-04-17 09:06:33.782 Status: Camera Jardin: Stop directive received.
2025-04-17 09:06:33.782 Status: Camera Jardin: onStop called - Begin
2025-04-17 09:06:33.782 Status: Camera Jardin: onStop called - End
2025-04-17 09:06:33.785 Error: Domoticz(pid:176494, tid:1537576('domoticz')) received fatal signal 6 (Aborted)
2025-04-17 09:06:33.785 Error: siginfo address=0x2b16e, address=0x7f0dffc098
2025-04-17 09:06:33.896 Status: Camera Jardin: Exiting work loop.
2025-04-17 09:06:33.982 Status: Camera Jardin: Stopping threads.
2025-04-17 09:06:33.982 Status: Camera Jardin: Stopped.
...
2025-04-17 09:06:37.074 Error: Did not find stack frame for thread (LWP 1537576)), printing full gdb output:
2025-04-17 09:06:37.074 Error: > gdb: warning: Couldn't determine a path for the index cache directory.
2025-04-17 09:06:37.074 Error: > [New LWP 176496]
...
2025-04-17 09:06:37.075 Error: > [Thread debugging using libthread_db enabled]
2025-04-17 09:06:37.075 Error: > Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
...
2025-04-17 09:06:37.076 Error: > Id Target Id Frame
...
2025-04-17 09:06:37.077 Error: > 54 Thread 0x7f0dffdf40 (LWP 1537576) "domoticz" 0x0000007fad16b83c in __GI___wait4 (pid=, stat_loc=0x7f0dffaa24, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27

2025-04-17 09:06:37.077 Error: > Thread 54 (Thread 0x7f0dffdf40 (LWP 1537576) "domoticz"):
2025-04-17 09:06:37.077 Error: > #0 0x0000007fad16b83c in __GI___wait4 (pid=, stat_loc=0x7f0dffaa24, options=0, usage=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:27
2025-04-17 09:06:37.077 Error: > https://github.com/domoticz/domoticz/pull/1 0x000000556fc6c240 in dumpstack_gdb(bool) ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/issues/2 0x000000556fc6c82c in signal_handler(int, siginfo_t*, void*) ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/3
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/4 raise (sig=6) at ../sysdeps/unix/sysv/linux/raise.c:50
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/5
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/6 __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/7 0x0000007fad0e8a60 in __GI_abort () at abort.c:79
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/8 0x000000557025c5d8 in __gnu_cxx::__verbose_terminate_handler() ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/9 0x000000557025afdc in __cxxabiv1::__terminate(void (*)()) ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/10 0x000000557025b040 in std::terminate() ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/11 0x000000557017d77c in boost::asio::detail::posix_thread::funcboost::asio::system_context::thread_function::run() ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/12 0x000000556fde1b3c in boost_asio_detail_posix_thread_function ()
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/pull/13 0x0000007fad302648 in start_thread (arg=0x7f0dffd840) at pthread_create.c:477
2025-04-17 09:06:37.078 Error: > https://github.com/domoticz/domoticz/issues/14 0x0000007fad199c9c in thread_start () at ../sysdeps/unix/sysv/linux/aarch64/clone.S:78

3 - Explanation of the issue
When performing a "sudo service domoticz stop" command the system raises a SIGTERM signal captured by the signal handler (signal_handler function) in SignalHandler.cpp file.
The management of the SIGTERM signal set the flag g_bStopApplication to true starting this way the closure of the domoticz application.
Sometimes a second signal SIGABRT is raised during the domoticz stopping process prior to its ending (see the above extract of the domoticz.log file) leaving this way this process in a pending state. For example not all cleaning activities are done expecially in Python Plugins which may create an abnormal situation when restarting Domoticz.

4 - Proposed solution
I propose to give some time to the main domoticz thread to complete the stopping process prior to ending the SIGABRT signal management.

From a coding perspective it means to keep the current c++ code for the management of the signals SIGSEGV, SIGILL, SIGFPE and to duplicate it to handle the signal SIGABRT first then add the if clause

if (g_bStopApplication)
{
_log.Log(LOG_ERROR, "Domoticz received abort signal - Give main thread a few seconds to shut down");
sleep(30);
}
prior to the sequence:

dumpstack(info, ucontext);
// re-raise signal to enforce core dump
signal(sig_num, SIG_DFL);
raise(sig_num);
break;
.
This way it leaves 30 seconds to domoticz to complete the stopping process.

BR