### PR TITLE
Match the poll interval to the refresh interval

### DIFF
--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -239,7 +239,7 @@ bool CTado::GetAccessToken()
 	else
 	{
 		//Mainly for debug reasons
-		Log(LOG_STATUS, "AccessToken refreshed.");
+		Log(LOG_STATUS, "Access Token refreshed.");
 	}
 
 	Json::Value root;

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -52,7 +52,14 @@ CTado::CTado(const int ID, const int PollInterval)
 		m_szRefreshToken = result[0][0];
 	}
 	if ((PollInterval > 10) && (PollInterval < 3600))
+	{
 		m_iPollInterval = PollInterval;
+		//Compute new maxloops based on pollinterval, if maxloops < 1, set to 1 to be save
+		//Basically the 500 should be a define I guess, being the refresh intervall
+	    m_iTADO_TOKEN_MAXLOOPS = 500 / m_iPollInterval
+		if ( m_iTADO_TOKEN_MAXLOOPS < 1  ) 
+			m_iTADO_TOKEN_MAXLOOPS = 1
+	}
 }
 
 bool CTado::StartHardware()
@@ -648,7 +655,7 @@ void CTado::Do_Work()
 		}
 		if (
 			(m_szAccessToken.empty())
-			|| (iTokenCycleCount++ > TADO_TOKEN_MAXLOOPS)
+			|| (iTokenCycleCount++ > m_iTADO_TOKEN_MAXLOOPS)
 			)
 		{
 			GetAccessToken();

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -56,7 +56,7 @@ CTado::CTado(const int ID, const int PollInterval)
 		m_iPollInterval = PollInterval;
 		//Compute new maxloops based on pollinterval, if maxloops < 1, set to 1 to be save
 		//Basically the 500 should be a define I guess, being the refresh intervall
-		m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval);
+		m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(m_iTADO_TOKEN_REFRESHTIME / m_iPollInterval);
 		if ( m_iTADO_TOKEN_MAXLOOPS < 1  ) 
 			m_iTADO_TOKEN_MAXLOOPS = 1;
 	}
@@ -239,7 +239,7 @@ bool CTado::GetAccessToken()
 	else
 	{
 		//Mainly for debug reasons
-		Log(LOG_STATUS, "Access Token refreshed.");
+		Log(LOG_NORM, "Access Token refreshed.");
 	}
 
 	Json::Value root;

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -56,7 +56,7 @@ CTado::CTado(const int ID, const int PollInterval)
 		m_iPollInterval = PollInterval;
 		//Compute new maxloops based on pollinterval, if maxloops < 1, set to 1 to be save
 		//Basically the 500 should be a define I guess, being the refresh intervall
-	    m_iTADO_TOKEN_MAXLOOPS = 500 / m_iPollInterval
+	    m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval)
 		if ( m_iTADO_TOKEN_MAXLOOPS < 1  ) 
 			m_iTADO_TOKEN_MAXLOOPS = 1
 	}

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -56,9 +56,9 @@ CTado::CTado(const int ID, const int PollInterval)
 		m_iPollInterval = PollInterval;
 		//Compute new maxloops based on pollinterval, if maxloops < 1, set to 1 to be save
 		//Basically the 500 should be a define I guess, being the refresh intervall
-	    m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval)
+	        m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval);
 		if ( m_iTADO_TOKEN_MAXLOOPS < 1  ) 
-			m_iTADO_TOKEN_MAXLOOPS = 1
+			m_iTADO_TOKEN_MAXLOOPS = 1;
 	}
 }
 
@@ -235,6 +235,11 @@ bool CTado::GetAccessToken()
 	{
 		Log(LOG_ERROR, "Failed to get a Refresh Token");
 		return false;
+	}
+	else
+	{
+		//Mainly for debug reasons
+		Log(LOG_STATUS, "AccessToken refreshed.");
 	}
 
 	Json::Value root;
@@ -618,6 +623,7 @@ bool CTado::Do_Login_Work()
 void CTado::Do_Work()
 {
 	Log(LOG_STATUS, "Worker started. Will poll every %d seconds.", m_iPollInterval);
+	Log(LOG_STATUS,"Max loops set to: %d", m_iTADO_TOKEN_MAXLOOPS);
 	int iSecCounter = m_iPollInterval - 3;
 	int iTokenCycleCount = 0;
 
@@ -655,7 +661,7 @@ void CTado::Do_Work()
 		}
 		if (
 			(m_szAccessToken.empty())
-			|| (iTokenCycleCount++ > m_iTADO_TOKEN_MAXLOOPS)
+			|| (iTokenCycleCount++ >= m_iTADO_TOKEN_MAXLOOPS)
 			)
 		{
 			GetAccessToken();

--- a/hardware/Tado.cpp
+++ b/hardware/Tado.cpp
@@ -56,7 +56,7 @@ CTado::CTado(const int ID, const int PollInterval)
 		m_iPollInterval = PollInterval;
 		//Compute new maxloops based on pollinterval, if maxloops < 1, set to 1 to be save
 		//Basically the 500 should be a define I guess, being the refresh intervall
-	        m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval);
+		m_iTADO_TOKEN_MAXLOOPS = static_cast<int>(500 / m_iPollInterval);
 		if ( m_iTADO_TOKEN_MAXLOOPS < 1  ) 
 			m_iTADO_TOKEN_MAXLOOPS = 1;
 	}

--- a/hardware/Tado.h
+++ b/hardware/Tado.h
@@ -86,6 +86,7 @@ private:
 	bool m_bDoGetZones = false;
 
 	int m_iPollInterval = 30;
+	int m_iTADO_TOKEN_MAXLOOPS = 12;
 
 	std::vector<_tTadoHome> m_TadoHomes;
 };

--- a/hardware/Tado.h
+++ b/hardware/Tado.h
@@ -87,6 +87,7 @@ private:
 
 	int m_iPollInterval = 30;
 	int m_iTADO_TOKEN_MAXLOOPS = 12;
+	int m_iTADO_TOKEN_REFRESHTIME = 500; //Time in seconds for the refresh to take place (600 is the time Tado sets)
 
 	std::vector<_tTadoHome> m_TadoHomes;
 };


### PR DESCRIPTION
Because the poll interval can be increased now, the token refresh interval/loop does not match the refresh token cycle, resulting in errormessages and a spoiled poll cycle. This fix computes the token refresh cycle base on the poll interval to match the 600 seconds Tado token refresh cycle.