### PR TITLE
Fixed double URIencoding of password when storing

### DIFF
--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -1214,7 +1214,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Toon") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var agreement = $("#hardwarecontent #divenecotoon #agreement").val();
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
@@ -1238,7 +1238,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Tesla") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var vinnr = $("#hardwarecontent #divtesla #vinnr").val();
 				var apikey = $("#hardwarecontent #divtesla #apikey").val();
 				var activeinterval = parseInt($("#hardwarecontent #divtesla #activeinterval").val());
@@ -1279,7 +1279,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Mercedes") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var vinnr = $("#hardwarecontent #divmercedes #vinnr").val();
 				var activeinterval = parseInt($("#hardwarecontent #divmercedes #activeinterval").val());
 				if (activeinterval < 1) {
@@ -1562,7 +1562,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Evohome via Web") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 
 				var Pollseconds = parseInt($("#hardwarecontent #divevohomeweb #updatefrequencyevohomeweb").val());
 				if ( Pollseconds < 10 ) {
@@ -1640,7 +1640,7 @@ define(['app'], function (app) {
 				}
 
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -2410,7 +2410,7 @@ define(['app'], function (app) {
 					return;
 				}
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var extra = "";
 				var Mode1 = "";
 				var Mode2 = "";
@@ -2850,7 +2850,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Toon") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var agreement = encodeURIComponent($("#hardwarecontent #divenecotoon #agreement").val());
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
@@ -2873,7 +2873,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Tesla") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var vinnr = encodeURIComponent($("#hardwarecontent #divtesla #vinnr").val());
 				var apikey = $("#hardwarecontent #divtesla #apikey").val();
 				var activeinterval = parseInt($("#hardwarecontent #divtesla #activeinterval").val());
@@ -2913,7 +2913,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Mercedes") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var vinnr = encodeURIComponent($("#hardwarecontent #divmercedes #vinnr").val());
 				var activeinterval = parseInt($("#hardwarecontent #divmercedes #activeinterval").val());
 				if (activeinterval < 1) {
@@ -2975,7 +2975,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Evohome via Web") >= 0) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				var Pollseconds = parseInt($("#hardwarecontent #divevohomeweb #updatefrequencyevohomeweb").val());
 				if ( Pollseconds < 10 ) {
 					Pollseconds = 60;
@@ -3036,7 +3036,7 @@ define(['app'], function (app) {
 				}
 
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -1320,7 +1320,7 @@ define(['app'], function (app) {
 				(text.indexOf("PVOutput") >= 0)
 			) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				$.ajax({
 					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
@@ -2954,7 +2954,7 @@ define(['app'], function (app) {
 				(text.indexOf("HTTP") >= 0)
 			) {
 				var username = $("#hardwarecontent #divlogin #username").val();
-				var password = encodeURIComponent($("#hardwarecontent #divlogin #password").val());
+				var password = $("#hardwarecontent #divlogin #password").val();
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +


### PR DESCRIPTION
Small fix (for certain Hardware types at the moment like Atag One) that prevents passwords being URIencoded twice when adding or updating hardware.

This caused that when updating the (Atag One) hardware (which uses a username and password as parameters), for example just disabling it or enabling it again, the password got _changed_ when it contained URIencoded characters.

For example, when the password was `t#stt@st`, after updating the hardware without any changes to the password, it would become `t%23stt%40st`. And after another update is would be `t%2523stt%2540st` (and so on, the `%`-sign kept being URIencoded over and over).

Just by looking at the code in '[Hardware.js](https://github.com/domoticz/domoticz/blob/development/www/app/hardware/Hardware.js)' it looks that for more hardware types, this behavior occurs as the password is encoded when extracting it and encoded again when sending it to the backend (so twice).