### PR TITLE
Oauth2 fixes for Alexa

### DIFF
--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -386,69 +386,60 @@ namespace http
 
 						// Maybe we should only allow this when in a safe 'local' network? So check if request comes from local networks?
 						int iUser = -1;
-						int iClient = -1;
-						if (request::get_req_header(&req, "Authorization") != nullptr)
+						int iClient = FindClient(client_id.c_str());
+
+						if (iClient != -1)
 						{
-							std::string auth_header = request::get_req_header(&req, "Authorization");
-							// Basic Auth header
-							size_t npos = auth_header.find("Basic ");
-							if (npos != std::string::npos)
+							std::string username = request::findValue(&req, "username");
+							std::string password = request::findValue(&req, "password");
+							if (!username.empty() && !password.empty())
 							{
-								std::string decoded = base64_decode(auth_header.substr(6));
-								npos = decoded.find(':');
-								if (npos != std::string::npos)
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Password grant for user (%s)", username.c_str());
+								iUser = FindUser(username.c_str());
+								if(iUser != -1)
 								{
-									std::string user = decoded.substr(0, npos);
-									std::string passwd = decoded.substr(npos + 1);
-									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found a Basic Auth Header for User (%s)", user.c_str());
-
-									iUser = FindUser(user.c_str());
-									if(iUser != -1)
+									if (GenerateMD5Hash(password).compare(m_users[iUser].Password) == 0)
 									{
-										if (GenerateMD5Hash(passwd).compare(m_users[iUser].Password) == 0)
+										Json::Value jwtpayload;
+										jwtpayload["preferred_username"] = m_users[iUser].Username;
+										jwtpayload["name"] = m_users[iUser].Username;
+										jwtpayload["roles"][0] = m_users[iUser].userrights;
+										std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+										if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iClient].Password, username, exptime, jwtpayload, issuer))
 										{
-											iClient = FindClient(client_id.c_str());
-											if (iClient != -1)
-											{
-												Json::Value jwtpayload;
-												jwtpayload["preferred_username"] = m_users[iUser].Username;
-												jwtpayload["name"] = m_users[iUser].Username;
-												jwtpayload["roles"][0] = m_users[iUser].userrights;
-
-												std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-												if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iClient].Password, user, exptime, jwtpayload, issuer))
-												{
-													root["access_token"] = jwttoken;
-													root["token_type"] = "Bearer";
-													root["expires_in"] = exptime;
-													rep.status = reply::ok;
-												}
-												else
-												{
-													root["error"] = "server_error";
-													_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate Access Token!");
-													iUser = -1;
-												}
-											}
-											else
-											{
-												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid client_id (%s)(%d) for user (%s) for Password grant flow!", client_id.c_str(), iClient, user.c_str());
-												iUser = -1;
-											}
+											root["access_token"] = jwttoken;
+											root["token_type"] = "Bearer";
+											root["expires_in"] = exptime;
+											rep.status = reply::ok;
 										}
 										else
 										{
-											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid credentials for user (%s) for Password grant flow!", user.c_str());
+											root["error"] = "server_error";
+											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate Access Token!");
 											iUser = -1;
 										}
 									}
 									else
 									{
-										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Could not find user (%s) for Password grant flow!", user.c_str());
+										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid credentials for user (%s) for Password grant flow!", username.c_str());
+										iUser = -1;
 									}
 								}
+								else
+								{
+									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Could not find user (%s) for Password grant flow!", username.c_str());
+								}
+							}
+							else
+							{
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Missing username or password in request body for Password grant flow!");
 							}
 						}
+						else
+						{
+							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid client_id (%s) for Password grant flow!", client_id.c_str());
+						}
+
 						if (iUser == -1)
 						{
 							root["error"] = "invalid_client";

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -366,15 +366,16 @@ namespace http
 											jwtpayload["roles"][0] = m_users[iUser].userrights;
 
 											std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-											if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, client_secret, m_users[iUser].Username, exptime, jwtpayload, issuer))
+											if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iUser].Username, exptime, jwtpayload, issuer))
 											{
 												std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
 												root["access_token"] = jwttoken;
 												root["token_type"] = "Bearer";
 												root["expires_in"] = exptime;
-												root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
+												uint32_t client_refreshexptime = (m_users[iClient].RefreshExpire > 0) ? m_users[iClient].RefreshExpire : refreshexptime;
+												root["refresh_token"] = GenerateOAuth2RefreshToken(username, client_refreshexptime);
 
-												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated a Refresh Token.");
+												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated a Refresh Token (lifetime: %u seconds).", client_refreshexptime);
 
 												m_sql.safe_query("UPDATE Applications SET LastSeen=datetime('now') WHERE (Applicationname == '%s')", m_users[iClient].Username.c_str());
 												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated an Access Token.");
@@ -435,8 +436,9 @@ namespace http
 										jwtpayload["preferred_username"] = m_users[iUser].Username;
 										jwtpayload["name"] = m_users[iUser].Username;
 										jwtpayload["roles"][0] = m_users[iUser].userrights;
+
 										std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-										if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iClient].Password, username, exptime, jwtpayload, issuer))
+										if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, username, exptime, jwtpayload, issuer))
 										{
 											root["access_token"] = jwttoken;
 											root["token_type"] = "Bearer";
@@ -498,13 +500,15 @@ namespace http
 										jwtpayload["roles"][0] = m_users[iUser].userrights;
 
 										std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-										if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iClient].Password, m_users[iUser].Username, exptime, jwtpayload, issuer))
