### PR TITLE
Add support for Philips Hue Secure Door/Window Sensors (v2 API)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ hardware/P1MeterTCP.cpp
 hardware/PhilipsHue/PhilipsHue.cpp
 hardware/PhilipsHue/PhilipsHueHelper.cpp
 hardware/PhilipsHue/PhilipsHueSensors.cpp
+hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
 hardware/PiFace.cpp
 hardware/Pinger.cpp
 hardware/PVOutput_Input.cpp

--- a/History.txt
+++ b/History.txt
@@ -1,7 +1,7 @@
 Version 2025.xxxx
 - Implemented: MQTT-AD, added support for Climate high/low setpoints
 - Implemented: Support for the Model Context Protocol (/mcp) for use with AI Agents
-- Implemented: PhilipsHue, v2 Door/Window Contacts (state/tamper/battery)
+- Implemented: PhilipsHue v2 API, just for Door/Window Contacts (state/tamper/battery)
 - Fixed: Chart zoom buttons (notable on iOS devices)
 - Changed: Enever, using v3 API
 - Changed: PhilipsHue, now used HTTP scheme (HTTP/HTTPS) based on port number (80/443)

--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,7 @@
 Version 2025.xxxx
 - Implemented: MQTT-AD, added support for Climate high/low setpoints
 - Implemented: Support for the Model Context Protocol (/mcp) for use with AI Agents
+- Implemented: PhilipsHue, v2 Door/Window Contacts (state/tamper/battery)
 - Fixed: Chart zoom buttons (notable on iOS devices)
 - Changed: Enever, using v3 API
 - Changed: PhilipsHue, now used HTTP scheme (HTTP/HTTPS) based on port number (80/443)

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -797,195 +797,8 @@ bool CPhilipsHue::GetStates()
 	GetGroups(root);
 	GetScenes(root);
 	GetSensors(root);
-
-	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
-	if (m_use_v2_sensors && m_v2sensors)
-	{
-		try
-		{
-			if (m_v2sensors->UpdateAll())
-			{
-				// Build map device id -> device data for name lookup
-				std::map<std::string, HueV2Device> deviceById;
-				for (const auto &d : m_v2sensors->GetDevices())
-					deviceById[d.id] = d;
-
-				// Map contact resources to Domoticz switches (one device per owner/device), but only when changed
-				for (const auto &c : m_v2sensors->GetContacts())
-				{
-					const std::string ownerRid = c.owner_rid;
-					if (ownerRid.empty())
-						continue;
-
-					// Name lookup
-					std::string friendlyName;
-					auto dit = deviceById.find(ownerRid);
-					if (dit != deviceById.end() && !dit->second.name.empty())
-						friendlyName = dit->second.name + " (Contact)";
-					else
-						friendlyName = "Hue V2 Contact";
-
-					// Compute Domoticz node for device (owner-based)
-					int nodeID = NodeIDFromRid(ownerRid);
-					int domoticzNodeID = nodeID + 3000;
-
-					// Check previous state: skip if state and changed timestamp are identical to last poll
-					bool doUpdate = true;
-					auto itPrevState = m_v2_contact_state.find(ownerRid);
-					auto itPrevChanged = m_v2_contact_changed.find(ownerRid);
-					if (itPrevState != m_v2_contact_state.end() && itPrevChanged != m_v2_contact_changed.end())
-					{
-						if (itPrevState->second == c.state && itPrevChanged->second == c.changed)
-							doUpdate = false;
-					}
-
-					if (!doUpdate)
-						continue;
-
-					// contact_report.state: "contact" => closed (not alarmed). "no_contact" => open
-					bool isOpen = (c.state == "no_contact");
-
-					// Update/create Domoticz device and record state
-					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_DoorContact, isOpen, friendlyName, 0);
-
-					// Store last-seen state and changed timestamp
-					m_v2_contact_state[ownerRid] = c.state;
-					m_v2_contact_changed[ownerRid] = c.changed;
-				}
-
-				// Map tamper resources similarly, only update when changed
-				for (const auto &t : m_v2sensors->GetTampers())
-				{
-					const std::string ownerRid = t.owner_rid;
-					if (ownerRid.empty())
-						continue;
-
-					std::string friendlyName;
-					auto dit = deviceById.find(ownerRid);
-					if (dit != deviceById.end() && !dit->second.name.empty())
-						friendlyName = dit->second.name + " (Tamper)";
-					else
-						friendlyName = "Hue V2 Tamper";
-
-					int nodeID = NodeIDFromRid(ownerRid);
-					int domoticzNodeID = nodeID + 4000;
-
-					// If there is no tamper report changed timestamp and no state, treat as no change
-					bool doUpdate = true;
-					auto itPrevState = m_v2_tamper_state.find(ownerRid);
-					auto itPrevChanged = m_v2_tamper_changed.find(ownerRid);
-					if (itPrevState != m_v2_tamper_state.end() && itPrevChanged != m_v2_tamper_changed.end())
-					{
-						if (itPrevState->second == t.state && itPrevChanged->second == t.changed)
-							doUpdate = false;
-					}
-
-					if (!doUpdate)
-						continue;
-					
-					bool isTampered = (t.state == "tampered");
-
-					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_OnOff, isTampered, friendlyName, 0);
-
-					m_v2_tamper_state[ownerRid] = t.state;
-					m_v2_tamper_changed[ownerRid] = t.changed;
-				}
-
-				// Map device_power to battery updates; only update existing devices and only when battery level changed
-				for (const auto &p : m_v2sensors->GetDevicePowers())
-				{
-					const std::string ownerRid = p.owner_rid;
-					if (ownerRid.empty())
-						continue;
-
-					// Only update battery for devices discovered in v2 device list
-					auto dit = deviceById.find(ownerRid);
-					if (dit == deviceById.end())
-						continue;
-
-					// Determine numeric batteryLevel: prefer explicit numeric; otherwise map battery_state heuristically.
-					int batteryLevel = p.battery_level; // parsed (-1 if missing)
-					if (batteryLevel < 0)
-					{
-						if (p.battery_state == "full" || p.battery_state == "normal")
-							batteryLevel = 100;
-						else if (p.battery_state == "high")
-							batteryLevel = 90;
-						else if (p.battery_state == "low")
-							batteryLevel = 20;
-						else if (p.battery_state == "critical")
-							batteryLevel = 5;
-						else
-							batteryLevel = 255; // unknown
-					}
-					if (batteryLevel > 100 && batteryLevel != 255) batteryLevel = 100;
-					if (batteryLevel == 255)
-						continue;
-
-					// Determine the Domoticz node IDs (owner-based)
-					int baseNode = NodeIDFromRid(ownerRid);
-					int domoticzNodeID_contact = baseNode + 3000;
-					int domoticzNodeID_tamper  = baseNode + 4000;
-
-					// Only update contact device if it exists; update only when battery changed
-					char szID[16];
-					std::vector<std::vector<std::string>> result;
-
-					sprintf(szID, "%08X", domoticzNodeID_contact);
-					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
-											m_HwdID, szID, 1);
-					if (!result.empty())
-					{
-						int deviceRowId = atoi(result[0][0].c_str());
-						int prevBattery = atoi(result[0][1].c_str());
-						if (prevBattery != batteryLevel)
-						{
-							// preserve current nValue for push
-							int nValue = 0;
-							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
-							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
-							bool contactIsOn = (nValue != 0);
-							std::string contactName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Contact)") : "Hue V2 Contact";
-
-							InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
-							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
-							m_v2_battery_level[ownerRid] = batteryLevel;
-						}
-					}
-
-					// Tamper device (same approach)
-					sprintf(szID, "%08X", domoticzNodeID_tamper);
-					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
-											m_HwdID, szID, 1);
-					if (!result.empty())
-					{
-						int deviceRowId = atoi(result[0][0].c_str());
-						int prevBattery = atoi(result[0][1].c_str());
-						if (prevBattery != batteryLevel)
-						{
-							int nValue = 0;
-							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
-							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
-							bool tamperIsOn = (nValue != 0);
-							std::string tamperName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Tamper)") : "Hue V2 Tamper";
-
-							InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
-							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
-							m_v2_battery_level[ownerRid] = batteryLevel;
-						}
-					}
-				}
-			}
-			else
-			{
-				_log.Debug(DEBUG_HARDWARE, "PhilipsHue: v2 sensors fetch returned no data or failed.");
-			}
-		}
-		catch (const std::exception &e)
-		{
-			_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
-		}
-	}
+	GetV2Sensors();
+	
 	return true;
 }
 
