### PR TITLE
Adding extra validations since Hue Bridge firmware 1.74.1974063020 crashes Domoticz in certain cases

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -4,7 +4,7 @@ Version 2025.xxxx
 - Implemented: PhilipsHue v2 API, just for Door/Window Contacts (state/tamper/battery)
 - Fixed: Chart zoom buttons (notable on iOS devices)
 - Fixed: Possible memory leak in Kodi Notification when destination is unreachable
-- Fixed: PhilipsHue v1 API crashes Domoticz in certain cases (added extra validations)
+- Fixed: PhilipsHue v1 API crashes Domoticz in certain cases since Hue Bridge firmware 1.74 (added extra validations)
 - Changed: Enever, using v3 API
 - Changed: PhilipsHue, now used HTTP scheme (HTTP/HTTPS) based on port number (80/443)
 

--- a/History.txt
+++ b/History.txt
@@ -4,7 +4,7 @@ Version 2025.xxxx
 - Implemented: PhilipsHue v2 API, just for Door/Window Contacts (state/tamper/battery)
 - Fixed: Chart zoom buttons (notable on iOS devices)
 - Fixed: Possible memory leak in Kodi Notification when destination is unreachable
-- Fixed: PhilipsHue v1 API crashes Domoticz in certain cases by adding extra validations
+- Fixed: PhilipsHue v1 API crashes Domoticz in certain cases (added extra validations)
 - Changed: Enever, using v3 API
 - Changed: PhilipsHue, now used HTTP scheme (HTTP/HTTPS) based on port number (80/443)
 

--- a/History.txt
+++ b/History.txt
@@ -4,6 +4,7 @@ Version 2025.xxxx
 - Implemented: PhilipsHue v2 API, just for Door/Window Contacts (state/tamper/battery)
 - Fixed: Chart zoom buttons (notable on iOS devices)
 - Fixed: Possible memory leak in Kodi Notification when destination is unreachable
