### PR TITLE
MQTT AutoDiscover: Fix fan and light device handling

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5055,7 +5055,54 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 		}
 		sValue = std_format("%d", level);
 
-		if (pSensor->devType != pTypeColorSwitch)
+		// For fans with separate state and percentage topics, only update the relevant value
+		if (pSensor->component_type == "fan")
+		{
+			if (!pSensor->percentage_state_topic.empty() && !pSensor->state_topic.empty())
+			{
+				if (pSensor->last_topic == pSensor->state_topic)
+				{
+					// Keep existing level
+					sValue = result[0][3];
+					level = atoi(sValue.c_str());
+					// If turning on, set nValue based on level
+					if (bOn)
+					{
+						if (level == 100)
+							nValue = gswitch_sOn;
+						else
+							nValue = gswitch_sSetLevel;
+						// Ensure LastLevel gets updated when turning on with a level
+						bHaveLevelChange = true;
+					}
+					else
+					{
+						nValue = gswitch_sOff;
+					}
+				}
+				else if (pSensor->last_topic == pSensor->percentage_state_topic)
+				{
+					// Keep existing on/off state - read current nValue
+					int currentNValue = atoi(result[0][2].c_str());
+					// Preserve whether it's on (1) or off (0), but update level representation
+					if (currentNValue == gswitch_sOff)
+					{
+						nValue = gswitch_sOff;
+					}
+					else
+					{
+						// It's on - set nValue based on level
+						if (level == 100)
+							nValue = gswitch_sOn;
+						else
+							nValue = gswitch_sSetLevel;
+						// Ensure LastLevel gets updated when fan is on
+						bHaveLevelChange = true;
+					}
+				}
+			}
+		}
+		else if (pSensor->devType != pTypeColorSwitch)
 		{
 			if (szSwitchCmd == "Set Level")
 			{

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5328,14 +5328,9 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 			if (pSensor->brightness_value_template.empty())
 			{
 				root["brightness"] = slevel;
-
-				//This seems to cause issues for Tuya 2 gang dimmers... not sure why
-				//not sure if this is needed for other devices
-				if (
-					(m_discovered_devices[pSensor->device_identifiers].manufacturer == "TuYa")
-					|| (m_discovered_devices[pSensor->device_identifiers].manufacturer == "Tuya")
-					|| (m_discovered_devices[pSensor->device_identifiers].manufacturer == "AVATTO")
-					)
+				// Only include state if the device supports ON/OFF payloads
+				// (some devices handle brightness without needing explicit ON/OFF commands)
+				if (!pSensor->payload_on.empty())
 				{
 					root["state"] = (slevel > 0) ? pSensor->payload_on : pSensor->payload_off;
 				}

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5678,15 +5678,22 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 		if (Unit == 1)
 		{
 			if (command == "On")
-				szSendValue = "50";
+				szSendValue = "ON";
 			else if (command == "Off")
-				szSendValue = "0";
+				szSendValue = "OFF";
 			else if (command == "Set Level")
 			{
 				if (level > 100)
 					level = 100;
-				int slevel = (int)round((255 / 100.0F) * level);
-				szSendValue = std::to_string(slevel);
+				// For fans with separate state and percentage topics, send ON if currently off
+				if (!pSensor->percentage_command_topic.empty() && !pSensor->command_topic.empty())
+				{
+					if (pSensor->nValue == gswitch_sOff && level > 0)
+					{
+						SendMessage(pSensor->command_topic, "ON");
+					}
+				}
+				szSendValue = std::to_string(level);
 				command_topic = pSensor->percentage_command_topic;
 			}
 		}

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5004,6 +5004,13 @@ void MQTTAutoDiscover::InsertUpdateSwitch(_tMQTTASensor* pSensor)
 					else if (szSwitchCmd == pSensor->state_locked)
 						szSwitchCmd = "on";
 				}
+				else if (pSensor->component_type == "fan")
+				{
+					if (szSwitchCmd == pSensor->payload_off)
+						szSwitchCmd = "off";
+					else if (szSwitchCmd == pSensor->payload_on)
+						szSwitchCmd = "on";
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes several issues with MQTT AutoDiscover fan and light devices (#6440)

**Fan Fixes:**
1. Add support for custom payload_on/payload_off values in fan state messages
2. Handle fans with separate state_topic (ON/OFF) and percentage_state_topic (speed level) - prevents state and level from overwriting each other
3. Fix command sending: send "ON"/"OFF" instead of "50"/"0", use 0-100 percentage instead of 0-255 scale
4. For fans with separate command topics: automatically send ON command when setting level from UI while fan is off

**Light Fixes:**
1. Include state field in brightness JSON based on whether payload_on is defined, rather than manufacturer-specific check
2. Supports lights that handle brightness without explicit ON/OFF commands (per Home Assistant MQTT light documentation)

These changes ensure proper state synchronization for devices with split state/level topics and fix broken fan command sending.
