### PR TITLE
feat: implement Teleinfo 1200/19200 async mode for RFXCOM (Fixes #6495)

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,6 @@
 Version 2026.xxxx
 - Added: Alexa Smart Home v3 API endpoint (see ALEXA.md)
+- Added: RFXCOM, Teleinfo 1200/19200 async mode support (Fixes #6495)
 - Added: Blinds + Stop type
 - Added: Comparing charts, show average across years in tooltip for month/quarter grouping
 - Added: Configurable pricing resolution (15/30/60 minutes) for dynamic energy contracts (with adapted P1 and kWh graphs)

--- a/hardware/RFXBase.cpp
+++ b/hardware/RFXBase.cpp
@@ -5,6 +5,18 @@
 #include "../main/Logger.h"
 #include "../main/RFXtrx.h"
 
+CRFXTeleinfoHelper::CRFXTeleinfoHelper()
+{
+	InitTeleinfo();
+	m_iRateLimit = 2;
+	m_bDisableCRC = false;
+}
+
+void CRFXTeleinfoHelper::SetHwdID(int HwdID)
+{
+	m_HwdID = HwdID;
+}
+
 CRFXBase::CRFXBase()
 {
 	m_NoiseLevel = 0;
@@ -177,6 +189,8 @@ void CRFXBase::SetAsyncType(_eRFXAsyncType const AsyncType)
 {
 	m_AsyncType = AsyncType;
 	Set_Async_Parameters(m_AsyncType);
+	if (AsyncType == ATYPE_TELEINFO_1200 || AsyncType == ATYPE_TELEINFO_19200)
+		m_teleinfoHelper.SetHwdID(m_HwdID);
 }
 
 void CRFXBase::Set_Async_Parameters(const _eRFXAsyncType AsyncType)
@@ -213,22 +227,23 @@ void CRFXBase::Set_Async_Parameters(const _eRFXAsyncType AsyncType)
 		cmnd = asyncreceiveP1;
 		Log(LOG_STATUS, "Async mode set to: 'DSMR 4/5'");
 		break;
-	case ATYPE_TELEINFO_1200://not handled yet!
+	case ATYPE_TELEINFO_1200:
 		baudrate = asyncbaud1200;
 		parity = asyncParityEven;
 		databits = asyncDatabits7;
 		stopbits = asyncStopbits1;
 		polarity = asyncPolarityInvers;
 		cmnd = asyncreceiveTeleinfo;
-		Log(LOG_STATUS, "Async mode set to: 'Teleinfo 1200' (not implemented yet!)");
+		Log(LOG_STATUS, "Async mode set to: 'Teleinfo 1200'");
 		break;
-	case ATYPE_TELEINFO_19200://not handled yet!
+	case ATYPE_TELEINFO_19200:
 		baudrate = asyncbaud19200;
 		parity = asyncParityEven;
 		databits = asyncDatabits7;
 		stopbits = asyncStopbits1;
 		polarity = asyncPolarityInvers;
-		Log(LOG_STATUS, "Async mode set to: 'Teleinfo 19200' (not implemented yet!)");
+		cmnd = asyncreceiveTeleinfo;
+		Log(LOG_STATUS, "Async mode set to: 'Teleinfo 19200'");
 		break;
 	case ATYPE_DISABLED:
 		Log(LOG_STATUS, "Async Disabled");
@@ -259,8 +274,14 @@ void CRFXBase::Parse_Async_Data(const uint8_t *pData, const int Len)
 	case ATYPE_P1_DSMR_3:
 	case ATYPE_P1_DSMR_4:
 	case ATYPE_P1_DSMR_5:
-	default:
 		ParseP1Data(pData, Len, false, 0);
+		break;
+	case ATYPE_TELEINFO_1200:
+	case ATYPE_TELEINFO_19200:
+		m_teleinfoHelper.ProcessData(reinterpret_cast<const char*>(pData), Len);
+		break;
+	default:
+		Log(LOG_ERROR, "Parse_Async_Data: unknown async type %d", m_AsyncType);
 		break;
 	}
 }

--- a/hardware/RFXBase.h
+++ b/hardware/RFXBase.h
@@ -3,8 +3,22 @@
 #include "ASyncSerial.h"
 #include "DomoticzHardware.h"
 #include "P1MeterBase.h"
+#include "TeleinfoBase.h"
 
 #define RX_BUFFER_SIZE 512
+
+// Lightweight helper that provides Teleinfo parsing for CRFXBase via composition
+class CRFXTeleinfoHelper : public CTeleinfoBase
+{
+public:
+	CRFXTeleinfoHelper();
+	~CRFXTeleinfoHelper() override = default;
+	void SetHwdID(int HwdID);
+	void ProcessData(const char* pData, int Len) { ParseTeleinfoData(pData, Len); }
+	bool StartHardware() override { return true; }
+	bool StopHardware() override { return true; }
+	bool WriteToHardware(const char* /*pdata*/, unsigned char /*length*/) override { return true; }
+};
 
 class CRFXBase : public P1MeterBase
 {
@@ -44,6 +58,7 @@ class CRFXBase : public P1MeterBase
 	std::mutex readQueueMutex;
 	unsigned char m_rxbuffer[RX_BUFFER_SIZE] = { 0 };
 	uint16_t m_rxbufferpos = { 0 };
+	CRFXTeleinfoHelper m_teleinfoHelper;
 
       private:
 	static bool CheckValidRFXData(const uint8_t *pData);


### PR DESCRIPTION
Add Teleinfo protocol parsing support to the RFXCOM async serial interface using a composition-based CTeleinfoBase delegate to avoid diamond inheritance. Fix missing cmnd assignment for Teleinfo 19200 mode and remove dangerous default fall-through in Parse_Async_Data that silently misrouted unknown async types to the P1 parser.