### PR TITLE
Spread data spikes over missing days in counter graphs

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -7893,13 +7893,6 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				}
 			}
 		}
-		else
-		{
-			//no new meter result received in last day
-			result = safe_query("INSERT INTO Meter_Calendar (DeviceRowID, Value, Price, Date) "
-					    "VALUES ('%" PRIu64 "', '%.2f', '%.4f', '%q')",
-					    ID, 0.0F, 0.0F, szDateStart);
-		}
 	}
 }
 

--- a/www/app/log/CounterLogCounter.js
+++ b/www/app/log/CounterLogCounter.js
@@ -48,6 +48,9 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
                     .concat(counterLogCounterSeriesSuppliers.counterTrendlineSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1000))
                     .concat(counterLogCounterSeriesSuppliers.counterPreviousSeriesSupplier(deviceTypeIndex, chart.valueMultipliers.m1000));
             },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
+            },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;
             },
@@ -111,6 +114,9 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
                     .concat(counterLogCounterSeriesSuppliers.counterTrendlineSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1))
                     .concat(counterLogCounterSeriesSuppliers.counterPreviousSeriesSupplier(deviceTypeIndex, chart.valueMultipliers.m1))
 					.concat(counterLogCounterSeriesSuppliers.counterPriceSeriesSuppliers());
+            },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;
@@ -176,6 +182,9 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
                     .concat(counterLogCounterSeriesSuppliers.counterPreviousSeriesSupplier(deviceTypeIndex, chart.valueMultipliers.m1, times1000, 0))
 					.concat(counterLogCounterSeriesSuppliers.counterPriceSeriesSuppliers());
             },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
+            },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;
             },
@@ -190,6 +199,7 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
             },
             preprocessMonthYearData: function (data) {
                 preprocessData.call(this, data);
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             chartParamsDayTemplate: {
 
@@ -236,6 +246,9 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
                     .concat(counterLogCounterSeriesSuppliers.counterSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1, undefined, decimalPlacesDiv1(divider)))
                     .concat(counterLogCounterSeriesSuppliers.counterTrendlineSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1, undefined, decimalPlacesDiv1(divider)))
                     .concat(counterLogCounterSeriesSuppliers.counterPreviousSeriesSupplier(deviceTypeIndex, chart.valueMultipliers.m1, undefined, decimalPlacesDiv1(divider)));
+            },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;
@@ -291,6 +304,9 @@ define(['app', 'lodash', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogCou
                     .concat(counterLogCounterSeriesSuppliers.counterSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1000))
                     .concat(counterLogCounterSeriesSuppliers.counterTrendlineSeriesSuppliers(deviceTypeIndex, chart.valueMultipliers.m1000))
                     .concat(counterLogCounterSeriesSuppliers.counterPreviousSeriesSupplier(deviceTypeIndex, chart.valueMultipliers.m1000));
+            },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;

