### PR TITLE
feat: cross-platform LHM HTTP support with mode selector and extended sensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,8 @@ hardware/FritzboxTCP.cpp
 hardware/Gpio.cpp
 hardware/GpioPin.cpp
 hardware/HardwareMonitor.cpp
+hardware/HardwareMonitorUnix.cpp
+hardware/HardwareMonitorLHM.cpp
 hardware/HarmonyHub.cpp
 hardware/Honeywell.cpp
 hardware/HEOS.cpp

--- a/hardware/HardwareMonitor.cpp
+++ b/hardware/HardwareMonitor.cpp
@@ -10,80 +10,27 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-//Note, for Windows we use Libre Hardware Monitor or Open Hardware Monitor
-//https://github.com/LibreHardwareMonitor/LibreHardwareMonitor
-//http://openhardwaremonitor.org/
-
-#ifdef WIN32
-#include <comdef.h>
-#elif defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined (__OpenBSD__)
-#if !defined ( __FreeBSD__) && !defined(__OpenBSD__)
-#include <sys/sysinfo.h>
-#endif
-#ifdef __OpenBSD__
-#include <sys/sysctl.h>
-#include <sys/sched.h>
-#include <sys/vmmeter.h>
-#endif
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <limits>
-#include <unistd.h>
-
-//USER_HZ detection, from openssl code
-#ifndef HZ
-# if defined(_SC_CLK_TCK) && (!defined(OPENSSL_SYS_VMS) || __CTRL_VER >= 70000000)
-#  define HZ ((double)sysconf(_SC_CLK_TCK))
-# else
-#  ifndef CLK_TCK
-#   ifndef _BSD_CLK_TCK_ /* FreeBSD hack */
-#    define HZ  100.0
-#   else /* _BSD_CLK_TCK_ */
-#    define HZ ((double)_BSD_CLK_TCK_)
-#   endif
-#  else /* CLK_TCK */
-#   define HZ ((double)CLK_TCK)
-#  endif
-# endif
-#endif
-
-#endif // defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined (__OpenBSD__)
-
 #define POLL_INTERVAL_CPU	30
 #define POLL_INTERVAL_TEMP	70
 #define POLL_INTERVAL_MEM	80
 #define POLL_INTERVAL_DISK	170
 
-CHardwareMonitor::CHardwareMonitor(const int ID)
+CHardwareMonitorBase::CHardwareMonitorBase(const int ID)
 {
 	m_HwdID = ID;
 	m_lastquerytime = 0;
 	m_totcpu = 0;
 	m_lastloadcpu = 0;
-#ifdef WIN32
-	m_pLocator = nullptr;
-	m_pServicesHM = nullptr;
-	m_pServicesSystem = nullptr;
-#endif
 }
 
-CHardwareMonitor::~CHardwareMonitor()
+CHardwareMonitorBase::~CHardwareMonitorBase()
 {
 	StopHardware();
 }
 
-bool CHardwareMonitor::StartHardware()
+bool CHardwareMonitorBase::StartHardware()
 {
 	StopHardware();
-
-	m_bHasInternalTemperature = false;
-	m_bHasInternalVoltage = false;
-	m_bHasInternalCurrent = false;
-
-	m_szInternalTemperatureCommand = "";
-	m_szInternalVoltageCommand = "";
-	m_szInternalCurrentCommand = "";
 
 	if (!GetOSType(m_OStype))
 	{
@@ -99,9 +46,7 @@ bool CHardwareMonitor::StartHardware()
 
 	RequestStart();
 
-#ifdef WIN32
-	InitWMI();
-#endif
+	OnStartPlatform();
 
 	m_lastquerytime = 0;
 	m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
@@ -112,7 +57,7 @@ bool CHardwareMonitor::StartHardware()
 	return true;
 }
 
-bool CHardwareMonitor::StopHardware()
+bool CHardwareMonitorBase::StopHardware()
 {
 	if (m_thread)
 	{
@@ -120,14 +65,12 @@ bool CHardwareMonitor::StopHardware()
 		m_thread->join();
 		m_thread.reset();
 	}
-#ifdef WIN32
-	ExitWMI();
-#endif
+	OnStopPlatform();
 	m_bIsStarted = false;
 	return true;
 }
 
-void CHardwareMonitor::Do_Work()
+void CHardwareMonitorBase::Do_Work()
 {
 	Log(LOG_STATUS, "Hardware Monitor: Started (OStype %s)", TranslateOSTypeToString(m_OStype).c_str());
 
@@ -194,7 +137,7 @@ void CHardwareMonitor::Do_Work()
 	Log(LOG_STATUS, "Hardware Monitor: Stopped...");
 }
 
-void CHardwareMonitor::SendCurrent(const unsigned long Idx, const float Curr, const std::string& defaultname)
+void CHardwareMonitorBase::SendCurrent(const unsigned long Idx, const float Curr, const std::string& defaultname)
 {
 	_tGeneralDevice gDevice;
 	gDevice.subtype = sTypeCurrent;
@@ -204,82 +147,7 @@ void CHardwareMonitor::SendCurrent(const unsigned long Idx, const float Curr, co
 	sDecodeRXMessage(this, (const unsigned char*)&gDevice, defaultname.c_str(), 255, nullptr);
 }
 
-void CHardwareMonitor::GetInternalTemperature()
-{
-	Debug(DEBUG_NORM, "Getting Internal Temperature");
-	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalTemperatureCommand, returncode);
-	if (ret.empty())
-		return;
-	std::string tmpline = ret[0];
-	if (tmpline.find("temp=") == std::string::npos)
-		return;
-	tmpline = tmpline.substr(5);
-	size_t pos = tmpline.find('\'');
-	if (pos != std::string::npos)
-	{
-		tmpline = tmpline.substr(0, pos);
-	}
-
-	float temperature = static_cast<float>(atof(tmpline.c_str()));
-	if (temperature == 0)
-		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
-
-	if ((temperature != 85) && (temperature != -127) && (temperature > -273))
-	{
-		SendTempSensor(1, 255, temperature, "Internal Temperature");
-	}
-}
-
-void CHardwareMonitor::GetInternalVoltage()
-{
-	Debug(DEBUG_NORM, "Getting Internal Voltage");
-	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalVoltageCommand, returncode);
-	if (ret.empty())
-		return;
-	std::string tmpline = ret[0];
-	if (tmpline.find("volt=") == std::string::npos)
-		return;
-	tmpline = tmpline.substr(5);
-	size_t pos = tmpline.find('\'');
-	if (pos != std::string::npos)
-	{
-		tmpline = tmpline.substr(0, pos);
-	}
-
-	float voltage = static_cast<float>(atof(tmpline.c_str()));
-	if (voltage == 0)
-		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
-
-	SendVoltageSensor(0, 1, 255, voltage, "Internal Voltage");
-}
-
-void CHardwareMonitor::GetInternalCurrent()
-{
-	Debug(DEBUG_NORM, "Getting Internal Current");
-	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalCurrentCommand, returncode);
-	if (ret.empty())
-		return;
-	std::string tmpline = ret[0];
-	if (tmpline.find("curr=") == std::string::npos)
-		return;
-	tmpline = tmpline.substr(5);
-	size_t pos = tmpline.find('\'');
-	if (pos != std::string::npos)
-	{
-		tmpline = tmpline.substr(0, pos);
-	}
-
-	float current = static_cast<float>(atof(tmpline.c_str()));
-	if (current == 0)
-		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
-
-	SendCurrent(1, current, "Internal Current");
-}
-
-void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int dindex, const std::string& devName, const std::string& devValue)
+void CHardwareMonitorBase::UpdateSystemSensor(const std::string& qType, const int dindex, const std::string& devName, const std::string& devValue)
 {
 	if (!m_HwdID) {
 		Debug(DEBUG_NORM, "Hardware Monitor: Id not found!");
@@ -322,9 +190,87 @@ void CHardwareMonitor::UpdateSystemSensor(const std::string& qType, const int di
 		float usage = static_cast<float>(atof(devValue.c_str()));
 		SendCustomSensor(0, doffset + dindex, 255, usage, devName, "MB");
 	}
+	else if (qType == "Power")
+	{
+		doffset = 1600;
+		float watts = static_cast<float>(atof(devValue.c_str()));
+		SendWattMeter(0, doffset + dindex, 255, watts, devName);
+	}
+	else if (qType == "Clock")
+	{
+		doffset = 1700;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "MHz");
+	}
+	else if (qType == "Data")
+	{
+		doffset = 1800;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "GB");
+	}
+	else if (qType == "SmallData")
+	{
+		doffset = 1900;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "MB");
+	}
+	else if (qType == "Throughput")
+	{
+		doffset = 2000;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "mbps");
+	}
+	else if (qType == "Level")
+	{
+		doffset = 2100;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendPercentageSensor(doffset + dindex, 0, 255, value, devName);
+	}
+	else if (qType == "Factor")
+	{
+		doffset = 2200;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "");
+	}
+	else if (qType == "StorageTemperature")
+	{
+		doffset = 2300;
+		float temp = static_cast<float>(atof(devValue.c_str()));
+		SendTempSensor(doffset + dindex, 255, temp, devName);
+	}
+	else if (qType == "GPUFan")
+	{
+		doffset = 2400;
+		int fanspeed = atoi(devValue.c_str());
+		SendFanSensor(doffset + dindex, 255, fanspeed, devName);
+	}
+	else if (qType == "CPULoad")
+	{
+		doffset = 2500;
+		float perc = static_cast<float>(atof(devValue.c_str()));
+		SendPercentageSensor(doffset + dindex, 0, 255, perc, devName);
+	}
+	else if (qType == "MemoryLoad")
+	{
+		doffset = 2600;
+		float perc = static_cast<float>(atof(devValue.c_str()));
+		SendPercentageSensor(doffset + dindex, 0, 255, perc, devName);
+	}
+	else if (qType == "MemoryData")
+	{
+		doffset = 2700;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "GB");
+	}
+	else if (qType == "StorageData")
+	{
+		doffset = 2800;
+		float value = static_cast<float>(atof(devValue.c_str()));
+		SendCustomSensor(0, doffset + dindex, 255, value, devName, "GB");
+	}
 }
 
-bool CHardwareMonitor::GetOSType(nOSType& OStype)
+bool CHardwareMonitorBase::GetOSType(nOSType& OStype)
 {
 	OStype = OStype_Unknown;
 
@@ -360,7 +306,7 @@ bool CHardwareMonitor::GetOSType(nOSType& OStype)
 	return true;
 }
 
-std::string CHardwareMonitor::TranslateOSTypeToString(nOSType OSType)
+std::string CHardwareMonitorBase::TranslateOSTypeToString(nOSType OSType)
 {
 	std::string sOSType;
 
@@ -395,718 +341,4 @@ std::string CHardwareMonitor::TranslateOSTypeToString(nOSType OSType)
 		break;
 	}
 	return sOSType;
