### PR TITLE
Feature/ModelContextProtol support for use with LLM clients (domoticz LLM Agent)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ main/WebServerHelper.cpp
 main/WindCalculation.cpp
 mdns/mdns.cpp
 iamserver/IamService.cpp
+mcpserver/McpService.cpp
 push/BasePush.cpp
 push/FibaroPush.cpp
 push/GooglePubSubPush.cpp

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -243,7 +243,7 @@ namespace http
 
 			if (g_bLlmMCPSupport)
 			{
-				m_pWebEm->RegisterPageCode("/sse", [this](auto&& session, auto&& req, auto&& rep) { GetMcpSse(session, req, rep); }, true);
+				m_pWebEm->RegisterPageCode("/mcp", [this](auto&& session, auto&& req, auto&& rep) { PostMcp(session, req, rep); }, true);
 			}
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto&& session, auto&& req, auto&& rep) { GetJSonPage(session, req, rep); });

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -61,6 +61,8 @@ extern std::string szAppHash;
 extern std::string szAppDate;
 extern std::string szPyVersion;
 
+extern bool g_bLlmMCPSupport;
+
 namespace http
 {
 	namespace server
@@ -237,6 +239,11 @@ namespace http
 					m_iamsettings.token_url.c_str(), [this](auto&& session, auto&& req, auto&& rep) { PostOauth2AccessToken(session, req, rep); }, true);
 				m_pWebEm->RegisterPageCode(
 					m_iamsettings.discovery_url.c_str(), [this](auto&& session, auto&& req, auto&& rep) { GetOpenIDConfiguration(session, req, rep); }, true);
+			}
+
+			if (g_bLlmMCPSupport)
+			{
+				m_pWebEm->RegisterPageCode("/sse", [this](auto&& session, auto&& req, auto&& rep) { GetMcpSse(session, req, rep); }, true);
 			}
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto&& session, auto&& req, auto&& rep) { GetJSonPage(session, req, rep); });

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -243,7 +243,7 @@ namespace http
 
 			if (g_bLlmMCPSupport)
 			{
-				m_pWebEm->RegisterPageCode("/mcp", [this](auto&& session, auto&& req, auto&& rep) { PostMcp(session, req, rep); }, true);
+				m_pWebEm->RegisterPageCode("/mcp", [this](auto&& session, auto&& req, auto&& rep) { PostMcp(session, req, rep); }, false);
 			}
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto&& session, auto&& req, auto&& rep) { GetJSonPage(session, req, rep); });

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -47,6 +47,8 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void PostOauth2AccessToken(WebEmSession &session, const request &req, reply &rep);
 	void GetOpenIDConfiguration(WebEmSession &session, const request &req, reply &rep);
 
+	void GetMcpSse(WebEmSession &session, const request &req, reply &rep);
+
 	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void UploadFloorplanImage(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void SetRego6XXType(WebEmSession & session, const request& req, std::string & redirect_uri);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -48,13 +48,6 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void GetOpenIDConfiguration(WebEmSession &session, const request &req, reply &rep);
 
 	void PostMcp(WebEmSession &session, const request &req, reply &rep);
-	void McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
 	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void UploadFloorplanImage(WebEmSession & session, const request& req, std::string & redirect_uri);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -48,6 +48,8 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void GetOpenIDConfiguration(WebEmSession &session, const request &req, reply &rep);
 
 	void PostMcp(WebEmSession &session, const request &req, reply &rep);
+	void McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
 	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void UploadFloorplanImage(WebEmSession & session, const request& req, std::string & redirect_uri);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -50,6 +50,11 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void PostMcp(WebEmSession &session, const request &req, reply &rep);
 	void McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
 	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void UploadFloorplanImage(WebEmSession & session, const request& req, std::string & redirect_uri);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -47,7 +47,7 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void PostOauth2AccessToken(WebEmSession &session, const request &req, reply &rep);
 	void GetOpenIDConfiguration(WebEmSession &session, const request &req, reply &rep);
 
-	void GetMcpSse(WebEmSession &session, const request &req, reply &rep);
+	void PostMcp(WebEmSession &session, const request &req, reply &rep);
 
 	void SetRFXCOMMode(WebEmSession & session, const request& req, std::string & redirect_uri);
 	void UploadFloorplanImage(WebEmSession & session, const request& req, std::string & redirect_uri);

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -163,6 +163,7 @@ http::server::server_settings webserver_settings;
 http::server::ssl_server_settings secure_webserver_settings;
 #endif
 iamserver::iam_settings iamserver_settings;
+bool g_bLlmMCPSupport = true;
 
 bool bStartWebBrowser = true;
 bool g_bUseWatchdog = true;

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -78,6 +78,7 @@ namespace
 		"\t-webroot additional web root, useful with proxy servers (for example domoticz)\n"
 		"\t-nocache ask browser not to cache pages\n"
 		"\t-nomdns do not enable mDNS broadcast and listening\n"
+		"\t-mcp enable Model Context Protocol (/mcp) for use with LLM Agents\n"
 		"\t-startupdelay seconds (default=0)\n"
 		"\t-nowwwpwd (in case you forgot the web server username/password)\n"
 		"\t-wwwcompress mode (on = always compress [default], off = always decompress, static = no processing but try precompressed first)\n"
@@ -163,7 +164,7 @@ http::server::server_settings webserver_settings;
 http::server::ssl_server_settings secure_webserver_settings;
 #endif
 iamserver::iam_settings iamserver_settings;
-bool g_bLlmMCPSupport = true;
+bool g_bLlmMCPSupport = false;
 
 bool bStartWebBrowser = true;
 bool g_bUseWatchdog = true;
@@ -1093,6 +1094,12 @@ int main(int argc, char**argv)
 	if (cmdLine.HasSwitch("-nomdns"))
 	{
 		bEnableMDNS = false;
+		_log.Log(LOG_STATUS, "mDNS Support disabled!");
+	}
+	if (cmdLine.HasSwitch("-mcp"))
+	{
+		g_bLlmMCPSupport = true;
+		_log.Log(LOG_STATUS, "Model Context Protocol (MCP) Support enabled (/mcp).");
 	}
 
 #if defined WIN32

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -1,0 +1,61 @@
+/*
+ * McpService.cpp
+ *
+ *  Created on: 4 April 2025
+ *      Author: kiddigital
+ * 
+ * 
+ * It contains routines that are part of the WebServer class, but for sourcecode management
+ * reasons separated out into its own file so it is easier to maintain the MCP related functions
+ * of the WebServer. The definitions of the methods here are still in 'main/Webserver.h'
+ *  
+*/
+
+#include "stdafx.h"
+#include <iostream>
+#include <json/json.h>
+#include "../main/Logger.h"
+#include "../main/SQLHelper.h"
+#include "../httpclient/UrlEncode.h"
+#include "../main/WebServer.h"
+#include "../webserver/Base64.h"
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+namespace http
+{
+	namespace server
+	{
+
+		void CWebServer::GetMcpSse(WebEmSession &session, const request &req, reply &rep)
+		{
+			_log.Debug(DEBUG_RECEIVED, "GetMcpSse (%d): %s (%s)", req.content_length, req.content.c_str(), req.uri.c_str());
+			// Check if the request is valid
+			if (req.get_req_header(&req, "Accept") != nullptr)
+			{
+				std::string accept = req.get_req_header(&req, "Accept");
+				if (accept.find("text/event-stream") == std::string::npos)
+				{
+					rep = reply::stock_reply(reply::bad_request);
+					return;
+				}
+			}
+			
+			// Set headers for SSE
+			reply::add_header(&rep, "Content-Type", "text/event-stream");
+			//reply::add_header(&rep, "Cache-Control", "no-cache");
+			//reply::add_header(&rep, "Connection", "keep-alive");
+		
+			Json::Value jsonRPC;
+			jsonRPC["jsonrpc"] = "2.0";
+			jsonRPC["result"] = "Welcome to the Domoticz Model Context Protocol ServerSideEvents\n\n";
+			jsonRPC["id"] = 1;
+
+			// Set response content
+			//rep.content = jsonRPC.toStyledString();
+			rep.status = reply::ok;
+		}
+
+	} // namespace server
+} // namespace http

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -28,30 +28,84 @@ namespace http
 	namespace server
 	{
 
-		void CWebServer::GetMcpSse(WebEmSession &session, const request &req, reply &rep)
+		void CWebServer::PostMcp(WebEmSession &session, const request &req, reply &rep)
 		{
-			_log.Debug(DEBUG_RECEIVED, "GetMcpSse (%d): %s (%s)", req.content_length, req.content.c_str(), req.uri.c_str());
+			_log.Debug(DEBUG_RECEIVED, "PostMcp (%d): %s (%s)", req.content_length, req.content.c_str(), req.uri.c_str());
 			// Check if the request is valid
 			if (req.get_req_header(&req, "Accept") != nullptr)
 			{
 				std::string accept = req.get_req_header(&req, "Accept");
-				if (accept.find("text/event-stream") == std::string::npos)
+				if (accept.find("text/event-stream") == std::string::npos && accept.find("application/json") == std::string::npos)
 				{
+					_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid Accept header: %s", accept.c_str());
 					rep = reply::stock_reply(reply::bad_request);
 					return;
 				}
 			}
-			
+
+			// Check if the request is a POST request
+			if (req.method != "POST")
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid method: %s", req.method.c_str());
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+
+			// Check if the request if a proper JSON-RPC request
+			if (req.content_length <= 0 || req.content.empty())
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid content length or empty content");
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+			Json::Value jsonRequest;
+			Json::CharReaderBuilder readerBuilder;	// Use ParseJSON instead of Json::Reader
+			std::string errs;
+			std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
+			if (!reader->parse(req.content.c_str(), req.content.c_str() + req.content_length, &jsonRequest, &errs))
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid JSON content: %s", errs.c_str());
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+
 			// Set headers for SSE
-			reply::add_header(&rep, "Content-Type", "text/event-stream");
+			reply::add_header(&rep, "Content-Type", "application/json");	// "text/event-stream" is also an option if we want to support SSE
 			//reply::add_header(&rep, "Cache-Control", "no-cache");
 			//reply::add_header(&rep, "Connection", "keep-alive");
 		
 			Json::Value jsonRPC;
 			jsonRPC["jsonrpc"] = "2.0";
-			jsonRPC["result"] = "Welcome to the Domoticz Model Context Protocol ServerSideEvents\n\n";
+			jsonRPC["result"] = "Welcome to the Domoticz Model Context Protocol over StreamableHTTP\n\n";
 			jsonRPC["id"] = 1;
-
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {
+      "logging": {},
+      "prompts": {
+        "listChanged": true
+      },
+      "resources": {
+        "subscribe": true,
+        "listChanged": true
+      },
+      "tools": {
+        "listChanged": true
+      }
+    },
+    "serverInfo": {
+      "name": "ExampleServer",
+      "title": "Example Server Display Name",
+      "version": "1.0.0"
+    },
+    "instructions": "Optional instructions for the client"
+  }
+}
+*/
 			// Set response content
 			//rep.content = jsonRPC.toStyledString();
 			rep.status = reply::ok;

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -124,6 +124,26 @@ namespace http
 			{
 				McpToolsList(jsonRequest, jsonRPCRep);
 			}
+			else if (sReqMethod == "tools/call")
+			{
+				McpToolsCall(jsonRequest, jsonRPCRep);
+			}
+			else if (sReqMethod == "resources/list")
+			{
+				McpResourcesList(jsonRequest, jsonRPCRep);
+			}
+			else if (sReqMethod == "resources/read")
+			{
+				McpResourcesRead(jsonRequest, jsonRPCRep);
+			}
+			else if (sReqMethod == "prompts/list")
+			{
+				McpPromptsList(jsonRequest, jsonRPCRep);
+			}
+			else if (sReqMethod == "prompts/get")
+			{
+				McpPromptsGet(jsonRequest, jsonRPCRep);
+			}
 			else
 			{
 				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Unsupported method: %s", sReqMethod.c_str());
@@ -233,6 +253,176 @@ namespace http
 			tool["inputSchema"]["properties"]["switchname"]["description"] = "Name of the switch to query";
 			tool["inputSchema"]["required"].append("switchname");
 			jsonRPCRep["result"]["tools"].append(tool);
+		}
+
+		void CWebServer::McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "Current weather in New York:\nTemperature: 72°F\nConditions: Partly cloudy"
+      }
+    ],
+    "isError": false
+  }
+}*/
+			// Prepare the result for the tools/list method
+			jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
+			Json::Value tool;
+			tool["type"] = "text";
+			tool["text"] = "The current state of the switch is: Off";
+			jsonRPCRep["result"]["content"].append(tool);
+			jsonRPCRep["result"]["isError"] = false;
+		}
+
+		void CWebServer::McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "resources": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "title": "Rust Software Application Main File",
+        "description": "Primary application entry point",
+        "mimeType": "text/x-rust"
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+idx	hardwareID	uniqueID	ena	name		type			subtype			value
+2	testmb		0000044C	1	Memory Usage	General			Percentage		57.96%
+3	testmb		000000DC	1	Process Usage	General			Custom Sensor	43.87 MB
+5	testmb		0000044D	1	CPU_Usage		General			Percentage		0.13%
+4	testmb		0000044E	1	HDD /			General			Percentage		26.31%
+6	testmb		0000044F	1	HDD /boot		General			Percentage		11.83%
+1	testdummy	00014051	1	dumswitch		Light/Switch	Switch			Off
+
+*/
+			// Prepare the result for the resources/list method
+			jsonRPCRep["result"]["resources"] = Json::Value(Json::arrayValue);
+			Json::Value resource;
+			resource["uri"] = "dom:///dom.local:8080/Light_Switch/Switch/1";
+			resource["name"] = "dumswitch";
+			resource["title"] = "dumswitch (testdummy - light switch - switch)";
+			resource["description"] = "A Sensor from the testdummy hardware of Type Light_switch and subtype Switch called dumswitch with ID 00014051 and IDX 1";
+			resource["mimeType"] = "plain/text";
+			jsonRPCRep["result"]["resources"].append(resource);
+		}
+
+		void CWebServer::McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "contents": [
+      {
+        "uri": "file:///project/src/main.rs",
+        "name": "main.rs",
+        "title": "Rust Software Application Main File",
+        "mimeType": "text/x-rust",
+        "text": "fn main() {\n    println!(\"Hello world!\");\n}"
+      }
+    ]
+  }
+}*/
+			// Prepare the result for the resources/read method
+			jsonRPCRep["result"]["contents"] = Json::Value(Json::arrayValue);
+			Json::Value resource;
+			resource["uri"] = "dom:///dom.local:8080/Light_Switch/Switch/1";
+			resource["name"] = "dumswitch";
+			resource["title"] = "dumswitch (testdummy - light switch - switch)";
+			resource["mimeType"] = "plain/text";
+			resource["text"] = "off";
+			jsonRPCRep["result"]["contents"].append(resource);
+		}
+
+		void CWebServer::McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "prompts": [
+      {
+        "name": "code_review",
+        "title": "Request Code Review",
+        "description": "Asks the LLM to analyze code quality and suggest improvements",
+        "arguments": [
+          {
+            "name": "code",
+            "description": "The code to review",
+            "required": true
+          }
+        ]
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}*/
+			// Prepare the result for the prompts/list method
+			jsonRPCRep["result"]["prompts"] = Json::Value(Json::arrayValue);
+			Json::Value prompt;
+			prompt["name"] = "status_check";
+			prompt["title"] = "Get the status overview";
+			prompt["description"] = "Asks the LLM to summarize the current status of all sensors and devices (either grouped by hardware, type or room)";
+			prompt["arguments"] = Json::Value(Json::arrayValue);
+			Json::Value arg;
+			arg["name"] = "hardware";
+			arg["description"] = "The hardware to summarize";
+			arg["required"] = false;
+			prompt["arguments"].append(arg);
+			arg["name"] = "type";
+			arg["description"] = "The type to summarize";
+			arg["required"] = false;
+			prompt["arguments"].append(arg);
+			arg["name"] = "room";
+			arg["description"] = "The room to summarize";
+			arg["required"] = false;
+			prompt["arguments"].append(arg);
+			jsonRPCRep["result"]["prompts"].append(prompt);
+		}
+
+		void CWebServer::McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "result": {
+    "description": "Code review prompt",
+    "messages": [
+      {
+        "role": "user",
+        "content": {
+          "type": "text",
+          "text": "Please review this Python code:\ndef hello():\n    print('world')"
+        }
+      }
+    ]
+  }
+}*/
+			// Prepare the result for the prompts/get method
+			jsonRPCRep["result"]["description"] = "Asks the LLM to summarize the current status of all sensors and devices (either grouped by hardware, type or room)";
+			jsonRPCRep["result"]["messages"] = Json::Value(Json::arrayValue);
+			Json::Value message;
+			message["role"] = "user";
+			message["content"] = Json::Value(Json::objectValue);
+			message["content"]["type"] = "text";
+			message["content"]["text"] = "Please review this Python code:\ndef hello():\n    print('world')";
+			jsonRPCRep["result"]["messages"].append(message);
 		}
 
 	} // namespace server

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -16,6 +16,7 @@
 #include <json/json.h>
 #include "../main/Logger.h"
 #include "../main/SQLHelper.h"
