### PR TITLE
cmake: turn DISABLE_UPDATER option into compiler macro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ option(USE_STATIC_OPENZWAVE "Build with static OpenZwave libraries" YES)
 
 # Disable updater functionality
 option(DISABLE_UPDATER "Disable updater functionality" NO)
+IF(DISABLE_UPDATER)
+  add_definitions(-DDISABLE_UPDATER)
+ENDIF()
 
 # Developer-oriented options
 option(USE_PRECOMPILED_HEADER "Use precompiled header feature to speed up build time " YES)


### PR DESCRIPTION
`cmake -DDISABLE_UPDATER=1` did not have any effect: `#ifdef DISABLE_UPDATER` in C++ code still returned false, since the option was not passed as macro to the compiler.

Let me know if you prefer this code further down outside of the option definitions. I thought to have it right below its option, so all updater related code is together.