--- a/www/app/log/CounterLogInstantAndCounter.js
+++ b/www/app/log/CounterLogInstantAndCounter.js
@@ -1,4 +1,4 @@
-define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesSuppliers'], function (app) {
+define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesSuppliers', 'log/CounterLogSeriesSupplier'], function (app) {
 
     app.directive('registerInstantAndCounter', function (chart, counterLogSubtypeRegistry, counterLogParams, counterLogEnergySeriesSuppliers, counterLogSeriesSupplier) {
         counterLogSubtypeRegistry.register('instantAndCounter', {
@@ -72,7 +72,10 @@ define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesS
                     .concat(counterLogEnergySeriesSuppliers.trendlineMonthYearSeriesSuppliers(deviceType))
 					.concat(counterLogEnergySeriesSuppliers.pastMonthYearSeriesSuppliers(deviceType))
 					.concat(counterLogEnergySeriesSuppliers.priceMonthYearSeriesSuppliers(deviceType));
-                    
+
+            },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             extendDataRequestCompare: function (dataRequest) {
                 return dataRequest;

--- a/www/app/log/CounterLogP1Energy.js
+++ b/www/app/log/CounterLogP1Energy.js
@@ -1,4 +1,4 @@
-define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesSuppliers'], function (app) {
+define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesSuppliers', 'log/CounterLogSeriesSupplier'], function (app) {
 
     app.directive('registerP1Energy', function (chart, counterLogSubtypeRegistry, counterLogParams, counterLogEnergySeriesSuppliers, counterLogSeriesSupplier) {
         counterLogSubtypeRegistry.register('p1Energy', {
@@ -158,6 +158,9 @@ define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesS
 					.concat(counterLogEnergySeriesSuppliers.p1PastMonthYearSeriesSuppliers(deviceType))
 					.concat(counterLogEnergySeriesSuppliers.powerPastReturnedMonthYearSeriesSuppliers(deviceType))
                     .concat(counterLogEnergySeriesSuppliers.p1PriceSeriesSuppliers(deviceType));
+            },
+            preprocessMonthYearData: function (data) {
+                counterLogSeriesSupplier.fillMissingDays(data);
             },
             preprocessCompareData: function (data) {
                 this.dataContainsDelivery = data.delivered ? true : false;

--- a/www/app/log/CounterLogSeriesSupplier.js
+++ b/www/app/log/CounterLogSeriesSupplier.js
@@ -4,7 +4,8 @@ define(['app', 'log/Chart'], function (app) {
         return {
             dataItemsKeysPredicatedSeriesSupplier: dataItemsKeysPredicatedSeriesSupplier,
             summingSeriesSupplier: summingSeriesSupplier,
-            counterCompareSeriesSuppliers: counterCompareSeriesSuppliers
+            counterCompareSeriesSuppliers: counterCompareSeriesSuppliers,
+            fillMissingDays: fillMissingDays
         };
 
         function dataItemsKeysPredicatedSeriesSupplier(dataItemValueKey, dataSeriesItemsKeysPredicate, seriesSupplierTemplate) {
@@ -150,6 +151,54 @@ define(['app', 'log/Chart'], function (app) {
                         []
                     );
             }
+        }
+
+        function fillMissingDays(data) {
+            // Fill in missing days in data.result to spread spikes
+            if (!data || !data.result || !Array.isArray(data.result)) return;
+
+            const result = [];
+            let lastDate = null;
+            let lastItem = null;
+
+            data.result.forEach(function(item) {
+                if (item.d) {
+                    const currentDate = new Date(item.d);
+                    if (lastDate && lastItem) {
+                        const daysDiff = Math.round((currentDate - lastDate) / (1000 * 60 * 60 * 24));
+                        if (daysDiff > 1) {
+                            const avgValue = parseFloat(item.v) / daysDiff;
+                            const avgV2 = item.v2 ? parseFloat(item.v2) / daysDiff : 0;
+                            const startCounter = parseFloat(lastItem.c || 0);
+                            const endCounter = parseFloat(item.c || 0);
+                            const counterIncrement = (endCounter - startCounter) / daysDiff;
+
+                            for (let i = 1; i < daysDiff; i++) {
+                                const fillDate = new Date(lastDate);
+                                fillDate.setDate(fillDate.getDate() + i);
+                                const filledItem = {
+                                    d: fillDate.toISOString().split('T')[0],
+                                    v: avgValue.toFixed(3),
+                                    p: item.p || "0.0000"
+                                };
+                                if (item.c) {
+                                    filledItem.c = (startCounter + (counterIncrement * i)).toFixed(3);
+                                }
+                                if (item.v2) {
+                                    filledItem.v2 = avgV2.toFixed(3);
+                                }
+                                result.push(filledItem);
+                            }
+                            item.v = avgValue.toFixed(3);
+                            if (item.v2) item.v2 = avgV2.toFixed(3);
+                        }
+                    }
+                    result.push(item);
+                    lastDate = currentDate;
+                    lastItem = item;
+                }
+            });
+            data.result = result;
         }
     });
 


### PR DESCRIPTION
When there are gaps in the data (e.g., device offline for multiple days), the accumulated usage appears as a large spike on the day data resumes. This preprocessing function detects gaps and spreads the accumulated value evenly across the missing days, preventing spikes from affecting graph scale.

It used to look like this:
<img width="2368" height="638" alt="Screenshot from 2025-12-01 11-32-14" src="https://github.com/user-attachments/assets/b24b1e27-37e4-44b7-9c07-c7e0c639faee" />

... now it looks like this:

<img width="2398" height="630" alt="Screenshot from 2025-12-01 11-53-24" src="https://github.com/user-attachments/assets/003771fa-1338-4c17-a24a-6fb83342af8d" />
