### PR TITLE
Native Alexa Smart Home API support

### DIFF
--- a/ALEXA.md
+++ b/ALEXA.md
@@ -1,0 +1,300 @@
+# Domoticz Alexa Smart Home Integration
+
+This integration allows you to control your Domoticz devices through Amazon Alexa using the Alexa Smart Home API v3.
+
+Domoticz includes native Alexa Smart Home API support and a built-in OAuth2 server that works with Alexa's account linking. A minimal AWS Lambda function acts as a passthrough, forwarding Alexa requests to your Domoticz instance.
+
+## Features
+
+- Control lights (on/off, dimming, color, color temperature)
+- Control scenes and groups
+- Control selector switches (mode controllers)
+- Monitor temperature and humidity sensors
+- Control thermostats
+- Control blinds and locks
+- Monitor various sensors (weight, pH, absolute humidity)
+
+## Requirements
+
+- **Domoticz home automation system** - Your Domoticz instance must be accessible from the Lambda function over Legacy IP, with a valid SSL certificate.
+- **Amazon Developer Account** - Sign up at [developer.amazon.com](https://developer.amazon.com) to create your Alexa Smart Home skill
+- **AWS Account** - Needed to host the Lambda function that bridges Alexa and Domoticz. AWS Lambda offers a free tier with 1 million requests per month, which is more than sufficient for typical home automation use.
+
+## Installation
+
+### Prepare Domoticz
+
+Before setting up the Alexa skill, ensure your Domoticz instance is properly configured:
+
+1. **Network accessibility** - Your Domoticz instance must be accessible from the internet via Legacy IP, as Lambda functions cannot use IPv6 without additional VPC configuration. You may need to configure port forwarding on your router.
+
+   Advanced users who don't want to open a public port can configure the Lambda function to run in their own specific VPC (private network), and can configure their local network to connect to that VPC via a VPN using the methods in [the AWS documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpn-connections.html). Such a configuration is outside the scope of this document.
+
+2. **Valid SSL certificate** - Domoticz must use HTTPS with a certificate from a recognized Certificate Authority. Self-signed certificates will not work. LetsEncrypt certificates work well and are free.
+
+3. **Create a dedicated Alexa user** (recommended):
+   - Go to Setup → Settings → Users
+   - Create a new user (e.g., "alexa")
+   - Set user rights to at least "User" if you want Alexa to control devices. With only "Viewer" permissions, Alexa will be able to see devices but not change anything.
+   - Grant access only to the devices you want to control via Alexa. If you don't explicitly add any devices to this user, Alexa will have access to everything, which is probably not what you want.
+   - This limits the scope of what Alexa can access
+
+4. **Configure OAuth2 application**:
+   - Go to More Options → Applications
+   - Enter Application Name: `domoticz-alexa` (or your preferred name)
+   - Enter Application Secret: Generate a secure random string (save this for later)
+   - Leave "Is Public" switch OFF
+   - Click "Add" and you'll see it added to the list
+   - Note the Application Name and Application Secret (these will be the Client ID and Client Secret you'll need for Alexa account linking)
+
+### Create an Alexa Smart Home Skill
+
+1. Log in to the [Alexa Developer Console](https://developer.amazon.com/alexa/console/ask)
+2. Click "Create Skill"
+3. Configure the skill:
+   - Skill name: Choose a name (e.g., "Domoticz")
+   - Primary locale: English (US) or your preferred locale
+   - Choose a model: Smart Home
+   - Choose a method to host: Provision your own
+4. Click "Create skill"
+5. Note your Skill ID (you'll need this later)
+
+Leave this browser tab open — you'll return to complete the skill setup after creating the Lambda function.
+
+### Create an AWS Lambda Function
+
+**NOTE:** The Lambda function must be created in the same AWS region as your Alexa account, or the skill will not work. The required region depends on your Amazon account's PFM (Preferred Marketplace), which can be found in your retail Amazon account settings. See [this Amazon blog post](https://developer.amazon.com/en-US/blogs/alexa/device-makers/2023/07/smart-home-discovery-alexa-july-2023) for more information about PFM and regional requirements.
+
+It's easiest to create the Lambda function using the Makefile if you have the AWS CLI configured, or you can do it through the AWS Console in your web browser.
+
+**Using the Makefile:**
+
+1. Configure AWS CLI credentials (see [AWS CLI Quick Start](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html)). For a personal setup, it's acceptable to use [user credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-authentication-user.html). The IAM user or role will need the following permissions:
+   - `iam:CreateRole`, `iam:GetRole`, `iam:PutRolePolicy` - to create the Lambda execution role
+   - `lambda:CreateFunction`, `lambda:UpdateFunctionCode`, `lambda:UpdateFunctionConfiguration`, `lambda:GetFunction`, `lambda:AddPermission` - to create and manage the Lambda function
+   - `sts:GetCallerIdentity` - to determine your AWS account ID
+   
+   These permissions are included in the AWS managed policies `IAMFullAccess` and `AWSLambda_FullAccess`, or you can create a custom policy with only the specific permissions listed above.
+
+2. Edit the `Makefile` in the `alexa/` directory:
+   - Set `REGION` to the same AWS region as your Alexa account
+   - Set `SKILL_ID` to your Alexa Skill ID (recommended for better security, but not strictly required)
+
+3. Run the setup commands from the `alexa/` directory:
+   ```bash
+   cd alexa
+   make create-role
+   make create-function
+   make add-alexa-permission
+   ```
+
+To deploy code updates later, you can run:
+```bash
+make deploy
+```
+
+**Using the AWS Console:**
+
+1. Log in to the [AWS Console](https://console.aws.amazon.com/)
+2. Select the same AWS region as your Alexa account using the region selector in the top-right corner
+3. Navigate to Lambda and click "Create function"
+4. Choose "Author from scratch"
+5. Configure the function:
+   - Function name: `domoticz-alexa` (or your preferred name)
+   - Runtime: Python 3.13 (or newer, if available)
+   - Architecture: arm64
+   - Execution role: Create a new role with basic Lambda permissions
+6. Click "Create function"
+7. In the Configuration tab:
+   - Set Timeout to 80 seconds
+   - (Optional) Under Environment variables, add `DOMOTICZ_URL` with your Domoticz server URL (e.g., `https://your-domoticz-host.example.com`) if you want to override the URL extracted from the JWT token
+8. In the Code tab, copy the contents of `alexa/lambda_function.py` and paste it into the code editor, replacing the default code
+9. Click "Deploy" to save the code
+10. Click "Add trigger"
+11. Select "Alexa" then "Alexa Smart Home"
+12. Enter your Skill ID (found in the Alexa Developer Console under "Skill ID")
+13. Click "Add"
+14. Note your Lambda function ARN (you'll need this later)
+
+### Complete the Skill Setup
+
+Return to the Alexa Developer Console browser tab from earlier. You should be in the Build tab.
+
+1. Go to "Smart Home"
+2. Ensure "Payload version" is set to "v3" (this is the default)
+3. Under "Default endpoint", enter your Lambda function ARN
+4. Click "Save"
+5. Go to your skill's "Account Linking" section
+6. Configure the OAuth settings to use Domoticz's built-in OAuth2 server:
+   - Authorization URI: `https://your-domoticz-host.example.com/oauth2/v1/authorize`
+   - Access Token URI: `https://your-domoticz-host.example.com/oauth2/v1/token`
+   - Client ID: Same as configured in Domoticz (e.g., `domoticz-alexa`)
+   - Client Secret: Same as configured in Domoticz
+   - Authentication Scheme: Credentials in request body
+   - Scope: `profile` (or any value — Domoticz doesn't use scopes but Alexa requires one)
+7. Click "Save"
+8. (Optional) Go to your skill's "Permissions" section and enable "Send Alexa Events". We do not support this yet, but we hope to add it in future.
+
+### Enable the Skill
+
+1. Open the Alexa app on your phone
+2. Go to Skills & Games → Your Skills → Dev
+3. Find your skill and click "Enable to Use"
+4. Complete the account linking process
+5. Alexa will discover your Domoticz devices
+
+### Discover Devices
+
+If you add devices which are visible to Alexa, you can say "Alexa, discover devices" or use the Alexa app:
+1. Open the Alexa app
+2. Go to Devices
+3. Tap the "+" icon
+4. Select "Add Device"
+5. Choose "Other" and follow the prompts
+
+Your Domoticz devices should now appear in Alexa!
+
+## Troubleshooting
+
+### Account linking fails
+
+**If you don't reach the Domoticz login page:**
+- Check that your Domoticz server is accessible from the Internet
+- Verify your SSL certificate is valid and from a recognized Certificate Authority
+- Visit `https://your-domoticz-host.example.com/.well-known/openid-configuration` from an external network to verify it's reachable
+
+**If login appears to succeed but linking fails:**
+- Check the `issuer` field in `https://your-domoticz-host.example.com/.well-known/openid-configuration`
+- If the `issuer` doesn't match your actual server URL, Domoticz is putting the wrong issuer into tokens
+- Set the `DOMOTICZ_URL` environment variable in your Lambda function configuration to override it (e.g., `https://your-domoticz-host.example.com`)
+
+### No devices discovered
+- Check your Lambda logs in CloudWatch to see what functions are being invoked
+- If you only see an `AcceptGrant` call but no `Discover` call, your Lambda function is likely in the wrong AWS region
+- Note: Alexa doesn't report this error correctly - it will appear as if linking succeeded, but no devices will be discovered (thanks, Amazon!)
+- Verify your Lambda function is in the same AWS region as your Alexa account (see the PFM note in the Lambda setup section)
+
+### Device not discovered
+- Check that the device is marked as "Used" in Domoticz
+- Verify the Alexa user has access to the device (for non-admin users)
+- Check Lambda CloudWatch logs for errors
+
+### Voice commands not working
+- Ensure device names are clear and distinct
+- Check that the device type is supported
+- Verify the skill is enabled in the Alexa app
+- Note: Alexa's natural language understanding (NLU) can be inconsistent. Try opening the device in the Alexa app and controlling it directly to determine if the issue is with the Smart Home integration or just Alexa's voice recognition
+
+### State not updating
+- State updates require polling (every 3 seconds when device is open in app)
+- Check Domoticz is accessible from Lambda
+- Review CloudWatch logs for errors
+
+## Supported Device Types
+
+### Lights
+- PowerController (on/off)
+- BrightnessController (dimming)
+- ColorController (RGB color)
+- ColorTemperatureController (white temperature)
+
+### Scenes and Groups
+- SceneController (activate scenes)
+- PowerController (on/off for groups)
+
+### Selector Switches
+- ModeController with custom modes based on Domoticz LevelNames
+
+### Temperature Sensors
+- TemperatureSensor
+
+### Humidity Sensors
+- TemperatureSensor and HumiditySensor (combined)
+
+### Thermostats
+- ThermostatController (set target temperature)
+- TemperatureSensor (current temperature)
+
+### Blinds
+- RangeController (position control with open/close presets)
+
+### Locks
+- LockController
+
+### Other Sensors
+- RangeController (weight, pH, absolute humidity)
+- PercentageController (percentage sensors)
+
+## Voice Control Examples
+
+### Lights
+- "Alexa, turn on the kitchen light"
+- "Alexa, dim the bedroom light to 50%"
+- "Alexa, set the living room light to blue"
+
+### Scenes
+- "Alexa, activate bedtime"
+- "Alexa, turn on movie time"
+
+### Selector Switches
+- "Alexa, set the thermostat to heat mode"
+- "Alexa, set lounge source to HDMI 1"
+
+### Thermostats
+- "Alexa, set kitchen temperature to 20 degrees"
+- "Alexa, what is the kitchen temperature?"
+- "Alexa, what is the kitchen set to?"
+
+### Blinds
+- "Alexa, open the bedroom blind"
+- "Alexa, close the living room blind"
+- "Alexa, set the office blind to 50 percent"
+- "Alexa, stop the landing blinds"
+
+### Sensors
+- "Alexa, what's the temperature in the bedroom?"
+
+## Development
+
+### Getting a Bearer Token for Testing
+
+To test the Lambda function, you need a JWT bearer token from Domoticz. You can obtain one using the OAuth2 token endpoint:
+
+```bash
+curl -X POST https://your-domoticz-host.example.com/oauth2/v1/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=password&username=alexa&password=your-password&client_id=domoticz-alexa&client_secret=your-client-secret"
+```
+
+The response will include an `access_token` field containing the JWT bearer token. Export this token for testing:
+
+```bash
+export BEARER_TOKEN="eyJhbGc..."
+```
+
+### Local Testing
+
+Test discovery:
+```bash
+cd alexa
+make test-discovery
+```
+
+Test device control:
+```bash
+make test-control ENDPOINT=device-id
+```
+
+### Logging
+
+CloudWatch logs show:
+- Incoming Alexa requests
+- Domoticz URL being forwarded to
+- HTTP response status
+- Errors
+
+View logs:
+```bash
+cd alexa
+make logs
+```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ ENDIF()
 set(
 domoticz_SRCS
 main/stdafx.cpp
+main/Alexa.cpp
 main/BaroForecastCalculator.cpp
 main/CmdLine.cpp
 main/Camera.cpp

--- a/alexa/Makefile
+++ b/alexa/Makefile
@@ -1,0 +1,262 @@
+.PHONY: help deploy create-function create-role add-alexa-permission lambda-status test-discovery test-statereport test-control clean show-current-version zip
+
+# Name of your Lambda function in AWS
+FUNCTION_NAME ?= domoticz-alexa
+# AWS CLI profile to use (leave empty for default profile)
+PROFILE ?=
+# AWS region where your Lambda function will be deployed
+AWS_REGION ?= eu-west-1
+# Your Alexa Skill ID (recommended for security, restricts which skills can invoke your Lambda)
+SKILL_ID ?=
+# Bearer token for testing (can be set via environment variable)
+BEARER_TOKEN ?=
+
+ACCOUNT_ID = $(shell aws sts get-caller-identity $(PROFILE_FLAG) --query Account --output text 2>/dev/null)
+ROLE_ARN ?= arn:aws:iam::$(ACCOUNT_ID):role/$(FUNCTION_NAME)-execution-role
+
+ifdef PROFILE
+PROFILE_FLAG = --profile $(PROFILE)
+else
+PROFILE_FLAG =
+endif
+
+help:
+	@echo "Initial setup:"
+	@echo "  First-time setup requires three steps:"
+	@echo "  1. Create an IAM role for the Lambda function to run with"
+	@echo "  2. Create the Lambda function itself"
+	@echo "  3. Add permissions for Alexa to invoke the function"
+	@echo ""
+	@echo "  create-role          - Create IAM role for Lambda"
+	@echo "  create-function      - Create new Lambda function"
+	@echo "  add-alexa-permission - Add Alexa Smart Home trigger permission"
+	@echo ""
+	@echo "Development:"
+	@echo "  deploy               - Package and deploy Lambda function"
+	@echo "  lambda-status        - Check Lambda function status and configuration"
+	@echo "  show-current-version - Show deployed Lambda version"
+	@echo ""
+	@echo "Testing:"
+	@echo "  test-discovery       - Test device discovery (use BEARER_TOKEN=xxx to specify JWT)"
+	@echo "  test-statereport     - Test state report (requires ENDPOINT=xxx, optional BEARER_TOKEN=xxx)"
+	@echo "  test-control         - Test device control (requires ENDPOINT=xxx, optional BEARER_TOKEN=xxx)"
+	@echo "  logs                 - Fetch recent CloudWatch logs"
+	@echo ""
+	@echo "Maintenance:"
+	@echo "  clean                - Remove build artifacts"
+	@echo ""
+	@echo "Variables:"
+	@echo "  PROFILE         - AWS profile (default: none)"
+	@echo "  FUNCTION_NAME   - Lambda function name (default: domoticz-alexa)"
+	@echo "  AWS_REGION      - AWS region (default: eu-west-1)"
+	@echo "  ROLE_ARN        - IAM role ARN (default: auto-detected)"
+	@echo "  SKILL_ID        - Alexa skill ID (default: none, allows all skills)"
+
+lambda-$(FUNCTION_NAME).zip: lambda_function.py
+	$(eval GIT_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown"))
+	@echo "Creating lambda-$(FUNCTION_NAME).zip (version: $(GIT_VERSION))..."
+	@zip -q lambda-$(FUNCTION_NAME).zip lambda_function.py
+
+zip: lambda-$(FUNCTION_NAME).zip
+
+deploy: lambda-$(FUNCTION_NAME).zip
+	@echo "Deploying Lambda function..."
+	$(eval GIT_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown"))
+	@aws lambda update-function-code \
+		--function-name $(FUNCTION_NAME) \
+		--zip-file fileb://lambda-$(FUNCTION_NAME).zip \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'LastModified' \
+		--output text
+	@echo "Waiting for function update to complete..."
+	@aws lambda wait function-updated \
+		--function-name $(FUNCTION_NAME) \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION)
+	@aws lambda update-function-configuration \
+		--function-name $(FUNCTION_NAME) \
+		--description "Domoticz Alexa Smart Home - $(GIT_VERSION)" \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'Description' \
+		--output text
+	@echo "Deployment complete"
+
+create-role:
+	@echo "Creating IAM role for Lambda execution..."
+	@echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lambda.amazonaws.com"},"Action":"sts:AssumeRole"}]}' > /tmp/trust-policy.json
+	@aws iam create-role \
+		--role-name $(FUNCTION_NAME)-execution-role \
+		--assume-role-policy-document file:///tmp/trust-policy.json \
+		$(PROFILE_FLAG) \
+		--query 'Role.Arn' \
+		--output text
+	@echo "Creating CloudWatch Logs policy..."
+	@echo '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"logs:CreateLogGroup","Resource":"arn:aws:logs:$(AWS_REGION):$(ACCOUNT_ID):*"},{"Effect":"Allow","Action":["logs:CreateLogStream","logs:PutLogEvents"],"Resource":["arn:aws:logs:$(AWS_REGION):$(ACCOUNT_ID):log-group:/aws/lambda/$(FUNCTION_NAME):*"]}]}' > /tmp/logs-policy.json
+	@aws iam put-role-policy \
+		--role-name $(FUNCTION_NAME)-execution-role \
+		--policy-name CloudWatchLogsPolicy \
+		--policy-document file:///tmp/logs-policy.json \
+		$(PROFILE_FLAG)
+	@rm -f /tmp/trust-policy.json /tmp/logs-policy.json
+	@echo "Role created. Use this ARN with create-function:"
+	@aws iam get-role \
+		--role-name $(FUNCTION_NAME)-execution-role \
+		$(PROFILE_FLAG) \
+		--query 'Role.Arn' \
+		--output text
+
+fix-logs:
+	@echo "Adding CloudWatch Logs permissions to Lambda role..."
+	@aws iam attach-role-policy \
+		--role-name $(shell echo $(ROLE_ARN) | sed 's|.*/||') \
+		--policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole \
+		$(PROFILE_FLAG)
+	@echo "Permissions added. Logs should now work."
+
+create-function: lambda-$(FUNCTION_NAME).zip
+	@echo "Creating Lambda function $(FUNCTION_NAME)..."
+	@echo "Using role: $(ROLE_ARN)"
+	$(eval GIT_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "unknown"))
+	@aws lambda create-function \
+		--function-name $(FUNCTION_NAME) \
+		--runtime python3.12 \
+		--role $(ROLE_ARN) \
+		--handler lambda_function.lambda_handler \
+		--architectures arm64 \
+		--timeout 80 \
+		--description "Domoticz Alexa Smart Home - $(GIT_VERSION)" \
+		--zip-file fileb://lambda-$(FUNCTION_NAME).zip \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'FunctionArn' \
+		--output text
+	@echo "Function created successfully"
+
+add-alexa-permission:
+ifdef SKILL_ID
+	@echo "Adding Alexa Smart Home permission for skill $(SKILL_ID)..."
+	$(eval SKILL_SUFFIX := $(shell echo $(SKILL_ID) | rev | cut -d. -f1 | rev))
+	@aws lambda add-permission \
+		--function-name $(FUNCTION_NAME) \
+		--statement-id alexa-smart-home-$(SKILL_SUFFIX) \
+		--action lambda:InvokeFunction \
+		--principal alexa-connectedhome.amazon.com \
+		--event-source-token $(SKILL_ID) \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'Statement' \
+		--output text
+	@echo "Permission added for skill $(SKILL_ID)"
+else
+	@echo "Adding Alexa Smart Home permission for all skills..."
+	@aws lambda add-permission \
+		--function-name $(FUNCTION_NAME) \
+		--statement-id alexa-smart-home \
+		--action lambda:InvokeFunction \
+		--principal alexa-connectedhome.amazon.com \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'Statement' \
+		--output text
+	@echo "Permission added for all Alexa Smart Home skills"
+endif
+
+lambda-status:
+	@echo "=== Lambda Function Status ==="
+	@echo ""
+	@echo "Checking IAM role..."
+	@aws iam get-role --role-name $(shell echo $(ROLE_ARN) | sed 's|.*/||') $(PROFILE_FLAG) --query 'Role.{Name:RoleName,Arn:Arn}' --output table 2>/dev/null || echo "Role not found: $(ROLE_ARN)"
+	@echo ""
+	@echo "Checking Lambda function..."
+	@aws lambda get-function-configuration --function-name $(FUNCTION_NAME) $(PROFILE_FLAG) --region $(AWS_REGION) --query '{Name:FunctionName,Runtime:Runtime,Role:Role,Description:Description,LastModified:LastModified}' --output table 2>/dev/null || echo "Function not found: $(FUNCTION_NAME)"
+	@echo ""
+	@echo "Checking Alexa permissions..."
+	@aws lambda get-policy --function-name $(FUNCTION_NAME) $(PROFILE_FLAG) --region $(AWS_REGION) --query 'Policy' --output text 2>/dev/null | jq -r '.Statement[] | select(.Principal.Service == "alexa-connectedhome.amazon.com") | "StatementId: \(.Sid)\nPrincipal: \(.Principal.Service)\nEventSourceToken: \(.Condition.StringEquals["lambda:EventSourceToken"] // "all skills")"' 2>/dev/null || echo "No Alexa permissions found"
+
+test-discovery:
+	@if [ -z "$(BEARER_TOKEN)" ]; then \
+		echo "Error: BEARER_TOKEN required. Set via environment or command line."; \
+		exit 1; \
+	fi
+	@echo "Testing device discovery..."
+	@echo '{"directive":{"header":{"namespace":"Alexa.Discovery","name":"Discover","payloadVersion":"3","messageId":"test"},"payload":{"scope":{"type":"BearerToken","token":"$(BEARER_TOKEN)"}}}}' > discovery-payload.json
+	@aws lambda invoke \
+		--function-name $(FUNCTION_NAME) \
+		--payload file://discovery-payload.json \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		discovery-response.json > /dev/null
+	@jq '.event.payload.endpoints | length' discovery-response.json | \
+		xargs -I {} echo "Discovered {} devices"
+	@jq -r '.event.payload.endpoints[].friendlyName' discovery-response.json | sort
+
+test-statereport:
+	@if [ -z "$(ENDPOINT)" ]; then \
+		echo "Error: ENDPOINT required. Usage: make test-statereport ENDPOINT=<endpointId>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(BEARER_TOKEN)" ]; then \
+		echo "Error: BEARER_TOKEN required. Set via environment or command line."; \
+		exit 1; \
+	fi
+	@echo "Testing state report for endpoint $(ENDPOINT)..."
+	@if [ ! -f discovery-response.json ]; then \
+		echo "Running discovery first to get device cookie..."; \
+		$(MAKE) test-discovery > /dev/null 2>&1; \
+	fi
+	@COOKIE=$$(jq -c '.event.payload.endpoints[] | select(.endpointId == "$(ENDPOINT)") | .cookie' discovery-response.json 2>/dev/null || echo '{}'); \
+	echo "{\"directive\":{\"header\":{\"namespace\":\"Alexa\",\"name\":\"ReportState\",\"payloadVersion\":\"3\",\"messageId\":\"test\",\"correlationToken\":\"test\"},\"endpoint\":{\"scope\":{\"type\":\"BearerToken\",\"token\":\"$(BEARER_TOKEN)\"},\"endpointId\":\"$(ENDPOINT)\",\"cookie\":$$COOKIE},\"payload\":{}}}" > statereport-payload.json
+	@aws lambda invoke \
+		--function-name $(FUNCTION_NAME) \
+		--payload file://statereport-payload.json \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		statereport-response.json > /dev/null
+	@echo "Response:"
+	@jq '.' statereport-response.json
+
+test-control:
+	@if [ -z "$(ENDPOINT)" ]; then \
+		echo "Error: ENDPOINT required. Usage: make test-control ENDPOINT=<endpointId>"; \
+		exit 1; \
+	fi
+	@if [ -z "$(BEARER_TOKEN)" ]; then \
+		echo "Error: BEARER_TOKEN required. Set via environment or command line."; \
+		exit 1; \
+	fi
+	@echo "Testing device control (TurnOn) for endpoint $(ENDPOINT)..."
+	@if [ ! -f discovery-response.json ]; then \
+		echo "Running discovery first to get device cookie..."; \
+		$(MAKE) test-discovery > /dev/null 2>&1; \
+	fi
+	@COOKIE=$$(jq -c '.event.payload.endpoints[] | select(.endpointId == "$(ENDPOINT)") | .cookie' discovery-response.json 2>/dev/null || echo '{}'); \
+	echo "{\"directive\":{\"header\":{\"namespace\":\"Alexa.PowerController\",\"name\":\"TurnOn\",\"payloadVersion\":\"3\",\"messageId\":\"test\",\"correlationToken\":\"test\"},\"endpoint\":{\"scope\":{\"type\":\"BearerToken\",\"token\":\"$(BEARER_TOKEN)\"},\"endpointId\":\"$(ENDPOINT)\",\"cookie\":$$COOKIE},\"payload\":{}}}" > control-payload.json
+	@aws lambda invoke \
+		--function-name $(FUNCTION_NAME) \
+		--payload file://control-payload.json \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		control-response.json > /dev/null
+	@jq '.' control-response.json
+
+logs:
+	@aws logs filter-log-events \
+		--log-group-name /aws/lambda/$(FUNCTION_NAME) \
+		--start-time $$(date -d '5 minutes ago' +%s)000 \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'events[*].message' \
+		--output text
+
+show-current-version:
+	@aws lambda get-function-configuration \
+		--function-name $(FUNCTION_NAME) \
+		$(PROFILE_FLAG) \
+		--region $(AWS_REGION) \
+		--query 'Description' \
+		--output text
+
+clean:
+	rm -f discovery-payload.json discovery-response.json control-payload.json control-response.json statereport-payload.json statereport-response.json lambda-$(FUNCTION_NAME).zip

--- a/alexa/lambda_function.py
+++ b/alexa/lambda_function.py
@@ -1,0 +1,50 @@
+import json
+import urllib3
+import base64
+import os
+
+http = urllib3.PoolManager()
+
+def lambda_handler(event, context):
+    print(f"Request: {event.get('directive', {}).get('header', {}).get('namespace')} / {event.get('directive', {}).get('header', {}).get('name')}")
+    
+    # Extract bearer token
+    bearer_token = (event.get('directive', {}).get('endpoint', {}).get('scope', {}).get('token') or
+                   event.get('directive', {}).get('payload', {}).get('scope', {}).get('token') or
+                   event.get('directive', {}).get('payload', {}).get('grantee', {}).get('token'))
+    
+    if not bearer_token:
+        print("Error: No bearer token found")
+        return {'event': {'header': {'namespace': 'Alexa', 'name': 'ErrorResponse'}, 
+                         'payload': {'type': 'INVALID_AUTHORIZATION_CREDENTIAL'}}}
+    
+    # Decode JWT to get issuer
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(bearer_token.split('.')[1] + '=='))
+        domoticz_url = payload['iss'].rstrip('/') + '/alexa.htm'
+        print(f"URL from JWT issuer: {domoticz_url}")
+    except Exception as e:
+        print(f"Error decoding JWT: {e}")
+        return {'event': {'header': {'namespace': 'Alexa', 'name': 'ErrorResponse'}, 
+                         'payload': {'type': 'INVALID_AUTHORIZATION_CREDENTIAL'}}}
+    
+    # Override with environment variable if set
+    env_url = os.environ.get('DOMOTICZ_URL')
+    if env_url:
+        domoticz_url = env_url.rstrip('/')
+        if not domoticz_url.endswith('/alexa.htm'):
+            domoticz_url += '/alexa.htm'
+        print(f"Overriding with DOMOTICZ_URL from environment: {domoticz_url}")
+    
+    # Forward request to Domoticz
+    try:
+        response = http.request('POST', domoticz_url,
+                               body=json.dumps(event),
+                               headers={'Authorization': f'Bearer {bearer_token}',
+                                       'Content-Type': 'application/json'})
+        print(f"Response status: {response.status}")
+        return json.loads(response.data)
+    except Exception as e:
+        print(f"Error forwarding request: {e}")
+        return {'event': {'header': {'namespace': 'Alexa', 'name': 'ErrorResponse'}, 
+                         'payload': {'type': 'INTERNAL_ERROR', 'message': str(e)}}}

--- a/iamserver/IamService.cpp
+++ b/iamserver/IamService.cpp
@@ -31,16 +31,11 @@ namespace http
 
 		std::string GetIssuerFromRequest(const request &req, const std::string &configured_realm)
 		{
-			// Only use Host header if the configured realm uses the default 'domoticz.local'
-			if (configured_realm.find("domoticz.local") != std::string::npos)
+			// Use Host header to determine the issuer
+			const char *host_header = request::get_req_header(&req, "Host");
+			if (host_header != nullptr)
 			{
-				const char *host_header = request::get_req_header(&req, "Host");
-				if (host_header != nullptr)
-				{
-					// Infer scheme from configured realm or default to http
-					std::string scheme = (configured_realm.find("https://") == 0) ? "https://" : "http://";
-					return scheme + std::string(host_header) + "/";
-				}
+				return "https://" + std::string(host_header) + "/";
 			}
 			return configured_realm;
 		}

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -396,7 +396,6 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 		devices_result = m_sql.safe_query(
 			"SELECT DISTINCT d.ID, d.Name, d.Type, d.SubType, d.SwitchType, d.Options, d.sValue "
 			"FROM DeviceStatus d "
-			"INNER JOIN DeviceToPlansMap p ON d.ID = p.DeviceRowID AND p.DevSceneType = 0 "
 			"WHERE d.Used = 1 "
 			"AND d.ID NOT IN (SELECT DeviceRowID FROM DeviceToPlansMap WHERE PlanID IN (SELECT ID FROM Plans WHERE Name = '$Hidden Devices') AND DevSceneType = 0) "
 			"ORDER BY d.ID");
@@ -408,7 +407,6 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 			"SELECT DISTINCT d.ID, d.Name, d.Type, d.SubType, d.SwitchType, d.Options, d.sValue "
 			"FROM DeviceStatus d "
 			"INNER JOIN SharedDevices s ON d.ID = s.DeviceRowID "
-			"INNER JOIN DeviceToPlansMap p ON d.ID = p.DeviceRowID AND p.DevSceneType = 0 "
 			"WHERE s.SharedUserID = %lu AND d.Used = 1 "
 			"AND d.ID NOT IN (SELECT DeviceRowID FROM DeviceToPlansMap WHERE PlanID IN (SELECT ID FROM Plans WHERE Name = '$Hidden Devices') AND DevSceneType = 0) "
 			"ORDER BY d.ID",
@@ -987,12 +985,11 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 		}
 	}
 
-	// Get scenes/groups that are in room plans and not protected
+	// Get scenes/groups that are not protected
 	std::vector<std::vector<std::string>> scenes_result;
 	scenes_result = m_sql.safe_query(
 		"SELECT s.ID, s.Name, s.SceneType, s.Protected "
 		"FROM Scenes s "
-		"INNER JOIN DeviceToPlansMap d ON s.ID = d.DeviceRowID AND d.DevSceneType = 1 "
 		"WHERE s.Protected = 0 "
 		"ORDER BY s.Name");
 

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -27,12 +27,14 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 		return;
 	}
 
-	root["event"]["header"]["namespace"] = "Alexa";
-	root["event"]["header"]["name"] = "ErrorResponse";
+	// Build discovery response structure
+	root["event"]["header"]["namespace"] = "Alexa.Discovery";
+	root["event"]["header"]["name"] = "Discover.Response";
 	root["event"]["header"]["payloadVersion"] = "3";
 	root["event"]["header"]["messageId"] = request_json["directive"]["header"]["messageId"].asString();
-	root["event"]["payload"]["type"] = "INTERNAL_ERROR";
-	root["event"]["payload"]["message"] = "Discovery not yet implemented";
+	root["event"]["payload"]["endpoints"] = Json::Value(Json::arrayValue);
+
+	// TODO: Query devices and scenes directly from database
 }
 
 void CWebServer::Alexa_HandleAcceptGrant(WebEmSession& session, const request& req, Json::Value& root)

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -4,7 +4,9 @@
 #include "../webserver/cWebem.h"
 #include "../webserver/request.hpp"
 #include "../webserver/reply.hpp"
+#include "../httpclient/HTTPClient.h"
 #include <json/json.h>
+#include <sstream>
 #include <string>
 
 extern CLogger _log;
@@ -46,12 +48,61 @@ void CWebServer::Alexa_HandleAcceptGrant(WebEmSession& session, const request& r
 		return;
 	}
 
-	root["event"]["header"]["namespace"] = "Alexa";
-	root["event"]["header"]["name"] = "ErrorResponse";
+	// Get authenticated username from session
+	std::string username = session.username;
+	_log.Log(LOG_STATUS, "Alexa: AcceptGrant for user '%s'", username.c_str());
+
+	// Extract authorization code
+	std::string auth_code = request_json["directive"]["payload"]["grant"]["code"].asString();
+
+	if (!auth_code.empty())
+	{
+		// TODO: Get CLIENT_ID and CLIENT_SECRET from configuration
+		std::string client_id = "";
+		std::string client_secret = "";
+
+		if (!client_id.empty() && !client_secret.empty())
+		{
+			// Exchange authorization code for tokens
+			std::stringstream post_data;
+			post_data << "grant_type=authorization_code"
+				<< "&code=" << auth_code
+				<< "&client_id=" << client_id
+				<< "&client_secret=" << client_secret;
+
+			std::vector<std::string> headers;
+			headers.push_back("Content-Type: application/x-www-form-urlencoded");
+
+			std::string response_data;
+			std::vector<std::string> response_headers;
+
+			// Make HTTPS POST to Amazon LWA
+			if (HTTPClient::POST("https://api.amazon.com/auth/o2/token",
+				post_data.str(), headers, response_data, response_headers))
+			{
+				// Parse token response
+				Json::Value token_response;
+				if (reader.parse(response_data, token_response))
+				{
+					std::string access_token = token_response["access_token"].asString();
+					std::string refresh_token = token_response["refresh_token"].asString();
+					int expires_in = token_response["expires_in"].asInt();
+
+					_log.Log(LOG_STATUS, "Alexa: Received access token for user '%s' (expires in %d seconds)", username.c_str(), expires_in);
+					_log.Log(LOG_STATUS, "Alexa: Received refresh token for user '%s'", username.c_str());
+
+					// TODO: Store tokens in database for user '%s'
+				}
+			}
+		}
+	}
+
+	// Always return success response (even if token exchange fails)
+	root["event"]["header"]["namespace"] = "Alexa.Authorization";
+	root["event"]["header"]["name"] = "AcceptGrant.Response";
 	root["event"]["header"]["payloadVersion"] = "3";
 	root["event"]["header"]["messageId"] = request_json["directive"]["header"]["messageId"].asString();
-	root["event"]["payload"]["type"] = "INTERNAL_ERROR";
-	root["event"]["payload"]["message"] = "AcceptGrant not yet implemented";
+	root["event"]["payload"] = Json::Value(Json::objectValue);
 }
 
 void CWebServer::Alexa_HandleControl(WebEmSession& session, const request& req, Json::Value& root)

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -1,0 +1,118 @@
+#include "stdafx.h"
+#include "WebServer.h"
+#include "Logger.h"
+#include "../webserver/cWebem.h"
+#include "../webserver/request.hpp"
+#include "../webserver/reply.hpp"
+#include <json/json.h>
+#include <string>
+
+extern CLogger _log;
+
+namespace http {
+namespace server {
+
+void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req, Json::Value& root)
+{
+	Json::Value request_json;
+	Json::Reader reader;
+	if (!reader.parse(req.content, request_json))
+	{
+		root["event"]["header"]["namespace"] = "Alexa";
+		root["event"]["header"]["name"] = "ErrorResponse";
+		root["event"]["payload"]["type"] = "INVALID_DIRECTIVE";
+		root["event"]["payload"]["message"] = "Invalid JSON";
+		return;
+	}
+
+	root["event"]["header"]["namespace"] = "Alexa";
+	root["event"]["header"]["name"] = "ErrorResponse";
+	root["event"]["header"]["payloadVersion"] = "3";
+	root["event"]["header"]["messageId"] = request_json["directive"]["header"]["messageId"].asString();
+	root["event"]["payload"]["type"] = "INTERNAL_ERROR";
+	root["event"]["payload"]["message"] = "Discovery not yet implemented";
+}
+
+void CWebServer::Alexa_HandleAcceptGrant(WebEmSession& session, const request& req, Json::Value& root)
+{
+	Json::Value request_json;
+	Json::Reader reader;
+	if (!reader.parse(req.content, request_json))
+	{
+		root["event"]["header"]["namespace"] = "Alexa";
+		root["event"]["header"]["name"] = "ErrorResponse";
+		root["event"]["payload"]["type"] = "INVALID_DIRECTIVE";
+		root["event"]["payload"]["message"] = "Invalid JSON";
+		return;
+	}
+
+	root["event"]["header"]["namespace"] = "Alexa";
+	root["event"]["header"]["name"] = "ErrorResponse";
+	root["event"]["header"]["payloadVersion"] = "3";
+	root["event"]["header"]["messageId"] = request_json["directive"]["header"]["messageId"].asString();
+	root["event"]["payload"]["type"] = "INTERNAL_ERROR";
+	root["event"]["payload"]["message"] = "AcceptGrant not yet implemented";
+}
+
+void CWebServer::Alexa_HandleControl(WebEmSession& session, const request& req, Json::Value& root)
+{
+	Json::Value request_json;
+	Json::Reader reader;
+	if (!reader.parse(req.content, request_json))
+	{
+		root["event"]["header"]["namespace"] = "Alexa";
+		root["event"]["header"]["name"] = "ErrorResponse";
+		root["event"]["payload"]["type"] = "INVALID_DIRECTIVE";
+		root["event"]["payload"]["message"] = "Invalid JSON";
+		return;
+	}
+
+	root["event"]["header"]["namespace"] = "Alexa";
+	root["event"]["header"]["name"] = "ErrorResponse";
+	root["event"]["header"]["payloadVersion"] = "3";
+	root["event"]["header"]["messageId"] = request_json["directive"]["header"]["messageId"].asString();
+	root["event"]["payload"]["type"] = "INTERNAL_ERROR";
+	root["event"]["payload"]["message"] = "Control not yet implemented";
+}
+
+void CWebServer::GetAlexaPage(WebEmSession& session, const request& req, reply& rep)
+{
+	Json::Value root;
+
+	// Parse request body for Alexa directive
+	Json::Value request_json;
+	Json::Reader reader;
+	if (!reader.parse(req.content, request_json))
+	{
+		rep.status = http::server::reply::bad_request;
+		return;
+	}
+
+	// Get directive namespace
+	std::string directive_namespace = request_json["directive"]["header"]["namespace"].asString();
+
+	// Route to appropriate handler
+	if (directive_namespace == "Alexa.Discovery")
+	{
+		Alexa_HandleDiscovery(session, req, root);
+	}
+	else if (directive_namespace == "Alexa.Authorization")
+	{
+		Alexa_HandleAcceptGrant(session, req, root);
+	}
+	else if (directive_namespace.find("Alexa") == 0)
+	{
+		Alexa_HandleControl(session, req, root);
+	}
+	else
+	{
+		rep.status = http::server::reply::not_found;
+		return;
+	}
+
+	reply::set_content(&rep, root.toStyledString());
+	rep.status = http::server::reply::ok;
+}
+
+} // namespace server
+} // namespace http

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -247,6 +247,7 @@ namespace http
 			}
 
 			m_pWebEm->RegisterPageCode("/json.htm", [this](auto&& session, auto&& req, auto&& rep) { GetJSonPage(session, req, rep); });
