### PR TITLE
Use IsLightOrSwitch() helper consistently

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -1733,31 +1733,12 @@ namespace http
 
 					bool bHasTimers = false;
 
-					if (
-						(dType == pTypeLighting1)
-						|| (dType == pTypeLighting2)
-						|| (dType == pTypeLighting3)
-						|| (dType == pTypeLighting4)
-						|| (dType == pTypeLighting5)
-						|| (dType == pTypeLighting6)
-						|| (dType == pTypeFan)
-						|| (dType == pTypeColorSwitch)
-						|| (dType == pTypeCurtain)
-						|| (dType == pTypeBlinds)
-						|| (dType == pTypeRFY)
-						|| (dType == pTypeChime)
-						|| (dType == pTypeThermostat2)
-						|| (dType == pTypeThermostat3)
-						|| (dType == pTypeThermostat4)
-						|| (dType == pTypeRemote)
-						|| (dType == pTypeGeneralSwitch)
-						|| (dType == pTypeHomeConfort)
-						|| (dType == pTypeFS20)
-						|| ((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator))
-						|| ((dType == pTypeRego6XXValue) && (dSubType == sTypeRego6XXStatus))
-						|| (dType == pTypeHunter)
-						|| (dType == pTypeDDxxxx)
-						)
+					if ((IsLightOrSwitch(dType, dSubType)
+					     || ((dType == pTypeRego6XXValue) && (dSubType == sTypeRego6XXStatus)))
+					    && (dType != pTypeSecurity1)
+					    && (dType != pTypeSecurity2)
+					    && (dType != pTypeHoneywell_AL)
+					    )
 					{
 						// add light details
 						bHasTimers = m_sql.HasTimers(sd[0]);

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -4993,13 +4993,7 @@ namespace http
 			_eSwitchType switchtype = (_eSwitchType)atoi(result[0][2].c_str());
 			std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(result[0][3]);
 
-			if (
-				(dType != pTypeLighting1) && (dType != pTypeLighting2) && (dType != pTypeLighting3) && (dType != pTypeLighting4) && (dType != pTypeLighting5) &&
-				(dType != pTypeLighting6) && (dType != pTypeFan) && (dType != pTypeColorSwitch) && (dType != pTypeSecurity1) && (dType != pTypeSecurity2) && (dType != pTypeEvohome) &&
-				(dType != pTypeEvohomeRelay) && (dType != pTypeCurtain) && (dType != pTypeBlinds) && (dType != pTypeRFY) && (dType != pTypeRego6XXValue) && (dType != pTypeChime) &&
-				(dType != pTypeThermostat2) && (dType != pTypeThermostat3) && (dType != pTypeThermostat4) && (dType != pTypeRemote) && (dType != pTypeGeneralSwitch) &&
-				(dType != pTypeHomeConfort) && (dType != pTypeFS20) && (!((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator))) && (dType != pTypeHunter) && (dType != pTypeDDxxxx) && (dType != pTypeHoneywell_AL)
-				)
+			if (!(IsLightOrSwitch(dType, dSubType) || (dType == pTypeEvohome) || (dType == pTypeEvohomeRelay) || (dType == pTypeRego6XXValue)))
 				return; // no light device! we should not be here!
 
 			root["status"] = "OK";

--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -2579,13 +2579,12 @@ namespace http
 					unsigned char switchtype = atoi(result[0][2].c_str());
 
 					int ii = 0;
-					if (
-						(dType == pTypeLighting1) || (dType == pTypeLighting2) || (dType == pTypeLighting3) || (dType == pTypeLighting4) || (dType == pTypeLighting5) ||
-						(dType == pTypeLighting6) || (dType == pTypeColorSwitch) || (dType == pTypeSecurity1) || (dType == pTypeSecurity2) || (dType == pTypeEvohome) ||
-						(dType == pTypeEvohomeRelay) || (dType == pTypeCurtain) || (dType == pTypeBlinds) || (dType == pTypeRFY) || (dType == pTypeChime) || (dType == pTypeThermostat2) ||
-						(dType == pTypeThermostat3) || (dType == pTypeThermostat4) || (dType == pTypeRemote) || (dType == pTypeGeneralSwitch) || (dType == pTypeHomeConfort) ||
-						(dType == pTypeFS20) || ((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator)) || (dType == pTypeDDxxxx) || (dType == pTypeHoneywell_AL)
-						)
+					if ((IsLightOrSwitch(dType, dSubType)
+					     || (dType == pTypeEvohome)
+					     || (dType == pTypeEvohomeRelay))
+					    && (dType != pTypeFan)
+					    && (dType != pTypeHunter)
+					    )
 					{
 						if (switchtype != STYPE_PushOff)
 						{

--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -3323,19 +3323,14 @@ namespace http
 					unsigned char dType = atoi(result[0][0].c_str());
 					unsigned char dSubType = atoi(result[0][1].c_str());
 
-					if (
-						(dType != pTypeLighting1) && (dType != pTypeLighting2) && (dType != pTypeLighting3) && (dType != pTypeLighting4) && (dType != pTypeLighting5) &&
-						(dType != pTypeLighting6) && (dType != pTypeFan) && (dType != pTypeColorSwitch) && (dType != pTypeSecurity1) && (dType != pTypeSecurity2) &&
-						(dType != pTypeEvohome) && (dType != pTypeEvohomeRelay) && (dType != pTypeCurtain) && (dType != pTypeBlinds) && (dType != pTypeRFY) && (dType != pTypeChime) &&
-						(dType != pTypeThermostat2) && (dType != pTypeThermostat4) && (dType != pTypeThermostat4) && (dType != pTypeRemote) && (dType != pTypeGeneralSwitch) &&
-						(dType != pTypeHomeConfort) && (dType != pTypeFS20) && (!((dType == pTypeRadiator1) && (dSubType == sTypeSmartwaresSwitchRadiator))) &&
-						(!((dType == pTypeGeneral) && (dSubType == sTypeTextStatus))) && (!((dType == pTypeGeneral) && (dSubType == sTypeAlert))) && (dType != pTypeHunter) && (dType != pTypeDDxxxx) && (dType != pTypeHoneywell_AL)
-						)
+					if ((IsLightOrSwitch(dType, dSubType) || (dType == pTypeEvohome) || (dType == pTypeEvohomeRelay))
+					    || ((dType == pTypeGeneral) && ((dSubType == sTypeTextStatus) || (dSubType == sTypeAlert))))
+					{
+						result = m_sql.safe_query("DELETE FROM LightingLog WHERE (DeviceRowID=='%q')", idx.c_str());
+						root["status"] = "OK";
+					}
+					else
 						return false; // no light device! we should not be here!
-
-
-					result = m_sql.safe_query("DELETE FROM LightingLog WHERE (DeviceRowID=='%q')", idx.c_str());
-					root["status"] = "OK";
 					break;
 				}
 				case "clearscenelog"_sh:

--- a/main/WebServerCommands.cpp
+++ b/main/WebServerCommands.cpp
@@ -508,51 +508,12 @@ namespace http
 							int Type = atoi(sd[2].c_str());
 							int SubType = atoi(sd[3].c_str());
 							int used = atoi(sd[4].c_str());
-							if (used)
+							if (used && (IsLightOrSwitch(Type, SubType) || (Type == pTypeEvohome) || (Type == pTypeEvohomeRelay)))
 							{
-								switch (Type)
-								{
-								case pTypeLighting1:
-								case pTypeLighting2:
-								case pTypeLighting3:
-								case pTypeLighting4:
-								case pTypeLighting5:
-								case pTypeLighting6:
-								case pTypeFan:
-								case pTypeColorSwitch:
-								case pTypeSecurity1:
-								case pTypeSecurity2:
-								case pTypeEvohome:
-								case pTypeEvohomeRelay:
-								case pTypeCurtain:
-								case pTypeBlinds:
-								case pTypeRFY:
-								case pTypeChime:
-								case pTypeThermostat2:
-								case pTypeThermostat3:
-								case pTypeThermostat4:
-								case pTypeRemote:
-								case pTypeGeneralSwitch:
-								case pTypeHomeConfort:
-								case pTypeFS20:
-								case pTypeHunter:
-								case pTypeDDxxxx:
-								case pTypeHoneywell_AL:
-									root["result"][ii]["type"] = 0;
-									root["result"][ii]["idx"] = ID;
-									root["result"][ii]["Name"] = "[Light/Switch] " + Name;
-									ii++;
-									break;
-								case pTypeRadiator1:
-									if (SubType == sTypeSmartwaresSwitchRadiator)
-									{
-										root["result"][ii]["type"] = 0;
-										root["result"][ii]["idx"] = ID;
-										root["result"][ii]["Name"] = "[Light/Switch] " + Name;
-										ii++;
-									}
-									break;
-								}
+								root["result"][ii]["type"] = 0;
+								root["result"][ii]["idx"] = ID;
+								root["result"][ii]["Name"] = "[Light/Switch] " + Name;
+								ii++;
 							}
 						}
 					} // end light/switches


### PR DESCRIPTION
There are a bunch of places in the code where we have a hard-coded list of pType/pSubType which are actually a switch, and for which SwitchType is STYPE_xxx (as opposed to being a meter type or something else).

Many of them seem to have *slightly* different criteria, which seems more by accident than design. Especially the one in the `clearlightlog` handler which checked for `pTypeThermostat4` twice, and not `pTypeThermostat3`. They mostly differ in their opinions about whether to include `pTypeRego6XXValue`/`sTypeRego6XXStatus`, and the EvoHome types.

This PR makes them all use IsLightOrSwitch() consistently, but *doesn't* actually make any functional changes except for the obvious pTypeThermostat3 typo. If some of the original code was wrong, we can fix the actual behaviour in subsequent commits but let's make the safe cleanup as a first step without functional changes.