-}
-
-void CHardwareMonitor::FetchCPU()
-{
-#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	FetchUnixCPU();
-#endif
-}
-
-void CHardwareMonitor::FetchDisk()
-{
-#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	FetchUnixDisk();
-#endif
-}
-
-void CHardwareMonitor::FetchMemory()
-{
-#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	FetchUnixMemory();
-#endif
-}
-
-void CHardwareMonitor::FetchData()
-{
-#ifdef WIN32
-	if (IsHMRunning()) {
-		Debug(DEBUG_NORM, "Fetching Windows sensor data (System sensors)");
-		RunWMIQuery("Sensor", "Temperature");
-		RunWMIQuery("Sensor", "Load");
-		RunWMIQuery("Sensor", "Fan");
-		RunWMIQuery("Sensor", "Voltage");
-		return;
-	}
-#elif defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	Debug(DEBUG_NORM, "Fetching *NIX sensor data (System sensors)");
-
-	if (m_bHasInternalTemperature)
-		GetInternalTemperature();
-
-	if (m_bHasInternalVoltage)
-		GetInternalVoltage();
-
-	if (m_bHasInternalCurrent)
-		GetInternalCurrent();
-#endif
-}
-
-#ifdef WIN32
-bool CHardwareMonitor::InitWMI()
-{
-	HRESULT hr;
-	if (m_pLocator)
-		return true; //already initialized
-	hr = CoCreateInstance(CLSID_WbemAdministrativeLocator, nullptr, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&m_pLocator);
-	if (FAILED(hr))
-		return false;
-
-	//First try Libre Hardware Monitor
-	hr = m_pLocator->ConnectServer(L"root\\LibreHardwareMonitor", nullptr, nullptr, nullptr, 0, nullptr, nullptr, &m_pServicesHM);
-	if (SUCCEEDED(hr))
-	{
-		hr = m_pLocator->ConnectServer(L"root\\CIMV2", nullptr, nullptr, nullptr, 0, nullptr, nullptr, &m_pServicesSystem);
-		if (SUCCEEDED(hr))
-		{
-			m_bIsLibreHardwareMonitor = true;
-			if (IsHMRunning())
-			{
-				return true;
-			}
-			m_bIsLibreHardwareMonitor = false;
-			m_pServicesSystem->Release();
-			m_pServicesSystem = nullptr;
-		}
-		m_pServicesHM->Release();
-		m_pServicesHM = nullptr;
-	}
-
-	//Try Open Hardware Monitor
-	hr = m_pLocator->ConnectServer(L"root\\OpenHardwareMonitor", nullptr, nullptr, nullptr, 0, nullptr, nullptr, &m_pServicesHM);
-	if (SUCCEEDED(hr))
-	{
-		hr = m_pLocator->ConnectServer(L"root\\CIMV2", nullptr, nullptr, nullptr, 0, nullptr, nullptr, &m_pServicesSystem);
-		if (SUCCEEDED(hr))
-		{
-			if (IsHMRunning())
-			{
-				return true;
-			}
-			m_pServicesSystem->Release();
-			m_pServicesSystem = nullptr;
-		}
-		m_pServicesHM->Release();
-		m_pServicesHM = nullptr;
-	}
-	Log(LOG_STATUS, "Hardware Monitor: Warning, neither Libre Hardware Monitor nor Open Hardware Monitor are installed on this system. (https://github.com/LibreHardwareMonitor/LibreHardwareMonitor , http://openhardwaremonitor.org)");
-	return false;
-}
-
-void CHardwareMonitor::ExitWMI()
-{
-	if (m_pServicesSystem != nullptr)
-		m_pServicesSystem->Release();
-	m_pServicesSystem = nullptr;
-	if (m_pServicesHM != nullptr)
-		m_pServicesHM->Release();
-	m_pServicesHM = nullptr;
-	if (m_pLocator != nullptr)
-		m_pLocator->Release();
-	m_pLocator = nullptr;
-}
-
-bool CHardwareMonitor::IsHMRunning()
-{
-	if ((m_pServicesHM == nullptr) || (m_pServicesSystem == nullptr))
-		return false;
-	bool bHMRunning = false;
-	IEnumWbemClassObject* pEnumerator = nullptr;
-	HRESULT hr;
-	if (m_bIsLibreHardwareMonitor)
-	{
-		hr = m_pServicesSystem->ExecQuery(L"WQL", L"Select * from win32_Process WHERE Name='LibreHardwareMonitor.exe'",
-			WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &pEnumerator);
-	}
-	else
-	{
-		hr = m_pServicesSystem->ExecQuery(L"WQL", L"Select * from win32_Process WHERE Name='OpenHardwareMonitor.exe'",
-			WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr, &pEnumerator);
-	}
-	if (FAILED(hr))
-		return false;
-	IWbemClassObject* pclsObj = nullptr;
-	ULONG uReturn = 0;
-	hr = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
-	if ((FAILED(hr)) || (0 == uReturn))
-	{
-		pEnumerator->Release();
-		return false;
-	}
-	VARIANT vtProp;
-	VariantInit(&vtProp);
-	hr = pclsObj->Get(L"ProcessId", 0, &vtProp, 0, 0);
-	if (SUCCEEDED(hr))
-	{
-		int procId = static_cast<int>(vtProp.iVal);
-		if (procId) {
-			bHMRunning = true;
-		}
-		VariantClear(&vtProp);
-	}
-	pclsObj->Release();
-	pEnumerator->Release();
-
-	return bHMRunning;
-}
-
-void CHardwareMonitor::RunWMIQuery(const char* qTable, const std::string& qType)
-{
-	if ((m_pServicesHM == nullptr) || (m_pServicesSystem == nullptr))
-		return;
-	HRESULT hr;
-	std::string query = "SELECT * FROM ";
-	query.append(qTable);
-	query.append(" WHERE SensorType = '");
-	query.append(qType);
-	query.append("'");
-	IEnumWbemClassObject* pEnumerator = nullptr;
-	hr = m_pServicesHM->ExecQuery(L"WQL", bstr_t(query.c_str()), WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, nullptr,
-		&pEnumerator);
-	if (!FAILED(hr))
-	{
-		int dindex = 0;
-
-		// Get the data from the query
-		IWbemClassObject* pclsObj = nullptr;
-		while (pEnumerator)
-		{
-			ULONG uReturn = 0;
-			hr = pEnumerator->Next(WBEM_INFINITE, 1, &pclsObj, &uReturn);
-			if (FAILED(hr) || (0 == uReturn))
-			{
-				break;
-			}
-
-			VARIANT vtProp;
-
-			hr = pclsObj->Get(L"Name", 0, &vtProp, 0, 0);
-			if (SUCCEEDED(hr))
-			{
-				std::string itemName = _bstr_t(vtProp.bstrVal);
-				stdreplace(itemName, "#", "");
-				VariantClear(&vtProp);
-
-				hr = pclsObj->Get(L"Value", 0, &vtProp, 0, 0);
-				if (SUCCEEDED(hr))
-				{
-					float fItemValue = float(vtProp.fltVal);
-					std::ostringstream itemValue;
-					if ((qType == "Load") || (qType == "Temperature")) {
-						itemValue.precision(3);
-					}
-					itemValue << fItemValue;
-					VariantClear(&vtProp);
-
-					//hr = pclsObj->Get(L"InstanceId", 0, &vtProp, 0, 0);
-					hr = pclsObj->Get(L"Identifier", 0, &vtProp, 0, 0); // instance id seems to drift
-					if (SUCCEEDED(hr))
-					{
-						std::string itemId = _bstr_t(vtProp.bstrVal);
-						if (itemId.find("/hdd") != std::string::npos)
-						{
-							itemName = itemId + " " + itemName;
-						}
-						itemId = "WMI" + itemId;
-						Debug(DEBUG_NORM, "Hardware Monitor: %s, %s, %s", itemId.c_str(), itemName.c_str(), itemValue.str().c_str());
-						UpdateSystemSensor(qType, dindex, itemName, itemValue.str());
-						VariantClear(&vtProp);
-						dindex++;
-					}
-				}
-			}
-			pclsObj->Release();
-		}
-		pEnumerator->Release();
-	}
-}
-#elif defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-double CHardwareMonitor::time_so_far()
-{
-	struct timeval tp;
-	if (gettimeofday(&tp, (struct timezone*)nullptr) == -1)
-		return 0;
-	return ((double)(tp.tv_sec)) +
-		(((double)tp.tv_usec) * 0.000001);
-}
-
-#if defined(__linux__)
-float CHardwareMonitor::GetProcessMemUsage()
-{
-	pid_t pid = getpid();
-	std::stringstream ssPidfile;
-	ssPidfile << "/proc/" << pid << "/status";
-	std::ifstream mfile(ssPidfile.str().c_str());
-	if (!mfile.is_open())
-		return -1;
-	uint32_t VmRSS = -1;
-	uint32_t VmSwap = -1;
-	std::string token;
-	while (mfile >> token)
-	{
-		if (token == "VmRSS:")
-			mfile >> VmRSS;
-		else if (token == "VmSwap:")
-			mfile >> VmSwap;
-
-		// ignore rest of the line
-		mfile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-	}
-	return (VmRSS + VmSwap) / 1000.F;
-}
-#endif
-
-float CHardwareMonitor::GetMemUsageLinux()
-{
-#if defined(__FreeBSD__)
-	std::ifstream mfile("/compat/linux/proc/meminfo");
-#else	// Linux
-	std::ifstream mfile("/proc/meminfo");
-#endif
-	if (!mfile.is_open())
-		return -1;
-	unsigned long MemTotal = -1;
-	unsigned long MemFree = -1;
-	unsigned long MemBuffers = -1;
-	unsigned long  MemCached = -1;
-	std::string token;
-	while (mfile >> token) {
-		if (token == "MemTotal:") {
-			mfile >> MemTotal;
-		}
-		else if (token == "MemFree:") {
-			mfile >> MemFree;
-		}
-		else if (token == "Buffers:") {
-			mfile >> MemBuffers;
-		}
-		else if (token == "Cached:") {
-			mfile >> MemCached;
-		}
-		// ignore rest of the line
-		mfile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
-	}
-	unsigned long MemUsed = MemTotal - MemFree - MemBuffers - MemCached;
-	float memusedpercentage = (100.0F / float(MemTotal)) * MemUsed;
-	return memusedpercentage;
-}
-
-#ifdef __OpenBSD__
-float CHardwareMonitor::GetMemUsageOpenBSD()
-{
-	int mibTotalMem[2] = {
-		CTL_HW,
-		HW_PHYSMEM64
-	};
-	int mibPageSize[2] = {
-		CTL_HW,
-		HW_PAGESIZE
-	};
-	int mibMemStats[2] = {
-		CTL_VM,
-		VM_METER
-	};
-	int pageSize;
-	int64_t totalMemBytes, usedMem;
-	size_t len = sizeof(totalMemBytes);
-	float percent;
-	struct vmtotal memStats;
-	if (sysctl(mibTotalMem, 2, &totalMemBytes, &len, nullptr, 0) == -1)
-	{
-		return -1;
-	}
-	len = sizeof(pageSize);
-	if (sysctl(mibPageSize, 2, &pageSize, &len, nullptr, 0) == -1)
-	{
-		return -1;
-	}
-	len = sizeof(memStats);
-	if (sysctl(mibMemStats, 2, &memStats, &len, nullptr, 0) == -1)
-	{
-		return -1;
-	}
-	usedMem = memStats.t_arm * pageSize;//active real memory
-	percent = (100.0f / float(totalMemBytes)) * usedMem;
-	return percent;
-}
-#endif
-
-void CHardwareMonitor::FetchUnixMemory()
-{
-	//Memory
-	char szTmp[300];
-	float memusedpercentage = GetMemUsageLinux();
-#ifndef __FreeBSD__
-	if (memusedpercentage == -1)
-	{
-#ifdef __OpenBSD__
-		memusedpercentage = GetMemUsageOpenBSD();
-#else
-		//old (wrong) way
-		struct sysinfo mySysInfo;
-		int ret = sysinfo(&mySysInfo);
-		if (ret != 0)
-			return;
-		unsigned long usedram = mySysInfo.totalram - mySysInfo.freeram;
-		memusedpercentage = (100.0F / float(mySysInfo.totalram)) * usedram;
-#endif
-	}
-#endif
-	sprintf(szTmp, "%.2f", memusedpercentage);
-	UpdateSystemSensor("Load", 0, "Memory Usage", szTmp);
-#ifdef __linux__
-	float memProcess = GetProcessMemUsage();
-	if (memProcess != -1)
-	{
-		sprintf(szTmp, "%.2f", memProcess);
-		UpdateSystemSensor("Process", 0, "Process Usage", szTmp);
-	}
-#endif
-}
-
-void CHardwareMonitor::FetchUnixCPU()
-{
-	//CPU
-	char szTmp[300];
-	char cname[50];
-	if (m_lastquerytime == 0)
-	{
-#if defined(__OpenBSD__)
-		//Get number of CPUs
-		// sysctl hw.ncpu
-		int mib[] = { CTL_HW, HW_NCPU };
-		int totcpu = -1;
-		size_t size = sizeof(totcpu);
-		long loads[CPUSTATES];
-		if (sysctl(mib, 2, &totcpu, &size, nullptr, 0) < 0)
-		{
-			Log(LOG_ERROR, "sysctl NCPU failed.");
-			return;
-		}
-		m_lastquerytime = time_so_far();
-		// In the emd there will be single value, so using
-		// average loads doesn't generate that much error.
-		mib[0] = CTL_KERN;
-		mib[1] = KERN_CPTIME;
-		size = sizeof(loads);
-		if (sysctl(mib, 2, loads, &size, nullptr, 0) < 0)
-		{
-			Log(LOG_ERROR, "sysctl CPTIME failed.");
-			return;
-		}
-		//Interrupts aren't measured.
-		m_lastloadcpu = loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS];
-		m_totcpu = totcpu;
-#else
-		//first time
-		m_lastquerytime = time_so_far();
-		int actload1, actload2, actload3;
-		int totcpu = -1;
-#if defined(__FreeBSD__)
-		FILE* fIn = fopen("/compat/linux/proc/stat", "r");
-#else	// Linux
-		FILE* fIn = fopen("/proc/stat", "r");
-#endif
-		if (fIn != nullptr)
-		{
-			bool bFirstLine = true;
-			while (fgets(szTmp, sizeof(szTmp), fIn) != nullptr)
-			{
-				int ret = sscanf(szTmp, "%s\t%d\t%d\t%d\n", cname, &actload1, &actload2, &actload3);
-				if ((bFirstLine) && (ret == 4)) {
-					bFirstLine = false;
-					m_lastloadcpu = actload1 + actload2 + actload3;
-				}
-				char* cPos = strstr(cname, "cpu");
-				if (cPos == nullptr)
-					break;
-				totcpu++;
-			}
-			fclose(fIn);
-		}
-		if (totcpu < 1)
-			m_lastquerytime = 0;
-		else
-			m_totcpu = totcpu;
-#endif // else __OpenBSD__
-	}
-	else
-	{
-		double acttime = time_so_far();
-#if defined(__OpenBSD__)
-		int mib[] = { CTL_KERN, KERN_CPTIME };
-		long loads[CPUSTATES];
-		size_t size = sizeof(loads);
-		if (sysctl(mib, 2, loads, &size, nullptr, 0) < 0)
-		{
-			Log(LOG_ERROR, "sysctl CPTIME failed.");
-			return;
-		}
-		else
-		{
-			int64_t t = (loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS]) - m_lastloadcpu;
-			double cpuper = ((double(t) / (difftime(acttime, m_lastquerytime) * HZ)) * 100);///double(m_totcpu);
-			if (cpuper > 0)
-			{
-				sprintf(szTmp, "%.2f", cpuper);
-				UpdateSystemSensor("Load", 1, "CPU_Usage", szTmp);
-			}
-			m_lastloadcpu = loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS];
-		}
-#else
-		int actload1, actload2, actload3;
-#if defined(__FreeBSD__)
-		FILE* fIn = fopen("/compat/linux/proc/stat", "r");
-#else	// Linux
-		FILE* fIn = fopen("/proc/stat", "r");
-#endif
-		if (fIn != nullptr)
-		{
-			int ret = fscanf(fIn, "%s\t%d\t%d\t%d\n", cname, &actload1, &actload2, &actload3);
-			fclose(fIn);
-			if (ret == 4)
-			{
-				int64_t t = (actload1 + actload2 + actload3) - m_lastloadcpu;
-				double cpuper = ((t / (difftime(acttime, m_lastquerytime) * HZ)) * 100) / double(m_totcpu);
-				if (cpuper > 0)
-				{
-					sprintf(szTmp, "%.2f", cpuper);
-					UpdateSystemSensor("Load", 1, "CPU_Usage", szTmp);
-				}
-				m_lastloadcpu = actload1 + actload2 + actload3;
-			}
-		}
-#endif //else Openbsd
-		m_lastquerytime = acttime;
-	}
-}
-
-void CHardwareMonitor::FetchUnixDisk()
-{
-	//Disk Usage
-	std::map<std::string, _tDUsageStruct> _disks;
-	std::map<std::string, std::string> _dmounts_;
-	int returncode = 0;
-	std::vector<std::string> _rlines = ExecuteCommandAndReturn(m_dfcommand, returncode);
-	if (!_rlines.empty())
-	{
-		for (const auto& ittDF : _rlines)
-		{
-			char dname[200];
-			char suse[30];
-			char smountpoint[300];
-			int64_t numblock, usedblocks, availblocks;
-			int ret = sscanf(ittDF.c_str(), "%s\t%" PRId64 "\t%" PRId64 "\t%" PRId64 "\t%s\t%s\n", dname, &numblock, &usedblocks, &availblocks, suse, smountpoint);
-			if (ret == 6)
-			{
-				auto it = _dmounts_.find(dname);
-				if (it != _dmounts_.end())
-				{
-					if (it->second.length() < strlen(smountpoint))
-					{
-						continue;
-					}
-				}
-#if defined(__linux__) || defined(__FreeBSD__) || defined (__OpenBSD__)
-				if (strstr(dname, "/dev") != nullptr)
-#elif defined(__CYGWIN32__)
-				if (strstr(smountpoint, "/cygdrive/") != nullptr)
-#endif
-				{
-					_tDUsageStruct dusage;
-					dusage.TotalBlocks = numblock;
-					dusage.UsedBlocks = usedblocks;
-					dusage.AvailBlocks = availblocks;
-					dusage.MountPoint = smountpoint;
-					_disks[dname] = dusage;
-					_dmounts_[dname] = smountpoint;
-				}
-			}
-		}
-		int dindex = 0;
-		for (const auto& ittDisks : _disks)
-		{
-			_tDUsageStruct dusage = ittDisks.second;
-			if (dusage.TotalBlocks > 0)
-			{
-				double UsagedPercentage = (100 / double(dusage.TotalBlocks)) * double(dusage.UsedBlocks);
-				//std::cout << "Disk: " << ittDisks.first << ", Mount: " << dusage.MountPoint << ", Used: " << UsagedPercentage << std::endl;
-				char szTmp[300];
-				sprintf(szTmp, "%.2f", UsagedPercentage);
-				std::string hddname = "HDD " + dusage.MountPoint;
-				dindex=0;
-				std::vector<std::vector<std::string> > listOfHdd;
-				listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name, Options FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
-				if (!listOfHdd.empty())
-				{
-					for (const auto& sd : listOfHdd)
-					{
-						std::string szIdx = sd[0];
-						std::string szDeviceId = sd[1];
-						std::string Name = sd[2];
-						int deviceId;
-						sscanf(szDeviceId.c_str(), "%x", &deviceId);
-						std::string sOptions = sd[3];
-						std::map<std::string, std::string> optionsMap = m_sql.BuildDeviceOptions(sOptions);
-						if (!optionsMap.empty() and !strcmp(optionsMap["hdd"].c_str(),hddname.c_str()))
-						{	
-							dindex=deviceId;
-							break;
-						}	
-						else
-						{
-							if (!strcmp(Name.c_str(),hddname.c_str()))
-							{
-								dindex=deviceId;
-								uint64_t idx = std::stoull(szIdx);
-								optionsMap["hdd"] = hddname;
-								m_sql.SetDeviceOptions(idx, optionsMap);
-								break;
-							}	
-						}
-					}
-				}
-				if (dindex==0)					
-				{
-					// new HDD
-					std::vector<std::vector<std::string> > listOfHdd;
-					listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
-					int firstFreedeviceId=1102;
-					if (!listOfHdd.empty())
-					{
-						for (int i=0; i<listOfHdd.size() ; i++)
-						{
-							for (const auto& sd : listOfHdd)
-							{
-								std::string szDeviceId = sd[1];
-								int deviceId;
-								sscanf(szDeviceId.c_str(), "%x", &deviceId);
-								if (firstFreedeviceId==deviceId)
-								{	
-									firstFreedeviceId++;
-									break;
-								}	
-							}
-						}
-					}
-					dindex=firstFreedeviceId;
-				}
-				dindex-=1102;	
-
-				UpdateSystemSensor("Load", 2 + dindex, hddname, szTmp);
-			}
-		}
-	}
-}
-#endif //WIN32/#elif defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__)
-
-bool CHardwareMonitor::IsWSL()
-{
-	// Detect WSL according to https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
-	bool is_wsl = false;
-
-#if defined(__linux__)
-	char buf[1024];
-
-	int status_fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
-	if (status_fd == -1)
-		return is_wsl;
-
-	ssize_t num_read = read(status_fd, buf, sizeof(buf) - 1);
-
-	if (num_read > 0)
-	{
-		buf[num_read] = 0;
-		is_wsl |= (strstr(buf, "Microsoft") != nullptr);
-		is_wsl |= (strstr(buf, "WSL") != nullptr);
-	}
-
-	status_fd = open("/proc/version", O_RDONLY);
-	if (status_fd == -1)
-		return is_wsl;
-
-	num_read = read(status_fd, buf, sizeof(buf) - 1);
-
-	if (num_read > 0)
-	{
-		buf[num_read] = 0;
-		is_wsl |= (strstr(buf, "Microsoft") != nullptr);
-		is_wsl |= (strstr(buf, "WSL") != nullptr);
-	}
-#endif
-
-	return is_wsl;
-}
-
-void CHardwareMonitor::CheckForOnboardSensors()
-{
-	Debug(DEBUG_NORM, "Checking for onboard sensors");
-
-#ifdef WIN32
-	Debug(DEBUG_NORM, "Detecting onboard sensors on Windows not supported this way! (But through Libre Hardware Monitor or Open Hardware Monitor and WMI)");
-	return;
-#endif
-
-#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	// Busybox df doesn't support -x parameter
-	int returncode = 0;
-	std::vector<std::string> ret = ExecuteCommandAndReturn("df -x nfs -x tmpfs -x devtmpfs 2> /dev/null", returncode);
-	returncode == 0 ?
-		m_dfcommand = "df -x nfs -x tmpfs -x devtmpfs" :
-		m_dfcommand = "df";
-#endif
-
-#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__)
-
-	if (!m_bHasInternalTemperature)
-	{
-		if (file_exist("/sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input"))
-		{
-			Log(LOG_STATUS, "System: Cubieboard/Cubietruck");
-			m_szInternalTemperatureCommand = R"(cat /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input | awk '{ printf ("temp=%0.2f\n",$1/1000); }')";
-			m_bHasInternalTemperature = true;
-		}
-		else if (file_exist("/sys/devices/virtual/thermal/thermal_zone0/temp"))
-		{
-			Log(LOG_STATUS, "System: ODroid/Raspberry");
-			m_szInternalTemperatureCommand = R"(cat /sys/devices/virtual/thermal/thermal_zone0/temp | awk '{ if ($1 < 100) printf("temp=%d\n",$1); else printf ("temp=%0.2f\n",$1/1000); }')";
-			m_bHasInternalTemperature = true;
-		}
-	}
-	if (file_exist("/sys/class/power_supply/ac/voltage_now"))
-	{
-		Debug(DEBUG_NORM, "Internal voltage sensor detected");
-		m_szInternalVoltageCommand = R"(cat /sys/class/power_supply/ac/voltage_now | awk '{ printf ("volt=%0.2f\n",$1/1000000); }')";
-		m_bHasInternalVoltage = true;
-	}
-	if (file_exist("/sys/class/power_supply/ac/current_now"))
-	{
-		Debug(DEBUG_NORM, "Internal current sensor detected");
-		m_szInternalCurrentCommand = R"(cat /sys/class/power_supply/ac/current_now | awk '{ printf ("curr=%0.2f\n",$1/1000000); }')";
-		m_bHasInternalCurrent = true;
-	}
-	//New Armbian Kernal 4.14+
-	if (file_exist("/sys/class/power_supply/axp20x-ac/voltage_now"))
-	{
-		Debug(DEBUG_NORM, "Internal voltage sensor detected");
-		m_szInternalVoltageCommand = R"(cat /sys/class/power_supply/axp20x-ac/voltage_now | awk '{ printf ("volt=%0.2f\n",$1/1000000); }')";
-		m_bHasInternalVoltage = true;
-	}
-	if (file_exist("/sys/class/power_supply/axp20x-ac/current_now"))
-	{
-		Debug(DEBUG_NORM, "Internal current sensor detected");
-		m_szInternalCurrentCommand = R"(cat /sys/class/power_supply/axp20x-ac/current_now | awk '{ printf ("curr=%0.2f\n",$1/1000000); }')";
-		m_bHasInternalCurrent = true;
-	}
-#endif
-
-#if defined (__OpenBSD__)
-	Debug(DEBUG_NORM, "Internal temperature- and voltage sensors detected");
-	m_szInternalTemperatureCommand = "sysctl hw.sensors.acpitz0.temp0|sed -e 's/.*temp0/temp/'|cut -d ' ' -f 1";
-	m_bHasInternalTemperature = true;
-	m_szInternalVoltageCommand = "sysctl hw.sensors.acpibat0.volt1|sed -e 's/.*volt1/volt/'|cut -d ' ' -f 1";
-	m_bHasInternalVoltage = true;
-#endif
-
 }