+#include "../main/json_helper.h"
 #include "../httpclient/UrlEncode.h"
 #include "../main/WebServer.h"
 #include "../webserver/Base64.h"
@@ -32,6 +33,7 @@ namespace http
 		{
 			_log.Debug(DEBUG_RECEIVED, "PostMcp (%d): %s (%s)", req.content_length, req.content.c_str(), req.uri.c_str());
 			// Check if the request is valid
+			std::string sProtocolRequestHeader;
 			if (req.get_req_header(&req, "Accept") != nullptr)
 			{
 				std::string accept = req.get_req_header(&req, "Accept");
@@ -40,6 +42,16 @@ namespace http
 					_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid Accept header: %s", accept.c_str());
 					rep = reply::stock_reply(reply::bad_request);
 					return;
+				}
+				if (req.get_req_header(&req, "mcp-protocol-version:") != nullptr)
+				{
+					sProtocolRequestHeader = req.get_req_header(&req, "mcp-protocol-version:");
+					if (sProtocolRequestHeader != "2025-06-18")
+					{
+						_log.Debug(DEBUG_WEBSERVER, "PostMcp: MCP-PROTOCOL-VERSION not supported: %s", sProtocolRequestHeader.c_str());
+						rep = reply::stock_reply(reply::bad_request);
+						return;
+					}
 				}
 			}
 
@@ -51,7 +63,7 @@ namespace http
 				return;
 			}
 
-			// Check if the request if a proper JSON-RPC request
+			// Check if the request is a proper JSON-RPC request
 			if (req.content_length <= 0 || req.content.empty())
 			{
 				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid content length or empty content");
@@ -59,25 +71,77 @@ namespace http
 				return;
 			}
 			Json::Value jsonRequest;
-			Json::CharReaderBuilder readerBuilder;	// Use ParseJSON instead of Json::Reader
-			std::string errs;
-			std::unique_ptr<Json::CharReader> reader(readerBuilder.newCharReader());
-			if (!reader->parse(req.content.c_str(), req.content.c_str() + req.content_length, &jsonRequest, &errs))
+			std::string sParseErr;
+			if (!ParseJSon(req.content, jsonRequest, &sParseErr))
 			{
-				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid JSON content: %s", errs.c_str());
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Failed to parse JSON content: %s", sParseErr.c_str());
 				rep = reply::stock_reply(reply::bad_request);
 				return;
 			}
