### PR TITLE
Refactor FCM config to use separate fields instead of json and increasing pref svalue threshold to 5000

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3301,7 +3301,7 @@ bool CSQLHelper::OpenDatabase()
 	UpdatePreferencesVar("DB_Version", DB_VERSION);
 
 	//Check preferences table for extreme sized sValues
-	result = safe_query("SELECT Key FROM Preferences WHERE LENGTH(sValue) > 1000");
+	result = safe_query("SELECT Key FROM Preferences WHERE LENGTH(sValue) > 5000");
 	if (!result.empty())
 	{
 		for (const auto &sd : result)
@@ -3309,7 +3309,7 @@ bool CSQLHelper::OpenDatabase()
 			_log.Log(LOG_ERROR, "Preferences: sValue of Key %s has an extreme size. Please report on the forum", sd[0].c_str() );
 		}
 		_log.Log(LOG_STATUS, "Empty extreme sized sValue(s) in Preferences table to prevent future issues" );
-		safe_query("UPDATE Preferences SET sValue ='' WHERE LENGTH(sValue) > 1000");
+		safe_query("UPDATE Preferences SET sValue ='' WHERE LENGTH(sValue) > 5000");
 	}
 
 	// Check if the default admin User password has been changed

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3301,7 +3301,7 @@ bool CSQLHelper::OpenDatabase()
 	UpdatePreferencesVar("DB_Version", DB_VERSION);
 
 	//Check preferences table for extreme sized sValues
-	result = safe_query("SELECT Key FROM Preferences WHERE LENGTH(sValue) > 5000");
+	result = safe_query("SELECT Key FROM Preferences WHERE LENGTH(sValue) > 2500");
 	if (!result.empty())
 	{
 		for (const auto &sd : result)
@@ -3309,7 +3309,7 @@ bool CSQLHelper::OpenDatabase()
 			_log.Log(LOG_ERROR, "Preferences: sValue of Key %s has an extreme size. Please report on the forum", sd[0].c_str() );
 		}
 		_log.Log(LOG_STATUS, "Empty extreme sized sValue(s) in Preferences table to prevent future issues" );
-		safe_query("UPDATE Preferences SET sValue ='' WHERE LENGTH(sValue) > 5000");
+		safe_query("UPDATE Preferences SET sValue ='' WHERE LENGTH(sValue) > 2500");
 	}
 
 	// Check if the default admin User password has been changed

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -58,41 +58,38 @@ CNotificationFCM::CNotificationFCM() : CNotificationBase(std::string("fcm"), OPT
 	m_slAccessToken_exp_time = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::time_point_cast<std::chrono::seconds>(std::chrono::system_clock::now()).time_since_epoch()).count();
 
 	SetupConfig(std::string("FCMEnabled"), &m_IsEnabled);
-	SetupConfigBase64(std::string("FCMServiceAccountJSON"), m_FCMServiceAccountJSON);
+	SetupConfig(std::string("FCMClientEmail"), m_FCMClientEmail);
+	SetupConfigBase64(std::string("FCMPrivateKey"), m_FCMPrivateKey);
+	SetupConfig(std::string("FCMProjectId"), m_FCMProjectId);
 }
 
 bool CNotificationFCM::IsConfigured()
 {
-	// Check if user has provided a service account JSON
-	if (m_FCMServiceAccountJSON.empty())
+	// Check if user has provided FCM configuration fields
+	if (m_FCMClientEmail.empty() || m_FCMPrivateKey.empty() || m_FCMProjectId.empty())
 	{
-		_log.Log(LOG_STATUS, "FCM: Service Account JSON not configured. Please configure your Firebase Admin SDK service account key in Settings > Notifications.");
+		if (m_FCMClientEmail.empty())
+			_log.Log(LOG_STATUS, "FCM: Client Email not configured. Please configure in Settings > Notifications.");
+		if (m_FCMPrivateKey.empty())
+			_log.Log(LOG_STATUS, "FCM: Private Key not configured. Please configure in Settings > Notifications.");
+		if (m_FCMProjectId.empty())
+			_log.Log(LOG_STATUS, "FCM: Project ID not configured. Please configure in Settings > Notifications.");
 		return false;
 	}
 
-	Json::Value root;
+	m_GAPI_FCM_issuer = m_FCMClientEmail;
+	m_GAPI_FCM_privkey = m_FCMPrivateKey;
 
-	if (ParseJSon(m_FCMServiceAccountJSON, root))
+	if (m_GAPI_FCM_issuer.empty() || m_GAPI_FCM_privkey.empty() || m_FCMProjectId.empty())
 	{
-		std::string sGAPI_FCM_ProjectID;
-
-		m_GAPI_FCM_issuer = root["client_email"].asString();
-		m_GAPI_FCM_privkey = root["private_key"].asString();
-		sGAPI_FCM_ProjectID = root["project_id"].asString();
-
-		if (m_GAPI_FCM_issuer.empty() || m_GAPI_FCM_privkey.empty() || sGAPI_FCM_ProjectID.empty())
-		{
-			_log.Log(LOG_ERROR, "FCM: Invalid Service Account JSON - missing required fields (client_email, private_key, or project_id)");
-			return false;
-		}
-
-		m_GAPI_FCM_PostURL = GAPI_FCM_POST_URL_BASE;
-		stdreplace(m_GAPI_FCM_PostURL, "##PROJECTID##", sGAPI_FCM_ProjectID);
-
-		return true;
+		_log.Log(LOG_ERROR, "FCM: Invalid configuration - missing required fields (client_email, private_key, or project_id)");
+		return false;
 	}
 
-	_log.Log(LOG_ERROR, "FCM: Invalid Service Account JSON format");
+	m_GAPI_FCM_PostURL = GAPI_FCM_POST_URL_BASE;
+	stdreplace(m_GAPI_FCM_PostURL, "##PROJECTID##", m_FCMProjectId);
+
+	return true;
 	return false;
 }
 

