### PR TITLE
Fix flash of unfiltered devices on live updates

### DIFF
--- a/www/app/LightsController.js
+++ b/www/app/LightsController.js
@@ -314,6 +314,21 @@ define(['app', 'livesocket'], function (app) {
 				return; //idx not found
 			}
 
+			var bigtext = TranslateStatusShort(item.Status);
+			if (item.UsedByCamera == true) {
+				var streamimg = '<img src="images/webcam.png" title="' + $.t('Stream Video') + '" height="16" width="16">';
+				var streamurl = "<a href=\"javascript:ShowCameraLiveStream('" + escape(item.Name) + "'," + item.CameraIdx + "," + item.CameraAspect + ")\">" + streamimg + "</a>";
+				bigtext += "&nbsp;" + streamurl;
+			}
+			var searchText = GenerateLiveSearchTextL(item, bigtext);
+			var query = $('.jsLiveSearch').val();
+			if (query && query.length > 0) {
+				var match = searchText.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+				if (!match) {
+					return; // Don't update items that don't match the filter
+				}
+			}
+
 			if ($(id + " #name").html() != item.Name) {
 				$(id + " #name").html(item.Name);
 			}
@@ -323,9 +338,7 @@ define(['app', 'livesocket'], function (app) {
 			var img3 = "";
 			var status = "";
 
-			//console.log(item);
-
-			var bigtext = TranslateStatusShort(item.Status);
+			bigtext = TranslateStatusShort(item.Status);
 			if (item.UsedByCamera == true) {
 				var streamimg = '<img src="images/webcam.png" title="' + $.t('Stream Video') + '" height="16" width="16">';
 				var streamurl = "<a href=\"javascript:ShowCameraLiveStream('" + escape(item.Name) + "'," + item.CameraIdx + "," + item.CameraAspect + ")\">" + streamimg + "</a>";
@@ -695,7 +708,6 @@ define(['app', 'livesocket'], function (app) {
 				$(id + " #lastupdate").html(item.LastUpdate);
 			}
 
-			var searchText = GenerateLiveSearchTextL(item, bigtext);
 			$(id).find('#name').attr('data-search', searchText);
 			
 			if (!document.hidden) {

--- a/www/app/ScenesController.js
+++ b/www/app/ScenesController.js
@@ -767,6 +767,21 @@ define(['app', 'livesocket'], function (app) {
 			var id = "#" + item.idx;
 			var obj = $element.find(id);
 			if (typeof obj != 'undefined') {
+				var bigtext = TranslateStatusShort(item.Status);
+				if (item.UsedByCamera == true) {
+					var streamimg = '<img src="images/webcam.png" title="' + $.t('Stream Video') + '" height="16" width="16">';
+					streamurl = "<a href=\"javascript:ShowCameraLiveStream('" + escape(item.Name) + "'," + item.CameraIdx + "," + item.CameraAspect + ")\">" + streamimg + "</a>";
+					bigtext += "&nbsp;" + streamurl;
+				}
+				var searchText = GenerateLiveSearchTextSG(item, bigtext);
+				var query = $('.jsLiveSearch').val();
+				if (query && query.length > 0) {
+					var match = searchText.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+					if (!match) {
+						return; // Don't update items that don't match the filter
+					}
+				}
+
 				if ($(id + " #name").html() != item.Name) {
 					$(id + " #name").html(item.Name);
 				}
@@ -778,7 +793,7 @@ define(['app', 'livesocket'], function (app) {
 				var img1 = "";
 				var img2 = "";
 
-				var bigtext = TranslateStatusShort(item.Status);
+				bigtext = TranslateStatusShort(item.Status);
 				
 				if (item.UsedByCamera == true) {
 					var streamimg = '<img src="images/webcam.png" title="' + $.t('Stream Video') + '" height="16" width="16">';
@@ -820,7 +835,6 @@ define(['app', 'livesocket'], function (app) {
 					$(id + " #lastupdate").html(item.LastUpdate);
 				}
 				
-				var searchText = GenerateLiveSearchTextSG(item, bigtext);
 				$(id).find('#name').attr('data-search', searchText);
 				
 				if (!document.hidden) {

--- a/www/app/TemperatureController.js
+++ b/www/app/TemperatureController.js
@@ -97,6 +97,13 @@ define(['app', 'livesocket'], function (app) {
 
 		RefreshItem = function (item) {
 			item.searchText = GenerateLiveSearchTextT(item);
+			var query = $('.jsLiveSearch').val();
+			if (query && query.length > 0) {
+				var match = item.searchText.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+				if (!match) {
+					return; // Don't update items that don't match the filter
+				}
+			}
 			ctrl.temperatures.forEach(function (olditem, oldindex, oldarray) {
 				if (olditem.idx == item.idx) {
 					oldarray[oldindex] = item;

--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -364,12 +364,33 @@ define(['app', 'livesocket'], function (app) {
 			id = "#utilitycontent #" + item.idx;
 			var obj = $(id);
 			if (typeof obj != 'undefined') {
+				var bigtext = "";
+				if ((typeof item.Usage != 'undefined') && (typeof item.UsageDeliv == 'undefined')) {
+					bigtext = item.Usage;
+				}
+				if (typeof item.Counter != 'undefined') {
+					if (
+						(item.SubType == "Gas") ||
+						(item.SubType == "RFXMeter counter") ||
+						(item.SubType == "Counter Incremental")
+					) {
+						bigtext = item.CounterToday;
+					}
+				}
+				var searchText = GenerateLiveSearchTextU(item, bigtext);
+				var query = $('.jsLiveSearch').val();
+				if (query && query.length > 0) {
+					var match = searchText.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+					if (!match) {
+						return; // Don't update items that don't match the filter
+					}
+				}
+
 				if ($(id + " #name").html() != item.Name) {
 					$(id + " #name").html(item.Name);
 				}
 				var img = "";
 				var status = "";
-				var bigtext = "";
 
 				if ((typeof item.Usage != 'undefined') && (typeof item.UsageDeliv == 'undefined')) {
 					bigtext = item.Usage;
@@ -519,7 +540,6 @@ define(['app', 'livesocket'], function (app) {
 					}
 				}
 				
-				var searchText = GenerateLiveSearchTextU(item, bigtext);
 				$(id).find('#name').attr('data-search', searchText);
 				
 				if (!document.hidden) {

--- a/www/app/WeatherController.js
+++ b/www/app/WeatherController.js
@@ -75,6 +75,13 @@ define(['app', 'livesocket'], function (app) {
 
 		RefreshItem = function (item) {
 			item.searchText = GenerateLiveSearchTextW(item);
+			var query = $('.jsLiveSearch').val();
+			if (query && query.length > 0) {
+				var match = item.searchText.toLowerCase().indexOf(query.toLowerCase()) !== -1;
+				if (!match) {
+					return; // Don't update items that don't match the filter
+				}
+			}
 			ctrl.items.forEach(function (olditem, oldindex, oldarray) {
 				if (olditem.idx == item.idx) {
 					oldarray[oldindex] = item;


### PR DESCRIPTION
When devices are updated via websocket (e.g., MQTT autodiscovery), they would briefly flash on screen even when a filter was active, before the filter logic would hide them again.

Fixed by checking the active filter in RefreshItem() and returning early without updating items that don't match. This prevents Angular from re-rendering non-matching items, eliminating the flash.

Fixes #6447