### PR TITLE
Improvement/oauth2appsupport allow custom URI scheme's and loopback devices in redirect URI's

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -61,8 +61,6 @@ extern std::string szAppHash;
 extern std::string szAppDate;
 extern std::string szPyVersion;
 
-extern bool g_bLlmMCPSupport;
-
 namespace http
 {
 	namespace server
@@ -239,11 +237,6 @@ namespace http
 					m_iamsettings.token_url.c_str(), [this](auto&& session, auto&& req, auto&& rep) { PostOauth2AccessToken(session, req, rep); }, true);
 				m_pWebEm->RegisterPageCode(
 					m_iamsettings.discovery_url.c_str(), [this](auto&& session, auto&& req, auto&& rep) { GetOpenIDConfiguration(session, req, rep); }, true);
-			}
-
-			if (g_bLlmMCPSupport)
-			{
-				m_pWebEm->RegisterPageCode("/mcp", [this](auto&& session, auto&& req, auto&& rep) { PostMcp(session, req, rep); }, false);
 			}
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto&& session, auto&& req, auto&& rep) { GetJSonPage(session, req, rep); });

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -106,6 +106,7 @@ private:
 	void InvalidateOAuth2RefreshToken(const std::string &refreshtoken);
 	void PresentOauth2LoginDialog(reply &rep, const std::string &sApp, const std::string &sError);
 	bool VerifySHA1TOTP(const std::string &code, const std::string &key);
+	bool ValidRedirectUri(const std::string &redirect_uri);
 
 	//Commands
 	void Cmd_GetTimerTypes(WebEmSession & session, const request& req, Json::Value &root);


### PR DESCRIPTION
This PR extends/expands the IamService to allow for custom/private URI scheme's and loopback device's as in [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252#section-7) as redirect URI's in an OAuth2/OIDC authorization flow.

With this extensions, in is now possible that mobile app's can register their own _redirect URI scheme_ allowing to go from the mobile APP to the domoticz authorization screen (on the web in a browser) and then being redirect back to the App (using the registered URI scheme).

Another improvement is that the _Security Realm_ is now in sync with the mDNS name so that the `<your domoticz server>/.well-known/openid-configuration` offers the correct OAuth2/OIDC endpoints (as needed by client that discover the endpoints as intended). 