### PR TITLE
Add combined Temperature/Setpoint for thermostats

### DIFF
--- a/hardware/Dummy.cpp
+++ b/hardware/Dummy.cpp
@@ -69,7 +69,7 @@ namespace http {
 			int subtype;
 		};
 
-		constexpr std::array<_mappedsensorname, 40> mappedsensorname{ {
+		constexpr std::array<_mappedsensorname, 44> mappedsensorname{ {
 			{ 249, pTypeAirQuality, sTypeVoc },	   // Air Quality
 			{ 7, pTypeGeneral, sTypeAlert },		   // Alert
 			{ 9, pTypeCURRENT, sTypeELEC1 },		   // Ampere (3 Phase)
@@ -109,7 +109,11 @@ namespace http {
 			{ 4, pTypeGeneral, sTypeVoltage },		   // Voltage
 			{ 1000, pTypeGeneral, sTypeWaterflow },		   // Waterflow
 			{ 86, pTypeWIND, sTypeWIND1 },			   // Wind
-			{ 1001, pTypeWIND, sTypeWIND4 }			   // Wind+Temp+Chill
+			{ 1001, pTypeWIND, sTypeWIND4 },			   // Wind+Temp+Chill
+			{ 1006, pTypeThermostat6, sTypeThermostat6Temp },	   // Thermostat (Temperature/Setpoint)
+			{ 1007, pTypeThermostat6, sTypeThermostat6TempHum },	   // Thermostat (Temperature/Humidity/Setpoint)
+			{ 1008, pTypeThermostat6, sTypeThermostat6TempBaro },	   // Thermostat (Temperature/Barometer/Setpoint)
+			{ 1009, pTypeThermostat6, sTypeThermostat6TempHumBaro }	   // Thermostat (Temperature/Humidity/Barometer/Setpoint)
 		} };
 
 		//TODO: Is this function called from anywhere, or can it be removed?

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1519,6 +1519,14 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 			pSensor->current_temperature_template = root["current_temperature_template"].asString();
 		if (!root["curr_temp_tpl"].empty())
 			pSensor->current_temperature_template = root["curr_temp_tpl"].asString();
+		if (!root["current_humidity_topic"].empty())
+			pSensor->current_humidity_topic = root["current_humidity_topic"].asString();
+		if (!root["curr_hum_t"].empty())
+			pSensor->current_humidity_topic = root["curr_hum_t"].asString();
+		if (!root["current_humidity_template"].empty())
+			pSensor->current_humidity_template = root["current_humidity_template"].asString();
+		if (!root["curr_hum_tpl"].empty())
+			pSensor->current_humidity_template = root["curr_hum_tpl"].asString();
 		if (!root["preset_modes"].empty())
 		{
 			for (const auto& ittMode : root["preset_modes"])
@@ -3481,6 +3489,24 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 		bIsJSON = root.isObject();
 	}
 
+	// Check for legacy devices once on first message
+	if (pSensor->devType == 0)
+	{
+		// If both topics exist, check database for old devices
+		if (!pSensor->temperature_command_topic.empty() && !pSensor->current_temperature_topic.empty())
+		{
+			std::vector<std::vector<std::string>> old_dev;
+			old_dev = m_sql.safe_query("SELECT COUNT(*) FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d OR Type==%d)",
+				m_HwdID, pSensor->unique_id.c_str(), CLIMATE_TEMP_SETPOINT_UNIT, pTypeTEMP, pTypeSetpoint);
+			pSensor->bUseLegacyClimate = !old_dev.empty() && atoi(old_dev[0][0].c_str()) > 0;
+		}
+		else
+		{
+			// Without both topics, always use legacy standalone handlers
+			pSensor->bUseLegacyClimate = true;
+		}
+	}
+
 	// Create/update Selector device for config and update payloads 
 	bool bValid = true;
 	bool isNull = false;
@@ -4246,15 +4272,6 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 		}
 	}
 
-	// Create/update SetPoint Thermostat for config and update payloads 
-	bValid = InsertUpdateSetpoint(
-		pSensor,
-		pSensor->temperature_command_topic,
-		pSensor->temperature_state_topic,
-		pSensor->temperature_state_template,
-		CLIMATE_TEMP_SETPOINT_UNIT,
-		message);
-
 	// Create/update SetPoint High Thermostat for config and update payloads 
 	bValid = InsertUpdateSetpoint(
 		pSensor,
@@ -4273,7 +4290,174 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 		CLIMATE_LOW_TEMP_SETPOINT_UNIT,
 		message);
 
-	// Create/update Temp device for config and update payloads
+	// Create/update combined Thermostat6 device for temp+setpoint
+	if (!pSensor->bUseLegacyClimate)
+	{
+		// Use new combined Thermostat6 device
+		double temp_current = 0;
+		double temp_setpoint = 18;
+		int humidity = 50;
+		int humidity_status = 1;
+		bool bHaveTemp = false;
+		bool bHaveSetpoint = false;
+		bool bHaveHumidity = false;
+
+		// Parse current temperature
+		if (pSensor->current_temperature_topic == topic)
+		{
+			if (bIsJSON && !pSensor->current_temperature_template.empty())
+			{
+				std::string tstring = GetValueFromTemplate(root, pSensor->current_temperature_template, isNull);
+				if (!tstring.empty())
+				{
+					temp_current = atof(tstring.c_str());
+					bHaveTemp = true;
+				}
+			}
+			else if (!bIsJSON)
+			{
+				temp_current = atof(qMessage.c_str());
+				bHaveTemp = true;
+			}
+		}
+
+		// Parse setpoint temperature
+		if (pSensor->temperature_state_topic == topic)
+		{
+			if (bIsJSON && !pSensor->temperature_state_template.empty())
+			{
+				std::string tstring = GetValueFromTemplate(root, pSensor->temperature_state_template, isNull);
+				if (!tstring.empty())
+				{
+					temp_setpoint = atof(tstring.c_str());
+					bHaveSetpoint = true;
+				}
+			}
+			else if (!bIsJSON)
+			{
+				temp_setpoint = atof(qMessage.c_str());
+				bHaveSetpoint = true;
+			}
+		}
+
+		// Parse current humidity
+		if (!pSensor->current_humidity_topic.empty() && pSensor->current_humidity_topic == topic)
+		{
+			if (bIsJSON && !pSensor->current_humidity_template.empty())
+			{
+				std::string hstring = GetValueFromTemplate(root, pSensor->current_humidity_template, isNull);
+				if (!hstring.empty())
+				{
+					humidity = atoi(hstring.c_str());
+					bHaveHumidity = true;
+				}
+			}
+			else if (!bIsJSON)
+			{
+				humidity = atoi(qMessage.c_str());
+				bHaveHumidity = true;
+			}
+		}
+
+		// Convert from Fahrenheit if needed
+		std::string szUnit = pSensor->temperature_unit;
+		stdlower(szUnit);
+		if (szUnit == "°f" || szUnit == "\xB0" "f" || szUnit == "f" || szUnit == "?f")
+		{
+			if (bHaveTemp)
+				temp_current = ConvertToCelsius(temp_current);
+			if (bHaveSetpoint)
+				temp_setpoint = ConvertToCelsius(temp_setpoint);
+		}
+
+		if (bHaveTemp || bHaveSetpoint || bHaveHumidity)
+		{
+			int Unit = CLIMATE_TEMP_SETPOINT_UNIT;
+			pSensor->devType = pTypeThermostat6;
+
+			// Determine subtype based on available data
+			bool bHasHumidity = !pSensor->current_humidity_topic.empty();
+			pSensor->subType = bHasHumidity ? sTypeThermostat6TempHum : sTypeThermostat6Temp;
+
+			// Query existing device to get current values
+			std::vector<std::vector<std::string>> result;
+			result = m_sql.safe_query("SELECT Name,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (Subtype==%d)",
+				m_HwdID, pSensor->unique_id.c_str(), Unit, pSensor->devType, pSensor->subType);
+
+			if (!result.empty())
+			{
+				// Parse existing values
+				std::vector<std::string> fields;
+				StringSplit(result[0][1], ";", fields);
+				if (bHasHumidity && fields.size() >= 4)
+				{
+					if (!bHaveTemp)
+						temp_current = atof(fields[0].c_str());
+					if (!bHaveSetpoint)
+						temp_setpoint = atof(fields[1].c_str());
+					if (!bHaveHumidity)
+					{
+						humidity = atoi(fields[2].c_str());
+						humidity_status = atoi(fields[3].c_str());
+					}
+				}
+				else if (!bHasHumidity && fields.size() >= 2)
+				{
+					if (!bHaveTemp)
+						temp_current = atof(fields[0].c_str());
+					if (!bHaveSetpoint)
+						temp_setpoint = atof(fields[1].c_str());
+				}
+			}
+
+			// Calculate humidity status
+			if (bHaveHumidity)
+				humidity_status = Get_Humidity_Level(humidity);
+
+			pSensor->nValue = 0;
+			if (bHasHumidity)
+				pSensor->sValue = std_format("%.1f;%.1f;%d;%d", temp_current, temp_setpoint, humidity, humidity_status);
+			else
+				pSensor->sValue = std_format("%.1f;%.1f", temp_current, temp_setpoint);
+
+			if (result.empty())
+			{
+				// Insert new device
+				if (!m_sql.m_bAcceptNewHardware)
+				{
+					Log(LOG_NORM, "Accept new hardware disabled. Ignoring new sensor %s", pSensor->name.c_str());
+					return;
+				}
+				int iUsed = (pSensor->bEnabled_by_default) ? 1 : 0;
+				m_sql.safe_query("INSERT INTO DeviceStatus (HardwareID, OrgHardwareID, DeviceID, Unit, Type, SubType, SignalLevel, BatteryLevel, Name, Used, nValue, sValue) "
+					"VALUES (%d, %d, '%q', %d, %d, %d, %d, %d, '%q', %d, %d, '%q')",
+					m_HwdID, 0, pSensor->unique_id.c_str(), Unit, pSensor->devType, pSensor->subType, pSensor->SignalLevel, pSensor->BatteryLevel, pSensor->name.c_str(), iUsed,
+					pSensor->nValue, pSensor->sValue.c_str());
+			}
+			else
+			{
+				// Update
+				UpdateValueInt(m_HwdID, pSensor->unique_id.c_str(), Unit, pSensor->devType, pSensor->subType, pSensor->SignalLevel, pSensor->BatteryLevel, pSensor->nValue,
+					pSensor->sValue.c_str(), result[0][0]);
+			}
+		}
+
+			return; // Don't fall through to legacy handlers
+	}
+
+	// Standalone setpoint device (when no temp topic, or legacy mode with both topics)
+	if (!pSensor->temperature_command_topic.empty())
+	{
+		bValid = InsertUpdateSetpoint(
+			pSensor,
+			pSensor->temperature_command_topic,
+			pSensor->temperature_state_topic,
+			pSensor->temperature_state_template,
+			CLIMATE_TEMP_SETPOINT_UNIT,
+			message);
+	}
+
+	// Standalone temp device (when no setpoint topic, or legacy mode with both topics)
 	bValid = true;
 	if (pSensor->current_temperature_topic == topic)
 	{
@@ -6075,8 +6259,29 @@ bool MQTTAutoDiscover::SetSetpoint(const std::string& DeviceID, const uint8_t Un
 	}
 
 	std::vector<std::vector<std::string>> result;
-	result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (Subtype==%d)",
-		m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeSetpoint, sTypeSetpoint);
+
+	// Use the flag to determine device type
+	bool bIsTempHum = false;
+	if (!pSensor->bUseLegacyClimate)
+	{
+		// Check for Thermostat6 device (combined temp+setpoint or temp+hum+setpoint)
+		result = m_sql.safe_query("SELECT Name,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (Subtype==%d)",
+			m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeThermostat6, sTypeThermostat6Temp);
+
+		if (result.empty())
+		{
+			result = m_sql.safe_query("SELECT Name,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (Subtype==%d)",
+				m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeThermostat6, sTypeThermostat6TempHum);
+			bIsTempHum = !result.empty();
+		}
+	}
+	else
+	{
+		// Legacy pTypeSetpoint device
+		result = m_sql.safe_query("SELECT Name,sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (Subtype==%d)",
+			m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeSetpoint, sTypeSetpoint);
+	}
+
 	if (result.empty())
 		return false; //?? That's impossible
 
@@ -6123,11 +6328,34 @@ bool MQTTAutoDiscover::SetSetpoint(const std::string& DeviceID, const uint8_t Un
 	//Because thermostats could be battery operated and not listening 24/7
 	//we force a value update internally in Domoticz so the user sees the just set SetPoint
 
-	pSensor->sValue = std_format("%.2f", Temp);
-	// Update
-	UpdateValueInt(m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeSetpoint, sTypeSetpoint, pSensor->SignalLevel, pSensor->BatteryLevel,
-		pSensor->nValue, pSensor->sValue.c_str(),
-		result[0][0]);
+	if (!pSensor->bUseLegacyClimate)
+	{
+		// Update Thermostat6 device - preserve current temp and humidity, update setpoint
+		std::vector<std::string> fields;
+		StringSplit(result[0][1], ";", fields);
+		double temp_current = (fields.size() >= 1) ? atof(fields[0].c_str()) : 20.0;
+		if (bIsTempHum && fields.size() >= 4)
+		{
+			int humidity = atoi(fields[2].c_str());
+			int humidity_status = atoi(fields[3].c_str());
+			pSensor->sValue = std_format("%.1f;%.1f;%d;%d", temp_current, Temp, humidity, humidity_status);
+			UpdateValueInt(m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeThermostat6, sTypeThermostat6TempHum, pSensor->SignalLevel, pSensor->BatteryLevel,
+				pSensor->nValue, pSensor->sValue.c_str(), result[0][0]);
+		}
+		else
+		{
+			pSensor->sValue = std_format("%.1f;%.1f", temp_current, Temp);
+			UpdateValueInt(m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeThermostat6, sTypeThermostat6Temp, pSensor->SignalLevel, pSensor->BatteryLevel,
+				pSensor->nValue, pSensor->sValue.c_str(), result[0][0]);
+		}
+	}
+	else
+	{
+		// Update old pTypeSetpoint device
+		pSensor->sValue = std_format("%.2f", Temp);
+		UpdateValueInt(m_HwdID, pSensor->unique_id.c_str(), Unit, pTypeSetpoint, sTypeSetpoint, pSensor->SignalLevel, pSensor->BatteryLevel,
+			pSensor->nValue, pSensor->sValue.c_str(), result[0][0]);
+	}
 
 	return true;
 }

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -4433,6 +4433,12 @@ void MQTTAutoDiscover::handle_auto_discovery_climate(_tMQTTASensor* pSensor, con
 					"VALUES (%d, %d, '%q', %d, %d, %d, %d, %d, '%q', %d, %d, '%q')",
 					m_HwdID, 0, pSensor->unique_id.c_str(), Unit, pSensor->devType, pSensor->subType, pSensor->SignalLevel, pSensor->BatteryLevel, pSensor->name.c_str(), iUsed,
 					pSensor->nValue, pSensor->sValue.c_str());
+				result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d) AND (Type==%d) AND (Subtype==%d)", m_HwdID,
+					pSensor->unique_id.c_str(), Unit, pSensor->devType, pSensor->subType);
+				//Set options
+				std::string new_options = std_format("ValueStep:%g;ValueMin:%g;ValueMax:%g;ValueUnit:%s;", pSensor->temp_step, pSensor->temp_min, pSensor->temp_max, pSensor->temperature_unit.c_str());
+				uint64_t ullidx = std::stoull(result[0][0]);
+				m_sql.SetDeviceOptions(ullidx, m_sql.BuildDeviceOptions(new_options, false));
 			}
 			else
 			{

--- a/hardware/MQTTAutoDiscover.h
+++ b/hardware/MQTTAutoDiscover.h
@@ -106,6 +106,8 @@ class MQTTAutoDiscover : public MQTT
 		std::string temperature_unit = "C";
 		std::string current_temperature_topic;
 		std::string current_temperature_template;
+		std::string current_humidity_topic;
+		std::string current_humidity_template;
 
 		std::string temperature_high_command_topic;
 		std::string temperature_high_command_template;
@@ -156,6 +158,7 @@ class MQTTAutoDiscover : public MQTT
 		std::map<std::string, std::string> keys;
 
 		bool bOnline = false;
+		bool bUseLegacyClimate = false;
 		time_t last_received = 0;
 		std::string last_value;
 		double prev_value = 0;

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -313,6 +313,44 @@ typedef struct _tSetpoint
 	}
 } tSetpoint;
 