@@ -1307,6 +1120,200 @@ bool CPhilipsHue::GetScenes(const Json::Value& root)
 			}
 		}
 	}
+	return true;
+}
+
+bool CPhilipsHue::GetV2Sensors()
+{
+	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
+	if (m_use_v2_sensors && m_v2sensors)
+	{
+		try
+		{
+			if (m_v2sensors->UpdateAll())
+			{
+				// Build map device id -> device data for name lookup
+				std::map<std::string, HueV2Device> deviceById;
+				for (const auto &d : m_v2sensors->GetDevices())
+					deviceById[d.id] = d;
+
+				// Map contact resources to Domoticz switches (one device per owner/device), but only when changed
+				for (const auto &c : m_v2sensors->GetContacts())
+				{
+					const std::string ownerRid = c.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					// Name lookup
+					std::string friendlyName;
+					auto dit = deviceById.find(ownerRid);
+					if (dit != deviceById.end() && !dit->second.name.empty())
+						friendlyName = dit->second.name + " (Contact)";
+					else
+						friendlyName = "Hue V2 Contact";
+
+					// Compute Domoticz node for device (owner-based)
+					int nodeID = NodeIDFromRid(ownerRid);
+					int domoticzNodeID = nodeID + 3000;
+
+					// Check previous state: skip if state and changed timestamp are identical to last poll
+					bool doUpdate = true;
+					auto itPrevState = m_v2_contact_state.find(ownerRid);
+					auto itPrevChanged = m_v2_contact_changed.find(ownerRid);
+					if (itPrevState != m_v2_contact_state.end() && itPrevChanged != m_v2_contact_changed.end())
+					{
+						if (itPrevState->second == c.state && itPrevChanged->second == c.changed)
+							doUpdate = false;
+					}
+
+					if (!doUpdate)
+						continue;
+
+					// contact_report.state: "contact" => closed (not alarmed). "no_contact" => open
+					bool isOpen = (c.state == "no_contact");
+
+					// Update/create Domoticz device and record state
+					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_DoorContact, isOpen, friendlyName, 0);
+
+					// Store last-seen state and changed timestamp
+					m_v2_contact_state[ownerRid] = c.state;
+					m_v2_contact_changed[ownerRid] = c.changed;
+				}
+
+				// Map tamper resources similarly, only update when changed
+				for (const auto &t : m_v2sensors->GetTampers())
+				{
+					const std::string ownerRid = t.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					std::string friendlyName;
+					auto dit = deviceById.find(ownerRid);
+					if (dit != deviceById.end() && !dit->second.name.empty())
+						friendlyName = dit->second.name + " (Tamper)";
+					else
+						friendlyName = "Hue V2 Tamper";
+
+					int nodeID = NodeIDFromRid(ownerRid);
+					int domoticzNodeID = nodeID + 4000;
+
+					// If there is no tamper report changed timestamp and no state, treat as no change
+					bool doUpdate = true;
+					auto itPrevState = m_v2_tamper_state.find(ownerRid);
+					auto itPrevChanged = m_v2_tamper_changed.find(ownerRid);
+					if (itPrevState != m_v2_tamper_state.end() && itPrevChanged != m_v2_tamper_changed.end())
+					{
+						if (itPrevState->second == t.state && itPrevChanged->second == t.changed)
+							doUpdate = false;
+					}
+
+					if (!doUpdate)
+						continue;
+					
+					bool isTampered = (t.state == "tampered");
+
+					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_OnOff, isTampered, friendlyName, 0);
+
+					m_v2_tamper_state[ownerRid] = t.state;
+					m_v2_tamper_changed[ownerRid] = t.changed;
+				}
+
+				// Map device_power to battery updates; only update existing devices and only when battery level changed
+				for (const auto &p : m_v2sensors->GetDevicePowers())
+				{
+					const std::string ownerRid = p.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					// Only update battery for devices discovered in v2 device list
+					auto dit = deviceById.find(ownerRid);
+					if (dit == deviceById.end())
+						continue;
+
+					// Determine numeric batteryLevel: prefer explicit numeric; otherwise map battery_state heuristically.
+					int batteryLevel = p.battery_level; // parsed (-1 if missing)
+					if (batteryLevel < 0)
+					{
+						if (p.battery_state == "full" || p.battery_state == "normal")
+							batteryLevel = 100;
+						else if (p.battery_state == "high")
+							batteryLevel = 90;
+						else if (p.battery_state == "low")
+							batteryLevel = 20;
+						else if (p.battery_state == "critical")
+							batteryLevel = 5;
+						else
+							batteryLevel = 255; // unknown
+					}
+					if (batteryLevel > 100 && batteryLevel != 255) batteryLevel = 100;
+					if (batteryLevel == 255)
+						continue;
+
+					// Determine the Domoticz node IDs (owner-based)
+					int baseNode = NodeIDFromRid(ownerRid);
+					int domoticzNodeID_contact = baseNode + 3000;
+					int domoticzNodeID_tamper  = baseNode + 4000;
+
+					// Only update contact device if it exists; update only when battery changed
+					char szID[16];
+					std::vector<std::vector<std::string>> result;
+
+					sprintf(szID, "%08X", domoticzNodeID_contact);
+					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+											m_HwdID, szID, 1);
+					if (!result.empty())
+					{
+						int deviceRowId = atoi(result[0][0].c_str());
+						int prevBattery = atoi(result[0][1].c_str());
+						if (prevBattery != batteryLevel)
+						{
+							// preserve current nValue for push
+							int nValue = 0;
+							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+							bool contactIsOn = (nValue != 0);
+							std::string contactName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Contact)") : "Hue V2 Contact";
+
+							InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
+							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+							m_v2_battery_level[ownerRid] = batteryLevel;
+						}
+					}
+
+					// Tamper device (same approach)
+					sprintf(szID, "%08X", domoticzNodeID_tamper);
+					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+											m_HwdID, szID, 1);
+					if (!result.empty())
+					{
+						int deviceRowId = atoi(result[0][0].c_str());
+						int prevBattery = atoi(result[0][1].c_str());
+						if (prevBattery != batteryLevel)
+						{
+							int nValue = 0;
+							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+							bool tamperIsOn = (nValue != 0);
+							std::string tamperName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Tamper)") : "Hue V2 Tamper";
+
+							InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
+							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+							m_v2_battery_level[ownerRid] = batteryLevel;
+						}
+					}
+				}
+			}
+			else
+			{
+				_log.Debug(DEBUG_HARDWARE, "PhilipsHue: v2 sensors fetch returned no data or failed.");
+			}
+		}
+		catch (const std::exception &e)
+		{
+			_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
+		}
+	}
+	
 	return true;
 }
 

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -1,6 +1,7 @@
 #include "stdafx.h"
 #include "PhilipsHue.h"
 #include "PhilipsHueSensors.h"