+			_log.Debug(DEBUG_RECEIVED, "PostMcp: Parsed JSON Request content: %s", jsonRequest.toStyledString().c_str());
+			// Check if the parsed JSON is valid JSON-RPC 2.0 format
+			if (!jsonRequest.isObject() || !jsonRequest.isMember("jsonrpc") || !jsonRequest.isMember("method"))	//  || !jsonRequest.isMember("params") || !jsonRequest.isMember("id")
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Invalid JSON-RPC request format");
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+			// Check if the JSON-RPC version is supported
+			if (jsonRequest["jsonrpc"].asString() != "2.0")
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Unsupported JSON-RPC version: %s", jsonRequest["jsonrpc"].asString().c_str());
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+			// Check if the method is supported and handle it
+			std::string sReqMethod = jsonRequest["method"].asString();
+			_log.Debug(DEBUG_WEBSERVER, "PostMcp: Request method: %s", sReqMethod.c_str());
 
-			// Set headers for SSE
+			if (sReqMethod.find("notifications/") != std::string::npos)
+			{
+				// Handle notifications, notifications do not require a response
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Notification: %s", sReqMethod.c_str());
+				rep = reply::stock_reply(reply::no_content);
+				return;
+			}
+			// Check if the request has an ID
+			std::string sReqID = (jsonRequest.isMember("id") ? jsonRequest["id"].asString() : "");
+
+			Json::Value jsonRPCRep;
+			jsonRPCRep["jsonrpc"] = "2.0";
+			jsonRPCRep["id"] = sReqID;
+
+			if (sReqMethod == "ping")
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Handling ping request");
+				jsonRPCRep["result"] = Json::Value(Json::objectValue);
+			}
+			else if (sReqMethod == "initialize")
+			{
+				McpInitialize(jsonRequest, jsonRPCRep);
+			}
+			else if (sReqMethod == "tools/list")
+			{
+				McpToolsList(jsonRequest, jsonRPCRep);
+			}
+			else
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PostMcp: Unsupported method: %s", sReqMethod.c_str());
+				rep = reply::stock_reply(reply::not_implemented);
+				return;
+			}
+			// Set response content
+			rep.content = jsonRPCRep.toStyledString();
+			rep.status = reply::ok;
+
+			// Set headers
 			reply::add_header(&rep, "Content-Type", "application/json");	// "text/event-stream" is also an option if we want to support SSE
 			//reply::add_header(&rep, "Cache-Control", "no-cache");
 			//reply::add_header(&rep, "Connection", "keep-alive");
-		
-			Json::Value jsonRPC;
-			jsonRPC["jsonrpc"] = "2.0";
-			jsonRPC["result"] = "Welcome to the Domoticz Model Context Protocol over StreamableHTTP\n\n";
-			jsonRPC["id"] = 1;
+		}
+
+		void CWebServer::McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
 /*
 {
   "jsonrpc": "2.0",
@@ -106,9 +170,69 @@ namespace http
   }
 }
 */
-			// Set response content
-			//rep.content = jsonRPC.toStyledString();
-			rep.status = reply::ok;
+			_log.Debug(DEBUG_WEBSERVER, "HandleMcpInitialize: Handling MCP initialization request");
+
+			// Prepare the result for the initialize method
+			jsonRPCRep["result"]["protocolVersion"] = "2025-06-18";
+			//jsonRPCRep["result"]["capabilities"]["logging"] = Json::Value(Json::objectValue);
+			//jsonRPCRep["result"]["capabilities"]["completion"] = Json::Value(Json::objectValue);
+			jsonRPCRep["result"]["capabilities"]["prompts"] = Json::Value(Json::objectValue);
+			//jsonRPCRep["result"]["capabilities"]["prompts"]["listChanged"] = true;
+			jsonRPCRep["result"]["capabilities"]["resources"] = Json::Value(Json::objectValue);
+			//jsonRPCRep["result"]["capabilities"]["resources"]["subscribe"] = true;
+			//jsonRPCRep["result"]["capabilities"]["resources"]["listChanged"] = true;
+			jsonRPCRep["result"]["capabilities"]["tools"] = Json::Value(Json::objectValue);
+			//jsonRPCRep["result"]["capabilities"]["tools"]["listChanged"] = true;
+
+			jsonRPCRep["result"]["serverInfo"]["name"] = "DomoticzMcp";
+			jsonRPCRep["result"]["serverInfo"]["title"] = "Domoticz MCP Server";
+			jsonRPCRep["result"]["serverInfo"]["version"] = "0.1.0";
+
+			if (jsonRequest.isMember("params") && jsonRequest["params"].isMember("instructions"))
+			{
+				jsonRPCRep["result"]["instructions"] = jsonRequest["params"]["instructions"];
+			}
+		}
+
+		void CWebServer::McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+		{
+/*
+
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "tools": [
+      {
+        "name": "get_weather",
+        "title": "Weather Information Provider",
+        "description": "Get current weather information for a location",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "string",
+              "description": "City name or zip code"
+            }
+          },
+          "required": ["location"]
+        }
+      }
+    ],
+    "nextCursor": "next-page-cursor"
+  }
+}
+*/
+			// Prepare the result for the tools/list method
+			jsonRPCRep["result"]["tools"] = Json::Value(Json::arrayValue);
+			Json::Value tool;
+			tool["name"] = "get_switch_state";
+			tool["title"] = "See the state of a switch in the system";
+			tool["description"] = "Get the current state of a given switch in the system";
+			tool["inputSchema"]["type"] = "object";
+			tool["inputSchema"]["properties"]["switchname"]["type"] = "string";
+			tool["inputSchema"]["properties"]["switchname"]["description"] = "Name of the switch to query";
+			tool["inputSchema"]["required"].append("switchname");
+			jsonRPCRep["result"]["tools"].append(tool);
 		}
 
 	} // namespace server

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -1,13 +1,17 @@
 /*
  * McpService.cpp
+ * The MCP Service of domoticz implements the Model Context Protocol (currently version 2025-06-18)
+ * so domoticz can be used as a agent in a LLM (Large Language Model) AI Agent context.
  *
  *  Created on: 4 April 2025
  *      Author: kiddigital
  * 
  * 
- * It contains routines that are part of the WebServer class, but for sourcecode management
- * reasons separated out into its own file so it is easier to maintain the MCP related functions
- * of the WebServer. The definitions of the methods here are still in 'main/Webserver.h'
+ * It contains the PostMCP routine that is part of the WebServer class, but for sourcecode management
+ * reasons separated out into its own file so it is easier to maintain this MCP related function
+ * of the WebServer. The definition of this method here is still in 'main/Webserver.h'
+ * Also it contains the implementation of the other Model Context Protocol methods, which are defined
+ * in 'mcpserver/McpService.hpp'.
  *  
 */
 
@@ -185,7 +189,7 @@ namespace http
 	} // namespace server
 } // namespace http
 
-namespace mcp
+namespace mcp		// Model Context Protocol
 {
 	void McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
@@ -247,6 +251,15 @@ namespace mcp
 		tool["inputSchema"]["properties"]["sensorname"]["description"] = "Name of the sensor to query";
 		tool["inputSchema"]["required"].append("sensorname");
 		jsonRPCRep["result"]["tools"].append(tool);
+		// Get logging tool
+		tool.clear();
+		tool["name"] = "get_logging";
+		tool["title"] = "Get the logging information";
+		tool["description"] = "Retrieve the current logging information";
+		tool["inputSchema"]["type"] = "object";
+		tool["inputSchema"]["properties"]["logdate"]["type"] = "number";
+		tool["inputSchema"]["properties"]["logdate"]["description"] = "The (Unixtimestamp) date and time from which to retrieve the logs (optional, default is 0, which means all logs)";
+		jsonRPCRep["result"]["tools"].append(tool);
 	}
 
 	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -288,6 +301,15 @@ namespace mcp
 			{
 				jsonRPCRep["error"]["code"] = -32602; // Invalid params
 				jsonRPCRep["error"]["message"] = "Error getting sensor value";
+				return;
+			}
+		}
+		else if (sMethodName == "get_logging")
+		{
+			if(!mcp::getLogging(jsonRequest, jsonRPCRep))
+			{
+				jsonRPCRep["error"]["code"] = -32001; // Resource not found
+				jsonRPCRep["error"]["message"] = "Error getting logging";
 				return;
 			}
 		}
@@ -444,6 +466,7 @@ namespace mcp
 		// Prepare the result for the prompts/list method
 		jsonRPCRep["result"]["prompts"] = Json::Value(Json::arrayValue);
 		Json::Value prompt;
+		// House Summary prompt
 		prompt["name"] = "housesummary";
 		prompt["title"] = "Get a status overview";
 		prompt["description"] = "Summarize the current status of all sensors and devices in the house (optionally limited to a specific room)";
@@ -454,6 +477,14 @@ namespace mcp
 		arg["required"] = false;
 		prompt["arguments"].append(arg);
 		jsonRPCRep["result"]["prompts"].append(prompt);
+		// System analysis prompt
+		prompt.clear();
+		prompt["name"] = "systemanalysis";
+		prompt["title"] = "Get a system analysis";
+		prompt["description"] = "Analyze the current status of the system and provide insights";
+		prompt["arguments"] = Json::Value(Json::arrayValue);
+		jsonRPCRep["result"]["prompts"].append(prompt);
+
 	}
 
 	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -471,10 +502,10 @@ namespace mcp
 			message["role"] = "user";
 			message["content"] = Json::Value(Json::objectValue);
 			message["content"]["type"] = "text";
-			std::string sText = "As the friendly butler of the house, please summarize the current status of all sensors and devices preferably grouped by room. Please also include the current state of the switches and sensors in your summary.";
+			std::string sText = "As the friendly butler of the house, please summarize the current status of all sensors and devices preferably grouped by room.";
 			Json::Value jsonDevices;
 			m_webservers.GetJSonDevices(jsonDevices, "", "", "", "", "", "", false, false, false, 0, "", "");
-			sText += "Include the following devices in your summary:";
+			sText += " Include the following devices in your summary:";
 			for(const auto &device : jsonDevices["result"])
 			{
 				if(device.isObject() && device.isMember("Name") && device.isMember("Data") && device.isMember("Type") && device.isMember("SubType"))
@@ -487,6 +518,21 @@ namespace mcp
 				}
 			}
 			// To-do: add all known swtches and sensors to the prompt. Filter if needed by room if specified in the arguments
