### PR TITLE
Fixing compiler warnings

### DIFF
--- a/main/KWHStats.cpp
+++ b/main/KWHStats.cpp
@@ -245,8 +245,12 @@ void CKWHStats::HandleKWHStatsHour()
 	const int hour = last_hour.tm_hour;
 	const int wday = last_hour.tm_wday;
 
-	char szStartTime[30];
-	snprintf(szStartTime, sizeof(szStartTime), "%04d-%02d-%02d %02d:%02d:%02d", last_hour.tm_year + 1900, last_hour.tm_mon + 1, last_hour.tm_mday, last_hour.tm_hour, 0, 0);
+	char szStartTime[32];
+	if (strftime(szStartTime, sizeof(szStartTime), "%Y-%m-%d %H:%M:%S", &last_hour) == 0) {
+    	// fallback (shouldn't normally happen, but keep a sensible default)
+    	strncpy(szStartTime, "1970-01-01 00:00:00", sizeof(szStartTime));
+    	szStartTime[sizeof(szStartTime) - 1] = '\0';
+	}
 
 	//First handle all P1 meters
 	auto result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (Type=%d)", pTypeP1Power);

--- a/main/KWHStats.cpp
+++ b/main/KWHStats.cpp
@@ -246,7 +246,11 @@ void CKWHStats::HandleKWHStatsHour()
 	const int wday = last_hour.tm_wday;
 
 	char szStartTime[32];
-	snprintf(szStartTime, sizeof(szStartTime), "%04d-%02d-%02d %02d:%02d:%02d", last_hour.tm_year + 1900, last_hour.tm_mon + 1, last_hour.tm_mday, last_hour.tm_hour, 0, 0);
+	if (strftime(szStartTime, sizeof(szStartTime), "%Y-%m-%d %H:%M:%S", &last_hour) == 0) {
+    	// fallback (shouldn't normally happen, but keep a sensible default)
+    	strncpy(szStartTime, "1970-01-01 00:00:00", sizeof(szStartTime));
+    	szStartTime[sizeof(szStartTime) - 1] = '\0';
+	}
 
 	//First handle all P1 meters
 	auto result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (Type=%d)", pTypeP1Power);

--- a/main/KWHStats.cpp
+++ b/main/KWHStats.cpp
@@ -246,11 +246,7 @@ void CKWHStats::HandleKWHStatsHour()
 	const int wday = last_hour.tm_wday;
 
 	char szStartTime[32];
-	if (strftime(szStartTime, sizeof(szStartTime), "%Y-%m-%d %H:%M:%S", &last_hour) == 0) {
-    	// fallback (shouldn't normally happen, but keep a sensible default)
-    	strncpy(szStartTime, "1970-01-01 00:00:00", sizeof(szStartTime));
-    	szStartTime[sizeof(szStartTime) - 1] = '\0';
-	}
+	snprintf(szStartTime, sizeof(szStartTime), "%04d-%02d-%02d %02d:%02d:%02d", last_hour.tm_year + 1900, last_hour.tm_mon + 1, last_hour.tm_mday, last_hour.tm_hour, 0, 0);
 
 	//First handle all P1 meters
 	auto result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (Type=%d)", pTypeP1Power);

--- a/main/unzip_iterator.h
+++ b/main/unzip_iterator.h
@@ -29,7 +29,7 @@
  *  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
- *  Last-modified: Sat 06 Jun 2009 16:45:00 JST
+ *  Last-modified: Sun 09 Nov 2025 14:50:00 CET
  */
 /* ------------------------------------------------------------------------- */
 #ifndef CLX_UNZIP_ITERATOR_H
@@ -37,7 +37,10 @@
 
 //#include "config.h"
 #include <iterator>
+#include <cstddef>
+#include <memory>
 #include <string>
+#include <cstdlib>
 #include <minizip/unzip.h>
 #include <zlib.h>
 #include "unzip_stream.h"