--- a/notifications/NotificationFCM.h
+++ b/notifications/NotificationFCM.h
@@ -14,7 +14,9 @@ public:
 	std::string m_GAPI_FCM_PostURL;
 	std::string m_GAPI_FCM_issuer;
 	std::string m_GAPI_FCM_privkey;
-	std::string m_FCMServiceAccountJSON;
+		std::string m_FCMClientEmail;
+		std::string m_FCMPrivateKey;
+		std::string m_FCMProjectId;
 
 	std::string m_slAccesToken_cached;
 	uint64_t m_slAccessToken_exp_time;

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -561,8 +561,14 @@ define(['app'], function (app) {
 					if (typeof data.FCMEnabled != 'undefined') {
 						$("#gcmtable #FCMEnabled").prop('checked', data.FCMEnabled == 1);
 					}
-					if (typeof data.FCMServiceAccountJSON != 'undefined') {
-						$("#gcmtable #FCMServiceAccountJSON").val(atob(data.FCMServiceAccountJSON));
+					if (typeof data.FCMClientEmail != 'undefined') {
+						$("#gcmtable #FCMClientEmail").val(data.FCMClientEmail);
+					}
+					if (typeof data.FCMPrivateKey != 'undefined') {
+						$("#gcmtable #FCMPrivateKey").val(atob(data.FCMPrivateKey));
+					}
+					if (typeof data.FCMProjectId != 'undefined') {
+						$("#gcmtable #FCMProjectId").val(data.FCMProjectId);
 					}
 					if (typeof data.LightHistoryDays != 'undefined') {
 						$("#lightlogtable #LightHistoryDays").val(data.LightHistoryDays);
@@ -1042,21 +1048,16 @@ define(['app'], function (app) {
 					var reader = new FileReader();
 					reader.onload = function(e) {
 						try {
-							// Validate it's valid JSON
-							var jsonContent = e.target.result;
-							JSON.parse(jsonContent);
-							$('#gcmtable #FCMServiceAccountJSON').val(jsonContent);
-							ShowNotify($.t('Firebase Service Account JSON file loaded successfully'), 2500);
-						} catch (error) {
-							ShowNotify($.t('Invalid JSON file format'), 2500, true);
+						// Parse JSON and extract required fields
+						var jsonContent = e.target.result;
+						var jsonObj = JSON.parse(jsonContent);
+						if (!jsonObj.client_email || !jsonObj.private_key || !jsonObj.project_id) {
+							ShowNotify($.t('Invalid Firebase JSON - missing required fields (client_email, private_key, project_id)'), 2500, true);
+							return;
 						}
-					};
-					reader.onerror = function() {
-						ShowNotify($.t('Error reading file'), 2500, true);
-					};
-					reader.readAsText(file);
-				}
-			});
+						$('#gcmtable #FCMClientEmail').val(jsonObj.client_email);
+						$('#gcmtable #FCMPrivateKey').val(jsonObj.private_key);
+						$('#gcmtable #FCMProjectId').val(jsonObj.project_id);
 			
 			$("#maindiv").i18n();
 			$scope.ShowSettings();

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -714,19 +714,26 @@
 												<td><button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('fcm')">Test</button></td>
 											</tr>
 											<tr>
-												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Service Account JSON:</label></td>
+												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Client Email:</label></td>
 												<td colspan="2">
-													<div style="margin-bottom:5px;">
-														<input type="file" id="FCMServiceAccountJSONFile" accept=".json" style="display:none;" />
-														<button type="button" class="btn btn-small" onclick="document.getElementById('FCMServiceAccountJSONFile').click();">
-															<i class="fa fa-upload"></i> Upload JSON File
-														</button>
-														<span style="margin-left:10px; font-size:11px; color:#999;">or paste JSON below</span>
-													</div>
-													<textarea id="FCMServiceAccountJSON" name="FCMServiceAccountJSON" rows="8" style="width:95%; font-family:monospace; font-size:11px;" placeholder='Paste your Firebase Admin SDK Service Account JSON here&#10;{&#10;  "type": "service_account",&#10;  "project_id": "your-project-id",&#10;  "private_key_id": "...",&#10;  "private_key": "...",&#10;  "client_email": "...",&#10;  ...&#10;}'></textarea>
+													<input type="text" id="FCMClientEmail" name="FCMClientEmail" style="width:95%; padding:5px;" class="text ui-widget-content ui-corner-all" placeholder="firebase-adminsdk-xxxxx@project-id.iam.gserviceaccount.com">
+													<div style="margin-top:5px; font-size:11px; color:#666;">From your Firebase Service Account JSON</div>
+												</td>
+											</tr>
+											<tr>
+												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Private Key:</label></td>
+												<td colspan="2">
+													<textarea id="FCMPrivateKey" name="FCMPrivateKey" rows="6" style="width:95%; font-family:monospace; font-size:11px;" placeholder='-----BEGIN PRIVATE KEY-----&#10;MIIEvQIBA...&#10;-----END PRIVATE KEY-----'></textarea>
+													<div style="margin-top:5px; font-size:11px; color:#666;">The private_key from your Firebase Service Account JSON</div>
+												</td>
+											</tr>
+											<tr>
+												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Project ID:</label></td>
+												<td colspan="2">
+													<input type="text" id="FCMProjectId" name="FCMProjectId" style="width:95%; padding:5px;" class="text ui-widget-content ui-corner-all" placeholder="domoticz-notifications">
 													<div style="margin-top:5px; font-size:12px; color:#666;">
-														<strong>Note:</strong> Generate this from Firebase Console > Project Settings > Service Accounts > Generate New Private Key. 
-														<a href="https://console.firebase.google.com/" target="_blank">Open Firebase Console</a>
+														<strong>Note:</strong> Enter only the required fields from your Firebase Service Account JSON.<br>
+														Get it from <a href="https://console.firebase.google.com/" target="_blank">Firebase Console</a> > Project Settings > Service Accounts > Generate New Private Key
 													</div>
 												</td>
 											</tr>

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -713,6 +713,14 @@
 												<td><input type="checkbox" id="FCMEnabled" name="FCMEnabled"><label for="FCMEnabled"></label></td>
 												<td><button data-i18n="Test" class="btn btn-info" ng-click="TestNotification('fcm')">Test</button></td>
 											</tr>
+											<!-- FCM: Upload JSON helper row -->
+											<tr>
+												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Upload JSON File:</label></td>
+												<td colspan="2">
+													<input type="file" id="FCMServiceAccountJSONFile" accept=".json" style="display:inline-block; margin-right:8px;" />
+													<span style="font-size:11px; color:#666;">Select your Firebase Service Account JSON to auto-fill the fields below (client_email, private_key, project_id).</span>
+												</td>
+											</tr>
 											<tr>
 												<td align="right" style="width:120px; vertical-align:top; padding-top:8px;"><label>Client Email:</label></td>
 												<td colspan="2">


### PR DESCRIPTION
This pull request refactors the Firebase Cloud Messaging (FCM) notification configuration to simplify setup and improve user experience. Instead of requiring users to paste or upload the entire Firebase Service Account JSON, the UI and backend now ask for only the essential fields: Client Email, Private Key, and Project ID. Additional improvements include better error handling.