+			message["content"]["text"] = sText;
+			jsonRPCRep["result"]["messages"].append(message);
+		}
+		else if (sPromptName == "systemanalysis")
+		{
+			std::string sRoom = ((jsonRequest["params"].isMember("arguments") && jsonRequest["params"]["arguments"].isMember("room")) ? jsonRequest["params"]["arguments"]["room"].asString() : "");
+			// Prepare the result for the prompts/get method
+			jsonRPCRep["result"]["description"] = "Analyze the current status of the system and provide insights";
+			jsonRPCRep["result"]["messages"] = Json::Value(Json::arrayValue);
+			Json::Value message;
+			message["role"] = "user";
+			message["content"] = Json::Value(Json::objectValue);
+			message["content"]["type"] = "text";
+			std::string sText = "As the friendly butler of the house, please make an analysis of the current status of the system by analyzing all available log information, and providing suggestions if needed.";
+			sText += "State the time window of the logging you have analyzed. If the latest log entries are older than 3 minutes, make sure to first retrieve the latest log entries before making your analysis.";
 			message["content"]["text"] = sText;
 			jsonRPCRep["result"]["messages"].append(message);
 		}
@@ -571,6 +617,62 @@ namespace mcp
 		jsonRPCRep["result"]["content"].append(tool);
 		jsonRPCRep["result"]["isError"] = !bFound;
 		return true;
+	}
+
+	bool getLogging(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+	{
+		bool bFound = false;
+		time_t iSinceUnixtime = 0;
+		if (jsonRequest["params"].isMember("arguments") && jsonRequest["params"]["arguments"].isMember("logdate"))
+		{
+			iSinceUnixtime = (time_t)jsonRequest["params"]["arguments"]["logdate"].asUInt64();
+			_log.Debug(DEBUG_WEBSERVER, "MCP: getLogging: Retrieving logs since Unixtime %ld", (uint64_t)iSinceUnixtime);
+		}
+		// Get the current log levels
+		std::string sResult = "The following loglevel are currently enabled: ";
+		if (_log.IsLogLevelEnabled(LOG_ALL))
+		{
+			bFound = true;
+			sResult += "ALL ";
+		}
+		if (_log.IsLogLevelEnabled(LOG_ERROR))
+		{
+			bFound = true;
+			sResult += "ERROR ";
+		}
+		if (_log.IsLogLevelEnabled(LOG_STATUS))
+		{
+			bFound = true;
+			sResult += "STATUS ";
+		}
+		if (_log.IsLogLevelEnabled(LOG_NORM))
+		{
+			bFound = true;
+			sResult += "NORM ";
+		}
+		if (_log.IsLogLevelEnabled(LOG_DEBUG_INT))
+		{
+			bFound = true;
+			sResult += "DEBUG ";
+		}
+		if (bFound)
+		{
+			sResult += "\nThe last log messages are:\n";
+			std::list<CLogger::_tLogLineStruct> logmessages = _log.GetLog(_eLogLevel::LOG_ALL, iSinceUnixtime);
+			for (const auto& msg : logmessages)
+			{
+				sResult += msg.logmessage + "\n";
+			}
+		}
+		else
+			sResult = "No loglevels are currently enabled!";
+		Json::Value tool;
+		tool["type"] = "text";
+		tool["text"] = sResult;;
+		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
+		jsonRPCRep["result"]["content"].append(tool);
+		jsonRPCRep["result"]["isError"] = !bFound;
+		return bFound;
 	}
 
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device)

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -259,6 +259,19 @@ namespace mcp		// Model Context Protocol
 		tool["inputSchema"]["properties"]["sensorname"]["description"] = "Name of the sensor to query";
 		tool["inputSchema"]["required"].append("sensorname");
 		jsonRPCRep["result"]["tools"].append(tool);
+		// Set Setpoint Value tool
+		tool.clear();
+		tool["name"] = "set_setpoint_value";
+		tool["title"] = "Set the target setpoint of a thermostat in the system";
+		tool["description"] = "Set the target setpoint of a given thermostat in the system";
+		tool["inputSchema"]["type"] = "object";
+		tool["inputSchema"]["properties"]["thermostatname"]["type"] = "string";
+		tool["inputSchema"]["properties"]["thermostatname"]["description"] = "Name of the thermostat to set";
+		tool["inputSchema"]["properties"]["setpoint"]["type"] = "number";
+		tool["inputSchema"]["properties"]["setpoint"]["description"] = "Temperature setpoint as an number";
+		tool["inputSchema"]["required"].append("thermostatname");
+		tool["inputSchema"]["required"].append("setpoint");
+		jsonRPCRep["result"]["tools"].append(tool);
 		// Get logging tool
 		tool.clear();
 		tool["name"] = "get_logging";
@@ -319,6 +332,15 @@ namespace mcp		// Model Context Protocol
 			{
 				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error getting sensor value";
+				return;
+			}
+		}
+		else if (sMethodName == "set_setpoint_value")
+		{
+			if (!mcp::setThermostatSetpoint(jsonRequest, jsonRPCRep))
+			{
+				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
+				jsonRPCRep["error"]["message"] = "Error setting thermostat setpoint";
 				return;
 			}
 		}
@@ -458,41 +480,66 @@ namespace mcp		// Model Context Protocol
 			jsonRPCRep["error"]["message"] = "Invalid resource URI, cannot extract IDX";
 			return;
 		}
-		auto result = m_sql.safe_query("SELECT Name, HardwareID, DeviceID, Type, SubType, nValue, sValue, LastUpdate from DeviceStatus WHERE ID=%d", nIdx);
-		if (result.empty() || result.size() != 1)
-		{
-			_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: No device found with IDX %d", nIdx);
-			jsonRPCRep["error"]["code"] = MCP_RESOURCE_NOT_FOUND;
-			jsonRPCRep["error"]["message"] = "No device found with the specified URI";
-			return;
-		}
-		auto &row = result[0];
-		std::string sName = row[0];
-		int iHardwareID = atoi(row[1].c_str());
-		std::string sDeviceID = row[2];
-		int iType = atoi(row[3].c_str());
-		int iSubType = atoi(row[4].c_str());
-		int nValue = atoi(row[5].c_str());
-		std::string sValue = row[6];
-		std::string sLastUpdate = row[7];
-		jsonRPCRep["result"]["contents"] = Json::Value(Json::arrayValue);
+		std::string sResourceType = sReadURI.substr(0, sReadURI.find(":///"));
 		Json::Value resource;
-		resource["uri"] = sReadURI;
-		resource["name"] = sName;
-		resource["title"] = sName + " (" + std::to_string(iHardwareID) + " - " + std::to_string(iType) + " - " + std::to_string(iSubType) + ")";
-		resource["mimeType"] = "plain/text";
-		resource["text"] = (sValue.empty() ? std::to_string(nValue) : sValue);
-		Json::Value meta;
-		meta["hardwareID"] = iHardwareID;
-		meta["type"] = iType;
-		meta["subtype"] = iSubType;
-		meta["idx"] = nIdx;
-		meta["id"] = sDeviceID;
-		resource["_meta"] = meta;
-		Json::Value annotations;
-		stdreplace(sLastUpdate, " ", "T");
-		annotations["lastModified"] = sLastUpdate + "Z";	// To-Do: Properly convert to ISO 8601 format (adjust for real timezone)
-		resource["annotations"] = annotations;
+		if (sResourceType == "floorplan")
+		{
+			// Read floorplan data from database
+			auto result = m_sql.safe_query("SELECT Name, Scalefactor FROM Floorplans WHERE ID=%d", nIdx);
+			if (result.empty() || result.size() != 1)
+			{
+				_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: No floorplan found with IDX %d", nIdx);
+				jsonRPCRep["error"]["code"] = MCP_RESOURCE_NOT_FOUND;
+				jsonRPCRep["error"]["message"] = "No floorplan found with the specified URI";
+				return;
+			}
+			auto &row = result[0];
+			jsonRPCRep["result"]["contents"] = Json::Value(Json::arrayValue);
+			resource["uri"] = sReadURI;
+			resource["name"] = row[0];
+			resource["title"] = "Floorplan " + row[0] + " (Scale factor: " + row[1] + ")";
+			Json::Value meta;
+			meta["idx"] = nIdx;
+			meta["type"] = "floorplan";
+			resource["_meta"] = meta;
+		}
+		else
+		{
+			auto result = m_sql.safe_query("SELECT Name, HardwareID, DeviceID, Type, SubType, nValue, sValue, LastUpdate from DeviceStatus WHERE ID=%d", nIdx);
+			if (result.empty() || result.size() != 1)
+			{
+				_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: No device found with IDX %d", nIdx);
+				jsonRPCRep["error"]["code"] = MCP_RESOURCE_NOT_FOUND;
+				jsonRPCRep["error"]["message"] = "No device found with the specified URI";
+				return;
+			}
+			auto &row = result[0];
+			std::string sName = row[0];
+			int iHardwareID = atoi(row[1].c_str());
+			std::string sDeviceID = row[2];
+			int iType = atoi(row[3].c_str());
+			int iSubType = atoi(row[4].c_str());
+			int nValue = atoi(row[5].c_str());
+			std::string sValue = row[6];
+			std::string sLastUpdate = row[7];
+			jsonRPCRep["result"]["contents"] = Json::Value(Json::arrayValue);
+			resource["uri"] = sReadURI;
+			resource["name"] = sName;
+			resource["title"] = sName + " (" + std::to_string(iHardwareID) + " - " + std::to_string(iType) + " - " + std::to_string(iSubType) + ")";
+			resource["mimeType"] = "plain/text";
+			resource["text"] = (sValue.empty() ? std::to_string(nValue) : sValue);
+			Json::Value meta;
+			meta["hardwareID"] = iHardwareID;
+			meta["type"] = iType;
+			meta["subtype"] = iSubType;
+			meta["idx"] = nIdx;
+			meta["id"] = sDeviceID;
+			resource["_meta"] = meta;
+			Json::Value annotations;
+			stdreplace(sLastUpdate, " ", "T");
+			annotations["lastModified"] = sLastUpdate + "Z";	// To-Do: Properly convert to ISO 8601 format (adjust for real timezone)
+			resource["annotations"] = annotations;
+		}
 
 		jsonRPCRep["result"]["contents"].append(resource);
 
