### PR TITLE
[MQTT] Repair Zwave RGB + WW

### DIFF
--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -71,6 +71,7 @@ class MQTTAutoDiscover : public MQTT
 		bool bColor_mode = false;
 		std::map<std::string, uint8_t> supported_color_modes;
 		std::string color_temp_value_template;
+		std::string color_temp_command_template;
 		std::string hs_value_template;
 
 		int min_mireds = 153;


### PR DESCRIPTION
Zwave js ui from version  10 uses colormode white is device as a warmwhite and or coldwhite channel.
This color mode can have warmWhite and or coldWhite. If it has both is also supports color temp mode.

This PR will use this white command to determine if it is RGBW or RGFBWW device.
Based on the device with will sue the correct color from domoticz to provide to the zwave device. Domoticz uses coldwhite for white channel and the zwave device can be warmWhite or coldWhite.

Tested with zipato E2 Bulb (RGBWW)
and using chinse RGBW(armhite) device.

Part of discovery message (which is used)
```
"color_temp_command_template": "{{ {'warmWhite': ((value - 245)|round(0)), 'coldWhite': (255 - (value - 245))|round(0))}|to_json }}",
"color_temp_value_template": "{{ '%03d%03d' | format((value_json.value.warmWhite || 0), (value_json.value.coldWhite || 0)) }}",
  
```