+#include "PhilipsHueV2Sensors.h"
 #include "../../main/Helper.h"
 #include "../../main/Logger.h"
 #include "../../main/RFXtrx.h"
@@ -61,8 +62,14 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 	m_HwdID = ID;
 	m_Port = Port;
 	m_poll_interval = PollInterval;
-	m_add_groups = (Options & HUE_NOT_ADD_GROUPS) != 0;
-	m_add_scenes = (Options & HUE_NOT_ADD_SCENES) != 0;
+	// Force-enable V2 sensors by default by OR-ing the option in here.
+    // This keeps callers unchanged but makes the behavior default-on.
+    int effectiveOptions = Options | CPhilipsHue::HUE_USE_V2_SENSORS;
+
+    m_add_groups = (effectiveOptions & HUE_NOT_ADD_GROUPS) != 0;
+    m_add_scenes = (effectiveOptions & HUE_NOT_ADD_SCENES) != 0;
+
+    m_use_v2_sensors = (effectiveOptions & HUE_USE_V2_SENSORS) != 0;
 
 	// Catch uninitialised Mode1 entry.
 	if (m_poll_interval < 1)
@@ -85,6 +92,22 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 
 void CPhilipsHue::Init()
 {
+	// instantiate V2 sensors helper if enabled
+	if (m_use_v2_sensors)
+	{
+		// Use m_UserName as hue-application-key for now (same field used for v1 username).
+		try
+		{
+			m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
+			Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled.");
+		}
+		catch (const std::exception &e)
+		{
+			Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
+			m_v2sensors.reset();
+			m_use_v2_sensors = false;
+		}
+	}
 }
 
 bool CPhilipsHue::StartHardware()
@@ -775,7 +798,207 @@ bool CPhilipsHue::GetStates()
 	GetScenes(root);
 	GetSensors(root);
 
+	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
+	if (m_use_v2_sensors && m_v2sensors)
+	{
+		try
+		{
+			if (m_v2sensors->UpdateAll())
+			{
+				// Build map device id -> device data for name lookup
+				std::map<std::string, HueV2Device> deviceById;
+				for (const auto &d : m_v2sensors->GetDevices())
+					deviceById[d.id] = d;
+
+				// Map contact resources to Domoticz switches (one device per owner/device), but only when changed
+				for (const auto &c : m_v2sensors->GetContacts())
+				{
+					const std::string ownerRid = c.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					// Name lookup
+					std::string friendlyName;
+					auto dit = deviceById.find(ownerRid);
+					if (dit != deviceById.end() && !dit->second.name.empty())
+						friendlyName = dit->second.name + " (Contact)";
+					else
+						friendlyName = "Hue V2 Contact";
+
+					// Compute Domoticz node for device (owner-based)
+					int nodeID = NodeIDFromRid(ownerRid);
+					int domoticzNodeID = nodeID + 3000;
+
+					// Check previous state: skip if state and changed timestamp are identical to last poll
+					bool doUpdate = true;
+					auto itPrevState = m_v2_contact_state.find(ownerRid);
+					auto itPrevChanged = m_v2_contact_changed.find(ownerRid);
+					if (itPrevState != m_v2_contact_state.end() && itPrevChanged != m_v2_contact_changed.end())
+					{
+						if (itPrevState->second == c.state && itPrevChanged->second == c.changed)
+							doUpdate = false;
+					}
+
+					if (!doUpdate)
+						continue;
+
+					// contact_report.state: "contact" => closed (not alarmed). "no_contact" => open
+					bool isOpen = (c.state == "no_contact");
+
+					// Update/create Domoticz device and record state
+					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_DoorContact, isOpen, friendlyName, 0);
+
+					// Store last-seen state and changed timestamp
+					m_v2_contact_state[ownerRid] = c.state;
+					m_v2_contact_changed[ownerRid] = c.changed;
+				}
+
+				// Map tamper resources similarly, only update when changed
+				for (const auto &t : m_v2sensors->GetTampers())
+				{
+					const std::string ownerRid = t.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					std::string friendlyName;
+					auto dit = deviceById.find(ownerRid);
+					if (dit != deviceById.end() && !dit->second.name.empty())
+						friendlyName = dit->second.name + " (Tamper)";
+					else
+						friendlyName = "Hue V2 Tamper";
+
+					int nodeID = NodeIDFromRid(ownerRid);
+					int domoticzNodeID = nodeID + 4000;
+
+					// If there is no tamper report changed timestamp and no state, treat as no change
+					bool doUpdate = true;
+					auto itPrevState = m_v2_tamper_state.find(ownerRid);
+					auto itPrevChanged = m_v2_tamper_changed.find(ownerRid);
+					if (itPrevState != m_v2_tamper_state.end() && itPrevChanged != m_v2_tamper_changed.end())
+					{
+						if (itPrevState->second == t.state && itPrevChanged->second == t.changed)
+							doUpdate = false;
+					}
+
+					if (!doUpdate)
+						continue;
+					
+					bool isTampered = (t.state == "tampered");
+
+					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_OnOff, isTampered, friendlyName, 0);
+
+					m_v2_tamper_state[ownerRid] = t.state;
+					m_v2_tamper_changed[ownerRid] = t.changed;
+				}
+
+				// Map device_power to battery updates; only update existing devices and only when battery level changed
+				for (const auto &p : m_v2sensors->GetDevicePowers())
+				{
+					const std::string ownerRid = p.owner_rid;
+					if (ownerRid.empty())
+						continue;
+
+					// Only update battery for devices discovered in v2 device list
+					auto dit = deviceById.find(ownerRid);
+					if (dit == deviceById.end())
+						continue;
+
+					// Determine numeric batteryLevel: prefer explicit numeric; otherwise map battery_state heuristically.
+					int batteryLevel = p.battery_level; // parsed (-1 if missing)
+					if (batteryLevel < 0)
+					{
+						if (p.battery_state == "full" || p.battery_state == "normal")
+							batteryLevel = 100;
+						else if (p.battery_state == "high")
+							batteryLevel = 90;
+						else if (p.battery_state == "low")
+							batteryLevel = 20;
+						else if (p.battery_state == "critical")
+							batteryLevel = 5;
+						else
+							batteryLevel = 255; // unknown
+					}
+					if (batteryLevel > 100 && batteryLevel != 255) batteryLevel = 100;
+					if (batteryLevel == 255)
+						continue;
+
+					// Determine the Domoticz node IDs (owner-based)
+					int baseNode = NodeIDFromRid(ownerRid);
+					int domoticzNodeID_contact = baseNode + 3000;
+					int domoticzNodeID_tamper  = baseNode + 4000;
+
+					// Only update contact device if it exists; update only when battery changed
+					char szID[16];
+					std::vector<std::vector<std::string>> result;
+
+					sprintf(szID, "%08X", domoticzNodeID_contact);
+					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+											m_HwdID, szID, 1);
+					if (!result.empty())
+					{
+						int deviceRowId = atoi(result[0][0].c_str());
+						int prevBattery = atoi(result[0][1].c_str());
+						if (prevBattery != batteryLevel)
+						{
+							// preserve current nValue for push
+							int nValue = 0;
+							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+							bool contactIsOn = (nValue != 0);
+							std::string contactName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Contact)") : "Hue V2 Contact";
+
+							InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
+							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+							m_v2_battery_level[ownerRid] = batteryLevel;
+						}
+					}
+
+					// Tamper device (same approach)
+					sprintf(szID, "%08X", domoticzNodeID_tamper);
+					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+											m_HwdID, szID, 1);
+					if (!result.empty())
+					{
+						int deviceRowId = atoi(result[0][0].c_str());
+						int prevBattery = atoi(result[0][1].c_str());
+						if (prevBattery != batteryLevel)
+						{
+							int nValue = 0;
+							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+							bool tamperIsOn = (nValue != 0);
+							std::string tamperName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Tamper)") : "Hue V2 Tamper";
+
+							InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
+							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+							m_v2_battery_level[ownerRid] = batteryLevel;
+						}
+					}
+				}
+			}
+			else
+			{
+				_log.Debug(DEBUG_HARDWARE, "PhilipsHue: v2 sensors fetch returned no data or failed.");
+			}
+		}
+		catch (const std::exception &e)
+		{
+			_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
+		}
+	}
 	return true;