@@ -792,6 +839,33 @@ namespace mcp		// Model Context Protocol
 		jsonRPCRep["result"]["content"].append(tool);
 		jsonRPCRep["result"]["isError"] = !bFound;
 		return bFound;
+	}
+
+	bool setThermostatSetpoint(const Json::Value& jsonRequest, Json::Value& jsonRPCRep)
+	{
+		if (!jsonRequest["params"].isMember("arguments") || !jsonRequest["params"]["arguments"].isMember("thermostatname") || !jsonRequest["params"]["arguments"].isMember("setpoint"))
+		{
+			_log.Debug(DEBUG_WEBSERVER, "MCP: setThermostatSetpoint: Missing required parameter 'thermostatname/setpoint'");
+			return false;
+		}
+		std::string sThermostatName = jsonRequest["params"]["arguments"]["thermostatname"].asString();
+		float fNewSetpoint = (float)atof(jsonRequest["params"]["arguments"]["setpoint"].asString().c_str());
+		std::string sThermostatState = "No thermostat exists with the name " + sThermostatName;
+		Json::Value device;
+		bool bFound = getDeviceByName(sThermostatName, device);
+		if (bFound)
+		{
+			sThermostatState = "The value of thermostat \"" + sThermostatName + "\" before setting was: " + device["Data"].asString() + ". ";
+			bFound = true;
+			sThermostatState += (m_mainworker.SetSetPoint(device["idx"].asString(), fNewSetpoint) == false ? "Error setting the setpoint." : "Setpoint set successfully.");
+		}
+		Json::Value tool;
+		tool["type"] = "text";
+		tool["text"] = sThermostatState;
+		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
+		jsonRPCRep["result"]["content"].append(tool);
+		jsonRPCRep["result"]["isError"] = !bFound;
+		return true;
 	}
 
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device)

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -150,6 +150,10 @@ namespace http
 			{
 				mcp::McpResourcesList(jsonRequest, jsonRPCRep);
 			}
+			else if (sReqMethod == "resources/templates/list")
+			{
+				mcp::McpResourcesTemplatesList(jsonRequest, jsonRPCRep);
+			}
 			else if (sReqMethod == "resources/read")
 			{
 				mcp::McpResourcesRead(jsonRequest, jsonRPCRep);
@@ -329,10 +333,13 @@ namespace mcp
 					//resource["uri"] = "dom:///dom.local:8080/" + device["Type"].asString() + "/" + device["SubType"].asString() + "/" + device["idx"].asString();
 					std::string sType = device["Type"].asString();
 					stdlower(sType);
-					// Replace spaces and slashes in sType to make it URL friendly
-					stdreplace(sType, " ", "-");
+					std::string sSubType = device["SubType"].asString();
+					stdlower(sSubType);
+					// Replace spaces and slashes to make it URL friendly
+					stdreplace(sType, " ", "_");
 					stdreplace(sType, "/", "-");
-					resource["uri"] = sType + ":///" + device["SubType"].asString() + "/" + device["idx"].asString();
+					stdreplace(sSubType, " ", "_");
+					resource["uri"] = sType + ":///" + sSubType + "/" + device["idx"].asString();
 					resource["name"] = device["Name"].asString();
 					resource["title"] = device["Name"].asString() + " (" + device["HardwareName"].asString() + " - " + device["Type"].asString() + " - " + device["SubType"].asString() + ")";
 					resource["description"] = "A Sensor from the " + device["HardwareName"].asString() + " hardware of Type " + device["Type"].asString() +
@@ -353,6 +360,17 @@ namespace mcp
 		_log.Debug(DEBUG_WEBSERVER, "McpResourcesList: Following resources offered:\n%s", jsonRPCRep.toStyledString().c_str());
 	}
 
+	void McpResourcesTemplatesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+	{
+		_log.Debug(DEBUG_WEBSERVER, "MCP: Handling resources/templates/list request.");
+
+		// Prepare the result for the resources/templates/list method
+		jsonRPCRep["result"]["resourceTemplates"] = Json::Value(Json::arrayValue);
+		// Currently we do not have any resource templates to offer
+
+		_log.Debug(DEBUG_WEBSERVER, "McpResourcesTemplatesList: Following resource templates offered:\n%s", jsonRPCRep.toStyledString().c_str());
+	}
+
 	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
 		// Check if the required parameters are present
@@ -368,16 +386,57 @@ namespace mcp
 
 		_log.Debug(DEBUG_WEBSERVER, "MCP: Handling resources/read request for %s.", sReadURI.c_str());
 
-		// Prepare the result for the resources/read method
-		// TODO : Actually read the resource specified in the request
+		int nIdx = -1;
+		try
+		{
+			nIdx = std::stoi(sReadURI.substr(sReadURI.find_last_of("/") + 1));
+		}
+		catch (const std::exception &e)
+		{
+			_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: Invalid resource URI, cannot extract IDX: %s", e.what());
+			jsonRPCRep["error"]["code"] = -32603; // Internal error
+			jsonRPCRep["error"]["message"] = "Invalid resource URI, cannot extract IDX";
+			return;
+		}
+		auto result = m_sql.safe_query("SELECT Name, HardwareID, DeviceID, Type, SubType, nValue, sValue, LastUpdate from DeviceStatus WHERE ID=%d", nIdx);
+		if (result.empty() || result.size() != 1)
+		{
+			_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: No device found with IDX %d", nIdx);
+			jsonRPCRep["error"]["code"] = -32002; // Resource not found
+			jsonRPCRep["error"]["message"] = "No device found with the specified URI";
+			return;
+		}
+		auto &row = result[0];
+		std::string sName = row[0];
+		int iHardwareID = atoi(row[1].c_str());
+		std::string sDeviceID = row[2];
+		int iType = atoi(row[3].c_str());
+		int iSubType = atoi(row[4].c_str());
+		int nValue = atoi(row[5].c_str());
+		std::string sValue = row[6];
+		std::string sLastUpdate = row[7];
 		jsonRPCRep["result"]["contents"] = Json::Value(Json::arrayValue);
 		Json::Value resource;
-		resource["uri"] = "dom:///dom.local:8080/Light_Switch/Switch/1";
-		resource["name"] = "dumswitch";
-		resource["title"] = "dumswitch (testdummy - light switch - switch)";
+		resource["uri"] = sReadURI;
+		resource["name"] = sName;
+		resource["title"] = sName + " (" + std::to_string(iHardwareID) + " - " + std::to_string(iType) + " - " + std::to_string(iSubType) + ")";
 		resource["mimeType"] = "plain/text";
-		resource["text"] = "off";
+		resource["text"] = (sValue.empty() ? std::to_string(nValue) : sValue);
+		Json::Value meta;
+		meta["hardwareID"] = iHardwareID;
+		meta["type"] = iType;
+		meta["subtype"] = iSubType;
+		meta["idx"] = nIdx;
+		meta["id"] = sDeviceID;
+		resource["_meta"] = meta;
+		Json::Value annotations;
+		stdreplace(sLastUpdate, " ", "T");
+		annotations["lastModified"] = sLastUpdate + "Z";	// To-Do: Properly convert to ISO 8601 format (adjust for real timezone)
+		resource["annotations"] = annotations;
+
 		jsonRPCRep["result"]["contents"].append(resource);
+
+		_log.Debug(DEBUG_WEBSERVER, "MCP: Offering resources/read request result %s.", resource.toStyledString().c_str());
 	}
 
 	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -398,7 +398,30 @@ namespace mcp		// Model Context Protocol
 				}
 			}
 		}
-		// To-Do: Add floorplans as resources too
+		// Add any available floorplans as resources too
+		auto result = m_sql.safe_query("SELECT ID, Name FROM Floorplans");
+		if (!result.empty())
+		{
+			for (const auto &row : result)
+			{
+				if (row.size() >= 2)
+				{
+					Json::Value resource;
+					std::string idx = row[0];
+					std::string sName = row[1];
+					resource["uri"] = "floorplan:///image/" + idx;
+					resource["name"] = sName;
+					resource["title"] = sName + " (Floorplan)";
+					resource["description"] = "A Floorplan called " + sName + " with IDX " + idx;
+					resource["mimeType"] = "image/*"; // unknown image type
+					Json::Value meta;
+					meta["idx"] = atoi(idx.c_str());
+					resource["_meta"] = meta;
+					jsonRPCRep["result"]["resources"].append(resource);
+				}
+			}
+		}
+
 		_log.Debug(DEBUG_WEBSERVER, "McpResourcesList: Following resources offered:\n%s", jsonRPCRep.toStyledString().c_str());
 	}
 