--- a/hardware/HardwareMonitor.h
+++ b/hardware/HardwareMonitor.h
@@ -2,13 +2,7 @@
 
 #include "DomoticzHardware.h"
 
-#if defined WIN32
-// for windows system info
-#include <wbemidl.h>
-#pragma comment(lib, "wbemuuid.lib")
-#endif
-
-class CHardwareMonitor : public CDomoticzHardwareBase
+class CHardwareMonitorBase : public CDomoticzHardwareBase
 {
 public:
 	enum nOSType
@@ -24,34 +18,29 @@ public:
 		OStype_Apple = 15
 	};
 
-	explicit CHardwareMonitor(int ID);
-	~CHardwareMonitor() override;
-	bool WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/) override
-	{
-		return false;
-	};
-	bool GetOSType(nOSType& OStype);
-	std::string TranslateOSTypeToString(nOSType);
+	explicit CHardwareMonitorBase(int ID);
+	~CHardwareMonitorBase() override;
+	bool WriteToHardware(const char* /*pdata*/, const unsigned char /*length*/) override { return false; }
 
-private:
+	bool GetOSType(nOSType& OStype);
+	std::string TranslateOSTypeToString(nOSType OSType);
+
+protected:
 	bool StartHardware() override;
 	bool StopHardware() override;
