### PR TITLE
Fix Lua 5.4 compatibility for dzVents runtime

### DIFF
--- a/dzVents/runtime/EventHelpers.lua
+++ b/dzVents/runtime/EventHelpers.lua
@@ -350,39 +350,27 @@ local function EventHelpers(domoticz, mainMethod)
 
 	function self.scandir(directory, type)
 		local pos, len
-		local i, t, popen = 0, {}, io.popen
-		local cmd
 		local namesLookup = {}
 
 		if (directory == nil) then
 			return {}
 		end
 
-		if (sep == '/') then
-			cmd = 'ls -a "' .. directory .. '"'
-		else
-			-- assume windows for now
-			cmd = 'dir "' .. directory .. '" /B'
-		end
+		local t = {}
+		local files = dz_scandir(directory)
 
-		t = {}
-		local pfile = popen(cmd)
-		for filename in pfile:lines() do
+		for _, filename in ipairs(files) do
 			pos, len = string.find(filename, '.lua', 1, true)
 			if (pos and pos > 0 and filename:sub(1, 1) ~= '.' and len == string.len(filename)) then
-
 				local name = string.sub(filename, 1, pos - 1)
 				table.insert(t, {
 					['type'] = type,
 					['name'] = name
 				})
-
-				namesLookup[name] = true -- for quick lookup for filename
-
-				--utils.log('Found module in ' .. directory .. ' folder: ' .. t[#t].name, utils.LOG_DEBUG)
+				namesLookup[name] = true
 			end
 		end
-		pfile:close()
+
 		return t, namesLookup
 	end
 
@@ -926,14 +914,14 @@ local function EventHelpers(domoticz, mainMethod)
 				utils.log('Script name: ' .. scripts[1].name  .. '.lua, has a malformed on = section. The trigger = ' .. utils.toStr(scriptTrigger) , utils.LOG_ERROR)
 				allEventScripts[scriptTrigger] = ''
 			elseif res then -- a wild-card was used
-				scriptTrigger = ('^' .. scriptTrigger:gsub("[%^$]","."):gsub("*", ".*") .. '$')
+				local triggerPattern = ('^' .. scriptTrigger:gsub("[%^$]","."):gsub("*", ".*") .. '$')
 
 				local function sMatch(text, match) -- specialized sanitized match function to allow combination of Lua magic chars in wildcards
 					local sanitizedMatch = match:gsub("([%%%(%)%[%]%+%-%?])", "%%%1") -- escaping all 'magic' chars except *, ., ^ and $
 					return text:match(sanitizedMatch)
 				end
 
-				if sMatch(target, scriptTrigger) then
+				if sMatch(target, triggerPattern) then
 					if modules == nil then modules = {} end
 
 					for i, mod in pairs(scripts) do

--- a/dzVents/runtime/Utils.lua
+++ b/dzVents/runtime/Utils.lua
@@ -27,10 +27,11 @@ end
 function self.cloneTable(original)
 	local copy = {}
 	for k, v in pairs(original) do
-		if type(v) == 'table' then
-			v = self.cloneTable(v)
+		local val = v
+		if type(val) == 'table' then
+			val = self.cloneTable(val)
 		end
-		copy[k] = v
+		copy[k] = val
 	end
 	return copy
 end
@@ -55,11 +56,11 @@ self.toStr = function (value)
 	elseif _.isTable(value) then
 		str = '{'
 		for k, v in pairs(value) do
-			v = ( _.isString(v) and dblQuote(v) ) or self.toStr(v)
+			local val = ( _.isString(v) and dblQuote(v) ) or self.toStr(v)
 			if _.isNumber(k) then
-				str = str .. v .. ', '
+				str = str .. val .. ', '
 			else
-				str = str .. '[' .. dblQuote(k) .. ']=' .. v .. ', '
+				str = str .. '[' .. dblQuote(k) .. ']=' .. val .. ', '
 			end
 		end
 		str = str:sub(0, ( #str - 2 ) ) .. '}'
@@ -140,8 +141,9 @@ function self.stringSplit(text, sep, convertNumber, convertNil)
 	if convertNil then include = '*' end
 	local t = {}
 	for str in string.gmatch(text, "([^" ..sep.. "]" .. include .. ")" ) do
-		if convertNil and str == '' then str = convertNil end
-		table.insert(t, ( convertNumber and tonumber(str) ) or str)
+		local value = str
+		if convertNil and value == '' then value = convertNil end
+		table.insert(t, ( convertNumber and tonumber(value) ) or value)
 	end
 	return t
 end

--- a/dzVents/runtime/lodash.lua
+++ b/dzVents/runtime/lodash.lua
@@ -1905,11 +1905,11 @@ _.str = function (value, ...)
     elseif _.isTable(value) then
         str = '{'
         for k, v in pairs(value) do
-            v = _.isString(v) and dblQuote(v) or _.str(v, ...)
+            local val = _.isString(v) and dblQuote(v) or _.str(v, ...)
             if _.isNumber(k) then
-                str = str .. v .. ', '
+                str = str .. val .. ', '
             else
-                str = str .. '[' .. dblQuote(k) .. ']=' .. v .. ', '
+                str = str .. '[' .. dblQuote(k) .. ']=' .. val .. ', '
             end
         end
         str = str:sub(0, #str - 2) .. '}'

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -13,6 +13,11 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include "../webserver/Base64.h"
+#ifdef WIN32
+#include "../main/dirent_windows.h"
+#else
+#include <dirent.h>
+#endif
 
 extern "C" {
 #include <lua.h>
@@ -55,6 +60,9 @@ void CdzVents::EvaluateDzVents(lua_State* lua_state, const std::vector<CEventSys
 	luaL_openlibs(lua_state);
 	lua_pushcfunction(lua_state, l_domoticz_print);
 	lua_setglobal(lua_state, "print");
+
+	lua_pushcfunction(lua_state, l_domoticz_scandir);
+	lua_setglobal(lua_state, "dz_scandir");
 
 	bool reasonTime = false;
 	bool reasonURL = false;
@@ -763,6 +771,30 @@ void CdzVents::IterateTable(lua_State* lua_state, const int tIndex, std::vector<
 
 		lua_pop(lua_state, 1);
 	}
+}
+
+int CdzVents::l_domoticz_scandir(lua_State* lua_state)
+{
+	// Takes a directory path as argument, returns a table of filenames
+	const char* dirpath = luaL_checkstring(lua_state, 1);
+
+	lua_newtable(lua_state);
+	int idx = 1;
+
+	DIR* d = opendir(dirpath);
+	if (d != nullptr)
+	{
+		struct dirent* ent;
+		while ((ent = readdir(d)) != nullptr)
+		{
+			lua_pushinteger(lua_state, idx++);
+			lua_pushstring(lua_state, ent->d_name);
+			lua_settable(lua_state, -3);
+		}
+		closedir(d);
+	}
+
+	return 1; // returns the table
 }
 
 int CdzVents::l_domoticz_print(lua_State* lua_state)

--- a/main/dzVents.h
+++ b/main/dzVents.h
@@ -57,6 +57,7 @@ private:
 	void ProcessNotification(lua_State* lua_state, const std::vector<CEventSystem::_tEventQueue>& items);
 	void ProcessNotificationItem(CLuaTable& luaTable, int& index, const CEventSystem::_tEventQueue& item);
 	static int l_domoticz_print(lua_State* lua_state);
+	static int l_domoticz_scandir(lua_State* lua_state);
 	static CdzVents m_dzvents;
 	std::string m_version;
 };


### PR DESCRIPTION
## Summary
- Fix "attempt to assign to const variable" errors caused by Lua 5.4 making generic for-loop variables read-only
- Replace `io.popen`-based directory listing in `scandir` with a native C++ `dz_scandir` function using `opendir`/`readdir`

### Files changed
- **dzVents/runtime/EventHelpers.lua** - Fix `scriptTrigger` loop var reassignment, replace `io.popen` scandir with `dz_scandir`
- **dzVents/runtime/Utils.lua** - Fix `v` and `str` loop var reassignments in `cloneTable`, `toStr`, `stringSplit`
- **dzVents/runtime/lodash.lua** - Fix `v` loop var reassignment in `_.str`
- **main/dzVents.cpp** - Add native `dz_scandir` Lua function using `opendir`/`readdir`
- **main/dzVents.h** - Add `l_domoticz_scandir` declaration

### Notes
- All fixes are backward compatible with Lua 5.3
- The native `dz_scandir` avoids shell commands and sandbox restrictions entirely

## Test plan
- [ ] Build on Windows (Visual Studio) and Linux (CMake)
- [ ] Verify dzVents scripts load without "attempt to assign to const variable" errors
- [ ] Verify dzVents scripts are discovered from both `scripts/` and `generated_scripts/` folders
- [ ] Test `Utils.stringSplit`, `Utils.cloneTable`, `Utils.toStr` with Lua 5.4
- [ ] Test wildcard device name matching in event triggers