@@ -662,9 +685,45 @@ namespace mcp		// Model Context Protocol
 			blob = m_sql.safe_queryBlob("SELECT Image FROM Floorplans WHERE ID=%d", atol(idx.c_str()));
 			if (!blob.empty())
 			{
+				// To-Do: refactor code together with CWebServer::GetFloorplanImage code (less duplication)
 				bFound = true;
 				sFloorplanValue = base64_encode(std::string(blob[0][0].begin(), blob[0][0].end()));
-				sMimeType = "image/png";	// To-Do: properly determine the mime type based on the actual image type
+				sMimeType = "image/*"; // unknown image type
+				if (blob[0][0].size() > 10)
+				{
+					// PNG
+					const unsigned char png_signature[8] = {0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+
+					// JPEG
+					const unsigned char jpeg_signature[3] = {0xFF, 0xD8, 0xFF};
+
+					// GIF87a
+					const unsigned char gif87a_signature[6] = {'G', 'I', 'F', '8', '7', 'a'};
+					// GIF89a
+					const unsigned char gif89a_signature[6] = {'G', 'I', 'F', '8', '9', 'a'};
+
+					// BMP
+					const unsigned char bmp_signature[2] = {'B', 'M'};
+
+					// WebP (RIFF....WEBP)
+					const unsigned char webp_riff_signature[4] = {'R', 'I', 'F', 'F'};
+					const unsigned char webp_webp_signature[4] = {'W', 'E', 'B', 'P'};
+
+					if (std::equal(png_signature, png_signature + sizeof(png_signature), reinterpret_cast<const unsigned char*>(&*blob[0][0].begin())))
+						sMimeType = "image/png";
+					else if (std::equal(jpeg_signature, jpeg_signature + sizeof(jpeg_signature), reinterpret_cast<const unsigned char*>(&*blob[0][0].begin())))
+						sMimeType = "image/jpeg";
+					else if (std::equal(bmp_signature, bmp_signature + sizeof(bmp_signature), reinterpret_cast<const unsigned char*>(&*blob[0][0].begin())))
+						sMimeType = "image/bmp";
+					else if (std::equal(gif87a_signature, gif87a_signature + sizeof(gif87a_signature), reinterpret_cast<const unsigned char*>(&*blob[0][0].begin())) ||
+							 std::equal(gif89a_signature, gif89a_signature + sizeof(gif89a_signature), reinterpret_cast<const unsigned char*>(&*blob[0][0].begin())))
+						sMimeType = "image/gif";
+					else if ((blob[0][0][0] == '<') && (blob[0][0][1] == 's') && (blob[0][0][2] == 'v') && (blob[0][0][3] == 'g'))
+						sMimeType = "image/svg+xml";
+					else if (blob[0][0].find("<svg") != std::string::npos) // some SVG's start with <xml
+						sMimeType = "image/svg+xml";
+					//_log.Debug(DEBUG_WEBSERVER, "MCP: getFloorplan: Detected floorplan image header: %.10s (%s)", std::string(blob[0][0].begin(), blob[0][0].begin() + 10).c_str(), sMimeType.c_str());
+				}
 			}
 		}
 

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -25,6 +25,7 @@
 #include "../main/json_helper.h"
 #include "../main/WebServer.h"
 #include "../main/WebServerHelper.h"
+#include "../webserver/Base64.h"
 
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
@@ -260,6 +261,15 @@ namespace mcp		// Model Context Protocol
 		tool["inputSchema"]["properties"]["logdate"]["type"] = "number";
 		tool["inputSchema"]["properties"]["logdate"]["description"] = "The (Unixtimestamp) date and time from which to retrieve the logs (optional, default is 0, which means all logs)";
 		jsonRPCRep["result"]["tools"].append(tool);
+		// Get Floorplan(s) tool
+		tool.clear();
+		tool["name"] = "get_floorplan";
+		tool["title"] = "Get the floorplan";
+		tool["description"] = "Retrieve the specific floorplan within the system";
+		tool["inputSchema"]["type"] = "object";
+		tool["inputSchema"]["properties"]["floorplan"]["type"] = "string";
+		tool["inputSchema"]["properties"]["floorplan"]["description"] = "The name of the floorplan to retrieve";
+		jsonRPCRep["result"]["tools"].append(tool);
 	}
 
 	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -277,6 +287,7 @@ namespace mcp		// Model Context Protocol
 
 		_log.Debug(DEBUG_WEBSERVER, "MCP: Handling tools/{%s} request.", sMethodName.c_str());
 
+		// To-Do: rewrite to switch/case statement using djb2hash or similar
 		if (sMethodName == "get_switch_state")
 		{
 			if(!mcp::getSwitchState(jsonRequest, jsonRPCRep))
@@ -313,6 +324,15 @@ namespace mcp		// Model Context Protocol
 				return;
 			}
 		}
+		else if (sMethodName == "get_floorplan")
+		{
+			if(!mcp::getFloorplan(jsonRequest, jsonRPCRep))
+			{
+				jsonRPCRep["error"]["code"] = -32602; // Invalid params
+				jsonRPCRep["error"]["message"] = "Error getting floorplan";
+				return;
+			}
+		}
 		else
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: Unsupported tool name: %s", sMethodName.c_str());
@@ -340,14 +360,15 @@ namespace mcp		// Model Context Protocol
 		jsonRPCRep["result"]["resources"] = Json::Value(Json::arrayValue);
 
 		Json::Value jsonDevices;
-		m_webservers.GetJSonDevices(jsonDevices, "", "", "", "", "", "", false, false, false, 0, "", "");
+		m_webservers.GetJSonDevices(jsonDevices, "", "", "", "", "", "", false, false, false, 0, "", "");	// To-Do: Use Database instead of WebServerHelper
 		if (jsonDevices.isObject() && jsonDevices.isMember("result"))
 		{
 			for (const auto &device : jsonDevices["result"])
 			{
 				//_log.Debug(DEBUG_WEBSERVER, "MCP: ResourcesList: Got device: %s", device.toStyledString().c_str());
 				if (device.isObject() && device.isMember("idx") && device.isMember("HardwareName") && device.isMember("ID") &&
-					device.isMember("Name") && device.isMember("Type") && device.isMember("SubType") && device.isMember("Data"))
+					device.isMember("Name") && device.isMember("Type") && device.isMember("SubType") && device.isMember("Data")	&&
+					device.isMember("Used") && atoi(device["Used"].asString().c_str()) == 1)
 				{
 					Json::Value resource;
 					//resource["uri"] = "dom:///dom.local:8080/" + device["Type"].asString() + "/" + device["SubType"].asString() + "/" + device["idx"].asString();
@@ -377,6 +398,7 @@ namespace mcp		// Model Context Protocol
 				}
 			}
 		}
+		// To-Do: Add floorplans as resources too
 		_log.Debug(DEBUG_WEBSERVER, "McpResourcesList: Following resources offered:\n%s", jsonRPCRep.toStyledString().c_str());
 	}
 
@@ -613,6 +635,50 @@ namespace mcp		// Model Context Protocol
 		Json::Value tool;
 		tool["type"] = "text";
 		tool["text"] = sSensorValue;
