### PR TITLE
Do not force re-enable RemoteSharedPort on startup

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3486,7 +3486,7 @@ bool CSQLHelper::OpenDatabase()
 	{
 		UpdatePreferencesVar("NotificationSwitchInterval", 0);
 	}
-	if ((!GetPreferencesVar("RemoteSharedPort", nValue)) || (nValue == 0))
+	if (!GetPreferencesVar("RemoteSharedPort", nValue))
 	{
 		UpdatePreferencesVar("RemoteSharedPort", 6144);
 	}

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1283,7 +1283,8 @@
 									<table class="display" id="remotesharedtable" border="0" cellpadding="0" cellspacing="0">
 									<tr>
 										<td align="right" style="width:60px"><label><span data-i18n="Port"></span>: </label></td>
-										<td><input type="input" id="RemoteSharedPort" name="RemoteSharedPort" style="width: 70px; padding: .2em;" class="text ui-widget-content ui-corner-all"></td>
+										<td><input type="input" id="RemoteSharedPort" name="RemoteSharedPort" style="width: 70px; padding: .2em;" class="text ui-widget-content ui-corner-all"><br>
+							<span data-i18n="0 = Disabled"></span></td>
 									</tr>
 									</table>
 								</div>


### PR DESCRIPTION
The user can currently set RemoteSharedPort to 0 to disable it, which is consistent with the -www and -sslwww command line options and works fine... until Domoticz is restarted, when it turns it back on again.

Stop forcing it back on again at restart, and add a note to the input box saying '0 = Disabled'.