### PR TITLE
feat: add event folders with drag-and-drop and ACE editor improvements

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -4141,6 +4141,7 @@ namespace http {
 		{
 			std::string ID;
 			std::string eventstatus;
+			std::string folderid;
 		};
 
 		void CWebServer::Cmd_Events(WebEmSession & session, const request& req, Json::Value &root)
@@ -4166,7 +4167,7 @@ namespace http {
 				root["interpreters"] = "Blockly:Lua:dzVents";
 #endif
 
-				result = m_sql.safe_query("SELECT ID, Name, XMLStatement, Status FROM EventMaster ORDER BY ID ASC");
+				result = m_sql.safe_query("SELECT ID, Name, XMLStatement, Status, FolderID FROM EventMaster ORDER BY ID ASC");
 				if (!result.empty())
 				{
 					std::map<std::string, _tSortedEventsInt> _levents;
@@ -4175,9 +4176,11 @@ namespace http {
 						std::string ID = sd[0];
 						std::string Name = sd[1];
 						std::string eventStatus = sd[3];
+						std::string folderID = sd[4];
 						_tSortedEventsInt eitem;
 						eitem.ID = ID;
 						eitem.eventstatus = eventStatus;
+						eitem.folderid = folderID;
 						if (_levents.find(Name) != _levents.end())
 						{
 							//Duplicate event name, add the ID
@@ -4194,6 +4197,21 @@ namespace http {
 						root["result"][ii]["name"] = event.first;
 						root["result"][ii]["id"] = event.second.ID;
 						root["result"][ii]["eventstatus"] = event.second.eventstatus;
+						root["result"][ii]["folderid"] = event.second.folderid;
+						ii++;
+					}
+				}
+
+				// Also return folders
+				result = m_sql.safe_query("SELECT ID, Name, [Order] FROM EventFolder ORDER BY [Order] ASC, Name ASC");
+				if (!result.empty())
+				{
+					int ii = 0;
+					for (const auto &sd : result)
+					{
+						root["folders"][ii]["id"] = sd[0];
+						root["folders"][ii]["name"] = sd[1];
+						root["folders"][ii]["order"] = atoi(sd[2].c_str());
 						ii++;
 					}
 				}
@@ -4407,6 +4425,53 @@ namespace http {
 				root["title"] = "StoreRecentEvents";
 				std::string recent_list = request::findValue(&req, "recent_list");
 				m_sql.UpdatePreferencesVar("events_recent_list", recent_list);
+				root["status"] = "OK";
+			}
+			else if (cparam == "create_folder")
+			{
+				root["title"] = "CreateEventFolder";
+				std::string foldername = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
+				if (foldername.empty())
+					return;
+				m_sql.safe_query("INSERT INTO EventFolder (Name, [Order]) VALUES ('%q', 0)", foldername.c_str());
+				root["status"] = "OK";
+			}
+			else if (cparam == "rename_folder")
+			{
+				root["title"] = "RenameEventFolder";
+				std::string idx = request::findValue(&req, "folder");
+				if (idx.empty())
+					return;
+				std::string foldername = HTMLSanitizer::Sanitize(request::findValue(&req, "name"));
+				if (foldername.empty())
+					return;
+				m_sql.safe_query("UPDATE EventFolder SET Name='%q' WHERE (ID == '%q')", foldername.c_str(), idx.c_str());
+				root["status"] = "OK";
+			}
+			else if (cparam == "delete_folder")
+			{
+				root["title"] = "DeleteEventFolder";
+				std::string idx = request::findValue(&req, "folder");
+				if (idx.empty())
+					return;
+				// Delete all events in the folder
+				result = m_sql.safe_query("SELECT ID FROM EventMaster WHERE (FolderID == '%q')", idx.c_str());
+				for (const auto &sd : result)
+				{
+					m_sql.DeleteEvent(sd[0]);
+				}
+				m_sql.safe_query("DELETE FROM EventFolder WHERE (ID == '%q')", idx.c_str());
+				m_mainworker.m_eventsystem.LoadEvents();
+				root["status"] = "OK";
+			}
+			else if (cparam == "move_event")
+			{
+				root["title"] = "MoveEvent";
+				std::string idx = request::findValue(&req, "event");
+				if (idx.empty())
+					return;
+				std::string folderid = request::findValue(&req, "folder");
+				m_sql.safe_query("UPDATE EventMaster SET FolderID='%q' WHERE (ID == '%q')", folderid.c_str(), idx.c_str());
 				root["status"] = "OK";
 			}
 			else if (cparam == "currentstates")

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -41,7 +41,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 175
+#define DB_VERSION 174
 
 #define DEFAULT_ADMINUSER "admin"
 #define DEFAULT_ADMINPWD "domoticz"
@@ -3301,7 +3301,7 @@ bool CSQLHelper::OpenDatabase()
 			// Add Passkeys column to Users table for WebAuthn/passkey support
 			query("ALTER TABLE Users ADD COLUMN [Passkeys] TEXT DEFAULT NULL");
 		}
-		if (dbversion < 175)
+		if (dbversion < 174)
 		{
 			if (!DoesColumnExistsInTable("FolderID", "EventMaster"))
 			{

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -41,7 +41,7 @@
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 
-#define DB_VERSION 173
+#define DB_VERSION 175
 
 #define DEFAULT_ADMINUSER "admin"
 #define DEFAULT_ADMINPWD "domoticz"
@@ -450,7 +450,14 @@ constexpr auto sqlCreateEventMaster =
 "[Interpreter] VARCHAR(10) DEFAULT 'Blockly', "
 "[Type] VARCHAR(10) DEFAULT 'All', "
 "[XMLStatement] TEXT NOT NULL, "
-"[Status] INTEGER DEFAULT 0);";
+"[Status] INTEGER DEFAULT 0, "
+"[FolderID] INTEGER DEFAULT 0);";
+
+constexpr auto sqlCreateEventFolder =
+"CREATE TABLE IF NOT EXISTS [EventFolder] ("
+"[ID] INTEGER PRIMARY KEY, "
+"[Name] VARCHAR(200) NOT NULL, "
+"[Order] INTEGER DEFAULT 0);";
 
 constexpr auto sqlCreateEventRules =
 "CREATE TABLE IF NOT EXISTS [EventRules] ("
@@ -737,6 +744,7 @@ bool CSQLHelper::OpenDatabase()
 	query(sqlCreateSharedDevicesTrigger);
 	query(sqlCreateEventMaster);
 	query(sqlCreateEventRules);
+	query(sqlCreateEventFolder);
 	query(sqlCreateWOLNodes);
 	query(sqlCreatePercentage);
 	query(sqlCreatePercentage_Calendar);
@@ -3292,6 +3300,13 @@ bool CSQLHelper::OpenDatabase()
 		{
 			// Add Passkeys column to Users table for WebAuthn/passkey support
 			query("ALTER TABLE Users ADD COLUMN [Passkeys] TEXT DEFAULT NULL");
+		}
+		if (dbversion < 175)
+		{
+			if (!DoesColumnExistsInTable("FolderID", "EventMaster"))
+			{
+				query("ALTER TABLE EventMaster ADD COLUMN [FolderID] INTEGER DEFAULT 0");
+			}
 		}
 	}
 	else if (bNewInstall)

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -132,7 +132,8 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
     	return {
     		confirm: confirm,
             confirmDecorator: confirmDecorator,
-            alert: alert
+            alert: alert,
+            prompt: prompt
 		};
 
 		function confirm(message) {
@@ -159,6 +160,22 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 		function alert(message) {
 			return bootbox.alert($.t(message));
         }
+
+		function prompt(message, defaultValue) {
+			return $q(function(resolve, reject) {
+				bootbox.prompt({
+					title: message,
+					value: defaultValue || '',
+					callback: function (result) {
+						if (result === null) {
+							reject();
+						} else {
+							resolve(result);
+						}
+					}
+				});
+			});
+		}
 	});
 
     app.factory('dzNotification', function($q) {

--- a/www/app/devices/Devices.html
+++ b/www/app/devices/Devices.html
@@ -125,13 +125,14 @@
         <h3 class="modal-title">{{:: 'Rename Device' | translate }}</h3>
     </div>
     <div class="modal-body">
-        <form class="form-horizontal" name="modalForm">
+        <form class="form-horizontal" name="modalForm" ng-submit="modalForm.$valid && !$ctrl.isSaving && $ctrl.renameDevice()">
             <div class="control-group">
                 <label class="control-label" for="device-name">{{:: 'Name' | translate }}:</label>
                 <div class="controls">
                     <input type="text"
                            id="device-name"
                            class="form-control"
+                           autofocus
                            required
                            minlength="2"
                            maxlength="100"

--- a/www/app/events/EventViewer.html
+++ b/www/app/events/EventViewer.html
@@ -29,6 +29,35 @@
         >
 
         <div class="pull-right">
+            <div class="ace-settings" ng-if="$ctrl.eventData.interpreter !== 'Blockly'">
+                <select class="ace-settings__theme"
+                        ng-model="$ctrl.aceSettings.theme"
+                        ng-options="t.id as ((t.dark ? '● ' : '○ ') + t.name) for t in $ctrl.themes"
+                        ng-change="$ctrl.setTheme($ctrl.aceSettings.theme)"
+                        title="Theme">
+                </select>
+
+                <button class="btn btn-default btn-xs" type="button"
+                        ng-click="$ctrl.decreaseFontSize()"
+                        title="Decrease font size">
+                    <b>A</b><small>-</small>
+                </button>
+                <span class="ace-settings__font-size">{{$ctrl.aceSettings.fontSize}}</span>
+                <button class="btn btn-default btn-xs" type="button"
+                        ng-click="$ctrl.increaseFontSize()"
+                        title="Increase font size">
+                    <b>A</b><small>+</small>
+                </button>
+
+                <button class="btn btn-default btn-xs" type="button"
+                        ng-class="{'active': $ctrl.aceSettings.wordWrap}"
+                        ng-click="$ctrl.toggleWordWrap()"
+                        title="Word wrap">
+                    <i class="icon-align-justify"></i>
+                </button>
+
+            </div>
+
             <div class="events-editor-file__type input-prepend" ng-show="$ctrl.isTriggerAvailable()">
                 <label class="add-on" for="trigger">{{:: 'Trigger' | translate }}</label>
                 <select id="trigger"

--- a/www/app/events/EventViewer.js
+++ b/www/app/events/EventViewer.js
@@ -11,6 +11,30 @@ define(['app', 'events/factories'], function (app) {
             var vm = this;
             var aceEditor;
             var blocklyWorkspace;
+            var debounceTimer;
+            var statusBarEl;
+
+            var ACE_SETTINGS_KEY = 'domoticz_ace_settings';
+            var DEFAULT_SETTINGS = {
+                theme: 'ace/theme/xcode',
+                fontSize: 14,
+                wordWrap: false
+            };
+
+            var THEMES = [
+                { id: 'ace/theme/chrome', name: 'Chrome', dark: false },
+                { id: 'ace/theme/eclipse', name: 'Eclipse', dark: false },
+                { id: 'ace/theme/github', name: 'GitHub', dark: false },
+                { id: 'ace/theme/solarized_light', name: 'Solarized Light', dark: false },
+                { id: 'ace/theme/tomorrow', name: 'Tomorrow', dark: false },
+                { id: 'ace/theme/xcode', name: 'XCode', dark: false },
+                { id: 'ace/theme/monokai', name: 'Monokai', dark: true },
+                { id: 'ace/theme/cobalt', name: 'Cobalt', dark: true },
+                { id: 'ace/theme/solarized_dark', name: 'Solarized Dark', dark: true },
+                { id: 'ace/theme/tomorrow_night', name: 'Tomorrow Night', dark: true },
+                { id: 'ace/theme/twilight', name: 'Twilight', dark: true },
+                { id: 'ace/theme/terminal', name: 'Terminal', dark: true }
+            ];
 
             vm.$onInit = init;
             vm.setEventState = setEventState;
@@ -20,8 +44,60 @@ define(['app', 'events/factories'], function (app) {
             vm.exportEvent = exportEvent;
             vm.markEventAsUpdated = markEventAsUpdated;
             vm.isTriggerAvailable = isTriggerAvailable;
+            vm.themes = THEMES;
+            vm.setTheme = setTheme;
+            vm.increaseFontSize = increaseFontSize;
+            vm.decreaseFontSize = decreaseFontSize;
+            vm.toggleWordWrap = toggleWordWrap;
+
+            function loadSettings() {
+                try {
+                    var stored = localStorage.getItem(ACE_SETTINGS_KEY);
+                    return stored ? angular.extend({}, DEFAULT_SETTINGS, JSON.parse(stored)) : angular.copy(DEFAULT_SETTINGS);
+                } catch (e) {
+                    return angular.copy(DEFAULT_SETTINGS);
+                }
+            }
+
+            function saveSettings(settings) {
+                try {
+                    localStorage.setItem(ACE_SETTINGS_KEY, JSON.stringify(settings));
+                } catch (e) {
+                    // localStorage not available
+                }
+            }
+
+            function setTheme(themeId) {
+                if (!aceEditor) return;
+                vm.aceSettings.theme = themeId;
+                aceEditor.setTheme(themeId);
+                saveSettings(vm.aceSettings);
+            }
+
+            function increaseFontSize() {
+                if (!aceEditor) return;
+                vm.aceSettings.fontSize = Math.min(vm.aceSettings.fontSize + 1, 32);
+                aceEditor.setFontSize(vm.aceSettings.fontSize);
+                saveSettings(vm.aceSettings);
+            }
+
+            function decreaseFontSize() {
+                if (!aceEditor) return;
+                vm.aceSettings.fontSize = Math.max(vm.aceSettings.fontSize - 1, 8);
+                aceEditor.setFontSize(vm.aceSettings.fontSize);
+                saveSettings(vm.aceSettings);
+            }
+
+            function toggleWordWrap() {
+                if (!aceEditor) return;
+                vm.aceSettings.wordWrap = !vm.aceSettings.wordWrap;
+                aceEditor.getSession().setUseWrapMode(vm.aceSettings.wordWrap);
+                saveSettings(vm.aceSettings);
+            }
 
             function init() {
+                vm.aceSettings = loadSettings();
+
                 vm.eventTypes = [
                     { value: 'All', label: 'All' },
                     { value: 'Device', label: 'Device' },
@@ -56,6 +132,21 @@ define(['app', 'events/factories'], function (app) {
                             }
                         });
                     });
+
+                $scope.$on('$destroy', function () {
+                    if (debounceTimer) {
+                        $timeout.cancel(debounceTimer);
+                    }
+                    if (aceEditor) {
+                        aceEditor.destroy();
+                        aceEditor = null;
+                    }
+                    if (statusBarEl && statusBarEl.parentNode) {
+                        statusBarEl.parentNode.removeChild(statusBarEl);
+                        statusBarEl = null;
+                    }
+                    $element.off('keydown');
+                });
             }
 
             function isTriggerAvailable() {
@@ -169,7 +260,8 @@ define(['app', 'events/factories'], function (app) {
             }
 
             function initAce(eventData) {
-                require(['ace', 'ace-language-tools'], function () {
+                require(['ace', 'ace-language-tools', 'ace-searchbox', 'ace-statusbar'], function () {
+                    ace.config.set('workerPath', '../js/ace');
                     var element = $element.find('.js-script-content')[0];
 
                     aceEditor = ace.edit(element);
@@ -183,15 +275,33 @@ define(['app', 'events/factories'], function (app) {
                         enableLiveAutocompletion: true
                     });
 
-                    aceEditor.setTheme('ace/theme/xcode');
+                    // Apply persisted settings
+                    aceEditor.setTheme(vm.aceSettings.theme);
+                    aceEditor.setFontSize(vm.aceSettings.fontSize);
+                    aceEditor.getSession().setUseWrapMode(vm.aceSettings.wordWrap);
+
                     aceEditor.setValue(eventData.xmlstatement);
                     aceEditor.getSession().setMode('ace/mode/' + interpreter.toLowerCase());
                     aceEditor.gotoLine(1);
                     aceEditor.scrollToLine(1, true, true);
 
-                    aceEditor.on('change', function (event) {
+                    // Status bar
+                    var StatusBar = ace.require('ace/ext/statusbar').StatusBar;
+                    statusBarEl = document.createElement('div');
+                    statusBarEl.className = 'ace-statusbar';
+                    element.parentNode.appendChild(statusBarEl);
+                    element.style.bottom = '21px';
+                    new StatusBar(aceEditor, statusBarEl);
+
+                    // Debounced change handler
+                    aceEditor.on('change', function () {
                         markEventAsUpdated();
-                        $scope.$apply();
+                        if (debounceTimer) {
+                            $timeout.cancel(debounceTimer);
+                        }
+                        debounceTimer = $timeout(function () {
+                            // digest cycle runs automatically via $timeout
+                        }, 300);
                     });
 
                     $scope.$apply();

--- a/www/app/events/EventViewer.js
+++ b/www/app/events/EventViewer.js
@@ -141,6 +141,10 @@ define(['app', 'events/factories'], function (app) {
                         aceEditor.destroy();
                         aceEditor = null;
                     }
+                    if (blocklyWorkspace) {
+                        blocklyWorkspace.dispose();
+                        blocklyWorkspace = null;
+                    }
                     if (statusBarEl && statusBarEl.parentNode) {
                         statusBarEl.parentNode.removeChild(statusBarEl);
                         statusBarEl = null;
@@ -316,6 +320,7 @@ define(['app', 'events/factories'], function (app) {
                         blocklyWorkspace = Blockly.inject(container, {
                             path: './',
                             toolbox: toolbox,
+                            sounds: false,
                             zoom: {
                                 controls: true,
                                 wheel: true,

--- a/www/app/events/Events.css
+++ b/www/app/events/Events.css
@@ -109,6 +109,7 @@
     flex: 1;
 }
 
+
 .events-editor__menu-item {
     text-decoration: none;
 }

--- a/www/app/events/Events.css
+++ b/www/app/events/Events.css
@@ -15,9 +15,32 @@
     flex-direction: column;
 }
 
-.events-editor__search {
-    padding: 4px;
+.events-editor__toolbar {
+    display: flex;
+    align-items: center;
+    gap: 2px;
     margin-bottom: 4px;
+}
+
+.events-editor__search {
+    flex: 1;
+    padding: 2px 4px;
+    font-size: 12px;
+    height: 24px;
+}
+
+.events-editor__toolbar-btn {
+    border: 1px solid grey;
+    border-radius: 2px;
+    background-color: #CCC;
+    padding: 2px 6px;
+    height: 24px;
+    line-height: 1;
+    color: #333;
+}
+
+.events-editor__toolbar-btn:hover {
+    background-color: #e8e8e8;
 }
 
 .events-editor__editor {
@@ -132,7 +155,98 @@
     color: blue;
 }
 
-/* ///////////////////// */
+.events-editor-tree-item_selected {
+    background-color: rgba(0, 120, 215, 0.15);
+}
+
+.events-editor-tree-item[draggable="true"] {
+    cursor: grab;
+}
+
+.events-editor-tree-item[draggable="true"]:active {
+    cursor: grabbing;
+}
+
+/* Folders */
+
+.events-editor-folder-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.events-editor-folder {
+    list-style: none;
+}
+
+.events-editor-folder__header,
+.events-editor-folder__header:link,
+.events-editor-folder__header:visited {
+    display: block;
+    padding: 4px 4px;
+    text-decoration: none;
+    color: #333;
+    cursor: default;
+    white-space: nowrap;
+    font-weight: bold;
+}
+
+.events-editor-folder__header:hover,
+.events-editor-folder__header:active {
+    color: blue;
+    text-decoration: none;
+}
+
+.events-editor-folder__header i {
+    margin-right: 4px;
+}
+
+.events-editor-folder__count {
+    font-weight: normal;
+    font-size: 10px;
+    vertical-align: middle;
+}
+
+.events-editor-folder__children {
+    list-style: none;
+    padding-left: 16px;
+    margin: 0;
+}
+
+.events-editor-folder__children .events-editor-tree-item__file:before {
+    left: 4px;
+}
+
+.events-editor-folder.drag-over {
+    background-color: rgba(0, 120, 215, 0.15);
+}
+
+.events-editor-folder.drag-over > .events-editor-folder__header {
+    color: #0078d7;
+}
+
+
+/* Context Menu */
+
+.events-context-menu {
+    position: fixed;
+    z-index: 10000;
+}
+
+.events-context-menu__list {
+    min-width: 160px;
+}
+
+.events-context-menu__list a {
+    cursor: default;
+    text-decoration: none;
+}
+
+.events-context-menu__list i {
+    margin-right: 6px;
+}
+
+/* ////// Tree items ////// */
 
 .events-editor-file {
     position: relative;

--- a/www/app/events/Events.css
+++ b/www/app/events/Events.css
@@ -300,3 +300,49 @@
 .blocklyTreeLabel {
     color: black;
 }
+
+/* ACE Editor Settings */
+
+.ace-settings {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-right: 8px;
+    vertical-align: middle;
+}
+
+.ace-settings__theme {
+    height: 26px;
+    font-size: 12px;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 2px;
+    background-color: #fff;
+    color: #333;
+}
+
+.ace-settings__font-size {
+    display: inline-block;
+    min-width: 20px;
+    text-align: center;
+    font-size: 12px;
+    color: #333;
+}
+
+/* ACE Status Bar */
+
+.ace-statusbar {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 20px;
+    padding: 0 8px;
+    background-color: #e8e8e8;
+    border-top: 1px solid #ccc;
+    font-size: 11px;
+    line-height: 20px;
+    color: #666;
+    text-align: right;
+    z-index: 1;
+}

--- a/www/app/events/Events.html
+++ b/www/app/events/Events.html
@@ -1,3 +1,39 @@
+<script type="text/ng-template" id="app/events/folderNameModal.html">
+    <div class="modal-header">
+        <h3 class="modal-title">{{:: 'Folder Name' | translate }}</h3>
+    </div>
+    <div class="modal-body">
+        <form class="form-horizontal" name="modalForm" ng-submit="modalForm.$valid && $close(folder.name)">
+            <div class="control-group">
+                <label class="control-label" for="folder-name">{{:: 'Name' | translate }}:</label>
+                <div class="controls">
+                    <input type="text"
+                           id="folder-name"
+                           class="form-control"
+                           autofocus
+                           required
+                           minlength="1"
+                           maxlength="100"
+                           ng-model="folder.name">
+                </div>
+            </div>
+        </form>
+    </div>
+    <div class="modal-footer">
+        <button type="button"
+                class="btn btn-primary"
+                ng-disabled="modalForm.$invalid"
+                ng-click="$close(folder.name)">
+            {{:: 'OK' | translate }}
+        </button>
+        <button type="button"
+                class="btn btn-default"
+                ng-click="$dismiss()">
+            {{:: 'Cancel' | translate }}
+        </button>
+    </div>
+</script>
+
 <div class="row" style="margin: -8px 0 0 -8px;">
 	<timesun></timesun>
 </div>
@@ -5,18 +41,72 @@
 	<div class="events-editor">
 		<section class="events-editor__tree" ng-show="$ctrl.isListExpanded">
 			<h2>{{:: 'My automation scripts' | translate }}</h2>
-			<input class="events-editor__search" type="search" ng-model="$ctrl.search.name" placeholder="{{:: 'Filter' | translate }}">
-			<nav class="events-editor-tree">
+			<div class="events-editor__toolbar">
+				<input class="events-editor__search" type="search" ng-model="$ctrl.search.name" placeholder="{{:: 'Filter' | translate }}">
+				<button class="events-editor__toolbar-btn" ng-click="$ctrl.expandAllFolders()" title="{{:: 'Expand All' | translate }}"><i class="icon-plus-sign"></i></button>
+				<button class="events-editor__toolbar-btn" ng-click="$ctrl.collapseAllFolders()" title="{{:: 'Collapse All' | translate }}"><i class="icon-minus-sign"></i></button>
+			</div>
+			<nav class="events-editor-tree"
+				 ng-on-contextmenu="$ctrl.showContextMenu($event, null, 'root')"
+				 events-drop-target="$ctrl.onDrop('0')"
+			>
+				<!-- Folders -->
+				<ul class="events-editor-folder-list">
+					<li class="events-editor-folder"
+						ng-repeat="folder in $ctrl.folders track by folder.id"
+						ng-show="!$ctrl.search.name || ($ctrl.getEventsInFolder(folder.id) | filter:$ctrl.search).length > 0"
+						ng-on-contextmenu="$ctrl.showContextMenu($event, folder, 'folder')"
+						events-drop-target="$ctrl.onDrop(folder.id)"
+					>
+						<a class="events-editor-folder__header"
+						   href="javascript:void(0)"
+						   ng-click="$ctrl.toggleFolder(folder)"
+						   draggable="false"
+						>
+							<i ng-class="{'icon-folder-open': $ctrl.isFolderExpanded(folder), 'icon-folder-close': !$ctrl.isFolderExpanded(folder)}"></i>
+							{{ folder.name }}
+							<span class="badge events-editor-folder__count">{{ $ctrl.getEventsInFolder(folder.id).length }}</span>
+						</a>
+						<ul class="events-editor-folder__children" ng-show="$ctrl.isFolderExpanded(folder) || $ctrl.search.name">
+							<li class="events-editor-tree-item"
+								ng-class="{
+									'events-editor-tree-item_disabled': event.eventstatus === '0',
+									'events-editor-tree-item_active': event.id === $ctrl.activeEventId,
+									'events-editor-tree-item_selected': $ctrl.isEventSelected(event)
+								}"
+								ng-repeat="event in $ctrl.getEventsInFolder(folder.id) | filter:$ctrl.search track by event.id"
+								events-drag-source="$ctrl.onDragStart(event)"
+								events-drag-end="$ctrl.onDragEnd()"
+							>
+								<a class="events-editor-tree-item__file"
+								   href="javascript:void(0)"
+								   ng-click="$ctrl.openEvent(event)"
+								   ng-on-mousedown="$ctrl.toggleEventSelection(event, $event)"
+								>
+									<span class="label label-important" ng-if="event.eventstatus === '0'">{{:: 'Disabled' | translate }}</span>
+									<span class="label label-warning" ng-if="event.eventstatus === '2'">{{:: 'Error' | translate }}</span>
+									{{ event.name }}
+								</a>
+							</li>
+						</ul>
+					</li>
+				</ul>
+
+				<!-- Root-level events (no folder) -->
 				<li class="events-editor-tree-item"
 					ng-class="{
 						'events-editor-tree-item_disabled': event.eventstatus === '0',
-						'events-editor-tree-item_active': event.id === $ctrl.activeEventId
+						'events-editor-tree-item_active': event.id === $ctrl.activeEventId,
+						'events-editor-tree-item_selected': $ctrl.isEventSelected(event)
 					}"
-					ng-repeat="event in $ctrl.events | filter:$ctrl.search track by event.id"
+					ng-repeat="event in $ctrl.getRootEvents() | filter:$ctrl.search track by event.id"
+					events-drag-source="$ctrl.onDragStart(event)"
+					events-drag-end="$ctrl.onDragEnd()"
 				>
 					<a class="events-editor-tree-item__file"
 					   href="javascript:void(0)"
 					   ng-click="$ctrl.openEvent(event)"
+					   ng-on-mousedown="$ctrl.toggleEventSelection(event, $event)"
 					>
 						<span class="label label-important" ng-if="event.eventstatus === '0'">{{:: 'Disabled' | translate }}</span>
 						<span class="label label-warning" ng-if="event.eventstatus === '2'">{{:: 'Error' | translate }}</span>
@@ -25,6 +115,32 @@
 				</li>
 			</nav>
 		</section>
+
+		<!-- Context Menu -->
+		<div class="events-context-menu"
+			 ng-show="$ctrl.contextMenu.visible"
+			 ng-style="{'left': $ctrl.contextMenu.x + 'px', 'top': $ctrl.contextMenu.y + 'px'}"
+			 ng-click="$event.stopPropagation()"
+		>
+			<ul class="dropdown-menu events-context-menu__list" style="display: block; position: static;">
+				<li>
+					<a href="javascript:void(0)" ng-click="$ctrl.createFolder()">
+						<i class="icon-plus"></i> {{:: 'New Folder' | translate }}
+					</a>
+				</li>
+				<li ng-if="$ctrl.contextMenu.targetType === 'folder'">
+					<a href="javascript:void(0)" ng-click="$ctrl.renameFolder($ctrl.contextMenu.target)">
+						<i class="icon-pencil"></i> {{:: 'Rename Folder' | translate }}
+					</a>
+				</li>
+				<li ng-if="$ctrl.contextMenu.targetType === 'folder'" class="divider"></li>
+				<li ng-if="$ctrl.contextMenu.targetType === 'folder'">
+					<a href="javascript:void(0)" ng-click="$ctrl.deleteFolder($ctrl.contextMenu.target)">
+						<i class="icon-trash"></i> {{:: 'Delete Folder' | translate }}
+					</a>
+				</li>
+			</ul>
+		</div>
 
 		<button type="button"
 				class="events-editor__splitter"
@@ -120,4 +236,3 @@
 		</section>
 	</div>
 </div>
-

--- a/www/app/events/Events.html
+++ b/www/app/events/Events.html
@@ -155,6 +155,7 @@
 					<a class="dropdown-toggle lcursor" data-toggle="dropdown"><i class="icon-tasks"></i></a>
 						<ul class="dropdown-menu events-editor__menu">
 							<li><a class="events-editor__menu-item" tabindex="-1" href="javascript:void(0)" ng-click="$ctrl.closeEvent(0)"><span data-i18n="Close">Close</span></a></li>
+							<li><a class="events-editor__menu-item" tabindex="-1" href="javascript:void(0)" ng-click="$ctrl.closeEvent(-2)"><span data-i18n="Close Others">Close Others</span></a></li>
 							<li><a class="events-editor__menu-item" tabindex="-1" href="javascript:void(0)" ng-click="$ctrl.closeEvent(-1)"><span data-i18n="Close All">Close All</span></a></li>
 						</ul>
 					</a>

--- a/www/app/events/Events.js
+++ b/www/app/events/Events.js
@@ -371,23 +371,39 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
         }
 
         function closeEvent(event, forceClose) {
-			if (event == -1) {
-				//close all events
+            if (event === -1) {
+                // Close all events (keep unsaved)
+                var hadUnsaved = vm.openedEvents.some(function (item) { return item.isChanged; });
                 vm.openedEvents = vm.openedEvents.filter(function (item) {
                     return item.isChanged;
                 });
-				setActiveEventId('states');
-				storeRecentEvents();
-				return;
-			}
+                if (hadUnsaved && vm.openedEvents.length > 0) {
+                    setActiveEventId(vm.openedEvents[0].id);
+                } else {
+                    setActiveEventId('states');
+                }
+                storeRecentEvents();
+                return;
+            }
 
-			if (event == 0) {
-				for (let i = 0; i < vm.openedEvents.length; i++) {
-					if (vm.openedEvents[i].id == vm.activeEventId) {
-						event = vm.openedEvents[i];
-					}
-				}				
-			}
+            if (event === -2) {
+                // Close other events (keep active + unsaved)
+                vm.openedEvents = vm.openedEvents.filter(function (item) {
+                    return item.id === vm.activeEventId || item.isChanged;
+                });
+                storeRecentEvents();
+                return;
+            }
+
+            if (event === 0) {
+                // Close current active event
+                var found = vm.openedEvents.find(function (item) {
+                    return item.id === vm.activeEventId;
+                });
+                if (!found) return;
+                event = found;
+            }
+
             $q.resolve(event.isChanged && !forceClose
                 ? bootbox.confirm($.t('This script has unsaved changes.\n\nAre you sure you want to close it?'))
                 : true
@@ -407,7 +423,7 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 vm.openedEvents = vm.openedEvents.filter(function (item) {
                     return item.id !== event.id
                 });
-				storeRecentEvents();
+                storeRecentEvents();
 
                 event.isChanged = false;
             });
@@ -466,13 +482,14 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
 
 			domoticzEventsApi.loadRecents().then(function (data) {
 				if (data.length > 0) {
-					const recentEvents = data.split(',');
-					for (id of recentEvents) {
-						vm.events.map(function (item) {
-							if (item.id == id) {
-								openEvent(item);
-							}
+					var recentIds = data.split(',');
+					for (var i = 0; i < recentIds.length; i++) {
+						var match = vm.events.find(function (item) {
+							return String(item.id) === recentIds[i];
 						});
+						if (match) {
+							openEvent(match);
+						}
 					}
 				} else {
 					//open first event
@@ -481,14 +498,13 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
 				vm.storeRecents = true;
 			});
 		}
-		
+
 		function storeRecentEvents() {
-			if (vm.storeRecents == false) {
+			if (vm.storeRecents === false) {
 				return;
 			}
-			var recentEvents = [];
-			vm.openedEvents.map(function (item) {
-				recentEvents.push(item.id);
+			var recentEvents = vm.openedEvents.map(function (item) {
+				return item.id;
 			});
 			domoticzEventsApi.storeRecents(recentEvents);
 		}

--- a/www/app/events/Events.js
+++ b/www/app/events/Events.js
@@ -1,7 +1,7 @@
 define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates'], function (app) {
     app.controller('EventsController', EventsController);
 
-    function EventsController($q, $rootScope, domoticzApi, domoticzEventsApi, bootbox) {
+    function EventsController($q, $rootScope, $uibModal, domoticzApi, domoticzEventsApi, bootbox) {
         var vm = this;
         vm.createEvent = createEvent;
         vm.openEvent = openEvent;
@@ -13,6 +13,22 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
 		vm.loadRecentEvents = loadRecentEvents;
         vm.setActiveEventId = setActiveEventId;
         vm.isInterpreterSupported = isInterpreterSupported;
+        vm.toggleFolder = toggleFolder;
+        vm.isFolderExpanded = isFolderExpanded;
+        vm.showContextMenu = showContextMenu;
+        vm.hideContextMenu = hideContextMenu;
+        vm.createFolder = createFolder;
+        vm.renameFolder = renameFolder;
+        vm.deleteFolder = deleteFolder;
+        vm.onDragStart = onDragStart;
+        vm.onDrop = onDrop;
+        vm.onDragEnd = onDragEnd;
+        vm.expandAllFolders = expandAllFolders;
+        vm.collapseAllFolders = collapseAllFolders;
+        vm.toggleEventSelection = toggleEventSelection;
+        vm.isEventSelected = isEventSelected;
+        vm.getEventsInFolder = getEventsInFolder;
+        vm.getRootEvents = getRootEvents;
 		
 		vm.storeRecents = true;
 
@@ -23,6 +39,12 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
             vm.activeEventId = 'states';
 
             vm.openedEvents = [];
+            vm.folders = [];
+            vm.expandedFolders = {};
+            vm.contextMenu = { visible: false, x: 0, y: 0, target: null, targetType: null };
+            vm.selectedEvents = {};
+            vm.dragState = { dragging: false };
+
             vm.dzVentsTemplates = [
                 { id: 'All', name: 'All (commented)' },
                 { id: 'Bare', name: 'Minimal' },
@@ -49,6 +71,14 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
             ];
 
             listEvents();
+
+            // Hide context menu on click elsewhere
+            $(document).on('click.eventsContextMenu', function () {
+                if (vm.contextMenu.visible) {
+                    vm.contextMenu.visible = false;
+                    $rootScope.$applyAsync();
+                }
+            });
         }
 
         function isInterpreterSupported(interpreter) {
@@ -65,11 +95,212 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
             return domoticzEventsApi.listEvents().then(function (data) {
                 vm.events = data.events;
                 vm.interpreters = data.interpreters;
+                var isFirstLoad = vm.folders.length === 0;
+                vm.folders = data.folders || [];
+
+                if (isFirstLoad) {
+                    expandAllFolders();
+                }
 
                 if (vm.events.length > 0 && vm.openedEvents.length === 0) {
 					loadRecentEvents();
                 }
             })
+        }
+
+        function getEventsInFolder(folderId) {
+            return (vm.events || []).filter(function (event) {
+                return event.folderid === String(folderId);
+            });
+        }
+
+        function getRootEvents() {
+            return (vm.events || []).filter(function (event) {
+                return !event.folderid || event.folderid === '0';
+            });
+        }
+
+        function toggleFolder(folder) {
+            vm.expandedFolders[folder.id] = !vm.expandedFolders[folder.id];
+        }
+
+        function isFolderExpanded(folder) {
+            return !!vm.expandedFolders[folder.id];
+        }
+
+        function expandAllFolders() {
+            vm.folders.forEach(function (folder) {
+                vm.expandedFolders[folder.id] = true;
+            });
+        }
+
+        function collapseAllFolders() {
+            vm.expandedFolders = {};
+        }
+
+        // Context menu
+        function showContextMenu(event, target, targetType) {
+            event.preventDefault();
+            event.stopPropagation();
+            vm.contextMenu = {
+                visible: true,
+                x: event.clientX,
+                y: event.clientY,
+                target: target,
+                targetType: targetType
+            };
+        }
+
+        function hideContextMenu() {
+            vm.contextMenu.visible = false;
+        }
+
+        function createFolder() {
+            hideContextMenu();
+            var scope = $rootScope.$new(true);
+            scope.folder = { name: '' };
+
+            $uibModal
+                .open({
+                    templateUrl: 'app/events/folderNameModal.html',
+                    scope: scope
+                }).result
+                .then(function (name) {
+                    if (name && name.trim()) {
+                        domoticzEventsApi.createFolder(name.trim()).then(function () {
+                            listEvents();
+                        });
+                    }
+                });
+        }
+
+        function renameFolder(folder) {
+            hideContextMenu();
+            var scope = $rootScope.$new(true);
+            scope.folder = { name: folder.name };
+
+            $uibModal
+                .open({
+                    templateUrl: 'app/events/folderNameModal.html',
+                    scope: scope
+                }).result
+                .then(function (name) {
+                    if (name && name.trim()) {
+                        domoticzEventsApi.renameFolder(folder.id, name.trim()).then(function () {
+                            listEvents();
+                        });
+                    }
+                });
+        }
+
+        function deleteFolder(folder) {
+            hideContextMenu();
+            var eventsInFolder = getEventsInFolder(folder.id);
+            var message;
+            if (eventsInFolder.length > 0) {
+                message = $.t('This folder contains') + ' ' + eventsInFolder.length + ' ' + $.t('script(s). Deleting the folder will also delete all scripts in it.') + '\n\n' + $.t('Are you sure?');
+            } else {
+                message = $.t('Are you sure you want to delete this folder?');
+            }
+            $q(function(resolve, reject) {
+                window.bootbox.confirm(message, function (result) {
+                    result === true ? resolve() : reject();
+                });
+            }).then(function () {
+                // Close any open events that are in this folder
+                eventsInFolder.forEach(function (evt) {
+                    var openedEvent = vm.openedEvents.find(function (item) {
+                        return item.id === evt.id;
+                    });
+                    if (openedEvent) {
+                        closeEvent(openedEvent, true);
+                    }
+                });
+                domoticzEventsApi.deleteFolder(folder.id).then(function () {
+                    listEvents();
+                });
+            });
+        }
+
+        // Multi-select
+        function toggleEventSelection(event, $event) {
+            var isSelected = vm.selectedEvents[event.id];
+            var selectedCount = Object.keys(vm.selectedEvents).filter(function (id) {
+                return vm.selectedEvents[id];
+            }).length;
+
+            if ($event && ($event.ctrlKey || $event.metaKey)) {
+                if (isSelected) {
+                    // Defer deselection to mouseup in case user is starting a drag
+                    vm._pendingDeselect = event.id;
+                    $(document).one('mouseup.eventsDeselect', function () {
+                        if (vm._pendingDeselect === event.id) {
+                            vm._pendingDeselect = null;
+                            vm.selectedEvents[event.id] = false;
+                            $rootScope.$applyAsync();
+                        }
+                    });
+                } else {
+                    vm.selectedEvents[event.id] = true;
+                }
+            } else if (isSelected && selectedCount > 1) {
+                // Clicked on an already-selected item in a multi-selection:
+                // defer narrowing to mouseup so drag can use the full selection
+                vm._pendingDeselect = 'narrow:' + event.id;
+                $(document).one('mouseup.eventsDeselect', function () {
+                    if (vm._pendingDeselect === 'narrow:' + event.id) {
+                        vm._pendingDeselect = null;
+                        vm.selectedEvents = {};
+                        vm.selectedEvents[event.id] = true;
+                        $rootScope.$applyAsync();
+                    }
+                });
+            } else {
+                vm.selectedEvents = {};
+                vm.selectedEvents[event.id] = true;
+            }
+        }
+
+        function isEventSelected(event) {
+            return !!vm.selectedEvents[event.id];
+        }
+
+        // Drag and drop
+        function onDragStart(event) {
+            // Cancel any pending deselection from mousedown - we're dragging now
+            vm._pendingDeselect = null;
+            $(document).off('mouseup.eventsDeselect');
+
+            if (!vm.selectedEvents[event.id]) {
+                vm.selectedEvents = {};
+                vm.selectedEvents[event.id] = true;
+            }
+            vm.dragState = {
+                dragging: true,
+                eventIds: Object.keys(vm.selectedEvents).filter(function (id) {
+                    return vm.selectedEvents[id];
+                })
+            };
+        }
+
+        function onDrop(targetFolderId) {
+            var eventIds = vm.dragState.eventIds || [];
+            vm.dragState = { dragging: false };
+
+            var promises = eventIds.map(function (eventId) {
+                return domoticzEventsApi.moveEvent(eventId, targetFolderId);
+            });
+
+            $q.all(promises).then(function () {
+                vm.selectedEvents = {};
+                vm.expandedFolders[targetFolderId] = true;
+                listEvents();
+            });
+        }
+
+        function onDragEnd() {
+            vm.dragState = { dragging: false };
+            $('.drag-over').removeClass('drag-over');
         }
 
         function createEvent(interpreter, eventtype) {
@@ -243,4 +474,77 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
 			domoticzEventsApi.storeRecents(recentEvents);
 		}
     }
+
+    app.directive('eventsDragSource', function () {
+        return {
+            restrict: 'A',
+            link: function (scope, element, attrs) {
+                var el = element[0];
+                el.draggable = true;
+
+                el.addEventListener('dragstart', function (e) {
+                    e.dataTransfer.setData('text/plain', '');
+                    e.dataTransfer.effectAllowed = 'move';
+                    scope.$apply(function () {
+                        scope.$eval(attrs.eventsDragSource);
+                    });
+
+                    // Show a badge with the count when dragging multiple items
+                    var dragState = scope.$ctrl && scope.$ctrl.dragState;
+                    if (dragState && dragState.eventIds && dragState.eventIds.length > 1) {
+                        var badge = document.createElement('div');
+                        badge.textContent = dragState.eventIds.length + ' scripts';
+                        badge.style.cssText = 'position:absolute;top:-9999px;left:-9999px;padding:4px 10px;background:#0078d7;color:#fff;border-radius:3px;font-size:12px;white-space:nowrap;';
+                        document.body.appendChild(badge);
+                        e.dataTransfer.setDragImage(badge, 0, 0);
+                        setTimeout(function () { document.body.removeChild(badge); }, 0);
+                    }
+                });
+
+                el.addEventListener('dragend', function () {
+                    scope.$apply(function () {
+                        scope.$eval(attrs.eventsDragEnd);
+                    });
+                });
+            }
+        };
+    });
+
+    app.directive('eventsDropTarget', function () {
+        return {
+            restrict: 'A',
+            link: function (scope, element, attrs) {
+                var el = element[0];
+                var dragCounter = 0;
+
+                el.addEventListener('dragover', function (e) {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = 'move';
+                });
+
+                el.addEventListener('dragenter', function (e) {
+                    e.preventDefault();
+                    dragCounter++;
+                    element.addClass('drag-over');
+                });
+
+                el.addEventListener('dragleave', function () {
+                    dragCounter--;
+                    if (dragCounter === 0) {
+                        element.removeClass('drag-over');
+                    }
+                });
+
+                el.addEventListener('drop', function (e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    dragCounter = 0;
+                    element.removeClass('drag-over');
+                    scope.$apply(function () {
+                        scope.$eval(attrs.eventsDropTarget);
+                    });
+                });
+            }
+        };
+    });
 });

--- a/www/app/events/Events.js
+++ b/www/app/events/Events.js
@@ -1,7 +1,7 @@
 define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates'], function (app) {
     app.controller('EventsController', EventsController);
 
-    function EventsController($q, $rootScope, $uibModal, domoticzApi, domoticzEventsApi, bootbox) {
+    function EventsController($scope, $q, $rootScope, $uibModal, domoticzApi, domoticzEventsApi, bootbox) {
         var vm = this;
         vm.createEvent = createEvent;
         vm.openEvent = openEvent;
@@ -78,6 +78,11 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                     vm.contextMenu.visible = false;
                     $rootScope.$applyAsync();
                 }
+            });
+
+            $scope.$on('$destroy', function () {
+                $(document).off('click.eventsContextMenu');
+                $(document).off('mouseup.eventsDeselect');
             });
         }
 
@@ -168,7 +173,11 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 .then(function (name) {
                     if (name && name.trim()) {
                         domoticzEventsApi.createFolder(name.trim()).then(function () {
-                            listEvents();
+                            return listEvents();
+                        }).then(function () {
+                            ShowNotify($.t('Folder created'), 2500);
+                        }).catch(function () {
+                            ShowNotify($.t('Failed to create folder'), 2500, true);
                         });
                     }
                 });
@@ -187,7 +196,11 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 .then(function (name) {
                     if (name && name.trim()) {
                         domoticzEventsApi.renameFolder(folder.id, name.trim()).then(function () {
-                            listEvents();
+                            return listEvents();
+                        }).then(function () {
+                            ShowNotify($.t('Folder renamed'), 2500);
+                        }).catch(function () {
+                            ShowNotify($.t('Failed to rename folder'), 2500, true);
                         });
                     }
                 });
@@ -217,7 +230,11 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                     }
                 });
                 domoticzEventsApi.deleteFolder(folder.id).then(function () {
-                    listEvents();
+                    return listEvents();
+                }).then(function () {
+                    ShowNotify($.t('Folder deleted'), 2500);
+                }).catch(function () {
+                    ShowNotify($.t('Failed to delete folder'), 2500, true);
                 });
             });
         }
@@ -233,6 +250,7 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 if (isSelected) {
                     // Defer deselection to mouseup in case user is starting a drag
                     vm._pendingDeselect = event.id;
+                    $(document).off('mouseup.eventsDeselect');
                     $(document).one('mouseup.eventsDeselect', function () {
                         if (vm._pendingDeselect === event.id) {
                             vm._pendingDeselect = null;
@@ -247,6 +265,7 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 // Clicked on an already-selected item in a multi-selection:
                 // defer narrowing to mouseup so drag can use the full selection
                 vm._pendingDeselect = 'narrow:' + event.id;
+                $(document).off('mouseup.eventsDeselect');
                 $(document).one('mouseup.eventsDeselect', function () {
                     if (vm._pendingDeselect === 'narrow:' + event.id) {
                         vm._pendingDeselect = null;
@@ -482,7 +501,7 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 var el = element[0];
                 el.draggable = true;
 
-                el.addEventListener('dragstart', function (e) {
+                function handleDragStart(e) {
                     e.dataTransfer.setData('text/plain', '');
                     e.dataTransfer.effectAllowed = 'move';
                     scope.$apply(function () {
@@ -493,18 +512,26 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                     var dragState = scope.$ctrl && scope.$ctrl.dragState;
                     if (dragState && dragState.eventIds && dragState.eventIds.length > 1) {
                         var badge = document.createElement('div');
-                        badge.textContent = dragState.eventIds.length + ' scripts';
+                        badge.textContent = dragState.eventIds.length + ' ' + $.t('scripts');
                         badge.style.cssText = 'position:absolute;top:-9999px;left:-9999px;padding:4px 10px;background:#0078d7;color:#fff;border-radius:3px;font-size:12px;white-space:nowrap;';
                         document.body.appendChild(badge);
                         e.dataTransfer.setDragImage(badge, 0, 0);
                         setTimeout(function () { document.body.removeChild(badge); }, 0);
                     }
-                });
+                }
 
-                el.addEventListener('dragend', function () {
+                function handleDragEnd() {
                     scope.$apply(function () {
                         scope.$eval(attrs.eventsDragEnd);
                     });
+                }
+
+                el.addEventListener('dragstart', handleDragStart);
+                el.addEventListener('dragend', handleDragEnd);
+
+                scope.$on('$destroy', function () {
+                    el.removeEventListener('dragstart', handleDragStart);
+                    el.removeEventListener('dragend', handleDragEnd);
                 });
             }
         };
@@ -517,25 +544,25 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                 var el = element[0];
                 var dragCounter = 0;
 
-                el.addEventListener('dragover', function (e) {
+                function handleDragOver(e) {
                     e.preventDefault();
                     e.dataTransfer.dropEffect = 'move';
-                });
+                }
 
-                el.addEventListener('dragenter', function (e) {
+                function handleDragEnter(e) {
                     e.preventDefault();
                     dragCounter++;
                     element.addClass('drag-over');
-                });
+                }
 
-                el.addEventListener('dragleave', function () {
+                function handleDragLeave() {
                     dragCounter--;
                     if (dragCounter === 0) {
                         element.removeClass('drag-over');
                     }
-                });
+                }
 
-                el.addEventListener('drop', function (e) {
+                function handleDrop(e) {
                     e.preventDefault();
                     e.stopPropagation();
                     dragCounter = 0;
@@ -543,6 +570,18 @@ define(['app', 'events/factories', 'events/EventViewer', 'events/CurrentStates']
                     scope.$apply(function () {
                         scope.$eval(attrs.eventsDropTarget);
                     });
+                }
+
+                el.addEventListener('dragover', handleDragOver);
+                el.addEventListener('dragenter', handleDragEnter);
+                el.addEventListener('dragleave', handleDragLeave);
+                el.addEventListener('drop', handleDrop);
+
+                scope.$on('$destroy', function () {
+                    el.removeEventListener('dragover', handleDragOver);
+                    el.removeEventListener('dragenter', handleDragEnter);
+                    el.removeEventListener('dragleave', handleDragLeave);
+                    el.removeEventListener('drop', handleDrop);
                 });
             }
         };

--- a/www/app/events/factories.js
+++ b/www/app/events/factories.js
@@ -9,7 +9,11 @@ define(['app'], function (app) {
             deleteEvent: deleteEvent,
 			loadRecents: loadRecents,
 			storeRecents: storeRecents,
-            getTemplate: getTemplate
+            getTemplate: getTemplate,
+            createFolder: createFolder,
+            renameFolder: renameFolder,
+            deleteFolder: deleteFolder,
+            moveEvent: moveEvent
         };
 
         function fetchCurrentStates() {
@@ -28,7 +32,8 @@ define(['app'], function (app) {
             }).then(function (data) {
                 return {
                     events: data.result || [],
-                    interpreters: data.interpreters ? data.interpreters.split(':') : []
+                    interpreters: data.interpreters ? data.interpreters.split(':') : [],
+                    folders: data.folders || []
                 }
             });
         }
@@ -97,6 +102,36 @@ define(['app'], function (app) {
             return domoticzApi.sendCommand('events', {
                 evparam: 'store_recents',
 				recent_list: arrStr
+            });
+        }
+
+        function createFolder(name) {
+            return domoticzApi.sendCommand('events', {
+                evparam: 'create_folder',
+                name: name
+            });
+        }
+
+        function renameFolder(folderId, name) {
+            return domoticzApi.sendCommand('events', {
+                evparam: 'rename_folder',
+                folder: folderId,
+                name: name
+            });
+        }
+
+        function deleteFolder(folderId) {
+            return domoticzApi.sendCommand('events', {
+                evparam: 'delete_folder',
+                folder: folderId
+            });
+        }
+
+        function moveEvent(eventId, folderId) {
+            return domoticzApi.sendCommand('events', {
+                evparam: 'move_event',
+                event: eventId,
+                folder: folderId
             });
         }
     });

--- a/www/app/main.js
+++ b/www/app/main.js
@@ -17,6 +17,8 @@ require.config({
 		'angular-websocket': '../js/angular-websocket',
 		'ace': '../js/ace/ace',
 		'ace-language-tools': '../js/ace/ext-language_tools',
+		'ace-searchbox': '../js/ace/ext-searchbox',
+		'ace-statusbar': '../js/ace/ext-statusbar',
 		'blockly': '../js/blockly/blockly_compressed',
 		'blockly-blocks': '../js/blockly/blocks_compressed',
 		'blockly-msg-en': '../js/blockly/msg/en',
@@ -45,6 +47,8 @@ require.config({
 		'angular.scrollglue': ['angular'],
 		'angular-websocket': ['angular'],
 		'ace-language-tools': ['ace'],
+		'ace-searchbox': ['ace'],
+		'ace-statusbar': ['ace'],
 		'blockly-blocks': ['blockly'],
 		'blockly-msg-en': ['blockly']
 	},


### PR DESCRIPTION
## Summary
- Add folder management for events: create, rename, delete folders via context menu
- Multi-select events with Ctrl+click and drag-and-drop to move between folders
- Fix memory leaks: proper `$destroy` cleanup for document listeners, ACE editor, and drag/drop directives
- Fix race condition in `toggleEventSelection` by clearing stale mouseup handlers
- Enhance ACE editor: search/replace (Ctrl+F/H), Lua syntax validation, debounced change handler, status bar with cursor position
- Add persistent editor settings (theme, font size, word wrap) via localStorage
- Add error notifications for folder operations
- Translate drag badge text for i18n

## Test plan
- [ ] Open Events page, create a folder, rename it, delete it — verify success notifications
- [ ] Multi-select events with Ctrl+click, drag to a folder — verify all move correctly
- [ ] Open a script, use Ctrl+F for search and Ctrl+H for replace
- [ ] Verify Lua syntax errors show inline annotations
- [ ] Change theme, font size, word wrap — reload page and verify settings persist
- [ ] Check status bar shows line:col and updates on cursor move
- [ ] Navigate away from Events and back — verify no duplicate listeners (DevTools)
- [ ] Close an event tab — verify ACE editor is destroyed (no DOM leaks)