-	double m_lastquerytime;
-	std::shared_ptr<std::thread> m_thread;
-	nOSType m_OStype;
 
-	void Do_Work();
-	void FetchData();
-	void FetchCPU();
-	void FetchMemory();
-	void FetchDisk();
-	void GetInternalTemperature();
-	void GetInternalVoltage();
-	void GetInternalCurrent();
-	void CheckForOnboardSensors();
+	// Platform-specific hooks (override in derived classes)
+	virtual void OnStartPlatform() {}
+	virtual void OnStopPlatform() {}
+	virtual void FetchData() = 0;
+	virtual void FetchCPU() {}
+	virtual void FetchMemory() {}
+	virtual void FetchDisk() {}
+	virtual void CheckForOnboardSensors() {}
+	virtual bool IsWSL() { return false; }
+
 	void UpdateSystemSensor(const std::string& qType, int dindex, const std::string& devName, const std::string& devValue);
 	void SendCurrent(unsigned long Idx, float Curr, const std::string& defaultname);
-	bool IsWSL();
 
 	struct _tDUsageStruct
 	{
@@ -61,41 +50,12 @@ private:
 		int64_t AvailBlocks;
 	};
 
+	double m_lastquerytime;
 	int64_t m_lastloadcpu;
 	int m_totcpu;
-	std::string m_dfcommand;
+	nOSType m_OStype;
 
-	bool m_bHasInternalTemperature;
-	std::string m_szInternalTemperatureCommand;
-
-	bool m_bHasInternalVoltage;
-	std::string m_szInternalVoltageCommand;
-
-	bool m_bHasInternalCurrent;
-	std::string m_szInternalCurrentCommand;
-
-#ifdef WIN32
-	bool InitWMI();
-	void ExitWMI();
-	bool IsHMRunning();
-	void RunWMIQuery(const char* qTable, const std::string& qType);
-	IWbemLocator* m_pLocator;
-	IWbemServices* m_pServicesHM;
-	IWbemServices* m_pServicesSystem;
-	bool m_bIsLibreHardwareMonitor = false;
-#elif defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-	void FetchUnixCPU();
-	void FetchUnixMemory();
-	void FetchUnixDisk();
-	double time_so_far();
-#if defined(__linux__)
-	float GetProcessMemUsage();
-#endif
-#if defined(__linux__) || defined(__FreeBSD__)
-	float GetMemUsageLinux();
-#endif
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
-	float GetMemUsageOpenBSD();
-#endif
-#endif
+private:
+	void Do_Work();
+	std::shared_ptr<std::thread> m_thread;
 };

--- a/hardware/HardwareMonitorLHM.cpp
+++ b/hardware/HardwareMonitorLHM.cpp
@@ -1,0 +1,323 @@
+#include "stdafx.h"
+
+#include "HardwareMonitorLHM.h"
+#include "../main/Helper.h"
+#include "../main/Logger.h"
+#include "../httpclient/HTTPClient.h"
+#include "../webserver/Base64.h"
+
+static bool IsValidLHMAddress(const std::string& addr)
+{
+	if (addr.empty())
+		return false;
+	// Reject characters that could cause URL injection
+	for (char c : addr)
+	{
+		if (c == '/' || c == '@' || c == '?' || c == '#' || c == ' ')
+			return false;
+	}
+	if (addr.find("://") != std::string::npos)
+		return false;
+	return true;
+}
+
+CHardwareMonitorLHM::CHardwareMonitorLHM(const int ID, const std::string& address, uint16_t port, const std::string& username, const std::string& password, bool bExtendedSensors)
+	: CHardwareMonitorBase(ID)
+	, m_szLHMAddress(IsValidLHMAddress(address) ? address : "127.0.0.1")
+	, m_usLHMPort(port == 0 ? 8085 : port)
+	, m_szUsername(username)
+	, m_szPassword(password)
+	, m_bExtendedSensors(bExtendedSensors)
+{
+	if (!address.empty() && !IsValidLHMAddress(address))
+		Log(LOG_ERROR, "Invalid LHM address '%s', using default 127.0.0.1", address.c_str());
+}
+
+void CHardwareMonitorLHM::FetchData()
+{
+	FetchLHMData();
+}
+
+static constexpr int MAX_JSON_DEPTH = 10;
+static constexpr int MAX_SENSORS_PER_TYPE = 100;
+
+// Detect storage hardware from LHM SensorId path
+static bool IsStorageSensor(const std::string& sensorId)
+{
+	return (sensorId.find("/nvme/") != std::string::npos
+		|| sensorId.find("/hdd/") != std::string::npos
+		|| sensorId.find("/ata/") != std::string::npos
+		|| sensorId.find("/ssd/") != std::string::npos);
+}
+
+// Detect GPU hardware from LHM SensorId path
+static bool IsGPUSensor(const std::string& sensorId)
+{
+	return (sensorId.find("/gpu") != std::string::npos);
+}
+
+// Detect CPU hardware from LHM SensorId path
+static bool IsCPUSensor(const std::string& sensorId)
+{
+	return (sensorId.find("/intelcpu/") != std::string::npos
+		|| sensorId.find("/amdcpu/") != std::string::npos
+		|| sensorId.find("/cpu/") != std::string::npos);
+}
+
+// Detect RAM hardware from LHM SensorId path
+static bool IsRAMSensor(const std::string& sensorId)
+{
+	return (sensorId.find("/ram/") != std::string::npos);
+}
+
+bool CHardwareMonitorLHM::FetchLHMData()
+{
+	std::string sURL = "http://" + m_szLHMAddress + ":" + std::to_string(m_usLHMPort) + "/data.json";
+	std::string sResult;
+
+	std::vector<std::string> ExtraHeaders;
+	if (!m_szUsername.empty())
+	{
+		std::string sAuth = m_szUsername + ":" + m_szPassword;
+		ExtraHeaders.push_back("Authorization: Basic " + base64_encode(sAuth));
+	}
+
+	if (!HTTPClient::GET(sURL, ExtraHeaders, sResult, true))
+	{
+		Log(LOG_ERROR, "Failed to connect to Libre Hardware Monitor at %s. "
+			"Ensure LHM is running and 'Remote Web Server' is enabled in Options > Remote Web Server.",
+			sURL.c_str());
+		return false;
+	}
+
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		Log(LOG_ERROR, "Failed to parse JSON from Libre Hardware Monitor at %s", sURL.c_str());
+		return false;
+	}
+
+	// Normal mode indices (always active)
+	int tempIdx = 0, fanIdx = 0;
+	int cpuLoadIdx = 0, memLoadIdx = 0, memDataIdx = 0, storageDataIdx = 0;
+	// Extended mode indices (only used when m_bExtendedSensors is true)
+	int storageTempIdx = 0, gpuFanIdx = 0;
+	int loadIdx = 0, voltIdx = 0;
+	int powerIdx = 0, clockIdx = 0, dataIdx = 0, smallDataIdx = 0;
+	int throughputIdx = 0, levelIdx = 0, factorIdx = 0;
+
+	ParseLHMNode(root, "",
+		tempIdx, fanIdx, cpuLoadIdx, memLoadIdx, memDataIdx, storageDataIdx,
+		storageTempIdx, gpuFanIdx, loadIdx, voltIdx,
+		powerIdx, clockIdx, dataIdx, smallDataIdx,
+		throughputIdx, levelIdx, factorIdx);
+
+	bool bAnySensor = (tempIdx + fanIdx + cpuLoadIdx + memLoadIdx + memDataIdx + storageDataIdx
+		+ storageTempIdx + gpuFanIdx + loadIdx + voltIdx
+		+ powerIdx + clockIdx + dataIdx + smallDataIdx
+		+ throughputIdx + levelIdx + factorIdx) > 0;
+
+	if (!bAnySensor)
+		Log(LOG_STATUS, "Connected to Libre Hardware Monitor but no supported sensors found");
+
+	return true;
+}
+
+void CHardwareMonitorLHM::ParseLHMNode(
+	const Json::Value& node,
+	const std::string& hwDevice,
+	int& tempIdx, int& fanIdx, int& cpuLoadIdx, int& memLoadIdx,
+	int& memDataIdx, int& storageDataIdx,
+	int& storageTempIdx, int& gpuFanIdx,
+	int& loadIdx, int& voltIdx, int& powerIdx, int& clockIdx,
+	int& dataIdx, int& smallDataIdx, int& throughputIdx,
+	int& levelIdx, int& factorIdx, int depth)
+{
+	if (!node.isObject())
+		return;
+
+	if (depth > MAX_JSON_DEPTH)
+	{
+		Log(LOG_ERROR, "LHM JSON tree depth exceeded maximum of %d, aborting parse", MAX_JSON_DEPTH);
+		return;
+	}
+
+	// Determine if this is a hardware device node (has HardwareId)
+	std::string currentDevice = hwDevice;
+	if (node.isMember("HardwareId") && node.isMember("Text"))
+		currentDevice = node["Text"].asString();
+
+	// Check if this is a leaf sensor node (has Type, SensorId, and empty Children)
+	if (node.isMember("Type") && node.isMember("SensorId") && node.isMember("Children"))
+	{
+		const Json::Value& children = node["Children"];
+		if (children.isArray() && children.empty())
+		{
+			std::string sType = node["Type"].asString();
+			std::string sName = node.isMember("Text") ? node["Text"].asString() : "";
+			std::string sSensorId = node["SensorId"].asString();
+
+			// Use RawValue for most consistent parsing (base units for throughput etc.)
+			std::string sValue;
+			if (node.isMember("RawValue") && !node["RawValue"].isNull())
+				sValue = node["RawValue"].asString();
+			else if (node.isMember("Value") && !node["Value"].isNull())
+				sValue = node["Value"].asString();
+			else
+				return;
+
+			// Extract numeric part: "42,0 °C" → "42,0"
+			size_t spacePos = sValue.find(' ');
+			std::string numericStr = (spacePos != std::string::npos) ? sValue.substr(0, spacePos) : sValue;
+
+			// Handle European comma decimal separator: "42,0" → "42.0"
+			stdreplace(numericStr, ",", ".");
+
+			// Build sensor name with hardware device prefix for disambiguation
+			std::string devName = sName;
+			if (!currentDevice.empty() && !sName.empty())
+				devName = currentDevice + " - " + sName;
+			else if (!currentDevice.empty())
+				devName = currentDevice;
+
+			// Classify hardware source from SensorId
+			bool bIsStorage = IsStorageSensor(sSensorId);
+			bool bIsGPU = IsGPUSensor(sSensorId);
+			bool bIsCPU = IsCPUSensor(sSensorId);
+			bool bIsRAM = IsRAMSensor(sSensorId);
+
+			// --- Normal mode sensors (always polled) ---
+			// Offset map:
+			//   Temperature (CPU/GPU/MB): 1000   Fan (CPU/system):       1200
+			//   CPULoad:                  2500   MemoryLoad:             2600
+			//   MemoryData:               2700   StorageData:            2800
+			//
+			// --- Extended mode adds (separate offsets, no ID conflicts) ---
+			//   StorageTemperature: 2300   GPUFan:    2400
+			//   Load:    1100   Voltage: 1300   Power:   1600   Clock:     1700
+			//   Data:    1800   SmallData: 1900  Throughput: 2000
+			//   Level:   2100   Factor:  2200
+
+			if (sType == "Temperature")
+			{
+				if (bIsStorage)
+				{
+					// Storage temps: extended only, separate offset
+					if (m_bExtendedSensors && storageTempIdx < MAX_SENSORS_PER_TYPE)
+						UpdateSystemSensor("StorageTemperature", storageTempIdx++, devName, numericStr);
+				}
+				else if (tempIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// CPU, GPU, Motherboard temps: always
+					UpdateSystemSensor("Temperature", tempIdx++, devName, numericStr);
+				}
+			}
+			else if (sType == "Fan")
+			{
+				if (bIsGPU)
+				{
+					// GPU fans: extended only, separate offset
+					if (m_bExtendedSensors && gpuFanIdx < MAX_SENSORS_PER_TYPE)
+						UpdateSystemSensor("GPUFan", gpuFanIdx++, devName, numericStr);
+				}
+				else if (fanIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// CPU and system fans: always
+					UpdateSystemSensor("Fan", fanIdx++, devName, numericStr);
+				}
+			}
+			else if (sType == "Load")
+			{
+				if (bIsCPU && cpuLoadIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// CPU usage: always (own offset)
+					UpdateSystemSensor("CPULoad", cpuLoadIdx++, devName, numericStr);
+				}
+				else if (bIsRAM && memLoadIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// Memory usage %: always (own offset)
+					UpdateSystemSensor("MemoryLoad", memLoadIdx++, devName, numericStr);
+				}
+				else if (m_bExtendedSensors && loadIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// GPU load, network utilization, etc.: extended only
+					UpdateSystemSensor("Load", loadIdx++, devName, numericStr);
+				}
+			}
+			else if (sType == "Data")
+			{
+				if (bIsRAM && memDataIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// Memory used/available GB: always (own offset)
+					UpdateSystemSensor("MemoryData", memDataIdx++, devName, numericStr);
+				}
+				else if (bIsStorage && storageDataIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// Disk used/available GB: always (own offset)
+					UpdateSystemSensor("StorageData", storageDataIdx++, devName, numericStr);
+				}
+				else if (m_bExtendedSensors && dataIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// Other data sensors: extended only
+					UpdateSystemSensor("Data", dataIdx++, devName, numericStr);
+				}
+			}
+			else if (m_bExtendedSensors)
+			{
+				// All remaining types are extended-only
+				if (sType == "Voltage" && voltIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("Voltage", voltIdx++, devName, numericStr);
+				}
+				else if (sType == "Power" && powerIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("Power", powerIdx++, devName, numericStr);
+				}
+				else if (sType == "Clock" && clockIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("Clock", clockIdx++, devName, numericStr);
+				}
+				else if (sType == "SmallData" && smallDataIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("SmallData", smallDataIdx++, devName, numericStr);
+				}
+				else if (sType == "Throughput" && throughputIdx < MAX_SENSORS_PER_TYPE)
+				{
+					// RawValue is in B/s, convert to mbps (megabits per second)
+					float bytesPerSec = static_cast<float>(atof(numericStr.c_str()));
+					float mbps = (bytesPerSec * 8.0F) / 1000000.0F;
+					char mbpsBuf[32];
+					snprintf(mbpsBuf, sizeof(mbpsBuf), "%.2f", mbps);
+					UpdateSystemSensor("Throughput", throughputIdx++, devName, std::string(mbpsBuf));
+				}
+				else if (sType == "Level" && levelIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("Level", levelIdx++, devName, numericStr);
+				}
+				else if (sType == "Factor" && factorIdx < MAX_SENSORS_PER_TYPE)
+				{
+					UpdateSystemSensor("Factor", factorIdx++, devName, numericStr);
+				}
+			}
+
+			return;
+		}
+	}
+
+	// Recurse into children
+	if (node.isMember("Children"))
+	{
+		const Json::Value& children = node["Children"];
+		if (children.isArray())
+		{
+			for (const auto& child : children)
+			{
+				ParseLHMNode(child, currentDevice,
+					tempIdx, fanIdx, cpuLoadIdx, memLoadIdx, memDataIdx, storageDataIdx,
+					storageTempIdx, gpuFanIdx, loadIdx, voltIdx,
+					powerIdx, clockIdx, dataIdx, smallDataIdx,
+					throughputIdx, levelIdx, factorIdx, depth + 1);
+			}
+		}
+	}
+}