+typedef struct _tThermostat6
+{
+	uint8_t len;
+	uint8_t type;
+	uint8_t subtype;
+	uint8_t id1;
+	uint8_t id2;
+	uint8_t id3;
+	uint8_t id4;
+	uint8_t dunit;
+	uint8_t battery_level;
+	float temperature;
+	float setpoint;
+	uint8_t humidity;
+	uint8_t humidity_status;
+	uint16_t barometer;
+	uint8_t update_flags; // Bit flags: 0x01=temp, 0x02=setpoint, 0x04=humidity, 0x08=barometer
+
+	_tThermostat6()
+	{
+		len = sizeof(_tThermostat6) - 1;
+		type = pTypeThermostat6;
+		subtype = sTypeThermostat6Temp;
+		battery_level = 255;
+		id1 = 1;
+		id2 = 0;
+		id3 = 0;
+		id4 = 0;
+		dunit = 0;
+		temperature = 0;
+		setpoint = 0;
+		humidity = 0;
+		humidity_status = 0;
+		barometer = 0;
+		update_flags = 0;
+	}
+} tThermostat6;
+
 typedef struct _tTempBaro
 {
 	uint8_t len;

--- a/hardware/hardwaretypes.h
+++ b/hardware/hardwaretypes.h
@@ -315,40 +315,21 @@ typedef struct _tSetpoint
 
 typedef struct _tThermostat6
 {
-	uint8_t len;
-	uint8_t type;
-	uint8_t subtype;
-	uint8_t id1;
-	uint8_t id2;
-	uint8_t id3;
-	uint8_t id4;
-	uint8_t dunit;
-	uint8_t battery_level;
-	float temperature;
-	float setpoint;
-	uint8_t humidity;
-	uint8_t humidity_status;
-	uint16_t barometer;
-	uint8_t update_flags; // Bit flags: 0x01=temp, 0x02=setpoint, 0x04=humidity, 0x08=barometer
-
-	_tThermostat6()
-	{
-		len = sizeof(_tThermostat6) - 1;
-		type = pTypeThermostat6;
-		subtype = sTypeThermostat6Temp;
-		battery_level = 255;
-		id1 = 1;
-		id2 = 0;
-		id3 = 0;
-		id4 = 0;
-		dunit = 0;
-		temperature = 0;
-		setpoint = 0;
-		humidity = 0;
-		humidity_status = 0;
-		barometer = 0;
-		update_flags = 0;
-	}
+	uint8_t len = sizeof(_tThermostat6) - 1;
+	uint8_t type = pTypeThermostat6;
+	uint8_t subtype = sTypeThermostat6Temp;
+	uint8_t id1 = 1;
+	uint8_t id2 = 0;
+	uint8_t id3 = 0;
+	uint8_t id4 = 0;
+	uint8_t dunit = 1;
+	uint8_t battery_level = 255;
+	float temperature = 0;
+	float setpoint = 0;
+	uint8_t humidity = 0;
+	uint8_t humidity_status = 0;
+	uint16_t barometer = 0;
+	uint8_t update_flags = 0; // Bit flags: 0x01=temp, 0x02=setpoint, 0x04=humidity, 0x08=barometer
 } tThermostat6;
 
 typedef struct _tTempBaro

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -502,6 +502,25 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 				}
 			}
 		}
