### PR TITLE
Support for Multicast DNS so User can browse to domoticz.local:<port> (no need to know IP-address)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,7 +515,7 @@ include_directories(${CMAKE_SOURCE_DIR}/main)
 ADD_CUSTOM_TARGET(revisiontag ALL)
 
 # creates appversion.h using cmake script
-ADD_CUSTOM_COMMAND(TARGET revisiontag COMMAND ${CMAKE_COMMAND}
+ADD_CUSTOM_COMMAND(TARGET revisiontag PRE_BUILD COMMAND ${CMAKE_COMMAND}
    -DSOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}
    -P ${CMAKE_CURRENT_SOURCE_DIR}/getgit.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,7 @@ main/WebServerCommands.cpp
 main/WebServerHandleGraph.cpp
 main/WebServerHelper.cpp
 main/WindCalculation.cpp
+mdns/mdns.cpp
 iamserver/IamService.cpp
 push/BasePush.cpp
 push/FibaroPush.cpp

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -32,6 +32,8 @@
 #include "appversion.h"
 #include "SignalHandler.h"
 
+#include "../mdns/mdns.hpp"
+
 #if defined WIN32
 	#include "../msbuild/WindowsHelper.h"
 	#include <Shlobj.h>
@@ -75,6 +77,7 @@ namespace
 #endif
 		"\t-webroot additional web root, useful with proxy servers (for example domoticz)\n"
 		"\t-nocache ask browser not to cache pages\n"
+		"\t-nomdns do not enable mDNS broadcast and listening\n"
 		"\t-startupdelay seconds (default=0)\n"
 		"\t-nowwwpwd (in case you forgot the web server username/password)\n"
 		"\t-wwwcompress mode (on = always compress [default], off = always decompress, static = no processing but try precompressed first)\n"
@@ -130,6 +133,7 @@ std::string dbasefile;
 std::string szCertFile = "./server_cert.pem";
 bool bDoCachePages = true;
 bool bNoCleanupDev = false;
+bool bEnableMDNS = true;
 
 std::string szAppVersion="???";
 int iAppRevision=0;
@@ -145,6 +149,7 @@ CLogger _log;
 http::server::CWebServerHelper m_webservers;
 CSQLHelper m_sql;
 CNotificationHelper m_notifications;
+domoticz_mdns::mDNS m_mdns;
 
 std::string logfile;
 std::string weblogfile;
@@ -1075,6 +1080,11 @@ int main(int argc, char**argv)
 	{
 		bNoCleanupDev = true;
 	}
+	if (cmdLine.HasSwitch("-nomdns"))
+	{
+		bEnableMDNS = false;
+	}
+
 #if defined WIN32
 	if (!bUseConfigFile) {
 		if (cmdLine.HasSwitch("-nobrowser"))

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1114,14 +1114,6 @@ bool MainWorker::Start()
 		return false;
 	}
 
-	std::string sValue;
-	std::string szInstanceName = "domoticz";
-	if(m_sql.GetPreferencesVar("Title", sValue))
-	{
-		stdlower(sValue);
-		szInstanceName = sValue;
-	}
-
 	HTTPClient::SetUserAgent(GenerateUserAgent());
 	m_notifications.Init();
 	GetSunSettings();
@@ -1169,7 +1161,7 @@ bool MainWorker::Start()
 	{
 		m_webservers.SetAllowPlainBasicAuth(static_cast<bool>(nValue));
 	}
-	sValue = "";	// Reset sValue
+	std::string sValue;
 	if (m_sql.GetPreferencesVar("WebTheme", sValue))
 	{
 		m_webservers.SetWebTheme(sValue);
@@ -1195,14 +1187,22 @@ bool MainWorker::Start()
 
 	if (bEnableMDNS)
 	{
+		std::string sValue;
+		std::string szInstanceName = "domoticz";
+		if(m_sql.GetPreferencesVar("Title", sValue))
+		{
+			szInstanceName = sValue;
+		}
+
 		m_mdns.setServiceHostname(szInstanceName);
 		m_mdns.setServicePort(std::stoi(m_webserver_settings.listening_port));
 #ifdef WWW_ENABLE_SSL
 		if (m_secure_webserver_settings.is_enabled())
 			m_mdns.setServicePort(std::stoi(m_secure_webserver_settings.listening_port));
 #endif
-		m_mdns.setServiceTxtRecord(std::string{"version"}, szAppVersion);
-		m_mdns.setServiceTxtRecord(std::string{"path"}, std::string{"/index.html"});
+		m_mdns.addServiceTxtRecord(std::string{"app"}, "domoticz");
+		m_mdns.addServiceTxtRecord(std::string{"version"}, szAppVersion);
+		m_mdns.addServiceTxtRecord(std::string{"path"}, "/");
 		m_mdns.startService();
 	}
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -1201,9 +1201,9 @@ bool MainWorker::Start()
 		if (m_secure_webserver_settings.is_enabled())
 			m_mdns.setServicePort(std::stoi(m_secure_webserver_settings.listening_port));
 #endif
-		m_mdns.setServiceName("_http._tcp.local");
+		m_mdns.setServiceTxtRecord(std::string{"version"}, szAppVersion);
+		m_mdns.setServiceTxtRecord(std::string{"path"}, std::string{"/index.html"});
 		m_mdns.startService();
-		_log.Log(LOG_STATUS, "mDNS enabled!");
 	}
 
 	HandleHourPrice();

--- a/mdns/include/README.md
+++ b/mdns/include/README.md
@@ -1,0 +1,91 @@
+# Public domain mDNS/DNS-SD library in C
+
+This library provides a header only cross-platform mDNS and DNS-DS library in C. The latest source code is always available at
+
+https://github.com/mjansson/mdns
+
+This library is put in the public domain; you can redistribute it and/or modify it without any restrictions.
+
+Created by Mattias Jansson ([@maniccoder](https://twitter.com/maniccoder))
+
+Discord server for discussions https://discord.gg/M8BwTQrt6c
+
+## Features
+
+The library does DNS-SD discovery and service as well as one-shot single record mDNS query and response. There are no memory allocations done by the library, all buffers used must be passed in by the caller. Custom data for use in processing can be passed along using a user data opaque pointer.
+
+## Usage
+
+The `mdns.c` test executable file demonstrates the use of all features, including discovery, query and service response. The documentation here is intentionally sparse, the example code is well documented and should provide all the details.
+
+### Sockets
+
+Socket for mDNS communication can either be opened by the library by using `mdns_socket_open_ipv4` or `mdns_socket_open_ipv6`, or by initializing an existing socket with `mdns_socket_setup_ipv4` or `mdns_socket_setup_ipv6`. The socket open/setup functions will initialize the socket with multicast membership (including loopback) and set to non-blocking mode.
+
+Call `mdns_socket_close` to close a socket opened with `mdns_socket_open_ipv4` or `mdns_socket_open_ipv6`.
+
+#### Port
+
+To open/setup the socket for one-shot queries you can pass a null pointer socket address, or set the port in the passed socket address to 0. This will bind the socket to a random ephemeral local UDP port as required by the RFCs for one-shot queries. You should NOT bind to port 5353 when doing one-shot queries (see the RFC for details).,
+
+To open/setup the socket for service, responding to incoming queries, you need pass in a socket address structure with the port set to 5353 (defined by MDNS_PORT in the header). You cannot pick any other port or you will not recieve any incoming queries.
+
+#### Network interface
+
+To do discovery or queries on the default network interface, you can pass a null pointer as socket address in the socket create/setup functions. This will bind the socket to the default network interface. Otherwise you should enumerate the available interfaces and pass the appropriate socket address to the create/setup function. See the example program in `mdns.c` for an example implementation of doing this for both IPv4 and IPv6.
+
+If you want to do mDNS service response to incoming queries, you do not need to enumerate interfaces to do service response on all interfaces as sockets receive data from all interfaces. See the example program in `mdns.c` for an example of setting up a service socket for both IPv4 and IPv6.
+
+### Discovery
+
+To send a DNS-SD service discovery request use `mdns_discovery_send`. This will send a single multicast packet (single PTR question record for `_services._dns-sd._udp.local.`) requesting a unicast response.
+
+To read discovery responses use `mdns_discovery_recv`. All records received since last call will be piped to the callback supplied in the function call. The entry type will be one of `MDNS_ENTRYTYPE_ANSWER`, `MDNS_ENTRYTYPE_AUTHORITY` and `MDNS_ENTRYTYPE_ADDITIONAL`.
+
+### Query
+
+To send a one-shot mDNS query for a single record use `mdns_query_send`. This will send a single multicast packet for the given record and name (for example PTR record for `_http._tcp.local.`). You can optionally pass in a query ID for the query for later filtering of responses (even though this is discouraged by the RFC), or pass 0 to be fully compliant. The function returns the query ID associated with this query, which if non-zero can be used to filter responses in `mdns_query_recv`. If the socket is bound to port 5353 a multicast response is requested, otherwise a unicast response.
+
+To read query responses use `mdns_query_recv`. All records received since last call will be piped to the callback supplied in the function call. If `query_id` parameter is non-zero the function will filter out any response with a query ID that does not match the given query ID. The entry type will be one of `MDNS_ENTRYTYPE_ANSWER`, `MDNS_ENTRYTYPE_AUTHORITY` and `MDNS_ENTRYTYPE_ADDITIONAL`.
+
+Note that a socket opened for one-shot queries from an emphemeral port will not recieve any unsolicited answers (announces) as these are sent as a multicast on port 5353.
+
+To send multiple queries in the same packet use `mdns_multiquery_send` which takes an array and count of service names and record types to query for.
+
+### Service
+
+To listen for incoming DNS-SD requests and mDNS queries the socket can be opened/setup on the default interface by passing 0 as socket address in the call to the socket open/setup functions (the socket will receive data from all network interfaces). Then call `mdns_socket_listen` either on notification of incoming data, or by setting blocking mode and calling `mdns_socket_listen` to block until data is available and parsed.
+
+The entry type passed to the callback will be `MDNS_ENTRYTYPE_QUESTION` and record type indicates which record to respond with. The example program responds to SRV, PTR, A and AAAA records. Use the `mdns_string_extract` function to get the name string of the service record that was asked for.
+
+If service record name is `_services._dns-sd._udp.local.` you should use `mdns_discovery_answer` to send the records of the services you provide (DNS-SD).
+
+If the service record name is a service you provide, use `mdns_query_answer_unicast` or `mdns_query_answer_multicast` depending on the response type flag in the question to send the service details back in response to the query.
+
+See the test executable implementation for more details on how to handle the parameters to the given functions.
+
+### Announce
+
+If you provide a mDNS service listening and answering queries on port 5353 it is encouraged to send announcement on startup of your service (as an unsolicited answer). Use the `mdns_announce_multicast` to announce the records for your service at startup, and `mdns_goodbye_multicast` to announce the end of service on termination.
+
+## Test executable
+The `mdns.c` file contains a test executable implementation using the library to do DNS-SD and mDNS queries. Compile into an executable and run to see command line options for discovery, query and service modes.
+
+### Windows
+
+#### Microsoft compiler
+`cl mdns.c /Zi /Fdmdns.pdb /link /out:mdns.exe ws2_32.lib iphlpapi.lib`
+
+### Linux
+
+#### GCC
+`gcc -o mdns mdns.c`
+
+#### clang
+`clang -o mdns mdns.c`
+
+## Using with cmake, conan or vcpkg
+
+* use cmake with `FetchContent` or install and `find_package`
+* use conan with dependency name `mdns/20200130`, and `find_package` -> https://conan.io/center/mdns/20200130
+* use with vcpkg and cmake: `vcpkg install mdns` and `find_package`

--- a/mdns/include/mdns.h
+++ b/mdns/include/mdns.h
@@ -1,0 +1,1621 @@
+/* mdns.h  -  mDNS/DNS-SD library  -  Public Domain  -  2017 Mattias Jansson
+ *
+ * This library provides a cross-platform mDNS and DNS-SD library in C.
+ * The implementation is based on RFC 6762 and RFC 6763.
+ *
+ * The latest source code is always available at
+ *
+ * https://github.com/mjansson/mdns
+ *
+ * This library is put in the public domain; you can redistribute it and/or modify it without any
+ * restrictions.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fcntl.h>
+#ifdef _WIN32
+#include <Winsock2.h>
+#include <Ws2tcpip.h>
+#define strncasecmp _strnicmp
+#else
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MDNS_INVALID_POS ((size_t)-1)
+
+#define MDNS_STRING_CONST(s) (s), (sizeof((s)) - 1)
+#define MDNS_STRING_ARGS(s) s.str, s.length
+#define MDNS_STRING_FORMAT(s) (int)((s).length), s.str
+
+#define MDNS_POINTER_OFFSET(p, ofs) ((void*)((char*)(p) + (ptrdiff_t)(ofs)))
+#define MDNS_POINTER_OFFSET_CONST(p, ofs) ((const void*)((const char*)(p) + (ptrdiff_t)(ofs)))
+#define MDNS_POINTER_DIFF(a, b) ((size_t)((const char*)(a) - (const char*)(b)))
+
+#define MDNS_PORT 5353
+#define MDNS_UNICAST_RESPONSE 0x8000U
+#define MDNS_CACHE_FLUSH 0x8000U
+#define MDNS_MAX_SUBSTRINGS 64
+
+enum mdns_record_type {
+	MDNS_RECORDTYPE_IGNORE = 0,
+	// Address
+	MDNS_RECORDTYPE_A = 1,
+	// Domain Name pointer
+	MDNS_RECORDTYPE_PTR = 12,
+	// Arbitrary text string
+	MDNS_RECORDTYPE_TXT = 16,
+	// IP6 Address [Thomson]
+	MDNS_RECORDTYPE_AAAA = 28,
+	// Server Selection [RFC2782]
+	MDNS_RECORDTYPE_SRV = 33,
+	// Any available records
+	MDNS_RECORDTYPE_ANY = 255
+};
+
+enum mdns_entry_type {
+	MDNS_ENTRYTYPE_QUESTION = 0,
+	MDNS_ENTRYTYPE_ANSWER = 1,
+	MDNS_ENTRYTYPE_AUTHORITY = 2,
+	MDNS_ENTRYTYPE_ADDITIONAL = 3
+};
+
+enum mdns_class { MDNS_CLASS_IN = 1, MDNS_CLASS_ANY = 255 };
+
+typedef enum mdns_record_type mdns_record_type_t;
+typedef enum mdns_entry_type mdns_entry_type_t;
+typedef enum mdns_class mdns_class_t;
+
+typedef int (*mdns_record_callback_fn)(int sock, const struct sockaddr* from, size_t addrlen,
+                                       mdns_entry_type_t entry, uint16_t query_id, uint16_t rtype,
+                                       uint16_t rclass, uint32_t ttl, const void* data, size_t size,
+                                       size_t name_offset, size_t name_length, size_t record_offset,
+                                       size_t record_length, void* user_data);
+
+typedef struct mdns_string_t mdns_string_t;
+typedef struct mdns_string_pair_t mdns_string_pair_t;
+typedef struct mdns_string_table_item_t mdns_string_table_item_t;
+typedef struct mdns_string_table_t mdns_string_table_t;
+typedef struct mdns_record_t mdns_record_t;
+typedef struct mdns_record_srv_t mdns_record_srv_t;
+typedef struct mdns_record_ptr_t mdns_record_ptr_t;
+typedef struct mdns_record_a_t mdns_record_a_t;
+typedef struct mdns_record_aaaa_t mdns_record_aaaa_t;
+typedef struct mdns_record_txt_t mdns_record_txt_t;
+typedef struct mdns_query_t mdns_query_t;
+
+#ifdef _WIN32
+typedef int mdns_size_t;
+typedef int mdns_ssize_t;
+#else
+typedef size_t mdns_size_t;
+typedef ssize_t mdns_ssize_t;
+#endif
+
+struct mdns_string_t {
+	const char* str;
+	size_t length;
+};
+
+struct mdns_string_pair_t {
+	size_t offset;
+	size_t length;
+	int ref;
+};
+
+struct mdns_string_table_t {
+	size_t offset[16];
+	size_t count;
+	size_t next;
+};
+
+struct mdns_record_srv_t {
+	uint16_t priority;
+	uint16_t weight;
+	uint16_t port;
+	mdns_string_t name;
+};
+
+struct mdns_record_ptr_t {
+	mdns_string_t name;
+};
+
+struct mdns_record_a_t {
+	struct sockaddr_in addr;
+};
+
+struct mdns_record_aaaa_t {
+	struct sockaddr_in6 addr;
+};
+
+struct mdns_record_txt_t {
+	mdns_string_t key;
+	mdns_string_t value;
+};
+
+struct mdns_record_t {
+	mdns_string_t name;
+	mdns_record_type_t type;
+	union mdns_record_data {
+		mdns_record_ptr_t ptr;
+		mdns_record_srv_t srv;
+		mdns_record_a_t a;
+		mdns_record_aaaa_t aaaa;
+		mdns_record_txt_t txt;
+	} data;
+	uint16_t rclass;
+	uint32_t ttl;
+};
+
+struct mdns_header_t {
+	uint16_t query_id;
+	uint16_t flags;
+	uint16_t questions;
+	uint16_t answer_rrs;
+	uint16_t authority_rrs;
+	uint16_t additional_rrs;
+};
+
+struct mdns_query_t {
+	mdns_record_type_t type;
+	const char* name;
+	size_t length;
+};
+
+// mDNS/DNS-SD public API
+
+//! Open and setup a IPv4 socket for mDNS/DNS-SD. To bind the socket to a specific interface, pass
+//! in the appropriate socket address in saddr, otherwise pass a null pointer for INADDR_ANY. To
+//! send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign a
+//! random user level ephemeral port. To run discovery service listening for incoming discoveries
+//! and queries, you must set MDNS_PORT as port.
+static inline int
+mdns_socket_open_ipv4(const struct sockaddr_in* saddr);
+
+//! Setup an already opened IPv4 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//! pass in the appropriate socket address in saddr, otherwise pass a null pointer for INADDR_ANY.
+//! To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign a
+//! random user level ephemeral port. To run discovery service listening for incoming discoveries
+//! and queries, you must set MDNS_PORT as port.
+static inline int
+mdns_socket_setup_ipv4(int sock, const struct sockaddr_in* saddr);
+
+//! Open and setup a IPv6 socket for mDNS/DNS-SD. To bind the socket to a specific interface, pass
+//! in the appropriate socket address in saddr, otherwise pass a null pointer for in6addr_any. To
+//! send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign a
+//! random user level ephemeral port. To run discovery service listening for incoming discoveries
+//! and queries, you must set MDNS_PORT as port.
+static inline int
+mdns_socket_open_ipv6(const struct sockaddr_in6* saddr);
+
+//! Setup an already opened IPv6 socket for mDNS/DNS-SD. To bind the socket to a specific interface,
+//! pass in the appropriate socket address in saddr, otherwise pass a null pointer for in6addr_any.
+//! To send one-shot discovery requests and queries pass a null pointer or set 0 as port to assign a
+//! random user level ephemeral port. To run discovery service listening for incoming discoveries
+//! and queries, you must set MDNS_PORT as port.
+static inline int
+mdns_socket_setup_ipv6(int sock, const struct sockaddr_in6* saddr);
+
+//! Close a socket opened with mdns_socket_open_ipv4 and mdns_socket_open_ipv6.
+static inline void
+mdns_socket_close(int sock);
+
+//! Listen for incoming multicast DNS-SD and mDNS query requests. The socket should have been opened
+//! on port MDNS_PORT using one of the mdns open or setup socket functions. Buffer must be 32 bit
+//! aligned. Parsing is stopped when callback function returns non-zero. Returns the number of
+//! queries parsed.
+static inline size_t
+mdns_socket_listen(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                   void* user_data);
+
+//! Send a multicast DNS-SD reqeuest on the given socket to discover available services. Returns 0
+//! on success, or <0 if error.
+static inline int
+mdns_discovery_send(int sock);
+
+//! Recieve unicast responses to a DNS-SD sent with mdns_discovery_send. Any data will be piped to
+//! the given callback for parsing. Buffer must be 32 bit aligned. Parsing is stopped when callback
+//! function returns non-zero. Returns the number of responses parsed.
+static inline size_t
+mdns_discovery_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                    void* user_data);
+
+//! Send a multicast mDNS query on the given socket for the given service name. The supplied buffer
+//! will be used to build the query packet and must be 32 bit aligned. The query ID can be set to
+//! non-zero to filter responses, however the RFC states that the query ID SHOULD be set to 0 for
+//! multicast queries. The query will request a unicast response if the socket is bound to an
+//! ephemeral port, or a multicast response if the socket is bound to mDNS port 5353. Returns the
+//! used query ID, or <0 if error.
+static inline int
+mdns_query_send(int sock, mdns_record_type_t type, const char* name, size_t length, void* buffer,
+                size_t capacity, uint16_t query_id);
+
+//! Send a multicast mDNS query on the given socket for the given service names. The supplied buffer
+//! will be used to build the query packet and must be 32 bit aligned. The query ID can be set to
+//! non-zero to filter responses, however the RFC states that the query ID SHOULD be set to 0 for
+//! multicast queries. Each additional service name query consists of a triplet - a record type
+//! (mdns_record_type_t), a name string pointer (const char*) and a name length (size_t). The list
+//! of variable arguments should be terminated with a record type of 0. The query will request a
+//! unicast response if the socket is bound to an ephemeral port, or a multicast response if the
+//! socket is bound to mDNS port 5353. Returns the used query ID, or <0 if error.
+static inline int
+mdns_multiquery_send(int sock, const mdns_query_t* query, size_t count, void* buffer,
+                     size_t capacity, uint16_t query_id);
+
+//! Receive unicast responses to a mDNS query sent with mdns_[multi]query_send, optionally filtering
+//! out any responses not matching the given query ID. Set the query ID to 0 to parse all responses,
+//! even if it is not matching the query ID set in a specific query. Any data will be piped to the
+//! given callback for parsing. Buffer must be 32 bit aligned. Parsing is stopped when callback
+//! function returns non-zero. Returns the number of responses parsed.
+static inline size_t
+mdns_query_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                void* user_data, int query_id);
+
+//! Send a variable unicast mDNS query answer to any question with variable number of records to the
+//! given address. Use the top bit of the query class field (MDNS_UNICAST_RESPONSE) in the query
+//! recieved to determine if the answer should be sent unicast (bit set) or multicast (bit not set).
+//! Buffer must be 32 bit aligned. The record type and name should match the data from the query
+//! recieved. Returns 0 if success, or <0 if error.
+static inline int
+mdns_query_answer_unicast(int sock, const void* address, size_t address_size, void* buffer,
+                          size_t capacity, uint16_t query_id, mdns_record_type_t record_type,
+                          const char* name, size_t name_length, mdns_record_t answer,
+                          const mdns_record_t* authority, size_t authority_count,
+                          const mdns_record_t* additional, size_t additional_count);
+
+//! Send a variable multicast mDNS query answer to any question with variable number of records. Use
+//! the top bit of the query class field (MDNS_UNICAST_RESPONSE) in the query recieved to determine
+//! if the answer should be sent unicast (bit set) or multicast (bit not set). Buffer must be 32 bit
+//! aligned. Returns 0 if success, or <0 if error.
+static inline int
+mdns_query_answer_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                            const mdns_record_t* authority, size_t authority_count,
+                            const mdns_record_t* additional, size_t additional_count);
+
+//! Send a variable multicast mDNS announcement (as an unsolicited answer) with variable number of
+//! records.Buffer must be 32 bit aligned. Returns 0 if success, or <0 if error. Use this on service
+//! startup to announce your instance to the local network.
+static inline int
+mdns_announce_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                        const mdns_record_t* authority, size_t authority_count,
+                        const mdns_record_t* additional, size_t additional_count);
+
+//! Send a variable multicast mDNS announcement. Use this on service end for removing the resource
+//! from the local network. The records must be identical to the according announcement.
+static inline int
+mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                       const mdns_record_t* authority, size_t authority_count,
+                       const mdns_record_t* additional, size_t additional_count);
+
+// Parse records functions
+
+//! Parse a PTR record, returns the name in the record
+static inline mdns_string_t
+mdns_record_parse_ptr(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity);
+
+//! Parse a SRV record, returns the priority, weight, port and name in the record
+static inline mdns_record_srv_t
+mdns_record_parse_srv(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity);
+
+//! Parse an A record, returns the IPv4 address in the record
+static inline struct sockaddr_in*
+mdns_record_parse_a(const void* buffer, size_t size, size_t offset, size_t length,
+                    struct sockaddr_in* addr);
+
+//! Parse an AAAA record, returns the IPv6 address in the record
+static inline struct sockaddr_in6*
+mdns_record_parse_aaaa(const void* buffer, size_t size, size_t offset, size_t length,
+                       struct sockaddr_in6* addr);
+
+//! Parse a TXT record, returns the number of key=value records parsed and stores the key-value
+//! pairs in the supplied buffer
+static inline size_t
+mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t length,
+                      mdns_record_txt_t* records, size_t capacity);
+
+// Internal functions
+
+static inline mdns_string_t
+mdns_string_extract(const void* buffer, size_t size, size_t* offset, char* str, size_t capacity);
+
+static inline int
+mdns_string_skip(const void* buffer, size_t size, size_t* offset);
+
+static inline size_t
+mdns_string_find(const char* str, size_t length, char c, size_t offset);
+
+//! Compare if two strings are equal. If the strings are equal it returns >0 and the offset variables are
+//! updated to the end of the corresponding strings. If the strings are not equal it returns 0 and 
+//! the offset variables are NOT updated.
+static inline int
+mdns_string_equal(const void* buffer_lhs, size_t size_lhs, size_t* ofs_lhs, const void* buffer_rhs,
+                  size_t size_rhs, size_t* ofs_rhs);
+
+static inline void*
+mdns_string_make(void* buffer, size_t capacity, void* data, const char* name, size_t length,
+                 mdns_string_table_t* string_table);
+
+static inline size_t
+mdns_string_table_find(mdns_string_table_t* string_table, const void* buffer, size_t capacity,
+                       const char* str, size_t first_length, size_t total_length);
+
+// Implementations
+
+static inline uint16_t
+mdns_ntohs(const void* data) {
+	uint16_t aligned;
+	memcpy(&aligned, data, sizeof(uint16_t));
+	return ntohs(aligned);
+}
+
+static inline uint32_t
+mdns_ntohl(const void* data) {
+	uint32_t aligned;
+	memcpy(&aligned, data, sizeof(uint32_t));
+	return ntohl(aligned);
+}
+
+static inline void*
+mdns_htons(void* data, uint16_t val) {
+	val = htons(val);
+	memcpy(data, &val, sizeof(uint16_t));
+	return MDNS_POINTER_OFFSET(data, sizeof(uint16_t));
+}
+
+static inline void*
+mdns_htonl(void* data, uint32_t val) {
+	val = htonl(val);
+	memcpy(data, &val, sizeof(uint32_t));
+	return MDNS_POINTER_OFFSET(data, sizeof(uint32_t));
+}
+
+static inline int
+mdns_socket_open_ipv4(const struct sockaddr_in* saddr) {
+	int sock = (int)socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock < 0)
+		return -1;
+	if (mdns_socket_setup_ipv4(sock, saddr)) {
+		mdns_socket_close(sock);
+		return -1;
+	}
+	return sock;
+}
+
+static inline int
+mdns_socket_setup_ipv4(int sock, const struct sockaddr_in* saddr) {
+	unsigned char ttl = 1;
+	unsigned char loopback = 1;
+	unsigned int reuseaddr = 1;
+	struct ip_mreq req;
+
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuseaddr, sizeof(reuseaddr));
+#ifdef SO_REUSEPORT
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char*)&reuseaddr, sizeof(reuseaddr));
+#endif
+	setsockopt(sock, IPPROTO_IP, IP_MULTICAST_TTL, (const char*)&ttl, sizeof(ttl));
+	setsockopt(sock, IPPROTO_IP, IP_MULTICAST_LOOP, (const char*)&loopback, sizeof(loopback));
+
+	memset(&req, 0, sizeof(req));
+	req.imr_multiaddr.s_addr = htonl((((uint32_t)224U) << 24U) | ((uint32_t)251U));
+	if (saddr)
+		req.imr_interface = saddr->sin_addr;
+	if (setsockopt(sock, IPPROTO_IP, IP_ADD_MEMBERSHIP, (char*)&req, sizeof(req)))
+		return -1;
+
+	struct sockaddr_in sock_addr;
+	if (!saddr) {
+		memset(&sock_addr, 0, sizeof(struct sockaddr_in));
+		sock_addr.sin_family = AF_INET;
+		sock_addr.sin_addr.s_addr = INADDR_ANY;
+#ifdef __APPLE__
+		sock_addr.sin_len = sizeof(struct sockaddr_in);
+#endif
+	} else {
+		memcpy(&sock_addr, saddr, sizeof(struct sockaddr_in));
+		setsockopt(sock, IPPROTO_IP, IP_MULTICAST_IF, (const char*)&sock_addr.sin_addr,
+		           sizeof(sock_addr.sin_addr));
+#ifndef _WIN32
+		sock_addr.sin_addr.s_addr = INADDR_ANY;
+#endif
+	}
+
+	if (bind(sock, (struct sockaddr*)&sock_addr, sizeof(struct sockaddr_in)))
+		return -1;
+
+#ifdef _WIN32
+	unsigned long param = 1;
+	ioctlsocket(sock, FIONBIO, &param);
+#else
+	const int flags = fcntl(sock, F_GETFL, 0);
+	fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+#endif
+
+	return 0;
+}
+
+static inline int
+mdns_socket_open_ipv6(const struct sockaddr_in6* saddr) {
+	int sock = (int)socket(AF_INET6, SOCK_DGRAM, IPPROTO_UDP);
+	if (sock < 0)
+		return -1;
+	if (mdns_socket_setup_ipv6(sock, saddr)) {
+		mdns_socket_close(sock);
+		return -1;
+	}
+	return sock;
+}
+
+static inline int
+mdns_socket_setup_ipv6(int sock, const struct sockaddr_in6* saddr) {
+	int hops = 1;
+	unsigned int loopback = 1;
+	unsigned int reuseaddr = 1;
+	struct ipv6_mreq req;
+
+	setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (const char*)&reuseaddr, sizeof(reuseaddr));
+#ifdef SO_REUSEPORT
+	setsockopt(sock, SOL_SOCKET, SO_REUSEPORT, (const char*)&reuseaddr, sizeof(reuseaddr));
+#endif
+	setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, (const char*)&hops, sizeof(hops));
+	setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, (const char*)&loopback, sizeof(loopback));
+
+	memset(&req, 0, sizeof(req));
+	req.ipv6mr_multiaddr.s6_addr[0] = 0xFF;
+	req.ipv6mr_multiaddr.s6_addr[1] = 0x02;
+	req.ipv6mr_multiaddr.s6_addr[15] = 0xFB;
+	if (setsockopt(sock, IPPROTO_IPV6, IPV6_JOIN_GROUP, (char*)&req, sizeof(req)))
+		return -1;
+
+	struct sockaddr_in6 sock_addr;
+	if (!saddr) {
+		memset(&sock_addr, 0, sizeof(struct sockaddr_in6));
+		sock_addr.sin6_family = AF_INET6;
+		sock_addr.sin6_addr = in6addr_any;
+#ifdef __APPLE__
+		sock_addr.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+	} else {
+		memcpy(&sock_addr, saddr, sizeof(struct sockaddr_in6));
+		unsigned int ifindex = 0;
+		setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_IF, (const char*)&ifindex, sizeof(ifindex));
+#ifndef _WIN32
+		sock_addr.sin6_addr = in6addr_any;
+#endif
+	}
+
+	if (bind(sock, (struct sockaddr*)&sock_addr, sizeof(struct sockaddr_in6)))
+		return -1;
+
+#ifdef _WIN32
+	unsigned long param = 1;
+	ioctlsocket(sock, FIONBIO, &param);
+#else
+	const int flags = fcntl(sock, F_GETFL, 0);
+	fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+#endif
+
+	return 0;
+}
+
+static inline void
+mdns_socket_close(int sock) {
+#ifdef _WIN32
+	closesocket(sock);
+#else
+	close(sock);
+#endif
+}
+
+static inline int
+mdns_is_string_ref(uint8_t val) {
+	return (0xC0 == (val & 0xC0));
+}
+
+static inline mdns_string_pair_t
+mdns_get_next_substring(const void* rawdata, size_t size, size_t offset) {
+	const uint8_t* buffer = (const uint8_t*)rawdata;
+	mdns_string_pair_t pair = {MDNS_INVALID_POS, 0, 0};
+	if (offset >= size)
+		return pair;
+	if (!buffer[offset]) {
+		pair.offset = offset;
+		return pair;
+	}
+	int recursion = 0;
+	while (mdns_is_string_ref(buffer[offset])) {
+		if (size < offset + 2)
+			return pair;
+
+		offset = mdns_ntohs(MDNS_POINTER_OFFSET(buffer, offset)) & 0x3fff;
+		if (offset >= size)
+			return pair;
+
+		pair.ref = 1;
+		if (++recursion > 16)
+			return pair;
+	}
+
+	size_t length = (size_t)buffer[offset++];
+	if (size < offset + length)
+		return pair;
+
+	pair.offset = offset;
+	pair.length = length;
+
+	return pair;
+}
+
+static inline int
+mdns_string_skip(const void* buffer, size_t size, size_t* offset) {
+	size_t cur = *offset;
+	mdns_string_pair_t substr;
+	unsigned int counter = 0;
+	do {
+		substr = mdns_get_next_substring(buffer, size, cur);
+		if ((substr.offset == MDNS_INVALID_POS) || (counter++ > MDNS_MAX_SUBSTRINGS))
+			return 0;
+		if (substr.ref) {
+			*offset = cur + 2;
+			return 1;
+		}
+		cur = substr.offset + substr.length;
+	} while (substr.length);
+
+	*offset = cur + 1;
+	return 1;
+}
+
+static inline int
+mdns_string_equal(const void* buffer_lhs, size_t size_lhs, size_t* ofs_lhs, const void* buffer_rhs,
+                  size_t size_rhs, size_t* ofs_rhs) {
+	size_t lhs_cur = *ofs_lhs;
+	size_t rhs_cur = *ofs_rhs;
+	size_t lhs_end = MDNS_INVALID_POS;
+	size_t rhs_end = MDNS_INVALID_POS;
+	mdns_string_pair_t lhs_substr;
+	mdns_string_pair_t rhs_substr;
+	unsigned int counter = 0;
+	do {
+		lhs_substr = mdns_get_next_substring(buffer_lhs, size_lhs, lhs_cur);
+		rhs_substr = mdns_get_next_substring(buffer_rhs, size_rhs, rhs_cur);
+		if ((lhs_substr.offset == MDNS_INVALID_POS) || (rhs_substr.offset == MDNS_INVALID_POS) ||
+		    (counter++ > MDNS_MAX_SUBSTRINGS))
+			return 0;
+		if (lhs_substr.length != rhs_substr.length)
+			return 0;
+		if (strncasecmp((const char*)MDNS_POINTER_OFFSET_CONST(buffer_rhs, rhs_substr.offset),
+		                (const char*)MDNS_POINTER_OFFSET_CONST(buffer_lhs, lhs_substr.offset),
+		                rhs_substr.length))
+			return 0;
+		if (lhs_substr.ref && (lhs_end == MDNS_INVALID_POS))
+			lhs_end = lhs_cur + 2;
+		if (rhs_substr.ref && (rhs_end == MDNS_INVALID_POS))
+			rhs_end = rhs_cur + 2;
+		lhs_cur = lhs_substr.offset + lhs_substr.length;
+		rhs_cur = rhs_substr.offset + rhs_substr.length;
+	} while (lhs_substr.length);
+
+	if (lhs_end == MDNS_INVALID_POS)
+		lhs_end = lhs_cur + 1;
+	*ofs_lhs = lhs_end;
+
+	if (rhs_end == MDNS_INVALID_POS)
+		rhs_end = rhs_cur + 1;
+	*ofs_rhs = rhs_end;
+
+	return 1;
+}
+
+static inline mdns_string_t
+mdns_string_extract(const void* buffer, size_t size, size_t* offset, char* str, size_t capacity) {
+	size_t cur = *offset;
+	size_t end = MDNS_INVALID_POS;
+	mdns_string_pair_t substr;
+	mdns_string_t result;
+	result.str = str;
+	result.length = 0;
+	char* dst = str;
+	unsigned int counter = 0;
+	size_t remain = capacity;
+	do {
+		substr = mdns_get_next_substring(buffer, size, cur);
+		if ((substr.offset == MDNS_INVALID_POS) || (counter++ > MDNS_MAX_SUBSTRINGS))
+			return result;
+		if (substr.ref && (end == MDNS_INVALID_POS))
+			end = cur + 2;
+		if (substr.length) {
+			size_t to_copy = (substr.length < remain) ? substr.length : remain;
+			memcpy(dst, (const char*)buffer + substr.offset, to_copy);
+			dst += to_copy;
+			remain -= to_copy;
+			if (remain) {
+				*dst++ = '.';
+				--remain;
+			}
+		}
+		cur = substr.offset + substr.length;
+	} while (substr.length);
+
+	if (end == MDNS_INVALID_POS)
+		end = cur + 1;
+	*offset = end;
+
+	result.length = capacity - remain;
+	return result;
+}
+
+static inline size_t
+mdns_string_table_find(mdns_string_table_t* string_table, const void* buffer, size_t capacity,
+                       const char* str, size_t first_length, size_t total_length) {
+	if (!string_table)
+		return MDNS_INVALID_POS;
+
+	for (size_t istr = 0; istr < string_table->count; ++istr) {
+		if (string_table->offset[istr] >= capacity)
+			continue;
+		size_t offset = 0;
+		mdns_string_pair_t sub_string =
+		    mdns_get_next_substring(buffer, capacity, string_table->offset[istr]);
+		if (!sub_string.length || (sub_string.length != first_length))
+			continue;
+		if (memcmp(str, MDNS_POINTER_OFFSET(buffer, sub_string.offset), sub_string.length))
+			continue;
+
+		// Initial substring matches, now match all remaining substrings
+		offset += first_length + 1;
+		while (offset < total_length) {
+			size_t dot_pos = mdns_string_find(str, total_length, '.', offset);
+			if (dot_pos == MDNS_INVALID_POS)
+				dot_pos = total_length;
+			size_t current_length = dot_pos - offset;
+
+			sub_string =
+			    mdns_get_next_substring(buffer, capacity, sub_string.offset + sub_string.length);
+			if (!sub_string.length || (sub_string.length != current_length))
+				break;
+			if (memcmp(str + offset, MDNS_POINTER_OFFSET(buffer, sub_string.offset),
+			           sub_string.length))
+				break;
+
+			offset = dot_pos + 1;
+		}
+
+		// Return reference offset if entire string matches
+		if (offset >= total_length)
+			return string_table->offset[istr];
+	}
+
+	return MDNS_INVALID_POS;
+}
+
+static inline void
+mdns_string_table_add(mdns_string_table_t* string_table, size_t offset) {
+	if (!string_table)
+		return;
+
+	string_table->offset[string_table->next] = offset;
+
+	size_t table_capacity = sizeof(string_table->offset) / sizeof(string_table->offset[0]);
+	if (++string_table->count > table_capacity)
+		string_table->count = table_capacity;
+	if (++string_table->next >= table_capacity)
+		string_table->next = 0;
+}
+
+static inline size_t
+mdns_string_find(const char* str, size_t length, char c, size_t offset) {
+	const void* found;
+	if (offset >= length)
+		return MDNS_INVALID_POS;
+	found = memchr(str + offset, c, length - offset);
+	if (found)
+		return (size_t)MDNS_POINTER_DIFF(found, str);
+	return MDNS_INVALID_POS;
+}
+
+static inline void*
+mdns_string_make_ref(void* data, size_t capacity, size_t ref_offset) {
+	if (capacity < 2)
+		return 0;
+	return mdns_htons(data, 0xC000 | (uint16_t)ref_offset);
+}
+
+static inline void*
+mdns_string_make(void* buffer, size_t capacity, void* data, const char* name, size_t length,
+                 mdns_string_table_t* string_table) {
+	size_t last_pos = 0;
+	size_t remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (name[length - 1] == '.')
+		--length;
+	while (last_pos < length) {
+		size_t pos = mdns_string_find(name, length, '.', last_pos);
+		size_t sub_length = ((pos != MDNS_INVALID_POS) ? pos : length) - last_pos;
+		size_t total_length = length - last_pos;
+
+		size_t ref_offset =
+		    mdns_string_table_find(string_table, buffer, capacity,
+		                           (char*)MDNS_POINTER_OFFSET(name, last_pos), sub_length,
+		                           total_length);
+		if (ref_offset != MDNS_INVALID_POS)
+			return mdns_string_make_ref(data, remain, ref_offset);
+
+		if (remain <= (sub_length + 1))
+			return 0;
+
+		*(unsigned char*)data = (unsigned char)sub_length;
+		memcpy(MDNS_POINTER_OFFSET(data, 1), name + last_pos, sub_length);
+		mdns_string_table_add(string_table, MDNS_POINTER_DIFF(data, buffer));
+
+		data = MDNS_POINTER_OFFSET(data, sub_length + 1);
+		last_pos = ((pos != MDNS_INVALID_POS) ? pos + 1 : length);
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	}
+
+	if (!remain)
+		return 0;
+
+	*(unsigned char*)data = 0;
+	return MDNS_POINTER_OFFSET(data, 1);
+}
+
+static inline size_t
+mdns_records_parse(int sock, const struct sockaddr* from, size_t addrlen, const void* buffer,
+                   size_t size, size_t* offset, mdns_entry_type_t type, uint16_t query_id,
+                   size_t records, mdns_record_callback_fn callback, void* user_data) {
+	size_t parsed = 0;
+	for (size_t i = 0; i < records; ++i) {
+		size_t name_offset = *offset;
+		mdns_string_skip(buffer, size, offset);
+		if (((*offset) + 10) > size)
+			return parsed;
+		size_t name_length = (*offset) - name_offset;
+		const uint16_t* data = (const uint16_t*)MDNS_POINTER_OFFSET(buffer, *offset);
+
+		uint16_t rtype = mdns_ntohs(data++);
+		uint16_t rclass = mdns_ntohs(data++);
+		uint32_t ttl = mdns_ntohl(data);
+		data += 2;
+		uint16_t length = mdns_ntohs(data++);
+
+		*offset += 10;
+
+		if (length <= (size - (*offset))) {
+			++parsed;
+			if (callback &&
+			    callback(sock, from, addrlen, type, query_id, rtype, rclass, ttl, buffer, size,
+			             name_offset, name_length, *offset, length, user_data))
+				break;
+		}
+
+		*offset += length;
+	}
+	return parsed;
+}
+
+static inline int
+mdns_unicast_send(int sock, const void* address, size_t address_size, const void* buffer,
+                  size_t size) {
+	if (sendto(sock, (const char*)buffer, (mdns_size_t)size, 0, (const struct sockaddr*)address,
+	           (socklen_t)address_size) < 0)
+		return -1;
+	return 0;
+}
+
+static inline int
+mdns_multicast_send(int sock, const void* buffer, size_t size) {
+	struct sockaddr_storage addr_storage;
+	struct sockaddr_in addr;
+	struct sockaddr_in6 addr6;
+	struct sockaddr* saddr = (struct sockaddr*)&addr_storage;
+	socklen_t saddrlen = sizeof(struct sockaddr_storage);
+	if (getsockname(sock, saddr, &saddrlen))
+		return -1;
+	if (saddr->sa_family == AF_INET6) {
+		memset(&addr6, 0, sizeof(addr6));
+		addr6.sin6_family = AF_INET6;
+#ifdef __APPLE__
+		addr6.sin6_len = sizeof(addr6);
+#endif
+		addr6.sin6_addr.s6_addr[0] = 0xFF;
+		addr6.sin6_addr.s6_addr[1] = 0x02;
+		addr6.sin6_addr.s6_addr[15] = 0xFB;
+		addr6.sin6_port = htons((unsigned short)MDNS_PORT);
+		saddr = (struct sockaddr*)&addr6;
+		saddrlen = sizeof(addr6);
+	} else {
+		memset(&addr, 0, sizeof(addr));
+		addr.sin_family = AF_INET;
+#ifdef __APPLE__
+		addr.sin_len = sizeof(addr);
+#endif
+		addr.sin_addr.s_addr = htonl((((uint32_t)224U) << 24U) | ((uint32_t)251U));
+		addr.sin_port = htons((unsigned short)MDNS_PORT);
+		saddr = (struct sockaddr*)&addr;
+		saddrlen = sizeof(addr);
+	}
+
+	if (sendto(sock, (const char*)buffer, (mdns_size_t)size, 0, saddr, saddrlen) < 0)
+		return -1;
+	return 0;
+}
+
+static const uint8_t mdns_services_query[] = {
+    // Query ID
+    0x00, 0x00,
+    // Flags
+    0x00, 0x00,
+    // 1 question
+    0x00, 0x01,
+    // No answer, authority or additional RRs
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    // _services._dns-sd._udp.local.
+    0x09, '_', 's', 'e', 'r', 'v', 'i', 'c', 'e', 's', 0x07, '_', 'd', 'n', 's', '-', 's', 'd',
+    0x04, '_', 'u', 'd', 'p', 0x05, 'l', 'o', 'c', 'a', 'l', 0x00,
+    // PTR record
+    0x00, MDNS_RECORDTYPE_PTR,
+    // QU (unicast response) and class IN
+    0x80, MDNS_CLASS_IN};
+
+static inline int
+mdns_discovery_send(int sock) {
+	return mdns_multicast_send(sock, mdns_services_query, sizeof(mdns_services_query));
+}
+
+static inline size_t
+mdns_discovery_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                    void* user_data) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	mdns_ssize_t ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	size_t records = 0;
+	const uint16_t* data = (uint16_t*)buffer;
+
+	uint16_t query_id = mdns_ntohs(data++);
+	uint16_t flags = mdns_ntohs(data++);
+	uint16_t questions = mdns_ntohs(data++);
+	uint16_t answer_rrs = mdns_ntohs(data++);
+	uint16_t authority_rrs = mdns_ntohs(data++);
+	uint16_t additional_rrs = mdns_ntohs(data++);
+
+	// According to RFC 6762 the query ID MUST match the sent query ID (which is 0 in our case)
+	if (query_id || (flags != 0x8400))
+		return 0;  // Not a reply to our question
+
+	// It seems some implementations do not fill the correct questions field,
+	// so ignore this check for now and only validate answer string
+	// if (questions != 1)
+	// 	return 0;
+
+	int i;
+	for (i = 0; i < questions; ++i) {
+		size_t offset = MDNS_POINTER_DIFF(data, buffer);
+		size_t verify_offset = 12;
+		// Verify it's our question, _services._dns-sd._udp.local.
+		if (!mdns_string_equal(buffer, data_size, &offset, mdns_services_query,
+		                       sizeof(mdns_services_query), &verify_offset))
+			return 0;
+		data = (const uint16_t*)MDNS_POINTER_OFFSET(buffer, offset);
+
+		uint16_t rtype = mdns_ntohs(data++);
+		uint16_t rclass = mdns_ntohs(data++);
+
+		// Make sure we get a reply based on our PTR question for class IN
+		if ((rtype != MDNS_RECORDTYPE_PTR) || ((rclass & 0x7FFF) != MDNS_CLASS_IN))
+			return 0;
+	}
+
+	for (i = 0; i < answer_rrs; ++i) {
+		size_t offset = MDNS_POINTER_DIFF(data, buffer);
+		size_t verify_offset = 12;
+		// Verify it's an answer to our question, _services._dns-sd._udp.local.
+		size_t name_offset = offset;
+		int is_answer = mdns_string_equal(buffer, data_size, &offset, mdns_services_query,
+		                                  sizeof(mdns_services_query), &verify_offset);
+		if (!is_answer && !mdns_string_skip(buffer, data_size, &offset))
+			break;
+		size_t name_length = offset - name_offset;
+		if ((offset + 10) > data_size)
+			return records;
+		data = (const uint16_t*)MDNS_POINTER_OFFSET(buffer, offset);
+
+		uint16_t rtype = mdns_ntohs(data++);
+		uint16_t rclass = mdns_ntohs(data++);
+		uint32_t ttl = mdns_ntohl(data);
+		data += 2;
+		uint16_t length = mdns_ntohs(data++);
+		if (length > (data_size - offset))
+			return 0;
+
+		if (is_answer) {
+			++records;
+			offset = MDNS_POINTER_DIFF(data, buffer);
+			if (callback &&
+			    callback(sock, saddr, addrlen, MDNS_ENTRYTYPE_ANSWER, query_id, rtype, rclass, ttl,
+			             buffer, data_size, name_offset, name_length, offset, length, user_data))
+				return records;
+		}
+		data = (const uint16_t*)MDNS_POINTER_OFFSET_CONST(data, length);
+	}
+
+	size_t total_records = records;
+	size_t offset = MDNS_POINTER_DIFF(data, buffer);
+	records =
+	    mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                       MDNS_ENTRYTYPE_AUTHORITY, query_id, authority_rrs, callback, user_data);
+	total_records += records;
+	if (records != authority_rrs)
+		return total_records;
+
+	records = mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                             MDNS_ENTRYTYPE_ADDITIONAL, query_id, additional_rrs, callback,
+	                             user_data);
+	total_records += records;
+	if (records != additional_rrs)
+		return total_records;
+
+	return total_records;
+}
+
+static inline size_t
+mdns_socket_listen(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                   void* user_data) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	mdns_ssize_t ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	const uint16_t* data = (const uint16_t*)buffer;
+
+	uint16_t query_id = mdns_ntohs(data++);
+	uint16_t flags = mdns_ntohs(data++);
+	uint16_t questions = mdns_ntohs(data++);
+	uint16_t answer_rrs = mdns_ntohs(data++);
+	uint16_t authority_rrs = mdns_ntohs(data++);
+	uint16_t additional_rrs = mdns_ntohs(data++);
+
+	size_t records;
+	size_t total_records = 0;
+	for (int iquestion = 0; iquestion < questions; ++iquestion) {
+		size_t question_offset = MDNS_POINTER_DIFF(data, buffer);
+		size_t offset = question_offset;
+		size_t verify_offset = 12;
+		int dns_sd = 0;
+		if (mdns_string_equal(buffer, data_size, &offset, mdns_services_query,
+		                      sizeof(mdns_services_query), &verify_offset)) {
+			dns_sd = 1;
+		} else if (!mdns_string_skip(buffer, data_size, &offset)) {
+			break;
+		}
+		size_t length = offset - question_offset;
+		data = (const uint16_t*)MDNS_POINTER_OFFSET_CONST(buffer, offset);
+
+		uint16_t rtype = mdns_ntohs(data++);
+		uint16_t rclass = mdns_ntohs(data++);
+		uint16_t class_without_flushbit = rclass & ~MDNS_CACHE_FLUSH;
+
+		// Make sure we get a question of class IN or ANY
+		if (!((class_without_flushbit == MDNS_CLASS_IN) ||
+		      (class_without_flushbit == MDNS_CLASS_ANY))) {
+			break;
+		}
+
+		if (dns_sd && flags)
+			continue;
+
+		++total_records;
+		if (callback && callback(sock, saddr, addrlen, MDNS_ENTRYTYPE_QUESTION, query_id, rtype,
+		                         rclass, 0, buffer, data_size, question_offset, length,
+		                         question_offset, length, user_data))
+			return total_records;
+	}
+
+	size_t offset = MDNS_POINTER_DIFF(data, buffer);
+	records = mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                             MDNS_ENTRYTYPE_ANSWER, query_id, answer_rrs, callback, user_data);
+	total_records += records;
+	if (records != answer_rrs)
+		return total_records;
+
+	records =
+	    mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                       MDNS_ENTRYTYPE_AUTHORITY, query_id, authority_rrs, callback, user_data);
+	total_records += records;
+	if (records != authority_rrs)
+		return total_records;
+
+	records = mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                             MDNS_ENTRYTYPE_ADDITIONAL, query_id, additional_rrs, callback,
+	                             user_data);
+
+	return total_records;
+}
+
+static inline int
+mdns_query_send(int sock, mdns_record_type_t type, const char* name, size_t length, void* buffer,
+                size_t capacity, uint16_t query_id) {
+	mdns_query_t query;
+	query.type = type;
+	query.name = name;
+	query.length = length;
+	return mdns_multiquery_send(sock, &query, 1, buffer, capacity, query_id);
+}
+
+static inline int
+mdns_multiquery_send(int sock, const mdns_query_t* query, size_t count, void* buffer, size_t capacity,
+                     uint16_t query_id) {
+	if (!count || (capacity < (sizeof(struct mdns_header_t) + (6 * count))))
+		return -1;
+
+	// Ask for a unicast response since it's a one-shot query
+	uint16_t rclass = MDNS_CLASS_IN | MDNS_UNICAST_RESPONSE;
+
+	struct sockaddr_storage addr_storage;
+	struct sockaddr* saddr = (struct sockaddr*)&addr_storage;
+	socklen_t saddrlen = sizeof(addr_storage);
+	if (getsockname(sock, saddr, &saddrlen) == 0) {
+		if ((saddr->sa_family == AF_INET) &&
+		    (ntohs(((struct sockaddr_in*)saddr)->sin_port) == MDNS_PORT))
+			rclass &= ~MDNS_UNICAST_RESPONSE;
+		else if ((saddr->sa_family == AF_INET6) &&
+		         (ntohs(((struct sockaddr_in6*)saddr)->sin6_port) == MDNS_PORT))
+			rclass &= ~MDNS_UNICAST_RESPONSE;
+	}
+
+	struct mdns_header_t* header = (struct mdns_header_t*)buffer;
+	// Query ID
+	header->query_id = htons((unsigned short)query_id);
+	// Flags
+	header->flags = 0;
+	// Questions
+	header->questions = htons((unsigned short)count);
+	// No answer, authority or additional RRs
+	header->answer_rrs = 0;
+	header->authority_rrs = 0;
+	header->additional_rrs = 0;
+	// Fill in questions
+	void* data = MDNS_POINTER_OFFSET(buffer, sizeof(struct mdns_header_t));
+	for (size_t iq = 0; iq < count; ++iq) {
+		// Name string
+		data = mdns_string_make(buffer, capacity, data, query[iq].name, query[iq].length, 0);
+		if (!data)
+			return -1;
+		size_t remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if (remain < 4)
+			return -1;
+		// Record type
+		data = mdns_htons(data, query[iq].type);
+		//! Optional unicast response based on local port, class IN
+		data = mdns_htons(data, rclass);
+	}
+
+	size_t tosend = MDNS_POINTER_DIFF(data, buffer);
+	if (mdns_multicast_send(sock, buffer, (size_t)tosend))
+		return -1;
+	return query_id;
+}
+
+static inline size_t
+mdns_query_recv(int sock, void* buffer, size_t capacity, mdns_record_callback_fn callback,
+                void* user_data, int only_query_id) {
+	struct sockaddr_in6 addr;
+	struct sockaddr* saddr = (struct sockaddr*)&addr;
+	socklen_t addrlen = sizeof(addr);
+	memset(&addr, 0, sizeof(addr));
+#ifdef __APPLE__
+	saddr->sa_len = sizeof(addr);
+#endif
+	mdns_ssize_t ret = recvfrom(sock, (char*)buffer, (mdns_size_t)capacity, 0, saddr, &addrlen);
+	if (ret <= 0)
+		return 0;
+
+	size_t data_size = (size_t)ret;
+	const uint16_t* data = (const uint16_t*)buffer;
+
+	uint16_t query_id = mdns_ntohs(data++);
+	uint16_t flags = mdns_ntohs(data++);
+	uint16_t questions = mdns_ntohs(data++);
+	uint16_t answer_rrs = mdns_ntohs(data++);
+	uint16_t authority_rrs = mdns_ntohs(data++);
+	uint16_t additional_rrs = mdns_ntohs(data++);
+	(void)sizeof(flags);
+
+	if ((only_query_id > 0) && (query_id != only_query_id))
+		return 0;  // Not a reply to the wanted one-shot query
+
+	// Skip questions part
+	int i;
+	for (i = 0; i < questions; ++i) {
+		size_t offset = MDNS_POINTER_DIFF(data, buffer);
+		if (!mdns_string_skip(buffer, data_size, &offset))
+			return 0;
+		data = (const uint16_t*)MDNS_POINTER_OFFSET_CONST(buffer, offset);
+		// Record type and class not used, skip
+		// uint16_t rtype = mdns_ntohs(data++);
+		// uint16_t rclass = mdns_ntohs(data++);
+		data += 2;
+	}
+
+	size_t records = 0;
+	size_t total_records = 0;
+	size_t offset = MDNS_POINTER_DIFF(data, buffer);
+	records = mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                             MDNS_ENTRYTYPE_ANSWER, query_id, answer_rrs, callback, user_data);
+	total_records += records;
+	if (records != answer_rrs)
+		return total_records;
+
+	records =
+	    mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                       MDNS_ENTRYTYPE_AUTHORITY, query_id, authority_rrs, callback, user_data);
+	total_records += records;
+	if (records != authority_rrs)
+		return total_records;
+
+	records = mdns_records_parse(sock, saddr, addrlen, buffer, data_size, &offset,
+	                             MDNS_ENTRYTYPE_ADDITIONAL, query_id, additional_rrs, callback,
+	                             user_data);
+	total_records += records;
+	if (records != additional_rrs)
+		return total_records;
+
+	return total_records;
+}
+
+static inline void*
+mdns_answer_add_question_unicast(void* buffer, size_t capacity, void* data,
+                                 mdns_record_type_t record_type, const char* name,
+                                 size_t name_length, mdns_string_table_t* string_table) {
+	data = mdns_string_make(buffer, capacity, data, name, name_length, string_table);
+	if (!data)
+		return 0;
+	size_t remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (remain < 4)
+		return 0;
+
+	data = mdns_htons(data, record_type);
+	data = mdns_htons(data, MDNS_UNICAST_RESPONSE | MDNS_CLASS_IN);
+
+	return data;
+}
+
+static inline void*
+mdns_answer_add_record_header(void* buffer, size_t capacity, void* data, mdns_record_t record,
+                              mdns_string_table_t* string_table) {
+	data = mdns_string_make(buffer, capacity, data, record.name.str, record.name.length, string_table);
+	if (!data)
+		return 0;
+	size_t remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	if (remain < 10)
+		return 0;
+
+	data = mdns_htons(data, record.type);
+	data = mdns_htons(data, record.rclass);
+	data = mdns_htonl(data, record.ttl);
+	data = mdns_htons(data, 0);  // Length, to be filled later
+	return data;
+}
+
+static inline void*
+mdns_answer_add_record(void* buffer, size_t capacity, void* data, mdns_record_t record,
+                       mdns_string_table_t* string_table) {
+	// TXT records will be coalesced into one record later
+	if (!data || (record.type == MDNS_RECORDTYPE_TXT))
+		return data;
+
+	data = mdns_answer_add_record_header(buffer, capacity, data, record, string_table);
+	if (!data)
+		return 0;
+
+	// Pointer to length of record to be filled at end
+	void* record_length = MDNS_POINTER_OFFSET(data, -2);
+	void* record_data = data;
+
+	size_t remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+	switch (record.type) {
+		case MDNS_RECORDTYPE_PTR:
+			data = mdns_string_make(buffer, capacity, data, record.data.ptr.name.str,
+			                        record.data.ptr.name.length, string_table);
+			break;
+
+		case MDNS_RECORDTYPE_SRV:
+			if (remain <= 6)
+				return 0;
+			data = mdns_htons(data, record.data.srv.priority);
+			data = mdns_htons(data, record.data.srv.weight);
+			data = mdns_htons(data, record.data.srv.port);
+			data = mdns_string_make(buffer, capacity, data, record.data.srv.name.str,
+			                        record.data.srv.name.length, string_table);
+			break;
+
+		case MDNS_RECORDTYPE_A:
+			if (remain < 4)
+				return 0;
+			memcpy(data, &record.data.a.addr.sin_addr.s_addr, 4);
+			data = MDNS_POINTER_OFFSET(data, 4);
+			break;
+
+		case MDNS_RECORDTYPE_AAAA:
+			if (remain < 16)
+				return 0;
+			memcpy(data, &record.data.aaaa.addr.sin6_addr, 16);  // ipv6 address
+			data = MDNS_POINTER_OFFSET(data, 16);
+			break;
+
+		default:
+			break;
+	}
+
+	if (!data)
+		return 0;
+
+	// Fill record length
+	mdns_htons(record_length, (uint16_t)MDNS_POINTER_DIFF(data, record_data));
+	return data;
+}
+
+static inline void
+mdns_record_update_rclass_ttl(mdns_record_t* record, uint16_t rclass, uint32_t ttl) {
+	if (!record->rclass)
+		record->rclass = rclass;
+	if (!record->ttl || !ttl)
+		record->ttl = ttl;
+	record->rclass &= (uint16_t)(MDNS_CLASS_IN | MDNS_CACHE_FLUSH);
+	// Never flush PTR record
+	if (record->type == MDNS_RECORDTYPE_PTR)
+		record->rclass &= ~(uint16_t)MDNS_CACHE_FLUSH;
+}
+
+static inline void*
+mdns_answer_add_txt_record(void* buffer, size_t capacity, void* data, const mdns_record_t* records,
+                           size_t record_count, uint16_t rclass, uint32_t ttl,
+                           mdns_string_table_t* string_table) {
+	// Pointer to length of record to be filled at end
+	void* record_length = 0;
+	void* record_data = 0;
+
+	size_t remain = 0;
+	for (size_t irec = 0; data && (irec < record_count); ++irec) {
+		if (records[irec].type != MDNS_RECORDTYPE_TXT)
+			continue;
+
+		mdns_record_t record = records[irec];
+		mdns_record_update_rclass_ttl(&record, rclass, ttl);
+		if (!record_data) {
+			data = mdns_answer_add_record_header(buffer, capacity, data, record, string_table);
+			if (!data)
+				return data;
+			record_length = MDNS_POINTER_OFFSET(data, -2);
+			record_data = data;
+		}
+
+		// TXT strings are unlikely to be shared, just make then raw. Also need one byte for
+		// termination, thus the <= check
+		size_t string_length = record.data.txt.key.length + record.data.txt.value.length + 1;
+		if (!data)
+			return 0;
+		remain = capacity - MDNS_POINTER_DIFF(data, buffer);
+		if ((remain <= string_length) || (string_length > 0x3FFF))
+			return 0;
+
+		unsigned char* strdata = (unsigned char*)data;
+		*strdata++ = (unsigned char)string_length;
+		memcpy(strdata, record.data.txt.key.str, record.data.txt.key.length);
+		strdata += record.data.txt.key.length;
+		*strdata++ = '=';
+		memcpy(strdata, record.data.txt.value.str, record.data.txt.value.length);
+		strdata += record.data.txt.value.length;
+
+		data = strdata;
+	}
+
+	// Fill record length
+	if (record_data)
+		mdns_htons(record_length, (uint16_t)MDNS_POINTER_DIFF(data, record_data));
+
+	return data;
+}
+
+static inline uint16_t
+mdns_answer_get_record_count(const mdns_record_t* records, size_t record_count) {
+	// TXT records will be coalesced into one record
+	uint16_t total_count = 0;
+	uint16_t txt_record = 0;
+	for (size_t irec = 0; irec < record_count; ++irec) {
+		if (records[irec].type == MDNS_RECORDTYPE_TXT)
+			txt_record = 1;
+		else
+			++total_count;
+	}
+	return total_count + txt_record;
+}
+
+static inline int
+mdns_query_answer_unicast(int sock, const void* address, size_t address_size, void* buffer,
+                          size_t capacity, uint16_t query_id, mdns_record_type_t record_type,
+                          const char* name, size_t name_length, mdns_record_t answer,
+                          const mdns_record_t* authority, size_t authority_count,
+                          const mdns_record_t* additional, size_t additional_count) {
+	if (capacity < (sizeof(struct mdns_header_t) + 32 + 4))
+		return -1;
+
+	// According to RFC 6762:
+	// The cache-flush bit MUST NOT be set in any resource records in a response message
+	// sent in legacy unicast responses to UDP ports other than 5353.
+	uint16_t rclass = MDNS_CLASS_IN;
+	uint32_t ttl = 10;
+
+	// Basic answer structure
+	struct mdns_header_t* header = (struct mdns_header_t*)buffer;
+	header->query_id = htons(query_id);
+	header->flags = htons(0x8400);
+	header->questions = htons(1);
+	header->answer_rrs = htons(1);
+	header->authority_rrs = htons(mdns_answer_get_record_count(authority, authority_count));
+	header->additional_rrs = htons(mdns_answer_get_record_count(additional, additional_count));
+
+	mdns_string_table_t string_table = {{0}, 0, 0};
+	void* data = MDNS_POINTER_OFFSET(buffer, sizeof(struct mdns_header_t));
+
+	// Fill in question
+	data = mdns_answer_add_question_unicast(buffer, capacity, data, record_type, name, name_length,
+	                                        &string_table);
+
+	// Fill in answer
+	answer.rclass = rclass;
+	answer.ttl = ttl;
+	data = mdns_answer_add_record(buffer, capacity, data, answer, &string_table);
+
+	// Fill in authority records
+	for (size_t irec = 0; data && (irec < authority_count); ++irec) {
+		mdns_record_t record = authority[irec];
+		record.rclass = rclass;
+		if (!record.ttl)
+			record.ttl = ttl;
+		data = mdns_answer_add_record(buffer, capacity, data, record, &string_table);
+	}
+	data = mdns_answer_add_txt_record(buffer, capacity, data, authority, authority_count,
+	                                  rclass, ttl, &string_table);
+
+	// Fill in additional records
+	for (size_t irec = 0; data && (irec < additional_count); ++irec) {
+		mdns_record_t record = additional[irec];
+		record.rclass = rclass;
+		if (!record.ttl)
+			record.ttl = ttl;
+		data = mdns_answer_add_record(buffer, capacity, data, record, &string_table);
+	}
+	data = mdns_answer_add_txt_record(buffer, capacity, data, additional, additional_count,
+	                                  rclass, ttl, &string_table);
+	if (!data)
+		return -1;
+
+	size_t tosend = MDNS_POINTER_DIFF(data, buffer);
+	return mdns_unicast_send(sock, address, address_size, buffer, tosend);
+}
+
+static inline int
+mdns_answer_multicast_rclass_ttl(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                                 const mdns_record_t* authority, size_t authority_count,
+                                 const mdns_record_t* additional, size_t additional_count,
+                                 uint16_t rclass, uint32_t ttl) {
+	if (capacity < (sizeof(struct mdns_header_t) + 32 + 4))
+		return -1;
+
+	// Basic answer structure
+	struct mdns_header_t* header = (struct mdns_header_t*)buffer;
+	header->query_id = 0;
+	header->flags = htons(0x8400);
+	header->questions = 0;
+	header->answer_rrs = htons(1);
+	header->authority_rrs = htons(mdns_answer_get_record_count(authority, authority_count));
+	header->additional_rrs = htons(mdns_answer_get_record_count(additional, additional_count));
+
+	mdns_string_table_t string_table = {{0}, 0, 0};
+	void* data = MDNS_POINTER_OFFSET(buffer, sizeof(struct mdns_header_t));
+
+	// Fill in answer
+	mdns_record_t record = answer;
+	mdns_record_update_rclass_ttl(&record, rclass, ttl);
+	data = mdns_answer_add_record(buffer, capacity, data, record, &string_table);
+
+	// Fill in authority records
+	for (size_t irec = 0; data && (irec < authority_count); ++irec) {
+		record = authority[irec];
+		mdns_record_update_rclass_ttl(&record, rclass, ttl);
+		data = mdns_answer_add_record(buffer, capacity, data, record, &string_table);
+	}
+	data = mdns_answer_add_txt_record(buffer, capacity, data, authority, authority_count,
+	                                  rclass, ttl, &string_table);
+
+	// Fill in additional records
+	for (size_t irec = 0; data && (irec < additional_count); ++irec) {
+		record = additional[irec];
+		mdns_record_update_rclass_ttl(&record, rclass, ttl);
+		data = mdns_answer_add_record(buffer, capacity, data, record, &string_table);
+	}
+	data = mdns_answer_add_txt_record(buffer, capacity, data, additional, additional_count,
+	                                  rclass, ttl, &string_table);
+	if (!data)
+		return -1;
+
+	size_t tosend = MDNS_POINTER_DIFF(data, buffer);
+	return mdns_multicast_send(sock, buffer, tosend);
+}
+
+static inline int
+mdns_query_answer_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                            const mdns_record_t* authority, size_t authority_count,
+                            const mdns_record_t* additional, size_t additional_count) {
+	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, answer, authority,
+	                                        authority_count, additional, additional_count,
+	                                        MDNS_CLASS_IN, 60);
+}
+
+static inline int
+mdns_announce_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                        const mdns_record_t* authority, size_t authority_count,
+                        const  mdns_record_t* additional, size_t additional_count) {
+	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, answer, authority,
+	                                        authority_count, additional, additional_count,
+	                                        MDNS_CLASS_IN | MDNS_CACHE_FLUSH, 60);
+}
+
+static inline int
+mdns_goodbye_multicast(int sock, void* buffer, size_t capacity, mdns_record_t answer,
+                       const mdns_record_t* authority, size_t authority_count,
+                       const mdns_record_t* additional, size_t additional_count) {
+	// Goodbye should have ttl of 0
+	return mdns_answer_multicast_rclass_ttl(sock, buffer, capacity, answer, authority,
+	                                        authority_count, additional, additional_count,
+	                                        MDNS_CLASS_IN, 0);
+}
+
+static inline mdns_string_t
+mdns_record_parse_ptr(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity) {
+	// PTR record is just a string
+	if ((size >= offset + length) && (length >= 2))
+		return mdns_string_extract(buffer, size, &offset, strbuffer, capacity);
+	mdns_string_t empty = {0, 0};
+	return empty;
+}
+
+static inline mdns_record_srv_t
+mdns_record_parse_srv(const void* buffer, size_t size, size_t offset, size_t length,
+                      char* strbuffer, size_t capacity) {
+	mdns_record_srv_t srv;
+	memset(&srv, 0, sizeof(mdns_record_srv_t));
+	// Read the service priority, weight, port number and the discovery name
+	// SRV record format (http://www.ietf.org/rfc/rfc2782.txt):
+	// 2 bytes network-order unsigned priority
+	// 2 bytes network-order unsigned weight
+	// 2 bytes network-order unsigned port
+	// string: discovery (domain) name, minimum 2 bytes when compressed
+	if ((size >= offset + length) && (length >= 8)) {
+		const uint16_t* recorddata = (const uint16_t*)MDNS_POINTER_OFFSET_CONST(buffer, offset);
+		srv.priority = mdns_ntohs(recorddata++);
+		srv.weight = mdns_ntohs(recorddata++);
+		srv.port = mdns_ntohs(recorddata++);
+		offset += 6;
+		srv.name = mdns_string_extract(buffer, size, &offset, strbuffer, capacity);
+	}
+	return srv;
+}
+
+static inline struct sockaddr_in*
+mdns_record_parse_a(const void* buffer, size_t size, size_t offset, size_t length,
+                    struct sockaddr_in* addr) {
+	memset(addr, 0, sizeof(struct sockaddr_in));
+	addr->sin_family = AF_INET;
+#ifdef __APPLE__
+	addr->sin_len = sizeof(struct sockaddr_in);
+#endif
+	if ((size >= offset + length) && (length == 4))
+		memcpy(&addr->sin_addr.s_addr, MDNS_POINTER_OFFSET(buffer, offset), 4);
+	return addr;
+}
+
+static inline struct sockaddr_in6*
+mdns_record_parse_aaaa(const void* buffer, size_t size, size_t offset, size_t length,
+                       struct sockaddr_in6* addr) {
+	memset(addr, 0, sizeof(struct sockaddr_in6));
+	addr->sin6_family = AF_INET6;
+#ifdef __APPLE__
+	addr->sin6_len = sizeof(struct sockaddr_in6);
+#endif
+	if ((size >= offset + length) && (length == 16))
+		memcpy(&addr->sin6_addr, MDNS_POINTER_OFFSET(buffer, offset), 16);
+	return addr;
+}
+
+static inline size_t
+mdns_record_parse_txt(const void* buffer, size_t size, size_t offset, size_t length,
+                      mdns_record_txt_t* records, size_t capacity) {
+	size_t parsed = 0;
+	const char* strdata;
+	size_t end = offset + length;
+
+	if (size < end)
+		end = size;
+
+	while ((offset < end) && (parsed < capacity)) {
+		strdata = (const char*)MDNS_POINTER_OFFSET(buffer, offset);
+		size_t sublength = *(const unsigned char*)strdata;
+
+		if (sublength >= (end - offset))
+			break;
+
+		++strdata;
+		offset += sublength + 1;
+
+		size_t separator = sublength;
+		for (size_t c = 0; c < sublength; ++c) {
+			// DNS-SD TXT record keys MUST be printable US-ASCII, [0x20, 0x7E]
+			if ((strdata[c] < 0x20) || (strdata[c] > 0x7E)) {
+				separator = 0;
+				break;
+			}
+			if (strdata[c] == '=') {
+				separator = c;
+				break;
+			}
+		}
+
+		if (!separator)
+			continue;
+
+		if (separator < sublength) {
+			records[parsed].key.str = strdata;
+			records[parsed].key.length = separator;
+			records[parsed].value.str = strdata + separator + 1;
+			records[parsed].value.length = sublength - (separator + 1);
+		} else {
+			records[parsed].key.str = strdata;
+			records[parsed].key.length = sublength;
+			records[parsed].value.str = 0;
+			records[parsed].value.length = 0;
+		}
+
+		++parsed;
+	}
+
+	return parsed;
+}
+
+#ifdef _WIN32
+#undef strncasecmp
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/mdns/mdns.cpp
+++ b/mdns/mdns.cpp
@@ -114,8 +114,12 @@ namespace domoticz_mdns
 		// PTR record reverse mapping "<_service-name>._tcp.local." to
 		// "<hostname>.<_service-name>._tcp.local."
 		service_record.record_ptr.name = to_mdns_str_ref(service_record.service);
-		service_record.record_ptr.type = MDNS_RECORDTYPE_PTR,
-		service_record.record_ptr.data.ptr = mdns_record_ptr_t{.name = to_mdns_str_ref(service_record.service_instance)};
+		service_record.record_ptr.type = MDNS_RECORDTYPE_PTR;
+		{
+			mdns_record_ptr_t ptr;
+			ptr.name = to_mdns_str_ref(service_record.service_instance);
+			service_record.record_ptr.data.ptr = ptr;
+		}
 		service_record.record_ptr.rclass = 0;
 		service_record.record_ptr.ttl = 0;
 
@@ -123,17 +127,25 @@ namespace domoticz_mdns
 		// "<hostname>.local." with port. Set weight & priority to 0.
 		service_record.record_srv.name = to_mdns_str_ref(service_record.service_instance);
 		service_record.record_srv.type = MDNS_RECORDTYPE_SRV;
-		service_record.record_srv.data.srv = mdns_record_srv_t{.priority = 0,
-															.weight = 0,
-															.port = service_record.port,
-															.name = to_mdns_str_ref(service_record.hostname_qualified)};
+		{
+			mdns_record_srv_t srv_data;
+			srv_data.priority = 0;
+			srv_data.weight = 0;
+			srv_data.port = service_record.port;
+			srv_data.name = to_mdns_str_ref(service_record.hostname_qualified);
+			service_record.record_srv.data.srv = srv_data;
+		}
 		service_record.record_srv.rclass = 0;
 		service_record.record_srv.ttl = 0;
 
 		// A/AAAA records mapping "<hostname>.local." to IPv4/IPv6 addresses
 		service_record.record_a.name = to_mdns_str_ref(service_record.hostname_qualified);
 		service_record.record_a.type = MDNS_RECORDTYPE_A;
-		service_record.record_a.data.a = {mdns_record_a_t{.addr = service_record.address_ipv4}};
+		{
+			mdns_record_a_t a_record;
+			a_record.addr = service_record.address_ipv4;
+			service_record.record_a.data.a = a_record;
+		}
 		service_record.record_a.rclass = 0;
 		service_record.record_a.ttl = 0;
 
@@ -520,11 +532,12 @@ namespace domoticz_mdns
 				// service name we advertise, typically on the "<_service-name>._tcp.local." format
 				// Answer PTR record reverse mapping "<_service-name>._tcp.local." to
 				// "<hostname>.<_service-name>._tcp.local."
-				mdns_record_t answer = {.name = name,
-										.type = MDNS_RECORDTYPE_PTR,
-										.data = {mdns_record_ptr_t{name = to_mdns_str_ref(service_record->service)}},
-										.rclass = MDNS_CLASS_IN,
-										.ttl = 60};
+				mdns_record_t answer;
+				answer.name = name;
+				answer.type = MDNS_RECORDTYPE_PTR;
+				answer.data.ptr.name = to_mdns_str_ref(service_record->service);
+				answer.rclass = MDNS_CLASS_IN;
+				answer.ttl = 60;
 				// Send the answer, unicast or multicast depending on flag in query
 				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
 				if (unicast)

--- a/mdns/mdns.cpp
+++ b/mdns/mdns.cpp
@@ -1,3 +1,4 @@
+#include "stdafx.h"
 #include "mdns.hpp"
 
 #include "../main/Logger.h"

--- a/mdns/mdns.cpp
+++ b/mdns/mdns.cpp
@@ -1,0 +1,39 @@
+#include "mdns.hpp"
+
+#include "../main/Logger.h"
+#include "../main/Helper.h"
+
+#include "include/mdns.h"
+
+namespace domoticz_mdns {
+    mDNS::~mDNS() { stopService(); }
+
+    void mDNS::startService(const bool dumpMode) {
+      dumpMode_ = dumpMode;
+      if (running_) {
+        stopService();
+      }
+
+      running_ = true;
+      mdns_worker_thread_ = std::thread([this]() { this->runMainLoop(); });
+      _log.Log(LOG_STATUS, "mDNS service started");
+    }
+
+    void mDNS::stopService() {
+        running_ = false;
+        if (mdns_worker_thread_.joinable()) {
+          mdns_worker_thread_.join();
+        }
+    }
+    
+    bool mDNS::isServiceRunning() { return running_; } 
+      
+    void mDNS::setServiceHostname(const std::string &hostname) { hostname_ = hostname; }
+
+    void mDNS::setServicePort(std::uint16_t port) { port_ = port; }
+
+    void mDNS::setServiceName(const std::string &name) { name_ = name; }
+
+    void mDNS::setServiceTxtRecord(const std::string &txt_record) { txt_record_ = txt_record; }
+
+}

--- a/mdns/mdns.cpp
+++ b/mdns/mdns.cpp
@@ -3,37 +3,771 @@
 #include "../main/Logger.h"
 #include "../main/Helper.h"
 
-#include "include/mdns.h"
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#else
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#endif
 
-namespace domoticz_mdns {
-    mDNS::~mDNS() { stopService(); }
+namespace domoticz_mdns
+{
 
-    void mDNS::startService(const bool dumpMode) {
-      dumpMode_ = dumpMode;
-      if (running_) {
-        stopService();
-      }
+	mdns_string_t to_mdns_str_ref(const std::string &str_ref) { return {str_ref.c_str(), str_ref.length()}; }
 
-      running_ = true;
-      mdns_worker_thread_ = std::thread([this]() { this->runMainLoop(); });
-      _log.Log(LOG_STATUS, "mDNS service started");
-    }
+	mDNS::~mDNS() { stopService(); }
 
-    void mDNS::stopService() {
-        running_ = false;
-        if (mdns_worker_thread_.joinable()) {
-          mdns_worker_thread_.join();
-        }
-    }
-    
-    bool mDNS::isServiceRunning() { return running_; } 
-      
-    void mDNS::setServiceHostname(const std::string &hostname) { hostname_ = hostname; }
+	void mDNS::startService()
+	{
+		if (running_)
+		{
+			stopService();
+		}
 
-    void mDNS::setServicePort(std::uint16_t port) { port_ = port; }
+		if (hostname_.empty() || port_ == 0 || name_.empty())
+		{
+			// We need a hostname and port to start the service
+			_log.Log(LOG_ERROR, "mDNS: Hostname or port not set!");
+			return;
+		}
 
-    void mDNS::setServiceName(const std::string &name) { name_ = name; }
+		running_ = true;
+		mdns_worker_thread_ = std::make_shared<std::thread>([this]() { this->mDnsMainLoop(); });
+		SetThreadName(mdns_worker_thread_->native_handle(), "mDnsWorker");
+		_log.Log(LOG_STATUS, "mDNS: Service started");
+	}
 
-    void mDNS::setServiceTxtRecord(const std::string &txt_record) { txt_record_ = txt_record; }
+	void mDNS::stopService()
+	{
+		if (running_ && mdns_worker_thread_->joinable())
+		{
+			running_ = false;
+			RequestStop();
+			mdns_worker_thread_->join();
+			mdns_worker_thread_.reset();
+			_log.Log(LOG_STATUS, "mDNS: Service stopped");
+		}
+	}
 
+	bool mDNS::isServiceRunning() { return running_; }
+
+	void mDNS::setServiceHostname(const std::string &hostname) { hostname_ = hostname; }
+
+	void mDNS::setServicePort(std::uint16_t port) { port_ = port; }
+
+	void mDNS::setServiceName(const std::string &name) { name_ = name; }
+
+	void mDNS::setServiceTxtRecord(const std::string &txt_record_key, const std::string &txt_record_value)
+	{
+		if (txt_record_key.empty() || txt_record_value.empty())
+			return;
+
+		for (size_t i = 0; i < MDNS_TXT_RECORD_COUNT; ++i) {
+			if (txt_key_pairs_[i].first.empty()) {
+				txt_key_pairs_[i] = {txt_record_key, txt_record_value};
+				break;
+			}
+		}
+	}
+
+	void mDNS::mDnsMainLoop()
+	{
+		constexpr size_t number_of_sockets = 32;
+		int sockets[number_of_sockets];
+
+		const int num_sockets = openServiceSockets(sockets, sizeof(sockets) / sizeof(sockets[0]));
+		if (num_sockets <= 0)
+		{
+			_log.Log(LOG_ERROR, "mDNS: Failed to open any client sockets!");
+			return;
+		}
+
+		if (name_[name_.length() - 1] != '.')
+		name_ += ".";
+
+		ServiceRecord service_record{};
+		service_record.service = name_;
+		service_record.hostname = hostname_;
+		{
+			// Build the service instance "<hostname>.<_service-name>._tcp.local." string
+			std::ostringstream oss;
+			oss << hostname_ << "." << name_;
+			service_record.service_instance = oss.str();
+		}
+		{
+			// Build the "<hostname>.local." string
+			std::ostringstream oss;
+			oss << hostname_ << ".local.";
+			service_record.hostname_qualified = oss.str();
+		}
+		service_record.address_ipv4 = service_address_ipv4_;
+		service_record.address_ipv6 = service_address_ipv6_;
+		service_record.port = port_;
+
+		// Setup our mDNS records
+
+		// PTR record reverse mapping "<_service-name>._tcp.local." to
+		// "<hostname>.<_service-name>._tcp.local."
+		service_record.record_ptr.name = to_mdns_str_ref(service_record.service);
+		service_record.record_ptr.type = MDNS_RECORDTYPE_PTR,
+		service_record.record_ptr.data.ptr = mdns_record_ptr_t{.name = to_mdns_str_ref(service_record.service_instance)};
+		service_record.record_ptr.rclass = 0;
+		service_record.record_ptr.ttl = 0;
+
+		// SRV record mapping "<hostname>.<_service-name>._tcp.local." to
+		// "<hostname>.local." with port. Set weight & priority to 0.
+		service_record.record_srv.name = to_mdns_str_ref(service_record.service_instance);
+		service_record.record_srv.type = MDNS_RECORDTYPE_SRV;
+		service_record.record_srv.data.srv = mdns_record_srv_t{.priority = 0,
+															.weight = 0,
+															.port = service_record.port,
+															.name = to_mdns_str_ref(service_record.hostname_qualified)};
+		service_record.record_srv.rclass = 0;
+		service_record.record_srv.ttl = 0;
+
+		// A/AAAA records mapping "<hostname>.local." to IPv4/IPv6 addresses
+		service_record.record_a.name = to_mdns_str_ref(service_record.hostname_qualified);
+		service_record.record_a.type = MDNS_RECORDTYPE_A;
+		service_record.record_a.data.a = {mdns_record_a_t{.addr = service_record.address_ipv4}};
+		service_record.record_a.rclass = 0;
+		service_record.record_a.ttl = 0;
+
+		service_record.record_aaaa.name = to_mdns_str_ref(service_record.hostname_qualified);
+		service_record.record_aaaa.type = MDNS_RECORDTYPE_AAAA;
+		service_record.record_aaaa.data.aaaa.addr = service_record.address_ipv6;
+		service_record.record_aaaa.rclass = 0;
+		service_record.record_aaaa.ttl = 0;
+
+		// Add TXT records for our service instance name, will be coalesced into one record with both key-value pair strings by the library
+		for (size_t i = 0; i < MDNS_TXT_RECORD_COUNT; ++i) {
+			service_record.txt_record[i].name = to_mdns_str_ref(service_record.service_instance);
+			service_record.txt_record[i].type = MDNS_RECORDTYPE_TXT;
+			service_record.txt_record[i].data.txt.key = to_mdns_str_ref(txt_key_pairs_[i].first);
+			service_record.txt_record[i].data.txt.value = to_mdns_str_ref(txt_key_pairs_[i].second);
+			service_record.txt_record[i].rclass = 0;
+			service_record.txt_record[i].ttl = 0;
+		}
+
+		_log.Log(LOG_NORM, "mDNS: Opened %d socket%s", num_sockets, (num_sockets > 1 ? "s" : ""));
+		_log.Log(LOG_NORM, "mDNS: Service: %s:%d", name_.c_str(), port_);
+		_log.Log(LOG_NORM, "mDNS: Hostname: %s", hostname_.c_str());
+
+		constexpr size_t capacity = 2048u;
+		std::shared_ptr<void> buffer(malloc(capacity), free);
+
+		// Send an announcement on startup of service
+		{
+			_log.Debug(DEBUG_NORM, "mDNS: Sending mDNS announce");
+			mdns_record_t additional[5] = {{}};
+			size_t additional_count = 0;
+			additional[additional_count++] = service_record.record_srv;
+			if (service_record.address_ipv4.sin_family == AF_INET)
+				additional[additional_count++] = service_record.record_a;
+			if (service_record.address_ipv6.sin6_family == AF_INET6)
+				additional[additional_count++] = service_record.record_aaaa;
+			additional[additional_count++] = service_record.txt_record[0];
+			additional[additional_count++] = service_record.txt_record[1];
+			for (int isock = 0; isock < num_sockets; ++isock)
+				mdns_announce_multicast(sockets[isock], buffer.get(), capacity, service_record.record_ptr, 0, 0, additional,
+										additional_count);
+		}
+
+		// This is a crude implementation that checks for incoming queries
+		while (running_)
+		{
+			int nfds = 0;
+			fd_set readfs{};
+			FD_ZERO(&readfs);
+			for (int isock = 0; isock < num_sockets; ++isock)
+			{
+				if (sockets[isock] >= nfds)
+					nfds = sockets[isock] + 1;
+				FD_SET(sockets[isock], &readfs);
+			}
+
+			struct timeval timeout;
+			timeout.tv_sec = 0;
+			timeout.tv_usec = 100000;
+			if (select(nfds, &readfs, 0, 0, &timeout) >= 0)
+			{
+				for (int isock = 0; isock < num_sockets; ++isock)
+				{
+					if (FD_ISSET(sockets[isock], &readfs))
+					{
+						mdns_socket_listen(sockets[isock], buffer.get(), capacity, service_callback, &service_record);
+					}
+					FD_SET(sockets[isock], &readfs);
+				}
+			}
+			else
+			{
+				break;
+			}
+		}
+
+		// Send a goodbye on end of service
+		{
+			_log.Debug(DEBUG_NORM, "mDNS: Sending mDNS goodbye");
+			mdns_record_t additional[5] = {{}};
+			size_t additional_count = 0;
+			additional[additional_count++] = service_record.record_srv;
+			if (service_record.address_ipv4.sin_family == AF_INET)
+				additional[additional_count++] = service_record.record_a;
+			if (service_record.address_ipv6.sin6_family == AF_INET6)
+				additional[additional_count++] = service_record.record_aaaa;
+			additional[additional_count++] = service_record.txt_record[0];
+			additional[additional_count++] = service_record.txt_record[1];
+
+			for (int isock = 0; isock < num_sockets; ++isock)
+				mdns_goodbye_multicast(sockets[isock], buffer.get(), capacity, service_record.record_ptr, 0, 0, additional,
+									   additional_count);
+		}
+
+		for (int isock = 0; isock < num_sockets; ++isock)
+		{
+			mdns_socket_close(sockets[isock]);
+		}
+		_log.Log(LOG_NORM, "mDNS: Closed %d socket%s", num_sockets, (num_sockets > 1 ? "s" : ""));
+	}
+
+	int mDNS::openServiceSockets(int *sockets, int max_sockets)
+	{
+		// When receiving, each socket can receive data from all network interfaces
+		// Thus we only need to open one socket for each address family
+		int num_sockets = 0;
+
+		// Call the client socket function to enumerate and get local addresses,
+		// but not open the actual sockets
+		openClientSockets(0, 0, 0);
+
+		if (num_sockets < max_sockets)
+		{
+			sockaddr_in sock_addr{};
+			sock_addr.sin_family = AF_INET;
+#ifdef _WIN32
+			sock_addr.sin_addr = in4addr_any;
+#else
+			sock_addr.sin_addr.s_addr = INADDR_ANY;
+#endif
+			sock_addr.sin_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+			sock_addr.sin_len = sizeof(struct sockaddr_in);
+#endif
+			const int sock = mdns_socket_open_ipv4(&sock_addr);
+			if (sock >= 0)
+			{
+				sockets[num_sockets++] = sock;
+			}
+		}
+
+		if (num_sockets < max_sockets)
+		{
+			sockaddr_in6 sock_addr{};
+			sock_addr.sin6_family = AF_INET6;
+			sock_addr.sin6_addr = in6addr_any;
+			sock_addr.sin6_port = htons(MDNS_PORT);
+#ifdef __APPLE__
+			sock_addr.sin6_len = sizeof(struct sockaddr_in6);
+#endif
+			int sock = mdns_socket_open_ipv6(&sock_addr);
+			if (sock >= 0)
+				sockets[num_sockets++] = sock;
+		}
+
+		return num_sockets;
+	}
+
+	int mDNS::openClientSockets(int *sockets, int max_sockets, int port)
+	{
+		// When sending, each socket can only send to one network interface
+		// Thus we need to open one socket for each interface and address family
+		int num_sockets = 0;
+
+#ifdef _WIN32
+
+		IP_ADAPTER_ADDRESSES *adapter_address = nullptr;
+		ULONG address_size = 8000;
+		unsigned int ret{};
+		unsigned int num_retries = 4;
+		do
+		{
+			adapter_address = (IP_ADAPTER_ADDRESSES *)malloc(address_size);
+			ret = GetAdaptersAddresses(AF_UNSPEC, GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_ANYCAST, 0, adapter_address,
+									   &address_size);
+			if (ret == ERROR_BUFFER_OVERFLOW)
+			{
+				free(adapter_address);
+				address_size *= 2;
+			}
+			else
+			{
+				break;
+			}
+		} while (num_retries-- > 0);
+
+		if (!adapter_address || (ret != NO_ERROR))
+		{
+			free(adapter_address);
+			_log.Log(LOG_ERROR, "mDNS: Failed to get network adapter addresses!");
+			return num_sockets;
+		}
+
+		int first_ipv4 = 1;
+		int first_ipv6 = 1;
+		for (PIP_ADAPTER_ADDRESSES adapter = adapter_address; adapter; adapter = adapter->Next)
+		{
+			if (adapter->TunnelType == TUNNEL_TYPE_TEREDO)
+			{
+				continue;
+			}
+			if (adapter->OperStatus != IfOperStatusUp)
+			{
+				continue;
+			}
+
+			for (IP_ADAPTER_UNICAST_ADDRESS *unicast = adapter->FirstUnicastAddress; unicast; unicast = unicast->Next)
+			{
+				if (unicast->Address.lpSockaddr->sa_family == AF_INET)
+				{
+					struct sockaddr_in *saddr = (struct sockaddr_in *)unicast->Address.lpSockaddr;
+					if ((saddr->sin_addr.S_un.S_un_b.s_b1 != 127) || (saddr->sin_addr.S_un.S_un_b.s_b2 != 0) ||
+						(saddr->sin_addr.S_un.S_un_b.s_b3 != 0) || (saddr->sin_addr.S_un.S_un_b.s_b4 != 1))
+					{
+						int log_addr = 0;
+						if (first_ipv4)
+						{
+							service_address_ipv4_ = *saddr;
+							first_ipv4 = 0;
+							log_addr = 1;
+						}
+
+						if (num_sockets < max_sockets)
+						{
+							saddr->sin_port = htons((unsigned short)port);
+							int sock = mdns_socket_open_ipv4(saddr);
+							if (sock >= 0)
+							{
+								sockets[num_sockets++] = sock;
+								log_addr = 1;
+							}
+							else
+							{
+								log_addr = 0;
+							}
+						}
+						if (log_addr)
+						{
+							char buffer[128];
+							const auto addr = sockaddrToString((struct sockaddr *)&saddr);
+							_log.Debug(DEBUG_NORM, "mDNS: Local IPv4 address: %s", addr.c_str());
+						}
+					}
+				}
+				else if (unicast->Address.lpSockaddr->sa_family == AF_INET6)
+				{
+					struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)unicast->Address.lpSockaddr;
+					// Ignore link-local addresses
+					if (saddr->sin6_scope_id)
+						continue;
+					static constexpr unsigned char localhost[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+					static constexpr unsigned char localhost_mapped[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1};
+					if ((unicast->DadState == NldsPreferred) && memcmp(saddr->sin6_addr.s6_addr, localhost, 16) &&
+						memcmp(saddr->sin6_addr.s6_addr, localhost_mapped, 16))
+					{
+						int log_addr = 0;
+						if (first_ipv6)
+						{
+							memcpy(&service_address_ipv6_, &saddr->sin6_addr, sizeof(saddr->sin6_addr));
+							first_ipv6 = 0;
+							log_addr = 1;
+						}
+
+						if (num_sockets < max_sockets)
+						{
+							saddr->sin6_port = htons((unsigned short)port);
+							int sock = mdns_socket_open_ipv6(saddr);
+							if (sock >= 0)
+							{
+								sockets[num_sockets++] = sock;
+								log_addr = 1;
+							}
+							else
+							{
+								log_addr = 0;
+							}
+						}
+						if (log_addr)
+						{
+							char buffer[128];
+							const auto addr = sockaddrToString((struct sockaddr *)&saddr);
+							_log.Debug(DEBUG_NORM, "mDNS: Local IPv6 address: %s", addr.c_str());
+						}
+					}
+				}
+			}
+		}
+
+		free(adapter_address);
+
+#else
+
+		struct ifaddrs *ifaddr = nullptr;
+		struct ifaddrs *ifa = nullptr;
+
+		if (getifaddrs(&ifaddr) < 0)
+		{
+			_log.Log(LOG_ERROR, "mDNS: Unable to get interface addresses!");
+		}
+
+		int first_ipv4 = 1;
+		int first_ipv6 = 1;
+		for (ifa = ifaddr; ifa; ifa = ifa->ifa_next)
+		{
+			if (!ifa->ifa_addr)
+			{
+				continue;
+			}
+			if (!(ifa->ifa_flags & IFF_UP) || !(ifa->ifa_flags & IFF_MULTICAST))
+				continue;
+			if ((ifa->ifa_flags & IFF_LOOPBACK) || (ifa->ifa_flags & IFF_POINTOPOINT))
+				continue;
+
+			if (ifa->ifa_addr->sa_family == AF_INET)
+			{
+				struct sockaddr_in *saddr = (struct sockaddr_in *)ifa->ifa_addr;
+				if (saddr->sin_addr.s_addr != htonl(INADDR_LOOPBACK))
+				{
+					int log_addr = 0;
+					if (first_ipv4)
+					{
+						service_address_ipv4_ = *saddr;
+						first_ipv4 = 0;
+						log_addr = 1;
+					}
+
+					if (num_sockets < max_sockets)
+					{
+						saddr->sin_port = htons(port);
+						int sock = mdns_socket_open_ipv4(saddr);
+						if (sock >= 0)
+						{
+							sockets[num_sockets++] = sock;
+							log_addr = 1;
+						}
+						else
+						{
+							log_addr = 0;
+						}
+					}
+					if (log_addr)
+					{
+						char buffer[128];
+						const auto addr = sockaddrToString((struct sockaddr *)&saddr);
+						_log.Debug(DEBUG_NORM, "mDNS: Local IPv4 address: %s", addr.c_str());
+					}
+				}
+			}
+			else if (ifa->ifa_addr->sa_family == AF_INET6)
+			{
+				struct sockaddr_in6 *saddr = (struct sockaddr_in6 *)ifa->ifa_addr;
+				// Ignore link-local addresses
+				if (saddr->sin6_scope_id)
+					continue;
+				static constexpr unsigned char localhost[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+				static constexpr unsigned char localhost_mapped[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1};
+				if (memcmp(saddr->sin6_addr.s6_addr, localhost, 16) && memcmp(saddr->sin6_addr.s6_addr, localhost_mapped, 16))
+				{
+					int log_addr = 0;
+					if (first_ipv6)
+					{
+						service_address_ipv6_ = *saddr;
+						first_ipv6 = 0;
+						log_addr = 1;
+					}
+
+					if (num_sockets < max_sockets)
+					{
+						saddr->sin6_port = htons(port);
+						int sock = mdns_socket_open_ipv6(saddr);
+						if (sock >= 0)
+						{
+							sockets[num_sockets++] = sock;
+							log_addr = 1;
+						}
+						else
+						{
+							log_addr = 0;
+						}
+					}
+					if (log_addr)
+					{
+						char buffer[128] = {};
+						const auto addr = sockaddrToString((struct sockaddr *)&saddr);
+						_log.Debug(DEBUG_NORM, "mDNS: Local IPv6 address: %s", addr.c_str());
+					}
+				}
+			}
+		}
+
+		freeifaddrs(ifaddr);
+
+#endif
+
+		return num_sockets;
+	}
+
+	int mDNS::service_callback(int sock, const struct sockaddr *from, size_t addrlen, mdns_entry_type entry, uint16_t query_id,
+							   uint16_t rtype, uint16_t rclass, uint32_t ttl, const void *data, size_t size, size_t name_offset,
+							   size_t name_length, size_t record_offset, size_t record_length, void *user_data)
+	{
+		(void)sizeof(ttl);
+
+		if (static_cast<int>(entry) != MDNS_ENTRYTYPE_QUESTION)
+		{
+			return 0;
+		}
+
+		const char dns_sd[] = "_services._dns-sd._udp.local.";
+		const ServiceRecord *service_record = (const ServiceRecord *)user_data;
+
+		char addrbuffer[64] = {0};
+		char namebuffer[256] = {0};
+
+		// const auto fromaddrstr = ipAddressToString(addrbuffer, sizeof(addrbuffer), from, addrlen);
+		const mdns_string_t service =
+			mdns_record_parse_ptr(data, size, record_offset, record_length, namebuffer, sizeof(namebuffer));
+		const size_t service_length = service_record->service.length();
+		char sendbuffer[1024] = {0};
+
+		size_t offset = name_offset;
+		mdns_string_t name = mdns_string_extract(data, size, &offset, namebuffer, sizeof(namebuffer));
+
+		const char *record_name = 0;
+		if (rtype == MDNS_RECORDTYPE_PTR)
+			record_name = "PTR";
+		else if (rtype == MDNS_RECORDTYPE_SRV)
+			record_name = "SRV";
+		else if (rtype == MDNS_RECORDTYPE_A)
+			record_name = "A";
+		else if (rtype == MDNS_RECORDTYPE_AAAA)
+			record_name = "AAAA";
+		else if (rtype == MDNS_RECORDTYPE_TXT)
+			record_name = "TXT";
+		else if (rtype == MDNS_RECORDTYPE_ANY)
+			record_name = "ANY";
+		else
+			return 0;
+		//_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s", record_name, MDNS_STRING_FORMAT(name));
+		const int str_capacity = 1000;
+		if ((name.length == (sizeof(dns_sd) - 1)) && (strncmp(name.str, dns_sd, sizeof(dns_sd) - 1) == 0))
+		{
+			if ((rtype == MDNS_RECORDTYPE_PTR) || (rtype == MDNS_RECORDTYPE_ANY))
+			{
+				// The PTR query was for the DNS-SD domain, send answer with a PTR record for the
+				// service name we advertise, typically on the "<_service-name>._tcp.local." format
+				// Answer PTR record reverse mapping "<_service-name>._tcp.local." to
+				// "<hostname>.<_service-name>._tcp.local."
+				mdns_record_t answer = {.name = name,
+										.type = MDNS_RECORDTYPE_PTR,
+										.data = {mdns_record_ptr_t{name = to_mdns_str_ref(service_record->service)}},
+										.rclass = MDNS_CLASS_IN,
+										.ttl = 60};
+				// Send the answer, unicast or multicast depending on flag in query
+				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+				_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s --> answer %.*s (%s)", record_name, MDNS_STRING_FORMAT(name),
+						MDNS_STRING_FORMAT(answer.data.ptr.name), (unicast ? "unicast" : "multicast"));
+				if (unicast)
+				{
+					mdns_query_answer_unicast(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+											  static_cast<mdns_record_type_t>(rtype), name.str, name.length, answer, 0, 0, 0, 0);
+				}
+				else
+				{
+					mdns_query_answer_multicast(sock, sendbuffer, sizeof(sendbuffer), answer, 0, 0, 0, 0);
+				}
+			}
+		}
+		else if ((service.length == service_length) &&
+				 (strncmp(service.str, service_record->service.c_str(), service_length) == 0))
+		{
+			if ((rtype == MDNS_RECORDTYPE_PTR) || (rtype == MDNS_RECORDTYPE_ANY))
+			{
+				// The PTR query was for our service (usually "<_service-name._tcp.local"), answer a PTR
+				// record reverse mapping the queried service name to our service instance name
+				// (typically on the "<hostname>.<_service-name>._tcp.local." format), and add
+				// additional records containing the SRV record mapping the service instance name to our
+				// qualified hostname (typically "<hostname>.local.") and port, as well as any IPv4/IPv6
+				// address for the hostname as A/AAAA records, and two test TXT records
+				// Answer PTR record reverse mapping "<_service-name>._tcp.local." to
+				// "<hostname>.<_service-name>._tcp.local."
+				mdns_record_t answer = service_record->record_ptr;
+				mdns_record_t additional[5] = {{}};
+				size_t additional_count = 0;
+				// SRV record mapping "<hostname>.<_service-name>._tcp.local." to
+				// "<hostname>.local." with port. Set weight & priority to 0.
+				additional[additional_count++] = service_record->record_srv;
+				// A/AAAA records mapping "<hostname>.local." to IPv4/IPv6 addresses
+				if (service_record->address_ipv4.sin_family == AF_INET)
+					additional[additional_count++] = service_record->record_a;
+				if (service_record->address_ipv6.sin6_family == AF_INET6)
+					additional[additional_count++] = service_record->record_aaaa;
+				// Add two test TXT records for our service instance name, will be coalesced into
+				// one record with both key-value pair strings by the library
+				additional[additional_count++] = service_record->txt_record[0];
+				additional[additional_count++] = service_record->txt_record[1];
+				// Send the answer, unicast or multicast depending on flag in query
+				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+				_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s --> answer %.*s port %d (%s)", record_name, MDNS_STRING_FORMAT(name),
+						MDNS_STRING_FORMAT(service_record->record_srv.data.srv.name), service_record->port, (unicast ? "unicast" : "multicast"));
+				if (unicast)
+				{
+					mdns_query_answer_unicast(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+											  static_cast<mdns_record_type_t>(rtype), name.str, name.length, answer, 0, 0,
+											  additional, additional_count);
+				}
+				else
+				{
+					mdns_query_answer_multicast(sock, sendbuffer, sizeof(sendbuffer), answer, 0, 0, additional, additional_count);
+				}
+			}
+		}
+		else if ((name.length == service_record->service_instance.length()) &&
+				 (strncmp(name.str, service_record->service_instance.c_str(), name.length) == 0))
+		{
+			if ((rtype == MDNS_RECORDTYPE_SRV) || (rtype == MDNS_RECORDTYPE_ANY))
+			{
+				// The SRV query was for our service instance (usually
+				// "<hostname>.<_service-name._tcp.local"), answer a SRV record mapping the service
+				// instance name to our qualified hostname (typically "<hostname>.local.") and port, as
+				// well as any IPv4/IPv6 address for the hostname as A/AAAA records, and two test TXT
+				// records
+				// Answer PTR record reverse mapping "<_service-name>._tcp.local." to
+				// "<hostname>.<_service-name>._tcp.local."
+				mdns_record_t answer = service_record->record_srv;
+				mdns_record_t additional[5] = {{}};
+				size_t additional_count = 0;
+				// A/AAAA records mapping "<hostname>.local." to IPv4/IPv6 addresses
+				if (service_record->address_ipv4.sin_family == AF_INET)
+					additional[additional_count++] = service_record->record_a;
+				if (service_record->address_ipv6.sin6_family == AF_INET6)
+					additional[additional_count++] = service_record->record_aaaa;
+				// Add two test TXT records for our service instance name, will be coalesced into
+				// one record with both key-value pair strings by the library
+				additional[additional_count++] = service_record->txt_record[0];
+				additional[additional_count++] = service_record->txt_record[1];
+				// Send the answer, unicast or multicast depending on flag in query
+				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+				_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s --> answer %.*s port %d (%s)", record_name, MDNS_STRING_FORMAT(name),
+						MDNS_STRING_FORMAT(service_record->record_srv.data.srv.name), service_record->port, (unicast ? "unicast" : "multicast"));
+				if (unicast)
+				{
+					mdns_query_answer_unicast(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+											  static_cast<mdns_record_type_t>(rtype), name.str, name.length, answer, 0, 0,
+											  additional, additional_count);
+				}
+				else
+				{
+					mdns_query_answer_multicast(sock, sendbuffer, sizeof(sendbuffer), answer, 0, 0, additional, additional_count);
+				}
+			}
+		}
+		else if ((name.length == service_record->hostname_qualified.length()) &&
+				 (strncmp(name.str, service_record->hostname_qualified.c_str(), name.length) == 0))
+		{
+			if (((rtype == MDNS_RECORDTYPE_A) || (rtype == MDNS_RECORDTYPE_ANY)) &&
+				(service_record->address_ipv4.sin_family == AF_INET))
+			{
+				// The A query was for our qualified hostname (typically "<hostname>.local.") and we
+				// have an IPv4 address, answer with an A record mappiing the hostname to an IPv4
+				// address, as well as any IPv6 address for the hostname, and two test TXT records
+				// Answer A records mapping "<hostname>.local." to IPv4 address
+				mdns_record_t answer = service_record->record_a;
+				mdns_record_t additional[5] = {{}};
+				size_t additional_count = 0;
+				// AAAA record mapping "<hostname>.local." to IPv6 addresses
+				if (service_record->address_ipv6.sin6_family == AF_INET6)
+					additional[additional_count++] = service_record->record_aaaa;
+				// Add two test TXT records for our service instance name, will be coalesced into
+				// one record with both key-value pair strings by the library
+				additional[additional_count++] = service_record->txt_record[0];
+				additional[additional_count++] = service_record->txt_record[1];
+				// Send the answer, unicast or multicast depending on flag in query
+				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+				const auto addrstr = sockaddrToString((struct sockaddr *)&service_record->record_a.data.a.addr);
+				_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s --> answer %.*s IPv4 %.*s (%s)", record_name, MDNS_STRING_FORMAT(name),
+						MDNS_STRING_FORMAT(service_record->record_a.name), (int)addrstr.length(), addrstr.c_str(), (unicast ? "unicast" : "multicast"));
+				if (unicast)
+				{
+					mdns_query_answer_unicast(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+											  static_cast<mdns_record_type_t>(rtype), name.str, name.length, answer, 0, 0,
+											  additional, additional_count);
+				}
+				else
+				{
+					mdns_query_answer_multicast(sock, sendbuffer, sizeof(sendbuffer), answer, 0, 0, additional, additional_count);
+				}
+			}
+			else if (((rtype == MDNS_RECORDTYPE_AAAA) || (rtype == MDNS_RECORDTYPE_ANY)) &&
+					 (service_record->address_ipv6.sin6_family == AF_INET6))
+			{
+				// The AAAA query was for our qualified hostname (typically "<hostname>.local.") and we
+				// have an IPv6 address, answer with an AAAA record mappiing the hostname to an IPv6
+				// address, as well as any IPv4 address for the hostname, and two test TXT records
+				// Answer AAAA records mapping "<hostname>.local." to IPv6 address
+				mdns_record_t answer = service_record->record_aaaa;
+				mdns_record_t additional[5] = {{}};
+				size_t additional_count = 0;
+				// A record mapping "<hostname>.local." to IPv4 addresses
+				if (service_record->address_ipv4.sin_family == AF_INET)
+					additional[additional_count++] = service_record->record_a;
+				// Add two test TXT records for our service instance name, will be coalesced into
+				// one record with both key-value pair strings by the library
+				additional[additional_count++] = service_record->txt_record[0];
+				additional[additional_count++] = service_record->txt_record[1];
+				// Send the answer, unicast or multicast depending on flag in query
+				uint16_t unicast = (rclass & MDNS_UNICAST_RESPONSE);
+				auto addrstr = sockaddrToString((struct sockaddr *)&service_record->record_aaaa.data.aaaa.addr);
+				_log.Debug(DEBUG_RECEIVED, "mDNS: Query %s:%.*s --> answer %.*s IPv6 %.*s (%s)", record_name, MDNS_STRING_FORMAT(name), 
+						MDNS_STRING_FORMAT(service_record->record_aaaa.name), (int)addrstr.length(), addrstr.c_str(), (unicast ? "unicast" : "multicast"));
+				if (unicast)
+				{
+					mdns_query_answer_unicast(sock, from, addrlen, sendbuffer, sizeof(sendbuffer), query_id,
+											  static_cast<mdns_record_type_t>(rtype), name.str, name.length, answer, 0, 0,
+											  additional, additional_count);
+				}
+				else
+				{
+					mdns_query_answer_multicast(sock, sendbuffer, sizeof(sendbuffer), answer, 0, 0, additional, additional_count);
+				}
+			}
+			// #endif
+		}
+		return 0;
+	}
+
+	std::string mDNS::sockaddrToString(const sockaddr* addr)
+	{
+		char buffer[INET6_ADDRSTRLEN]; // Large enough for both IPv4 and IPv6 addresses
+
+		if (addr->sa_family == AF_INET) {
+			// IPv4
+			const sockaddr_in* ipv4 = reinterpret_cast<const sockaddr_in*>(addr);
+			if (inet_ntop(AF_INET, &(ipv4->sin_addr), buffer, sizeof(buffer)) == nullptr) {
+				return "Invalid IPv4 address";
+			}
+			return std::string(buffer);
+		} else if (addr->sa_family == AF_INET6) {
+			// IPv6
+			const sockaddr_in6* ipv6 = reinterpret_cast<const sockaddr_in6*>(addr);
+			if (inet_ntop(AF_INET6, &(ipv6->sin6_addr), buffer, sizeof(buffer)) == nullptr) {
+				return "Invalid IPv6 address";
+			}
+			return std::string(buffer);
+		}
+		return "Unknown address family";
+	}
 }

--- a/mdns/mdns.hpp
+++ b/mdns/mdns.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <string>
+#include <thread>
+
+namespace domoticz_mdns {
+    class mDNS {
+        public:
+         ~mDNS();
+       
+         void startService(bool dumpMode = false);
+         void stopService();
+         bool isServiceRunning();
+       
+         void setServiceHostname(const std::string &hostname);
+         void setServicePort(std::uint16_t port);
+         void setServiceName(const std::string &name);
+         void setServiceTxtRecord(const std::string &text_record);
+       
+         using ServiceQueries = std::vector<std::pair<std::string, int>>;
+         void executeQuery(ServiceQueries service);
+         void executeDiscovery();
+       
+        private:
+         void runMainLoop();
+         void runDumpMode(int *sockets, int num_sockets);
+         int openClientSockets(int *sockets, int max_sockets, int port);
+         int openServiceSockets(int *sockets, int max_sockets);
+       
+         std::string hostname_{"domoticz"};
+         std::string name_{"_http._tcp.local."};
+         std::uint16_t port_{8080};
+         std::string txt_record_{};
+       
+         bool running_{false};
+         bool dumpMode_{false};
+       
+         struct sockaddr_in service_address_ipv4_;
+         struct sockaddr_in6 service_address_ipv6_;
+       
+         std::thread mdns_worker_thread_;
+       };    
+}

--- a/mdns/mdns.hpp
+++ b/mdns/mdns.hpp
@@ -6,7 +6,7 @@
 #include "include/mdns.h"
 
 #define DOMOTICZ_MDNS_SERVICE_TYPE "_http._tcp.local."
-#define MDNS_TXT_RECORD_COUNT 2
+#define MAX_MDNS_TXT_RECORD_COUNT 10
 
 namespace domoticz_mdns
 {
@@ -27,7 +27,7 @@ namespace domoticz_mdns
 		mdns_record_t record_srv;
 		mdns_record_t record_a;
 		mdns_record_t record_aaaa;
-		mdns_record_t txt_record[MDNS_TXT_RECORD_COUNT];
+		std::vector<mdns_record_t> txt_records;
 	};
 
 	class mDNS : public StoppableTask
@@ -42,7 +42,7 @@ namespace domoticz_mdns
 		void setServiceHostname(const std::string &hostname);
 		void setServicePort(std::uint16_t port);
 		void setServiceName(const std::string &name);
-		void setServiceTxtRecord(const std::string &text_record_key, const std::string &text_record_value);
+		void addServiceTxtRecord(const std::string &text_record_key, const std::string &text_record_value);
 
 		using ServiceQueries = std::vector<std::pair<std::string, int>>;
 		void executeQuery(ServiceQueries service);
@@ -52,7 +52,7 @@ namespace domoticz_mdns
 		std::string name_{DOMOTICZ_MDNS_SERVICE_TYPE};
 		std::string hostname_;
 		std::uint16_t port_;
-		std::array<std::pair<std::string, std::string>, MDNS_TXT_RECORD_COUNT> txt_key_pairs_;
+		std::map<std::string, std::string> txt_key_pairs_;
 
 		bool running_{false};
 		struct sockaddr_in service_address_ipv4_;

--- a/mdns/mdns.hpp
+++ b/mdns/mdns.hpp
@@ -3,41 +3,70 @@
 #include <string>
 #include <thread>
 
-namespace domoticz_mdns {
-    class mDNS {
-        public:
-         ~mDNS();
-       
-         void startService(bool dumpMode = false);
-         void stopService();
-         bool isServiceRunning();
-       
-         void setServiceHostname(const std::string &hostname);
-         void setServicePort(std::uint16_t port);
-         void setServiceName(const std::string &name);
-         void setServiceTxtRecord(const std::string &text_record);
-       
-         using ServiceQueries = std::vector<std::pair<std::string, int>>;
-         void executeQuery(ServiceQueries service);
-         void executeDiscovery();
-       
-        private:
-         void runMainLoop();
-         void runDumpMode(int *sockets, int num_sockets);
-         int openClientSockets(int *sockets, int max_sockets, int port);
-         int openServiceSockets(int *sockets, int max_sockets);
-       
-         std::string hostname_{"domoticz"};
-         std::string name_{"_http._tcp.local."};
-         std::uint16_t port_{8080};
-         std::string txt_record_{};
-       
-         bool running_{false};
-         bool dumpMode_{false};
-       
-         struct sockaddr_in service_address_ipv4_;
-         struct sockaddr_in6 service_address_ipv6_;
-       
-         std::thread mdns_worker_thread_;
-       };    
+#include "include/mdns.h"
+
+#define DOMOTICZ_MDNS_SERVICE_TYPE "_http._tcp.local."
+#define MDNS_TXT_RECORD_COUNT 2
+
+namespace domoticz_mdns
+{
+
+	static mdns_record_txt_t txtbuffer[128];
+
+	class ServiceRecord
+	{
+	public:
+		std::string service;
+		std::string hostname;
+		std::string service_instance;
+		std::string hostname_qualified;
+		struct sockaddr_in address_ipv4;
+		struct sockaddr_in6 address_ipv6;
+		uint16_t port;
+		mdns_record_t record_ptr;
+		mdns_record_t record_srv;
+		mdns_record_t record_a;
+		mdns_record_t record_aaaa;
+		mdns_record_t txt_record[MDNS_TXT_RECORD_COUNT];
+	};
+
+	class mDNS : public StoppableTask
+	{
+	public:
+		~mDNS();
+
+		void startService();
+		void stopService();
+		bool isServiceRunning();
+
+		void setServiceHostname(const std::string &hostname);
+		void setServicePort(std::uint16_t port);
+		void setServiceName(const std::string &name);
+		void setServiceTxtRecord(const std::string &text_record_key, const std::string &text_record_value);
+
+		using ServiceQueries = std::vector<std::pair<std::string, int>>;
+		void executeQuery(ServiceQueries service);
+		void executeDiscovery();
+
+	private:
+		std::string name_{DOMOTICZ_MDNS_SERVICE_TYPE};
+		std::string hostname_;
+		std::uint16_t port_;
+		std::array<std::pair<std::string, std::string>, MDNS_TXT_RECORD_COUNT> txt_key_pairs_;
+
+		bool running_{false};
+		struct sockaddr_in service_address_ipv4_;
+		struct sockaddr_in6 service_address_ipv6_;
+		std::shared_ptr<std::thread> mdns_worker_thread_;
+
+		void mDnsMainLoop();
+		int openClientSockets(int *sockets, int max_sockets, int port);
+		int openServiceSockets(int *sockets, int max_sockets);
+
+		static int service_callback(int sock, const struct sockaddr *from, size_t addrlen, mdns_entry_type entry, uint16_t query_id,
+									uint16_t rtype, uint16_t rclass, uint32_t ttl, const void *data, size_t size, size_t name_offset,
+									size_t name_length, size_t record_offset, size_t record_length, void *user_data);
+
+		static std::string sockaddrToString(const sockaddr* addr);
+	};
 }

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -723,6 +723,7 @@
     <ClInclude Include="..\hardware\ZWaveCommands.h" />
     <ClInclude Include="..\httpclient\HTTPClient.h" />
     <ClInclude Include="..\iamserver\iam_settings.hpp" />
+    <ClInclude Include="..\mdns\mdns.hpp" />
     <ClInclude Include="..\main\appversion.h" />
     <ClInclude Include="..\hardware\ASyncSerial.h" />
     <ClInclude Include="..\main\BaroForecastCalculator.h" />
@@ -1024,6 +1025,7 @@
     <ClCompile Include="..\hardware\ZWaveBase.cpp" />
     <ClCompile Include="..\httpclient\HTTPClient.cpp" />
     <ClCompile Include="..\iamserver\IamService.cpp" />
+    <ClCompile Include="..\mdns\mdns.cpp" />
     <ClCompile Include="..\main\BaroForecastCalculator.cpp" />
     <ClCompile Include="..\main\Camera.cpp" />
     <ClCompile Include="..\hardware\Rego6XXSerial.cpp" />

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -116,7 +116,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;../msbuild/Windows Libraries/openzwave/OpenZWaveD.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/OpenZWaveD.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <Profile>false</Profile>
     </Link>
@@ -145,7 +145,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;../msbuild/Windows Libraries/openzwave/x64/OpenZWaved.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/x64/OpenZWaved.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <Profile>false</Profile>
     </Link>
@@ -176,7 +176,7 @@
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
       <OptimizeReferences>false</OptimizeReferences>
       <AdditionalLibraryDirectories>./Windows Libraries/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>lua.lib;libcurl.lib;minizip.lib;jsoncpp.lib;libcrypto.lib;libssl.lib;Wldap32.lib;zlib.lib;pthreadVC3.lib;sqlite3.lib;mosquitto.lib;Crypt32.lib;Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;../msbuild/Windows Libraries/openzwave/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>lua.lib;libcurl.lib;minizip.lib;jsoncpp.lib;libcrypto.lib;libssl.lib;Wldap32.lib;zlib.lib;pthreadVC3.lib;sqlite3.lib;mosquitto.lib;boost_thread-vc140-mt.lib;boost_chrono-vc140-mt.lib;boost_system-vc140-mt.lib;Crypt32.lib;Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <IgnoreSpecificDefaultLibraries>MSVCRT</IgnoreSpecificDefaultLibraries>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -206,7 +206,7 @@
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
       <OptimizeReferences>false</OptimizeReferences>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;../msbuild/Windows Libraries/openzwave/x64/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/x64/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <IgnoreSpecificDefaultLibraries>
       </IgnoreSpecificDefaultLibraries>

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -176,7 +176,7 @@
       <EnableCOMDATFolding>false</EnableCOMDATFolding>
       <OptimizeReferences>false</OptimizeReferences>
       <AdditionalLibraryDirectories>./Windows Libraries/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalDependencies>lua.lib;libcurl.lib;minizip.lib;jsoncpp.lib;libcrypto.lib;libssl.lib;Wldap32.lib;zlib.lib;pthreadVC3.lib;sqlite3.lib;mosquitto.lib;boost_thread-vc140-mt.lib;boost_chrono-vc140-mt.lib;boost_system-vc140-mt.lib;Crypt32.lib;Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>lua.lib;libcurl.lib;minizip.lib;jsoncpp.lib;libcrypto.lib;libssl.lib;Wldap32.lib;zlib.lib;pthreadVC3.lib;sqlite3.lib;mosquitto.lib;Crypt32.lib;Setupapi.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dnsapi.lib;IPHLPAPI.lib;../msbuild/Windows Libraries/openzwave/OpenZWave.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>AsInvoker</UACExecutionLevel>
       <IgnoreSpecificDefaultLibraries>MSVCRT</IgnoreSpecificDefaultLibraries>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>


### PR DESCRIPTION
_This PR is a better/re-implementation replacing PR #6238 !_

This PR adds initial Multicast DNS support (mDNS), see [RFC6762](https://datatracker.ietf.org/doc/html/rfc6762)

Domoticz now announces itself on the local netwerk that it can be found at `domoticz.local:<port>` and listens to mDNS requests for mDNS queries that request details.

Next to A (IPv4) and AAAA (IPv6) resolving records, also domoticz is discoverably as an `_http._tcp`-service. The SRV record gives the resolvable name AND port. The extra TXT records report the `app` (domoticz), `path` (/) and `version` (for example 2025.1 (Build 16701)).

So by default, the mDNS name will be `domoticz.local`.
The user can specify something different under Settings / System / Location / Name. Then it will be `<thenamespecified>.local` (after restart!).

It is possible to disable mDNS by specifying `-nomdns` as a startup option.

To see more details of what is going on, enable the received debug flag via the commandline (`-debuglevel normal, received`).

mDNS support in Domoticz is also needed for future support for Matter as it utilizes mDNS (over IPv6) a lot. So this is a start.