--- a/hardware/HardwareMonitorLHM.h
+++ b/hardware/HardwareMonitorLHM.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "HardwareMonitor.h"
+#include "../main/json_helper.h"
+
+class CHardwareMonitorLHM : public CHardwareMonitorBase
+{
+public:
+	CHardwareMonitorLHM(int ID, const std::string& address, uint16_t port, const std::string& username, const std::string& password, bool bExtendedSensors);
+	~CHardwareMonitorLHM() override = default;
+
+protected:
+	void FetchData() override;
+
+private:
+	bool FetchLHMData();
+	void ParseLHMNode(const Json::Value& node, const std::string& hwDevice,
+	                   int& tempIdx, int& fanIdx, int& cpuLoadIdx, int& memLoadIdx,
+	                   int& memDataIdx, int& storageDataIdx,
+	                   int& storageTempIdx, int& gpuFanIdx,
+	                   int& loadIdx, int& voltIdx, int& powerIdx, int& clockIdx,
+	                   int& dataIdx, int& smallDataIdx, int& throughputIdx,
+	                   int& levelIdx, int& factorIdx, int depth = 0);
+
+	std::string m_szLHMAddress;
+	uint16_t m_usLHMPort;
+	std::string m_szUsername;
+	std::string m_szPassword;
+	bool m_bExtendedSensors;
+};

