### PR TITLE
add net current meter to P1 base

### DIFF
--- a/hardware/DomoticzHardware.cpp
+++ b/hardware/DomoticzHardware.cpp
@@ -771,19 +771,22 @@ void CDomoticzHardwareBase::SendCurrentSensor(const int NodeID, const int Batter
 	tsen.CURRENT.battery_level = BatteryLevel;
 
 	int at10 = ground(std::abs(Current1 * 10.0F));
-	tsen.CURRENT.ch1h = (BYTE)(at10 / 256);
-	at10 -= (tsen.TEMP.temperatureh * 256);
+	tsen.CURRENT.ch1h = (BYTE)(at10 / 256 & 0x7f);
+	at10 -= (tsen.CURRENT.ch1h * 256);
 	tsen.CURRENT.ch1l = (BYTE)(at10);
+	tsen.CURRENT.temp1sign = (Current1 >= 0) ? 0 : 1;
 
 	at10 = ground(std::abs(Current2 * 10.0F));
-	tsen.CURRENT.ch2h = (BYTE)(at10 / 256);
-	at10 -= (tsen.TEMP.temperatureh * 256);
+	tsen.CURRENT.ch2h = (BYTE)(at10 / 256 & 0x7f);
+	at10 -= (tsen.CURRENT.ch2h * 256);
 	tsen.CURRENT.ch2l = (BYTE)(at10);
-
+	tsen.CURRENT.temp2sign = (Current2 >= 0) ? 0 : 1;
+	
 	at10 = ground(std::abs(Current3 * 10.0F));
-	tsen.CURRENT.ch3h = (BYTE)(at10 / 256);
-	at10 -= (tsen.TEMP.temperatureh * 256);
+	tsen.CURRENT.ch3h = (BYTE)(at10 / 256 & 0x7f);
+	at10 -= (tsen.CURRENT.ch3h * 256);
 	tsen.CURRENT.ch3l = (BYTE)(at10);
+	tsen.CURRENT.temp3sign = (Current3 >= 0) ? 0 : 1;
 
 	sDecodeRXMessage(this, (const unsigned char *)&tsen.CURRENT, defaultname.c_str(), BatteryLevel, nullptr);
 }

--- a/hardware/P1MeterBase.cpp
+++ b/hardware/P1MeterBase.cpp
@@ -561,14 +561,33 @@ bool P1MeterBase::MatchLine()
 						float I3 = avr_usage[2] / m_voltagel3;
 						SendCurrentSensor(0, 255, I1, I2, I3, "Current L1/L2/L3");
 
+						// Calculate net current (usage-delivery)
+						float net_I1 = I1;
+						float net_I2 = I2;
+						float net_I3 = I3;
+
 						//Do the same for delivered
 						if (m_powerdell1 || m_powerdell2 || m_powerdell3)
 						{
 							I1 = avr_deliv[0] / m_voltagel1;
 							I2 = avr_deliv[1] / m_voltagel2;
 							I3 = avr_deliv[2] / m_voltagel3;
-							SendCurrentSensor(1, 255, I1, I2, I3, "Delivery Current L1/L2/L3");
+						} else {
+							// Set values to zero
+							I1 = 0.0f;
+							I2 = 0.0f;
+							I3 = 0.0f;
 						}
+
+						SendCurrentSensor(1, 255, I1, I2, I3, "Delivery Current L1/L2/L3");
+
+						// calculate net current (usage-delivery)
+						net_I1 = net_I1 - I1;
+						net_I2 = net_I2 - I2;
+						net_I3 = net_I3 - I3; 
+						
+						// Send net current sensor
+						SendCurrentSensor(2, 255, net_I1, net_I2, net_I3, "Net Current L1/L2/L3");
 					}
 
 					if ((m_gas.gasusage > 0) && ((m_gas.gasusage != m_lastgasusage) || (difftime(atime, m_lastSharedSendGas) >= 300)))
@@ -723,14 +742,14 @@ bool P1MeterBase::MatchLine()
 					* Electricity meter 02h
 					* Gas meter 03h
 					* Heat meter 04h
-					* Warm water meter (30°C ... 90°C) 06h
+					* Warm water meter (30ï¿½C ... 90ï¿½C) 06h
 					* Water meter 07h
 					* Heat Cost Allocator 08h
 					* Cooling meter (Volume measured at return temperature: outlet) 0Ah
 					* Cooling meter (Volume measured at flow temperature: inlet) 0Bh
 					* Heat meter (Volume measured at flow temperature: inlet) 0Ch
 					* Combined Heat / Cooling meter 0Dh
