### PR TITLE
Clean up MQTT to remove unneeded extra thread, reduce CPU and memory usage

### DIFF
--- a/hardware/MQTT.cpp
+++ b/hardware/MQTT.cpp
@@ -123,11 +123,6 @@ bool MQTT::StopHardware()
 		m_thread->join();
 		m_thread.reset();
 	}
-	if (m_mqtt_thread)
-	{
-		m_mqtt_thread->join();
-		m_mqtt_thread.reset();
-	}
 	m_IsConnected = false;
 	return true;
 }
@@ -199,7 +194,7 @@ void MQTT::on_message(const struct mosquitto_message *message)
 	std::string qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
 
 	Debug(DEBUG_HARDWARE, "Topic: %s, Message: %s", topic.c_str(), qMessage.c_str());
-	
+
 	if (qMessage.empty())
 		return;
 
@@ -584,7 +579,6 @@ void MQTT::on_disconnect(int rc)
 	{
 		if (!IsStopRequested(0))
 		{
-			disconnect();
 			if (rc == 5)
 			{
 				Log(LOG_ERROR, "Disconnected, Invalid Username/Password (rc=%d)", rc);
@@ -602,11 +596,6 @@ void MQTT::on_disconnect(int rc)
 //called when hardware is stopped
 void MQTT::on_going_down()
 {
-	if (isConnected())
-	{
-		m_IsConnected = false;
-		disconnect();
-	}
 }
 
 bool MQTT::ReconnectNow()
@@ -683,39 +672,97 @@ bool MQTT::ConnectIntEx()
 void MQTT::Do_Work()
 {
 	bool bFirstTime = true;
-	int sec_counter = 0;
+	time_t last_heartbeat = mytime(nullptr);
+	time_t last_reconnect = mytime(nullptr);
+	time_t last_ping = mytime(nullptr);
 
 	set_callbacks();
 
-	time_t last_time = time(nullptr);
-
-	while (!IsStopRequested(1000))
+	while (!IsStopRequested(0))
 	{
-		sec_counter++;
+		time_t now = mytime(nullptr);
 
-		if (sec_counter % 12 == 0)
-		{
-			m_LastHeartbeat = mytime(nullptr);
-		}
-
+		// Handle periodic tasks
 		if (bFirstTime)
 		{
 			bFirstTime = false;
 			ConnectInt();
-
-			m_mqtt_thread = std::make_shared<std::thread>([this] { Do_MQTT_Work(); });
-			SetThreadNameInt(m_mqtt_thread->native_handle());
+			last_heartbeat = last_reconnect = last_ping = now;
 		}
 		else
 		{
-			if (sec_counter % 30 == 0)
+			if (now - last_heartbeat >= 12)
 			{
-				if (m_bDoReconnect)
-					ConnectIntEx();
+				m_LastHeartbeat = now;
+				last_heartbeat = now;
 			}
-			if (isConnected() && sec_counter % 10 == 0)
+
+			if (m_bDoReconnect && now - last_reconnect >= 30)
+			{
+				ConnectIntEx();
+				last_reconnect = now;
+			}
+
+			if (isConnected() && now - last_ping >= 10)
 			{
 				SendHeartbeat();
+				last_ping = now;
+			}
+		}
+
+		// Get mosquitto socket
+		int mosq_fd = socket();
+
+		// Setup select with both mosquitto socket and stop fd
+		fd_set rfds, wfds;
+		FD_ZERO(&rfds);
+		FD_ZERO(&wfds);
+
+		int stop_fd = GetStopFd();
+		FD_SET(stop_fd, &rfds);
+		int maxfd = stop_fd;
+
+		if (mosq_fd >= 0)
+		{
+			FD_SET(mosq_fd, &rfds);
+			if (want_write())
+				FD_SET(mosq_fd, &wfds);
+			if (mosq_fd > maxfd)
+				maxfd = mosq_fd;
+		}
+
+		// Wait up to 1 second for activity
+		struct timeval tv;
+		tv.tv_sec = 1;
+		tv.tv_usec = 0;
+
+		int ret = select(maxfd + 1, &rfds, &wfds, nullptr, &tv);
+
+		if (ret > 0)
+		{
+			// Check for stop signal
+			if (FD_ISSET(stop_fd, &rfds))
+				break;
+
+			// Handle mosquitto I/O
+			if (mosq_fd >= 0)
+			{
+				try
+				{
+					if (FD_ISSET(mosq_fd, &rfds))
+						loop_read();
+					if (FD_ISSET(mosq_fd, &wfds))
+						loop_write();
+					loop_misc();
+				}
+				catch (const std::exception &)
+				{
+					if (!IsStopRequested(0))
+					{
+						if (!m_bDoReconnect)
+							reconnect();
+					}
+				}
 			}
 		}
 	}
@@ -730,27 +777,6 @@ void MQTT::Do_Work()
 		m_sSwitchSceneConnection.disconnect();
 
 	Log(LOG_STATUS, "Worker stopped...");
-}
-
-void MQTT::Do_MQTT_Work()
-{
-	while (!IsStopRequested(5))
-	{
-		if (!m_bDoReconnect)
-		{
-			int rc = loop_forever();
-			if (rc)
-			{
-				if (rc != MOSQ_ERR_NO_CONN)
-				{
-					if (!IsStopRequested(0))
-					{
-						m_bDoReconnect = true;
-					}
-				}
-			}
-		}
-	}
 }
 
 void MQTT::SendHeartbeat()

--- a/hardware/MQTT.h
+++ b/hardware/MQTT.h
@@ -74,12 +74,10 @@ private:
 	void SendSceneInfo(uint64_t SceneIdx, const std::string& SceneName);
 	void StopMQTT();
 	void Do_Work();
-	void Do_MQTT_Work();
 	void SubscribeTopic(const std::string& szTopic, int qos = -1);
 	virtual void SendHeartbeat();
 	void WriteInt(const std::string& sendStr) override;
 	std::shared_ptr<std::thread> m_thread;
-	std::shared_ptr<std::thread> m_mqtt_thread;
 	boost::signals2::connection m_sDeviceReceivedConnection;
 	boost::signals2::connection m_sSwitchSceneConnection;
 	_ePublishTopics m_publish_scheme;


### PR DESCRIPTION
A previous commit (hidden in with unrelated CounterHelper changes) changed MQTT to use *two* threads, to work around the problem that our worker threads are always obsessed with their own death: they spend their entire time just waiting to die in `IsStopRequested()` even while there is actual work for them to do.

Only when their `IsStopRequested()` call times out without them being asked to die, do they do some work just kind of as an afterthought. This is why MQTT was so slow (#6433) — because the thread was spending 100ms at a time waiting to see if it should die, while it had a backlog of message to process!

The previous commit worked around this by introducing yet another thread, which runs the `mosquitto_loop_forever()` and actually *does* wake up promptly when it has work to do. So the original `MQTT::Do_Work()` was now free to obsess only about death, as its primary job now is *just* to react to the stop signal by calling `mosquitto_disconnect()`.

This worked because mosquitto's own loop function *does* have a proper worker thread model which can wake up promptly on *either* work *or* the stop/disconnect request.

Now that our `StoppableThread` implementation has been fixed to allow threads to wait for both work *and* stop signal efficiently, there's no need for spawning a separate thread just to work around its limitations. Remove that, and use our own worker thread for its intended purpose with the improved `StoppableThread` implementation.