### PR TITLE
Fix thread-safety violations in plugin TCP/TLS socket I/O

### DIFF
--- a/hardware/plugins/PluginTransports.cpp
+++ b/hardware/plugins/PluginTransports.cpp
@@ -364,29 +364,37 @@ namespace Plugins {
 
 	void CPluginTransportTCP::handleWrite(const std::vector<byte>& pMessage)
 	{
-		if (m_Socket)
+		if (!m_Socket)
 		{
+			_log.Log(LOG_ERROR, "%s: Data not sent to NULL socket.", __func__);
+			return;
+		}
+
+		// Post write to the ASIO service thread.
+		// Socket objects are not thread-safe, so all I/O must be serialized
+		// on the thread that runs ios.run() to avoid racing with pending
+		// async_read_some operations.
+		auto pData = std::make_shared<std::vector<byte>>(pMessage);
+		boost::asio::post(ios, [this, pData]() {
+			if (!m_Socket)
+				return;
 			try
 			{
-				size_t iSentBytes = boost::asio::write(*m_Socket, boost::asio::buffer(pMessage, pMessage.size()));
+				size_t iSentBytes = boost::asio::write(*m_Socket, boost::asio::buffer(*pData, pData->size()));
 				m_iTotalBytes += iSentBytes;
-				if (iSentBytes != pMessage.size())
+				if (iSentBytes != pData->size())
 				{
-					CPlugin* pPlugin = ((CConnection*)m_pConnection)->pPlugin;
-					if (!pPlugin)
-						return;
-					pPlugin->Log(LOG_ERROR, "Not all data written to socket (%s:%s). %d expected, %d written", m_IP.c_str(), m_Port.c_str(), int(pMessage.size()), int(iSentBytes));
+					CPlugin *pPlugin = ((CConnection *)m_pConnection)->pPlugin;
+					if (pPlugin)
+						pPlugin->Log(LOG_ERROR, "Not all data written to socket (%s:%s). %d expected, %d written", m_IP.c_str(), m_Port.c_str(),
+							     int(pData->size()), int(iSentBytes));
 				}
 			}
-			catch (std::exception & e)
+			catch (std::exception &e)
 			{
 				_log.Log(LOG_ERROR, "%s: Exception thrown: '%s'", __func__, std::string(e.what()).c_str());
 			}
-		}
-		else
-		{
-			_log.Log(LOG_ERROR, "%s: Data not sent to NULL socket.", __func__);
-		}
+		});
 	}
 
 	bool CPluginTransportTCP::handleDisconnect()
@@ -401,67 +409,82 @@ namespace Plugins {
 		}
 
 		m_tLastSeen = time(nullptr);
+		bool bWasConnecting = m_bConnecting;
+		bool bWasConnected = m_bConnected;
+		m_bConnected = false;
+		m_bConnecting = false;
 