+		// Look for Thermostat6 devices and link their mode selectors
+		else if (device_type == pTypeThermostat6)
+		{
+			// Look for Mode selector with " Mode" suffix
+			std::string mode_name = device_name + " Mode";
+			for (const auto& mode_row : devices_result)
+			{
+				std::string mode_idx = mode_row[0];
+				std::string mode_device_name = mode_row[1];
+				int mode_switch_type = atoi(mode_row[4].c_str());
+
+				if (mode_device_name == mode_name && mode_switch_type == STYPE_Selector)
+				{
+					thermostat_components[device_idx]["mode"] = mode_idx;
+					linked_devices.insert(mode_idx); // Hide mode selector
+					break;
+				}
+			}
+		}
 	}
 
 	for (const auto& device_row : devices_result)
@@ -897,8 +916,30 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 			Json::Value endpoint = CreateEndpoint("thermostat6_" + device_idx, device_name, "Thermostat", "THERMOSTAT");
 			endpoint["capabilities"] = Json::Value(Json::arrayValue);
 
+			// Check if this Thermostat6 has a linked mode selector
+			std::string mode_idx_str;
+			if (thermostat_components.find(device_idx) != thermostat_components.end())
+			{
+				auto& components = thermostat_components[device_idx];
+				if (components.find("mode") != components.end())
+				{
+					mode_idx_str = components["mode"];
+				}
+			}
+
 			// Add ThermostatController
 			Json::Value thermo_capability = CreateCapabilityWithProperties("Alexa.ThermostatController", "targetSetpoint", false, true, !bControlPermitted);
+			if (!mode_idx_str.empty())
+			{
+				// Add thermostatMode to supported properties
+				thermo_capability["properties"]["supported"].append(Json::Value());
+				thermo_capability["properties"]["supported"][1]["name"] = "thermostatMode";
+
+				thermo_capability["configuration"]["supportsScheduling"] = false;
+				thermo_capability["configuration"]["supportedModes"] = Json::Value(Json::arrayValue);
+				thermo_capability["configuration"]["supportedModes"].append("HEAT");
+				thermo_capability["configuration"]["supportedModes"].append("OFF");
+			}
 			endpoint["capabilities"].append(thermo_capability);
 
 			// Add TemperatureSensor
@@ -918,6 +959,10 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 			endpoint["cookie"]["WhatAmI"] = "thermostat6";
 			endpoint["cookie"]["deviceName"] = device_name;
 			endpoint["cookie"]["subType"] = device_subtype;
+			if (!mode_idx_str.empty())
+			{
+				endpoint["cookie"]["modeIdx"] = mode_idx_str;
+			}
 
 			root["event"]["payload"]["endpoints"].append(endpoint);
 		}
@@ -1615,8 +1660,10 @@ static void Alexa_HandleControl_ColorTemperatureController(WebEmSession& session
 	CreateErrorResponse(root, request_json, "INVALID_DIRECTIVE", "ColorTemperatureController only supports SetColorTemperature/IncreaseColorTemperature/DecreaseColorTemperature");
 }
 