@@ -50,23 +53,46 @@ namespace clx {
 		class CharT,
 		class Traits = std::char_traits<CharT>
 	>
-	class basic_unzip_iterator : public std::iterator<std::input_iterator_tag, basic_unzip_stream<CharT, Traits> > {
+	class basic_unzip_iterator {
 	public:
-		typedef basic_unzip_stream<CharT, Traits> stream_type;
-		typedef std::shared_ptr<stream_type> stream_ptr;
-		typedef unzFile handler_type;
-		typedef std::basic_string<CharT, Traits> string_type;
+		// Replace deprecated std::iterator inheritance with explicit typedefs
+		using iterator_category = std::input_iterator_tag;
+		using value_type        = basic_unzip_stream<CharT, Traits>;
+		using difference_type   = std::ptrdiff_t;
+		// The iterator stores and returns shared_ptr to the underlying stream object.
+		// This matches the implementation below which maintains stream_ptr instances.
+		using pointer           = std::shared_ptr<value_type>;
+		using reference         = value_type&;
 
-		basic_unzip_iterator()
-			: cur_()
-			, pass_()
-		{
+		// convenience aliases used in the implementation
+		using stream_type = value_type;
+		using stream_ptr = pointer;
+		using handler_type = unzFile;
+		using string_type = std::basic_string<CharT>;
+
+		basic_unzip_iterator() noexcept : cur_(), m_stream_ptr(nullptr), handler_(nullptr), pass_() {}
+		
+		reference operator*() const {
+			return *m_stream_ptr;
+		}
+
+		pointer operator->() const {
+			return m_stream_ptr;
+		}
+
+		// non-const accessors (preserve original overloads)
+		stream_type& operator*() {
+			return *cur_;
+		}
+		stream_ptr operator->() {
+			return cur_;
 		}
 
 		basic_unzip_iterator(const basic_unzip_iterator& cp) :
-			cur_(cp.cur_), handler_(cp.handler_), pass_(cp.pass_) {}
+			cur_(cp.cur_), m_stream_ptr(cp.m_stream_ptr), handler_(cp.handler_), pass_(cp.pass_) {}
 		
 		basic_unzip_iterator& operator=(const basic_unzip_iterator& cp) {
+			m_stream_ptr = cp.m_stream_ptr;
 			handler_ = cp.handler_;
 			cur_ = cp.cur_;
 			pass_ = cp.pass_;
@@ -75,18 +101,16 @@ namespace clx {
 		
 		template <class Unzip>
 		basic_unzip_iterator(const Unzip& cp) :
-			cur_(), handler_(cp.handler()), pass_(cp.password()) {
+			cur_(), m_stream_ptr(), handler_(cp.handler()), pass_(cp.password()) {
 			this->create();
 		}
 		
-		stream_type& operator*() { return *cur_; }
-		stream_ptr& operator->() { return cur_; }
-
-		//End-user needs to call "free" on return object
-		//returns NULL when error, or a pointer to the buffer and file_size
+		// End-user needs to call "free" on return object
+		// returns NULL when error, or a pointer to the buffer and file_size
 		void *Extract(uLong &file_size, const int ExtraAllocBytes=0) {
 			file_size = 0;
-			int err = 0;// unzOpenCurrentFilePassword((unzFile)handler_, pass_.c_str());
+			int err = 0; // placeholder: if you need to open the current file with password, set err accordingly
+			// Example (commented out in original): unzOpenCurrentFilePassword((unzFile)handler_, pass_.c_str());
 			if (err != UNZ_OK)
 			{
 				//printf("error %d with zipfile in unzOpenCurrentFilePassword\n",err);
@@ -101,7 +125,7 @@ namespace clx {
 			unsigned char *buf = (unsigned char*)malloc(file_size + ExtraAllocBytes);
 			if (buf == NULL)
 				return NULL;
-			//Extract into our buffer
+			// Extract into our buffer
 			int offset = 0;
 			int tot_read = 0;
 			do
@@ -128,21 +152,28 @@ namespace clx {
 			if (cur_ && !cur_->path().empty()) {
 				if (unzLocateFile(handler_, cur_->path().c_str(), 0) != UNZ_OK) {
 					cur_ = stream_ptr();
+					m_stream_ptr = nullptr;
 					return *this;
 				}
 			}
 			
-			if (unzGoToNextFile(handler_) == UNZ_OK) return this->create();
-			else cur_ = stream_ptr();
+			if (unzGoToNextFile(handler_) == UNZ_OK) {
+				return this->create();
+			} else {
+				cur_ = stream_ptr();
+				m_stream_ptr = nullptr;
+			}
 			return *this;
 		}
 		
 		basic_unzip_iterator operator++(int) {
-			return ++(*this);
+			basic_unzip_iterator tmp = *this;
+			++(*this);
+			return tmp;
 		}
 		
 		friend bool operator==(const basic_unzip_iterator& lhs, const basic_unzip_iterator& rhs) {
-			return lhs.cur_ == rhs.cur_;
+			return lhs.m_stream_ptr == rhs.m_stream_ptr;
 		}
 		
 		friend bool operator!=(const basic_unzip_iterator& lhs, const basic_unzip_iterator& rhs) {
@@ -151,6 +182,7 @@ namespace clx {
 		
 	private:
 		stream_ptr cur_;
+		pointer m_stream_ptr;
 		handler_type handler_{ nullptr };
 		string_type pass_;
 		
@@ -161,7 +193,13 @@ namespace clx {
 				int status = UNZ_OK;
 				if (!pass_.empty()) status = unzOpenCurrentFilePassword(handler_, pass_.c_str());
 				else status = unzOpenCurrentFile(handler_);
-				if (status == UNZ_OK) cur_ = stream_ptr(new stream_type(handler_));
+				if (status == UNZ_OK) {
+					cur_ = stream_ptr(new stream_type(handler_));
+					m_stream_ptr = cur_;
+				} else {
+					cur_ = stream_ptr();
+					m_stream_ptr = nullptr;
+				}
 			}
 			return *this;
 		}

--- a/main/unzip_iterator.h
+++ b/main/unzip_iterator.h
@@ -105,12 +105,11 @@ namespace clx {
 			this->create();
 		}
 		
-		// End-user needs to call "free" on return object
-		// returns NULL when error, or a pointer to the buffer and file_size
+		//End-user needs to call "free" on return object
+		//returns NULL when error, or a pointer to the buffer and file_size
 		void *Extract(uLong &file_size, const int ExtraAllocBytes=0) {
 			file_size = 0;
-			int err = 0; // placeholder: if you need to open the current file with password, set err accordingly
-			// Example (commented out in original): unzOpenCurrentFilePassword((unzFile)handler_, pass_.c_str());
+			int err = 0;// unzOpenCurrentFilePassword((unzFile)handler_, pass_.c_str());
 			if (err != UNZ_OK)
 			{
 				//printf("error %d with zipfile in unzOpenCurrentFilePassword\n",err);
@@ -125,7 +124,7 @@ namespace clx {
 			unsigned char *buf = (unsigned char*)malloc(file_size + ExtraAllocBytes);
 			if (buf == NULL)
 				return NULL;
-			// Extract into our buffer
+			//Extract into our buffer
 			int offset = 0;
 			int tot_read = 0;
 			do


### PR DESCRIPTION
With the help off copilot I have solved some compiling Warnings;

```
main/unzip_iterator.h:53:50: warning: 'template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator' is deprecated [-Wdeprecated-declarations]
   53 |         class basic_unzip_iterator : public std::iterator<std::input_iterator_tag, basic_unzip_stream<CharT, Traits> > {
      |                                                  ^~~~~~~~
In file included from /usr/include/c++/12/string:45,
                 from /home/lauwers/domoticz/main/stdafx.h:18,
                 from /home/lauwers/domoticz/CMakeFiles/domoticz.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/c++/12/bits/stl_iterator_base_types.h:127:34: note: declared here
  127 |     struct _GLIBCXX17_DEPRECATED iterator
```

```
warning: ‘%02d’ directive output may be truncated writing 2 bytes into a region of size between 0 and 16 [-Wformat-truncation=]
  249 |         snprintf(szStartTime, sizeof(szStartTime), "%04d-%02d-%02d %02d:%02d:%02d", last_hour.tm_year + 1900, last_hour.tm_mon + 1, last_hour.tm_mday, last_hour.tm_hour, 0, 0);
      |                                                                         ^~~~
In file included from /usr/include/stdio.h:894,
                 from /home/runner/work/domoticz/domoticz/main/stdafx.h:16,
                 from /home/runner/work/domoticz/domoticz/CMakeFiles/domoticz.dir/cmake_pch.hxx:5,
                 from <command-line>:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:71:35: note: ‘__builtin___snprintf_chk’ output between 20 and 54 bytes into a destination of size 30
   71 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   72 |                                    __glibc_objsize (__s), __fmt,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   73 |                                    __va_arg_pack ());
      |                                    ~~~~~~~~~~~~~~~~~
```

There is still a Warning from JSON-Reader

Kind Regards