+}
+
+// NEW: deterministic conversion from v2 uuid/rid string to numeric node ID
+int CPhilipsHue::NodeIDFromRid(const std::string &rid)
+{
+	// Stable non-cryptographic hash -> 32-bit int. Guaranteed deterministic across restarts.
+	std::hash<std::string> hasher;
+	uint32_t h = static_cast<uint32_t>(hasher(rid));
+	// Keep it in a safe positive range; mask off sign bit
+	const uint32_t safe = h & 0x7FFFFFFF;
+	// Limit to a range so NodeIDs are not ridiculously large (optional)
+	return static_cast<int>(safe % 2000000); // produces 0 .. 1_999_999
 }
 
 void CPhilipsHue::LightStateFromJSON(const Json::Value& lightstate, _tHueLightState& tlight, _eHueLightType& LType)

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -16,6 +16,7 @@
 #define HUE_DEFAULT_POLL_INTERVAL 10
 #define HUE_NOT_ADD_GROUPS 0x01
 #define HUE_NOT_ADD_SCENES 0x02
+#define HUE_USE_V2_SENSORS 0x04
 
 #define SensorTypeDaylight "Daylight"
 #define SensorTypeZGPSwitch "ZGPSwitch"
@@ -64,7 +65,8 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 	m_poll_interval = PollInterval;
 	// Force-enable V2 sensors by default by OR-ing the option in here.
     // This keeps callers unchanged but makes the behavior default-on.
-    int effectiveOptions = Options | CPhilipsHue::HUE_USE_V2_SENSORS;
+    //int effectiveOptions = Options | CPhilipsHue::HUE_USE_V2_SENSORS;
+	int effectiveOptions = Options | HUE_USE_V2_SENSORS;
 
     m_add_groups = (effectiveOptions & HUE_NOT_ADD_GROUPS) != 0;
     m_add_scenes = (effectiveOptions & HUE_NOT_ADD_SCENES) != 0;
@@ -104,7 +106,7 @@ void CPhilipsHue::Init()
 		catch (const std::exception &e)
 		{
 			Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
-			m_v2sensors.reset();
+			//m_v2sensors.reset();
 			m_use_v2_sensors = false;
 		}
 	}