+										if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iUser].Username, exptime, jwtpayload, issuer))
 										{
 											std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
 											root["access_token"] = jwttoken;
 											root["token_type"] = "Bearer";
 											root["expires_in"] = exptime;
-											root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
+											uint32_t client_refreshexptime = (m_users[iClient].RefreshExpire > 0) ? m_users[iClient].RefreshExpire : refreshexptime;
+											root["refresh_token"] = GenerateOAuth2RefreshToken(username, client_refreshexptime);
+											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated a Refresh Token (lifetime: %u seconds).", client_refreshexptime);
 											rep.status = reply::ok;
 										}
 										else

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -27,6 +27,22 @@ namespace http
 	namespace server
 	{
 
+		std::string GetIssuerFromRequest(const request &req, const std::string &configured_realm)
+		{
+			// Only use Host header if the configured realm uses the default 'domoticz.local'
+			if (configured_realm.find("domoticz.local") != std::string::npos)
+			{
+				const char *host_header = request::get_req_header(&req, "Host");
+				if (host_header != nullptr)
+				{
+					// Infer scheme from configured realm or default to http
+					std::string scheme = (configured_realm.find("https://") == 0) ? "https://" : "http://";
+					return scheme + std::string(host_header) + "/";
+				}
+			}
+			return configured_realm;
+		}
+
 		void CWebServer::GetOauth2AuthCode(WebEmSession &session, const request &req, reply &rep)
 		{
 			bool bAuthenticated = false;
@@ -305,7 +321,8 @@ namespace http
 													jwtpayload["name"] = m_users[iUser].Username;
 													jwtpayload["roles"][0] = m_users[iUser].userrights;
 
-													if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, client_secret, m_users[iUser].Username, exptime, jwtpayload))
+													std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+													if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, client_secret, m_users[iUser].Username, exptime, jwtpayload, issuer))
 													{
 														std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
 														root["access_token"] = jwttoken;
@@ -398,7 +415,8 @@ namespace http
 												jwtpayload["name"] = m_users[iUser].Username;
 												jwtpayload["roles"][0] = m_users[iUser].userrights;
 
-												if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iClient].Password, user, exptime, jwtpayload))
+												std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+												if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, m_users[iClient].Password, user, exptime, jwtpayload, issuer))
 												{
 													root["access_token"] = jwttoken;
 													root["token_type"] = "Bearer";
@@ -460,7 +478,8 @@ namespace http
 									jwtpayload["name"] = m_users[iUser].Username;
 									jwtpayload["roles"][0] = m_users[iUser].userrights;
 
-									if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iClient].Password, m_users[iUser].Username, exptime, jwtpayload))
+									std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+									if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iClient].Password, m_users[iUser].Username, exptime, jwtpayload, issuer))
 									{
 										std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
 										root["access_token"] = jwttoken;
@@ -520,9 +539,10 @@ namespace http
 			reply::add_header_content_type(&rep, "application/json;charset=UTF-8");
 			rep.status = reply::bad_request;
 
-			std::string base_url = m_pWebEm->m_DigistRealm.substr(0, m_pWebEm->m_DigistRealm.size()-1);
+			std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+			std::string base_url = issuer.substr(0, issuer.size()-1);
 
-			root["issuer"] = m_pWebEm->m_DigistRealm;
+			root["issuer"] = issuer;
 			root["authorization_endpoint"] = base_url + m_iamsettings.auth_url;
 			root["token_endpoint"] = base_url + m_iamsettings.token_url;
 			jaRTS.append("code");

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -233,6 +233,35 @@ namespace http
 			std::string code_verifier = request::findValue(&req, "code_verifier");
 			std::string redirect_uri = CURLEncode::URLDecode(request::findValue(&req, "redirect_uri"));
 
+			// Check for client credentials in Basic Auth header (client_secret_basic method)
+			if (request::get_req_header(&req, "Authorization") != nullptr)
+			{
+				std::string auth_header = request::get_req_header(&req, "Authorization");
+				size_t npos = auth_header.find("Basic ");
+				if (npos != std::string::npos)
+				{
+					std::string encoded = auth_header.substr(6);
+					std::string decoded = base64_decode(encoded);
+					npos = decoded.find(':');
+					if (npos != std::string::npos)
+					{
+						std::string basic_client_id = decoded.substr(0, npos);
+						std::string basic_client_secret = decoded.substr(npos + 1);
+						// Use Basic auth credentials if client_id matches or is empty
+						if (client_id.empty() || client_id == basic_client_id)
+						{
+							client_id = basic_client_id;
+							client_secret = basic_client_secret;
+							_log.Debug(DEBUG_AUTH, "[Basic] Found Basic Auth credentials for client '%s'", client_id.c_str());
+						}
+						else
+						{
+							_log.Debug(DEBUG_AUTH, "[Basic] client_id mismatch: body='%s' vs Basic='%s'", client_id.c_str(), basic_client_id.c_str());
+						}
+					}
+				}
+			}
+
 			if (!state.empty())
 			{
 				root["state"] = state;

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -267,158 +267,160 @@ namespace http
 				root["state"] = state;
 			}
 
+			// Validate client credentials once for all grant types
+			int iClient = -1;
+			if (!client_id.empty())
+			{
+				iClient = FindClient(client_id.c_str());
+				if (iClient != -1)
+				{
+					// Public clients (ActiveTabs == 1) don't require client_secret
+					bool bPublicClient = (m_users[iClient].ActiveTabs == 1);
+					if (!bPublicClient || !client_secret.empty())
+					{
+						std::string hashedsecret = client_secret;
+						if (!(client_secret.length() == 32 && isHexRepresentation(client_secret)))
+						{
+							hashedsecret = GenerateMD5Hash(client_secret);
+						}
+						if (hashedsecret != m_users[iClient].Password)
+						{
+							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Client secret validation failed for '%s'", client_id.c_str());
+							iClient = -1;
+						}
+					}
+				}
+				else
+				{
+					_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: No match for client ID '%s'", client_id.c_str());
+				}
+			}
+			else
+			{
+				_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: No client ID provided");
+			}
+
 			if (req.method == "POST")
 			{
-				bool bValidGrantType = false;
-				if(!grant_type.empty())
+				if (iClient != -1)
 				{
-					if (grant_type.compare("authorization_code") == 0 )
+					bool bValidGrantType = false;
+					if (!grant_type.empty())
 					{
-						bValidGrantType = true;
-						int iClient = -1;
-						int iUser = -1;
-						if (!client_id.empty())
+						if (grant_type.compare("authorization_code") == 0 )
 						{
-							iClient = FindClient(client_id.c_str());
-							if (iClient != -1)
+							bValidGrantType = true;
+							int iUser = -1;
+
+							// Let's find the user for this client with the right auth_code, if any
+							iUser = 0;
+							for (const auto &ac : m_accesscodes)
 							{
-								// Let's find the user for this client with the right auth_code, if any
-								iUser = 0;
-								for (const auto &ac : m_accesscodes)
+								if (ac.AuthCode.compare(auth_code.c_str()) == 0)
 								{
-									if (ac.AuthCode.compare(auth_code.c_str()) == 0)
-									{
-										if (ac.clientID == iClient || (ac.clientID == -1 && iUser == iClient))
-											break;
-									}
-									iUser++;
+									if (ac.clientID == iClient || (ac.clientID == -1 && iUser == iClient))
+										break;
 								}
+								iUser++;
+							}
 
-								if ((iUser < static_cast<int>(m_accesscodes.size())) && (m_accesscodes[iUser].AuthCode.compare(auth_code.c_str()) == 0))
+							if ((iUser < static_cast<int>(m_accesscodes.size())) && (m_accesscodes[iUser].AuthCode.compare(auth_code.c_str()) == 0))
+							{
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found Authorization Code (%s) for user (%d)!", m_accesscodes[iUser].AuthCode.c_str(), iUser);
+
+								std::string acRedirectUri = m_accesscodes[iUser].RedirectUri;
+								std::string acScope = m_accesscodes[iUser].Scope;
+								std::string CodeChallenge = m_accesscodes[iUser].CodeChallenge;
+								uint64_t AuthTime = m_accesscodes[iUser].AuthTime;
+								uint64_t CodeTime = m_accesscodes[iUser].ExpTime;
+								uint64_t CurTime = (uint64_t) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+
+								m_accesscodes[iUser].AuthCode = "";	// Once used, make sure it cannot be used again
+								m_accesscodes[iUser].RedirectUri = "";
+								m_accesscodes[iUser].Scope = "";
+								m_accesscodes[iUser].clientID = -1;
+								m_accesscodes[iUser].AuthTime = 0;
+								m_accesscodes[iUser].ExpTime = 0;
+								m_accesscodes[iUser].CodeChallenge = "";
+
+								if(acRedirectUri.compare(redirect_uri.c_str()) == 0)
 								{
-									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found Authorization Code (%s) for user (%d)!", m_accesscodes[iUser].AuthCode.c_str(), iUser);
-
-									std::string acRedirectUri = m_accesscodes[iUser].RedirectUri;
-									std::string acScope = m_accesscodes[iUser].Scope;
-									std::string CodeChallenge = m_accesscodes[iUser].CodeChallenge;
-									uint64_t AuthTime = m_accesscodes[iUser].AuthTime;
-									uint64_t CodeTime = m_accesscodes[iUser].ExpTime;
-									uint64_t CurTime = (uint64_t) std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
-
-									m_accesscodes[iUser].AuthCode = "";	// Once used, make sure it cannot be used again
-									m_accesscodes[iUser].RedirectUri = "";
-									m_accesscodes[iUser].Scope = "";
-									m_accesscodes[iUser].clientID = -1;
-									m_accesscodes[iUser].AuthTime = 0;
-									m_accesscodes[iUser].ExpTime = 0;
-									m_accesscodes[iUser].CodeChallenge = "";
-
-									// For so-called (registered) 'public' clients, it is not mandatory to send the client_secret as it is never a real secret with public clients
-									// So in those cases, we use the registered secret
-									if(m_users[iClient].ActiveTabs == 1 && client_secret.empty())
+									if (CodeTime > CurTime)
 									{
-										client_secret = m_users[iClient].Password;
-									}
-
-									std::string hashedsecret = client_secret;
-									if (!(client_secret.length() == 32 && isHexRepresentation(client_secret)))	// 2 * MD5_DIGEST_LENGTH
-									{
-										hashedsecret = GenerateMD5Hash(client_secret);
-									}
-
-									if(hashedsecret == m_users[iClient].Password)		// The client_secrets should match (for public clients we just took the secret itself so will always match)
-									{
-										if(acRedirectUri.compare(redirect_uri.c_str()) == 0)
+										bool bPKCE = false;
+										if(!(code_verifier.empty() || CodeChallenge.empty()))
 										{
-											if (CodeTime > CurTime)
+											// We have a code_challenge from the Auth request and now also a code_verifier.. let's see if they match
+											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Verifiying PKCE Code Challenge (%s) using provided verifyer!", CodeChallenge.c_str());
+											if (CodeChallenge.compare(base64url_encode(sha256raw(code_verifier))) == 0)
 											{
-												bool bPKCE = false;
-												if(!(code_verifier.empty() || CodeChallenge.empty()))
-												{
-													// We have a code_challenge from the Auth request and now also a code_verifier.. let's see if they match
-													_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Verifiying PKCE Code Challenge (%s) using provided verifyer!", CodeChallenge.c_str());
-													if (CodeChallenge.compare(base64url_encode(sha256raw(code_verifier))) == 0)
-													{
-														bPKCE = true;
-													}
-												}
-												if(code_verifier.empty() || bPKCE)
-												{
-													Json::Value jwtpayload;
-													jwtpayload["auth_time"] = AuthTime;
-													jwtpayload["preferred_username"] = m_users[iUser].Username;
-													jwtpayload["name"] = m_users[iUser].Username;
-													jwtpayload["roles"][0] = m_users[iUser].userrights;
+												bPKCE = true;
+											}
+										}
+										if(code_verifier.empty() || bPKCE)
+										{
+											Json::Value jwtpayload;
+											jwtpayload["auth_time"] = AuthTime;
+											jwtpayload["preferred_username"] = m_users[iUser].Username;
+											jwtpayload["name"] = m_users[iUser].Username;
+											jwtpayload["roles"][0] = m_users[iUser].userrights;
 
-													std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-													if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, client_secret, m_users[iUser].Username, exptime, jwtpayload, issuer))
-													{
-														std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
-														root["access_token"] = jwttoken;
-														root["token_type"] = "Bearer";
-														root["expires_in"] = exptime;
-														root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
+											std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+											if (m_pWebEm->GenerateJwtToken(jwttoken, client_id, client_secret, m_users[iUser].Username, exptime, jwtpayload, issuer))
+											{
+												std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
+												root["access_token"] = jwttoken;
+												root["token_type"] = "Bearer";
+												root["expires_in"] = exptime;
+												root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
 
-														_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated a Refresh Token.");
+												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated a Refresh Token.");
 
-														m_sql.safe_query("UPDATE Applications SET LastSeen=datetime('now') WHERE (Applicationname == '%s')", m_users[iClient].Username.c_str());
-														_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated an Access Token.");
-														rep.status = reply::ok;
-													}
-													else
-													{
-														root["error"] = "server_error";
-														_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate Access Token!");
-														iUser = -1;
-													}
-												}
-												else
-												{
-													_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: PKCE Code verification failed!");
-													iUser = -1;
-												}
+												m_sql.safe_query("UPDATE Applications SET LastSeen=datetime('now') WHERE (Applicationname == '%s')", m_users[iClient].Username.c_str());
+												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Succesfully generated an Access Token.");
+												rep.status = reply::ok;
 											}
 											else
 											{
-												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Authorization code has expired (%" PRIu64 ") (%" PRIu64 ")!", CodeTime, CurTime);
+												root["error"] = "server_error";
+												_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate Access Token!");
 												iUser = -1;
 											}
 										}
 										else
 										{
-											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Redirect URI does not match (%s) (%s)!", acRedirectUri.c_str(), redirect_uri.c_str());
+											root["error"] = "access_denied";
+											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: PKCE Code verification failed!");
 											iUser = -1;
 										}
 									}
 									else
 									{
-										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Client Secret does not match for client (%s)!", m_users[iClient].Username.c_str());
+										root["error"] = "access_denied";
+										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Authorization code has expired (%" PRIu64 ") (%" PRIu64 ")!", CodeTime, CurTime);
 										iUser = -1;
 									}
 								}
 								else
 								{
-									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Cannot find valid access code (%s) for user!", auth_code.c_str());
+									root["error"] = "invalid_request";
+									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Redirect URI does not match (%s) (%s)!", acRedirectUri.c_str(), redirect_uri.c_str());
 									iUser = -1;
 								}
 							}
-						}
-						if(iUser == -1)
+							else
+							{
+								root["error"] = "access_denied";
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Cannot find valid access code (%s) for user!", auth_code.c_str());
+								iUser = -1;
+							}
+						} // end 'authorization_code' grant_type
+						if (grant_type.compare("password") == 0 )
 						{
-							root["error"] = "unauthorized_client";
-							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Unauthorized/Unknown client_id (%s)!", client_id.c_str());
-						}
-					} // end 'authorization_code' grant_type
-					if (grant_type.compare("password") == 0 )
-					{
-						bValidGrantType = true;
+							bValidGrantType = true;
 
-						// Maybe we should only allow this when in a safe 'local' network? So check if request comes from local networks?
-						int iUser = -1;
-						int iClient = FindClient(client_id.c_str());
-
-						if (iClient != -1)
-						{
+							// Maybe we should only allow this when in a safe 'local' network? So check if request comes from local networks?
+							int iUser = -1;
 							std::string username = request::findValue(&req, "username");
 							std::string password = request::findValue(&req, "password");
 							if (!username.empty() && !password.empty())
@@ -450,97 +452,99 @@ namespace http
 									}
 									else
 									{
+										root["error"] = "access_denied";
 										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid credentials for user (%s) for Password grant flow!", username.c_str());
 										iUser = -1;
 									}
 								}
 								else
 								{
+									root["error"] = "access_denied";
 									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Could not find user (%s) for Password grant flow!", username.c_str());
 								}
 							}
 							else
 							{
+								root["error"] = "access_denied";
 								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Missing username or password in request body for Password grant flow!");
 							}