+			m_pWebEm->RegisterPageCode("/alexa.htm", [this](auto&& session, auto&& req, auto&& rep) { GetAlexaPage(session, req, rep); });
 			// These 'Pages' should probably be 'moved' to become Command codes handled by the 'json.htm API', so we get all API calls through one entry point
 			// And why .php or .cgi while all these commands are NOT handled by a PHP or CGI processor but by Domoticz ?? Legacy? Rename these?
 			m_pWebEm->RegisterPageCode("/backupdatabase.php", [this](auto&& session, auto&& req, auto&& rep) { GetDatabaseBackup(session, req, rep); });

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -43,6 +43,8 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void Alexa_HandleDiscovery(WebEmSession& session, const request& req, Json::Value& root);
 	void Alexa_HandleAcceptGrant(WebEmSession& session, const request& req, Json::Value& root);
 	void Alexa_HandleControl(WebEmSession& session, const request& req, Json::Value& root);
+	bool CheckDeviceAccess(const WebEmSession& session, uint64_t device_idx, bool& bControlPermitted);
+	bool CheckDeviceAccess(const WebEmSession& session, const std::vector<uint64_t>& device_indices, bool& bControlPermitted);
 	void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
 	void GetFloorplanImage(WebEmSession& session, const request& req, reply& rep);
 	void GetServiceWorker(WebEmSession& session, const request& req, reply& rep);

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -37,7 +37,12 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void RegisterCommandCode(const char *idname, const webserver_response_function &ResponseFunction, bool bypassAuthentication = false);
 
 	void GetJSonPage(WebEmSession & session, const request& req, reply & rep);
