### PR TITLE
Set selector device active/inActive based on level

### DIFF
--- a/dzVents/runtime/device-adapters/switch_device.lua
+++ b/dzVents/runtime/device-adapters/switch_device.lua
@@ -148,6 +148,8 @@ return {
 			device.levelNames = device.levelNames and utils.stringSplit(device.levelNames, '|') or {}
 			device.level = tonumber(device.rawData[1])
 			device.levelName = device.state
+			if device.level == 0 then device.active=false else device.active=true end
+			if device.active then device.inActive = false else device.inActive = true end
 		end
 
 	end


### PR DESCRIPTION
Without this,  domotice.devices("MySelector").active is always false and .inActive always true and it cannot be tested in the same way as boolean 'on/off' switches althought it can. Tested during 3 days without issue