-					* Hot water meter (= 90°C) 15h
+					* Hot water meter (= 90ï¿½C) 15h
 					* Cold water meter a 16h
 					* Breaker (electricity) 20h
 					* Valve (gas or water) 21h

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -2778,16 +2778,40 @@ typedef union tRBUF {
         BYTE id1;
         BYTE id2;
         BYTE count;
-        BYTE ch1h;
-        BYTE ch1l;
-        BYTE ch2h;
-        BYTE ch2l;
-        BYTE ch3h;
-        BYTE ch3l;
 #ifdef IS_BIG_ENDIAN
+        BYTE temp1sign: 1;
+        BYTE ch1h : 7;
+
+        BYTE ch1l;
+
+        BYTE temp2sign: 1;
+        BYTE ch2h : 7;
+
+        BYTE ch2l;
+
+        BYTE temp3sign : 1;
+        BYTE ch3h : 7;
+
+        BYTE ch3l;
+
         BYTE rssi : 4;
         BYTE battery_level : 4;
 #else
+        BYTE ch1h : 7;
+        BYTE temp1sign: 1;
+
+        BYTE ch1l;
+
+        BYTE ch2h : 7;
+        BYTE temp2sign: 1;
+
+        BYTE ch2l;
+
+        BYTE ch3h : 7;
+        BYTE temp3sign : 1;
+
+        BYTE ch3l;
+
         BYTE battery_level : 4;
         BYTE rssi : 4;
 #endif

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -8849,9 +8849,36 @@ void MainWorker::decode_Current(const CDomoticzHardwareBase* pHardware, const tR
 	uint8_t SignalLevel = pResponse->CURRENT.rssi;
 	uint8_t BatteryLevel = get_BateryLevel(pHardware->HwdType, false, pResponse->CURRENT.battery_level & 0x0F);
 
-	float CurrentChannel1 = float((pResponse->CURRENT.ch1h * 256) + pResponse->CURRENT.ch1l) / 10.0F;
-	float CurrentChannel2 = float((pResponse->CURRENT.ch2h * 256) + pResponse->CURRENT.ch2l) / 10.0F;
-	float CurrentChannel3 = float((pResponse->CURRENT.ch3h * 256) + pResponse->CURRENT.ch3l) / 10.0F;
+	float CurrentChannel1 = 0.0f;
+    if (!pResponse->CURRENT.temp1sign)
+	{
+		CurrentChannel1 = float((pResponse->CURRENT.ch1h * 256) + pResponse->CURRENT.ch1l) / 10.0F;
+	}
+	else
+	{
+		CurrentChannel1 = -(float(((pResponse->CURRENT.ch1h & 0x7F) * 256) + pResponse->CURRENT.ch1l) / 10.0F);
+	}
+
+	float CurrentChannel2 = 0.0f;
+    if (!pResponse->CURRENT.temp2sign)
+	{
+		CurrentChannel2 = float((pResponse->CURRENT.ch2h * 256) + pResponse->CURRENT.ch2l) / 10.0F;
+	}
+	else
+	{
+		CurrentChannel2 = -(float(((pResponse->CURRENT.ch2h & 0x7F) * 256) + pResponse->CURRENT.ch2l) / 10.0F);
+	}
+
+	float CurrentChannel3 = 0.0f;
+    if (!pResponse->CURRENT.temp3sign)
+	{
+		CurrentChannel3 = float((pResponse->CURRENT.ch3h * 256) + pResponse->CURRENT.ch3l) / 10.0F;
+	}
+	else
+	{
+		CurrentChannel3 = -(float(((pResponse->CURRENT.ch3h & 0x7F) * 256) + pResponse->CURRENT.ch3l) / 10.0F);
+	}
+
 	sprintf(szTmp, "%.1f;%.1f;%.1f", CurrentChannel1, CurrentChannel2, CurrentChannel3);
 	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, cmnd, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
 	if (DevRowIdx == (uint64_t)-1)


### PR DESCRIPTION
Adds net current meter (can be used for EVCC use case) to P1 base

also fixes https://github.com/domoticz/domoticz/issues/6367

Don't merge, yet, cause i have to wait till the sun comes up to really test (now only simulated tests), but would be nice if the code could be reviewed:  I had to make a change to RFCtrx.h. SO i don't know the impact on RFX devices (and can't test, cause i don't have one)

