### PR TITLE
fix: update scripts wait for process exit before restart

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -71,6 +71,7 @@ Version 2026.xxxx
 - Fixed: Scene triggering delay caused by event system thread pool saturation
 - Fixed: SolarEdge API, power readings persisting stale values when idle
 - Fixed: Temperature Compare Chart (Min/Max values)
+- Fixed: Web update not restarting properly when Python plugins are active (#6602)
 - Fixed: WOL, Corrected magic packet creation and supporting IPv6 broadcast
 - Changed: Domoticz Remote, Do not force re-enable RemoteSharedPort on startup
 - Changed: Enphase, default to new firmware info request

--- a/updatebeta
+++ b/updatebeta
@@ -11,6 +11,7 @@ readonly MAX_BACKUPS=5
 readonly DOWNLOAD_URL="https://www.domoticz.com/download.php"
 readonly ARCHIVE_NAME="domoticz_update.tgz"
 readonly CHANNEL_KEYWORD="beta"
+readonly STOP_TIMEOUT=60
 
 # List of required packages (can be extended as needed)
 readonly REQUIRED_PACKAGES=(
@@ -186,14 +187,6 @@ create_backup() {
     log_info "Backup complete."
 }
 
-# Stop Domoticz service
-stop_service() {
-    log_info "Stopping Domoticz service..."
-    if ! sudo service domoticz.sh stop; then
-        log_warn "Failed to stop service (may not be running)"
-    fi
-}
-
 # Check if Domoticz service is running
 is_service_running() {
     # Check if domoticz process is running
@@ -212,6 +205,35 @@ is_service_running() {
         fi
     fi
     return 1
+}
+
+# Stop Domoticz service
+stop_service() {
+    log_info "Stopping Domoticz service..."
+    if ! sudo service domoticz.sh stop; then
+        log_warn "Failed to stop service (may not be running)"
+    fi
+
+    # Wait for process to actually exit (up to STOP_TIMEOUT seconds)
+    local wait_count=0
+    while is_service_running; do
+        if [[ $wait_count -ge $STOP_TIMEOUT ]]; then
+            log_warn "Domoticz process still running after ${STOP_TIMEOUT}s, force killing..."
+            sudo killall -9 domoticz 2>/dev/null || true
+            sleep 2
+            if is_service_running; then
+                log_warn "Domoticz process still running after force kill - continuing with update anyway"
+            fi
+            break
+        fi
+        if [[ $((wait_count % 10)) -eq 0 ]] && [[ $wait_count -gt 0 ]]; then
+            log_info "Still waiting for Domoticz to stop... (${wait_count}s)"
+        fi
+        sleep 1
+        ((wait_count++))
+    done
+
+    log_info "Domoticz process stopped."
 }
 
 # Start Domoticz service
@@ -276,7 +298,7 @@ main() {
     
     # Stop service
     stop_service
-    
+
     # Create backup unless skipped
     if [[ "$skip_backup" == false ]]; then
         create_backup

--- a/updaterelease
+++ b/updaterelease
@@ -11,6 +11,7 @@ readonly MAX_BACKUPS=5
 readonly DOWNLOAD_URL="https://www.domoticz.com/download.php"
 readonly ARCHIVE_NAME="domoticz_update.tgz"
 readonly CHANNEL_KEYWORD="release"
+readonly STOP_TIMEOUT=60
 
 # List of required packages (can be extended as needed)
 readonly REQUIRED_PACKAGES=(
@@ -186,14 +187,6 @@ create_backup() {
     log_info "Backup complete."
 }
 
-# Stop Domoticz service
-stop_service() {
-    log_info "Stopping Domoticz service..."
-    if ! sudo service domoticz.sh stop; then
-        log_warn "Failed to stop service (may not be running)"
-    fi
-}
-
 # Check if Domoticz service is running
 is_service_running() {
     # Check if domoticz process is running
@@ -212,6 +205,35 @@ is_service_running() {
         fi
     fi
     return 1
+}
+
+# Stop Domoticz service
+stop_service() {
+    log_info "Stopping Domoticz service..."
+    if ! sudo service domoticz.sh stop; then
+        log_warn "Failed to stop service (may not be running)"
+    fi
+
+    # Wait for process to actually exit (up to STOP_TIMEOUT seconds)
+    local wait_count=0
+    while is_service_running; do
+        if [[ $wait_count -ge $STOP_TIMEOUT ]]; then
+            log_warn "Domoticz process still running after ${STOP_TIMEOUT}s, force killing..."
+            sudo killall -9 domoticz 2>/dev/null || true
+            sleep 2
+            if is_service_running; then
+                log_warn "Domoticz process still running after force kill - continuing with update anyway"
+            fi
+            break
+        fi
+        if [[ $((wait_count % 10)) -eq 0 ]] && [[ $wait_count -gt 0 ]]; then
+            log_info "Still waiting for Domoticz to stop... (${wait_count}s)"
+        fi
+        sleep 1
+        ((wait_count++))
+    done
+
+    log_info "Domoticz process stopped."
 }
 
 # Start Domoticz service
@@ -276,7 +298,7 @@ main() {
     
     # Stop service
     stop_service
-    
+
     # Create backup unless skipped
     if [[ "$skip_backup" == false ]]; then
         create_backup

--- a/www/app/UpdateController.js
+++ b/www/app/UpdateController.js
@@ -9,6 +9,7 @@ define(['app'], function (app) {
 		$scope.statusText = "";
 		$scope.outputLines = [];  // Store last 10 lines of output
 		$scope.showOutput = false;  // Toggle output box visibility
+		$scope.updateElapsed = 0;
 
 		$scope.ProgressData = {
 			label: 0,
@@ -116,15 +117,21 @@ define(['app'], function (app) {
 						$scope.serviceRestarting = true;
 						$scope.showOutput = false;
 						$scope.statusText = $.t("Service is restarting, please wait...");
+						$scope.topText = $.t("Service is restarting, please wait...");
 					}
 				}
 			);
 		};
 
 		$scope.progressupdatesystem = function () {
-			var val = $scope.ProgressData.label;
-			$scope.ProgressData.label = val + 1;
-			if ((val == 100)||($scope.updateReady)) {
+			$scope.updateElapsed = ($scope.updateElapsed || 0) + 1;
+			if ($scope.ProgressData.label < 100) {
+				$scope.ProgressData.label = $scope.ProgressData.label + 1;
+				if ($scope.ProgressData.label == 100 && !$scope.updateReady) {
+					$scope.topText = $.t("Waiting for service to restart, please wait...");
+				}
+			}
+			if (($scope.updateElapsed == 300)||($scope.updateReady)) {
 				if (typeof $scope.mytimer != 'undefined') {
 					$interval.cancel($scope.mytimer);
 					$scope.mytimer = undefined;

--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -1,3 +1,5 @@
 {
-	"Consider enabling 2FA or passkeys for your admin account in User Settings": "Consider enabling 2FA or passkeys for your admin account in User Settings"
+	"Consider enabling 2FA or passkeys for your admin account in User Settings": "Consider enabling 2FA or passkeys for your admin account in User Settings",
+	"Service is restarting, please wait...": "Service is restarting, please wait...",
+	"Waiting for service to restart, please wait...": "Waiting for service to restart, please wait..."
 }


### PR DESCRIPTION
## Summary

Fixes #6602 — After a web-initiated update, Domoticz doesn't come back online when Python plugins (e.g., Zigbee4Domoticz) are active. The root cause is `stop_service()` in the update scripts not waiting for the process to actually exit before starting the new service.

- **Update scripts** (`updatebeta`/`updaterelease`): `stop_service()` now polls `is_service_running()` for up to 60 seconds, with `killall -9` as a last resort. Progress logged every 10 seconds so the frontend shows activity.
- **Frontend** (`UpdateController.js`): Timeout extended from 100s to 300s using a separate elapsed counter (progress bar still fills 0-100%). Shows "Waiting for service to restart" at 100% and "Service is restarting" when HTTP requests fail during the restart phase.
- **Translations**: Two new strings added to `to_be_translated.json`.

## Test plan

- [ ] Trigger web update with a Python plugin (e.g., Zigbee4Domoticz) active
- [ ] Verify update script waits for process to exit (check `update.log` for "Still waiting" messages)
- [ ] Verify frontend shows "Waiting for service to restart" when progress bar reaches 100%
- [ ] Verify frontend shows "Service is restarting" during HTTP connection failures
- [ ] Verify dashboard loads automatically after successful update
- [ ] Verify error message appears correctly if update actually fails