-						}
-						else
-						{
-							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid client_id (%s) for Password grant flow!", client_id.c_str());
-						}
 
-						if (iUser == -1)
-						{
-							root["error"] = "invalid_client";
-							rep.status = reply::unauthorized;
-							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Password grant flow failed!");
-						}
-					} // end 'password' grant_type
-					if (grant_type.compare("refresh_token") == 0 )
-					{
-						bValidGrantType = true;
-						std::string refresh_token = request::findValue(&req, "refresh_token");
-						if (!refresh_token.empty())
-						{
-							std::string usernamefromtoken;
-							if (ValidateOAuth2RefreshToken(refresh_token, usernamefromtoken))
+							if (iUser == -1)
 							{
-								std::vector<std::string> strarray;
-								StringSplit(usernamefromtoken,";", strarray);
-								if(strarray.size() == 2)
+								rep.status = reply::unauthorized;
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Password grant flow failed!");
+							}
+						} // end 'password' grant_type
+						if (grant_type.compare("refresh_token") == 0 )
+						{
+							bValidGrantType = true;
+							std::string refresh_token = request::findValue(&req, "refresh_token");
+							if (!refresh_token.empty())
+							{
+								std::string usernamefromtoken;
+								if (ValidateOAuth2RefreshToken(refresh_token, usernamefromtoken))
 								{
-									int iClient = std::atoi(strarray[0].c_str());
-									int iUser = std::atoi(strarray[1].c_str());
-									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found valid Refresh token (%s) (c:%d,u:%d)!", refresh_token.c_str(), iClient, iUser);
-
-									Json::Value jwtpayload;
-									jwtpayload["preferred_username"] = m_users[iUser].Username;
-									jwtpayload["name"] = m_users[iUser].Username;
-									jwtpayload["roles"][0] = m_users[iUser].userrights;
-
-									std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
-									if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iClient].Password, m_users[iUser].Username, exptime, jwtpayload, issuer))
+									std::vector<std::string> strarray;
+									StringSplit(usernamefromtoken,";", strarray);
+									if(strarray.size() == 2)
 									{
-										std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
-										root["access_token"] = jwttoken;
-										root["token_type"] = "Bearer";
-										root["expires_in"] = exptime;
-										root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
-										rep.status = reply::ok;
+										int iClient = std::atoi(strarray[0].c_str());
+										int iUser = std::atoi(strarray[1].c_str());
+										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Found valid Refresh token (%s) (c:%d,u:%d)!", refresh_token.c_str(), iClient, iUser);
+
+										Json::Value jwtpayload;
+										jwtpayload["preferred_username"] = m_users[iUser].Username;
+										jwtpayload["name"] = m_users[iUser].Username;
+										jwtpayload["roles"][0] = m_users[iUser].userrights;
+
+										std::string issuer = GetIssuerFromRequest(req, m_pWebEm->m_DigistRealm);
+										if (m_pWebEm->GenerateJwtToken(jwttoken, m_users[iClient].Username, m_users[iClient].Password, m_users[iUser].Username, exptime, jwtpayload, issuer))
+										{
+											std::string username = std::to_string(iClient) + ";" + std::to_string(iUser);
+											root["access_token"] = jwttoken;
+											root["token_type"] = "Bearer";
+											root["expires_in"] = exptime;
+											root["refresh_token"] = GenerateOAuth2RefreshToken(username, refreshexptime);
+											rep.status = reply::ok;
+										}
+										else
+										{
+											root["error"] = "server_error";
+											_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate new Access Token from Resfreshtoken!");
+										}
 									}
 									else
 									{
-										root["error"] = "server_error";
-										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Something went wrong! Unable to generate new Access Token from Resfreshtoken!");
+										root["error"] = "access_denied";
+										rep.status = reply::unauthorized;
+										_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Refresh token (%s) does not contain valid reference to client/user (%s)!", refresh_token.c_str(), usernamefromtoken.c_str());
 									}
 								}
 								else
 								{
 									root["error"] = "access_denied";
 									rep.status = reply::unauthorized;
-									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Refresh token (%s) does not contain valid reference to client/user (%s)!", refresh_token.c_str(), usernamefromtoken.c_str());
+									_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Refresh token (%s) is not valid or expired!", refresh_token.c_str());
 								}
