### PR TITLE
feat: add Angular Current sensor log for pTypeCURRENT 3-phase devices…

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,5 +1,6 @@
 Version 2026.xxxx
 - Added: Alexa Smart Home v3 API endpoint (see ALEXA.md)
+- Added: Angular Current sensor log with 3-phase support and compare chart (Fixes #6560)
 - Added: RFXCOM, Teleinfo 1200/19200 async mode support (Fixes #6495)
 - Added: Blinds + Stop type
 - Added: Comparing charts, show average across years in tooltip for month/quarter grouping

--- a/main/WebServerHandleGraph.cpp
+++ b/main/WebServerHandleGraph.cpp
@@ -3149,6 +3149,13 @@ namespace http
 					}
 					else if (dType == pTypeCURRENT)
 					{
+						if (!sgroupby.empty())
+						{
+							root["status"] = "OK";
+							root["title"] = "Comparing " + sensor;
+							MakeCompareDataSensor(root, sgroupby, dbasetable, idx, "(Value2+Value4+Value6)/3", 10.0);
+							return;
+						}
 						result = m_sql.safe_query("SELECT Value1,Value2,Value3,Value4,Value5,Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64
 							" AND Date>='%q' AND Date<='%q') ORDER BY Date ASC",
 							dbasetable.c_str(), idx, szDateStart, szDateEnd);

--- a/www/app/devices/deviceFactory.js
+++ b/www/app/devices/deviceFactory.js
@@ -165,6 +165,8 @@ define(function () {
                     return '%';
                 } else if (this.Type === 'Weight') {
                     return this.SwitchTypeVal === 0 ? 'kg' : 'lbs';
+                } else if (this.Type === 'Current') {
+                    return 'A';
                 } else if (this.Type === 'Rain') {
                     return 'mm';
                 } else if (this.Direction !== undefined && /Wind/i.test(this.Type)) {

--- a/www/app/log/CurrentLog.html
+++ b/www/app/log/CurrentLog.html
@@ -1,0 +1,19 @@
+<current-short-chart
+        class="device-log-chart"
+        device="::$ctrl.device"></current-short-chart>
+<br/>
+<current-long-chart
+        class="device-log-chart"
+        device="::$ctrl.device"
+        range="month"></current-long-chart>
+<br/>
+<current-long-chart
+        class="device-log-chart"
+        device="::$ctrl.device"
+        range="year"></current-long-chart>
+<br/>
+<current-compare-chart
+        class="device-log-chart"
+        device="::$ctrl.device"
+        range="compare">
+</current-compare-chart>

--- a/www/app/log/CurrentLog.js
+++ b/www/app/log/CurrentLog.js
@@ -1,0 +1,306 @@
+define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Chart'],
+	function (app, _, RefreshingChart, DataLoader, ChartLoader) {
+
+		app.component('deviceCurrentLog', {
+			bindings: {
+				device: '<'
+			},
+			templateUrl: 'app/log/CurrentLog.html',
+			controllerAs: '$ctrl',
+			controller: function () {
+				const $ctrl = this;
+				$ctrl.autoRefresh = true;
+			}
+		});
+
+		app.component('currentShortChart', {
+			require: {
+				logCtrl: '^deviceCurrentLog'
+			},
+			bindings: {
+				device: '<'
+			},
+			templateUrl: 'app/log/chart-day.html',
+			controllerAs: 'vm',
+			controller: function ($location, $route, $scope, $timeout, $element, domoticzGlobals, domoticzApi, domoticzDataPointApi, chart) {
+				const self = this;
+				self.range = 'day';
+
+				self.$onInit = function () {
+					var shortSeriesDefinitions = [
+						{
+							id: 'v1',
+							phase: 'L1',
+							valueKeySuffix: '',
+							template: {
+								name: 'L1',
+								color: 'rgba(3,190,252,0.8)'
+							}
+						},
+						{
+							id: 'v2',
+							phase: 'L2',
+							valueKeySuffix: '',
+							template: {
+								name: 'L2',
+								color: 'rgba(252,190,3,0.8)'
+							}
+						},
+						{
+							id: 'v3',
+							phase: 'L3',
+							valueKeySuffix: '',
+							template: {
+								name: 'L3',
+								color: 'rgba(190,252,3,0.8)'
+							}
+						}
+					];
+
+					new RefreshingChart(
+						chart.baseParams($),
+						chart.angularParams($location, $route, $scope, $timeout, $element),
+						chart.domoticzParams(domoticzGlobals, domoticzApi, domoticzDataPointApi),
+						chartParams(
+							domoticzGlobals,
+							self,
+							true,
+							function (dataItem, yearOffset = 0) {
+								return GetLocalDateTimeFromString(dataItem.d, yearOffset);
+							},
+							function (data) {
+								return shortSeriesDefinitions
+									.filter(function (s) {
+										if (s.phase === 'L1') { return data.haveL1 !== false; }
+										if (s.phase === 'L2') { return data.haveL2 !== false; }
+										if (s.phase === 'L3') { return data.haveL3 !== false; }
+										return true;
+									})
+									.map(function (seriesSupplier) {
+										return _.merge(
+											{
+												dataItemKeys: [seriesSupplier.id]
+											},
+											seriesSupplier
+										);
+									});
+							}
+						)
+					);
+				}
+			}
+		});
+
+		app.component('currentLongChart', {
+			require: {
+				logCtrl: '^deviceCurrentLog'
+			},
+			bindings: {
+				device: '<',
+				range: '@'
+			},
+			templateUrl: function($element, $attrs) { return 'app/log/chart-' + $attrs.range + '.html'; },
+			controllerAs: 'vm',
+			controller: function ($location, $route, $scope, $timeout, $element, domoticzGlobals, domoticzApi, domoticzDataPointApi, chart) {
+				const self = this;
+
+				self.$onInit = function () {
+					var longSeriesDefinitions = [
+						{
+							id: 'v1',
+							phase: 'L1',
+							valueKeySuffix: '',
+							template: {
+								name: 'L1_Min',
+								color: 'rgba(3,190,252,0.8)'
+							}
+						},
+						{
+							id: 'v2',
+							phase: 'L1',
+							valueKeySuffix: '',
+							template: {
+								name: 'L1_Max',
+								color: 'rgba(3,252,190,0.8)'
+							}
+						},
+						{
+							id: 'v3',
+							phase: 'L2',
+							valueKeySuffix: '',
+							template: {
+								name: 'L2_Min',
+								color: 'rgba(252,190,3,0.8)'
+							}
+						},
+						{
+							id: 'v4',
+							phase: 'L2',
+							valueKeySuffix: '',
+							template: {
+								name: 'L2_Max',
+								color: 'rgba(252,3,190,0.8)'
+							}
+						},
+						{
+							id: 'v5',
+							phase: 'L3',
+							valueKeySuffix: '',
+							template: {
+								name: 'L3_Min',
+								color: 'rgba(190,252,3,0.8)'
+							}
+						},
+						{
+							id: 'v6',
+							phase: 'L3',
+							valueKeySuffix: '',
+							template: {
+								name: 'L3_Max',
+								color: 'rgba(3,252,3,0.8)'
+							}
+						}
+					];
+
+					new RefreshingChart(
+						chart.baseParams($),
+						chart.angularParams($location, $route, $scope, $timeout, $element),
+						chart.domoticzParams(domoticzGlobals, domoticzApi, domoticzDataPointApi),
+						chartParams(
+							domoticzGlobals,
+							self,
+							false,
+							function (dataItem, yearOffset = 0) {
+								return GetLocalDateFromString(dataItem.d, yearOffset);
+							},
+							function (data) {
+								return longSeriesDefinitions
+									.filter(function (s) {
+										if (s.phase === 'L1') { return data.haveL1 !== false; }
+										if (s.phase === 'L2') { return data.haveL2 !== false; }
+										if (s.phase === 'L3') { return data.haveL3 !== false; }
+										return true;
+									})
+									.map(function (seriesSupplier) {
+										return _.merge(
+											{
+												dataItemKeys: [seriesSupplier.id]
+											},
+											seriesSupplier
+										);
+									});
+							}
+						)
+					);
+				}
+			}
+		});
+
+		app.directive('currentCompareChart', function () {
+			return {
+				require: {
+					logCtrl: '^deviceCurrentLog'
+				},
+				scope: {
+					device: '<',
+					range: '@'
+				},
+				templateUrl: function($element, $attrs) { return 'app/log/chart-' + $attrs.range + '.html'; },
+				replace: true,
+				bindToController: true,
+				controllerAs: 'vm',
+				controller: function ($location, $route, $scope, $timeout, $element, domoticzGlobals, domoticzApi, domoticzDataPointApi, chart) {
+					const self = this;
+
+					self.$onInit = function() {
+						self.groupingBy = 'month';
+						self.sensorType = 'counter';
+						self.chart = new RefreshingChart(
+							chart.baseParams($),
+							chart.angularParams($location, $route, $scope, $timeout, $element),
+							chart.domoticzParams(domoticzGlobals, domoticzApi, domoticzDataPointApi),
+							chart.chartParamsCompare(
+								domoticzGlobals,
+								self,
+								chart.chartParamsCompareTemplate(self, self.device.Name, self.device.getUnit()),
+								{
+									isShortLogChart: false,
+									yAxes: [{
+										title: {
+											text: $.t('Current') + ' (' + self.device.getUnit() + ')'
+										}
+									}],
+									extendDataRequest: function (dataRequest) {
+										dataRequest['groupby'] = self.groupingBy;
+										return dataRequest;
+									},
+									preprocessData: function (data) {
+										this.firstYear = data.firstYear;
+										this.categories = categoriesFromGroupingBy.call(this, self.groupingBy);
+										if (self.chart.chart.xAxis[0].categories === true) {
+											self.chart.chart.xAxis[0].categories = [];
+										} else {
+											self.chart.chart.xAxis[0].categories.length = 0;
+										}
+										this.categories.forEach(function (c) {
+											self.chart.chart.xAxis[0].categories.push(c); });
+
+										function categoriesFromGroupingBy(groupingBy) {
+											if (groupingBy === 'year') {
+												if (this.firstYear === undefined) {
+													return [];
+												}
+												return _.range(this.firstYear, new Date().getFullYear() + 1).map(year => year.toString());
+											} else if (groupingBy === 'quarter') {
+												return ['Q1', 'Q2', 'Q3', 'Q4'];
+											} else if (groupingBy === 'month') {
+												return _.range(1, 13).map(month => pad2(month));
+											}
+
+											function pad2(i) {
+												return (i < 10 ? '0' : '') + i.toString();
+											}
+										}
+									},
+								},
+								chart.compareSeriesSuppliers(self)
+							),
+							new DataLoader(),
+							new ChartLoader($location),
+							null
+						);
+					};
+				}
+			}
+		});
+
+		function chartParams(domoticzGlobals, ctrl, isShortLogChart, timestampFromDataItem, seriesSuppliers) {
+			return {
+				ctrl: ctrl,
+				range: ctrl.range,
+				device: ctrl.device,
+				sensorType: 'counter',
+				chartName: $.t('Current'),
+				autoRefreshIsEnabled: function() { return ctrl.logCtrl.autoRefresh; },
+				dataSupplier: {
+					yAxes: [
+						{
+							title: {
+								text: $.t('Current') + ' (' + ctrl.device.getUnit() + ')'
+							},
+							labels: {
+								formatter: function () {
+									return this.value;
+								}
+							}
+						}
+					],
+					valueSuffix: ' ' + ctrl.device.getUnit(),
+					timestampFromDataItem: timestampFromDataItem,
+					isShortLogChart: isShortLogChart,
+					seriesSuppliers: seriesSuppliers
+				}
+			};
+		}
+	}
+);

--- a/www/app/log/DeviceLog.html
+++ b/www/app/log/DeviceLog.html
@@ -22,6 +22,7 @@
 	<device-wind-log ng-if="::vm.isWindLog()" device="::vm.device"></device-wind-log>
 	<device-uv-log ng-if="::vm.isUvLog()" device="::vm.device"></device-uv-log>
 	<device-fan-log ng-if="::vm.isFanLog()" device="::vm.device"></device-fan-log>
+	<device-current-log ng-if="::vm.isCurrentLog()" device="::vm.device"></device-current-log>
     <device-counter-log ng-if="::vm.isInstantAndCounterLog()" device="::vm.device" subtype="'instantAndCounter'"></device-counter-log>
     <device-counter-log ng-if="::vm.isP1EnergyLog()" device="::vm.device" subtype="'p1Energy'"></device-counter-log>
     <device-counter-log ng-if="::vm.isCounterLog() && vm.isEnergyUsedDevice()" device="::vm.device" subtype="'energy-used'"></device-counter-log>

--- a/www/app/log/DeviceLog.js
+++ b/www/app/log/DeviceLog.js
@@ -1,4 +1,4 @@
-define(['app', 'log/Chart', 'log/TextLog', 'log/TemperatureLog', 'log/LightLog', 'log/GraphLog', 'log/CounterLog', 'log/CounterLogCounter', 'log/CounterLogInstantAndCounter', 'log/CounterLogP1Energy', 'log/RainLog', 'log/SetpointLog', 'log/AirQualityLog', 'log/BarometerLog', 'log/WindLog', 'log/UVLog', 'log/FanLog'], function (app) {
+define(['app', 'log/Chart', 'log/TextLog', 'log/TemperatureLog', 'log/LightLog', 'log/GraphLog', 'log/CounterLog', 'log/CounterLogCounter', 'log/CounterLogInstantAndCounter', 'log/CounterLogP1Energy', 'log/RainLog', 'log/SetpointLog', 'log/AirQualityLog', 'log/BarometerLog', 'log/WindLog', 'log/UVLog', 'log/FanLog', 'log/CurrentLog'], function (app) {
     app.controller('DeviceLogController', function ($location, $routeParams, domoticzApi, deviceApi, chart) {
         var vm = this;
 
@@ -13,6 +13,7 @@ define(['app', 'log/Chart', 'log/TextLog', 'log/TemperatureLog', 'log/LightLog',
 		vm.isWindLog = isWindLog;
 		vm.isUvLog = isUvLog;
 		vm.isFanLog = isFanLog;
+		vm.isCurrentLog = isCurrentLog;
         vm.isReportAvailable = isReportAvailable;
         vm.isInstantAndCounterLog = isInstantAndCounterLog;
         vm.isP1EnergyLog = isP1EnergyLog;
@@ -152,6 +153,13 @@ define(['app', 'log/Chart', 'log/TextLog', 'log/TemperatureLog', 'log/LightLog',
 				return undefined;
 			}
 			return (vm.device.SubType === 'Fan');
+		}
+
+		function isCurrentLog() {
+			if (!vm.device) {
+				return undefined;
+			}
+			return (vm.device.Type === 'Current');
 		}
 
         function isP1EnergyLog() {


### PR DESCRIPTION
… (Fixes #6560)

Add dedicated CurrentLog Angular component for pTypeCURRENT/sTypeELEC1 (Ampere 3 Phase) devices that were showing an empty log page after the legacy chart migration. Includes day/month/year charts with L1/L2/L3 phase series and a compare chart using averaged peak current across all three phases. Also add backend groupby handler for pTypeCURRENT compare data and proper unit support for Type='Current' devices.