+		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
+		jsonRPCRep["result"]["content"].append(tool);
+		jsonRPCRep["result"]["isError"] = !bFound;
+		return true;
+	}
+
+	bool getFloorplan(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+	{
+		if (!jsonRequest["params"].isMember("arguments") || !jsonRequest["params"]["arguments"].isMember("floorplan"))
+		{
+			_log.Debug(DEBUG_WEBSERVER, "MCP: getFloorplan: Missing required parameter 'floorplan'");
+			return false;
+		}
+		std::string sFloorplan = jsonRequest["params"]["arguments"]["floorplan"].asString();
+		std::string sFloorplanValue = "No floorplan exists with the name " + sFloorplan;
+		std::string sMimeType;
+		Json::Value tool;
+		bool bFound = false;
+
+		auto result = m_sql.safe_query("SELECT ID FROM Floorplans WHERE Name='%q'", sFloorplan.c_str());
+		if (!result.empty() && result.size() == 1 )
+		{
+			std::string idx = result[0][0];
+			std::vector<std::vector<std::string>> blob;
+			blob = m_sql.safe_queryBlob("SELECT Image FROM Floorplans WHERE ID=%d", atol(idx.c_str()));
+			if (!blob.empty())
+			{
+				bFound = true;
+				sFloorplanValue = base64_encode(std::string(blob[0][0].begin(), blob[0][0].end()));
+				sMimeType = "image/png";	// To-Do: properly determine the mime type based on the actual image type
+			}
+		}
+
+		if (bFound)
+		{
+			tool["type"] = "image";
+			tool["mimeType"] = sMimeType;
+			tool["data"] = sFloorplanValue;
+		}
+		else
+		{
+			tool["type"] = "text";
+			tool["text"] = sFloorplanValue;
+		}
 		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
 		jsonRPCRep["result"]["content"].append(tool);
 		jsonRPCRep["result"]["isError"] = !bFound;

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -264,11 +264,9 @@ namespace mcp
 
 		_log.Debug(DEBUG_WEBSERVER, "MCP: Handling tools/{%s} request.", sMethodName.c_str());
 
-		Json::Value jsonDevices;
-		m_webservers.GetJSonDevices(jsonDevices, "", "", "", "", "", "", false, false, false, 0, "", "");
 		if (sMethodName == "get_switch_state")
 		{
-			if(!mcp::getSwitchState(jsonRequest, jsonRPCRep, jsonDevices))
+			if(!mcp::getSwitchState(jsonRequest, jsonRPCRep))
 			{
 				jsonRPCRep["error"]["code"] = -32602; // Invalid params
 				jsonRPCRep["error"]["message"] = "Error getting switch state";
@@ -277,7 +275,7 @@ namespace mcp
 		}
 		else if (sMethodName == "toggle_switch_state")
 		{
-			if(!mcp::toggleSwitchState(jsonRequest, jsonRPCRep, jsonDevices))
+			if(!mcp::toggleSwitchState(jsonRequest, jsonRPCRep))
 			{
 				jsonRPCRep["error"]["code"] = -32602; // Invalid params
 				jsonRPCRep["error"]["message"] = "Error toggling switch state";
@@ -286,7 +284,7 @@ namespace mcp
 		}
 		else if (sMethodName == "get_sensor_value")
 		{
-			if(!mcp::getSensorValue(jsonRequest, jsonRPCRep, jsonDevices))
+			if(!mcp::getSensorValue(jsonRequest, jsonRPCRep))
 			{
 				jsonRPCRep["error"]["code"] = -32602; // Invalid params
 				jsonRPCRep["error"]["message"] = "Error getting sensor value";
@@ -500,7 +498,7 @@ namespace mcp
 		}
 	}
 
-	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices)
+	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
 		if (!jsonRequest["params"].isMember("arguments") || !jsonRequest["params"]["arguments"].isMember("switchname"))
 		{
@@ -510,7 +508,7 @@ namespace mcp
 		std::string sSwitchName = jsonRequest["params"]["arguments"]["switchname"].asString();
 		std::string sSwitchState = "No switch exists with the name " + sSwitchName;
 		Json::Value device;
-		bool bFound = getDeviceByName(sSwitchName, device, jsonDevices);
+		bool bFound = getDeviceByName(sSwitchName, device);
 		if (bFound)
 		{
 			sSwitchState = "The current state of switch \"" + sSwitchName + "\" is: " + device["Data"].asString();
@@ -524,7 +522,7 @@ namespace mcp
 		return true;
 	}
 
-	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices)
+	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
 		if (!jsonRequest["params"].isMember("arguments") || !jsonRequest["params"]["arguments"].isMember("switchname"))
 		{
@@ -534,7 +532,7 @@ namespace mcp
 		std::string sSwitchName = jsonRequest["params"]["arguments"]["switchname"].asString();
 		std::string sSwitchState = "No switch exists with the name " + sSwitchName;
 		Json::Value device;
-		bool bFound = getDeviceByName(sSwitchName, device, jsonDevices);
+		bool bFound = getDeviceByName(sSwitchName, device);
 		if (bFound)
 		{
 			sSwitchState = "The state of switch \"" + sSwitchName + "\" before toggle was: " + device["Data"].asString() + ". ";
@@ -551,7 +549,7 @@ namespace mcp
 		return true;
 	}
 
-	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices)
+	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
 		if (!jsonRequest["params"].isMember("arguments") || !jsonRequest["params"]["arguments"].isMember("sensorname"))
 		{
@@ -561,7 +559,7 @@ namespace mcp
 		std::string sSensorName = jsonRequest["params"]["arguments"]["sensorname"].asString();
 		std::string sSensorValue = "No sensor exists with the name " + sSensorName;
 		Json::Value device;
-		bool bFound = getDeviceByName(sSensorName, device, jsonDevices);
+		bool bFound = getDeviceByName(sSensorName, device);
 		if (bFound)
 		{
 			sSensorValue = "The current value for sensor \"" + sSensorName + "\" is: " + device["Data"].asString();
@@ -575,8 +573,11 @@ namespace mcp
 		return true;
 	}
 
-	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices)
+	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device)
 	{
+		Json::Value jsonDevices;
+		m_webservers.GetJSonDevices(jsonDevices, "", "", "", "", "", "", false, false, false, 0, "", "");
+
 		for (const auto &dev : jsonDevices["result"])
 		{
 			if (dev.isObject() && dev.isMember("Name") && dev["Name"].asString() == sDeviceName)

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -30,6 +30,18 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
+#define JSONRPC_PARSE_ERROR -32700
+#define JSONRPC_INVALID_REQUEST -32600
+#define JSONRPC_METHOD_NOT_FOUND -32601
+#define JSONRPC_INVALID_PARAMETER -32602
+#define JSONRPC_INTERNAL_ERROR -32603
+#define MCP_SERVER_ERROR -32000
+#define MCP_TOOL_EXECUTION_FAILED -32000
+#define MCP_RESOURCE_NOT_FOUND -32001
+#define MCP_PERMISSION_DENIED -32002
+#define MCP_RATE_LIMIT_EXCEEDED -32003
+#define MCP_TIMEOUT_OCCURRED -32004
+
 extern http::server::CWebServerHelper m_webservers;
 extern CLogger _log;
 
@@ -37,7 +49,6 @@ namespace http
 {
 	namespace server
 	{
-
 		void CWebServer::PostMcp(WebEmSession &session, const request &req, reply &rep)
 		{
 			_log.Debug(DEBUG_RECEIVED, "MCP: Post (%d): %s (%s)", req.content_length, req.content.c_str(), req.uri.c_str());
@@ -69,12 +80,12 @@ namespace http
 			// Check if the request is a POST request
 			if (req.method != "POST")
 			{
-				_log.Debug(DEBUG_WEBSERVER, "MCP: Invalid method: %s", req.method.c_str());
-				rep = reply::stock_reply(reply::bad_request);
-				// VScode MCP client does sends GET's
+				// VScode MCP client does sends GET's (maybe other do as well?)
 				// It does this to look for asynchronous notifications support
 				// but we don't support that yet, so we return bad request
 				// And the MCP spec does not support GET for requests anyway
+				_log.Debug(DEBUG_WEBSERVER, "MCP: Invalid method: %s", req.method.c_str());
+				rep = reply::stock_reply(reply::bad_request);
 				return;
 			}
 
@@ -83,11 +94,11 @@ namespace http
 			if (!mcp::validRPC(req.content, jsonRequest, sParseErr))
 			{
 				_log.Debug(DEBUG_WEBSERVER, "MCP: Invalid JSON-RPC request: %s", sParseErr.c_str());
-				rep = reply::stock_reply(reply::bad_request);
+				rep = reply::stock_reply(reply::bad_request);	// Or should we send a valid JSON-RPC response with error -32700 (Parse error)?
 				return;
 			}
 
-			_log.Debug(DEBUG_RECEIVED, "MCP: Parsed JSON Request content: %s", jsonRequest.toStyledString().c_str());
+			//_log.Debug(DEBUG_RECEIVED, "MCP: Parsed JSON Request content: %s", jsonRequest.toStyledString().c_str());
 
 			// Check if the method is supported and handle it
 			std::string sReqMethod = jsonRequest["method"].asString();
@@ -105,20 +116,16 @@ namespace http
 			jsonRPCRep["jsonrpc"] = "2.0";
 
 			// Check if the request has an ID
-			std::string sReqID;
-			int iReqID;
 			if (jsonRequest.isMember("id"))
 			{
 				if (jsonRequest["id"].isInt())
 				{
-					iReqID = jsonRequest["id"].asInt();
-					jsonRPCRep["id"] = iReqID;
+					jsonRPCRep["id"] = jsonRequest["id"].asInt();
 
 				}
 				else if (jsonRequest["id"].isString())
 				{
-					sReqID = jsonRequest["id"].asString();
-					jsonRPCRep["id"] = sReqID;
+					jsonRPCRep["id"] = jsonRequest["id"].asString();
 				}
 				else
 				{
@@ -278,7 +285,7 @@ namespace mcp		// Model Context Protocol
 		if (!jsonRequest.isMember("params") || !jsonRequest["params"].isMember("name"))
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: Missing required tool parameter 'name' in tools/{tool} request.");
-			jsonRPCRep["error"]["code"] = -32602; // Invalid params
+			jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 			jsonRPCRep["error"]["message"] = "Missing required parameter 'name'";
 			return;
 		}
@@ -292,7 +299,7 @@ namespace mcp		// Model Context Protocol
 		{
 			if(!mcp::getSwitchState(jsonRequest, jsonRPCRep))
 			{
-				jsonRPCRep["error"]["code"] = -32602; // Invalid params
+				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error getting switch state";
 				return;
 			}
@@ -301,7 +308,7 @@ namespace mcp		// Model Context Protocol
 		{
 			if(!mcp::toggleSwitchState(jsonRequest, jsonRPCRep))
 			{
-				jsonRPCRep["error"]["code"] = -32602; // Invalid params
+				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error toggling switch state";
 				return;
 			}
@@ -310,7 +317,7 @@ namespace mcp		// Model Context Protocol
 		{
 			if(!mcp::getSensorValue(jsonRequest, jsonRPCRep))
 			{
-				jsonRPCRep["error"]["code"] = -32602; // Invalid params
+				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error getting sensor value";
 				return;
 			}
@@ -319,7 +326,7 @@ namespace mcp		// Model Context Protocol
 		{
 			if(!mcp::getLogging(jsonRequest, jsonRPCRep))
 			{
-				jsonRPCRep["error"]["code"] = -32001; // Resource not found
+				jsonRPCRep["error"]["code"] = MCP_RESOURCE_NOT_FOUND;
 				jsonRPCRep["error"]["message"] = "Error getting logging";
 				return;
 			}
@@ -328,7 +335,7 @@ namespace mcp		// Model Context Protocol
 		{
 			if(!mcp::getFloorplan(jsonRequest, jsonRPCRep))
 			{
-				jsonRPCRep["error"]["code"] = -32602; // Invalid params
+				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error getting floorplan";
 				return;
 			}
@@ -336,20 +343,11 @@ namespace mcp		// Model Context Protocol
 		else
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: Unsupported tool name: %s", sMethodName.c_str());
-			jsonRPCRep["error"]["code"] = -32601; // Method not found
+			jsonRPCRep["error"]["code"] = JSONRPC_METHOD_NOT_FOUND;
 			jsonRPCRep["error"]["message"] = "Method not found";
 			return;
 		}
-		// std::string sLastMod = (device.isMember("LastUpdate") ? device["LastUpdate"].asString() : "");
-		// if (!sLastMod.empty())
-		// 	stdreplace(sLastMod, " ", "T");
-		// 	annotations["lastModified"] = sLastMod + "Z";	// To-Do: Properly convert to ISO 8601 format
-		// break;
-		// if (annotations.isMember("lastModified"))
-		// {
-		// 	tool["annotations"] = annotations;
-		// }
-		_log.Debug(DEBUG_WEBSERVER, "McpToolsCall: Returning result for method (%s): %s", sMethodName.c_str(), jsonRPCRep.toStyledString().c_str());
+		//_log.Debug(DEBUG_WEBSERVER, "McpToolsCall: Returning result for method (%s): %s", sMethodName.c_str(), jsonRPCRep.toStyledString().c_str());
 	}
 
 	void McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -404,25 +402,23 @@ namespace mcp		// Model Context Protocol
 		{
 			for (const auto &row : result)
 			{
-				if (row.size() >= 2)
-				{
-					Json::Value resource;
-					std::string idx = row[0];
-					std::string sName = row[1];
-					resource["uri"] = "floorplan:///image/" + idx;
-					resource["name"] = sName;
-					resource["title"] = sName + " (Floorplan)";
-					resource["description"] = "A Floorplan called " + sName + " with IDX " + idx;
-					resource["mimeType"] = "image/*"; // unknown image type
-					Json::Value meta;
-					meta["idx"] = atoi(idx.c_str());
-					resource["_meta"] = meta;
-					jsonRPCRep["result"]["resources"].append(resource);
-				}
+				Json::Value resource;
+				std::string idx = row[0];
+				std::string sName = row[1];
+				resource["uri"] = "floorplan:///image/" + idx;
+				resource["name"] = sName;
+				resource["title"] = sName + " (Floorplan)";
+				resource["description"] = "A Floorplan called " + sName + " with IDX " + idx;
+				resource["mimeType"] = "image/*"; // unknown image type
+				Json::Value meta;
+				meta["idx"] = atoi(idx.c_str());
+				resource["_meta"] = meta;
+				jsonRPCRep["result"]["resources"].append(resource);
 			}
 		}
 
-		_log.Debug(DEBUG_WEBSERVER, "McpResourcesList: Following resources offered:\n%s", jsonRPCRep.toStyledString().c_str());
+		//_log.Debug(DEBUG_WEBSERVER, "MCP: ResourcesList: Following resources offered:\n%s", jsonRPCRep.toStyledString().c_str());
+		_log.Debug(DEBUG_WEBSERVER, "MCP: ResourcesList: Number of resources offered: %d", jsonRPCRep["result"]["resources"].size());
 	}
 
 	void McpResourcesTemplatesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -432,8 +428,7 @@ namespace mcp		// Model Context Protocol
 		// Prepare the result for the resources/templates/list method
 		jsonRPCRep["result"]["resourceTemplates"] = Json::Value(Json::arrayValue);
 		// Currently we do not have any resource templates to offer
-
-		_log.Debug(DEBUG_WEBSERVER, "McpResourcesTemplatesList: Following resource templates offered:\n%s", jsonRPCRep.toStyledString().c_str());
+		_log.Debug(DEBUG_WEBSERVER, "MCP: ResourcesTemplatesList: Following resource templates offered:\n%s", jsonRPCRep.toStyledString().c_str());
 	}
 
 	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -442,7 +437,7 @@ namespace mcp		// Model Context Protocol
 		if (!jsonRequest.isMember("params") || !jsonRequest["params"].isMember("uri"))
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: Missing required resource parameter 'uri' in resources/read request.");
-			jsonRPCRep["error"]["code"] = -32602; // Invalid params
+			jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 			jsonRPCRep["error"]["message"] = "Missing required parameter 'uri'";
 			return;
 		}
@@ -459,7 +454,7 @@ namespace mcp		// Model Context Protocol
 		catch (const std::exception &e)
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: Invalid resource URI, cannot extract IDX: %s", e.what());
-			jsonRPCRep["error"]["code"] = -32603; // Internal error
+			jsonRPCRep["error"]["code"] = MCP_SERVER_ERROR;
 			jsonRPCRep["error"]["message"] = "Invalid resource URI, cannot extract IDX";
 			return;
 		}
@@ -467,7 +462,7 @@ namespace mcp		// Model Context Protocol
 		if (result.empty() || result.size() != 1)
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: resources/read: No device found with IDX %d", nIdx);
-			jsonRPCRep["error"]["code"] = -32002; // Resource not found
+			jsonRPCRep["error"]["code"] = MCP_RESOURCE_NOT_FOUND;
 			jsonRPCRep["error"]["message"] = "No device found with the specified URI";
 			return;
 		}
@@ -529,7 +524,6 @@ namespace mcp		// Model Context Protocol
 		prompt["description"] = "Analyze the current status of the system and provide insights";
 		prompt["arguments"] = Json::Value(Json::arrayValue);
 		jsonRPCRep["result"]["prompts"].append(prompt);
-
 	}
 
 	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -584,7 +578,7 @@ namespace mcp		// Model Context Protocol
 		else
 		{
 			_log.Debug(DEBUG_WEBSERVER, "MCP: prompts/get: Unsupported prompt name: %s", sPromptName.c_str());
-			jsonRPCRep["error"]["code"] = -32601; // Method not found
+			jsonRPCRep["error"]["code"] = JSONRPC_METHOD_NOT_FOUND;
 			jsonRPCRep["error"]["message"] = "Method not found";
 		}
 	}

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include <json/json.h>
+#include "../main/Helper.h"
+#include "../main/mainworker.h"
+
+namespace mcp
+{
+    bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+    bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+    bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+    bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices);
+}

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -19,4 +19,6 @@ namespace mcp
 	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
 	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices);
+
+	bool validRPC(const std::string &sInput, Json::Value &jsonRequest, std::string &sError);
 }

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -7,8 +7,16 @@
 
 namespace mcp
 {
-    bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-    bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-    bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-    bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices);
+	void McpInitialize(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+
+	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
+	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices);
 }

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -17,10 +17,12 @@ namespace mcp
 	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
 	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