@@ -1126,193 +1128,194 @@ bool CPhilipsHue::GetScenes(const Json::Value& root)
 bool CPhilipsHue::GetV2Sensors()
 {
 	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
-	if (m_use_v2_sensors && m_v2sensors)
+	if (!m_use_v2_sensors || !m_v2sensors) return false;
+	//if (m_use_v2_sensors && m_v2sensors)
+	//{
+	try
 	{
-		try
+		if (m_v2sensors->UpdateAll())
 		{
-			if (m_v2sensors->UpdateAll())
+			// Build map device id -> device data for name lookup
+			std::map<std::string, HueV2Device> deviceById;
+			for (const auto &d : m_v2sensors->GetDevices())
+				deviceById[d.id] = d;
+
+			// Map contact resources to Domoticz switches (one device per owner/device), but only when changed
+			for (const auto &c : m_v2sensors->GetContacts())
 			{
-				// Build map device id -> device data for name lookup
-				std::map<std::string, HueV2Device> deviceById;
-				for (const auto &d : m_v2sensors->GetDevices())
-					deviceById[d.id] = d;
+				const std::string ownerRid = c.owner_rid;
+				if (ownerRid.empty())
+					continue;
 
-				// Map contact resources to Domoticz switches (one device per owner/device), but only when changed
-				for (const auto &c : m_v2sensors->GetContacts())
+				// Name lookup
+				std::string friendlyName;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					friendlyName = dit->second.name + " (Contact)";
+				else
+					friendlyName = "Hue V2 Contact";
+
+				// Compute Domoticz node for device (owner-based)
+				int nodeID = NodeIDFromRid(ownerRid);
+				int domoticzNodeID = nodeID + 3000;
+
+				// Check previous state: skip if state and changed timestamp are identical to last poll
+				bool doUpdate = true;
+				auto itPrevState = m_v2_contact_state.find(ownerRid);
+				auto itPrevChanged = m_v2_contact_changed.find(ownerRid);
+				if (itPrevState != m_v2_contact_state.end() && itPrevChanged != m_v2_contact_changed.end())
 				{
-					const std::string ownerRid = c.owner_rid;
-					if (ownerRid.empty())
-						continue;
-
-					// Name lookup
-					std::string friendlyName;
-					auto dit = deviceById.find(ownerRid);
-					if (dit != deviceById.end() && !dit->second.name.empty())
-						friendlyName = dit->second.name + " (Contact)";
-					else
-						friendlyName = "Hue V2 Contact";
-
-					// Compute Domoticz node for device (owner-based)
-					int nodeID = NodeIDFromRid(ownerRid);
-					int domoticzNodeID = nodeID + 3000;
-
-					// Check previous state: skip if state and changed timestamp are identical to last poll
-					bool doUpdate = true;
-					auto itPrevState = m_v2_contact_state.find(ownerRid);
-					auto itPrevChanged = m_v2_contact_changed.find(ownerRid);
-					if (itPrevState != m_v2_contact_state.end() && itPrevChanged != m_v2_contact_changed.end())
-					{
-						if (itPrevState->second == c.state && itPrevChanged->second == c.changed)
-							doUpdate = false;
-					}
-
-					if (!doUpdate)
-						continue;
-
-					// contact_report.state: "contact" => closed (not alarmed). "no_contact" => open
-					bool isOpen = (c.state == "no_contact");
-
-					// Update/create Domoticz device and record state
-					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_DoorContact, isOpen, friendlyName, 0);
-
-					// Store last-seen state and changed timestamp
-					m_v2_contact_state[ownerRid] = c.state;
-					m_v2_contact_changed[ownerRid] = c.changed;
+					if (itPrevState->second == c.state && itPrevChanged->second == c.changed)
+						doUpdate = false;
 				}
 
-				// Map tamper resources similarly, only update when changed
-				for (const auto &t : m_v2sensors->GetTampers())
-				{
-					const std::string ownerRid = t.owner_rid;
-					if (ownerRid.empty())
-						continue;
+				if (!doUpdate)
+					continue;
 
-					std::string friendlyName;
-					auto dit = deviceById.find(ownerRid);
-					if (dit != deviceById.end() && !dit->second.name.empty())
-						friendlyName = dit->second.name + " (Tamper)";
-					else
-						friendlyName = "Hue V2 Tamper";
+				// contact_report.state: "contact" => closed (not alarmed). "no_contact" => open
+				bool isOpen = (c.state == "no_contact");
 
-					int nodeID = NodeIDFromRid(ownerRid);
-					int domoticzNodeID = nodeID + 4000;
+				// Update/create Domoticz device and record state
+				InsertUpdateSwitch(domoticzNodeID, 1, STYPE_DoorContact, isOpen, friendlyName, 0);
 
-					// If there is no tamper report changed timestamp and no state, treat as no change
-					bool doUpdate = true;
-					auto itPrevState = m_v2_tamper_state.find(ownerRid);
-					auto itPrevChanged = m_v2_tamper_changed.find(ownerRid);
-					if (itPrevState != m_v2_tamper_state.end() && itPrevChanged != m_v2_tamper_changed.end())
-					{
-						if (itPrevState->second == t.state && itPrevChanged->second == t.changed)
-							doUpdate = false;
-					}
-
-					if (!doUpdate)
-						continue;
-					
-					bool isTampered = (t.state == "tampered");
-
-					InsertUpdateSwitch(domoticzNodeID, 1, STYPE_OnOff, isTampered, friendlyName, 0);
-
-					m_v2_tamper_state[ownerRid] = t.state;
-					m_v2_tamper_changed[ownerRid] = t.changed;
-				}
-
-				// Map device_power to battery updates; only update existing devices and only when battery level changed
-				for (const auto &p : m_v2sensors->GetDevicePowers())
-				{
-					const std::string ownerRid = p.owner_rid;
-					if (ownerRid.empty())
-						continue;
-
-					// Only update battery for devices discovered in v2 device list
-					auto dit = deviceById.find(ownerRid);
-					if (dit == deviceById.end())
-						continue;
-
-					// Determine numeric batteryLevel: prefer explicit numeric; otherwise map battery_state heuristically.
-					int batteryLevel = p.battery_level; // parsed (-1 if missing)
-					if (batteryLevel < 0)
-					{
-						if (p.battery_state == "full" || p.battery_state == "normal")
-							batteryLevel = 100;
-						else if (p.battery_state == "high")
-							batteryLevel = 90;
-						else if (p.battery_state == "low")
-							batteryLevel = 20;
-						else if (p.battery_state == "critical")
-							batteryLevel = 5;
-						else
-							batteryLevel = 255; // unknown
-					}
-					if (batteryLevel > 100 && batteryLevel != 255) batteryLevel = 100;
-					if (batteryLevel == 255)
-						continue;
-
-					// Determine the Domoticz node IDs (owner-based)
-					int baseNode = NodeIDFromRid(ownerRid);
-					int domoticzNodeID_contact = baseNode + 3000;
-					int domoticzNodeID_tamper  = baseNode + 4000;
-
-					// Only update contact device if it exists; update only when battery changed
-					char szID[16];
-					std::vector<std::vector<std::string>> result;
-
-					sprintf(szID, "%08X", domoticzNodeID_contact);
-					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
-											m_HwdID, szID, 1);
-					if (!result.empty())
-					{
-						int deviceRowId = atoi(result[0][0].c_str());
-						int prevBattery = atoi(result[0][1].c_str());
-						if (prevBattery != batteryLevel)
-						{
-							// preserve current nValue for push
-							int nValue = 0;
-							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
-							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
-							bool contactIsOn = (nValue != 0);
-							std::string contactName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Contact)") : "Hue V2 Contact";
-
-							InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
-							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
-							m_v2_battery_level[ownerRid] = batteryLevel;
-						}
-					}
-
-					// Tamper device (same approach)
-					sprintf(szID, "%08X", domoticzNodeID_tamper);
-					result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
-											m_HwdID, szID, 1);
-					if (!result.empty())
-					{
-						int deviceRowId = atoi(result[0][0].c_str());
-						int prevBattery = atoi(result[0][1].c_str());
-						if (prevBattery != batteryLevel)
-						{
-							int nValue = 0;
-							auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
-							if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
-							bool tamperIsOn = (nValue != 0);
-							std::string tamperName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Tamper)") : "Hue V2 Tamper";
-
-							InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
-							m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
-							m_v2_battery_level[ownerRid] = batteryLevel;
-						}
-					}
-				}
+				// Store last-seen state and changed timestamp
+				m_v2_contact_state[ownerRid] = c.state;
+				m_v2_contact_changed[ownerRid] = c.changed;
 			}
