### PR TITLE
feat: First-run setup wizard replacing default admin credentials

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -33,6 +33,8 @@ Version 2026.xxxx
 - Added: Web Interface, Modernized log viewer with WebSocket live streaming, level filtering, search/regex, render cap, and performance optimizations
 - Added: Web Interface, Passkey (WebAuthn/FIDO2) authentication support - register and sign in with Windows Hello, Touch ID, or security keys
 - Added: Web Interface, Passkey management in My Profile (register, view device info, delete)
+- Added: Web Interface, First-run setup wizard for admin account creation, replacing default credentials
+- Added: Docker environment variable support for admin provisioning (DOMOTICZ_ADMIN_PASSWORD, DOMOTICZ_ADMIN_USERNAME)
 - Fixed: Buienradar, fallback when station measurements are empty
 - Fixed: CalcMeterPrice/CalcMultiMeterPrice off-by-one price error with dynamic tariffs (Fixes #6181)
 - Fixed: Chart zoom buttons (notable on iOS devices)
@@ -49,6 +51,7 @@ Version 2026.xxxx
 - Fixed: Memory leak in Python event scripts caused by missing reference count decrement in user variables (Fixes #5091)
 - Fixed: MQTT, crashes and race conditions in message handling
 - Fixed: MQTTPush/InfluxPush crash on shutdown (#6600)
+- Fixed: Missing Passkeys column on fresh Docker installs causing SQL errors (#6601)
 - Fixed: Negative rain values at midnight when counter resets (Fixes #6571)
 - Fixed: OpenZWave setpoint devices
 - Fixed: P1Power hourly graph empty due to incorrect SQL format escaping in pricing resolution grouping

--- a/README.md
+++ b/README.md
@@ -19,9 +19,7 @@ Some Information
 
 ## Support
 
-By default Domoticz is protected by a username (admin) and password (domoticz).
-
-Please either change the password as soon as possible or create a different admin user and remove the default (admin) user.
+On first run, Domoticz will present a setup wizard to create your admin account. For Docker deployments, you can set the `DOMOTICZ_ADMIN_PASSWORD` and optionally `DOMOTICZ_ADMIN_USERNAME` environment variables to provision the admin account automatically.
 
 More information on securing your Domoticz setup can be found in the [SECURITY SETUP](SECURITY_SETUP.md) documentation.
 

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -2,6 +2,7 @@
 #include "SQLHelper.h"
 #include <iostream>	 /* standard I/O functions						 */
 #include <string>
+#include <cstdlib>
 #ifdef WIN32
 #include <tchar.h>
 #else
@@ -3324,11 +3325,41 @@ bool CSQLHelper::OpenDatabase()
 		query("INSERT INTO Plans (Name) VALUES ('$Hidden Devices')");
 		// Add hardware for internal use
 		safe_query("INSERT INTO Hardware (Name, Enabled, Type, Address, Port, Username, Password, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6) VALUES ('Domoticz Internal',1, %d,'',1,'','',0,0,0,0,0,0)", HTYPE_DomoticzInternal);
-		safe_query("INSERT INTO Users (Active, Username, Password, Rights, TabsEnabled) VALUES (1, '%s', '%s', %d, 0x1F)", base64_encode(DEFAULT_ADMINUSER).c_str(), GenerateMD5Hash(DEFAULT_ADMINPWD).c_str(), http::server::URIGHTS_ADMIN);
+		// Admin user is no longer created here - created via setup wizard or Docker env vars
 		safe_query("INSERT INTO Applications (Active, Public, Applicationname) VALUES (1, 1, 'domoticzUI')");
 		safe_query("INSERT INTO Applications (Active, Public, Applicationname) VALUES (0, 0, 'domoticzMobileApp')");
 	}
 	UpdatePreferencesVar("DB_Version", DB_VERSION);
+
+	// Check for Docker environment variable provisioning
+	// Only applies when no admin user exists (fresh install or admin was deleted)
+	{
+		auto adminResult = safe_query("SELECT ID FROM Users WHERE Rights=%d", http::server::URIGHTS_ADMIN);
+		if (adminResult.empty())
+		{
+			const char *envPassword = std::getenv("DOMOTICZ_ADMIN_PASSWORD");
+			if (envPassword != nullptr && strlen(envPassword) > 0)
+			{
+				const char *envUsername = std::getenv("DOMOTICZ_ADMIN_USERNAME");
+				std::string username = (envUsername != nullptr && strlen(envUsername) > 0) ? envUsername : DEFAULT_ADMINUSER;
+				std::string password = envPassword;
+
+				safe_query("INSERT INTO Users (Active, Username, Password, Rights, TabsEnabled) VALUES (1, '%q', '%q', %d, 0x1F)",
+					base64_encode(username).c_str(), GenerateMD5Hash(password).c_str(), http::server::URIGHTS_ADMIN);
+
+				_log.Log(LOG_STATUS, "Admin user '%s' created from environment variables", username.c_str());
+			}
+		}
+		else
+		{
+			// Admin already exists - ignore env vars if set
+			const char *envPassword = std::getenv("DOMOTICZ_ADMIN_PASSWORD");
+			if (envPassword != nullptr && strlen(envPassword) > 0)
+			{
+				_log.Log(LOG_STATUS, "Admin account already exists, ignoring DOMOTICZ_ADMIN_PASSWORD environment variable");
+			}
+		}
+	}
 
 	//Check preferences table for extreme sized sValues
 	result = safe_query("SELECT Key FROM Preferences WHERE LENGTH(sValue) > 2500");

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -297,6 +297,8 @@ namespace http
 			RegisterCommandCode("getauth", [this](auto&& session, auto&& req, auto&& root) { Cmd_GetAuth(session, req, root); }, true);
 			RegisterCommandCode("getuptime", [this](auto&& session, auto&& req, auto&& root) { Cmd_GetUptime(session, req, root); }, true);
 			RegisterCommandCode("getconfig", [this](auto&& session, auto&& req, auto&& root) { Cmd_GetConfig(session, req, root); }, true);
+			RegisterCommandCode("getsetuprequired", [this](auto&& session, auto&& req, auto&& root) { Cmd_GetSetupRequired(session, req, root); }, true);
+			RegisterCommandCode("setupwizardcreateadmin", [this](auto&& session, auto&& req, auto&& root) { Cmd_SetupWizardCreateAdmin(session, req, root); }, true);
 
 			// Commands that require authentication
 			RegisterCommandCode("sendopenthermcommand", [this](auto&& session, auto&& req, auto&& root) { Cmd_SendOpenThermCommand(session, req, root); });

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -201,6 +201,8 @@ private:
 	void Cmd_ChangePlanDeviceOrder(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetVersion(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetAuth(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetSetupRequired(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_SetupWizardCreateAdmin(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_GetMyProfile(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_UpdateMyProfile(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_GetUptime(WebEmSession & session, const request& req, Json::Value &root);

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -2524,6 +2524,60 @@ namespace http
 			}
 		}
 
+		void CWebServer::Cmd_GetSetupRequired(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["status"] = "OK";
+			root["title"] = "GetSetupRequired";
+			root["SetupRequired"] = !FindAdminUser();
+		}
+
+		void CWebServer::Cmd_SetupWizardCreateAdmin(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["title"] = "SetupWizardCreateAdmin";
+
+			static std::mutex setupMutex;
+			std::lock_guard<std::mutex> lock(setupMutex);
+
+			// Security: only allow when no admin user exists
+			if (FindAdminUser())
+			{
+				_log.Log(LOG_ERROR, "Setup wizard attempt blocked: admin account already exists (IP: %s)", session.remote_host.c_str());
+				root["status"] = "ERR";
+				root["message"] = "Setup has already been completed";
+				return;
+			}
+
+			std::string username = CURLEncode::URLDecode(request::findValue(&req, "username"));
+			std::string password = CURLEncode::URLDecode(request::findValue(&req, "password"));
+
+			if (username.empty() || password.empty())
+			{
+				root["status"] = "ERR";
+				root["message"] = "Username and password are required";
+				return;
+			}
+
+			if (username.length() > 128)
+			{
+				root["status"] = "ERR";
+				root["message"] = "Username is too long";
+				return;
+			}
+
+			// Username is sent as plaintext, we base64 encode for storage
+			// Password is sent as MD5 hash from the frontend (same as login flow)
+			m_sql.safe_query(
+				"INSERT INTO Users (Active, Username, Password, Rights, TabsEnabled) VALUES (1, '%q', '%q', %d, 0x1F)",
+				base64_encode(username).c_str(), password.c_str(), http::server::URIGHTS_ADMIN);
+
+			_log.Log(LOG_STATUS, "Admin user '%s' created via setup wizard", username.c_str());
+
+			// Reload users so the new admin is immediately available for login
+			LoadUsers();
+
+			root["status"] = "OK";
+		}
+
 		void CWebServer::Cmd_GetMyProfile(WebEmSession& session, const request& req, Json::Value& root)
 		{
 			root["status"] = "ERR";

--- a/www/app/LoginController.js
+++ b/www/app/LoginController.js
@@ -57,6 +57,14 @@ define(['app'], function (app) {
 				$rootScope.GetGlobalConfig();
 
 				$location.path('/Dashboard');
+
+				// Show security recommendation only after initial setup wizard completion
+				if (parseInt(data.rights) === 2 && sessionStorage.getItem('setupJustCompleted')) {
+					sessionStorage.removeItem('setupJustCompleted');
+					setTimeout(function() {
+						ShowNotify($.t('Consider enabling 2FA or passkeys for your admin account in User Settings'), 8000);
+					}, 2000);
+				}
 			}
 		}
 

--- a/www/app/SetupWizardController.js
+++ b/www/app/SetupWizardController.js
@@ -1,0 +1,268 @@
+define(['app'], function (app) {
+	app.controller('SetupWizardController', ['$scope', '$location', '$http', 'md5', function ($scope, $location, $http, md5) {
+
+		$scope.setup = {
+			username: 'admin',
+			password: '',
+			confirmPassword: ''
+		};
+		$scope.errorMessage = '';
+		$scope.isSubmitting = false;
+
+		// --- Canvas particle constellation animation (same as LoginController) ---
+
+		function initCanvas() {
+			var canvas = document.getElementById('canvas-login');
+			if (!canvas) { return; }
+			var ctx = canvas.getContext('2d');
+			var particles = [];
+			var particleCount = 80;
+			var connectionDistance = 120;
+			var mouse = { x: null, y: null, radius: 150 };
+
+			// Set canvas size
+			function resizeCanvas() {
+				canvas.width = window.innerWidth;
+				canvas.height = window.innerHeight;
+			}
+			resizeCanvas();
+			window.addEventListener('resize', resizeCanvas);
+
+			// Track mouse
+			window.addEventListener('mousemove', function (e) {
+				mouse.x = e.x;
+				mouse.y = e.y;
+			});
+			window.addEventListener('mouseout', function () {
+				mouse.x = null;
+				mouse.y = null;
+			});
+
+			// Particle class
+			function Particle() {
+				this.x = Math.random() * canvas.width;
+				this.y = Math.random() * canvas.height;
+				this.vx = (Math.random() - 0.5) * 0.8;
+				this.vy = (Math.random() - 0.5) * 0.8;
+				this.radius = Math.random() * 2 + 1;
+				this.color = 'rgba(100, 200, 255, ' + (Math.random() * 0.5 + 0.5) + ')';
+			}
+
+			Particle.prototype.draw = function () {
+				ctx.beginPath();
+				ctx.arc(this.x, this.y, this.radius, 0, Math.PI * 2);
+				ctx.fillStyle = this.color;
+				ctx.fill();
+
+				// Glow effect
+				ctx.shadowBlur = 15;
+				ctx.shadowColor = 'rgba(100, 200, 255, 0.5)';
+			};
+
+			Particle.prototype.update = function () {
+				// Mouse interaction - particles move away from cursor
+				if (mouse.x !== null && mouse.y !== null) {
+					var dx = this.x - mouse.x;
+					var dy = this.y - mouse.y;
+					var dist = Math.sqrt(dx * dx + dy * dy);
+					if (dist < mouse.radius) {
+						var force = (mouse.radius - dist) / mouse.radius;
+						this.vx += (dx / dist) * force * 0.5;
+						this.vy += (dy / dist) * force * 0.5;
+					}
+				}
+
+				// Apply velocity with damping
+				this.vx *= 0.99;
+				this.vy *= 0.99;
+
+				// Ensure minimum movement
+				var speed = Math.sqrt(this.vx * this.vx + this.vy * this.vy);
+				if (speed < 0.2) {
+					this.vx += (Math.random() - 0.5) * 0.1;
+					this.vy += (Math.random() - 0.5) * 0.1;
+				}
+
+				this.x += this.vx;
+				this.y += this.vy;
+
+				// Wrap around edges
+				if (this.x < 0) { this.x = canvas.width; }
+				if (this.x > canvas.width) { this.x = 0; }
+				if (this.y < 0) { this.y = canvas.height; }
+				if (this.y > canvas.height) { this.y = 0; }
+			};
+
+			// Create particles
+			for (var i = 0; i < particleCount; i++) {
+				particles.push(new Particle());
+			}
+
+			// Draw connections between nearby particles
+			function drawConnections() {
+				for (var i = 0; i < particles.length; i++) {
+					for (var j = i + 1; j < particles.length; j++) {
+						var dx = particles[i].x - particles[j].x;
+						var dy = particles[i].y - particles[j].y;
+						var dist = Math.sqrt(dx * dx + dy * dy);
+
+						if (dist < connectionDistance) {
+							var opacity = 1 - (dist / connectionDistance);
+							ctx.beginPath();
+							ctx.moveTo(particles[i].x, particles[i].y);
+							ctx.lineTo(particles[j].x, particles[j].y);
+							ctx.strokeStyle = 'rgba(100, 200, 255, ' + (opacity * 0.4) + ')';
+							ctx.lineWidth = 1;
+							ctx.stroke();
+						}
+					}
+				}
+			}
+
+			// Animation loop
+			function animate() {
+				ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+				// Draw gradient background
+				var gradient = ctx.createRadialGradient(
+					canvas.width / 2, canvas.height / 2, 0,
+					canvas.width / 2, canvas.height / 2, canvas.width * 0.7
+				);
+				gradient.addColorStop(0, '#1a1a2e');
+				gradient.addColorStop(0.5, '#16213e');
+				gradient.addColorStop(1, '#0f0f23');
+				ctx.fillStyle = gradient;
+				ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+				ctx.shadowBlur = 0;
+				drawConnections();
+
+				for (var i = 0; i < particles.length; i++) {
+					particles[i].update();
+					particles[i].draw();
+				}
+
+				requestAnimationFrame(animate);
+			}
+
+			animate();
+		}
+
+		// --- Password strength indicator ---
+
+		$scope.passwordStrength = null;
+
+		$scope.checkPasswordStrength = function () {
+			var pwd = $scope.setup.password;
+			if (!pwd || pwd.length === 0) {
+				$scope.passwordStrength = null;
+				return;
+			}
+			var hasUpper = /[A-Z]/.test(pwd);
+			var hasLower = /[a-z]/.test(pwd);
+			var hasNumber = /[0-9]/.test(pwd);
+			var hasSpecial = /[^A-Za-z0-9]/.test(pwd);
+			var categories = (hasUpper ? 1 : 0) + (hasLower ? 1 : 0) + (hasNumber ? 1 : 0) + (hasSpecial ? 1 : 0);
+
+			if (pwd.length >= 12 && categories >= 3) {
+				$scope.passwordStrength = { level: 'strong', label: 'Strong', percent: 100 };
+			} else if (pwd.length >= 8 && categories >= 2) {
+				$scope.passwordStrength = { level: 'medium', label: 'Medium', percent: 66 };
+			} else {
+				$scope.passwordStrength = { level: 'weak', label: 'Weak', percent: 33 };
+			}
+		};
+
+		// --- Setup form submission ---
+
+		$scope.DoSetup = function () {
+			if ($scope.isSubmitting) { return; }
+			$scope.isSubmitting = true;
+			$scope.errorMessage = '';
+
+			if ($scope.setup.password !== $scope.setup.confirmPassword) {
+				$scope.errorMessage = 'Passwords do not match';
+				$scope.isSubmitting = false;
+				return;
+			}
+
+			if ($scope.setup.password.length < 5) {
+				$scope.errorMessage = 'Password must be at least 5 characters';
+				$scope.isSubmitting = false;
+				return;
+			}
+
+			if ($scope.setup.password.toLowerCase() === 'domoticz') {
+				$scope.errorMessage = 'This password is a known default and cannot be used';
+				$scope.isSubmitting = false;
+				return;
+			}
+
+			var md5Password = md5.createHash($scope.setup.password);
+
+			$http.get('json.htm', {
+				params: {
+					type: 'command',
+					param: 'setupwizardcreateadmin',
+					username: $scope.setup.username,
+					password: md5Password
+				}
+			}).then(function (response) {
+				var data = response.data;
+				if (data.status === 'OK') {
+					window.needsSetup = false;
+					sessionStorage.setItem('setupJustCompleted', 'true');
+					$location.path('/Login');
+				} else {
+					$scope.errorMessage = data.message || 'Failed to create account';
+					$scope.isSubmitting = false;
+				}
+			}, function () {
+				$scope.errorMessage = 'Connection error. Please try again.';
+				$scope.isSubmitting = false;
+			});
+		};
+
+		// --- Initialisation ---
+
+		init();
+
+		function init() {
+			// Load language so translated error messages work
+			$.ajax({
+				url: "json.htm?type=command&param=getlanguages",
+				async: false,
+				dataType: 'json',
+				success: function (data) {
+					if (typeof data.language != 'undefined') {
+						SetLanguage(data.language);
+					} else {
+						SetLanguage('en');
+					}
+				},
+				error: function () {}
+			});
+
+			// Translate input placeholders
+			var $inputs = $('#username, #password, #confirmPassword');
+			$inputs.each(function () {
+				$(this).attr("placeholder", $.t($(this).attr("placeholder")));
+			});
+
+			// Check if setup is actually required — redirect away if not
+			$http.get('json.htm', {
+				params: { type: 'command', param: 'getsetuprequired' }
+			}).then(function (response) {
+				var data = response.data;
+				if (!data.SetupRequired) {
+					$location.path('/Login');
+				}
+			}).catch(function () {
+				// Network error - allow form to render; backend will reject if setup not needed
+				console.warn('Failed to check setup status');
+			});
+
+			initCanvas();
+		}
+	}]);
+});

--- a/www/app/app.js
+++ b/www/app/app.js
@@ -221,13 +221,17 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				},
 				responseError: function (response) {
 					if (response && response.status === 401) {
-						var permissionList = {
-							isloggedin: false,
-							rights: -1,
-							user: ''
-						};
-						permissions.setPermissions(permissionList);
-						$location.path('/Login');
+						if (window.needsSetup) {
+							$location.path('/SetupWizard');
+						} else {
+							var permissionList = {
+								isloggedin: false,
+								rights: -1,
+								user: ''
+							};
+							permissions.setPermissions(permissionList);
+							$location.path('/Login');
+						}
 						return $q.reject(response);
 					}
 					return $q.reject(response);
@@ -564,6 +568,18 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 			}
 		});
 
+		// Check if initial setup is required (no admin user exists)
+		$.ajax({
+			url: 'json.htm?type=command&param=getsetuprequired',
+			async: false,
+			dataType: 'json',
+			success: function (data) {
+				if (data.SetupRequired) {
+					window.needsSetup = true;
+				}
+			}
+		});
+
 		$rootScope.$on("$routeChangeStart", function (scope, next, current) {
 			if (!isOnline) {
 				$location.path('/Offline');
@@ -583,7 +599,13 @@ define(['angularAMD', 'app.routes', 'app.constants', 'app.notifications', 'app.p
 				//	return;
 				//}
 
-				if ((!permissions.isAuthenticated()) && (next.templateUrl != "views/login.html")) {
+				// If setup wizard is needed, redirect there instead of login
+				if (window.needsSetup && next.templateUrl !== "views/setup-wizard.html") {
+					$location.path('/SetupWizard');
+					return;
+				}
+
+				if ((!permissions.isAuthenticated()) && (next.templateUrl != "views/login.html") && (next.templateUrl !== "views/setup-wizard.html")) {
 					$location.path('/Login');
 					//$window.location = '/#Login';
 					//$window.location.reload();

--- a/www/app/app.routes.js
+++ b/www/app/app.routes.js
@@ -128,6 +128,11 @@ define(['angularAMD', 'angular', 'angular-route'], function (angularAMD) {
                 templateUrl: 'views/login.html',
                 controller: 'LoginController'
             }))
+            .when('/SetupWizard', angularAMD.route({
+                templateUrl: 'views/setup-wizard.html',
+                controller: 'SetupWizardController',
+                controllerUrl: 'app/SetupWizardController.js'
+            }))
             .when('/Logout', angularAMD.route({
                 templateUrl: 'views/logout.html',
                 controller: 'LogoutController'

--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -1,0 +1,3 @@
+{
+	"Consider enabling 2FA or passkeys for your admin account in User Settings": "Consider enabling 2FA or passkeys for your admin account in User Settings"
+}

--- a/www/views/setup-wizard.html
+++ b/www/views/setup-wizard.html
@@ -1,0 +1,138 @@
+<style>
+	#canvas-login {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		z-index: -1;
+	}
+	body, #foreground, #midground {
+		background: none;
+	}
+
+	/* Setup wizard styles (shared glass styles are in css/style.css) */
+	.login-title {
+		font-size: 2em;
+		font-weight: 300;
+		color: #fff;
+		text-shadow: 0 0 30px rgba(100, 200, 255, 0.5);
+		margin-bottom: 6px;
+		letter-spacing: 3px;
+	}
+
+	.login-logo {
+		width: 57px;
+		height: 57px;
+		margin-bottom: 10px;
+	}
+
+	.setup-subtitle {
+		color: rgba(255, 255, 255, 0.65);
+		font-size: 0.9em;
+		margin-bottom: 20px;
+		line-height: 1.5;
+	}
+
+	.password-strength-bar {
+		height: 4px;
+		border-radius: 2px;
+		background: rgba(255, 255, 255, 0.1);
+		margin: -4px 0 12px 0;
+		overflow: hidden;
+	}
+
+	.password-strength-fill {
+		height: 100%;
+		border-radius: 2px;
+		transition: width 0.3s ease, background 0.3s ease;
+	}
+
+	.password-strength-fill.strength-weak {
+		background: rgba(255, 80, 80, 0.8);
+	}
+
+	.password-strength-fill.strength-medium {
+		background: rgba(255, 200, 50, 0.8);
+	}
+
+	.password-strength-fill.strength-strong {
+		background: rgba(80, 220, 100, 0.8);
+	}
+
+	.password-strength-label {
+		font-size: 0.8em;
+		margin: -8px 0 12px 0;
+		text-align: right;
+	}
+
+	.password-strength-label.strength-weak { color: rgba(255, 80, 80, 0.8); }
+	.password-strength-label.strength-medium { color: rgba(255, 200, 50, 0.8); }
+	.password-strength-label.strength-strong { color: rgba(80, 220, 100, 0.8); }
+
+	.setup-error {
+		color: rgba(255, 100, 100, 0.9);
+		background: rgba(255, 50, 50, 0.1);
+		border: 1px solid rgba(255, 100, 100, 0.3);
+		border-radius: 10px;
+		padding: 10px 14px;
+		margin-bottom: 12px;
+		font-size: 0.9em;
+	}
+
+	.domoticz-link {
+		display: block;
+		text-align: center;
+		margin-top: 16px;
+		color: rgba(100, 200, 255, 0.6);
+		font-size: 0.85em;
+		text-decoration: none;
+	}
+
+	.domoticz-link:hover {
+		color: rgba(100, 200, 255, 0.9);
+	}
+</style>
+
+<canvas id="canvas-login"></canvas>
+
+<div class="glass-container">
+	<center>
+		<div class="glass-card" style="max-width: 380px;">
+			<img class="login-logo" src="images/logo/57.png" alt="Domoticz">
+			<h1 class="login-title">Domoticz</h1>
+			<p class="setup-subtitle">Create your admin account to get started</p>
+
+			<form name="setupForm" ng-submit="DoSetup()" novalidate>
+				<input type="text" id="username" name="username" class="glass-input"
+				       autocapitalize="none" autocorrect="off"
+				       placeholder="Username" ng-model="setup.username" required autofocus>
+				<input type="password" id="password" name="password" class="glass-input"
+				       placeholder="Password" ng-model="setup.password" ng-change="checkPasswordStrength()" required>
+				<div ng-show="passwordStrength">
+					<div class="password-strength-bar">
+						<div class="password-strength-fill" ng-class="'strength-' + passwordStrength.level"
+						     ng-style="{'width': passwordStrength.percent + '%'}"></div>
+					</div>
+					<div class="password-strength-label" ng-class="'strength-' + passwordStrength.level">
+						{{ passwordStrength.label }}
+					</div>
+				</div>
+				<input type="password" id="confirmPassword" name="confirmPassword" class="glass-input"
+				       placeholder="Confirm Password" ng-model="setup.confirmPassword" required>
+
+				<div class="setup-error" ng-show="errorMessage">
+					{{ errorMessage }}
+				</div>
+
+				<button type="submit" class="btn-modern" style="width: 100%; padding: 12px;"
+				        ng-disabled="setupForm.$invalid || setup.password !== setup.confirmPassword || isSubmitting">
+					<span ng-if="!isSubmitting">Create Account</span>
+					<span ng-if="isSubmitting">Creating...</span>
+				</button>
+			</form>
+
+			<a class="domoticz-link" href="http://www.domoticz.com">www.domoticz.com</a>
+		</div>
+	</center>
+</div>


### PR DESCRIPTION
## Summary

Replaces the hardcoded `admin/domoticz` default account with a first-run setup wizard, addressing #6601 and improving security for all new installations.

- **Setup Wizard**: On first run (no admin user exists), all routes redirect to a setup wizard page where the user creates their admin account. The wizard uses the same glassmorphism design as the login screen.
- **Password Safety**: Minimum 5-character password, blocks "domoticz" as a known default, includes a real-time strength indicator (weak/medium/strong).
- **Docker Support**: `DOMOTICZ_ADMIN_PASSWORD` and optional `DOMOTICZ_ADMIN_USERNAME` environment variables for automated/headless deployments. Env vars only apply on first run; ignored if an admin already exists.
- **Security Hardening**: Setup API endpoint protected with mutex against race conditions, `%q` SQL format specifier to prevent injection, username length validation, and security logging for blocked attempts.
- **Post-Setup Notification**: One-time toast notification after initial setup recommending 2FA or passkey configuration.
- **DB Fix**: Includes the fix for missing `Passkeys` column on fresh installs (#6601), bumps DB version to 175.

## Files Changed

### Backend (C++)
- `main/SQLHelper.cpp` — Remove default admin INSERT, add Docker env var provisioning, DB v175 migration
- `main/WebServer.cpp` — Register new public API commands
- `main/WebServer.h` — Declare new command handlers
- `main/WebServerCmds.cpp` — `Cmd_GetSetupRequired` and `Cmd_SetupWizardCreateAdmin` endpoints

### Frontend (AngularJS)
- `www/views/setup-wizard.html` — New setup wizard page (glassmorphism design)
- `www/app/SetupWizardController.js` — New controller with canvas animation, password strength, form validation
- `www/app/app.routes.js` — `/SetupWizard` route
- `www/app/app.js` — Setup-required check and route redirect logic
- `www/app/LoginController.js` — One-time security recommendation notification

### Docs
- `README.md` — Updated to reflect new setup flow
- `History.txt` — Added changelog entries

## Test plan

- [ ] Fresh install without env vars: setup wizard appears, can create admin, redirects to login
- [ ] Fresh install with `DOMOTICZ_ADMIN_PASSWORD`: admin created automatically, no wizard shown
- [ ] Existing install upgrade: no behavior change, login works as before
- [ ] Password validation: rejects empty, < 5 chars, "domoticz"; strength indicator updates live
- [ ] Double-submit protection: button disabled and shows "Creating..." during submission
- [ ] Setup endpoint blocked after admin exists (returns error + logs warning)
- [ ] Docker restart with env vars after setup: logs "already exists" message, no duplicate user
- [ ] Security notification appears once after initial setup login, not on subsequent logins