### PR TITLE
Fix Philips Hue Add Hardware not sending poll interval

### DIFF
--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -86,7 +86,7 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 	if (m_poll_interval < 5)
 	{
 		m_poll_interval = HUE_DEFAULT_POLL_INTERVAL;
-		Log(LOG_STATUS, "Poll interval to short. Using default interval of %d seconds.", m_poll_interval);
+		Log(LOG_STATUS, "Poll interval too short. Using default interval of %d seconds.", m_poll_interval);
 	}
 	else
 	{

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -2449,13 +2449,20 @@ define(['app'], function (app) {
 					ShowNotify($.t('Please enter a username!'), 2500, true);
 					return;
 				}
+				var pollinterval = $("#hardwarecontent #hardwareparamsphilipshue #pollinterval").val();
+				if (pollinterval == "") {
+					ShowNotify($.t('Please enter poll interval!'), 2500, true);
+					return;
+				}
+				Mode1 = pollinterval;
 				$.ajax({
 					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
 					"&address=" + address +
 					"&port=" + port +
 					"&username=" + encodeURIComponent(username) +
-					"&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout,
+					"&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout +
+					"&Mode1=" + Mode1,
 					async: false,
 					dataType: 'json',
 					success: function (data) {


### PR DESCRIPTION
## Problem

When adding a new Philips Hue Bridge hardware via the UI, the poll interval value entered by the user was silently discarded. The `Mode1` (poll interval) parameter was not included in the `addhardware` AJAX request, causing the backend to always receive `0`.

This triggered a spurious warning on every fresh add:
```
Poll interval to short. Using default interval of 10 seconds.
```

The **Update** (edit) handler already sent `Mode1` correctly, so editing and saving the hardware afterward would fix the stored value — but the initial add was broken.

## Fix

- **`www/app/hardware/Hardware.js`**: Add `Mode1` (poll interval) to the Philips Hue `addhardware` AJAX request, matching the existing `updatehardware` handler.
- **`hardware/PhilipsHue/PhilipsHue.cpp`**: Fix typo in warning message ("to short" → "too short").

## Testing

1. Add a new Philips Hue Bridge hardware with poll interval set to 10
2. Log now shows `Using poll interval of 10 seconds.` instead of the spurious warning
3. Update (edit) flow still works as before