### PR TITLE
Fix issue 6310

### DIFF
--- a/tcpserver/TCPServer.h
+++ b/tcpserver/TCPServer.h
@@ -63,6 +63,7 @@ public:
 	void stop() override;
 	/// Stop the specified connection.
 	void stopClient(CTCPClient_ptr c) override;
+	bool flghandle_stop_Completed;
 
 private:
 	void handleAccept(const boost::system::error_code& error);


### PR DESCRIPTION
During the shutdown of TCPServer shared server make sure that Thread 2 (CTCPServerInt::handle_stop()) has completed its job before Thread 1 (Domoticz) deletes the TCP Server object.