-// Helper to report thermostat state (setpoint, mode, optional humidity)
-static void ReportThermostatState(Json::Value& root, const Json::Value& cookie, uint64_t setpoint_idx, bool is_evohome_zone, const std::string& setpoint_sValue = "")
+// Helper to report thermostat state (setpoint and mode)
+// Supports overrides for setpoint and mode, for when they're being set and other cases
+// where the caller knows the value already and the database query can be skipped
+static void ReportThermostatState(Json::Value& root, const Json::Value& cookie, uint64_t setpoint_idx, bool is_evohome_zone, const std::string& setpoint_sValue = "", const std::string& mode_sValue = "")
 {
 	// Query and report setpoint
 	std::string sValue = setpoint_sValue;
@@ -1642,17 +1689,21 @@ static void ReportThermostatState(Json::Value& root, const Json::Value& cookie, 
 	// Query and report mode (not for Evohome zones)
 	if (!is_evohome_zone)
 	{
-		std::string mode = "HEAT"; // Default
-		std::string mode_idx_str = cookie.get("modeIdx", "").asString();
-		if (!mode_idx_str.empty())
+		std::string mode = mode_sValue;
+		if (mode.empty())
 		{
-			uint64_t mode_idx = std::stoull(mode_idx_str);
-			std::vector<std::vector<std::string>> mode_result;
-			mode_result = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE (ID = %llu)", mode_idx);
-			if (!mode_result.empty())
+			mode = "HEAT"; // Default
+			std::string mode_idx_str = cookie.get("modeIdx", "").asString();
+			if (!mode_idx_str.empty())
 			{
-				int level = atoi(mode_result[0][0].c_str());
-				mode = (level == 0) ? "OFF" : "HEAT";
+				uint64_t mode_idx = std::stoull(mode_idx_str);
+				std::vector<std::vector<std::string>> mode_result;
+				mode_result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (ID = %llu)", mode_idx);
+				if (!mode_result.empty())
+				{
+					int level = atoi(mode_result[0][0].c_str());
+					mode = (level == 0) ? "OFF" : "HEAT";
+				}
 			}
 		}
 		root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "thermostatMode", mode));
@@ -1687,11 +1738,8 @@ static void Alexa_HandleControl_ThermostatController(WebEmSession& session, cons
 			std::string idx_str = std::to_string(device_idx);
 			m_mainworker.SetSetPoint(idx_str, static_cast<float>(target_temp));
 
-			// Report updated state
-			Json::Value temp_value;
-			temp_value["value"] = target_temp;
-			temp_value["scale"] = "CELSIUS";
-			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", temp_value));
+			// Report updated state using common function
+			ReportThermostatState(root, cookie, 0, false, std::to_string(target_temp));
 		}
 		else
 		{
@@ -1785,12 +1833,19 @@ static void Alexa_HandleControl_ThermostatController(WebEmSession& session, cons
 			return;
 		}
 
-		// Multi-device thermostat mode control
+		// Check for mode control support
 		std::string mode_idx_str = cookie.get("modeIdx", "").asString();
 
 		if (mode_idx_str.empty())
 		{
 			CreateErrorResponse(root, request_json, "NOT_SUPPORTED_IN_CURRENT_MODE", "Thermostat does not have mode control");
+			return;
+		}
+
+		// Validate mode is supported (only HEAT and OFF)
+		if (mode != "HEAT" && mode != "OFF")
+		{
+			CreateErrorResponse(root, request_json, "INVALID_VALUE", "Unsupported thermostat mode. Supported modes: HEAT, OFF");
 			return;
 		}
 
@@ -1811,9 +1866,28 @@ static void Alexa_HandleControl_ThermostatController(WebEmSession& session, cons
 		}
 
 		// Report updated state
-		std::string setpoint_idx_str = cookie.get("setpointIdx", "").asString();
-		uint64_t setpoint_idx = std::stoull(setpoint_idx_str);
-		ReportThermostatState(root, cookie, setpoint_idx, false);
+		if (what_am_i == "thermostat6")
+		{
+			// For thermostat6, query the device itself to get setpoint
+			std::vector<std::vector<std::string>> result;
+			result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (ID = %llu)", device_idx);
+			if (!result.empty())
+			{
+				std::vector<std::string> values;
+				StringSplit(result[0][0], ";", values);
+				if (values.size() >= 2)
+				{
+					ReportThermostatState(root, cookie, 0, false, values[1], mode);
+				}
+			}
+		}
+		else
+		{
+			// For multi-device thermostats
+			std::string setpoint_idx_str = cookie.get("setpointIdx", "").asString();
+			uint64_t setpoint_idx = std::stoull(setpoint_idx_str);
+			ReportThermostatState(root, cookie, setpoint_idx, false, "", mode);
+		}
 
 		root["context"]["properties"].append(CreateEndpointHealthProperty());
 		return;
@@ -2152,12 +2226,8 @@ static void Alexa_HandleControl_ReportState(WebEmSession& session, const Json::V
 			temp_value["scale"] = "CELSIUS";
 			root["context"]["properties"].append(CreateProperty("Alexa.TemperatureSensor", "temperature", temp_value));
 
-			// Report target setpoint
-			double setpoint = atof(values[1].c_str());
-			Json::Value setpoint_value;
-			setpoint_value["value"] = setpoint;
-			setpoint_value["scale"] = "CELSIUS";
-			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", setpoint_value));
+			// Report target setpoint and mode using common function
+			ReportThermostatState(root, cookie, 0, false, values[1]);
 
 			// Report humidity for TempHum and TempHumBaro subtypes
 			if ((dSubType == sTypeThermostat6TempHum || dSubType == sTypeThermostat6TempHumBaro) && values.size() >= 3)

--- a/main/Alexa.cpp
+++ b/main/Alexa.cpp
@@ -891,6 +891,36 @@ void CWebServer::Alexa_HandleDiscovery(WebEmSession& session, const request& req
 
 			root["event"]["payload"]["endpoints"].append(endpoint);
 		}
+		// Handle pTypeThermostat6 (combined temperature/setpoint devices)
+		else if (device_type == pTypeThermostat6)
+		{
+			Json::Value endpoint = CreateEndpoint("thermostat6_" + device_idx, device_name, "Thermostat", "THERMOSTAT");
+			endpoint["capabilities"] = Json::Value(Json::arrayValue);
+
+			// Add ThermostatController
+			Json::Value thermo_capability = CreateCapabilityWithProperties("Alexa.ThermostatController", "targetSetpoint", false, true, !bControlPermitted);
+			endpoint["capabilities"].append(thermo_capability);
+
+			// Add TemperatureSensor
+			endpoint["capabilities"].append(CreateCapabilityWithProperties("Alexa.TemperatureSensor", "temperature", false, true));
+
+			// Add RangeController for humidity (TempHum and TempHumBaro subtypes)
+			if (device_subtype == sTypeThermostat6TempHum || device_subtype == sTypeThermostat6TempHumBaro)
+			{
+				Json::Value humidity_capability = CreateCapabilityWithProperties("Alexa.RangeController", "rangeValue", false, true);
+				humidity_capability["instance"] = "Humidity.Humidity";
+				endpoint["capabilities"].append(humidity_capability);
+			}
+
+			endpoint["capabilities"].append(CreateCapability("Alexa.EndpointHealth"));
+			endpoint["capabilities"].append(CreateCapability("Alexa"));
+
+			endpoint["cookie"]["WhatAmI"] = "thermostat6";
+			endpoint["cookie"]["deviceName"] = device_name;
+			endpoint["cookie"]["subType"] = device_subtype;
+
+			root["event"]["payload"]["endpoints"].append(endpoint);
+		}
 		// Handle Weight sensors
 		else if (device_type == pTypeWEIGHT)
 		{
@@ -1651,6 +1681,18 @@ static void Alexa_HandleControl_ThermostatController(WebEmSession& session, cons
 			temp_value["scale"] = "CELSIUS";
 			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", temp_value));
 		}
+		else if (what_am_i == "thermostat6")
+		{
+			// For thermostat6, use SetSetPoint on the main device
+			std::string idx_str = std::to_string(device_idx);
+			m_mainworker.SetSetPoint(idx_str, static_cast<float>(target_temp));
+
+			// Report updated state
+			Json::Value temp_value;
+			temp_value["value"] = target_temp;
+			temp_value["scale"] = "CELSIUS";
+			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", temp_value));
+		}
 		else
 		{
 			// Use regular SetSetPoint for multi-device thermostats
@@ -2085,6 +2127,44 @@ static void Alexa_HandleControl_ReportState(WebEmSession& session, const Json::V
 			setpoint_value["value"] = setpoint;
 			setpoint_value["scale"] = "CELSIUS";
 			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", setpoint_value));
+		}
+
+		root["context"]["properties"].append(CreateEndpointHealthProperty());
+		return;
+	}
+
+	// Handle pTypeThermostat6 (combined temperature/setpoint devices)
+	if (dType == pTypeThermostat6)
+	{
+		root["event"]["header"]["name"] = "StateReport";
+
+		// Parse data from sValue based on subtype
+		std::string sValue = result[0][4];
+		std::vector<std::string> values;
+		StringSplit(sValue, ";", values);
+
+		if (values.size() >= 2)
+		{
+			// Report current temperature
+			double temp = atof(values[0].c_str());
+			Json::Value temp_value;
+			temp_value["value"] = temp;
+			temp_value["scale"] = "CELSIUS";
+			root["context"]["properties"].append(CreateProperty("Alexa.TemperatureSensor", "temperature", temp_value));
+
+			// Report target setpoint
+			double setpoint = atof(values[1].c_str());
+			Json::Value setpoint_value;
+			setpoint_value["value"] = setpoint;
+			setpoint_value["scale"] = "CELSIUS";
+			root["context"]["properties"].append(CreateProperty("Alexa.ThermostatController", "targetSetpoint", setpoint_value));
+
+			// Report humidity for TempHum and TempHumBaro subtypes
+			if ((dSubType == sTypeThermostat6TempHum || dSubType == sTypeThermostat6TempHumBaro) && values.size() >= 3)
+			{
+				int humidity = atoi(values[2].c_str());
+				root["context"]["properties"].append(CreateProperty("Alexa.RangeController", "rangeValue", humidity, "Humidity.Humidity"));
+			}
 		}
 
 		root["context"]["properties"].append(CreateEndpointHealthProperty());

--- a/main/Helper.cpp
+++ b/main/Helper.cpp
@@ -1132,6 +1132,7 @@ bool IsTemp(const int dType, const int dSubType)
 		|| (dType == pTypeThermostat1)
 		|| ((dType == pTypeRFXSensor) && (dSubType == sTypeRFXSensorTemp))
 		|| (dType == pTypeRego6XXTemp)
+		|| (dType == pTypeThermostat6)
 		);
 }
 

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -478,6 +478,7 @@ const char* RFX_Type_Desc(const unsigned char i, const unsigned char snum)
 		{ pTypeThermostat2, "Thermostat 2", "temperature" },
 		{ pTypeThermostat3, "Thermostat 3", "temperature" },
 		{ pTypeThermostat4, "Thermostat 4", "temperature" },
+		{ pTypeThermostat6, "Thermostat 6", "temperature" },
 		{ pTypeRadiator1, "Radiator 1", "temperature" },
 		{ pTypeTEMP, "Temp", "temperature" },
 		{ pTypeHUM, "Humidity", "temperature" },
@@ -710,6 +711,11 @@ const char* RFX_Type_SubType_Desc(const unsigned char dType, const unsigned char
 		{ pTypeThermostat4, sTypeMCZ1, "MCZ 1 fan model" },
 		{ pTypeThermostat4, sTypeMCZ2, "MCZ 2 fan model" },
 		{ pTypeThermostat4, sTypeMCZ3, "MCZ 3 fan model" },
+
+		{ pTypeThermostat6, sTypeThermostat6Temp, "Temp/Setpoint" },
+		{ pTypeThermostat6, sTypeThermostat6TempHum, "Temp/Hum/Setpoint" },
+		{ pTypeThermostat6, sTypeThermostat6TempBaro, "Temp/Baro/Setpoint" },
+		{ pTypeThermostat6, sTypeThermostat6TempHumBaro, "Temp/Hum/Baro/Setpoint" },
 
 		{ pTypeRadiator1, sTypeSmartwares, "Smartwares" },
 		{ pTypeRadiator1, sTypeSmartwaresSwitchRadiator, "Smartwares Mode" },

--- a/main/RFXtrx.h
+++ b/main/RFXtrx.h
@@ -1278,6 +1278,12 @@ SDK version 4.9
 #define thermostat5_sOnHeaterLow 0x3
 #define thermostat5_sOnHeaterHigh 0x04
 
+#define pTypeThermostat6 0x49
+#define sTypeThermostat6Temp 0x00
+#define sTypeThermostat6TempHum 0x01
+#define sTypeThermostat6TempBaro 0x02
+#define sTypeThermostat6TempHumBaro 0x03
+
 //types for Radiator valve
 #define pTypeRadiator1 0x48
 #define sTypeSmartwares 0x0	//Homewizard smartwares

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -4428,7 +4428,35 @@ namespace http
 				}
 				sprintf(szTmp, "%.2f", tempcelcius);
 
-				if (dType != pTypeEvohomeZone && dType != pTypeEvohomeWater) // sql update now done in setsetpoint for evohome devices
+				if (dType == pTypeThermostat6)
+				{
+					// For Thermostat6, preserve existing temperature and mode, only update setpoint
+					std::vector<std::vector<std::string>> currentResult;
+					currentResult = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (ID == '%q')", idx.c_str());
+					if (!currentResult.empty())
+					{
+						std::vector<std::string> strarray;
+						StringSplit(currentResult[0][0], ";", strarray);
+						if (dSubType == sTypeThermostat6Temp && strarray.size() >= 2)
+						{
+							sprintf(szTmp, "%s;%.2f", strarray[0].c_str(), tempcelcius);
+						}
+						else if (dSubType == sTypeThermostat6TempHum && strarray.size() >= 4)
+						{
+							sprintf(szTmp, "%s;%.2f;%s;%s", strarray[0].c_str(), tempcelcius, strarray[2].c_str(), strarray[3].c_str());
+						}
+						else if (dSubType == sTypeThermostat6TempBaro && strarray.size() >= 3)
+						{
+							sprintf(szTmp, "%s;%.2f;%s", strarray[0].c_str(), tempcelcius, strarray[2].c_str());
+						}
+						else if (dSubType == sTypeThermostat6TempHumBaro && strarray.size() >= 5)
+						{
+							sprintf(szTmp, "%s;%.2f;%s;%s;%s", strarray[0].c_str(), tempcelcius, strarray[2].c_str(), strarray[3].c_str(), strarray[4].c_str());
+						}
+						m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, sValue='%q' WHERE (ID == '%q')", used, szTmp, idx.c_str());
+					}
+				}
+				else if (dType != pTypeEvohomeZone && dType != pTypeEvohomeWater) // sql update now done in setsetpoint for evohome devices
 				{
 					m_sql.safe_query("UPDATE DeviceStatus SET Used=%d, sValue='%q' WHERE (ID == '%q')", used, szTmp, idx.c_str());
 				}

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -316,7 +316,7 @@ namespace http
 								|| dType == pTypeRFXSensor && dSubType == sTypeRFXSensorTemp
 								|| dType == pTypeGeneral && dSubType == sTypeSystemTemp
 								|| dType == pTypeGeneral && dSubType == sTypeBaro
-								|| dType == pTypeEvohomeZone
+								|| dType == pTypeEvohomeZone || dType == pTypeThermostat6
 								|| dType == pTypeEvohomeWater
 								)
 							{
@@ -328,11 +328,11 @@ namespace http
 								double tvalue = ConvertTemperature(atof(sd[1].c_str()), tempsign);
 								root["result"][ii]["ch"] = tvalue;
 							}
-							if ((dType == pTypeHUM) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO))
+							if ((dType == pTypeHUM) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO) || ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempHum) || (dSubType == sTypeThermostat6TempHumBaro))))
 							{
 								root["result"][ii]["hu"] = sd[2];
 							}
