### PR TITLE
Pressure: allow 2 decimals for pressure sensors

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7012,8 +7012,8 @@ void CSQLHelper::UpdateMeter()
 			}
 			else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
 			{
-				double fValue = atof(sValue.c_str()) * 10.0F;
-				sprintf(szTmp, "%.1f", fValue);
+				double fValue = atof(sValue.c_str()) * 1000.0F;
+				sprintf(szTmp, "%.0f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeUsage)

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7013,7 +7013,7 @@ void CSQLHelper::UpdateMeter()
 			else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
 			{
 				double fValue = atof(sValue.c_str()) * 10.0F;
-				sprintf(szTmp, "%.0f", fValue);
+				sprintf(szTmp, "%.1f", fValue);
 				sValue = szTmp;
 			}
 			else if (dType == pTypeUsage)

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -3342,7 +3342,7 @@ namespace http
 						}
 						else if (dSubType == sTypePressure)
 						{
-							sprintf(szData, "%.1f Bar", atof(sValue.c_str()));
+							sprintf(szData, "%.2f Bar", atof(sValue.c_str()));
 							root["result"][ii]["Data"] = szData;
 							root["result"][ii]["TypeImg"] = "gauge";
 							root["result"][ii]["HaveTimeout"] = bHaveTimeout;

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -620,7 +620,7 @@ namespace http
 						root["status"] = "OK";
 						root["title"] = "Graph " + sensor + " " + srange;
 						float vdiv = 10.0F;
-						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)))
+						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)) || ((dType == pTypeGeneral) && (dSubType == sTypePressure)))
 						{
 							vdiv = 1000.0F;
 						}
@@ -642,6 +642,8 @@ namespace http
 								if ((dType == pTypeGeneral) && (dSubType == sTypeVoltage))
 									sprintf(szTmp, "%.3f", fValue);
 								else if ((dType == pTypeGeneral) && (dSubType == sTypeCurrent))
+									sprintf(szTmp, "%.3f", fValue);
+								else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
 									sprintf(szTmp, "%.3f", fValue);
 								else
 									sprintf(szTmp, "%.1f", fValue);
@@ -2907,7 +2909,7 @@ namespace http
 						root["status"] = "OK";
 
 						float vdiv = 10.0F;
-						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)))
+						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)) || ((dType == pTypeGeneral) && (dSubType == sTypePressure)))
 						{
 							vdiv = 1000.0F;
 						}
@@ -2947,7 +2949,7 @@ namespace http
 										fValue2 *= 0.6214F;
 									}
 								}
-								if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)))
+								if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)) || ((dType == pTypeGeneral) && (dSubType == sTypePressure)))
 								{
 									sprintf(szTmp, "%.3f", fValue1);
 									root["result"][ii]["v_min"] = szTmp;
@@ -3624,7 +3626,7 @@ namespace http
 						((dType == pTypeGeneral) && (dSubType == sTypeSoundLevel)))
 					{
 						float vdiv = 10.0F;
-						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)))
+						if (((dType == pTypeGeneral) && (dSubType == sTypeVoltage)) || ((dType == pTypeGeneral) && (dSubType == sTypeCurrent)) || ((dType == pTypeGeneral) && (dSubType == sTypePressure)))
 						{
 							vdiv = 1000.0F;
 						}
@@ -3655,12 +3657,16 @@ namespace http
 								sprintf(szTmp, "%.3f", fValue1);
 							else if ((dType == pTypeGeneral) && (dSubType == sTypeCurrent))
 								sprintf(szTmp, "%.3f", fValue1);
+							else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
+								sprintf(szTmp, "%.3f", fValue1);
 							else
 								sprintf(szTmp, "%.1f", fValue1);
 							root["result"][ii]["v_min"] = szTmp;
 							if ((dType == pTypeGeneral) && (dSubType == sTypeVoltage))
 								sprintf(szTmp, "%.3f", fValue2);
 							else if ((dType == pTypeGeneral) && (dSubType == sTypeCurrent))
+								sprintf(szTmp, "%.3f", fValue2);
+							else if ((dType == pTypeGeneral) && (dSubType == sTypePressure))
 								sprintf(szTmp, "%.3f", fValue2);
 							else
 								sprintf(szTmp, "%.1f", fValue2);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -10108,7 +10108,7 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 	}
 	else if (subType == sTypePressure)
 	{
-		sprintf(szTmp, "%.1f", pMeter->floatval1);
+		sprintf(szTmp, "%.2f", pMeter->floatval1);
 		DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 		if (DevRowIdx == (uint64_t)-1)
 			return;
@@ -10235,7 +10235,7 @@ void MainWorker::decode_General(const CDomoticzHardwareBase* pHardware, const tR
 			break;
 		case sTypePressure:
 			WriteMessage("subtype       = Pressure");
-			sprintf(szTmp, "Pressure = %.1f bar", pMeter->floatval1);
+			sprintf(szTmp, "Pressure = %.2f bar", pMeter->floatval1);
 			WriteMessage(szTmp);
 			break;
 		case sTypeBaro:


### PR DESCRIPTION
Plugwise Adam reports boiler pressure in 2 decimals, e.g. 1.53 bar, but domoticz internally lops off the second decimal. To make it worse, SQLHelper them drops *all* decimals.

In the context of Plugwise, the difference between '2.49' and '2.00' is significant, presenting and storing both as '2' is very misleading. I noticed this when wanting to use Domoticz to see if the repair to the leak in the central heating was successful.

Increase precision by one decimal everywhere: "%.2f", except for SQLHelper, that changes to "%.1f".

The net result is that data push to e.g. InfluxDB will have actually useful values.