--- a/hardware/HardwareMonitorUnix.cpp
+++ b/hardware/HardwareMonitorUnix.cpp
@@ -1,0 +1,642 @@
+#include "stdafx.h"
+
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+
+#include "HardwareMonitorUnix.h"
+#include "../main/Helper.h"
+#include "../main/Logger.h"
+#include "../main/mainworker.h"
+#include "../main/SQLHelper.h"
+#include <wchar.h>
+
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
+
+// Unix-specific includes
+#if !defined(__FreeBSD__) && !defined(__OpenBSD__)
+#include <sys/sysinfo.h>
+#endif
+#ifdef __OpenBSD__
+#include <sys/sysctl.h>
+#include <sys/sched.h>
+#include <sys/vmmeter.h>
+#endif
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <limits>
+#include <unistd.h>
+#include <fcntl.h>
+
+//USER_HZ detection, from openssl code
+#ifndef HZ
+# if defined(_SC_CLK_TCK) && (!defined(OPENSSL_SYS_VMS) || __CTRL_VER >= 70000000)
+#  define HZ ((double)sysconf(_SC_CLK_TCK))
+# else
+#  ifndef CLK_TCK
+#   ifndef _BSD_CLK_TCK_ /* FreeBSD hack */
+#    define HZ  100.0
+#   else /* _BSD_CLK_TCK_ */
+#    define HZ ((double)_BSD_CLK_TCK_)
+#   endif
+#  else /* CLK_TCK */
+#   define HZ ((double)CLK_TCK)
+#  endif
+# endif
+#endif
+
+CHardwareMonitorUnix::CHardwareMonitorUnix(const int ID)
+	: CHardwareMonitorBase(ID)
+{
+}
+
+void CHardwareMonitorUnix::FetchData()
+{
+	Debug(DEBUG_NORM, "Fetching *NIX sensor data (System sensors)");
+
+	if (m_bHasInternalTemperature)
+		GetInternalTemperature();
+
+	if (m_bHasInternalVoltage)
+		GetInternalVoltage();
+
+	if (m_bHasInternalCurrent)
+		GetInternalCurrent();
+}
+
+void CHardwareMonitorUnix::FetchCPU()
+{
+	FetchUnixCPU();
+}
+
+void CHardwareMonitorUnix::FetchMemory()
+{
+	FetchUnixMemory();
+}
+
+void CHardwareMonitorUnix::FetchDisk()
+{
+	FetchUnixDisk();
+}
+
+void CHardwareMonitorUnix::GetInternalTemperature()
+{
+	Debug(DEBUG_NORM, "Getting Internal Temperature");
+	int returncode = 0;
+	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalTemperatureCommand, returncode);
+	if (ret.empty())
+		return;
+	std::string tmpline = ret[0];
+	if (tmpline.find("temp=") == std::string::npos)
+		return;
+	tmpline = tmpline.substr(5);
+	size_t pos = tmpline.find('\'');
+	if (pos != std::string::npos)
+	{
+		tmpline = tmpline.substr(0, pos);
+	}
+
+	float temperature = static_cast<float>(atof(tmpline.c_str()));
+	if (temperature == 0)
+		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
+
+	if ((temperature != 85) && (temperature != -127) && (temperature > -273))
+	{
+		SendTempSensor(1, 255, temperature, "Internal Temperature");
+	}
+}
+
+void CHardwareMonitorUnix::GetInternalVoltage()
+{
+	Debug(DEBUG_NORM, "Getting Internal Voltage");
+	int returncode = 0;
+	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalVoltageCommand, returncode);
+	if (ret.empty())
+		return;
+	std::string tmpline = ret[0];
+	if (tmpline.find("volt=") == std::string::npos)
+		return;
+	tmpline = tmpline.substr(5);
+	size_t pos = tmpline.find('\'');
+	if (pos != std::string::npos)
+	{
+		tmpline = tmpline.substr(0, pos);
+	}
+
+	float voltage = static_cast<float>(atof(tmpline.c_str()));
+	if (voltage == 0)
+		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
+
+	SendVoltageSensor(0, 1, 255, voltage, "Internal Voltage");
+}
+
+void CHardwareMonitorUnix::GetInternalCurrent()
+{
+	Debug(DEBUG_NORM, "Getting Internal Current");
+	int returncode = 0;
+	std::vector<std::string> ret = ExecuteCommandAndReturn(m_szInternalCurrentCommand, returncode);
+	if (ret.empty())
+		return;
+	std::string tmpline = ret[0];
+	if (tmpline.find("curr=") == std::string::npos)
+		return;
+	tmpline = tmpline.substr(5);
+	size_t pos = tmpline.find('\'');
+	if (pos != std::string::npos)
+	{
+		tmpline = tmpline.substr(0, pos);
+	}
+
+	float current = static_cast<float>(atof(tmpline.c_str()));
+	if (current == 0)
+		return; //hardly possible for a on board temp sensor, if it is, it is probably not working
+
+	SendCurrent(1, current, "Internal Current");
+}
+
+double CHardwareMonitorUnix::time_so_far()
+{
+	struct timeval tp;
+	if (gettimeofday(&tp, (struct timezone*)nullptr) == -1)
+		return 0;
+	return ((double)(tp.tv_sec)) +
+		(((double)tp.tv_usec) * 0.000001);
+}
+
+#if defined(__linux__)
+float CHardwareMonitorUnix::GetProcessMemUsage()
+{
+	pid_t pid = getpid();
+	std::stringstream ssPidfile;
+	ssPidfile << "/proc/" << pid << "/status";
+	std::ifstream mfile(ssPidfile.str().c_str());
+	if (!mfile.is_open())
+		return -1;
+	uint32_t VmRSS = -1;
+	uint32_t VmSwap = -1;
+	std::string token;
+	while (mfile >> token)
+	{
+		if (token == "VmRSS:")
+			mfile >> VmRSS;
+		else if (token == "VmSwap:")
+			mfile >> VmSwap;
+
+		// ignore rest of the line
+		mfile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+	}
+	return (VmRSS + VmSwap) / 1000.F;
+}
+#endif
+
+float CHardwareMonitorUnix::GetMemUsageLinux()
+{
+#if defined(__FreeBSD__)
+	std::ifstream mfile("/compat/linux/proc/meminfo");
+#else	// Linux
+	std::ifstream mfile("/proc/meminfo");
+#endif
+	if (!mfile.is_open())
+		return -1;
+	unsigned long MemTotal = -1;
+	unsigned long MemFree = -1;
+	unsigned long MemBuffers = -1;
+	unsigned long  MemCached = -1;
+	std::string token;
+	while (mfile >> token) {
+		if (token == "MemTotal:") {
+			mfile >> MemTotal;
+		}
+		else if (token == "MemFree:") {
+			mfile >> MemFree;
+		}
+		else if (token == "Buffers:") {
+			mfile >> MemBuffers;
+		}
+		else if (token == "Cached:") {
+			mfile >> MemCached;
+		}
+		// ignore rest of the line
+		mfile.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+	}
+	unsigned long MemUsed = MemTotal - MemFree - MemBuffers - MemCached;
+	float memusedpercentage = (100.0F / float(MemTotal)) * MemUsed;
+	return memusedpercentage;
+}
+
+#ifdef __OpenBSD__
+float CHardwareMonitorUnix::GetMemUsageOpenBSD()
+{
+	int mibTotalMem[2] = {
+		CTL_HW,
+		HW_PHYSMEM64
+	};
+	int mibPageSize[2] = {
+		CTL_HW,
+		HW_PAGESIZE
+	};
+	int mibMemStats[2] = {
+		CTL_VM,
+		VM_METER
+	};
+	int pageSize;
+	int64_t totalMemBytes, usedMem;
+	size_t len = sizeof(totalMemBytes);
+	float percent;
+	struct vmtotal memStats;
+	if (sysctl(mibTotalMem, 2, &totalMemBytes, &len, nullptr, 0) == -1)
+	{
+		return -1;
+	}
+	len = sizeof(pageSize);
+	if (sysctl(mibPageSize, 2, &pageSize, &len, nullptr, 0) == -1)
+	{
+		return -1;
+	}
+	len = sizeof(memStats);
+	if (sysctl(mibMemStats, 2, &memStats, &len, nullptr, 0) == -1)
+	{
+		return -1;
+	}
+	usedMem = memStats.t_arm * pageSize;//active real memory
+	percent = (100.0f / float(totalMemBytes)) * usedMem;
+	return percent;
+}
+#endif
+
+void CHardwareMonitorUnix::FetchUnixMemory()
+{
+	//Memory
+	char szTmp[300];
+	float memusedpercentage = GetMemUsageLinux();
+#ifndef __FreeBSD__
+	if (memusedpercentage == -1)
+	{
+#ifdef __OpenBSD__
+		memusedpercentage = GetMemUsageOpenBSD();
+#else
+		//old (wrong) way
+		struct sysinfo mySysInfo;
+		int ret = sysinfo(&mySysInfo);
+		if (ret != 0)
+			return;
+		unsigned long usedram = mySysInfo.totalram - mySysInfo.freeram;
+		memusedpercentage = (100.0F / float(mySysInfo.totalram)) * usedram;
+#endif
+	}
+#endif
+	sprintf(szTmp, "%.2f", memusedpercentage);
+	UpdateSystemSensor("Load", 0, "Memory Usage", szTmp);
+#ifdef __linux__
+	float memProcess = GetProcessMemUsage();
+	if (memProcess != -1)
+	{
+		sprintf(szTmp, "%.2f", memProcess);
+		UpdateSystemSensor("Process", 0, "Process Usage", szTmp);
+	}
+#endif
+}
+
+void CHardwareMonitorUnix::FetchUnixCPU()
+{
+	//CPU
+	char szTmp[300];
+	char cname[50];
+	if (m_lastquerytime == 0)
+	{
+#if defined(__OpenBSD__)
+		//Get number of CPUs
+		// sysctl hw.ncpu
+		int mib[] = { CTL_HW, HW_NCPU };
+		int totcpu = -1;
+		size_t size = sizeof(totcpu);
+		long loads[CPUSTATES];
+		if (sysctl(mib, 2, &totcpu, &size, nullptr, 0) < 0)
+		{
+			Log(LOG_ERROR, "sysctl NCPU failed.");
+			return;
+		}
+		m_lastquerytime = time_so_far();
+		// In the emd there will be single value, so using
+		// average loads doesn't generate that much error.
+		mib[0] = CTL_KERN;
+		mib[1] = KERN_CPTIME;
+		size = sizeof(loads);
+		if (sysctl(mib, 2, loads, &size, nullptr, 0) < 0)
+		{
+			Log(LOG_ERROR, "sysctl CPTIME failed.");
+			return;
+		}
+		//Interrupts aren't measured.
+		m_lastloadcpu = loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS];
+		m_totcpu = totcpu;
+#else
+		//first time
+		m_lastquerytime = time_so_far();
+		int actload1, actload2, actload3;
+		int totcpu = -1;
+#if defined(__FreeBSD__)
+		FILE* fIn = fopen("/compat/linux/proc/stat", "r");
+#else	// Linux
+		FILE* fIn = fopen("/proc/stat", "r");
+#endif
+		if (fIn != nullptr)
+		{
+			bool bFirstLine = true;
+			while (fgets(szTmp, sizeof(szTmp), fIn) != nullptr)
+			{
+				int ret = sscanf(szTmp, "%s\t%d\t%d\t%d\n", cname, &actload1, &actload2, &actload3);
+				if ((bFirstLine) && (ret == 4)) {
+					bFirstLine = false;
+					m_lastloadcpu = actload1 + actload2 + actload3;
+				}
+				char* cPos = strstr(cname, "cpu");
+				if (cPos == nullptr)
+					break;
+				totcpu++;
+			}
+			fclose(fIn);
+		}
+		if (totcpu < 1)
+			m_lastquerytime = 0;
+		else
+			m_totcpu = totcpu;
+#endif // else __OpenBSD__
+	}
+	else
+	{
+		double acttime = time_so_far();
+#if defined(__OpenBSD__)
+		int mib[] = { CTL_KERN, KERN_CPTIME };
+		long loads[CPUSTATES];
+		size_t size = sizeof(loads);
+		if (sysctl(mib, 2, loads, &size, nullptr, 0) < 0)
+		{
+			Log(LOG_ERROR, "sysctl CPTIME failed.");
+			return;
+		}
+		else
+		{
+			int64_t t = (loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS]) - m_lastloadcpu;
+			double cpuper = ((double(t) / (difftime(acttime, m_lastquerytime) * HZ)) * 100);///double(m_totcpu);
+			if (cpuper > 0)
+			{
+				sprintf(szTmp, "%.2f", cpuper);
+				UpdateSystemSensor("Load", 1, "CPU_Usage", szTmp);
+			}
+			m_lastloadcpu = loads[CP_USER] + loads[CP_NICE] + loads[CP_SYS];
+		}
+#else
+		int actload1, actload2, actload3;
+#if defined(__FreeBSD__)
+		FILE* fIn = fopen("/compat/linux/proc/stat", "r");
+#else	// Linux
+		FILE* fIn = fopen("/proc/stat", "r");
+#endif
+		if (fIn != nullptr)
+		{
+			int ret = fscanf(fIn, "%s\t%d\t%d\t%d\n", cname, &actload1, &actload2, &actload3);
+			fclose(fIn);
+			if (ret == 4)
+			{
+				int64_t t = (actload1 + actload2 + actload3) - m_lastloadcpu;
+				double cpuper = ((t / (difftime(acttime, m_lastquerytime) * HZ)) * 100) / double(m_totcpu);
+				if (cpuper > 0)
+				{
+					sprintf(szTmp, "%.2f", cpuper);
+					UpdateSystemSensor("Load", 1, "CPU_Usage", szTmp);
+				}
+				m_lastloadcpu = actload1 + actload2 + actload3;
+			}
+		}
+#endif //else Openbsd
+		m_lastquerytime = acttime;
+	}
+}
+
+void CHardwareMonitorUnix::FetchUnixDisk()
+{
+	//Disk Usage
+	std::map<std::string, _tDUsageStruct> _disks;
+	std::map<std::string, std::string> _dmounts_;
+	int returncode = 0;
+	std::vector<std::string> _rlines = ExecuteCommandAndReturn(m_dfcommand, returncode);
+	if (!_rlines.empty())
+	{
+		for (const auto& ittDF : _rlines)
+		{
+			char dname[200];
+			char suse[30];
+			char smountpoint[300];
+			int64_t numblock, usedblocks, availblocks;
+			int ret = sscanf(ittDF.c_str(), "%s\t%" PRId64 "\t%" PRId64 "\t%" PRId64 "\t%s\t%s\n", dname, &numblock, &usedblocks, &availblocks, suse, smountpoint);
+			if (ret == 6)
+			{
+				auto it = _dmounts_.find(dname);
+				if (it != _dmounts_.end())
+				{
+					if (it->second.length() < strlen(smountpoint))
+					{
+						continue;
+					}
+				}
+#if defined(__linux__) || defined(__FreeBSD__) || defined (__OpenBSD__)
+				if (strstr(dname, "/dev") != nullptr)
+#elif defined(__CYGWIN32__)
+				if (strstr(smountpoint, "/cygdrive/") != nullptr)
+#endif
+				{
+					_tDUsageStruct dusage;
+					dusage.TotalBlocks = numblock;
+					dusage.UsedBlocks = usedblocks;
+					dusage.AvailBlocks = availblocks;
+					dusage.MountPoint = smountpoint;
+					_disks[dname] = dusage;
+					_dmounts_[dname] = smountpoint;
+				}
+			}
+		}
+		int dindex = 0;
+		for (const auto& ittDisks : _disks)
+		{
+			_tDUsageStruct dusage = ittDisks.second;
+			if (dusage.TotalBlocks > 0)
+			{
+				double UsagedPercentage = (100 / double(dusage.TotalBlocks)) * double(dusage.UsedBlocks);
+				//std::cout << "Disk: " << ittDisks.first << ", Mount: " << dusage.MountPoint << ", Used: " << UsagedPercentage << std::endl;
+				char szTmp[300];
+				sprintf(szTmp, "%.2f", UsagedPercentage);
+				std::string hddname = "HDD " + dusage.MountPoint;
+				dindex=0;
+				std::vector<std::vector<std::string> > listOfHdd;
+				listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name, Options FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
+				if (!listOfHdd.empty())
+				{
+					for (const auto& sd : listOfHdd)
+					{
+						std::string szIdx = sd[0];
+						std::string szDeviceId = sd[1];
+						std::string Name = sd[2];
+						int deviceId;
+						sscanf(szDeviceId.c_str(), "%x", &deviceId);
+						std::string sOptions = sd[3];
+						std::map<std::string, std::string> optionsMap = m_sql.BuildDeviceOptions(sOptions);
+						if (!optionsMap.empty() and !strcmp(optionsMap["hdd"].c_str(),hddname.c_str()))
+						{
+							dindex=deviceId;
+							break;
+						}
+						else
+						{
+							if (!strcmp(Name.c_str(),hddname.c_str()))
+							{
+								dindex=deviceId;
+								uint64_t idx = std::stoull(szIdx);
+								optionsMap["hdd"] = hddname;
+								m_sql.SetDeviceOptions(idx, optionsMap);
+								break;
+							}
+						}
+					}
+				}
+				if (dindex==0)
+				{
+					// new HDD
+					std::vector<std::vector<std::string> > listOfHdd;
+					listOfHdd = m_sql.safe_query("SELECT ID, DeviceID, Name FROM DeviceStatus WHERE (HardwareID=%d AND DeviceID>'0000044D' AND DeviceID<'000004B0')", m_HwdID);
+					int firstFreedeviceId=1102;
+					if (!listOfHdd.empty())
+					{
+						for (int i=0; i<listOfHdd.size() ; i++)
+						{
+							for (const auto& sd : listOfHdd)
+							{
+								std::string szDeviceId = sd[1];
+								int deviceId;
+								sscanf(szDeviceId.c_str(), "%x", &deviceId);
+								if (firstFreedeviceId==deviceId)
+								{
+									firstFreedeviceId++;
+									break;
+								}
+							}
+						}
+					}
+					dindex=firstFreedeviceId;
+				}
+				dindex-=1102;
+
+				UpdateSystemSensor("Load", 2 + dindex, hddname, szTmp);
+			}
+		}
+	}
+}
+
+bool CHardwareMonitorUnix::IsWSL()
+{
+	// Detect WSL according to https://github.com/Microsoft/WSL/issues/423#issuecomment-221627364
+	bool is_wsl = false;
+
+#if defined(__linux__)
+	char buf[1024];
+
+	int status_fd = open("/proc/sys/kernel/osrelease", O_RDONLY);
+	if (status_fd == -1)
+		return is_wsl;
+
+	ssize_t num_read = read(status_fd, buf, sizeof(buf) - 1);
+	close(status_fd);
+
+	if (num_read > 0)
+	{
+		buf[num_read] = 0;
+		is_wsl |= (strstr(buf, "Microsoft") != nullptr);
+		is_wsl |= (strstr(buf, "WSL") != nullptr);
+	}
+
+	status_fd = open("/proc/version", O_RDONLY);
+	if (status_fd == -1)
+		return is_wsl;
+
+	num_read = read(status_fd, buf, sizeof(buf) - 1);
+	close(status_fd);
+
+	if (num_read > 0)
+	{
+		buf[num_read] = 0;
+		is_wsl |= (strstr(buf, "Microsoft") != nullptr);
+		is_wsl |= (strstr(buf, "WSL") != nullptr);
+	}
+#endif
+
+	return is_wsl;
+}
+
+void CHardwareMonitorUnix::CheckForOnboardSensors()
+{
+	Debug(DEBUG_NORM, "Checking for onboard sensors");
+
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+	// Busybox df doesn't support -x parameter
+	int returncode = 0;
+	std::vector<std::string> ret = ExecuteCommandAndReturn("df -x nfs -x tmpfs -x devtmpfs 2> /dev/null", returncode);
+	returncode == 0 ?
+		m_dfcommand = "df -x nfs -x tmpfs -x devtmpfs" :
+		m_dfcommand = "df";
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__)
+
+	if (!m_bHasInternalTemperature)
+	{
+		if (file_exist("/sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input"))
+		{
+			Log(LOG_STATUS, "System: Cubieboard/Cubietruck");
+			m_szInternalTemperatureCommand = R"(cat /sys/devices/platform/sunxi-i2c.0/i2c-0/0-0034/temp1_input | awk '{ printf ("temp=%0.2f\n",$1/1000); }')";
+			m_bHasInternalTemperature = true;
+		}
+		else if (file_exist("/sys/devices/virtual/thermal/thermal_zone0/temp"))
+		{
+			Log(LOG_STATUS, "System: ODroid/Raspberry");
+			m_szInternalTemperatureCommand = R"(cat /sys/devices/virtual/thermal/thermal_zone0/temp | awk '{ if ($1 < 100) printf("temp=%d\n",$1); else printf ("temp=%0.2f\n",$1/1000); }')";
+			m_bHasInternalTemperature = true;
+		}
+	}
+	if (file_exist("/sys/class/power_supply/ac/voltage_now"))
+	{
+		Debug(DEBUG_NORM, "Internal voltage sensor detected");
+		m_szInternalVoltageCommand = R"(cat /sys/class/power_supply/ac/voltage_now | awk '{ printf ("volt=%0.2f\n",$1/1000000); }')";
+		m_bHasInternalVoltage = true;
+	}
+	if (file_exist("/sys/class/power_supply/ac/current_now"))
+	{
+		Debug(DEBUG_NORM, "Internal current sensor detected");
+		m_szInternalCurrentCommand = R"(cat /sys/class/power_supply/ac/current_now | awk '{ printf ("curr=%0.2f\n",$1/1000000); }')";
+		m_bHasInternalCurrent = true;
+	}
+	//New Armbian Kernal 4.14+
+	if (file_exist("/sys/class/power_supply/axp20x-ac/voltage_now"))
+	{
+		Debug(DEBUG_NORM, "Internal voltage sensor detected");
+		m_szInternalVoltageCommand = R"(cat /sys/class/power_supply/axp20x-ac/voltage_now | awk '{ printf ("volt=%0.2f\n",$1/1000000); }')";
+		m_bHasInternalVoltage = true;
+	}
+	if (file_exist("/sys/class/power_supply/axp20x-ac/current_now"))
+	{
+		Debug(DEBUG_NORM, "Internal current sensor detected");
+		m_szInternalCurrentCommand = R"(cat /sys/class/power_supply/axp20x-ac/current_now | awk '{ printf ("curr=%0.2f\n",$1/1000000); }')";
+		m_bHasInternalCurrent = true;
+	}
+#endif
+
+#if defined (__OpenBSD__)
+	Debug(DEBUG_NORM, "Internal temperature- and voltage sensors detected");
+	m_szInternalTemperatureCommand = "sysctl hw.sensors.acpitz0.temp0|sed -e 's/.*temp0/temp/'|cut -d ' ' -f 1";
+	m_bHasInternalTemperature = true;
+	m_szInternalVoltageCommand = "sysctl hw.sensors.acpibat0.volt1|sed -e 's/.*volt1/volt/'|cut -d ' ' -f 1";
+	m_bHasInternalVoltage = true;
+#endif
+
+}
+
+#endif // defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)