-							if ((dType == pTypeTEMP_HUM_BARO) || (dType == pTypeTEMP_BARO) || ((dType == pTypeGeneral) && (dSubType == sTypeBaro)))
+							if ((dType == pTypeTEMP_HUM_BARO) || (dType == pTypeTEMP_BARO) || ((dType == pTypeGeneral) && (dSubType == sTypeBaro)) || ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempBaro) || (dSubType == sTypeThermostat6TempHumBaro))))
 							{
 								if (dType == pTypeTEMP_HUM_BARO)
 								{
@@ -354,8 +354,13 @@ namespace http
 									sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
 									root["result"][ii]["ba"] = szTmp;
 								}
+								else if ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempBaro) || (dSubType == sTypeThermostat6TempHumBaro)))
+								{
+									sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+									root["result"][ii]["ba"] = szTmp;
+								}
 							}
-							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
+							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater) || (dType == pTypeThermostat6))
 							{
 								double se = ConvertTemperature(atof(sd[5].c_str()), tempsign);
 								root["result"][ii]["se"] = se;
@@ -2128,7 +2133,7 @@ namespace http
 								|| ((dType == pTypeRFXSensor) && (dSubType == sTypeRFXSensorTemp))
 								|| ((dType == pTypeUV) && (dSubType == sTypeUV3))
 								|| ((dType == pTypeGeneral) && (dSubType == sTypeSystemTemp))
-								|| (dType == pTypeEvohomeZone)
+								|| (dType == pTypeEvohomeZone) || (dType == pTypeThermostat6)
 								|| (dType == pTypeEvohomeWater)
 								|| ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
 								)
@@ -2182,7 +2187,7 @@ namespace http
 									root["result"][ii]["ba"] = szTmp;
 								}
 							}
-							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
+							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater) || (dType == pTypeThermostat6))
 							{
 								double sm = ConvertTemperature(atof(sd[8].c_str()), tempsign);
 								double sx = ConvertTemperature(atof(sd[9].c_str()), tempsign);
@@ -2244,7 +2249,7 @@ namespace http
 							|| (dType == pTypeRadiator1)
 							|| ((dType == pTypeUV) && (dSubType == sTypeUV3))
 							|| ((dType == pTypeWIND) && (dSubType == sTypeWIND4))
-							|| (dType == pTypeEvohomeZone)
+							|| (dType == pTypeEvohomeZone) || (dType == pTypeThermostat6)
 							|| (dType == pTypeEvohomeWater)
 							)
 						{
@@ -2289,7 +2294,7 @@ namespace http
 								root["result"][ii]["ba"] = szTmp;
 							}
 						}
-						if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
+						if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater) || (dType == pTypeThermostat6))
 						{
 							double sx = ConvertTemperature(atof(sd[8].c_str()), tempsign);
 							double sm = ConvertTemperature(atof(sd[7].c_str()), tempsign);
@@ -2351,7 +2356,7 @@ namespace http
 								|| ((dType == pTypeRFXSensor) && (dSubType == sTypeRFXSensorTemp))
 								|| ((dType == pTypeUV) && (dSubType == sTypeUV3))
 								|| ((dType == pTypeGeneral) && (dSubType == sTypeSystemTemp))
-								|| (dType == pTypeEvohomeZone)
+								|| (dType == pTypeEvohomeZone) || (dType == pTypeThermostat6)
 								|| (dType == pTypeEvohomeWater)
 								)
 							{
@@ -2404,7 +2409,7 @@ namespace http
 									root["resultprev"][iPrev]["ba"] = szTmp;
 								}
 							}
-							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))
+							if ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater) || (dType == pTypeThermostat6))
 							{
 								double sx = ConvertTemperature(atof(sd[8].c_str()), tempsign);
 								double sm = ConvertTemperature(atof(sd[7].c_str()), tempsign);
@@ -3976,11 +3981,11 @@ namespace http
 						((dType == pTypeRego6XXTemp) || (dType == pTypeTEMP) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO) || (dType == pTypeTEMP_BARO) ||
 							(dType == pTypeWIND) || (dType == pTypeThermostat1) || (dType == pTypeRadiator1) || ((dType == pTypeUV) && (dSubType == sTypeUV3)) ||
 							((dType == pTypeWIND) && (dSubType == sTypeWIND4)) || ((dType == pTypeRFXSensor) && (dSubType == sTypeRFXSensorTemp)) ||
-							((dType == pTypeSetpoint) && (dSubType == sTypeSetpoint)) || (dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater)))
+							((dType == pTypeSetpoint) && (dSubType == sTypeSetpoint)) || (dType == pTypeEvohomeZone) || (dType == pTypeThermostat6) || (dType == pTypeEvohomeWater)))
 					{
 						sendTemp = true;
 					}
-					if ((sgraphSet == "true") && ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater))) // FIXME cheat for water setpoint is just on or off
+					if ((sgraphSet == "true") && ((dType == pTypeEvohomeZone) || (dType == pTypeEvohomeWater) || (dType == pTypeThermostat6))) // FIXME cheat for water setpoint is just on or off
 					{
 						sendSet = true;
 					}
@@ -3988,11 +3993,11 @@ namespace http
 					{
 						sendChill = true;
 					}
-					if ((sgraphHum == "true") && ((dType == pTypeHUM) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO)))
+					if ((sgraphHum == "true") && ((dType == pTypeHUM) || (dType == pTypeTEMP_HUM) || (dType == pTypeTEMP_HUM_BARO) || ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempHum) || (dSubType == sTypeThermostat6TempHumBaro)))))
 					{
 						sendHum = true;
 					}
-					if ((sgraphBaro == "true") && ((dType == pTypeTEMP_HUM_BARO) || (dType == pTypeTEMP_BARO) || ((dType == pTypeGeneral) && (dSubType == sTypeBaro))))
+					if ((sgraphBaro == "true") && ((dType == pTypeTEMP_HUM_BARO) || (dType == pTypeTEMP_BARO) || ((dType == pTypeGeneral) && (dSubType == sTypeBaro)) || ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempBaro) || (dSubType == sTypeThermostat6TempHumBaro)))))
 					{
 						sendBaro = true;
 					}
@@ -4051,6 +4056,11 @@ namespace http
 										root["result"][ii]["ba"] = szTmp;
 									}
 									else if ((dType == pTypeGeneral) && (dSubType == sTypeBaro))