-			else
+
+			// Map tamper resources similarly, only update when changed
+			for (const auto &t : m_v2sensors->GetTampers())
 			{
-				_log.Debug(DEBUG_HARDWARE, "PhilipsHue: v2 sensors fetch returned no data or failed.");
+				const std::string ownerRid = t.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				std::string friendlyName;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					friendlyName = dit->second.name + " (Tamper)";
+				else
+					friendlyName = "Hue V2 Tamper";
+
+				int nodeID = NodeIDFromRid(ownerRid);
+				int domoticzNodeID = nodeID + 4000;
+
+				// If there is no tamper report changed timestamp and no state, treat as no change
+				bool doUpdate = true;
+				auto itPrevState = m_v2_tamper_state.find(ownerRid);
+				auto itPrevChanged = m_v2_tamper_changed.find(ownerRid);
+				if (itPrevState != m_v2_tamper_state.end() && itPrevChanged != m_v2_tamper_changed.end())
+				{
+					if (itPrevState->second == t.state && itPrevChanged->second == t.changed)
+						doUpdate = false;
+				}
+
+				if (!doUpdate)
+					continue;
+				
+				bool isTampered = (t.state == "tampered");
+
+				InsertUpdateSwitch(domoticzNodeID, 1, STYPE_OnOff, isTampered, friendlyName, 0);
+
+				m_v2_tamper_state[ownerRid] = t.state;
+				m_v2_tamper_changed[ownerRid] = t.changed;
+			}
+
+			// Map device_power to battery updates; only update existing devices and only when battery level changed
+			for (const auto &p : m_v2sensors->GetDevicePowers())
+			{
+				const std::string ownerRid = p.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				// Only update battery for devices discovered in v2 device list
+				auto dit = deviceById.find(ownerRid);
+				if (dit == deviceById.end())
+					continue;
+
+				// Determine numeric batteryLevel: prefer explicit numeric; otherwise map battery_state heuristically.
+				int batteryLevel = p.battery_level; // parsed (-1 if missing)
+				if (batteryLevel < 0)
+				{
+					if (p.battery_state == "full" || p.battery_state == "normal")
+						batteryLevel = 100;
+					else if (p.battery_state == "high")
+						batteryLevel = 90;
+					else if (p.battery_state == "low")
+						batteryLevel = 20;
+					else if (p.battery_state == "critical")
+						batteryLevel = 5;
+					else
+						batteryLevel = 255; // unknown
+				}
+				if (batteryLevel > 100 && batteryLevel != 255) batteryLevel = 100;
+				if (batteryLevel == 255)
+					continue;
+
+				// Determine the Domoticz node IDs (owner-based)
+				int baseNode = NodeIDFromRid(ownerRid);
+				int domoticzNodeID_contact = baseNode + 3000;
+				int domoticzNodeID_tamper  = baseNode + 4000;
+
+				// Only update contact device if it exists; update only when battery changed
+				char szID[16];
+				std::vector<std::vector<std::string>> result;
+
+				sprintf(szID, "%08X", domoticzNodeID_contact);
+				result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+										m_HwdID, szID, 1);
+				if (!result.empty())
+				{
+					int deviceRowId = atoi(result[0][0].c_str());
+					int prevBattery = atoi(result[0][1].c_str());
+					if (prevBattery != batteryLevel)
+					{
+						// preserve current nValue for push
+						int nValue = 0;
+						auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+						if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+						bool contactIsOn = (nValue != 0);
+						std::string contactName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Contact)") : "Hue V2 Contact";
+
+						InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
+						m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+						m_v2_battery_level[ownerRid] = batteryLevel;
+					}
+				}
+
+				// Tamper device (same approach)
+				sprintf(szID, "%08X", domoticzNodeID_tamper);
+				result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+										m_HwdID, szID, 1);
+				if (!result.empty())
+				{
+					int deviceRowId = atoi(result[0][0].c_str());
+					int prevBattery = atoi(result[0][1].c_str());
+					if (prevBattery != batteryLevel)
+					{
+						int nValue = 0;
+						auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+						if (!res2.empty()) nValue = atoi(res2[0][0].c_str());
+						bool tamperIsOn = (nValue != 0);
+						std::string tamperName = (dit != deviceById.end() && !dit->second.name.empty()) ? (dit->second.name + " (Tamper)") : "Hue V2 Tamper";
+
+						InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
+						m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+						m_v2_battery_level[ownerRid] = batteryLevel;
+					}
+				}
 			}
 		}
-		catch (const std::exception &e)
+		else
 		{
-			_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
+			_log.Debug(DEBUG_HARDWARE, "PhilipsHue: v2 sensors fetch returned no data or failed.");
 		}
 	}
+	catch (const std::exception &e)
+	{
+		_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
+	}
+	//}
 	
 	return true;
 }

--- a/hardware/PhilipsHue/PhilipsHue.h
+++ b/hardware/PhilipsHue/PhilipsHue.h
@@ -67,6 +67,7 @@ private:
 	bool GetGroups(const Json::Value& root);
 	bool GetScenes(const Json::Value& root);
 	bool GetSensors(const Json::Value& root);
+	bool GetV2Sensors(); // NEW: v2 sensors integration
 	void InsertUpdateLamp(int NodeID, _eHueLightType LType, _tHueLightState tstate, const std::string& Name, const std::string& Options, const std::string& modelid, bool AddMissingDevice);
 	bool InsertUpdateSelectorSwitch(int NodeID, uint8_t Unitcode, uint8_t selectorLevel, const std::string& Name, uint8_t BatteryLevel);
 	void InsertUpdateSwitch(int NodeID, uint8_t Unitcode, _eSwitchType SType, bool bIsOn, const std::string& Name, uint8_t BatteryLevel);

--- a/hardware/PhilipsHue/PhilipsHue.h
+++ b/hardware/PhilipsHue/PhilipsHue.h
@@ -97,11 +97,11 @@ private:
 	std::map<int, std::string> m_lightModels;
 
 // NEW: V2 sensors integration members
-public:
+//public:
 	// Option flag (bit) to enable Philips Hue v2 CLIP sensors support
 	// Set this bit in the 'Options' parameter when constructing CPhilipsHue
 	// Example: Options | HUE_USE_V2_SENSORS
