### PR TITLE
Fix: skip plugin credential injection for loopback HTTP requests

### DIFF
--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -813,35 +813,45 @@ namespace Plugins {
 			sHttp += " HTTP/1.1\r\n";
 
 			// If username &/or password specified then add a basic auth header (if one was not supplied)
+			// Skip for loopback destinations — the credentials are meant for the external device,
+			// not for Domoticz's own web server (which would reject them and override trusted network status)
 			PyBorrowedRef pHead;
 			if (pHeaders) pHead = PyDict_GetItemString(pHeaders, "Authorization");
 			if (!pHead)
 			{
-				std::string		User;
-				std::string		Pass;
-				PyObject* pModule = (PyObject*)WriteMessage->m_pConnection->pPlugin->PythonModule();
-				PyNewRef		pDict = PyObject_GetAttrString(pModule, "Parameters");
-				if (pDict)
+				std::string sAddress;
+				if (WriteMessage->m_pConnection->Address)
+					sAddress = PyUnicode_AsUTF8(WriteMessage->m_pConnection->Address);
+
+				bool bIsLoopback = (sAddress == "127.0.0.1" || sAddress == "::1" || sAddress == "localhost");
+				if (!bIsLoopback)
 				{
-					PyBorrowedRef pUser = PyDict_GetItemString(pDict, "Username");
-					if (pUser) User = PyUnicode_AsUTF8(pUser);
-					PyBorrowedRef pPass = PyDict_GetItemString(pDict, "Password");
-					if (pPass) Pass = PyUnicode_AsUTF8(pPass);
-				}
-				if (User.length() > 0 || Pass.length() > 0)
-				{
-					std::string auth;
-					if (User.length() > 0)
+					std::string		User;
+					std::string		Pass;
+					PyObject* pModule = (PyObject*)WriteMessage->m_pConnection->pPlugin->PythonModule();
+					PyNewRef		pDict = PyObject_GetAttrString(pModule, "Parameters");
+					if (pDict)
 					{
-						auth += User;
+						PyBorrowedRef pUser = PyDict_GetItemString(pDict, "Username");
+						if (pUser) User = PyUnicode_AsUTF8(pUser);
+						PyBorrowedRef pPass = PyDict_GetItemString(pDict, "Password");
+						if (pPass) Pass = PyUnicode_AsUTF8(pPass);
 					}
-					auth += ":";
-					if (Pass.length() > 0)
+					if (User.length() > 0 || Pass.length() > 0)
 					{
-						auth += Pass;
+						std::string auth;
+						if (User.length() > 0)
+						{
+							auth += User;
+						}
+						auth += ":";
+						if (Pass.length() > 0)
+						{
+							auth += Pass;
+						}
+						std::string encodedAuth = base64_encode(auth);
+						sHttp += "Authorization: Basic " + encodedAuth + "\r\n";
 					}
-					std::string encodedAuth = base64_encode(auth);
-					sHttp += "Authorization: Basic " + encodedAuth + "\r\n";
 				}
 			}
 


### PR DESCRIPTION
When a plugin uses `Domoticz.Connection(Protocol="HTTP")` to call Domoticz's own JSON API (e.g., for notifications or room plans), the plugin framework in `PluginProtocols.cpp` automatically injects a `Basic Authorization` header using the plugin's `Parameters["Username"]` and `Parameters["Password"]`.

These credentials are meant for the external device the plugin manages (e.g., an inverter, thermostat), not for Domoticz itself. When the web server receives these invalid credentials, it clears the trusted network session and returns 401 Unauthorized — even though the connection comes from a trusted loopback address.

**Root cause:** `PluginProtocols.cpp` unconditionally injects the plugin's device credentials on every HTTP request, including requests to Domoticz itself.

**Fix:** Before injecting the Basic auth header, check if the target address is a loopback address (`127.0.0.1`, `::1`, or `localhost`) and skip the credential injection. The web server's authentication logic is left untouched.

This is a follow-up to the closed PR #6547, addressing the review feedback from @kiddigital to fix the real cause in the plugin protocol layer rather than modifying `cWebem.cpp`.