+									{
+										sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
+										root["result"][ii]["ba"] = szTmp;
+									}
+									else if ((dType == pTypeThermostat6) && ((dSubType == sTypeThermostat6TempBaro) || (dSubType == sTypeThermostat6TempHumBaro)))
 									{
 										sprintf(szTmp, "%.1f", atof(sd[3].c_str()) / 10.0F);
 										root["result"][ii]["ba"] = szTmp;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -13010,6 +13010,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		return false;
 
 	bool ret = true;
+	bool bWriteToHardware = false;
 
 	unsigned long ID;
 	std::stringstream s_strid;
@@ -13025,13 +13026,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	uint8_t dSubType = atoi(sd[4].c_str());
 	//_eSwitchType switchtype = (_eSwitchType)atoi(sd[5].c_str());
 
-	_tSetpoint tmeter;
-	tmeter.subtype = sTypeSetpoint;
-	tmeter.id1 = ID1;
-	tmeter.id2 = ID2;
-	tmeter.id3 = ID3;
-	tmeter.id4 = ID4;
-	tmeter.dunit = Unit;
+	float temp_celsius = (m_sql.m_tempsign[0] != 'F') ? TempValue : static_cast<float>(ConvertToCelsius(TempValue));
 
 	if ((dType == pTypeSetpoint) && (dSubType == sTypeSetpoint))
 	{
@@ -13040,23 +13035,18 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		std::string value_unit = options["ValueUnit"];
 
 		if (
-			(value_unit.empty())
-			|| (value_unit == "�C")
-			|| (value_unit == "�F")
-			|| (value_unit == "C")
-			|| (value_unit == "F")
-			|| (value_unit.find_last_of("°F") != std::string::npos)
-			|| (value_unit.find_last_of("°C") != std::string::npos)
+			!(value_unit.empty())
+			&& (value_unit != "�C")
+			&& (value_unit != "�F")
+			&& (value_unit != "C")
+			&& (value_unit != "F")
+			&& (value_unit.find_last_of("°F") == std::string::npos)
+			&& (value_unit.find_last_of("°C") == std::string::npos)
 			)
 		{
-			tmeter.value = (m_sql.m_tempsign[0] != 'F') ? TempValue : static_cast<float>(ConvertToCelsius(TempValue));
+			// Non-temperature unit, use raw value
+			temp_celsius = TempValue;
 		}
-		else
-			tmeter.value = TempValue;
-	}
-	else
-	{
-		tmeter.value = (m_sql.m_tempsign[0] != 'F') ? TempValue : static_cast<float>(ConvertToCelsius(TempValue));
 	}
 
 
@@ -13172,43 +13162,60 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 	}
 	else
 	{
-		if (dType == pTypeRadiator1)
-		{
-			tRBUF lcmd;
-			lcmd.RADIATOR1.packetlength = sizeof(lcmd.RADIATOR1) - 1;
-			lcmd.RADIATOR1.packettype = dType;
-			lcmd.RADIATOR1.subtype = dSubType;
-			lcmd.RADIATOR1.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
-			lcmd.RADIATOR1.id1 = ID1;
-			lcmd.RADIATOR1.id2 = ID2;
-			lcmd.RADIATOR1.id3 = ID3;
-			lcmd.RADIATOR1.id4 = ID4;
-			lcmd.RADIATOR1.unitcode = Unit;
-			lcmd.RADIATOR1.filler = 0;
-			lcmd.RADIATOR1.rssi = 12;
-			lcmd.RADIATOR1.cmnd = Radiator1_sSetTemp;
-
-			char szTemp[20];
-			sprintf(szTemp, "%.1f", TempValue);
-			std::vector<std::string> strarray;
-			StringSplit(szTemp, ".", strarray);
-			lcmd.RADIATOR1.temperature = (uint8_t)atoi(strarray[0].c_str());
-			lcmd.RADIATOR1.tempPoint5 = (uint8_t)atoi(strarray[1].c_str());
-			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
-				return false;
-			PushAndWaitRxMessage(pHardware, (const uint8_t*)&lcmd, nullptr, -1, nullptr);
-			return true;
-		}
-		else
-		{
-			if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tSetpoint)))
-				return false;
-		}
+		// For other hardware types we use WriteToHardware(), once the correct type of
+		// message has been created below for the device type.
+		bWriteToHardware = true;
 	}
 	if (!ret)
 		return false;
 	//Also put it in the database, not all devices are awake (battery operated nodes)
-	PushAndWaitRxMessage(pHardware, (const uint8_t*)&tmeter, nullptr, -1, nullptr);
+	if (dType == pTypeRadiator1)
+	{
+		tRBUF lcmd;
+		lcmd.RADIATOR1.packetlength = sizeof(lcmd.RADIATOR1) - 1;
+		lcmd.RADIATOR1.packettype = dType;
+		lcmd.RADIATOR1.subtype = dSubType;
+		lcmd.RADIATOR1.seqnbr = m_hardwaredevices[hindex]->m_SeqNr++;
+		lcmd.RADIATOR1.id1 = ID1;
+		lcmd.RADIATOR1.id2 = ID2;
+		lcmd.RADIATOR1.id3 = ID3;
+		lcmd.RADIATOR1.id4 = ID4;
+		lcmd.RADIATOR1.unitcode = Unit;
+		lcmd.RADIATOR1.filler = 0;
+		lcmd.RADIATOR1.rssi = 12;
+		lcmd.RADIATOR1.cmnd = Radiator1_sSetTemp;
+
+		char szTemp[20];
+		sprintf(szTemp, "%.1f", TempValue);
+		std::vector<std::string> strarray;
+		StringSplit(szTemp, ".", strarray);
+		lcmd.RADIATOR1.temperature = (uint8_t)atoi(strarray[0].c_str());
+		lcmd.RADIATOR1.tempPoint5 = (uint8_t)atoi(strarray[1].c_str());
+		if (bWriteToHardware)
+		{
+			if (!WriteToHardware(HardwareID, (const char*)&lcmd, sizeof(lcmd.RADIATOR1)))
+				return false;
+		}
+		PushAndWaitRxMessage(pHardware, (const uint8_t*)&lcmd, nullptr, -1, nullptr);
+	}
+	else
+	{
+		_tSetpoint tmeter;
+		tmeter.subtype = sTypeSetpoint;
+		tmeter.id1 = ID1;
+		tmeter.id2 = ID2;
+		tmeter.id3 = ID3;
+		tmeter.id4 = ID4;
+		tmeter.dunit = Unit;
+		tmeter.value = temp_celsius;
+
+		if (bWriteToHardware)
+		{
+			if (!WriteToHardware(HardwareID, (const char*)&tmeter, sizeof(_tSetpoint)))
+				return false;
+		}
+		PushAndWaitRxMessage(pHardware, (const uint8_t*)&tmeter, nullptr, -1, nullptr);
+	}
 	return true;
 }
 

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -13139,7 +13139,6 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		}
 	}
 
