### PR TITLE
Fix CounterHelper race condition on simultaneous restart

### DIFF
--- a/hardware/CounterHelper.cpp
+++ b/hardware/CounterHelper.cpp
@@ -21,10 +21,13 @@ void CounterHelper::Reset()
 	m_sql.safe_query("UPDATE UserVariables SET Value='%q', LastUpdate='%s' WHERE (Name=='%q')", std::to_string(m_CounterOffset).c_str(), TimeToString(nullptr, TF_DateTime).c_str(), m_szUservariableName.c_str());
 }
 
-void CounterHelper::Init(const std::string& szUservariableName, CDomoticzHardwareBase* pHardwareBase)
+void CounterHelper::Init(const std::string& szUservariableName, CDomoticzHardwareBase* pHardwareBase, int NodeID, int ChildID)
 {
 	m_szUservariableName = szUservariableName;
 	m_pHardwareBase = pHardwareBase;
+	m_NodeID = NodeID;
+	m_ChildID = ChildID;
+
 	auto result = m_sql.safe_query("SELECT ID, Value FROM UserVariables WHERE (Name=='%q')", m_szUservariableName.c_str());
 	if (result.empty())
 	{
@@ -34,6 +37,20 @@ void CounterHelper::Init(const std::string& szUservariableName, CDomoticzHardwar
 	if (!result.empty())
 	{
 		m_CounterOffset = std::stod(result[0][1]);
+	}
+
+	// Restore m_nLastCounterValue from the device's last reported total
+	auto device_result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d)",
+		m_pHardwareBase->m_HwdID, std::to_string(m_NodeID).c_str(), m_ChildID);
+	if (!device_result.empty())
+	{
+		// sValue format for kWh meters is "usage;total" - extract the total
+		std::string sValue = device_result[0][0];
+		size_t pos = sValue.find(';');
+		if (pos != std::string::npos)
+		{
+			m_nLastCounterValue = std::stod(sValue.substr(pos + 1));
+		}
 	}
 }
 

--- a/hardware/CounterHelper.h
+++ b/hardware/CounterHelper.h
@@ -9,7 +9,7 @@ class CounterHelper
 public:
 	CounterHelper();
 	~CounterHelper();
-	void Init(const std::string &szUservariableName, CDomoticzHardwareBase *pHardwareBase);
+	void Init(const std::string &szUservariableName, CDomoticzHardwareBase *pHardwareBase, int NodeID, int ChildID);
 	void SendKwhMeter(int NodeID, int ChildID, int BatteryLevel, double musage, double mtotal, const std::string& defaultname, int RssiLevel = 12);
 	double SetCounterValue(const double nNewCounbterValue);
 	double GetCounterValue() const { return m_nLastCounterValue; };
@@ -17,6 +17,8 @@ public:
 private:
 	std::string m_szUservariableName;
 	CDomoticzHardwareBase* m_pHardwareBase = nullptr;
+	int m_NodeID = 0;
+	int m_ChildID = 0;
 
 	double m_nLastCounterValue = 0;
 	double m_CounterOffset = 0;

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -163,7 +163,7 @@ EnphaseAPI::EnphaseAPI(
 	//(We can probably not use them both at the same time)
 
 	//Init Production counter
-	m_ProductionCounter.Init("EnphaseOffset_Production_" + std::to_string(m_HwdID), this);
+	m_ProductionCounter.Init("EnphaseOffset_Production_" + std::to_string(m_HwdID), this, m_HwdID, 1);
 }
 
 bool EnphaseAPI::StartHardware()

--- a/hardware/MitsubishiWF.cpp
+++ b/hardware/MitsubishiWF.cpp
@@ -74,7 +74,7 @@ MitsubishiWF::MitsubishiWF(const int ID, const std::string& IPAddress, const uns
 		PollInterval = 300;
 	m_poll_interval = PollInterval;
 
-	m_kWhCounter.Init("MitsubishiWF_kWh_" + std::to_string(ID), this);
+	m_kWhCounter.Init("MitsubishiWF_kWh_" + std::to_string(ID), this, 1, 1);
 }
 
 bool MitsubishiWF::StartHardware()


### PR DESCRIPTION
When both Domoticz and a meter device restart simultaneously, the m_nLastCounterValue was not persisted, causing rollover detection to fail. The meter would reset to 0 and the monotonic counter would incorrectly report the old offset value instead of continuing from the last reported total.

Fix by:
- Adding NodeID and ChildID parameters to Init()
- Querying DeviceStatus to restore m_nLastCounterValue from the device's last reported total value on restart
- This allows proper rollover detection even when both systems reset

Note: This fix is entirely untested.