--- a/hardware/HardwareMonitorUnix.h
+++ b/hardware/HardwareMonitorUnix.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "HardwareMonitor.h"
+
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+
+class CHardwareMonitorUnix : public CHardwareMonitorBase
+{
+public:
+	explicit CHardwareMonitorUnix(int ID);
+	~CHardwareMonitorUnix() override = default;
+
+protected:
+	void FetchData() override;
+	void FetchCPU() override;
+	void FetchMemory() override;
+	void FetchDisk() override;
+	void CheckForOnboardSensors() override;
+	bool IsWSL() override;
+
+private:
+	void FetchUnixCPU();
+	void FetchUnixMemory();
+	void FetchUnixDisk();
+	double time_so_far();
+
+	void GetInternalTemperature();
+	void GetInternalVoltage();
+	void GetInternalCurrent();
+
+#if defined(__linux__)
+	float GetProcessMemUsage();
+#endif
+#if defined(__linux__) || defined(__FreeBSD__)
+	float GetMemUsageLinux();
+#endif
+#if defined(__FreeBSD__) || defined(__OpenBSD__)
+	float GetMemUsageOpenBSD();
+#endif
+
+	std::string m_dfcommand;
+
+	bool m_bHasInternalTemperature = false;
+	std::string m_szInternalTemperatureCommand;
+
+	bool m_bHasInternalVoltage = false;
+	std::string m_szInternalVoltageCommand;
+
+	bool m_bHasInternalCurrent = false;
+	std::string m_szInternalCurrentCommand;
+};
+
+#endif // defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -1602,7 +1602,7 @@ bool CSQLHelper::OpenDatabase()
 			result = safe_query("SELECT ID FROM Hardware WHERE (Type==%d)", HTYPE_System);
 			if (result.empty())
 			{
-				safe_query("INSERT INTO Hardware (Name, Enabled, Type, Address, Port, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) VALUES ('Motherboard',1, %d,'',1,'','',0,0,0,0,0,0)", HTYPE_System);
+				safe_query("INSERT INTO Hardware (Name, Enabled, Type, Address, Port, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) VALUES ('Motherboard',1, %d,'127.0.0.1',8085,'','',0,0,0,0,0,0)", HTYPE_System);
 			}
 		}
 		if (dbversion < 85)

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -43,6 +43,10 @@
 #include "../hardware/DarkSky.h"
 #include "../hardware/VisualCrossing.h"
 #include "../hardware/HardwareMonitor.h"
+#include "../hardware/HardwareMonitorLHM.h"
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#include "../hardware/HardwareMonitorUnix.h"
+#endif
 #include "../hardware/Dummy.h"
 #include "../hardware/Tellstick.h"
 #include "../hardware/PiFace.h"
