### PR TITLE
Build fixes for Boost 1.89.0+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ INCLUDE(TestBigEndian)
 #
 #
 ## required min. libBoost version
-SET(DOMO_MIN_LIBBOOST_VERSION 1.66.0)
+SET(DOMO_MIN_LIBBOOST_VERSION 1.69.0)
 ##
 
 ### USER-SETTABLE OPTIONS
@@ -682,14 +682,14 @@ ELSE(USE_STATIC_BOOST)
    message(STATUS "Linking against boost dynamic libraries")
 ENDIF(USE_STATIC_BOOST)
 
-find_package(Boost REQUIRED COMPONENTS thread system)
+find_package(Boost REQUIRED COMPONENTS thread)
 IF(Boost_FOUND)
     MESSAGE(STATUS "BOOST includes found at: ${Boost_INCLUDE_DIR}")
 ELSE(Boost_FOUND)
-    MESSAGE(FATAL_ERROR "Boost thread/system library not found on your system, try to get this installed.")
+    MESSAGE(FATAL_ERROR "Boost thread library not found on your system, try to get this installed.")
 ENDIF(Boost_FOUND)
 
-target_link_libraries(domoticz Boost::thread Boost::system)
+target_link_libraries(domoticz Boost::thread)
 
 # compare found vs required libBoost version
 IF(Boost_VERSION VERSION_LESS DOMO_MIN_LIBBOOST_VERSION)

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -12,7 +12,7 @@
 #include <json/json.h>
 
 #include <boost/asio.hpp>
-#include <boost/asio/deadline_timer.hpp> // for deadline_timer
+#include <boost/asio/deadline_timer.hpp>
 
 #include "pinger/icmp_header.h"
 #include "pinger/ipv4_header.h"

--- a/hardware/Pinger.cpp
+++ b/hardware/Pinger.cpp
@@ -12,6 +12,7 @@
 #include <json/json.h>
 
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp> // for deadline_timer
 
 #include "pinger/icmp_header.h"
 #include "pinger/ipv4_header.h"

--- a/hardware/plugins/PluginTransports.h
+++ b/hardware/plugins/PluginTransports.h
@@ -2,6 +2,7 @@
 
 #include "../ASyncSerial.h"
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp> // for deadline_timer
 #include <ctime>
 
 namespace Plugins {

--- a/hardware/plugins/PluginTransports.h
+++ b/hardware/plugins/PluginTransports.h
@@ -2,7 +2,7 @@
 
 #include "../ASyncSerial.h"
 #include <boost/asio.hpp>
-#include <boost/asio/deadline_timer.hpp> // for deadline_timer
+#include <boost/asio/deadline_timer.hpp>
 #include <ctime>
 
 namespace Plugins {

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp> // for deadline_timer
 #include <boost/thread.hpp>
 #include "server.hpp"
 #include "session_store.hpp"

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <boost/asio.hpp>
-#include <boost/asio/deadline_timer.hpp> // for deadline_timer
+#include <boost/asio/deadline_timer.hpp>
 #include <boost/thread.hpp>
 #include "server.hpp"
 #include "session_store.hpp"

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -12,6 +12,7 @@
 #define HTTP_CONNECTION_HPP
 
 #include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp> // for deadline_timer
 #include <deque>
 #include <fstream>
 #include "reply.hpp"

--- a/webserver/connection.hpp
+++ b/webserver/connection.hpp
@@ -12,7 +12,7 @@
 #define HTTP_CONNECTION_HPP
 
 #include <boost/asio.hpp>
-#include <boost/asio/deadline_timer.hpp> // for deadline_timer
+#include <boost/asio/deadline_timer.hpp>
 #include <deque>
 #include <fstream>
 #include "reply.hpp"


### PR DESCRIPTION
Since version 1.69.0, Boost.System is header-only. A stub library was still built for compatibility, but linking to it was no longer necessary. Version 1.89.0 removed the stub library, so require 1.69.0+ and get rid of the library. It also removed deadline_timer, basic_deadline_timer and time_traits from the convenience header boost/asio.hpp, so we need to #include <boost/asio/deadline_timer.hpp> for deadline_timer where used.