### PR TITLE
Update the smoke detector device history when ResetSecurityStatus in invoked (either via JSON or User Interface)

### DIFF
--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -686,6 +686,11 @@ namespace http
 					{
 						m_sql.safe_query("UPDATE DeviceStatus SET nValue=%d WHERE (ID == '%q')", nValue, idx.c_str());
 						m_sql.UpdateLastUpdate(idx);
+						uint64_t ulID = std::stoull(idx.c_str());
+						m_sql.safe_query(
+							"INSERT INTO LightingLog (DeviceRowID, nValue, User) "
+							"VALUES ('%" PRIu64 "', '%d', '%q')",ulID,nValue, szSwitchUser.c_str());
+						m_mainworker.m_eventsystem.GetCurrentStates();
 					}
 					root["status"] = "OK";
 					break;


### PR DESCRIPTION
Update the smoke detector device history when ResetSecurityStatus in invoked (either via JSON or User Interface)

The objective is to record in smoke device history the ResetSecurityStatus action processed by the user after fixing physically the issue.

Prior to the current PR the state was recorded directly in DeviceStatus database but the information about who processed the ResetSecurityStatus action and when was lost
