### PR TITLE
Modernize log viewer with WebSocket support and performance optimizations

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -23,6 +23,7 @@ Version 2026.xxxx
 - Added: Support for the Model Context Protocol (/mcp) for use with AI Agents
 - Added: Thermostat, combined Temperature/Setpoint display
 - Added: Web Interface, Better XSS prevention
+- Added: Web Interface, Modernized log viewer with WebSocket live streaming, level filtering, search/regex, render cap, and performance optimizations
 - Added: Web Interface, Passkey (WebAuthn/FIDO2) authentication support - register and sign in with Windows Hello, Touch ID, or security keys
 - Added: Web Interface, Passkey management in My Profile (register, view device info, delete)
 - Fixed: Buienradar, fallback when station measurements are empty

--- a/www/app/LogController.js
+++ b/www/app/LogController.js
@@ -202,10 +202,25 @@ define(['app'], function (app) {
 			}
 		}
 
+		// Get text selected by the user in the log console, if any
+		function getSelectedLogText() {
+			var selection = window.getSelection();
+			if (!selection || selection.isCollapsed) return '';
+			var logContainer = document.getElementById('logdata');
+			if (!logContainer) return '';
+			// Check if selection is within the log container
+			var range = selection.getRangeAt(0);
+			if (logContainer.contains(range.commonAncestorContainer)) {
+				return selection.toString().trim();
+			}
+			return '';
+		}
+
 		// Copy filtered log to clipboard
 		$scope.copyFeedback = false;
 		$scope.copyToClipboard = function () {
-			var text = formatLogText($scope.filteredItems);
+			var selectedText = getSelectedLogText();
+			var text = selectedText || formatLogText($scope.filteredItems);
 			if (!text) return;
 
 			if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/www/app/LogController.js
+++ b/www/app/LogController.js
@@ -1,5 +1,5 @@
 define(['app'], function (app) {
-	app.controller('LogController', ['$scope', '$rootScope', '$http', 'livesocket', 'bootbox', function ($scope, $rootScope, $http, livesocket, bootbox) {
+	app.controller('LogController', ['$scope', '$rootScope', '$http', '$timeout', 'livesocket', 'bootbox', function ($scope, $rootScope, $http, $timeout, livesocket, bootbox) {
 
 		// Constants
 		var LOG_NORM = 0x0000001;
@@ -8,10 +8,17 @@ define(['app'], function (app) {
 		var LOG_DEBUG = 0x0000008;
 		var LOG_ALL = 0xFFFFFFF;
 		var MAX_LOG_LINES = 1000;
+		var RENDER_LIMIT_STEP = 200;
+		var BATCH_INTERVAL = 100;
 
 		// State
+		var nextId = 0;
+		var logVersion = 0;
 		$scope.logitems = [];
 		$scope.filteredItems = [];
+		$scope.renderItems = [];
+		$scope.renderLimit = RENDER_LIMIT_STEP;
+		$scope.hasOlderMessages = false;
 		$scope.LastLogTime = 0;
 		$scope.searchText = '';
 
@@ -63,6 +70,22 @@ define(['app'], function (app) {
 			}
 		}
 
+		// Tiered retention: remove oldest normal/debug entries first
+		function trimLogBuffer() {
+			while ($scope.logitems.length > MAX_LOG_LINES) {
+				var idx = -1;
+				for (var i = 0; i < $scope.logitems.length; i++) {
+					if ($scope.logitems[i].level !== LOG_ERROR && $scope.logitems[i].level !== LOG_STATUS) {
+						idx = i;
+						break;
+					}
+				}
+				if (idx === -1) idx = 0;
+				var removed = $scope.logitems.splice(idx, 1)[0];
+				updateCounts(removed.level, -1);
+			}
+		}
+
 		// Add a log entry (handles multiline messages)
 		$scope.addLogEntry = function (level, message) {
 			var lines = message.replace(/\n/g, '\n').split('\n');
@@ -84,6 +107,7 @@ define(['app'], function (app) {
 				var text = match ? match[2] : lineMsg;
 
 				$scope.logitems.push({
+					id: nextId++,
 					timestamp: timestamp,
 					level: level,
 					levelClass: getLevelClass(level),
@@ -95,11 +119,8 @@ define(['app'], function (app) {
 				updateCounts(level, 1);
 			}
 
-			// Enforce max buffer
-			while ($scope.logitems.length > MAX_LOG_LINES) {
-				var removed = $scope.logitems.shift();
-				updateCounts(removed.level, -1);
-			}
+			trimLogBuffer();
+			logVersion++;
 		};
 
 		// Compute filtered items
@@ -131,18 +152,36 @@ define(['app'], function (app) {
 				}
 				return true;
 			});
+
+			updateRenderItems();
 		}
 
-		// Watch for filter changes
+		// Render cap: only put last N filtered items into the DOM
+		function updateRenderItems() {
+			var total = $scope.filteredItems.length;
+			var start = Math.max(0, total - $scope.renderLimit);
+			$scope.renderItems = $scope.filteredItems.slice(start);
+			$scope.hasOlderMessages = start > 0;
+		}
+
+		$scope.showOlderMessages = function () {
+			$scope.renderLimit += RENDER_LIMIT_STEP;
+			updateRenderItems();
+		};
+
+		// Watch for filter changes — reset render window
 		$scope.$watchGroup(['searchText', 'levelFilters.norm', 'levelFilters.status',
 			'levelFilters.error', 'levelFilters.debug'], function () {
+			$scope.renderLimit = RENDER_LIMIT_STEP;
 			updateFilteredItems();
 		});
 
-		// Also update when new items are added (watch array length)
-		$scope.$watch('logitems.length', function () {
-			updateFilteredItems();
-			scrollIfNeeded();
+		// Update when new items are added (version changes even when length stays the same at capacity)
+		$scope.$watch(function () { return logVersion; }, function (newVal, oldVal) {
+			if (newVal !== oldVal) {
+				updateFilteredItems();
+				scrollIfNeeded();
+			}
 		});
 
 		// Initial load via HTTP
@@ -171,6 +210,9 @@ define(['app'], function (app) {
 				}).then(function () {
 					$scope.logitems = [];
 					$scope.filteredItems = [];
+					$scope.renderItems = [];
+					$scope.hasOlderMessages = false;
+					$scope.renderLimit = RENDER_LIMIT_STEP;
 					$scope.counts = { norm: 0, status: 0, error: 0, debug: 0 };
 					$scope.LastLogTime = 0;
 					livesocket.subscribeTo('log');
@@ -180,10 +222,21 @@ define(['app'], function (app) {
 			}, angular.noop);
 		};
 
-		// WebSocket listener
+		// Batched WebSocket listener
+		var pendingMessages = [];
+		var batchTimer = null;
+
 		var unsubLog = $scope.$on('log', function (event, data) {
-			$scope.addLogEntry(data.level, data.message);
-			$scope.$digest();
+			pendingMessages.push({ level: data.level, message: data.message });
+			if (!batchTimer) {
+				batchTimer = $timeout(function () {
+					pendingMessages.forEach(function (msg) {
+						$scope.addLogEntry(msg.level, msg.message);
+					});
+					pendingMessages = [];
+					batchTimer = null;
+				}, BATCH_INTERVAL);
+			}
 		});
 
 		// Format log items as plain text
@@ -206,11 +259,10 @@ define(['app'], function (app) {
 		function getSelectedLogText() {
 			var selection = window.getSelection();
 			if (!selection || selection.isCollapsed) return '';
-			var logContainer = document.getElementById('logdata');
-			if (!logContainer) return '';
-			// Check if selection is within the log container
+			var logEl = document.getElementById('logdata');
+			if (!logEl) return '';
 			var range = selection.getRangeAt(0);
-			if (logContainer.contains(range.commonAncestorContainer)) {
+			if (logEl.contains(range.commonAncestorContainer)) {
 				return selection.toString().trim();
 			}
 			return '';
@@ -271,6 +323,7 @@ define(['app'], function (app) {
 			if (!logContainer) return;
 
 			logContainer.addEventListener('scroll', function () {
+				if (ignoreScrollEvents) return;
 				var atBottom = (logContainer.scrollHeight - logContainer.scrollTop - logContainer.clientHeight) < 20;
 				if ($scope.autoScroll !== atBottom) {
 					$scope.autoScroll = atBottom;
@@ -279,27 +332,42 @@ define(['app'], function (app) {
 			});
 		}
 
+		var ignoreScrollEvents = false;
+
 		$scope.scrollToBottom = function () {
 			if (!logContainer) return;
+			ignoreScrollEvents = true;
+			$scope.renderLimit = RENDER_LIMIT_STEP;
+			updateRenderItems();
 			logContainer.scrollTop = logContainer.scrollHeight;
 			$scope.autoScroll = true;
+			$timeout(function () {
+				ignoreScrollEvents = false;
+			});
 		};
 
 		function scrollIfNeeded() {
 			if ($scope.autoScroll && logContainer) {
+				ignoreScrollEvents = true;
 				requestAnimationFrame(function () {
-					logContainer.scrollTop = logContainer.scrollHeight;
+					if (logContainer) {
+						logContainer.scrollTop = logContainer.scrollHeight;
+					}
+					ignoreScrollEvents = false;
 				});
 			}
 		}
 
-		// Init
-		initScrollHandler();
-		loadInitialLogs();
-		livesocket.subscribeTo('log');
+		// Init - defer to allow DOM to render
+		$timeout(function () {
+			initScrollHandler();
+			loadInitialLogs();
+			livesocket.subscribeTo('log');
+		});
 
 		// Cleanup
 		$scope.$on('$destroy', function () {
+			if (batchTimer) $timeout.cancel(batchTimer);
 			unsubLog();
 			livesocket.unsubscribeFrom('log');
 		});

--- a/www/app/LogController.js
+++ b/www/app/LogController.js
@@ -1,165 +1,292 @@
 define(['app'], function (app) {
-	app.controller('LogController', ['$scope', '$rootScope', '$location', '$http', '$interval', '$sce', 'livesocket', function ($scope, $rootScope, $location, $http, $interval, $sce, livesocket) {
+	app.controller('LogController', ['$scope', '$rootScope', '$http', 'livesocket', 'bootbox', function ($scope, $rootScope, $http, livesocket, bootbox) {
 
-		$scope.LastLogTime = 0;
-		$scope.logitems = [];
-		$scope.logitems_status = [];
-		$scope.logitems_error = [];
-		$scope.logitems_debug = [];
+		// Constants
 		var LOG_NORM = 0x0000001;
 		var LOG_STATUS = 0x0000002;
 		var LOG_ERROR = 0x0000004;
 		var LOG_DEBUG = 0x0000008;
 		var LOG_ALL = 0xFFFFFFF;
+		var MAX_LOG_LINES = 1000;
 
-		$scope.addLogLine = function(item) {
-			var message = item.message.replace(/\n/gi, "<br>");
-			var lines = message.split("<br>")
-			if (lines.length < 1) return;
-			var fline = lines[0].split(" ")
-			if (fline.length < 3) return;
+		// State
+		$scope.logitems = [];
+		$scope.filteredItems = [];
+		$scope.LastLogTime = 0;
+		$scope.searchText = '';
 
-			var sdate = fline[0];
-			var stime = fline[1];
-
-			for (i = 0; i < lines.length; i++) {
-				var lmessage = "";
-				if (i == 0) {
-					lmessage = lines[i];
-				}
-				else {
-					lmessage = sdate + " " + stime + " " + lines[i];
-				}
-				var logclass = "";
-				logclass = getLogClass(item.level);
-
-				//All
-				if ($scope.logitems.length >= 300)
-					$scope.logitems.splice(0, ($scope.logitems.length - 300));
-				$scope.logitems = $scope.logitems.concat({
-					mclass: logclass,
-					text: lmessage
-				});
-				if (item.level == LOG_ERROR) {
-					//Error
-					if ($scope.logitems_error.length >= 300)
-						$scope.logitems_error.splice(0, ($scope.logitems_error.length - 300));
-					$scope.logitems_error = $scope.logitems_error.concat({
-						mclass: logclass,
-						text: lmessage
-					});
-				}
-				else if (item.level == LOG_STATUS) {
-					//Status
-					if ($scope.logitems_status.length >= 300)
-						$scope.logitems_status.splice(0, ($scope.logitems_status.length - 300));
-					$scope.logitems_status = $scope.logitems_status.concat({
-						mclass: logclass,
-						text: lmessage
-					});
-				}
-				else if (item.level == LOG_DEBUG) {
-					//Debug
-					$scope.logitems_debug = $scope.logitems_debug.concat({
-						mclass: logclass,
-						text: lmessage
-					});
-				}
-			}
-		}
-
-		$scope.RefreshLog = function () {
-			var bWasAtBottom = true;
-			var div = $("#logcontent #logdata");
-			if (div != null) {
-				if (div[0] != null) {
-					var diff = Math.abs((div[0].scrollHeight - div.scrollTop()) - div.height());
-					if (diff > 9) {
-						bWasAtBottom = false;
-					}
-				}
-			}
-			var lastscrolltop = $("#logcontent #logdata").scrollTop();
-			var llogtime = $scope.LastLogTime;
-			$http({
-			    url: "json.htm?type=command&param=getlog&lastlogtime=" + $scope.LastLogTime + "&loglevel=" + LOG_ALL,
-				async: false,
-				dataType: 'json'
-			}).then(function successCallback(response) {
-				var data = response.data;
-				if (typeof data.result != 'undefined') {
-					if (typeof data.LastLogTime != 'undefined') {
-						$scope.LastLogTime = parseInt(data.LastLogTime);
-					}
-					$.each(data.result, function (i, item) {
-						$scope.addLogLine(item);
-					});
-				}
-			}, function errorCallback(response) {
-			});
-		}
-
-		$scope.ClearLog = function () {
-			livesocket.unsubscribeFrom("log");
-			$http({
-				url: "json.htm?type=command&param=clearlog",
-				async: false,
-				dataType: 'json'
-			}).then(function successCallback(response) {
-				var data = response.data;
-				$scope.logitems = [];
-				$scope.logitems_error = [];
-				$scope.logitems_status = [];
-				$scope.logitems_debug = [];
-				livesocket.subscribeTo("log");
-			}, function errorCallback(response) {
-				livesocket.subscribeTo("log");
-			});
-		}
-
-		$scope.ResizeLogWindow = function () {
-			var pheight = $(window).innerHeight();
-			var poffset = 210;
-			$("#logcontent #logdata").height(pheight - poffset);
-			$("#logcontent #logdata_status").height(pheight - poffset);
-			$("#logcontent #logdata_error").height(pheight - poffset);
-			$("#logcontent #logdata_debug").height(pheight - poffset);
-		}
-
-		init();
-
-		function init() {
-			$("#logcontent").i18n();
-			$scope.LastLogTime = 0;
-			$scope.RefreshLog();
-			$(window).resize(function () { $scope.ResizeLogWindow(); });
-			$scope.ResizeLogWindow();
-			livesocket.subscribeTo("log");
+		// Level visibility
+		$scope.levelFilters = {
+			norm: true,
+			status: true,
+			error: true,
+			debug: true
 		};
 
-		function getLogClass(level) {
-			var logclass;
-			if (level == LOG_STATUS) {
-				logclass = "logstatus";
+		// Level counts
+		$scope.counts = { norm: 0, status: 0, error: 0, debug: 0 };
+
+		function getLevelClass(level) {
+			switch (level) {
+				case LOG_STATUS: return 'log-level-status';
+				case LOG_ERROR: return 'log-level-error';
+				case LOG_DEBUG: return 'log-level-debug';
+				default: return 'log-level-norm';
 			}
-			else if (level == LOG_ERROR) {
-				logclass = "logerror";
-			}
-			else {
-				logclass = "lognorm";
-			}
-			return (logclass);
 		}
 
-		$scope.$on('log', function (event, data) {
-			$scope.addLogLine(data);
+		function getLevelLabel(level) {
+			switch (level) {
+				case LOG_STATUS: return 'STATUS';
+				case LOG_ERROR: return 'ERROR';
+				case LOG_DEBUG: return 'DEBUG';
+				default: return 'NORM';
+			}
+		}
+
+		function isLevelVisible(level) {
+			switch (level) {
+				case LOG_NORM: return $scope.levelFilters.norm;
+				case LOG_STATUS: return $scope.levelFilters.status;
+				case LOG_ERROR: return $scope.levelFilters.error;
+				case LOG_DEBUG: return $scope.levelFilters.debug;
+				default: return true;
+			}
+		}
+
+		function updateCounts(level, delta) {
+			switch (level) {
+				case LOG_NORM: $scope.counts.norm += delta; break;
+				case LOG_STATUS: $scope.counts.status += delta; break;
+				case LOG_ERROR: $scope.counts.error += delta; break;
+				case LOG_DEBUG: $scope.counts.debug += delta; break;
+			}
+		}
+
+		// Add a log entry (handles multiline messages)
+		$scope.addLogEntry = function (level, message) {
+			var lines = message.replace(/\n/g, '\n').split('\n');
+			if (lines.length < 1) return;
+
+			var firstParts = lines[0].split(' ');
+			if (firstParts.length < 3) return;
+
+			var sdate = firstParts[0];
+			var stime = firstParts[1];
+
+			for (var i = 0; i < lines.length; i++) {
+				if (!lines[i]) continue;
+				var lineMsg = (i === 0) ? lines[i] : sdate + ' ' + stime + ' ' + lines[i];
+
+				// Parse timestamp from message
+				var match = lineMsg.match(/^(\S+\s+\S+)\s+(.*)$/);
+				var timestamp = match ? match[1] : '';
+				var text = match ? match[2] : lineMsg;
+
+				$scope.logitems.push({
+					timestamp: timestamp,
+					level: level,
+					levelClass: getLevelClass(level),
+					levelLabel: getLevelLabel(level),
+					text: text,
+					raw: lineMsg
+				});
+
+				updateCounts(level, 1);
+			}
+
+			// Enforce max buffer
+			while ($scope.logitems.length > MAX_LOG_LINES) {
+				var removed = $scope.logitems.shift();
+				updateCounts(removed.level, -1);
+			}
+		};
+
+		// Compute filtered items
+		function updateFilteredItems() {
+			var searchRegex = null;
+			var searchLower = '';
+
+			if ($scope.searchText) {
+				var regexMatch = $scope.searchText.match(/^\/(.+)\/([gimsuy]*)$/);
+				if (regexMatch) {
+					try {
+						searchRegex = new RegExp(regexMatch[1], regexMatch[2]);
+					} catch (e) {
+						searchRegex = null;
+					}
+				}
+				if (!searchRegex) {
+					searchLower = $scope.searchText.toLowerCase();
+				}
+			}
+
+			$scope.filteredItems = $scope.logitems.filter(function (item) {
+				if (!isLevelVisible(item.level)) return false;
+				if ($scope.searchText) {
+					if (searchRegex) {
+						return searchRegex.test(item.raw);
+					}
+					return item.raw.toLowerCase().indexOf(searchLower) !== -1;
+				}
+				return true;
+			});
+		}
+
+		// Watch for filter changes
+		$scope.$watchGroup(['searchText', 'levelFilters.norm', 'levelFilters.status',
+			'levelFilters.error', 'levelFilters.debug'], function () {
+			updateFilteredItems();
+		});
+
+		// Also update when new items are added (watch array length)
+		$scope.$watch('logitems.length', function () {
+			updateFilteredItems();
+			scrollIfNeeded();
+		});
+
+		// Initial load via HTTP
+		function loadInitialLogs() {
+			$http({
+				url: 'json.htm?type=command&param=getlog&lastlogtime=0&loglevel=' + LOG_ALL
+			}).then(function (response) {
+				var data = response.data;
+				if (data.result) {
+					if (data.LastLogTime) {
+						$scope.LastLogTime = parseInt(data.LastLogTime);
+					}
+					data.result.forEach(function (item) {
+						$scope.addLogEntry(item.level, item.message);
+					});
+				}
+			});
+		}
+
+		// Clear log
+		$scope.ClearLog = function () {
+			bootbox.confirm('Are you sure you want to clear the log?').then(function () {
+				livesocket.unsubscribeFrom('log');
+				$http({
+					url: 'json.htm?type=command&param=clearlog'
+				}).then(function () {
+					$scope.logitems = [];
+					$scope.filteredItems = [];
+					$scope.counts = { norm: 0, status: 0, error: 0, debug: 0 };
+					$scope.LastLogTime = 0;
+					livesocket.subscribeTo('log');
+				}, function () {
+					livesocket.subscribeTo('log');
+				});
+			}, angular.noop);
+		};
+
+		// WebSocket listener
+		var unsubLog = $scope.$on('log', function (event, data) {
+			$scope.addLogEntry(data.level, data.message);
 			$scope.$digest();
 		});
 
-		$scope.$on('$destroy', function () {
-			$(window).off("resize");
-			livesocket.unsubscribeFrom("log");
-		});
+		// Format log items as plain text
+		function formatLogText(items) {
+			return items.map(function (item) {
+				return item.raw;
+			}).join('\n');
+		}
 
+		// Safe digest helper
+		function safeApply(fn) {
+			if ($scope.$$phase || $rootScope.$$phase) {
+				fn();
+			} else {
+				$scope.$apply(fn);
+			}
+		}
+
+		// Copy filtered log to clipboard
+		$scope.copyFeedback = false;
+		$scope.copyToClipboard = function () {
+			var text = formatLogText($scope.filteredItems);
+			if (!text) return;
+
+			if (navigator.clipboard && navigator.clipboard.writeText) {
+				navigator.clipboard.writeText(text).then(function () {
+					safeApply(function () { $scope.copyFeedback = true; });
+					setTimeout(function () {
+						safeApply(function () { $scope.copyFeedback = false; });
+					}, 2000);
+				});
+			} else {
+				var textarea = document.createElement('textarea');
+				textarea.value = text;
+				textarea.style.position = 'fixed';
+				textarea.style.opacity = '0';
+				document.body.appendChild(textarea);
+				textarea.select();
+				document.execCommand('copy');
+				document.body.removeChild(textarea);
+				$scope.copyFeedback = true;
+				setTimeout(function () {
+					safeApply(function () { $scope.copyFeedback = false; });
+				}, 2000);
+			}
+		};
+
+		// Download filtered log as .txt file
+		$scope.downloadLog = function () {
+			var text = formatLogText($scope.filteredItems);
+			if (!text) return;
+
+			var timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+			var filename = 'domoticz-log-' + timestamp + '.txt';
+			var blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+			var url = URL.createObjectURL(blob);
+			var a = document.createElement('a');
+			a.href = url;
+			a.download = filename;
+			a.click();
+			URL.revokeObjectURL(url);
+		};
+
+		// Auto-scroll state
+		$scope.autoScroll = true;
+		var logContainer = null;
+
+		function initScrollHandler() {
+			logContainer = document.getElementById('logdata');
+			if (!logContainer) return;
+
+			logContainer.addEventListener('scroll', function () {
+				var atBottom = (logContainer.scrollHeight - logContainer.scrollTop - logContainer.clientHeight) < 20;
+				if ($scope.autoScroll !== atBottom) {
+					$scope.autoScroll = atBottom;
+					safeApply(function () {});
+				}
+			});
+		}
+
+		$scope.scrollToBottom = function () {
+			if (!logContainer) return;
+			logContainer.scrollTop = logContainer.scrollHeight;
+			$scope.autoScroll = true;
+		};
+
+		function scrollIfNeeded() {
+			if ($scope.autoScroll && logContainer) {
+				requestAnimationFrame(function () {
+					logContainer.scrollTop = logContainer.scrollHeight;
+				});
+			}
+		}
+
+		// Init
+		initScrollHandler();
+		loadInitialLogs();
+		livesocket.subscribeTo('log');
+
+		// Cleanup
+		$scope.$on('$destroy', function () {
+			unsubLog();
+			livesocket.unsubscribeFrom('log');
+		});
 	}]);
 });

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1106,7 +1106,7 @@ div.log {
 	padding: 4px 8px;
 	border-radius: 3px;
 	font-family: inherit;
-	font-size: 11px;
+	font-size: 14px;
 }
 
 .log-search-input:focus {
@@ -1189,6 +1189,21 @@ mark.log-highlight {
 
 .log-scroll-indicator:hover {
 	background: rgba(100, 200, 255, 0.15);
+}
+
+.log-show-older {
+	text-align: center;
+	padding: 6px;
+	color: #889;
+	font-size: 11px;
+	cursor: pointer;
+	border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+	transition: color 0.15s, background 0.15s;
+}
+
+.log-show-older:hover {
+	color: #ddd;
+	background: rgba(100, 200, 255, 0.08);
 }
 
 .log-statusbar-paused {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1035,11 +1035,11 @@ div.log {
 .log-console-container {
 	display: flex;
 	flex-direction: column;
-	height: calc(100vh - 80px);
+	height: calc(100vh - 110px);
 	border: 1px solid var(--accent-color, #283750);
 	border-radius: 5px;
 	position: relative;
-	font-size: 12px;
+	font-size: 14px;
 }
 
 .log-toolbar {
@@ -1061,10 +1061,10 @@ div.log {
 }
 
 .log-line {
-	padding: 1px 0;
+	padding: 0;
 	white-space: pre-wrap;
 	word-break: break-all;
-	line-height: 1.6;
+	line-height: 1.4;
 	color: #ccc;
 }
 
@@ -1136,32 +1136,33 @@ mark.log-highlight {
 	gap: 4px;
 }
 
-.log-toggle {
+.log-filter-btn {
 	display: inline-flex;
 	align-items: center;
 	gap: 4px;
-	cursor: pointer;
-	font-size: 11px;
-	opacity: 0.5;
+	background: rgba(0, 0, 0, 0.3) !important;
+	border: 1px solid rgba(255, 255, 255, 0.15) !important;
+	opacity: 0.45;
 	transition: opacity 0.15s;
-	user-select: none;
 }
 
-.log-toggle-active {
+.log-filter-btn-active {
 	opacity: 1;
+	border-color: rgba(255, 255, 255, 0.3) !important;
 }
 
-.log-toggle-label {
+.log-filter-btn span:first-child {
 	font-weight: 600;
 }
 
 .log-toggle-count {
-	background: rgba(255, 255, 255, 0.08);
-	padding: 0 5px;
+	background: rgba(255, 255, 255, 0.12);
+	padding: 1px 5px;
 	border-radius: 8px;
-	font-size: 10px;
+	font-size: 11px;
 	min-width: 18px;
 	text-align: center;
+	line-height: 1.4;
 }
 
 .log-actions {

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -1003,32 +1003,200 @@ table.mobileitem {
 	filter: none;
 }
 
+/* Legacy log classes (used by DeviceLog, SceneLog, etc.) */
 div.log {
-	background-color: #FAFAFA;
 	height: 300px;
 	overflow: auto;
-	border: 1px dotted #AAAAAA;
+	border: 1px solid var(--accent-color, #283750);
 	padding: 4px;
-	font-family: "Courier New", monospace;
-	color: #666666;
+	font-family: 'Courier New', Consolas, monospace;
+	color: #ccc;
 	font-size: 11px;
 	word-wrap: break-word;
 	text-align: left;
 }
 
 .lognorm {
-	color: #000000;
+	color: #ccc;
 }
 
 .logerror {
-	color: #860016;
+	color: #ff6b6b;
 	font-weight: 600;
 }
 
 .logstatus {
-	color: #067676;
+	color: #4ec9b0;
 	font-size: 11px;
 	font-weight: 600;
+}
+
+/* Modern log console */
+.log-console-container {
+	display: flex;
+	flex-direction: column;
+	height: calc(100vh - 80px);
+	border: 1px solid var(--accent-color, #283750);
+	border-radius: 5px;
+	position: relative;
+	font-size: 12px;
+}
+
+.log-toolbar {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 12px;
+	background: var(--accent-color, #283750);
+	border-bottom: 1px solid var(--accent-color, #283750);
+	flex-shrink: 0;
+	flex-wrap: wrap;
+}
+
+.log-console {
+	flex: 1;
+	overflow-y: auto;
+	padding: 4px 12px;
+	font-family: 'Courier New', Consolas, monospace;
+}
+
+.log-line {
+	padding: 1px 0;
+	white-space: pre-wrap;
+	word-break: break-all;
+	line-height: 1.6;
+	color: #ccc;
+}
+
+.log-line:hover {
+	background: rgba(255, 255, 255, 0.04);
+}
+
+.log-level-norm { color: #ccc; }
+.log-level-status { color: #4ec9b0; }
+.log-level-error { color: #ff6b6b; font-weight: 600; }
+.log-level-debug { color: #9cdcfe; }
+
+.log-statusbar {
+	padding: 4px 12px;
+	background: var(--accent-color, #283750);
+	color: #aac;
+	font-size: 11px;
+	flex-shrink: 0;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+/* Toolbar components */
+.log-search {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	flex: 1;
+	max-width: 400px;
+}
+
+.log-search-input {
+	flex: 1;
+	background: rgba(0, 0, 0, 0.3);
+	border: 1px solid rgba(255, 255, 255, 0.15);
+	color: #ddd;
+	padding: 4px 8px;
+	border-radius: 3px;
+	font-family: inherit;
+	font-size: 11px;
+}
+
+.log-search-input:focus {
+	border-color: rgba(100, 200, 255, 0.5);
+	outline: none;
+}
+
+.log-search-input::placeholder {
+	color: #667;
+}
+
+.log-search-count {
+	color: #889;
+	font-size: 10px;
+	white-space: nowrap;
+}
+
+mark.log-highlight {
+	background: rgba(100, 200, 255, 0.2);
+	color: #fff;
+	padding: 0 2px;
+	border-radius: 2px;
+}
+
+.log-level-toggles {
+	display: flex;
+	gap: 4px;
+}
+
+.log-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+	cursor: pointer;
+	font-size: 11px;
+	opacity: 0.5;
+	transition: opacity 0.15s;
+	user-select: none;
+}
+
+.log-toggle-active {
+	opacity: 1;
+}
+
+.log-toggle-label {
+	font-weight: 600;
+}
+
+.log-toggle-count {
+	background: rgba(255, 255, 255, 0.08);
+	padding: 0 5px;
+	border-radius: 8px;
+	font-size: 10px;
+	min-width: 18px;
+	text-align: center;
+}
+
+.log-actions {
+	display: flex;
+	gap: 4px;
+}
+
+.log-scroll-indicator {
+	position: absolute;
+	bottom: 32px;
+	left: 50%;
+	transform: translateX(-50%);
+	background: var(--accent-color, #283750);
+	color: #ddd;
+	padding: 6px 16px;
+	border-radius: 20px;
+	border: 1px solid rgba(100, 200, 255, 0.3);
+	cursor: pointer;
+	font-size: 11px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+	z-index: 10;
+	transition: background 0.2s;
+}
+
+.log-scroll-indicator:hover {
+	background: rgba(100, 200, 255, 0.15);
+}
+
+.log-statusbar-paused {
+	color: #ffdd57;
+	font-weight: 600;
+}
+
+.log-statusbar-following {
+	color: #4ec9b0;
 }
 
 .obtext {

--- a/www/views/log.html
+++ b/www/views/log.html
@@ -29,13 +29,14 @@
     <a class="btn btn-danger" ng-click="ClearLog()" data-i18n="Clear">Clear</a>
   </div>
   <div id="logdata" class="log-console">
-    <div class="log-line" ng-class="item.levelClass" ng-repeat="item in filteredItems track by $index">{{item.raw}}</div>
+    <div class="log-show-older" ng-show="hasOlderMessages" ng-click="showOlderMessages()">&#x25B2; Show older messages ({{filteredItems.length - renderItems.length}} hidden)</div>
+    <div class="log-line" ng-class="::item.levelClass" ng-repeat="item in renderItems track by item.id">{{::item.raw}}</div>
   </div>
   <div class="log-scroll-indicator" ng-show="!autoScroll" ng-click="scrollToBottom()">
     &#x2193; New messages below
   </div>
   <div class="log-statusbar">
-    <span>{{filteredItems.length}} / {{logitems.length}} lines</span>
+    <span>{{renderItems.length}} of {{filteredItems.length}} / {{logitems.length}} lines</span>
     <span ng-show="!autoScroll" class="log-statusbar-paused">PAUSED</span>
     <span ng-show="autoScroll" class="log-statusbar-following">Following</span>
   </div>

--- a/www/views/log.html
+++ b/www/views/log.html
@@ -1,52 +1,45 @@
-<div id="logcontent" class="logcontent container force-select">
-	<div class="page-header-small">
-		<h1 data-i18n="Log">Protokoll</h1>
-	</div>
-	<table style="width: 100%;" border="0" cellpadding="0" cellspacing="0">
-		<tr>
-			<td align="left">
-				<ul id="tabs" class="nav nav-tabs sub-tabs" data-tabs="tabs">
-					<li class="active"><a data-target="#taball" data-toggle="tab" data-i18n="All">All</a></li>
-					<li><a data-target="#tabstatus" data-toggle="tab" data-i18n="Status">Status</a></li>
-					<li ng-show="logitems_error.length>0"><a data-target="#taberror" data-toggle="tab" data-i18n="Error">Error</a></li>
-					<li ng-show="logitems_debug.length>0"><a data-target="#tabdebug" data-toggle="tab" data-i18n="Debug">Debug</a></li>
-				</ul>
-			</td>
-			<td align="right" valign="bottom">
-				<span data-i18n="Filter">Filter</span>: <input ng-model='filterExpr'>
-				<a class="lcursor" style="color: red;font-weight: bold;" ng-click="ClearLog()"><b>X</b></a>
-			</td>
-		</tr>
-	</table>
-	<div id="my-tab-content" class="tab-content">
-		<div class="tab-pane active" id="taball">
-			<div id="logdata" class="log" scroll-glue>
-				<div ng-repeat='item in filtered = (logitems | filter:filterExpr) track by $index'>
-					<span class="{{item.mclass}}">{{item.text}}</span>
-				</div>
-			</div>
-		</div>
-		<div class="tab-pane" id="tabstatus">
-			<div id="logdata_status" class="log" scroll-glue>
-				<div ng-repeat='item in filtered = (logitems_status | filter:filterExpr) track by $index'>
-					<span class="{{item.mclass}}">{{item.text}}</span>
-				</div>
-			</div>
-		</div>
-		<div class="tab-pane" id="taberror">
-			<div id="logdata_error" class="log" scroll-glue>
-				<div ng-repeat='item in filtered = (logitems_error | filter:filterExpr) track by $index'>
-					<span class="{{item.mclass}}">{{item.text}}</span>
-				</div>
-			</div>
-		</div>
-		<div class="tab-pane" id="tabdebug">
-			<!--style="display:none;"-->
-			<div id="logdata_debug" class="log" scroll-glue>
-				<div ng-repeat='item in filtered = (logitems_debug | filter:filterExpr) track by $index'>
-					<span class="{{item.mclass}}">{{item.text}}</span>
-				</div>
-			</div>
-		</div>
-	</div>
+<div id="logcontent" class="log-console-container force-select">
+  <div class="log-toolbar">
+    <div class="log-level-toggles">
+      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.norm}">
+        <input type="checkbox" id="logfilter_norm" ng-model="levelFilters.norm"><label for="logfilter_norm"></label>
+        <span class="log-toggle-label log-level-norm" ng-click="levelFilters.norm = !levelFilters.norm">Normal</span>
+        <span class="log-toggle-count">{{counts.norm}}</span>
+      </span>
+      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.status}">
+        <input type="checkbox" id="logfilter_status" ng-model="levelFilters.status"><label for="logfilter_status"></label>
+        <span class="log-toggle-label log-level-status" ng-click="levelFilters.status = !levelFilters.status">Status</span>
+        <span class="log-toggle-count">{{counts.status}}</span>
+      </span>
+      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.error}">
+        <input type="checkbox" id="logfilter_error" ng-model="levelFilters.error"><label for="logfilter_error"></label>
+        <span class="log-toggle-label log-level-error" ng-click="levelFilters.error = !levelFilters.error">Error</span>
+        <span class="log-toggle-count">{{counts.error}}</span>
+      </span>
+    </div>
+    <div class="log-search">
+      <input type="text" class="log-search-input" ng-model="searchText" ng-model-options="{ debounce: 150 }" placeholder="Filter logs... (use /regex/ for regex)">
+      <span class="log-search-count" ng-show="searchText">{{filteredItems.length}} matches</span>
+      <a class="btnstyle3" ng-show="searchText" ng-click="searchText = ''">&times;</a>
+    </div>
+    <div class="log-actions">
+      <a class="btnstyle3" ng-click="copyToClipboard()">
+        <span ng-hide="copyFeedback" data-i18n="Copy">Copy</span>
+        <span ng-show="copyFeedback" style="color: #4ec9b0;">Copied!</span>
+      </a>
+      <a class="btnstyle3" ng-click="downloadLog()" data-i18n="Download">Download</a>
+    </div>
+    <a class="btn btn-danger" ng-click="ClearLog()" data-i18n="Clear">Clear</a>
+  </div>
+  <div id="logdata" class="log-console">
+    <div class="log-line" ng-class="item.levelClass" ng-repeat="item in filteredItems track by $index">{{item.raw}}</div>
+  </div>
+  <div class="log-scroll-indicator" ng-show="!autoScroll" ng-click="scrollToBottom()">
+    &#x2193; New messages below
+  </div>
+  <div class="log-statusbar">
+    <span>{{filteredItems.length}} / {{logitems.length}} lines</span>
+    <span ng-show="!autoScroll" class="log-statusbar-paused">PAUSED</span>
+    <span ng-show="autoScroll" class="log-statusbar-following">Following</span>
+  </div>
 </div>

--- a/www/views/log.html
+++ b/www/views/log.html
@@ -1,21 +1,18 @@
 <div id="logcontent" class="log-console-container force-select">
   <div class="log-toolbar">
     <div class="log-level-toggles">
-      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.norm}">
-        <input type="checkbox" id="logfilter_norm" ng-model="levelFilters.norm"><label for="logfilter_norm"></label>
-        <span class="log-toggle-label log-level-norm" ng-click="levelFilters.norm = !levelFilters.norm">Normal</span>
+      <a class="btnstyle3 log-filter-btn" ng-class="{'log-filter-btn-active': levelFilters.norm}" ng-click="levelFilters.norm = !levelFilters.norm">
+        <span class="log-level-norm">Normal</span>
         <span class="log-toggle-count">{{counts.norm}}</span>
-      </span>
-      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.status}">
-        <input type="checkbox" id="logfilter_status" ng-model="levelFilters.status"><label for="logfilter_status"></label>
-        <span class="log-toggle-label log-level-status" ng-click="levelFilters.status = !levelFilters.status">Status</span>
+      </a>
+      <a class="btnstyle3 log-filter-btn" ng-class="{'log-filter-btn-active': levelFilters.status}" ng-click="levelFilters.status = !levelFilters.status">
+        <span class="log-level-status">Status</span>
         <span class="log-toggle-count">{{counts.status}}</span>
-      </span>
-      <span class="log-toggle" ng-class="{'log-toggle-active': levelFilters.error}">
-        <input type="checkbox" id="logfilter_error" ng-model="levelFilters.error"><label for="logfilter_error"></label>
-        <span class="log-toggle-label log-level-error" ng-click="levelFilters.error = !levelFilters.error">Error</span>
+      </a>
+      <a class="btnstyle3 log-filter-btn" ng-class="{'log-filter-btn-active': levelFilters.error}" ng-click="levelFilters.error = !levelFilters.error">
+        <span class="log-level-error">Error</span>
         <span class="log-toggle-count">{{counts.error}}</span>
-      </span>
+      </a>
     </div>
     <div class="log-search">
       <input type="text" class="log-search-input" ng-model="searchText" ng-model-options="{ debounce: 150 }" placeholder="Filter logs... (use /regex/ for regex)">


### PR DESCRIPTION
## Summary
- Replace polling-based log updates with WebSocket-first real-time streaming via existing `livesocket` infrastructure
- Rewrite log view from tab-based layout to single scrollable console with level filter toggles with counts, text/regex search, copy/download, and auto-scroll with pause/resume
- Implement four performance optimizations: tiered retention (errors/status survive buffer trimming longer), render cap (only 200 lines in DOM with "show older" expansion), batched WebSocket updates (1 digest per batch instead of per message), and stable track-by IDs with one-time bindings
- Fix auto-scroll stopping at buffer capacity by replacing length-based watcher with a version counter
- Fix initial scroll by deferring DOM initialization until after Angular template render

## Test plan
- [ ] Open the Log page and verify initial logs load and auto-scroll to bottom
- [ ] Confirm new WebSocket messages appear in real-time while following
- [ ] Scroll up and verify "New messages below" indicator appears and auto-scroll pauses
- [ ] Click "New messages below" and verify it resumes following
- [ ] Toggle Normal/Status/Error level filters and verify counts update correctly
- [ ] Type in the filter input and verify text search works (also test `/regex/` syntax)
- [ ] Wait for 1000+ messages and verify the log continues scrolling (doesn't freeze at capacity)
- [ ] Verify "Show older messages" button appears when buffer exceeds 200 visible lines
- [ ] Click Copy and verify clipboard contains filtered log text
- [ ] Click Download and verify .txt file is saved
- [ ] Click Clear and confirm log is emptied after confirmation
- [ ] Verify styling matches Domoticz theme (accent colors, button styles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)