+- Fixed: PhilipsHue v1 API crashes Domoticz in certain cases by adding extra validations
 - Changed: Enever, using v3 API
 - Changed: PhilipsHue, now used HTTP scheme (HTTP/HTTPS) based on port number (80/443)
 

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -94,21 +94,27 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 
 void CPhilipsHue::Init()
 {
-	// instantiate V2 sensors helper if enabled
-	if (m_use_v2_sensors)
-	{
-		// Use m_UserName as hue-application-key for now (same field used for v1 username).
-		try
+	if (m_Port == 443) {
+		// instantiate V2 sensors helper if enabled and Port is 443 (HTTPS)
+		if (m_use_v2_sensors)
 		{
-			m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
-			Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled.");
+			// Use m_UserName as hue-application-key for now (same field used for v1 username).
+			try
+			{
+				m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
+				Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled.");
+			}
+			catch (const std::exception& e)
+			{
+				Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
+				//m_v2sensors.reset();
+				m_use_v2_sensors = false;
+			}
 		}
-		catch (const std::exception& e)
-		{
-			Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
-			//m_v2sensors.reset();
-			m_use_v2_sensors = false;
-		}
+	} else {
+		// no v2 sensors on non-HTTPS connections
+		Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled.");
+		m_use_v2_sensors = false;
 	}
 }
 

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -65,7 +65,6 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 	m_poll_interval = PollInterval;
 	// Force-enable V2 sensors by default by OR-ing the option in here.
 	// This keeps callers unchanged but makes the behavior default-on.
-	//int effectiveOptions = Options | CPhilipsHue::HUE_USE_V2_SENSORS;
 	int effectiveOptions = Options | HUE_USE_V2_SENSORS;
 
 	m_add_groups = (effectiveOptions & HUE_NOT_ADD_GROUPS) != 0;
@@ -94,8 +93,8 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 
 void CPhilipsHue::Init()
 {
+	// instantiate V2 sensors helper when Port is 443 (HTTPS) and if enabled
 	if (m_Port == 443) {
-		// instantiate V2 sensors helper if enabled and Port is 443 (HTTPS)
 		if (m_use_v2_sensors)
 		{
 			// Use m_UserName as hue-application-key for now (same field used for v1 username).
@@ -107,7 +106,6 @@ void CPhilipsHue::Init()
 			catch (const std::exception& e)
 			{
 				Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
-				//m_v2sensors.reset();
 				m_use_v2_sensors = false;
 			}
 		}
@@ -1061,7 +1059,6 @@ bool CPhilipsHue::GetGroups(const Json::Value& root)
 			_eHueLightType LType;
 			bool bDoSend = true;
 			//LightStateFromJSON(group["action"], tstate, LType); //TODO: Verify there is no crash with "bad" key -> done?!
-			// new
 			Json::Value action = group.get("action", Json::Value());
 			if (!action.isObject()) {
 				Log(LOG_ERROR, "Hue group %d has invalid or missing 'action' object. Skipping.", gID);
@@ -1077,7 +1074,6 @@ bool CPhilipsHue::GetGroups(const Json::Value& root)
 				Log(LOG_ERROR, "Exception while parsing Hue group %d action: %s", gID, e.what());
 				continue;
 			}
-			// /new
 
 			auto myGroup = m_groups.find(gID);
 			if (myGroup != m_groups.end())

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -95,23 +95,23 @@ void CPhilipsHue::Init()
 {
 	// instantiate V2 sensors helper when Port is 443 (HTTPS) and if enabled
 	if (m_Port == 443) {
-		if (m_use_v2_sensors)
-		{
+		if (m_use_v2_sensors) {
 			// Use m_UserName as hue-application-key for now (same field used for v1 username).
-			try
-			{
+			try {
 				m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
-				Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled.");
+				Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled (Port==443).");
 			}
-			catch (const std::exception& e)
-			{
+			catch (const std::exception& e) {
 				Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
 				m_use_v2_sensors = false;
 			}
+		} else {
+			// no v2 sensors when disabled/false
+			Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled.");
 		}
 	} else {
 		// no v2 sensors on non-HTTPS connections
-		Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled.");
+		Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled (Port<>443).");
 		m_use_v2_sensors = false;
 	}
 }

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -838,60 +838,160 @@ void CPhilipsHue::LightStateFromJSON(const Json::Value& lightstate, _tHueLightSt
 
 		LType = HLTYPE_NORMAL;
 
-		if (!lightstate["on"].empty())
+		// if (!lightstate["on"].empty())
+		// {
+		// 	tlight.on = lightstate["on"].asBool();
+		// }
+		// ---- "on" ----
+		if (lightstate.isMember("on") && lightstate["on"].isBool())
 		{
 			tlight.on = lightstate["on"].asBool();
 		}
-		if (!lightstate["colormode"].empty())
+		else
+		{
+			// default safe
+			tlight.on = false;
+		}
+
+		// if (!lightstate["colormode"].empty())
+		// {
+		// 	std::string sMode = lightstate["colormode"].asString();
+		// 	if (sMode == "hs") tlight.mode = HLMODE_HS;
+		// 	if (sMode == "xy") tlight.mode = HLMODE_XY;
+		// 	if (sMode == "ct") tlight.mode = HLMODE_CT;
+		// }
+		// ---- "colormode" ----
+		if (lightstate.isMember("colormode") && lightstate["colormode"].isString())
 		{
 			std::string sMode = lightstate["colormode"].asString();
-			if (sMode == "hs") tlight.mode = HLMODE_HS;
-			if (sMode == "xy") tlight.mode = HLMODE_XY;
-			if (sMode == "ct") tlight.mode = HLMODE_CT;
+			if (sMode == "hs")       tlight.mode = HLMODE_HS;
+			else if (sMode == "xy")  tlight.mode = HLMODE_XY;
+			else if (sMode == "ct")  tlight.mode = HLMODE_CT;
+			else                     tlight.mode = HLMODE_NONE; // Unknown mode (Hue sometimes sends "")
 		}
-		if (!lightstate["bri"].empty())
+		else
 		{
-			//Lamp with brightness control
+			// Some bridges leave colormode out when off or switching
+			tlight.mode = HLMODE_NONE;
+		}
+
+		// if (!lightstate["bri"].empty())
+		// {
+		// 	//Lamp with brightness control
+		// 	hasBri = true;
+		// 	int tbri = lightstate["bri"].asInt();
+		// 	// Clamp to conform to HUE API
+		// 	tbri = std::max(1, tbri);
+		// 	tbri = std::min(254, tbri);
+		// 	tlight.level = int(std::ceil((100.0F / 254.0F) * float(tbri)));
+		// }
+		// ---- "bri" ----
+		if (lightstate.isMember("bri") && lightstate["bri"].isInt())
+		{
 			hasBri = true;
 			int tbri = lightstate["bri"].asInt();
-			// Clamp to conform to HUE API
+
+			// Hue sometimes gives 0 (should be 1..254)
 			tbri = std::max(1, tbri);
 			tbri = std::min(254, tbri);
+
 			tlight.level = int(std::ceil((100.0F / 254.0F) * float(tbri)));
 		}
-		if (!lightstate["sat"].empty())
+		else
 		{
-			//Lamp with color control
-			hasHueSat = true;
-			tlight.sat = lightstate["sat"].asInt();
-			// Clamp to conform to HUE API
-			tlight.sat = std::max(0, tlight.sat);
-			tlight.sat = std::min(254, tlight.sat);
+			// safe fallback
+			hasBri = false;
+			tlight.level = 0;
 		}
-		if (!lightstate["hue"].empty())
+
+
+		// if (!lightstate["sat"].empty())
+		// {
+		// 	//Lamp with color control
+		// 	hasHueSat = true;
+		// 	tlight.sat = lightstate["sat"].asInt();
+		// 	// Clamp to conform to HUE API
+		// 	tlight.sat = std::max(0, tlight.sat);
+		// 	tlight.sat = std::min(254, tlight.sat);
+		// }
+		// ---- "sat" ----
+		if (lightstate.isMember("sat") && lightstate["sat"].isInt())
 		{
-			//Lamp with color control
 			hasHueSat = true;
-			tlight.hue = lightstate["hue"].asInt();
-			// Clamp to conform to HUE API
-			tlight.hue = std::max(0, tlight.hue);
-			tlight.hue = std::min(65535, tlight.hue);
+			int tsat = lightstate["sat"].asInt();
+			tsat = std::max(0, tsat);
+			tsat = std::min(254, tsat);
+			tlight.sat = tsat;
 		}
-		if (!lightstate["ct"].empty())
+		else
 		{
-			//Lamp with color temperature control
+			// some bulbs don't have saturation
+			tlight.sat = 0;
+		}
+
+		// if (!lightstate["hue"].empty())
+		// {
+		// 	//Lamp with color control
+		// 	hasHueSat = true;
+		// 	tlight.hue = lightstate["hue"].asInt();
+		// 	// Clamp to conform to HUE API
+		// 	tlight.hue = std::max(0, tlight.hue);
+		// 	tlight.hue = std::min(65535, tlight.hue);
+		// }
+		// ---- "hue" ----
+		if (lightstate.isMember("hue") && lightstate["hue"].isInt())
+		{
+			hasHueSat = true;
+			int thue = lightstate["hue"].asInt();
+			thue = std::max(0, thue);
+			thue = std::min(65535, thue);
+			tlight.hue = thue;
+		}
+		else
+		{
+			tlight.hue = 0;
+		}
+
+		// if (!lightstate["ct"].empty())
+		// {
+		// 	//Lamp with color temperature control
+		// 	hasTemp = true;
+		// 	tlight.ct = lightstate["ct"].asInt();
+		// 	// Clamp to conform to HUE API
+		// 	tlight.ct = std::max(153, tlight.ct);
+		// 	tlight.ct = std::min(500, tlight.ct);
+		// }
+		// ---- "ct" ----
+		if (lightstate.isMember("ct") && lightstate["ct"].isInt())
+		{
 			hasTemp = true;
-			tlight.ct = lightstate["ct"].asInt();
-			// Clamp to conform to HUE API
-			tlight.ct = std::max(153, tlight.ct);
-			tlight.ct = std::min(500, tlight.ct);
+			int tct = lightstate["ct"].asInt();
+			tct = std::max(153, tct);
+			tct = std::min(500, tct);
+			tlight.ct = tct;
 		}
-		if (!lightstate["xy"].empty())
+		else
 		{
+			tlight.ct = 0;
+		}
+		
+		// if (!lightstate["xy"].empty())
+		// {
+		// 	//Lamp with color control
+		// 	hasHueSat = true;
+		// 	tlight.x = lightstate["xy"][0].asDouble();
+		// 	tlight.y = lightstate["xy"][1].asDouble();
+		// }
+		// new
+		if (lightstate.isMember("xy") && lightstate["xy"].isArray() && lightstate["xy"].size() >= 2) {
 			//Lamp with color control
 			hasHueSat = true;
 			tlight.x = lightstate["xy"][0].asDouble();
 			tlight.y = lightstate["xy"][1].asDouble();
+		} else {
+			// default safe values
+			tlight.x = 0.0;
+			tlight.y = 0.0;
 		}
 
 		if (hasBri) LType = HLTYPE_DIM;
@@ -954,7 +1054,24 @@ bool CPhilipsHue::GetGroups(const Json::Value& root)
 			_tHueLightState tstate;
 			_eHueLightType LType;
 			bool bDoSend = true;
-			LightStateFromJSON(group["action"], tstate, LType); //TODO: Verify there is no crash with "bad" key
+			//LightStateFromJSON(group["action"], tstate, LType); //TODO: Verify there is no crash with "bad" key -> done?!
+			// new
+			Json::Value action = group.get("action", Json::Value());
+			if (!action.isObject()) {
+				Log(LOG_ERROR, "Hue group %d has invalid or missing 'action' object. Skipping.", gID);
+				continue;
+			} else {
+				Log(LOG_DEBUG_INT, "Hue group %d has 'action' object. ", gID);
+			}
+
+			try {
+				LightStateFromJSON(action, tstate, LType);
+			}
+			catch (const std::exception& e) {
+				Log(LOG_ERROR, "Exception while parsing Hue group %d action: %s", gID, e.what());
+				continue;
+			}
+			// /new
 
 			auto myGroup = m_groups.find(gID);
 			if (myGroup != m_groups.end())
@@ -1130,8 +1247,7 @@ bool CPhilipsHue::GetV2Sensors()
 	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
 	if (!m_use_v2_sensors || !m_v2sensors)
 		return false;
-	//if (m_use_v2_sensors && m_v2sensors)
-	//{
+	
 	try
 	{
 		if (m_v2sensors->UpdateAll())
@@ -1316,8 +1432,7 @@ bool CPhilipsHue::GetV2Sensors()
 	{
 		_log.Log(LOG_ERROR, "PhilipsHue: exception in v2 sensor handling: %s", e.what());
 	}
-	//}
-
+	
 	return true;
 }
 

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
@@ -66,7 +66,7 @@ bool CPhilipsHueV2Sensors::FetchDevices()
 	std::string sResult;
 	if (!http_get_with_key(url, m_ApplicationKey, sResult))
 	{
-		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevices HTTP GET failed (%s)", url.c_str());
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchDevices HTTP GET failed (%s)", url.c_str());
 		return false;
 	}
 	Json::Value root;
@@ -86,7 +86,7 @@ bool CPhilipsHueV2Sensors::FetchContacts()
 	std::string sResult;
 	if (!http_get_with_key(url, m_ApplicationKey, sResult))
 	{
-		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchContacts HTTP GET failed (%s)", url.c_str());
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchContacts HTTP GET failed (%s)", url.c_str());
 		return false;
 	}
 	Json::Value root;
@@ -106,7 +106,7 @@ bool CPhilipsHueV2Sensors::FetchTamper()
 	std::string sResult;
 	if (!http_get_with_key(url, m_ApplicationKey, sResult))
 	{
-		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchTamper HTTP GET failed (%s)", url.c_str());
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchTamper HTTP GET failed (%s)", url.c_str());
 		return false;
 	}
 	Json::Value root;
@@ -126,7 +126,7 @@ bool CPhilipsHueV2Sensors::FetchDevicePower()
 	std::string sResult;
 	if (!http_get_with_key(url, m_ApplicationKey, sResult))
 	{
-		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchDevicePower HTTP GET failed (%s)", url.c_str());
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchDevicePower HTTP GET failed (%s)", url.c_str());
 		return false;
 	}
 	Json::Value root;

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.h
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.h
@@ -1,6 +1,5 @@
 #pragma once
 
-//#include "stdafx.h"
 #include "PhilipsHueSensors.h"
 #include <string>
 #include <vector>


### PR DESCRIPTION
I've added some extra validations to Philips Hue Bridge API v1 code since several Philips Hue v2 Bridges are experiencing issues with the new firmware 1.74.1974063020. 

The root cause is unclear at this moment as I cannot reproduce it. However I hope and suspect this commit will eliminate Domoticz crashes or at least it could give some more information regarding the issue.

I've also changed the Hue v2 API LOG_ERROR messages into LOG_DEBUG_INT as these are not real errors, which could be confusing.