### PR TITLE
Fix Linux compile warnings EnphaseAPI

### DIFF
--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -1438,7 +1438,7 @@ bool EnphaseAPI::getInverterDetails()
 			{
 				//nothing received for the last hour!
 				std::string szLogMsg = "Last update more then 1 hour ago from inverter " + TimeToString(&last_reported, TF_DateTime) + ", serial: " + szSerialNumber + ")";
-				Log(LOG_ERROR, szLogMsg.c_str());
+				Log(LOG_ERROR, "%s", szLogMsg.c_str());
 				continue;
 			}
 			// Insert
@@ -1460,7 +1460,7 @@ bool EnphaseAPI::getInverterDetails()
 			{
 				//nothing received for the last hour!
 				std::string szLogMsg = "Last update more then 1 hour ago from inverter: \"" + result[0][0] + "\" (" + TimeToString(&last_reported, TF_DateTime) + ", serial: " + szSerialNumber + ")";
-				Log(LOG_ERROR, szLogMsg.c_str());
+				Log(LOG_ERROR, "%s", szLogMsg.c_str());
 				continue;
 			}
 			// Update


### PR DESCRIPTION
Fix Linux compile warnings in `hardware\EnphaseAPI.cpp` (commit [#953c64a](https://github.com/domoticz/domoticz/commit/953c64a4889a1719ea1c9dde5f740ea1f65e347a))