-		if (m_Timer)
-		{
-			m_Timer->cancel();
-		}
-
-		if (m_Socket && m_bConnecting)
-		{
-			m_Socket->close();
-		}
-
-		if (m_Socket && m_bConnected)
-		{
-			boost::system::error_code e;
-			m_Socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, e);
-			if (e)
+		// Post socket operations to the ASIO service thread.
+		// Socket objects are not thread-safe, so shutdown/close must be
+		// serialized on the thread that runs ios.run() to avoid racing
+		// with pending async_read_some/async_connect operations.
+		boost::asio::post(ios, [this, bWasConnecting, bWasConnected]() {
+			if (m_Timer)
 			{
-				pPlugin->Log(LOG_ERROR, "Socket Shutdown Error: %d, %s", e.value(), e.message().c_str());
+				m_Timer->cancel();
 			}
-			else
+
+			m_Resolver.cancel();
+
+			if (m_Socket && bWasConnecting)
 			{
 				m_Socket->close();
 			}
-		}
 
-		if (m_Acceptor)
-		{
-			m_Acceptor->cancel();
-		}
+			if (m_Socket && bWasConnected)
+			{
+				boost::system::error_code e;
+				m_Socket->shutdown(boost::asio::ip::tcp::socket::shutdown_both, e);
+				if (!e)
+				{
+					m_Socket->close();
+				}
+				else
+				{
+					// Shutdown failed (e.g. not connected), force close
+					m_Socket->close();
+				}
+			}
 
-		m_bConnected = false;
+			if (m_Acceptor)
+			{
+				m_Acceptor->cancel();
+			}
+		});
 
 		return true;
 	}
 
 	void CPluginTransportTCPSecure::handleWrite(const std::vector<byte>& pMessage)
 	{
-		if (m_TLSSock && m_Socket)
+		if (!m_TLSSock || !m_Socket)
 		{
+			_log.Log(LOG_ERROR, "%s: Data not sent to NULL socket.", __func__);
+			return;
+		}
+
+		// Post write to the ASIO service thread (see CPluginTransportTCP::handleWrite)
+		auto pData = std::make_shared<std::vector<byte>>(pMessage);
+		boost::asio::post(ios, [this, pData]() {
+			if (!m_TLSSock || !m_Socket)
+				return;
 			try
 			{
-				size_t iSentBytes = boost::asio::write(*m_TLSSock, boost::asio::buffer(pMessage, pMessage.size()));
+				size_t iSentBytes = boost::asio::write(*m_TLSSock, boost::asio::buffer(*pData, pData->size()));
 				m_iTotalBytes += iSentBytes;
-				if (iSentBytes != pMessage.size())
+				if (iSentBytes != pData->size())
 				{
-					CPlugin* pPlugin = ((CConnection*)m_pConnection)->pPlugin;
-					if (!pPlugin)
-						return;
-					pPlugin->Log(LOG_ERROR, "Not all data written to secure socket (%s:%s). %d expected, %d written", m_IP.c_str(), m_Port.c_str(), int(pMessage.size()),
-						     int(iSentBytes));
+					CPlugin *pPlugin = ((CConnection *)m_pConnection)->pPlugin;
+					if (pPlugin)
+						pPlugin->Log(LOG_ERROR, "Not all data written to secure socket (%s:%s). %d expected, %d written", m_IP.c_str(), m_Port.c_str(),
+							     int(pData->size()), int(iSentBytes));
 				}
 			}
-			catch (std::exception & e)
+			catch (std::exception &e)
 			{
 				_log.Log(LOG_ERROR, "%s: Exception thrown: '%s'", __func__, std::string(e.what()).c_str());
 			}
-		}
-		else
-		{
-			_log.Log(LOG_ERROR, "%s: Data not sent to NULL socket.", __func__);
-		}
+		});
 	}
 
 	CPluginTransportTCP::~CPluginTransportTCP()


### PR DESCRIPTION
Plugin socket write (handleWrite) and disconnect (handleDisconnect) were called from the plugin Do_Work thread while async_read_some was pending on the Plugin_ASIO thread running ios.run(). This is a thread-safety violation: boost::asio socket objects are not safe for concurrent access from multiple threads.

This could cause a segfault (signal 11) on the Plugin_ASIO thread with a corrupt stack, typically when multiple plugins send WebSocket pings (via Connection.Send) while their connections have outstanding async reads.

Fix: post all socket operations (write, shutdown, close) to the ASIO io_context via boost::asio::post() so they are serialized on the same thread that services async_read_some callbacks. Write data is captured in a shared_ptr to outlive the calling scope.

Changes:
- CPluginTransportTCP::handleWrite: post synchronous write to ios
- CPluginTransportTCP::handleDisconnect: post socket shutdown/close and resolver/timer cancel to ios; set state flags immediately to prevent new operations from being queued
- CPluginTransportTCPSecure::handleWrite: same pattern for TLS writes


[domoticz_crash_logs.txt](https://github.com/user-attachments/files/25276149/domoticz_crash_logs.txt)

These domoticz plugins were using websocket:
- PLUGSG3-PALIER
- PRO1PM-1
- OUTDOORPLUGS-GEN3
- PWRSTRIP-GEN4

The python plugin is: https://github.com/lemassykoi/Domoticz-Shelly-Plugin