### PR TITLE
MQTT: Reinstate 'total_increasing' support for kWh sensors

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2055,34 +2055,27 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 			return false;
 		}
 
+		sValue = std_format("%.3f", fUsage);
+
 		float fkWh = 0.0F;
 		_tMQTTASensor* pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "kwh");
-		if (pkWhSensor)
-			fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) * 1000.0F;
-		else
-		{
+		if (!pkWhSensor)
 			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wh");
-			if (pkWhSensor)
-				fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str()));
-			else
-			{
-				pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
-				if (pkWhSensor)
-					fkWh = static_cast<float>(atof(pkWhSensor->last_value.c_str())) / 60.0F;
-			}
-		}
+		if (!pkWhSensor)
+			pkWhSensor = get_auto_discovery_sensor_unit(pSensor, "wm");
+
 		if (pkWhSensor)
 		{
 			if (pkWhSensor->last_received != 0)
 			{
-				pkWhSensor->sValue = std_format("%.3f;%.3f", fUsage, fkWh);
+				pkWhSensor->sValue = std_format("%.3f;%.3f", fUsage, pkWhSensor->prev_value);
+
 				mosquitto_message xmessage;
 				xmessage.retain = false;
 				// Trigger extra update for the kWh sensor with the new W value
 				handle_auto_discovery_sensor(pkWhSensor, &xmessage);
 			}
 		}
-		sValue = std_format("%.3f", fUsage);
 	}
 	else if (
 		(szUnit == "kwh")
@@ -2109,27 +2102,61 @@ bool MQTTAutoDiscover::GuessSensorTypeValue(_tMQTTASensor* pSensor, uint8_t& dev
 			return false;
 		}
 
-		if (dkWh == 0)
+		// zwavejs2mqtt and ZWave-JS UI lie about 'total_increasing'. Don't trust them.
+		// https://github.com/domoticz/domoticz/issues/6180#issuecomment-3516413840
+		bool bTotalIncreasing = (pSensor->state_class == "total_increasing" &&
+					 !pSensor->unique_id.find("zwave"));
+
+		// Zero could be the first ever value received.
+		// Or it could also be that the middleware sends 0 when it has not received it before
+		if (dkWh == 0 || bTotalIncreasing)
 		{
-			//could be the first every value received.
-			//could also be that this the middleware sends 0 when it has not received it before
-			auto result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
-				m_HwdID, pSensor->unique_id.c_str(), devType, subType);
-			if (!result.empty())
+			double dPrevkWh = pSensor->prev_value;
+
+			if (pSensor->last_received != 0)
 			{
-				std::vector<std::string> strarray;
-				StringSplit(result[0][0], ";", strarray);
-				if (strarray.size() == 2)
-				{
-					dkWh = atof(strarray[1].c_str());
+				auto result = m_sql.safe_query("SELECT sValue,StrParam1 FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
+					m_HwdID, pSensor->unique_id.c_str(), devType, subType);
+				if (!result.empty()) {
+					std::vector<std::string> strarray;
+					StringSplit(result[0][0], ";", strarray);
+					if (strarray.size() == 2)
+						dPrevkWh = atof(strarray[1].c_str());
+
+					// For total_increasing sensors, the epoch is stored in StrParam1
+					if (!result[0][1].empty())
+						pSensor->epoch = atof(result[0][1].c_str());
 				}
 			}
+
+			// GuessSensorTypeValue() is sometimes invoked with empty sValue to do
+			// only what its name implies, nothing more. Do not bump the epoch when
+			// when that happens; just use the previous value.
+			if (dkWh == 0)
+			{
+				dkWh = dPrevkWh;
+			}
+			else if (bTotalIncreasing)
+			{
+				// If the value resulting from this reading would be lower than the
+				// previous value, the sensor must have reset. Bump its epoch, which
+				// we store in StrParam1.
+				if (dkWh + pSensor->epoch < dPrevkWh)
+				{
+					pSensor->epoch = dPrevkWh;
+					m_sql.safe_query("UPDATE DeviceStatus SET StrParam1='%f' WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Type==%d) AND (Subtype==%d)",
+							 pSensor->epoch, m_HwdID, pSensor->unique_id.c_str(), devType, subType);
+				}
+
+				dkWh += pSensor->epoch;
+			}
 		}
+		pSensor->prev_value = dkWh;
 
 		_tMQTTASensor* pWattSensor = get_auto_discovery_sensor_WATT_unit(pSensor);
-		if (pWattSensor)
+		if (pWattSensor && pWattSensor->last_received != 0)
 		{
-			dUsage = atof(pWattSensor->last_value.c_str());
+			dUsage = atof(pWattSensor->sValue.c_str());
 		}
 		sValue = std_format("%.3f;%.3f", dUsage, dkWh);
 	}

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -152,6 +152,8 @@ class MQTTAutoDiscover : public MQTT
 
 		bool bOnline = false;
 		time_t last_received = 0;
+		double prev_value = 0;
+		double epoch = 0;
 		std::string last_value;
 		std::string last_topic;
 		bool bIsJSON = false;


### PR DESCRIPTION
This was reverted due to a ZWave-JS-UI bug where it advertised sensors with 'total_increasing' even when they shouldn't be. So this commit reinstates it except *not* for ZWave devices.

A state class of "total_increasing" indicates "a monotonically increasing increasing positive total which periodically restarts counting from 0" … "A decreasing value is interpreted as the start of a new meter cycle or the replacement of the meter".

Handle this by storing an "epoch" for the measurement; this is the base value added to the raw measurement, to reach the actual total to be recorded.

If the result of adding a measurement to this epoch is ever *lower* than the previous recorded value, that means the counter must have restarted, so the epoch is increased to match the previous value and we keep counting from there.

The epoch is stored in "StrParam1" of the DeviceStatus record.

Clean up the matching of power and usage sensors to use the *actual* value of the paired sensor instead of its raw last_value. This keeps knowledge about one type of sensor away from the other type. So the code handling the Watt sensor no longer needs to care about different multipliers for kWh/Wh/Wm sensors, etc. — and, more to the point, doesn't need to learn about the epoch handling. It was already failing to throw away bogus (< -1000000) readings as the paired sensor should.

Fixes: #6160