-	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getLogging(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getFloorplan(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+
+	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool setThermostatSetpoint(const Json::Value& jsonRequest, Json::Value& jsonRPCRep);
 
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device);
 

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -20,6 +20,8 @@ namespace mcp
 	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getLogging(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool getFloorplan(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device);
 
 	bool validRPC(const std::string &sInput, Json::Value &jsonRequest, std::string &sError);

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -16,10 +16,10 @@ namespace mcp
 	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
-	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep, const Json::Value &jsonDevices);
-	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device, const Json::Value &jsonDevices);
+	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device);
 
 	bool validRPC(const std::string &sInput, Json::Value &jsonRequest, std::string &sError);
 }

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -11,6 +11,7 @@ namespace mcp
 	void McpToolsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpResourcesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	void McpResourcesTemplatesList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpResourcesRead(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpPromptsList(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	void McpPromptsGet(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -19,6 +19,7 @@ namespace mcp
 	bool getSensorValue(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
+	bool getLogging(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device);
 
 	bool validRPC(const std::string &sInput, Json::Value &jsonRequest, std::string &sError);

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -728,6 +728,7 @@
     <ClInclude Include="..\main\KWHStats.h" />
     <ClInclude Include="..\mdns\include\mdns.h" />
     <ClInclude Include="..\mdns\mdns.hpp" />
+    <ClInclude Include="..\mcpserver\McpService.hpp" />
     <ClInclude Include="..\main\appversion.h" />
     <ClInclude Include="..\hardware\ASyncSerial.h" />
     <ClInclude Include="..\main\BaroForecastCalculator.h" />
@@ -1031,6 +1032,7 @@
     <ClCompile Include="..\iamserver\IamService.cpp" />
     <ClCompile Include="..\main\KWHStats.cpp" />
     <ClCompile Include="..\mdns\mdns.cpp" />
+    <ClCompile Include="..\mcpserver\McpService.cpp" />
     <ClCompile Include="..\main\BaroForecastCalculator.cpp" />
     <ClCompile Include="..\main\Camera.cpp" />
     <ClCompile Include="..\hardware\Rego6XXSerial.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -2254,6 +2254,8 @@
     </ClInclude>
     <ClInclude Include="..\main\KWHStats.h">
       <Filter>Helpers</Filter>
+    <ClInclude Include="..\mcpserver\McpService.hpp">
+      <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -3045,6 +3047,8 @@
     </ClCompile>
     <ClCompile Include="..\main\KWHStats.cpp">
       <Filter>Helpers</Filter>
+    <ClCompile Include="..\mcpserver\McpService.cpp">
+      <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -3048,7 +3048,7 @@
     </ClCompile>
     <ClCompile Include="..\main\KWHStats.cpp">
       <Filter>Helpers</Filter>
-    </ClInclude>
+    </ClCompile>
     <ClCompile Include="..\mcpserver\McpService.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -2254,6 +2254,7 @@
     </ClInclude>
     <ClInclude Include="..\main\KWHStats.h">
       <Filter>Helpers</Filter>
+    </ClInclude>
     <ClInclude Include="..\mcpserver\McpService.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -3047,6 +3048,7 @@
     </ClCompile>
     <ClCompile Include="..\main\KWHStats.cpp">
       <Filter>Helpers</Filter>
+    </ClInclude>
     <ClCompile Include="..\mcpserver\McpService.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
This PR adds support for the [Model Context Protocol](https://modelcontextprotocol.io/specification/2025-06-18) (MCP)  to domoticz so domoticz can be used as an agent by LLM clients.

For safety reasons, it is not enabled by default. It has to be enabled explicitly.
To enable it, start domoticz with the `-mcp` flag (A status message should tell that support is enabled).

_NOTE_: Make sure that your LLM client (like Claude or any other) is either running within the private network range of domoticz (configure it in the security settings) or supports OAuth2/OIDC authentication. Otherwise the client gets rejected due to no authorization. When using OAuth2, please create an _application_ with a name and secret.

This PR currently implements some basic stuff.
_Only specification version 2025-06-18 is supported!_
_Only basic Streamable HTTP support (no STDIO or SSE)_ (And not really _streamable_, just stateless HTTP calls)

__resources__
Available devices are offered as `resources`.
Same for the floorplans.

__tools__
At the moment the following `tools` are offered:

- get_switch_state
- toggle_switch_state
- get_sensor_value
- get_logging
- get_floorplan
- set_thermostat_setpoint

More will follow if needed (which is to be expected :) )

__prompts__
The following `prompts` are suggested:
- _housesummary_
- _systemanalysis_


**Example use : Claud Desktop**
Configure local MCP Servers in Claude desktop. As Claude Desktop only supports STDIO for standard users (Pro/MAX users should get remote MCP support), I used [MCP-Proxy](https://github.com/sparfenyuk/mcp-proxy) as an intermediate to do the STDIO<->Streamable HTTP translation.

```JSON
    "dom-mcp-proxy": {
        "command": "<location of the proxy software on the filesystem>/mcp-proxy.exe",
        "args": ["--transport", "streamablehttp", "http://domoticz.local:8080/mcp"],
        "env": {
          "API_ACCESS_TOKEN": "<A valid JWT or put your client in the Private Network range>"
        }		
    },
```

**Example use : VS Code**
In Visual Studio Code, you can configure MCP servers. Via the _command palette_  (See _View_ / CTRL+SHIFT+P) you can __MCP: Add Server...__. Or at _Extensions_ (at the bottom their is a _MCP Servers - Installed_ section).
```
{
    "servers": {
        "dommcp": {
            "type": "http",
            "url": "http://127.0.0.1:8080/mcp"
        }
    }
}
```
When you press _start server_, it will try to connect and the first time it will go through the Authorization process. You have to register an _Application_ within domoticz (for example 'domoticzMCP' and an _Application Secret_) which is needed as ClientID and ClientSecret as asked for by VSCode to complete the Authorization process.

__NOTE:__ If Authorization is successful or failed in VSCode, you can see the information under the _Account_ info (bottom left of the screen). Here you can also delete that info so it you can re-enter it if needed.
 