### PR TITLE
Fix OpenZWave setpoint devices

### DIFF
--- a/hardware/ZWaveBase.cpp
+++ b/hardware/ZWaveBase.cpp
@@ -732,7 +732,7 @@ void ZWaveBase::SendDevice2Domoticz(_tZWaveDevice* pDevice)
 	else if (pDevice->devType == ZDTYPE_SENSOR_SETPOINT)
 	{
 		_tSetpoint tmeter;
-		tmeter.subtype = sTypeSetPoint;
+		tmeter.subtype = sTypeSetpoint;
 		tmeter.id1 = ID1;
 		tmeter.id2 = ID2;
 		tmeter.id3 = ID3;
@@ -896,7 +896,7 @@ bool ZWaveBase::WriteToHardware(const char* pdata, const unsigned char length)
 		Log(LOG_ERROR, "ZWave: Node not found! (NodeID: %d, 0x%02x)", nodeID, nodeID);
 		return false;
 	}
-	if ((packettype == pTypeSetpoint) && (subtype == sTypeSetPoint))
+	if ((packettype == pTypeSetpoint) && (subtype == sTypeSetpoint))
 	{
 		//Set Point
 		const _tSetpoint* pMeter = reinterpret_cast<const _tSetpoint*>(pdata);


### PR DESCRIPTION
It appears that, after [the original OpenZWave code](https://github.com/domoticz/domoticz/blob/e4a6cba30777ee70a5d473091d9769ae941ddae6/hardware/ZWaveBase.cpp#L903) was removed, [the names of some constants/definitions were changed](https://github.com/domoticz/domoticz/commit/3c85c85f25491eeebb7b0355780e2145b3dd9020#diff-8c13f76f87236ff537a02af181abdca582e3923dbcb04bb9f17f658e9052c6f7L47) [resulting in two very similar constants](https://github.com/domoticz/domoticz/blob/9eae2a6912437263a47792f626dc7d91fd8a21b8/hardware/hardwaretypes.h#L38-L51) being in use, and then when the OpenZWave code was restored [the wrong constant was used](https://github.com/domoticz/domoticz/blob/b0eadaa2ec6d6340df7eeba0e6e373b71ba393fc/hardware/ZWaveBase.cpp#L898) to identify packets for Setpoint type devices.

This commit changes the constant used back to the original value and fixes OpenZWave setpoint devices. I confirmed this works with the Horstmann SRT323 thermostat.