+	void GetAlexaPage(WebEmSession & session, const request& req, reply & rep);
 	void GetCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
+
+	void Alexa_HandleDiscovery(WebEmSession& session, const request& req, Json::Value& root);
+	void Alexa_HandleAcceptGrant(WebEmSession& session, const request& req, Json::Value& root);
+	void Alexa_HandleControl(WebEmSession& session, const request& req, Json::Value& root);
 	void GetInternalCameraSnapshot(WebEmSession & session, const request& req, reply & rep);
 	void GetFloorplanImage(WebEmSession& session, const request& req, reply& rep);
 	void GetServiceWorker(WebEmSession& session, const request& req, reply& rep);

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -1035,6 +1035,7 @@
     <ClCompile Include="..\main\KWHStats.cpp" />
     <ClCompile Include="..\mdns\mdns.cpp" />
     <ClCompile Include="..\mcpserver\McpService.cpp" />
+    <ClCompile Include="..\main\Alexa.cpp" />
     <ClCompile Include="..\main\BaroForecastCalculator.cpp" />
     <ClCompile Include="..\main\Camera.cpp" />
     <ClCompile Include="..\hardware\Rego6XXSerial.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -345,6 +345,9 @@
     <Filter Include="Devices\AccuWeather">
       <UniqueIdentifier>{3a086069-f89a-44b7-b3a8-19cb9b7509eb}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Alexa">