+								InvalidateOAuth2RefreshToken(refresh_token);
 							}
 							else
 							{
-								root["error"] = "access_denied";
-								rep.status = reply::unauthorized;
-								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Refresh token (%s) is not valid or expired!", refresh_token.c_str());
+								root["error"] = "invalid_request";
+								rep.status = reply::bad_request;
+								_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Unable to process refresh token request!");
 							}
-							InvalidateOAuth2RefreshToken(refresh_token);
-						}
-						else
-						{
-							root["error"] = "invalid_request";
-							rep.status = reply::bad_request;
-							_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Unable to process refresh token request!");
-						}
-					} // end 'refresh_token' grant_type
+						} // end 'refresh_token' grant_type
+					}
+					if(!bValidGrantType)
+					{
+						root["error"] = "unsupported_grant_type";
+						_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid/unsupported grant_type (%s)!", grant_type.c_str());
+					}
 				}
-				if(!bValidGrantType)
+				else
 				{
-					root["error"] = "unsupported_grant_type";
-					_log.Debug(DEBUG_AUTH, "OAuth2 Access Token: Invalid/unsupported grant_type (%s)!", grant_type.c_str());
+					root["error"] = "unauthorized_client";
 				}
 			}
 			else

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -67,7 +67,7 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void ReloadCustomSwitchIcons();
 
 	void LoadUsers();