-
 	if (pHardware->HwdType == HTYPE_PythonPlugin)
 	{
 #ifdef ENABLE_PYTHON

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -13118,7 +13118,7 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 
 	float temp_celsius = (m_sql.m_tempsign[0] != 'F') ? TempValue : static_cast<float>(ConvertToCelsius(TempValue));
 
-	if ((dType == pTypeSetpoint) && (dSubType == sTypeSetpoint))
+	if (dType == pTypeThermostat6 || (dType == pTypeSetpoint) && (dSubType == sTypeSetpoint))
 	{
 		std::string sOptions = sd[8].c_str();
 		std::map<std::string, std::string> options = m_sql.BuildDeviceOptions(sOptions);

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -2178,6 +2178,9 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 		case pTypeSetpoint: //own type
 			decode_Thermostat(pHardware, reinterpret_cast<const tRBUF*>(pRXCommand), procResult);
 			break;
+		case pTypeThermostat6:
+			decode_Thermostat6(pHardware, reinterpret_cast<const tRBUF*>(pRXCommand), procResult);
+			break;
 		case pTypeThermostat1:
 			decode_Thermostat1(pHardware, reinterpret_cast<const tRBUF*>(pRXCommand), procResult);
 			break;
@@ -8372,6 +8375,93 @@ void MainWorker::decode_Thermostat(const CDomoticzHardwareBase* pHardware, const
 	procResult.DeviceRowIdx = DevRowIdx;
 }
 
+void MainWorker::decode_Thermostat6(const CDomoticzHardwareBase* pHardware, const tRBUF* pResponse, _tRxMessageProcessingResult& procResult)
+{
+	const _tThermostat6* pMeter = reinterpret_cast<const _tThermostat6*>(pResponse);
+	uint8_t devType = pMeter->type;
+	uint8_t subType = pMeter->subtype;
+
+	char szTmp[200];
+	sprintf(szTmp, "%X%02X%02X%02X", pMeter->id1, pMeter->id2, pMeter->id3, pMeter->id4);
+	std::string ID = szTmp;
+	uint8_t Unit = pMeter->dunit;
+	uint8_t SignalLevel = 12;
+	uint8_t BatteryLevel = pMeter->battery_level;
+
+	// Get existing values if partial update
+	float temperature = pMeter->temperature;
+	float setpoint = pMeter->setpoint;
+	uint8_t humidity = pMeter->humidity;
+	uint8_t humidity_status = pMeter->humidity_status;
+	uint16_t barometer = pMeter->barometer;
+
+	// Determine expected flags based on subtype
+	uint8_t expected_flags = 0x03; // temp + setpoint for sTypeThermostat6Temp
+	if (subType == sTypeThermostat6TempHum)
+		expected_flags = 0x07; // temp + setpoint + humidity
+	else if (subType == sTypeThermostat6TempBaro)
+		expected_flags = 0x0B; // temp + setpoint + barometer
+	else if (subType == sTypeThermostat6TempHumBaro)
+		expected_flags = 0x0F; // temp + setpoint + humidity + barometer
+
+	if (pMeter->update_flags != expected_flags)
+	{
+		// Partial update - read existing values
+		std::vector<std::vector<std::string>> result;
+		result = m_sql.safe_query("SELECT sValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (SubType==%d)",
+			pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
+		if (!result.empty())
+		{
+			std::vector<std::string> values;
+			StringSplit(result[0][0], ";", values);
+
+			if (!(pMeter->update_flags & 0x01) && values.size() >= 1)
+				temperature = static_cast<float>(atof(values[0].c_str()));
+			if (!(pMeter->update_flags & 0x02) && values.size() >= 2)
+				setpoint = static_cast<float>(atof(values[1].c_str()));
+			if (!(pMeter->update_flags & 0x04) && values.size() >= 4)
+			{
+				humidity = atoi(values[2].c_str());
+				humidity_status = atoi(values[3].c_str());
+			}
+			if (!(pMeter->update_flags & 0x08))
+			{
+				if (subType == sTypeThermostat6TempBaro && values.size() >= 3)
+					barometer = atoi(values[2].c_str());
+				else if (subType == sTypeThermostat6TempHumBaro && values.size() >= 5)
+					barometer = atoi(values[4].c_str());
+			}
+		}
+	}
+
+	// Build sValue based on subtype
+	switch (subType)
+	{
+	case sTypeThermostat6Temp:
+		sprintf(szTmp, "%.1f;%.1f", temperature, setpoint);
+		break;
+	case sTypeThermostat6TempHum:
+		sprintf(szTmp, "%.1f;%.1f;%d;%d", temperature, setpoint, humidity, humidity_status);
+		break;
+	case sTypeThermostat6TempBaro:
+		sprintf(szTmp, "%.1f;%.1f;%d", temperature, setpoint, barometer);
+		break;
+	case sTypeThermostat6TempHumBaro:
+		sprintf(szTmp, "%.1f;%.1f;%d;%d;%d", temperature, setpoint, humidity, humidity_status, barometer);
+		break;
+	default:
+		sprintf(szTmp, "ERROR: Unknown Sub type for Packet type= %02X:%02X", pMeter->type, pMeter->subtype);
+		WriteMessage(szTmp);
+		return;
+	}
+
+	uint64_t DevRowIdx = m_sql.UpdateValue(pHardware->m_HwdID, 0, ID.c_str(), Unit, devType, subType, SignalLevel, BatteryLevel, 0, szTmp, procResult.DeviceName, true, procResult.Username.c_str());
+	if (DevRowIdx == (uint64_t)-1)
+		return;
+
+	procResult.DeviceRowIdx = DevRowIdx;
+}
+
 void MainWorker::decode_Thermostat1(const CDomoticzHardwareBase* pHardware, const tRBUF* pResponse, _tRxMessageProcessingResult& procResult)
 {
 	char szTmp[100];
@@ -13198,6 +13288,25 @@ bool MainWorker::SetSetPointInt(const std::vector<std::string>& sd, const float 
 		}
 		PushAndWaitRxMessage(pHardware, (const uint8_t*)&lcmd, nullptr, -1, nullptr);
 	}
+	else if (dType == pTypeThermostat6)
+	{
+		// For Thermostat6, construct _tThermostat6 message
+		_tThermostat6 t6meter;
+		t6meter.subtype = dSubType;
+		t6meter.id1 = ID1;
+		t6meter.id2 = ID2;
+		t6meter.id3 = ID3;
+		t6meter.id4 = ID4;
+		t6meter.dunit = Unit;
+		t6meter.setpoint = temp_celsius;
+		t6meter.update_flags = 0x02; // Update setpoint only
+		if (bWriteToHardware)
+		{
+			if (!WriteToHardware(HardwareID, (const char*)&t6meter, sizeof(_tThermostat6)))
+				return false;
+		}
+		PushAndWaitRxMessage(pHardware, (const uint8_t*)&t6meter, nullptr, -1, nullptr);
+	}
 	else
 	{
 		_tSetpoint tmeter;
@@ -14107,6 +14216,125 @@ bool MainWorker::UpdateDevice(const int HardwareID, const int OrgHardwareID, con
 					uint64_t tID = ((uint64_t)(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
 					m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
 				}
+			}
+
+			if (devType == pTypeThermostat6)
+			{
+				std::vector<std::string> strarray;
+				StringSplit(sValue, ";", strarray);
+
+				if (strarray.size() < 2)
+				{
+					_log.Log(LOG_ERROR, "Thermostat6: Invalid sValue - need at least temp;setpoint");
+					g_bUseEventTrigger = true;
+					return false;
+				}
+
+				float temp = 0.0F;
+				float setpoint = 0.0F;
+				std::string hum, hum_status;
+				float fbarometer = 0.0F;
+				float AddjValue = 0.0F;
+				float AddjValue2 = 0.0F;
+				bool bSetpointUpdated = false;
+
+				// Query existing values and adjustment values
+				std::vector<std::vector<std::string>> result;
+				result = m_sql.safe_query("SELECT sValue, AddjValue, AddjValue2 FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (SubType==%d)",
+					HardwareID, DeviceID.c_str(), unit, devType, subType);
+				if (!result.empty())
+				{
+					std::vector<std::string> values;
+					StringSplit(result[0][0], ";", values);
+
+					if (values.size() >= 1)
+						temp = static_cast<float>(atof(values[0].c_str()));
+					if (values.size() >= 2)
+						setpoint = static_cast<float>(atof(values[1].c_str()));
+
+					if (subType == sTypeThermostat6TempHum || subType == sTypeThermostat6TempHumBaro)
+					{
+						if (values.size() >= 4)
+						{
+							hum = values[2];
+							hum_status = values[3];
+						}
+					}
+
+					if (subType == sTypeThermostat6TempBaro && values.size() >= 3)
+					{
+						fbarometer = static_cast<float>(atof(values[2].c_str()));
+					}
+					else if (subType == sTypeThermostat6TempHumBaro && values.size() >= 5)
+					{
+						fbarometer = static_cast<float>(atof(values[4].c_str()));
+					}
+
+					AddjValue = static_cast<float>(atof(result[0][1].c_str()));
+					AddjValue2 = static_cast<float>(atof(result[0][2].c_str()));
+				}
+
+				// Overwrite with provided non-empty values and apply adjustments
+				if (!strarray[0].empty())
+				{
+					temp = static_cast<float>(atof(strarray[0].c_str()));
+					temp += AddjValue;
+
+					// Calculate temperature trend
+					uint64_t tID = ((uint64_t)(HardwareID & 0x7FFFFFFF) << 32) | (devidx & 0x7FFFFFFF);
+					m_trend_calculator[tID].AddValueAndReturnTendency(static_cast<double>(temp), _tTrendCalculator::TAVERAGE_TEMP);
+				}
+				if (!strarray[1].empty())
+				{
+					setpoint = static_cast<float>(atof(strarray[1].c_str()));
+					bSetpointUpdated = true;
+				}
+
+				if (subType == sTypeThermostat6TempHum || subType == sTypeThermostat6TempHumBaro)
+				{
+					if (strarray.size() >= 4)
+					{
+						if (!strarray[2].empty())
+							hum = strarray[2];
+						if (!strarray[3].empty())
+							hum_status = strarray[3];
+					}
+					if (strarray.size() >= 5 && !strarray[4].empty())
+					{
+						fbarometer = static_cast<float>(atof(strarray[4].c_str()));
+						fbarometer += AddjValue2;
+					}
+				}
+				else if (subType == sTypeThermostat6TempBaro)
+				{
+					if (strarray.size() >= 3 && !strarray[2].empty())
+					{
+						fbarometer = static_cast<float>(atof(strarray[2].c_str()));
+						fbarometer += AddjValue2;
+					}
+				}
+
+				char szTmp[50];
+				sprintf(szTmp, "%.2f;%.2f", temp, setpoint);
+				sValue = szTmp;
+
+				if (subType == sTypeThermostat6TempHum || subType == sTypeThermostat6TempHumBaro)
+				{
+					sValue += ";" + hum + ";" + hum_status;
+				}
+
+				if (subType == sTypeThermostat6TempBaro || subType == sTypeThermostat6TempHumBaro)
+				{
+					sprintf(szTmp, ";%.1f", fbarometer);
+					sValue += szTmp;
+				}
+
+				// Call SetSetPoint to update the physical device if setpoint changed
+				if (bSetpointUpdated)
+				{
+					SetSetPoint(std::to_string(devidx), setpoint);
+				}
+				// Continue to update sensor values in database below
 			}
 		}
 

--- a/main/mainworker.h
+++ b/main/mainworker.h
@@ -281,6 +281,7 @@ private:
 	void decode_GeneralSwitch(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
 	void decode_HomeConfort(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
 	void decode_Thermostat(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
+	void decode_Thermostat6(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
 	void decode_Chime(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
 	void decode_BBQ(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);
 	void decode_Power(const CDomoticzHardwareBase *pHardware, const tRBUF *pResponse, _tRxMessageProcessingResult & procResult);

--- a/notifications/NotificationHelper.cpp
+++ b/notifications/NotificationHelper.cpp
@@ -485,6 +485,7 @@ bool CNotificationHelper::CheckAndHandleNotification(const uint64_t DevRowIdx, c
 		case pTypeEvohomeRelay:
 		case pTypeEvohomeWater:
 		case pTypeEvohomeZone:
+		case pTypeThermostat6:
 			//not handled
 			return false;
 			break;

--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -49,7 +49,7 @@ define(['app', 'livesocket'], function (app) {
 			$("#dialog-editsetpoint #devicedescription").val(unescape(description));
 			$("#dialog-editsetpoint #setpoint").val(setpoint);
 			if (mode.indexOf("Override") == -1)
-				$(":button:contains('Cancel Override')").attr("disabled", "d‌​isabled").addClass('ui-state-disabled');
+				$(":button:contains('Cancel Override')").attr("disabled", "disabled").addClass('ui-state-disabled');
 			else
 				$(":button:contains('Cancel Override')").removeAttr("disabled").removeClass('ui-state-disabled');
 			$("#dialog-editsetpoint #until").datetimepicker({
@@ -565,7 +565,7 @@ define(['app', 'livesocket'], function (app) {
 						return typeof item.Temp != 'undefined';
 					};
 					ctrl.displaySetPoint = function () {
-						return (item.SubType == 'Zone' || item.SubType == 'Hot Water') && typeof item.SetPoint != 'undefined';
+					return (item.SubType == 'Zone' || item.SubType == 'Hot Water' || item.SubType == 'Temp/Setpoint' || item.SubType == 'Temp/Hum/Setpoint' || item.SubType == 'Temp/Baro/Setpoint' || item.SubType == 'Temp/Hum/Baro/Setpoint') && typeof item.SetPoint != 'undefined';
 					};
 					ctrl.isSetPointOn = function () {
 						return item.SetPoint != 325.1;
@@ -671,6 +671,13 @@ define(['app', 'livesocket'], function (app) {
 
 					ctrl.EditSetPoint = function (fn) {
 						return EditSetPoint(item.idx, escape(item.Name), escape(item.Description), item.SetPoint, item.Status, item.Until, fn);
+					};
+					
+					ctrl.ShowSetpointPopup = function (event) {
+						var step = item.step || 0.5;
+						var min = item.min || -200;
+						var max = item.max || 200;
+						ShowSetpointPopup(event, item.idx, item.Protected, item.SetPoint, false, step, min, max);
 					};
 
 					ctrl.EditState = function (fn) {

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -1722,6 +1722,10 @@
 						<option value="0xF701" data-i18n="Temp+Baro">Temp+Baro</option>
 						<option value="0xF313" data-i18n="Text">Text</option>
 						<option value="0xF201" data-i18n="Thermostat Setpoint">Thermostat Setpoint</option>
+						<option value="0x4900" data-i18n="Thermostat (Temperature/Setpoint)">Thermostat (Temperature/Setpoint)</option>
+						<option value="0x4901" data-i18n="Thermostat (Temperature/Humidity/Setpoint)">Thermostat (Temperature/Humidity/Setpoint)</option>
+						<option value="0x4902" data-i18n="Thermostat (Temperature/Barometer/Setpoint)">Thermostat (Temperature/Barometer/Setpoint)</option>
+						<option value="0x4903" data-i18n="Thermostat (Temperature/Humidity/Barometer/Setpoint)">Thermostat (Temperature/Humidity/Barometer/Setpoint)</option>
 						<option value="0xF801" data-i18n="Usage (Electric)">Usage (Electric)</option>
 						<option value="0x5701" data-i18n="UV">UV</option>
 						<option value="0xF301" data-i18n="Visibility">Visibility</option>

--- a/www/views/temperature_widget.html
+++ b/www/views/temperature_widget.html
@@ -14,18 +14,26 @@
                     <span ng-show="ctrl.displayHumidity() && (ctrl.displayTemp() || ctrl.displaySetPoint() || ctrl.displayState() || ctrl.displayHeat())">/</span>
                     <span ng-show="ctrl.displayHumidity()">{{item.Humidity}}%</span>
 
+                    <span ng-show="ctrl.displayBarometer() && (ctrl.displayTemp() || ctrl.displaySetPoint() || ctrl.displayState() || ctrl.displayHeat() || ctrl.displayHumidity())">/</span>
+                    <span ng-show="ctrl.displayBarometer()">{{item.Barometer}} hPa</span>
+
                     <span ng-show="ctrl.displayChill() && (ctrl.displayTemp() || ctrl.displaySetPoint() || ctrl.displayState() || ctrl.displayHeat())">/</span>
                     <span ng-show="ctrl.displayChill()">{{item.Chill}}&#176; {{tempsign}}</span>
                 </td>
-                <td id="img"><img ng-src="images/{{ctrl.image()}}" height="48" width="48"></td>
+                <td id="img">
+                    <img ng-if="item.Type != 'Thermostat 6'" ng-src="images/{{ctrl.image()}}" height="48" width="48">
+                    <img ng-if="item.Type == 'Thermostat 6'" ng-src="images/{{ctrl.image()}}" height="48" width="48" class="lcursor" ng-click="ctrl.ShowSetpointPopup($event)">
+                </td>
                 <td id="status" class="ng-cloak">
                     <!-- NB : weird comments to avoid unwanted spaces due to new line -->
-                    <span ng-show="ctrl.displaySetPoint()" data-i18n="Set Point">Set Point</span><span ng-show="ctrl.displaySetPoint() && ctrl.isSetPointOn()">: {{item.SetPoint}}&#176; {{tempsign}}, </span><span ng-show="ctrl.displaySetPoint() && !ctrl.isSetPointOn()">: Off, </span><!--
+                    <span ng-show="ctrl.displaySetPoint()" data-i18n="Set Point">Set Point</span><span ng-show="ctrl.displaySetPoint() && ctrl.isSetPointOn()">: {{item.SetPoint}}&#176; {{tempsign}}</span><span ng-show="ctrl.displayMode()">, </span><span ng-show="ctrl.displaySetPoint() && !ctrl.isSetPointOn()">: Off, </span><!--
                     --><span ng-show="ctrl.displayState()" data-i18n="State">State</span><span ng-show="ctrl.displayState()">: {{item.State}}, </span><span ng-show="ctrl.displayMode()" data-i18n="Mode">Mode</span><span ng-show="ctrl.displayMode()">: {{ctrl.EvoDisplayTextMode()}}</span><!--
                     --><span ng-show="ctrl.displayUntil()">, </span><!--
                     --><span ng-show="ctrl.displayUntil()" data-i18n="Until">Until</span><span ng-show="ctrl.displayUntil()">: {{ctrl.dtUntil()}} </span><!--
+                    --><span ng-show="ctrl.displaySetPoint() && ctrl.displayHumidityStatus()">, </span><!--
                     --><span ng-show="ctrl.displayHumidityStatus()">{{ctrl.HumidityStatus()}}</span><!--
                     --><span ng-show="(ctrl.displayMode() || ctrl.displayHumidityStatus()) && ctrl.displayBarometer()">, </span><!--
+                    --><span ng-show="ctrl.displaySetPoint() && !ctrl.displayMode() && !ctrl.displayHumidityStatus() && ctrl.displayBarometer()">, </span><!--
                     --><span ng-show="ctrl.displayBarometer()" data-i18n="Barometer">Barometer</span><span ng-show="ctrl.displayBarometer()">: {{item.Barometer}} hPa</span><!--
                     --><span ng-show="ctrl.displayForecast()">, </span><!--
                     --><span ng-show="ctrl.displayForecast()" data-i18n="Prediction">Prediction</span><span ng-show="ctrl.displayForecast()">: </span><span ng-show="ctrl.displayForecast()">{{ctrl.ForecastStr()}}</span><br ng-show="ctrl.displayForecast()"><!--
@@ -33,7 +41,7 @@
                     --><span ng-show="ctrl.displayGust()">, </span><!--
                     --><span ng-show="ctrl.displayGust()" data-i18n="Gust">Gust</span><span ng-show="ctrl.displayGust()">: {{item.Gust}} {{windsign}}</span><!--
                     --><span ng-show="(ctrl.displayMode() || ctrl.displayHumidityStatus()) && !ctrl.displayForecast() && ctrl.displayDewPoint()">, </span><!--
-                    --><span ng-show="ctrl.displayDewPoint()" data-i18n="Dew Point">Dew Point</span><span ng-show="ctrl.displayDewPoint()">: {{item.DewPoint}}&#176; {{tempsign}}</span>
+                    --><span ng-show="ctrl.displayDewPoint()" data-i18n="Dew Point">Dew Point</span><span ng-show="ctrl.displayDewPoint()">: {{item.DewPoint | number:2}}&#176; {{tempsign}}</span>
                 </td>
                 <td id="lastupdate" ng-bind="item.LastUpdate"></td>
                 <td class="options">
@@ -51,7 +59,8 @@
                     </span>
 
                     <a ng-show="item.forecast_url" class="btnsmall" ng-click="ctrl.ShowForecast('#tempcontent', 'ShowTemps')" data-i18n="Forecast">Forecast</a>
-		    <a ng-show="(item.SetPoint && item.SubType != 'Hot Water')" id="set" class="btnsmall" ng-click="ctrl.EditSetPoint('ShowTemps')" data-i18n="Set">Set</a>
+		    <a ng-show="(item.SetPoint && item.SubType != 'Hot Water' && item.Type != 'Thermostat 6')" id="set" class="btnsmall" ng-click="ctrl.EditSetPoint('ShowTemps')" data-i18n="Set">Set</a>
+		    <a ng-show="(item.SetPoint && item.SubType != 'Hot Water' && item.Type == 'Thermostat 6')" id="set" class="btnsmall" ng-click="ctrl.ShowSetpointPopup($event)" data-i18n="Set">Set</a>
                     <a ng-show="(item.State || item.SubType == 'Hot Water')" id="set" class="btnsmall" ng-click="ctrl.EditState('ShowTemps')" data-i18n="Set">Set</a>                    
                 </td>
             </tr>


### PR DESCRIPTION
We have lovely combined devices for Temp/Hum/Baro, and even for Evohome zones we have a combined setpoint/temp with a lovely graph that shows them together. Let's have the setpoint support for non-Evohome too.

This adds a pTypeThermostat6 type, with subtypes for the different hum/baro combinations. Uses the existing graph support for those in the UI and just has to enable it for the appropriate types, as well as the setpoint control.

Hook it up to Alexa, allow users to make them as virtual sensors, make MQTT 'climate' devices register a single combined Domoticz device where they can instead of the separate setpoint/temp/etc, and we have nice shiny thermostat support...

<img width="1062" height="614" alt="Screenshot from 2025-11-22 01-34-44" src="https://github.com/user-attachments/assets/4baa96d8-2884-42dd-929e-b074981b2332" />
<img width="2414" height="752" alt="Screenshot from 2025-11-22 01-36-35" src="https://github.com/user-attachments/assets/920f5235-a504-4bb8-865d-698eb4846fcf" />