### PR TITLE
fix: SIGHUP log rotation broken under systemd (#6605)

### DIFF
--- a/domoticz.logrotate
+++ b/domoticz.logrotate
@@ -1,0 +1,11 @@
+/home/*/domoticz/domoticz.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    postrotate
+        systemctl reload domoticz > /dev/null 2>&1 || true
+    endscript
+}

--- a/main/SignalHandler.cpp
+++ b/main/SignalHandler.cpp
@@ -404,8 +404,9 @@ void signal_handler(int sig_num
 	{
 #ifndef WIN32
 	case SIGHUP:
-		if (!logfile.empty())
-			_log.SetOutputFile(logfile.c_str());
+		// Only set atomic flag - defer actual log reopen to main thread
+		// SetOutputFile() uses mutex and C++ streams, not async-signal-safe
+		g_bReopenLogFile.store(true, std::memory_order_release);
 		break;
 #endif
 	case SIGINT:
@@ -524,6 +525,7 @@ static void heartbeat_check()
 }
 
 bool g_stop_watchdog = false;
+std::atomic<bool> g_bReopenLogFile{false};
 
 void Do_Watchdog_Work()
 {

--- a/main/SignalHandler.h
+++ b/main/SignalHandler.h
@@ -1,6 +1,8 @@
 #pragma once
+#include <atomic>
 
 extern bool g_stop_watchdog;
+extern std::atomic<bool> g_bReopenLogFile;
 
 void signal_handler(int sig_num
 #ifndef WIN32

--- a/main/domoticz.cpp
+++ b/main/domoticz.cpp
@@ -1215,6 +1215,7 @@ int main(int argc, char**argv)
 		sigaction(SIGILL, &newSigAction, nullptr);  // catch invalid program image
 		sigaction(SIGFPE, &newSigAction, nullptr);  // catch floating point error
 		sigaction(SIGUSR1, &newSigAction, nullptr); // catch SIGUSR1 (used by watchdog)
+		sigaction(SIGHUP, &newSigAction, nullptr);  // catch HUP, for log rotation
 #else
 		signal(SIGINT, signal_handler);
 		signal(SIGTERM, signal_handler);
@@ -1260,6 +1261,13 @@ int main(int argc, char**argv)
 	{
 		sleep_seconds(1);
 		m_LastHeartbeat = mytime(nullptr);
+
+		// Deferred SIGHUP processing: reopen log file in safe thread context
+		if (g_bReopenLogFile.exchange(false, std::memory_order_acq_rel))
+		{
+			if (!logfile.empty())
+				_log.SetOutputFile(logfile.c_str());
+		}
 	}
 #endif
 	_log.Log(LOG_STATUS, "Closing application!...");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -563,6 +563,7 @@ Group=${Current_user}
 WorkingDirectory=${Dest_folder}
 ExecStart=${Dest_folder}/domoticz -www ${http_port} -sslwww ${https_port}
 ExecReload=/bin/kill -HUP \$MAINPID
+AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
 Restart=on-failure
 RestartSec=5
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -562,6 +562,7 @@ User=${Current_user}
 Group=${Current_user}
 WorkingDirectory=${Dest_folder}
 ExecStart=${Dest_folder}/domoticz -www ${http_port} -sslwww ${https_port}
+ExecReload=/bin/kill -HUP \$MAINPID
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

- Register SIGHUP signal handler in non-daemon mode (systemd) so `kill -HUP` no longer terminates the process
- Make SIGHUP handler async-signal-safe using an atomic flag with deferred processing in the main loop, preventing deadlocks from calling `SetOutputFile()` (mutex + C++ streams) in signal context
- Add `ExecReload=/bin/kill -HUP $MAINPID` to the install script's generated systemd service so `systemctl reload domoticz` works
- Add `AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW` so the System Alive Checker (Pinger) can send ICMP packets when running as non-root

## Root Cause

### SIGHUP / log rotation (#6605)

Three bugs combined:

1. **`main/domoticz.cpp`**: SIGHUP was only registered in `daemonize()` (daemon mode). The non-daemon signal setup block was missing it, so the default SIGHUP disposition (terminate) applied under systemd.

2. **`main/SignalHandler.cpp`**: The SIGHUP handler called `_log.SetOutputFile()` directly from signal context, which acquires a mutex and uses C++ streams — neither is async-signal-safe. This could cause deadlocks on systems where the interrupted thread holds glibc's malloc lock (related to #6522).

3. **`scripts/install.sh`**: The generated systemd service file had no `ExecReload` directive, making `systemctl reload domoticz` a no-op.

### System Alive Checker broken (#6607)

PR #6537 replaced the SysV init script with a systemd service but only granted `CAP_NET_BIND_SERVICE` (for privileged ports). The Pinger hardware plugin uses ICMP raw sockets which require `CAP_NET_RAW`. Without this capability, pings silently fail and all devices stay "Off".

## Changes

| File | Change |
|------|--------|
| `main/domoticz.cpp` | Add `sigaction(SIGHUP, ...)` in non-daemon mode; add deferred log reopen in main loop |
| `main/SignalHandler.h` | Declare `extern std::atomic<bool> g_bReopenLogFile` |
| `main/SignalHandler.cpp` | SIGHUP handler sets atomic flag instead of calling SetOutputFile(); define the flag |
| `scripts/install.sh` | Add `ExecReload=/bin/kill -HUP $MAINPID` and `AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW` to generated systemd service |

## Test plan

- [ ] Build succeeds on Linux (x86_64)
- [ ] Start Domoticz without `-daemon` flag, send `kill -HUP <pid>`, verify process stays running
- [ ] Start with `-log /tmp/test.log`, rotate the file, send SIGHUP, verify new log file is created
- [ ] Send 10 rapid SIGHUPs — no deadlock or crash
- [ ] SIGHUP with no `-log` flag is a harmless no-op
- [ ] Verify install script generates service file with `ExecReload` and `AmbientCapabilities` lines
- [ ] `systemctl reload domoticz` keeps same PID (no restart)
- [ ] System Alive Checker (Pinger) works as non-root user under systemd
- [ ] Daemon mode (`-daemon`) still works (regression test)

Closes #6605
Closes #6607