### PR TITLE
Kodi tvshow type support

### DIFF
--- a/hardware/Kodi.cpp
+++ b/hardware/Kodi.cpp
@@ -244,6 +244,8 @@ void CKodiNode::handleMessage(std::string& pMessage)
 									m_CurrentStatus.Status(MSTAT_VIDEO);
 								else if (root["params"]["data"]["item"]["type"] == "movie")
 									m_CurrentStatus.Status(MSTAT_VIDEO);
+								else if (root["params"]["data"]["item"]["type"] == "tvshow")
+									m_CurrentStatus.Status(MSTAT_VIDEO);
 								else if (root["params"]["data"]["item"]["type"] == "song")
 									m_CurrentStatus.Status(MSTAT_AUDIO);
 								else if (root["params"]["data"]["item"]["type"] == "musicvideo")


### PR DESCRIPTION
Resolves error like:
`Error: Kodi: (Kodi) Message error, unknown type in OnPlay/OnResume message: 'tvshow' from '{"jsonrpc":"2.0","method":"Player.OnResume","params":{"data":{"item":{"title":"So 30.08 19:00 - 19:50 | Události","type":"tvshow"},"player":{"playerid":1,"speed":1}},"sender":"xbmc"}}'`