-	void AddUser(unsigned long ID, const std::string &username, const std::string &password, const std::string& mfatoken, int userrights, int activetabs, const std::string &pemfile = "");
+	void AddUser(unsigned long ID, const std::string &username, const std::string &password, const std::string& mfatoken, int userrights, int activetabs, const std::string &pemfile = "", uint32_t refreshexpire = 0, const std::string &signingsecret = "", time_t accept_legacy_until = 0);
 	void ClearUserPasswords();
 	bool FindAdminUser();
 	int CountAdminUsers();

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1865,7 +1865,13 @@ namespace http {
 				}
 				else if (_ah.method == "BASIC")
 				{
-					if (req.uri.find("/json.htm?") != std::string::npos)	// Exception for the main API endpoint so scripts can execute them with 'just' Basic AUTH
+					// OAuth2 endpoints handle their own client authentication, don't validate as user here
+					if (req.uri.find("/oauth2/") != std::string::npos)
+					{
+						_log.Debug(DEBUG_AUTH, "[Auth Check] Basic Authorization header found for OAuth2 endpoint, will be validated by OAuth2 handler");
+						// Don't set session, let OAuth2 code handle it
+					}
+					else if (req.uri.find("/json.htm?") != std::string::npos)	// Exception for the main API endpoint so scripts can execute them with 'just' Basic AUTH
 					{
 						if (AllowBasicAuth())	// Check if Basic Auth is allowed either over HTTPS or when explicitly enabled
 						{

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1263,7 +1263,19 @@ namespace http {
 						// Step 3: Using the (hashed :( ) password of the ClientID as our ClientSecret to verify the JWT signature
 						std::string JWTalgo = decodedJWT.get_algorithm();
 						std::error_code ec;
-						auto JWTverifyer = jwt::verify().with_issuer(myWebem->m_DigistRealm).with_audience(clientid);
+						// Build issuer for verification - use Host header if realm is default
+						std::string expected_issuer = myWebem->m_DigistRealm;
+						if (expected_issuer.find("domoticz.local") != std::string::npos)
+						{
+							const char *host_header = request::get_req_header(&req, "Host");
+							if (host_header != nullptr)
+							{
+								std::string scheme = (expected_issuer.find("https://") == 0) ? "https://" : "http://";
+								expected_issuer = scheme + std::string(host_header) + "/";
+							}
+						}
+
+						auto JWTverifyer = jwt::verify().with_issuer(expected_issuer).with_audience(clientid);
 						if (JWTalgo.compare("HS256") == 0)
 						{
 							JWTverifyer.allow_algorithm(jwt::algorithm::hs256{ clientsecret });
@@ -1352,7 +1364,7 @@ namespace http {
 			return 0;
 		}
 
-		bool cWebem::GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload)
+		bool cWebem::GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload, const std::string &issuer)
 		{
 			bool bOk = false;
 			// Did we get a 'plain' clientsecret or an already MD5Hashed one?
@@ -1371,10 +1383,11 @@ namespace http {
 						if ((my.Password == hashedsecret) || (my.ActiveTabs == 1))	// We 'abuse' the Users ActiveTabs as the Application Public 'boolean'
 						{
 							_log.Debug(DEBUG_AUTH, "[JWT] Generate Token for %s using clientid %s (privKey %d)!", user.c_str(), clientid.c_str(), my.ActiveTabs);
+							std::string jwt_issuer = issuer.empty() ? m_DigistRealm : issuer;
 							auto JWT = jwt::create()
 								.set_type("JWT")
 								.set_key_id(std::to_string(my.ID))
-								.set_issuer(m_DigistRealm)
+								.set_issuer(jwt_issuer)
 								.set_issued_at(std::chrono::system_clock::now())
 								.set_not_before(std::chrono::system_clock::now())
 								.set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{exptime})

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -630,7 +630,7 @@ namespace http {
 			return false;
 		}
 
-		void cWebem::AddUserPassword(const unsigned long ID, const std::string &username, const std::string &password, const std::string &mfatoken, const _eUserRights userrights, const int activetabs, const std::string &privkey, const std::string &pubkey)
+		void cWebem::AddUserPassword(const unsigned long ID, const std::string &username, const std::string &password, const std::string &mfatoken, const _eUserRights userrights, const int activetabs, const std::string &privkey, const std::string &pubkey, uint32_t refreshexpire, const std::string &signingsecret, time_t accept_legacy_until)
 		{
 			_tWebUserPassword wtmp;
 			wtmp.ID = ID;
@@ -641,6 +641,9 @@ namespace http {
 			wtmp.PubKey = pubkey;
 			wtmp.userrights = userrights;
 			wtmp.ActiveTabs = activetabs;
+			wtmp.SigningSecret = signingsecret;
+			wtmp.RefreshExpire = refreshexpire;
+			wtmp.AcceptLegacyTokensUntil = accept_legacy_until;
 			wtmp.TotSensors = 0;
 			m_userpasswords.push_back(wtmp);
 		}
@@ -1236,7 +1239,9 @@ namespace http {
 						std::string JWTsubject = decodedJWT.get_subject();
 						_log.Debug(DEBUG_AUTH,"[JWT] Token audience : %s", clientid.c_str());
 
-						std::string clientsecret;
+						std::string signingsecret;
+						std::string client_password;
+						time_t accept_legacy_until = 0;
 						std::string clientpubkey;
 						std::string client_key_id;
 						bool clientispublic = false;
@@ -1247,15 +1252,17 @@ namespace http {
 							{
 								if (my.userrights == URIGHTS_CLIENTID || clientid.compare(JWTsubject) == 0)
 								{
-									clientsecret = my.Password;
+									signingsecret = my.SigningSecret;
 									clientpubkey = my.PubKey;
 									client_key_id = std::to_string(my.ID);
+									client_password = my.Password;
+									accept_legacy_until = my.AcceptLegacyTokensUntil;
 									clientispublic = my.ActiveTabs;
 									break;
 								}
 							}
 						}
-						if (client_key_id.empty() || (clientsecret.empty() && clientpubkey.empty()))
+						if (client_key_id.empty() || (signingsecret.empty() && clientpubkey.empty()))
 						{
 							_log.Debug(DEBUG_AUTH, "[JWT] Unable to verify token as no ClientID for the audience has been found!");
 							return 0;
@@ -1278,15 +1285,15 @@ namespace http {
 						auto JWTverifyer = jwt::verify().with_issuer(expected_issuer).with_audience(clientid);
 						if (JWTalgo.compare("HS256") == 0)
 						{
-							JWTverifyer.allow_algorithm(jwt::algorithm::hs256{ clientsecret });
+							JWTverifyer.allow_algorithm(jwt::algorithm::hs256{ signingsecret });
 						}
 						else if (JWTalgo.compare("HS384") == 0)
 						{
-							JWTverifyer.allow_algorithm(jwt::algorithm::hs384{ clientsecret });
+							JWTverifyer.allow_algorithm(jwt::algorithm::hs384{ signingsecret });
 						}
 						else if (JWTalgo.compare("HS512") == 0)
 						{
-							JWTverifyer.allow_algorithm(jwt::algorithm::hs512{ clientsecret });
+							JWTverifyer.allow_algorithm(jwt::algorithm::hs512{ signingsecret });
 						}
 						else if (JWTalgo.compare("RS256") == 0)
 						{
@@ -1305,6 +1312,39 @@ namespace http {
 						JWTverifyer.not_before_leeway(60);
 						JWTverifyer.issued_at_leeway(60);
 						JWTverifyer.verify(decodedJWT, ec);
+						if(ec)
+						{
+							// Try legacy verification with client_password if within acceptance window
+							time_t now = mytime(nullptr);
+							if (accept_legacy_until > 0 && now < accept_legacy_until && !client_password.empty())
+							{
+								_log.Debug(DEBUG_AUTH, "[JWT] Trying legacy verification with client_password");
+								std::error_code legacy_ec;
+								auto LegacyVerifyer = jwt::verify().with_issuer(expected_issuer).with_audience(clientid);
+								if (JWTalgo.compare("HS256") == 0)
+								{
+									LegacyVerifyer.allow_algorithm(jwt::algorithm::hs256{ client_password });
+								}
+								else if (JWTalgo.compare("HS384") == 0)
+								{
+									LegacyVerifyer.allow_algorithm(jwt::algorithm::hs384{ client_password });
+								}
+								else if (JWTalgo.compare("HS512") == 0)
+								{
+									LegacyVerifyer.allow_algorithm(jwt::algorithm::hs512{ client_password });
+								}
+								LegacyVerifyer.expires_at_leeway(60);
+								LegacyVerifyer.not_before_leeway(60);
+								LegacyVerifyer.issued_at_leeway(60);
+								LegacyVerifyer.verify(decodedJWT, legacy_ec);
+								if (!legacy_ec)
+								{
+									_log.Debug(DEBUG_AUTH, "[JWT] Legacy token accepted (expires %ld)", (long)accept_legacy_until);
+									ec.clear();
+								}
+							}
+						}
+
 						if(ec)
 						{
 							_log.Debug(DEBUG_AUTH, "[JWT] Token not valid! (%s)", ec.message().c_str());
@@ -1364,15 +1404,9 @@ namespace http {
 			return 0;
 		}
 
-		bool cWebem::GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload, const std::string &issuer)
+		bool cWebem::GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload, const std::string &issuer)
 		{
 			bool bOk = false;
-			// Did we get a 'plain' clientsecret or an already MD5Hashed one?
-			std::string hashedsecret = clientsecret;
-			if (!(clientsecret.length() == 32 && isHexRepresentation(clientsecret)))	// 2 * MD5_DIGEST_LENGTH
-			{
-				hashedsecret = GenerateMD5Hash(clientsecret);
-			}
 			// Check if the clientID exists and we have a valid clientSecret for it (used when generating Tokens for registered clients)
 			for (const auto &my : myRequestHandler.Get_myWebem()->m_userpasswords)
 			{
@@ -1380,56 +1414,54 @@ namespace http {
 				{
 					if (my.userrights == URIGHTS_CLIENTID)	// The 'user' should have CLIENTID rights to be a real Client
 					{
-						if ((my.Password == hashedsecret) || (my.ActiveTabs == 1))	// We 'abuse' the Users ActiveTabs as the Application Public 'boolean'
+						// Client already validated by caller
+						_log.Debug(DEBUG_AUTH, "[JWT] Generate Token for %s using clientid %s (privKey %d)!", user.c_str(), clientid.c_str(), my.ActiveTabs);
+						std::string jwt_issuer = issuer.empty() ? m_DigistRealm : issuer;
+						auto JWT = jwt::create()
+							.set_type("JWT")
+							.set_key_id(std::to_string(my.ID))
+							.set_issuer(jwt_issuer)
+							.set_issued_at(std::chrono::system_clock::now())
+							.set_not_before(std::chrono::system_clock::now())
+							.set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{exptime})
+							.set_audience(clientid)
+							.set_subject(user)
+							.set_id(GenerateUUID());
+						if (!jwtpayload.empty())
 						{
-							_log.Debug(DEBUG_AUTH, "[JWT] Generate Token for %s using clientid %s (privKey %d)!", user.c_str(), clientid.c_str(), my.ActiveTabs);
-							std::string jwt_issuer = issuer.empty() ? m_DigistRealm : issuer;
-							auto JWT = jwt::create()
-								.set_type("JWT")
-								.set_key_id(std::to_string(my.ID))
-								.set_issuer(jwt_issuer)
-								.set_issued_at(std::chrono::system_clock::now())
-								.set_not_before(std::chrono::system_clock::now())
-								.set_expires_at(std::chrono::system_clock::now() + std::chrono::seconds{exptime})
-								.set_audience(clientid)
-								.set_subject(user)
-								.set_id(GenerateUUID());
-							if (!jwtpayload.empty())
+							for (auto const& id : jwtpayload.getMemberNames())
 							{
-								for (auto const& id : jwtpayload.getMemberNames())
+								if(!(jwtpayload[id].isNull()))
 								{
-									if(!(jwtpayload[id].isNull()))
+									if(jwtpayload[id].isNumeric())
 									{
-										if(jwtpayload[id].isNumeric())
-										{
-											double dVal(jwtpayload[id].asDouble());
-											JWT.set_payload_claim(id, picojson::value(dVal));
-										}
-										else if(jwtpayload[id].isString())
-										{
-											std::string sVal(jwtpayload[id].asString());
-											JWT.set_payload_claim(id, picojson::value(sVal));
-										}
-										else if(jwtpayload[id].isArray())
-										{
-											std::vector<std::string> aStrList;
-											aStrList.reserve(jwtpayload[id].size());
-											std::transform(jwtpayload[id].begin(), jwtpayload[id].end(), std::back_inserter(aStrList),[](const auto& s) { return s.asString(); });
-											JWT.set_payload_claim(id, jwt::claim(aStrList.begin(), aStrList.end()));
-										}
+										double dVal(jwtpayload[id].asDouble());
+										JWT.set_payload_claim(id, picojson::value(dVal));
+									}
+									else if(jwtpayload[id].isString())
+									{
+										std::string sVal(jwtpayload[id].asString());
+										JWT.set_payload_claim(id, picojson::value(sVal));
+									}
+									else if(jwtpayload[id].isArray())
+									{
+										std::vector<std::string> aStrList;
+										aStrList.reserve(jwtpayload[id].size());
+										std::transform(jwtpayload[id].begin(), jwtpayload[id].end(), std::back_inserter(aStrList),[](const auto& s) { return s.asString(); });
+										JWT.set_payload_claim(id, jwt::claim(aStrList.begin(), aStrList.end()));
 									}
 								}
 							}
-							if (my.ActiveTabs)
-							{
-								jwttoken = JWT.sign(jwt::algorithm::ps256{"", my.PrivKey, "", ""}, &base64url_encode);
-							}
-							else
-							{
-								jwttoken = JWT.sign(jwt::algorithm::hs256{my.Password}, &base64url_encode);
-							}
-							bOk = true;
 						}
+						if (my.ActiveTabs)
+						{
+							jwttoken = JWT.sign(jwt::algorithm::ps256{"", my.PrivKey, "", ""}, &base64url_encode);
+						}
+						else
+						{
+							jwttoken = JWT.sign(jwt::algorithm::hs256{my.SigningSecret}, &base64url_encode);
+						}
+						bOk = true;
 					}
 				}
 			}

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -192,7 +192,7 @@ namespace http
 			std::string ExtractRequestPath(const std::string &original_request_path);
 			bool IsBadRequestPath(const std::string &original_request_path);
 
-			bool GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload = "");
+			bool GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload = "", const std::string &issuer = "");
 			bool FindAuthenticatedUser(std::string &user, const request &req, reply &rep);
 			bool CheckVHost(const request &req);
 			bool findRealHostBehindProxies(const request &req, std::string &realhost);

--- a/webserver/cWebem.h
+++ b/webserver/cWebem.h
@@ -40,6 +40,9 @@ namespace http
 			_eUserRights userrights = URIGHTS_VIEWER;
 			int TotSensors = 0;
 			int ActiveTabs = 0;
+			uint32_t RefreshExpire = 0;
+			std::string SigningSecret;
+			time_t AcceptLegacyTokensUntil = 0;
 		} WebUserPassword;
 
 		typedef struct _tWebEmSession
@@ -188,11 +191,11 @@ namespace http
 			void SetAuthenticationMethod(_eAuthenticationMethod amethod);
 			void SetWebTheme(const std::string &themename);
 			void SetWebRoot(const std::string &webRoot);
-			void AddUserPassword(unsigned long ID, const std::string &username, const std::string &password, const std::string &mfatoken, _eUserRights userrights, int activetabs, const std::string &privkey = "", const std::string &pubkey = "");
+			void AddUserPassword(unsigned long ID, const std::string &username, const std::string &password, const std::string &mfatoken, _eUserRights userrights, int activetabs, const std::string &privkey = "", const std::string &pubkey = "", uint32_t refreshexpire = 0, const std::string &signingsecret = "", time_t accept_legacy_until = 0);
 			std::string ExtractRequestPath(const std::string &original_request_path);
 			bool IsBadRequestPath(const std::string &original_request_path);
 
-			bool GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &clientsecret, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload = "", const std::string &issuer = "");
+			bool GenerateJwtToken(std::string &jwttoken, const std::string &clientid, const std::string &user, const uint32_t exptime, const Json::Value jwtpayload = "", const std::string &issuer = "");
 			bool FindAuthenticatedUser(std::string &user, const request &req, reply &rep);
 			bool CheckVHost(const request &req);
 			bool findRealHostBehindProxies(const request &req, std::string &realhost);

--- a/www/app/ApplicationsController.js
+++ b/www/app/ApplicationsController.js
@@ -1,4 +1,5 @@
 define(['app'], function (app) {
+
 	app.controller('ApplicationsController', ['$scope', '$rootScope', '$location', '$http', '$interval', 'md5', function ($scope, $rootScope, $location, $http, $interval, md5) {
 
 		DeleteApplication = function (idx) {
@@ -32,6 +33,8 @@ define(['app'], function (app) {
 			csettings.bPublic = $('#applicationcontent #applicationparamstable #applicationpublic').is(":checked");
 			csettings.secret = $("#applicationcontent #applicationparamstable #applicationsecret").val();
 			csettings.pemfile = $("#applicationcontent #applicationparamstable #applicationpemfile").val();
+			csettings.refreshexpire = parseInt($("#applicationcontent #applicationparamstable #refreshexpire").val()) || 0;
+			csettings.signingsecret = $("#applicationcontent #applicationparamstable #signingsecret").val();
 			if ((csettings.bPublic == false) && (csettings.secret == "")) {
 				ShowNotify($.t('Please enter a Secret!'), 2500, true);
 				return;
@@ -59,7 +62,9 @@ define(['app'], function (app) {
 				"&applicationname=" + csettings.applicationname +
 				"&secret=" + csettings.secret +
 				"&pemfile=" + csettings.pemfile +
-				"&public=" + csettings.bPublic,
+				"&public=" + csettings.bPublic +
+				"&refreshexpire=" + csettings.refreshexpire +
+				"&signingsecret=" + csettings.signingsecret,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -86,7 +91,9 @@ define(['app'], function (app) {
 				"&applicationname=" + csettings.applicationname +
 				"&secret=" + csettings.secret +
 				"&pemfile=" + csettings.pemfile +
-				"&public=" + csettings.bPublic,
+				"&public=" + csettings.bPublic +
+				"&refreshexpire=" + csettings.refreshexpire +
+				"&signingsecret=" + csettings.signingsecret,
 				async: false,
 				dataType: 'json',
 				success: function (data) {
@@ -134,6 +141,8 @@ define(['app'], function (app) {
 								"Applicationname": item.Applicationname,
 								"Applicationsecret": item.Secret,
 								"Applicationpemfile": item.Pemfile,
+								"RefreshExpire": item.RefreshExpire || 0,
+								"SigningSecret": item.SigningSecret || "",
 								"Public": item.Public,
 								"Last seen": item.LastSeen,
 								"0": enabledstr,
@@ -173,6 +182,8 @@ define(['app'], function (app) {
 						$("#applicationcontent #applicationparamstable #applicationname").val(data["Applicationname"]);
 						$("#applicationcontent #applicationparamstable #applicationsecret").val(data["Applicationsecret"]);
 						$("#applicationcontent #applicationparamstable #applicationpemfile").val(data["Applicationpemfile"]);
+						$("#applicationcontent #applicationparamstable #refreshexpire").val(data["RefreshExpire"] || 0);
+						$("#applicationcontent #applicationparamstable #signingsecret").val(data["SigningSecret"] || "");
 						$('#applicationcontent #applicationparamstable #applicationpublic').prop('checked', (data["Public"] == "true"));
 						togglePublic();
 					}

--- a/www/views/applications.html
+++ b/www/views/applications.html
@@ -38,6 +38,16 @@
                 <td><input type="text" id="applicationpemfile" name="applicationpemfile" style="width: 200px; padding: .2em;" class="text ui-widget-content ui-corner-all"></td>
             </tr>
             <tr>
+                <td align="right" style="width:200px"><label for="refreshexpire"><span data-i18n="Refresh Token Lifetime">Refresh Token Lifetime (seconds, 0=default)</span>:</label></td>
+                <td><input type="number" id="refreshexpire" name="refreshexpire" min="0" value="0" style="width: 200px; padding: .2em;" class="text ui-widget-content ui-corner-all"></td>
+            </tr>
+            <tr>
+                <td align="right" style="width:200px"><label for="signingsecret"><span data-i18n="JWT Signing Secret">JWT Signing Secret (leave blank to auto-generate)</span>:</label></td>
+                <td>
+                    <input type="password" id="signingsecret" name="signingsecret" style="width: 200px; padding: .2em;" class="text ui-widget-content ui-corner-all">
+                </td>
+            </tr>
+            <tr>
                 <td></td>
                 <td>
                     <a class="btn btn-info" onclick="AddApplication();" data-i18n="Add">Add</a>


### PR DESCRIPTION
I've been working on getting Alexa integration working with our OAuth2 support: https://github.com/dwmw2/alexa_domo

1. Our default refresh lifetime for a token is only a single day, and I think that means the user would have to relink the Alexa skill if they go a day without invoking it. So I've made it a per-client setting.

2. Alexa Smart Home skills also recommend using Basic auth, which is mandatory in RFC6749. Alexa did work with the 'credentials in request' method, and I've documented that the user should do so, but it's one more thing for a user to trip over, so it's better to fix it and simplify the docs.

3. The [password grant flow](https://datatracker.ietf.org/doc/html/rfc6749#section-4.3) was previously looking for user creds in the Basic auth header, when they should be in the body of the request. Fixed that to get them from the right place.

4. **[SECURITY]** The password flow also wasn't even checking the client creds at all! Pull the client cred checking right up to the start of the function and do it once, instead of leaving it to be checked in each individual grant flow and potentially forgotten.

5. **[SECURITY]** Signing JWTs with the client_secret means that the client can just _make up_ tokens for any user it wants, without actually having to log in. So for example I've carefully set up an `alexa` user with only the permissions I want it to have, but setting up a client cred for Alexa to do OAuth2 has given it a way to fake tokens for *any* admin user in my system! Fix this by generating a new signing secret for each client, which is known *only* to Domoticz. The old tokens signed with the client secret are accepted only for 24 hours after the upgrade, after which they will have expired anyway, and any *refreshed* tokens are signed with the new signing secret. So we upgrade, and don't even break any existing tokens in the process.

6. I've made it easier to get the correct URIs in as the JWT issuer, and in the `/.well-known/openid-configuration` result. By using the content of the `Host:` header in the request, *if* the hostname is still set to the default 'domoticz.local'. This fixes OAuth2 for people whose Domoticz server is accessible only through port forwarding on a hostname and port number that Domoticz has no way of knowing.

I'm slightly unsure about the last one, as it dilutes the meaning of the 'issuer' field in the JWT. A client can put *anything* in the Host: header, and that means we can ask Domoticz to issue tokens with anything in the `iss` field. I don't *think* that matters, as these tokens are only for use with this one Domoticz server anyway. Similarly, Domoticz does currently check the issuer when accepting a token. And now a client can just present a Host: header which matches the issue from the token, diluting the issuer check... but who cares? If that token is correctly signed and accepted by the local Domoticz server, checking the 'issuer' string doesn't do anything anyway.

Having the correct URI in the issuer of the JWT is really helpful because the Alexa Lambda function can then use it and not have to be explicitly configured with the server's hostname and port. My current documentation just tells users to ensure Domoticz is running with the right `-vhostname` argument, but that doesn't solve the port issue, for those who are using port forwarding. And since Lambda can only use Legacy IP and not IPv6, *most* people are likely to be using port forwarding for external access, with Domoticz itself not even knowing which *external* port number is used.

@kiddigital what do you think?