+      <UniqueIdentifier>{4b8294bc-714f-458e-9a88-5e5b20672ea8}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Pushers">
       <UniqueIdentifier>{b669cde0-9cf1-43ae-a5c0-5f01851e9b45}</UniqueIdentifier>
     </Filter>
@@ -2892,6 +2895,9 @@
     </ClCompile>
     <ClCompile Include="..\hardware\DenkoviUSBDevices.cpp">
       <Filter>Devices\Denkovi</Filter>
+    </ClCompile>
+    <ClCompile Include="..\main\Alexa.cpp">
+      <Filter>Alexa</Filter>
     </ClCompile>
     <ClCompile Include="..\main\BaroForecastCalculator.cpp">
       <Filter>Helpers</Filter>

--- a/webserver/cWebem.cpp
+++ b/webserver/cWebem.cpp
@@ -1270,16 +1270,12 @@ namespace http {
 						// Step 3: Using the (hashed :( ) password of the ClientID as our ClientSecret to verify the JWT signature
 						std::string JWTalgo = decodedJWT.get_algorithm();
 						std::error_code ec;
-						// Build issuer for verification - use Host header if realm is default
+						// Build issuer for verification - use Host header
 						std::string expected_issuer = myWebem->m_DigistRealm;
-						if (expected_issuer.find("domoticz.local") != std::string::npos)
+						const char *host_header = request::get_req_header(&req, "Host");
+						if (host_header != nullptr)
 						{
-							const char *host_header = request::get_req_header(&req, "Host");
-							if (host_header != nullptr)
-							{
-								std::string scheme = (expected_issuer.find("https://") == 0) ? "https://" : "http://";
-								expected_issuer = scheme + std::string(host_header) + "/";
-							}
+							expected_issuer = "https://" + std::string(host_header) + "/";
 						}
 
 						auto JWTverifyer = jwt::verify().with_issuer(expected_issuer).with_audience(clientid);


### PR DESCRIPTION
This adds a native Alexa Smart Home API endpoint to Domoticz, with support for the most common device types.

Providing a native API endpoint gives the most control over how devices appear in Alexa. It lets us implement specific features and utterances on the devices, and do proactive push notifications to Alexa (not yet implemented).

It does currently require the user to set up a Lambda function which *just* proxies the HTTP request to the Domoticz server, like the HA one (https://www.home-assistant.io/integrations/alexa.smart_home/). I've worked on simplifying and automating that process, and will probably pull in the docs and scripting that I've implemented for https://github.com/dwmw2/alexa_domo/blob/master/README.md 

My documentation says that you do need to open a port to Domoticz from the outside, although it *only* needs to do OAuth2 and not the normal API or authentication and perhaps we could have a mode which restricts all other access, to improve security.

And it should actually be possible to run the Lambda function in a VPC (private network) and have the Domoticz server [VPN in](https://docs.aws.amazon.com/vpc/latest/userguide/vpn-connections.html) to that same network, so there's no need for a public-facing port at all. Or we could provide the Lambda with a client SSL cert, and allow *only* connections with that cert from the outside, perhaps?

Since HA also exposes a native Alexa endpoint, I'm hoping that Alexa will eventually learn to discover those automatically and avoid the need for external access.

There are other ways we can expose devices to Alexa, even with automatic local discovery. But the simpler it gets, the more it's like playing "[game of telephone](https://en.wikipedia.org/wiki/Telephone_game)" with the device models. Some stuff can be exposed as a Philips Hue light bulb, or other types of device for which the manufacturer has created a skill with local discovery.

A decent compromise in the future for those who really don't want an external port (or to wait for local discovery to be added) might be to expose devices via Matter; the Alexa support for discovering those is improving. There's still a bit of 'game of telephone' as we translate Domoticz devices to Matter, and then we're at the mercy of Alexa's own interpretation of the Matter devices into its own model. We can add that later if we want, and this Alexa support can serve as a model for how we do so.