@@ -973,7 +977,18 @@ bool MainWorker::AddHardwareFromParams(
 		pHardware = new CPiFace(ID);
 		break;
 	case HTYPE_System:
-		pHardware = new CHardwareMonitor(ID);
+		if (Mode1 == 1)
+			pHardware = new CHardwareMonitorLHM(ID, Address, Port, Username, Password, Mode2 == 1);
+#if defined(__linux__) || defined(__CYGWIN32__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+		else
+			pHardware = new CHardwareMonitorUnix(ID);
+#else
+		else
+		{
+			_log.Log(LOG_ERROR, "Local system sensors are only supported on Linux/BSD. Use Libre Hardware Monitor mode.");
+			return false;
+		}
+#endif
 		break;
 	case HTYPE_RaspberryGPIO:
 		//Raspberry Pi GPIO port access

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -648,6 +648,8 @@
     <ClInclude Include="..\hardware\Kodi.h" />
     <ClInclude Include="..\hardware\Limitless.h" />
     <ClInclude Include="..\hardware\HardwareMonitor.h" />
+    <ClInclude Include="..\hardware\HardwareMonitorLHM.h" />
+    <ClInclude Include="..\hardware\HardwareMonitorUnix.h" />
     <ClInclude Include="..\hardware\LogitechMediaServer.h" />
     <ClInclude Include="..\hardware\Meteostick.h" />
     <ClInclude Include="..\hardware\MochadTCP.h" />
@@ -951,6 +953,8 @@
     <ClCompile Include="..\hardware\Kodi.cpp" />
     <ClCompile Include="..\hardware\Limitless.cpp" />
     <ClCompile Include="..\hardware\HardwareMonitor.cpp" />
+    <ClCompile Include="..\hardware\HardwareMonitorLHM.cpp" />
+    <ClCompile Include="..\hardware\HardwareMonitorUnix.cpp" />
     <ClCompile Include="..\hardware\LogitechMediaServer.cpp" />
     <ClCompile Include="..\hardware\Meteostick.cpp" />
     <ClCompile Include="..\hardware\MochadTCP.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -1645,6 +1645,12 @@
     <ClInclude Include="..\hardware\HardwareMonitor.h">
       <Filter>Devices\HardwareMonitor</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\HardwareMonitorLHM.h">
+      <Filter>Devices\HardwareMonitor</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hardware\HardwareMonitorUnix.h">
+      <Filter>Devices\HardwareMonitor</Filter>
+    </ClInclude>
     <ClInclude Include="..\hardware\WOL.h">
       <Filter>Devices\WOL</Filter>
     </ClInclude>
@@ -2434,6 +2440,12 @@
       <Filter>Devices\ICY Thermostat</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\HardwareMonitor.cpp">
+      <Filter>Devices\HardwareMonitor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\HardwareMonitorLHM.cpp">
+      <Filter>Devices\HardwareMonitor</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\HardwareMonitorUnix.cpp">
       <Filter>Devices\HardwareMonitor</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\WOL.cpp">

--- a/www/app/hardware/Hardware.html
+++ b/www/app/hardware/Hardware.html
@@ -793,6 +793,32 @@
                 </tr>
             </table>
         </div>
+        <div id="divmotherboardmode">
+            <table class="display" id="hardwareparamsmotherboardmode" border="0" cellpadding="0" cellspacing="20">
+                <tr>
+                    <td align="right" style="width:110px"><label id="lblmotherboardmode" for="name"><span data-i18n="Sensor Mode">Sensor Mode</span>: </label></td>
+                    <td>
+                        <select id="combomotherboardmode" style="width:260px" class="combobox ui-corner-all">
+                            <option value="0">Local System Sensors (Linux/BSD)</option>
+                            <option value="1">Libre Hardware Monitor (HTTP)</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+        </div>
+        <div id="divlhmextendedsensors">
+            <table class="display" id="hardwareparamslhmextendedsensors" border="0" cellpadding="0" cellspacing="20">
+                <tr>
+                    <td align="right" style="width:110px"><label id="lbllhmextendedsensors"><span data-i18n="Extended Sensors">Extended Sensors</span>: </label></td>
+                    <td>
+                        <select id="combolhmextendedsensors" style="width:260px" class="combobox ui-corner-all">
+                            <option value="0">Disabled</option>
+                            <option value="1">Enabled</option>
+                        </select>
+                    </td>
+                </tr>
+            </table>
+        </div>
         <div id="divremote">
             <table class="display" id="hardwareparamsremote" border="0" cellpadding="0" cellspacing="20">
                 <tr>

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -329,7 +329,6 @@ define(['app'], function (app) {
 				(text.indexOf("System Alive") >= 0) ||
 				(text.indexOf("PiFace") >= 0) ||
 				(text.indexOf("I2C ") >= 0) ||
-				(text.indexOf("Motherboard") >= 0) ||
 				(text.indexOf("Kodi Media") >= 0) ||
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
@@ -519,6 +518,49 @@ define(['app'], function (app) {
 						} else {
 							RefreshHardwareTable();
 						}
+					},
+					error: function () {
+						ShowNotify($.t('Problem updating hardware!'), 2500, true);
+					}
+				});
+			}
+			else if (text.indexOf("Motherboard") >= 0) {
+				var mbMode = $("#hardwarecontent #divmotherboardmode #combomotherboardmode").val();
+				var mbExtended = $("#hardwarecontent #divlhmextendedsensors #combolhmextendedsensors").val();
+				var address = "";
+				var port = "";
+				var username = "";
+				var password = "";
+				if (mbMode == "1") {
+					address = $("#hardwarecontent #divremote #tcpaddress").val();
+					if (address == "") {
+						ShowNotify($.t('Please enter an Address!'), 2500, true);
+						return;
+					}
+					port = $("#hardwarecontent #divremote #tcpport").val();
+					if (port == "") {
+						ShowNotify($.t('Please enter a Port!'), 2500, true);
+						return;
+					}
+					username = $("#hardwarecontent #divlogin #username").val();
+					password = $("#hardwarecontent #divlogin #password").val();
+				}
+				$.ajax({
+					url: "json.htm?type=command&param=updatehardware&htype=" + hardwaretype +
+					"&loglevel=" + logLevel +
+					"&address=" + encodeURIComponent(address) +
+					"&port=" + encodeURIComponent(port) +
+					"&username=" + encodeURIComponent(username) +
+					"&password=" + encodeURIComponent(password) +
+					"&name=" + encodeURIComponent(name) +
+					"&enabled=" + bEnabled +
+					"&idx=" + idx +
+					"&datatimeout=" + datatimeout +
+					"&Mode1=" + mbMode + "&Mode2=" + mbExtended + "&Mode3=0&Mode4=0&Mode5=0&Mode6=0",
+					async: false,
+					dataType: 'json',
+					success: function (data) {
+						RefreshHardwareTable();
 					},
 					error: function () {
 						ShowNotify($.t('Problem updating hardware!'), 2500, true);
@@ -1913,6 +1955,48 @@ define(['app'], function (app) {
 					}
 				});
 			}
+			else if (text.indexOf("Motherboard") >= 0) {
+				var mbMode = $("#hardwarecontent #divmotherboardmode #combomotherboardmode").val();
+				var mbExtended = $("#hardwarecontent #divlhmextendedsensors #combolhmextendedsensors").val();
+				var address = "";
+				var port = "";
+				var username = "";
+				var password = "";
+				if (mbMode == "1") {
+					address = $("#hardwarecontent #divremote #tcpaddress").val();
+					if (address == "") {
+						ShowNotify($.t('Please enter an Address!'), 2500, true);
+						return;
+					}
+					port = $("#hardwarecontent #divremote #tcpport").val();
+					if (port == "") {
+						ShowNotify($.t('Please enter a Port!'), 2500, true);
+						return;
+					}
+					username = $("#hardwarecontent #divlogin #username").val();
+					password = $("#hardwarecontent #divlogin #password").val();
+				}
+				$.ajax({
+					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
+					"&loglevel=" + logLevel +
+					"&address=" + encodeURIComponent(address) +
+					"&port=" + encodeURIComponent(port) +
+					"&username=" + encodeURIComponent(username) +
+					"&password=" + encodeURIComponent(password) +
+					"&name=" + encodeURIComponent(name) +
+					"&enabled=" + bEnabled +
+					"&datatimeout=" + datatimeout +
+					"&Mode1=" + mbMode + "&Mode2=" + mbExtended,
+					async: false,
+					dataType: 'json',
+					success: function (data) {
+						RefreshHardwareTable();
+					},
+					error: function () {
+						ShowNotify($.t('Problem adding hardware!'), 2500, true);
+					}
+				});
+			}
 			else if (
 				(text.indexOf("Panasonic") >= 0) ||
 				(text.indexOf("BleBox") >= 0) ||
@@ -1924,7 +2008,6 @@ define(['app'], function (app) {
 				(text.indexOf("PiFace") >= 0) ||
 				(text.indexOf("Evohome") >= 0 && text.indexOf("script") >= 0) ||
 				(text.indexOf("Tellstick") >= 0) ||
-				(text.indexOf("Motherboard") >= 0) ||
 				(text.indexOf("YeeLight") >= 0) ||
 				(text.indexOf("Arilux AL-LC0x") >= 0)
 			) {
@@ -3991,7 +4074,11 @@ define(['app'], function (app) {
 							else if ((item.Type == 14) || (item.Type == 25) || (item.Type == 28) || (item.Type == 30) || (item.Type == 34)) {
 								SerialName = "WWW";
 							}
-							else if ((item.Type == 15) || (item.Type == 23) || (item.Type == 26) || (item.Type == 27) || (item.Type == 51) || (item.Type == 54)) {
+							else if (item.Type == 23) {
+								// Motherboard/System: show port for LHM mode, WWW for local
+								SerialName = (item.Mode1 == 1) ? item.Port : "WWW";
+							}
+							else if ((item.Type == 15) || (item.Type == 26) || (item.Type == 27) || (item.Type == 51) || (item.Type == 54)) {
 								SerialName = "";
 							}
 							else if ((item.Type == 16) || (item.Type == 32)) {
@@ -4480,6 +4567,17 @@ define(['app'], function (app) {
 									}
 								}
 							}
+						}
+						else if (data["Type"].indexOf("Motherboard") >= 0) {
+							$("#hardwarecontent #divmotherboardmode #combomotherboardmode").val(data["Mode1"]);
+							$("#hardwarecontent #divlhmextendedsensors #combolhmextendedsensors").val(data["Mode2"]);
+							if (data["Mode1"] == 1) {
+								$("#hardwarecontent #hardwareparamsremote #tcpaddress").val(data["Address"]);
+								$("#hardwarecontent #hardwareparamsremote #tcpport").val(data["Port"]);
+								$("#hardwarecontent #divlogin #username").val(data["Username"]);
+								$("#hardwarecontent #divlogin #password").val(data["Password"]);
+							}
+							$("#hardwarecontent #divmotherboardmode #combomotherboardmode").trigger("change");
 						}
 						else if ((data["Type"].indexOf("Underground") >= 0) || (data["Type"].indexOf("DarkSky") >= 0) || (data["Type"].indexOf("Visual Crossing") >= 0) || (data["Type"].indexOf("AccuWeather") >= 0)) {
 							$("#hardwarecontent #hardwareparamsunderground #apikey").val(data["Username"]);
@@ -5069,6 +5167,8 @@ define(['app'], function (app) {
 			$("#hardwarecontent #divbuienradar").hide();
 			$("#hardwarecontent #divmeteorologisk").hide();
 			$("#hardwarecontent #divserial").hide();
+			$("#hardwarecontent #divmotherboardmode").hide();
+			$("#hardwarecontent #divlhmextendedsensors").hide();
 			$("#hardwarecontent #divremote").hide();
 			$("#hardwarecontent #divlogin").hide();
 			$("#hardwarecontent #divhttppoller").hide();
@@ -5257,6 +5357,26 @@ define(['app'], function (app) {
 							$("#hardwarecontent #username").hide();
 							$("#hardwarecontent #lblusername").hide();
 						}
+			}
+			else if (text.indexOf("Motherboard") >= 0) {
+				$("#hardwarecontent #divmotherboardmode").show();
+				$("#hardwarecontent #divmotherboardmode #combomotherboardmode").off("change").on("change", function () {
+					var mode = $(this).val();
+					if (mode == "1") {
+						$("#hardwarecontent #divremote").show();
+						$("#hardwarecontent #divlogin").show();
+						$("#hardwarecontent #divlhmextendedsensors").show();
+						if ($("#hardwarecontent #hardwareparamsremote #tcpaddress").val() == "")
+							$("#hardwarecontent #hardwareparamsremote #tcpaddress").val("127.0.0.1");
+						if ($("#hardwarecontent #hardwareparamsremote #tcpport").val() == "")
+							$("#hardwarecontent #hardwareparamsremote #tcpport").val(8085);
+					} else {
+						$("#hardwarecontent #divremote").hide();
+						$("#hardwarecontent #divlogin").hide();
+						$("#hardwarecontent #divlhmextendedsensors").hide();
+					}
+				});
+				$("#hardwarecontent #divmotherboardmode #combomotherboardmode").trigger("change");
 			}
 			else if (text.indexOf("Domoticz") >= 0) {
 				$("#hardwarecontent #divremote").show();


### PR DESCRIPTION
## Summary

- Rename `HardwareMonitorWindows` to `HardwareMonitorLHM` and remove WIN32 guards, allowing Linux users to poll a remote Libre Hardware Monitor instance over HTTP
- Add Mode1 selector: 0 = local system sensors (Linux/BSD), 1 = LHM HTTP (any platform)
- Add Mode2 extended sensors toggle (disabled by default) to reduce sensor clutter
- Add Basic Authentication support (username/password) for LHM connections
- Add SensorId-based hardware classification (CPU, GPU, RAM, storage, network) for per-category filtering
- Use dedicated offsets per sensor sub-type so toggling extended mode never shifts existing device IDs
- Fix port field showing "WWW" instead of actual port number when editing LHM mode hardware

### Normal mode sensors
- CPU/GPU/Motherboard temperatures, CPU/system fans
- CPU usage, memory usage/data, disk space

### Extended mode adds
- Storage temperatures, GPU fans, voltages, load, power, clock, data, throughput, level, factor

## Test plan
- [ ] Windows build: verify MSVC builds clean with renamed files
- [ ] Linux build: verify CMake builds clean
- [ ] Windows + LHM mode: set Mode1=1, verify sensors appear
- [ ] Linux + local mode: set Mode1=0, verify CPU/memory/disk sensors work
- [ ] Linux + LHM mode: set Mode1=1 pointing to remote LHM, verify sensors appear
- [ ] Auth test: set username/password, verify Basic Auth header is sent
- [ ] UI test: toggle mode dropdown, verify fields show/hide correctly
- [ ] Extended sensors: toggle combobox, verify additional sensors appear/disappear
- [ ] Edit hardware: verify port number displays correctly (not "WWW")
- [ ] Upgrade test: existing installations with Mode1=0 continue working unchanged