-	static const int HUE_USE_V2_SENSORS = 0x04;
+	//static const int HUE_USE_V2_SENSORS = 0x04;
 
 private:
 	bool m_use_v2_sensors = false;

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
@@ -1,0 +1,285 @@
+#include "stdafx.h"
+#include "PhilipsHueV2Sensors.h"
+#include "../../httpclient/HTTPClient.h"
+#include "../../main/json_helper.h"
+#include "../../main/Logger.h"
+#include <json/json.h> // Json::Value
+#include <algorithm>
+
+using namespace std;
+
+// Constructor
+CPhilipsHueV2Sensors::CPhilipsHueV2Sensors(const std::string &html_schema,
+                                           const std::string &ipAddress,
+                                           const std::string &port,
+                                           const std::string &applicationKey) :
+	m_html_schema(html_schema),
+	m_IPAddress(ipAddress),
+	m_Port(port),
+	m_ApplicationKey(applicationKey)
+{
+	SetBaseURLv2FromParts();
+}
+
+// Destructor
+CPhilipsHueV2Sensors::~CPhilipsHueV2Sensors()
+{
+}
+
+// Build base URL using stream as requested
+void CPhilipsHueV2Sensors::SetBaseURLv2FromParts()
+{
+	m_BaseURLv2.str("");
+	m_BaseURLv2.clear();
+	m_BaseURLv2 << m_html_schema << "://" << m_IPAddress;
+	if (!m_Port.empty()) m_BaseURLv2 << ":" << m_Port;
+	// callers append /clip/v2/resource/...
+}
+
+// High-level update: attempt all endpoints; partial success still returns true if any succeeded
+bool CPhilipsHueV2Sensors::UpdateAll()
+{
+	bool ok1 = FetchDevices();
+	bool ok2 = FetchContacts();
+	bool ok3 = FetchTamper();
+	bool ok4 = FetchDevicePower();
+	return ok1 || ok2 || ok3 || ok4;
+}
+
+// Helper: GET with hue-application-key header using project HTTPClient
+static bool http_get_with_key(const std::string &url, const std::string &appKey, std::string &outBody)
+{
+	std::vector<std::string> ExtraHeaders;
+	ExtraHeaders.push_back("Accept: application/json");
+	if (!appKey.empty())
+	{
+		ExtraHeaders.push_back(std::string("hue-application-key: ") + appKey);
+	}
+	return HTTPClient::GET(url, ExtraHeaders, outBody);
+}
+
+// Fetch /clip/v2/resource/device
+bool CPhilipsHueV2Sensors::FetchDevices()
+{
+	m_devices.clear();
+	std::string url = m_BaseURLv2.str() + "/clip/v2/resource/device";
+	std::string sResult;
+	if (!http_get_with_key(url, m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevices HTTP GET failed (%s)", url.c_str());
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevices JSON parse failed");
+		return false;
+	}
+	return parseDeviceJson(root);
+}
+
+// Fetch /clip/v2/resource/contact
+bool CPhilipsHueV2Sensors::FetchContacts()
+{
+	m_contacts.clear();
+	std::string url = m_BaseURLv2.str() + "/clip/v2/resource/contact";
+	std::string sResult;
+	if (!http_get_with_key(url, m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchContacts HTTP GET failed (%s)", url.c_str());
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchContacts JSON parse failed");
+		return false;
+	}
+	return parseContactJson(root);
+}
+
+// Fetch /clip/v2/resource/tamper
+bool CPhilipsHueV2Sensors::FetchTamper()
+{
+	m_tampers.clear();
+	std::string url = m_BaseURLv2.str() + "/clip/v2/resource/tamper";
+	std::string sResult;
+	if (!http_get_with_key(url, m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchTamper HTTP GET failed (%s)", url.c_str());
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchTamper JSON parse failed");
+		return false;
+	}
+	return parseTamperJson(root);
+}
+
+// Fetch /clip/v2/resource/device_power
+bool CPhilipsHueV2Sensors::FetchDevicePower()
+{
+	m_devicePowers.clear();
+	std::string url = m_BaseURLv2.str() + "/clip/v2/resource/device_power";
+	std::string sResult;
+	if (!http_get_with_key(url, m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevicePower HTTP GET failed (%s)", url.c_str());
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevicePower JSON parse failed");
+		return false;
+	}
+	return parseDevicePowerJson(root);
+}
+
+// parse /clip/v2/resource/device (root is Json::Value)
+bool CPhilipsHueV2Sensors::parseDeviceJson(const Json::Value &root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseDeviceJson unexpected structure");
+		return false;
+	}
+	for (const auto &item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2Device d;
+		if (item.isMember("id")) d.id = item["id"].asString();
+		if (item.isMember("metadata") && item["metadata"].isObject() && item["metadata"].isMember("name"))
+			d.name = item["metadata"]["name"].asString();
+
+		if (item.isMember("product_data") && item["product_data"].isObject())
+		{
+			const auto &pd = item["product_data"];
+			if (pd.isMember("model_id")) d.model_id = pd["model_id"].asString();
+			if (pd.isMember("product_name")) d.product_name = pd["product_name"].asString();
+			if (pd.isMember("manufacturer_name")) d.manufacturer_name = pd["manufacturer_name"].asString();
+			if (pd.isMember("software_version")) d.software_version = pd["software_version"].asString();
+		}
+		if (item.isMember("services") && item["services"].isArray())
+		{
+			for (const auto &srv : item["services"])
+			{
+				if (srv.isMember("rid")) d.services_rids.push_back(srv["rid"].asString());
+			}
+		}
+		m_devices.push_back(d);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/contact
+bool CPhilipsHueV2Sensors::parseContactJson(const Json::Value &root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseContactJson unexpected structure");
+		return false;
+	}
+	for (const auto &item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2Contact c;
+		if (item.isMember("id")) c.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			c.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled")) c.enabled = item["enabled"].asBool();
+		if (item.isMember("contact_report") && item["contact_report"].isObject())
+		{
+			const auto &cr = item["contact_report"];
+			if (cr.isMember("state")) c.state = cr["state"].asString();
+			if (cr.isMember("changed")) c.changed = cr["changed"].asString();
+		}
+		m_contacts.push_back(c);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/tamper
+bool CPhilipsHueV2Sensors::parseTamperJson(const Json::Value &root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseTamperJson unexpected structure");
+		return false;
+	}
+	for (const auto &item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2Tamper t;
+		if (item.isMember("id")) t.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			t.owner_rid = item["owner"]["rid"].asString();
+		// tamper_reports may be empty; pick last if present
+		if (item.isMember("tamper_reports") && item["tamper_reports"].isArray() && item["tamper_reports"].size() > 0)
+		{
+			const auto &arr = item["tamper_reports"];
+			const Json::Value &last = arr[arr.size() - 1];
+			if (last.isMember("state")) t.state = last["state"].asString();
+			if (last.isMember("source")) t.source = last["source"].asString();
+			if (last.isMember("changed")) t.changed = last["changed"].asString();
+		}
+		m_tampers.push_back(t);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/device_power
+bool CPhilipsHueV2Sensors::parseDevicePowerJson(const Json::Value &root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseDevicePowerJson unexpected structure");
+		return false;
+	}
+	for (const auto &item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2DevicePower p;
+		if (item.isMember("id")) p.id = item["id"].asString();
+        // optional id_v1 mapping (e.g. "/sensors/25")
+		if (item.isMember("id_v1") && item["id_v1"].isString())
+			p.id_v1 = item["id_v1"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			p.owner_rid = item["owner"]["rid"].asString();
+        // default = missing
+		p.battery_level = -1;
+		if (item.isMember("power_state") && item["power_state"].isObject())
+		{
+			const auto &ps = item["power_state"];
+            if (ps.isMember("battery_state") && ps["battery_state"].isString())
+				p.battery_state = ps["battery_state"].asString();
+													  
+			if (ps.isMember("battery_level") && ps["battery_level"].isInt())
+				p.battery_level = ps["battery_level"].asInt();
+		}
+        // Clamp battery_level if present
+		if (p.battery_level >= 0)
+			p.battery_level = std::clamp(p.battery_level, 0, 100);
+
+		// Debug: parsed device_power
+		_log.Debug(DEBUG_HARDWARE, "PhilipsHueV2: parsed device_power id=%s id_v1=%s owner=%s battery_state=%s battery_level=%d",
+			p.id.c_str(),
+			p.id_v1.c_str(),
+			p.owner_rid.c_str(),
+			p.battery_state.c_str(),
+			p.battery_level);
+
+		m_devicePowers.push_back(p);
+	}
+	return true;
+}
+
+/*
+- Example URLs:
+    m_BaseURLv2 << "/clip/v2/resource/device"
+    m_BaseURLv2 << "/clip/v2/resource/contact"
+    m_BaseURLv2 << "/clip/v2/resource/tamper"
+    m_BaseURLv2 << "/clip/v2/resource/device_power"
+*/

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.h
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "stdafx.h"
+#include "PhilipsHueSensors.h"
+#include <string>
+#include <vector>
+#include <sstream>
+#include <map>
+
+// Using existing json wrapper in project
+// Json::Value is used (same style as PhilipsHue.cpp / PhilipsHueSensors.cpp)
+namespace Json {
+	class Value;
+}
+
+struct HueV2Device {
+	std::string id;
+	std::string name;
+	std::string model_id;
+	std::string product_name;
+	std::string manufacturer_name;
+	std::string software_version;
+	std::vector<std::string> services_rids; // rids to lookup contact/tamper/device_power
+};
+
+struct HueV2Contact {
+	std::string id;
+	std::string owner_rid;
+	bool enabled = false;
+	std::string state;   // "contact" / "no_contact" ...
+	std::string changed; // ISO timestamp
+};
+
+struct HueV2Tamper {
+	std::string id;
+	std::string owner_rid;
+	std::string state;   // "tampered" / "not_tampered" ...
+	std::string source;  // e.g. "battery_door"
+	std::string changed; // ISO timestamp (last report)
+};
+
+struct HueV2DevicePower {
+	std::string id;
+    std::string id_v1;
+	std::string owner_rid;
+	std::string battery_state; // e.g. "normal"
+	int battery_level = -1;    // 0..100 or -1 if missing
+};
+
+class CPhilipsHueV2Sensors {
+public:
+	// html_schema should be "http" or "https" per existing code usage
+	CPhilipsHueV2Sensors(const std::string &html_schema,
+	                     const std::string &ipAddress,
+	                     const std::string &port,
+	                     const std::string &applicationKey);
+	~CPhilipsHueV2Sensors();
+
+   	// Not copyable
+	CPhilipsHueV2Sensors(const CPhilipsHueV2Sensors&) = delete;
+	CPhilipsHueV2Sensors& operator=(const CPhilipsHueV2Sensors&) = delete;
+
+	// Build base URL into m_BaseURLv2 stream as requested
+	void SetBaseURLv2FromParts();
+
+	// Fetch and parse all v2 resources; partial success still stores parsed data
+	bool UpdateAll();
+
+	// Individual fetch functions (public for testing)
+	bool FetchDevices();
+	bool FetchContacts();
+	bool FetchTamper();
+	bool FetchDevicePower();
+
+	// Getters
+	const std::vector<HueV2Device>& GetDevices() const { return m_devices; }
+	const std::vector<HueV2Contact>& GetContacts() const { return m_contacts; }
+	const std::vector<HueV2Tamper>& GetTampers() const { return m_tampers; }
+	const std::vector<HueV2DevicePower>& GetDevicePowers() const { return m_devicePowers; }
+
+	// Simple setters
+	void SetApplicationKey(const std::string &key) { m_ApplicationKey = key; }
+	void SetIPAddress(const std::string &ip) { m_IPAddress = ip; SetBaseURLv2FromParts(); }
+	void SetPort(const std::string &port) { m_Port = port; SetBaseURLv2FromParts(); }
+	void SetSchema(const std::string &schema) { m_html_schema = schema; SetBaseURLv2FromParts(); }
+
+private:
+	// parse helpers
+	bool parseDeviceJson(const Json::Value &root);
+	bool parseContactJson(const Json::Value &root);
+	bool parseTamperJson(const Json::Value &root);
+	bool parseDevicePowerJson(const Json::Value &root);
+
+private:
+	std::string m_html_schema;
+	std::string m_IPAddress;
+	std::string m_Port;
+	std::ostringstream m_BaseURLv2; // use stream as requested
+	std::string m_ApplicationKey;
+
+	std::vector<HueV2Device> m_devices;
+	std::vector<HueV2Contact> m_contacts;
+	std::vector<HueV2Tamper> m_tampers;
+	std::vector<HueV2DevicePower> m_devicePowers;
+};

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.h
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "stdafx.h"
+//#include "stdafx.h"
 #include "PhilipsHueSensors.h"
 #include <string>
 #include <vector>

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -672,6 +672,7 @@
     <ClInclude Include="..\hardware\PanasonicTV.h" />
     <ClInclude Include="..\hardware\PhilipsHue\PhilipsHue.h" />
     <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueSensors.h" />
+    <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.h" />
     <ClInclude Include="..\hardware\PiFace.h" />
     <ClInclude Include="..\hardware\Pinger.h" />
     <ClInclude Include="..\hardware\plugins\DelayedLink.h" />
@@ -980,6 +981,7 @@
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHue.cpp" />
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueHelper.cpp" />
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueSensors.cpp" />
+    <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.cpp" />
     <ClCompile Include="..\hardware\PiFace.cpp" />
     <ClCompile Include="..\hardware\Pinger.cpp" />
     <ClCompile Include="..\hardware\plugins\DelayedLink.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -1694,6 +1694,9 @@
     <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueSensors.h">
       <Filter>Devices\Philips Hue</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.h">
+      <Filter>Devices\Philips Hue</Filter>
+    </ClInclude>
     <ClInclude Include="..\hardware\EvohomeBase.h">
       <Filter>Devices\EvoHome</Filter>
     </ClInclude>
@@ -2483,6 +2486,9 @@
       <Filter>Devices\Philips Hue</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueSensors.cpp">
+      <Filter>Devices\Philips Hue</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.cpp">
       <Filter>Devices\Philips Hue</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\EvohomeBase.cpp">


### PR DESCRIPTION
New Philips Hue Secure Sensors like Door/Window Contacts use the Philips Hue v2 API.
The v2 API can be debugged and JSON output can be viewed at: https://ip-philips-hue/debug/clip.html
Url's read:
"/clip/v2/resource/device"
"/clip/v2/resource/contact"
"/clip/v2/resource/tamper"
"/clip/v2/resource/device_power"

This PR implements the v2 API just for Door/Window Contacts (contact_state/tamper_state/battery_level)  and leaves v1 devices alone. The behavior of v2 API devices is the same as v1 API devices.
In the future it is possible to expand the usage of the v2 API and/or migrate completely from v1 to v2 API via new PR(s).