### PR TITLE
Add Battery Voltage [V] display option to Energy Dashboard

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -3852,8 +3852,7 @@ namespace http
 				int ESolar = atoi(request::findValue(&req, "ESolar").c_str());
 				int EBatteryWatt = atoi(request::findValue(&req, "EBatteryWatt").c_str());
 				int EBatterySoc = atoi(request::findValue(&req, "EBatterySoc").c_str());
-				std::string EBatterySocMode = request::findValue(&req, "EBatterySocMode");
-				if (EBatterySocMode != "volt") EBatterySocMode = "soc";
+				int EBatteryVolt = atoi(request::findValue(&req, "EBatteryVolt").c_str());
 				int ETextSensor = atoi(request::findValue(&req, "ETextSensor").c_str());
 				int EOutsideTempSensor = atoi(request::findValue(&req, "EOutsideTempSensor").c_str());
 				int EExtra1 = atoi(request::findValue(&req, "EExtra1").c_str());
@@ -3879,7 +3878,7 @@ namespace http
 				ESettings["idSolar"] = ESolar;
 				ESettings["idBatteryWatt"] = EBatteryWatt;
 				ESettings["idBatterySoc"] = EBatterySoc;
-				ESettings["BatterySocMode"] = EBatterySocMode;
+				ESettings["idBatteryVolt"] = EBatteryVolt;
 				ESettings["idTextSensor"] = ETextSensor;
 				ESettings["idOutsideTempSensor"] = EOutsideTempSensor;
 				ESettings["idExtra1"] = EExtra1;

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -3852,6 +3852,8 @@ namespace http
 				int ESolar = atoi(request::findValue(&req, "ESolar").c_str());
 				int EBatteryWatt = atoi(request::findValue(&req, "EBatteryWatt").c_str());
 				int EBatterySoc = atoi(request::findValue(&req, "EBatterySoc").c_str());
+				std::string EBatterySocMode = request::findValue(&req, "EBatterySocMode");
+				if (EBatterySocMode != "volt") EBatterySocMode = "soc";
 				int ETextSensor = atoi(request::findValue(&req, "ETextSensor").c_str());
 				int EOutsideTempSensor = atoi(request::findValue(&req, "EOutsideTempSensor").c_str());
 				int EExtra1 = atoi(request::findValue(&req, "EExtra1").c_str());
@@ -3877,6 +3879,7 @@ namespace http
 				ESettings["idSolar"] = ESolar;
 				ESettings["idBatteryWatt"] = EBatteryWatt;
 				ESettings["idBatterySoc"] = EBatterySoc;
+				ESettings["BatterySocMode"] = EBatterySocMode;
 				ESettings["idTextSensor"] = ETextSensor;
 				ESettings["idOutsideTempSensor"] = EOutsideTempSensor;
 				ESettings["idExtra1"] = EExtra1;

--- a/www/app/EnergyDashboardController.js
+++ b/www/app/EnergyDashboardController.js
@@ -7,7 +7,7 @@ define(['app'], function (app) {
 		$scope.idSolar = -1;
 		$scope.idBattWatt = -1;
 		$scope.idBattSoc = -1;
-		$scope.idBattSocMode = "soc";   // "soc" = [%], "volt" = [V]
+		$scope.idBattVolt = -1;
 		$scope.fBattVolt = 0;
 		$scope.idTextObj = -1;
 		$scope.idOutsideTemp = -1;
@@ -116,6 +116,7 @@ define(['app'], function (app) {
 			if ($scope.idSolar != -1) devArray.push($scope.idSolar);
 			if ($scope.idBattWatt != -1) devArray.push($scope.idBattWatt);
 			if ($scope.idBattSoc != -1) devArray.push($scope.idBattSoc);
+			if ($scope.idBattVolt != -1) devArray.push($scope.idBattVolt);
 			if ($scope.idTextObj != -1) devArray.push($scope.idTextObj);
 			if ($scope.idOutsideTemp != -1) devArray.push($scope.idOutsideTemp);
 			if ($scope.idItemH1 != -1) devArray.push($scope.idItemH1);
@@ -162,9 +163,9 @@ define(['app'], function (app) {
 					$scope.idSolar = data.result.ESettings.idSolar;
 					$scope.idBattWatt = data.result.ESettings.idBatteryWatt;
 					$scope.idBattSoc = data.result.ESettings.idBatterySoc;
-					if (typeof data.result.ESettings.BatterySocMode != 'undefined') {
-						$scope.idBattSocMode = data.result.ESettings.BatterySocMode;
-					}
+					if (typeof data.result.ESettings.idBatteryVolt != 'undefined') {
+     					$scope.idBattVolt = data.result.ESettings.idBatteryVolt;
+ 					}
 					$scope.idTextObj = data.result.ESettings.idTextSensor;
 					if (typeof data.result.ESettings.idOutsideTempSensor != 'undefined') {
 						$scope.idOutsideTemp = data.result.ESettings.idOutsideTempSensor;
@@ -240,6 +241,9 @@ define(['app'], function (app) {
 				case $scope.idBattSoc:
 					bHandledData = $scope.handleBattSoc(item);
 					break;
+				case $scope.idBattVolt:
+     				bHandledData = $scope.handleBattVolt(item);
+     				break;
 				case $scope.idTextObj:
 					bHandledData = $scope.handleTextObj(item);
 					break;
@@ -441,14 +445,13 @@ define(['app'], function (app) {
 		}
 		
 		$scope.handleBattSoc = function(item) {
-			if ($scope.idBattSocMode === "volt") {
-				$scope.fBattVolt = parseFloat(item["Data"]) || 0;
-				$scope.fBattSoc = -1;
-			} else {
-				$scope.fBattSoc = parseFloat(item["Data"].replace('%','')) || 0;
-				$scope.fBattVolt = -1;
-			}
+			$scope.fBattSoc = parseFloat(item["Data"].replace('%','')) || 0;
 			$scope.customIconBatt = $scope.GetIconForItem(item);
+			return true;
+		}
+		
+		$scope.handleBattVolt = function(item) {
+			$scope.fBattVolt = parseFloat(item["Data"]) || 0;
 			return true;
 		}
 
@@ -714,7 +717,7 @@ define(['app'], function (app) {
 					//We have a problem!!! Not enough power to charge the battery!!
 					//The reason is likely that the Solar Wattage is not accurate
 					//Or that the battery is fully charged and not taking any power
-					if ($scope.idBattSocMode === "soc" && $scope.fBattSoc==100) {
+					if ($scope.fBattSoc==100) {
 						fActualBattWatt = 0;
 						fSolarToHome += fSolarToBatt;
 						fActualHomeUsage += fSolarToBatt;

--- a/www/app/EnergyDashboardController.js
+++ b/www/app/EnergyDashboardController.js
@@ -7,6 +7,8 @@ define(['app'], function (app) {
 		$scope.idSolar = -1;
 		$scope.idBattWatt = -1;
 		$scope.idBattSoc = -1;
+		$scope.idBattSocMode = "soc";   // "soc" = [%], "volt" = [V]
+		$scope.fBattVolt = 0;
 		$scope.idTextObj = -1;
 		$scope.idOutsideTemp = -1;
 		$scope.idItemH1 = -1;
@@ -160,6 +162,9 @@ define(['app'], function (app) {
 					$scope.idSolar = data.result.ESettings.idSolar;
 					$scope.idBattWatt = data.result.ESettings.idBatteryWatt;
 					$scope.idBattSoc = data.result.ESettings.idBatterySoc;
+					if (typeof data.result.ESettings.BatterySocMode != 'undefined') {
+						$scope.idBattSocMode = data.result.ESettings.BatterySocMode;
+					}
 					$scope.idTextObj = data.result.ESettings.idTextSensor;
 					if (typeof data.result.ESettings.idOutsideTempSensor != 'undefined') {
 						$scope.idOutsideTemp = data.result.ESettings.idOutsideTempSensor;
@@ -436,7 +441,13 @@ define(['app'], function (app) {
 		}
 		
 		$scope.handleBattSoc = function(item) {
-			$scope.fBattSoc = parseFloat(item["Data"].replace('%','')) || 0;
+			if ($scope.idBattSocMode === "volt") {
+				$scope.fBattVolt = parseFloat(item["Data"]) || 0;
+				$scope.fBattSoc = -1;
+			} else {
+				$scope.fBattSoc = parseFloat(item["Data"].replace('%','')) || 0;
+				$scope.fBattVolt = -1;
+			}
 			$scope.customIconBatt = $scope.GetIconForItem(item);
 			return true;
 		}
@@ -703,7 +714,7 @@ define(['app'], function (app) {
 					//We have a problem!!! Not enough power to charge the battery!!
 					//The reason is likely that the Solar Wattage is not accurate
 					//Or that the battery is fully charged and not taking any power
-					if ($scope.fBattSoc==100) {
+					if ($scope.idBattSocMode === "soc" && $scope.fBattSoc==100) {
 						fActualBattWatt = 0;
 						fSolarToHome += fSolarToBatt;
 						fActualHomeUsage += fSolarToBatt;

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -376,6 +376,10 @@ define(['app'], function (app) {
 										listBatterySoc.push({"idx": item.idx, "name": item.Name});
 										listExtra.push({"idx": item.idx, "name": item.Name});
 									}
+									else if (item.SubType == "Voltage") {
+										listBatterySoc.push({"idx": item.idx, "name": item.Name});
+										listExtra.push({"idx": item.idx, "name": item.Name});
+									}
 									else if (item.SubType == "Text") {
 										listText.push({"idx": item.idx, "name": item.Name});
 										listExtra.push({"idx": item.idx, "name": item.Name});
@@ -845,6 +849,8 @@ define(['app'], function (app) {
 						$("#comboESolar").val(data.ESettings.idSolar);
 						$("#comboEBatteryWatt").val(data.ESettings.idBatteryWatt);
 						$("#comboEBatterySoc").val(data.ESettings.idBatterySoc);
+						if (typeof data.ESettings.BatterySocMode != 'undefined') {
+							$("#comboEBatterySocMode").val(data.ESettings.BatterySocMode); }
 						$("#comboETextSensor").val(data.ESettings.idTextSensor);
 						$("#comboEExtra1").val(data.ESettings.idExtra1);
 						$("#comboEExtra2").val(data.ESettings.idExtra2);

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -311,6 +311,7 @@ define(['app'], function (app) {
 						let listSolar = [];
 						let listBatteryWatt = [];
 						let listBatterySoc = [];
+						let listBatteryVolt = [];
 						let listText = [];
 						let listExtra = [];
 						let listTemperatureSensors = [];
@@ -323,6 +324,7 @@ define(['app'], function (app) {
 
 						let $comboEBatteryWatt = $("#comboEBatteryWatt");
 						let $comboEBatterySoc = $("#comboEBatterySoc");
+						let $comboEBatteryVolt = $("#comboEBatteryVolt");
 
 						let $comboEText = $("#comboETextSensor");
 						let $comboEExtra1 = $("#comboEExtra1");
@@ -429,6 +431,9 @@ define(['app'], function (app) {
 						});
 						$.each(listBatterySoc, function (i, item) {
 							$comboEBatterySoc.append($("<option />").val(item.idx).text(item.name));
+						});
+						$.each(listBatteryVolt, function (i, item) {
+							$comboEBatteryVolt.append($("<option />").val(item.idx).text(item.name));
 						});
 						$.each(listText, function (i, item) {
 							$comboEText.append($("<option />").val(item.idx).text(item.name));
@@ -849,8 +854,9 @@ define(['app'], function (app) {
 						$("#comboESolar").val(data.ESettings.idSolar);
 						$("#comboEBatteryWatt").val(data.ESettings.idBatteryWatt);
 						$("#comboEBatterySoc").val(data.ESettings.idBatterySoc);
-						if (typeof data.ESettings.BatterySocMode != 'undefined') {
-							$("#comboEBatterySocMode").val(data.ESettings.BatterySocMode); }
+						if (typeof data.ESettings.idBatteryVolt != 'undefined') {
+							$("#comboEBatteryVolt").val(data.ESettings.idBatteryVolt);
+						}
 						$("#comboETextSensor").val(data.ESettings.idTextSensor);
 						$("#comboEExtra1").val(data.ESettings.idExtra1);
 						$("#comboEExtra2").val(data.ESettings.idExtra2);

--- a/www/views/energy_dashboard.html
+++ b/www/views/energy_dashboard.html
@@ -260,26 +260,27 @@ History:
 					<g transform="matrix(0.010083, 0, 0, 0.008335, 27.65, 45.2)">
 						<path d="m 319.089 27.221 h -36.475 v -27.221 h -95.27 v 27.221 h -34.607 c -22.517 0 -40.829 18.317 -40.829 40.832 v 362.946 c 0 22.51 18.317 40.83 40.829 40.83 h 166.352 c 22.524 0 40.832 -18.32 40.832 -40.83 v -362.947 c 0 -22.514 -18.308 -40.831 -40.832 -40.831 z m 13.616 403.781 c 0 7.501 -6.108 13.607 -13.616 13.607 h -166.352 c -7.501 0 -13.608 -6.095 -13.608 -13.607 v -362.95 c 0 -7.501 6.107 -13.611 13.608 -13.611 h 166.352 c 7.508 0 13.616 6.109 13.616 13.611 v 362.95 z"/>
 					</g>
-					<g id="batt_5" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.3)" ng-show="fBattSoc>=85">
+					<g id="batt_5" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.3)" ng-show="fBattSoc>=85 && idBattSocMode==='soc'">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_4" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.92)" ng-show="fBattSoc>=65">
+					<g id="batt_4" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.92)" ng-show="fBattSoc>=65 && idBattSocMode==='soc'">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_3" transform="matrix(0.010083, 0, 0, 0.008335, 31, 47.55)" ng-show="fBattSoc>=45">
+					<g id="batt_3" transform="matrix(0.010083, 0, 0, 0.008335, 31, 47.55)" ng-show="fBattSoc>=45 && idBattSocMode==='soc'">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_2" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.18)" ng-show="fBattSoc>=25">
+					<g id="batt_2" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.18)" ng-show="fBattSoc>=25 && idBattSocMode==='soc'">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_1" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.8)" ng-show="fBattSoc>5">
+					<g id="batt_1" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.8)" ng-show="fBattSoc>5 && idBattSocMode==='soc'">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
 				</g>
 				<g transform="matrix(0.075, 0, 0, 0.075, 28.2, 45)" ng-show="customIconBatt">
 					<image width="48" height="48" xlink:href="{{customIconBatt}}" />
 				</g>
-				<text class="etext" x="30" y="51.7" font-size="2.1px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;">{{ fBattSoc }}%</text>
+				<text class="etext" x="30" y="51.7" font-size="2.1px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;" ng-show="idBattSocMode==='soc'">{{ fBattSoc }}%</text>
+				<text class="etext" x="30" y="51.7" font-size="2.1px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;" ng-show="idBattSocMode==='volt'">{{ fBattVolt | number:1 }} V</text>
 				<text class="etext" x="30" y="54" font-size="1.7px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;">{{ fActualBattWatt }} Watt</text>
 			</g>
 			<g id="groupSolar" ng-show="idSolar != -1">

--- a/www/views/energy_dashboard.html
+++ b/www/views/energy_dashboard.html
@@ -260,27 +260,27 @@ History:
 					<g transform="matrix(0.010083, 0, 0, 0.008335, 27.65, 45.2)">
 						<path d="m 319.089 27.221 h -36.475 v -27.221 h -95.27 v 27.221 h -34.607 c -22.517 0 -40.829 18.317 -40.829 40.832 v 362.946 c 0 22.51 18.317 40.83 40.829 40.83 h 166.352 c 22.524 0 40.832 -18.32 40.832 -40.83 v -362.947 c 0 -22.514 -18.308 -40.831 -40.832 -40.831 z m 13.616 403.781 c 0 7.501 -6.108 13.607 -13.616 13.607 h -166.352 c -7.501 0 -13.608 -6.095 -13.608 -13.607 v -362.95 c 0 -7.501 6.107 -13.611 13.608 -13.611 h 166.352 c 7.508 0 13.616 6.109 13.616 13.611 v 362.95 z"/>
 					</g>
-					<g id="batt_5" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.3)" ng-show="fBattSoc>=85 && idBattSocMode==='soc'">
+					<g id="batt_5" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.3)" ng-show="fBattSoc>=85">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_4" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.92)" ng-show="fBattSoc>=65 && idBattSocMode==='soc'">
+					<g id="batt_4" transform="matrix(0.010083, 0, 0, 0.008335, 31, 46.92)" ng-show="fBattSoc>=65">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_3" transform="matrix(0.010083, 0, 0, 0.008335, 31, 47.55)" ng-show="fBattSoc>=45 && idBattSocMode==='soc'">
+					<g id="batt_3" transform="matrix(0.010083, 0, 0, 0.008335, 31, 47.55)" ng-show="fBattSoc>=45">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_2" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.18)" ng-show="fBattSoc>=25 && idBattSocMode==='soc'">
+					<g id="batt_2" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.18)" ng-show="fBattSoc>=25">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
-					<g id="batt_1" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.8)" ng-show="fBattSoc>5 && idBattSocMode==='soc'">
+					<g id="batt_1" transform="matrix(0.010083, 0, 0, 0.008335, 31, 48.8)" ng-show="fBattSoc>5">
 						<path d="m -14.843 -2.502 h -163.896 v -59.719 h 163.896 v 59.719 z"/>
 					</g>
 				</g>
 				<g transform="matrix(0.075, 0, 0, 0.075, 28.2, 45)" ng-show="customIconBatt">
 					<image width="48" height="48" xlink:href="{{customIconBatt}}" />
 				</g>
-				<text class="etext" x="30" y="51.7" font-size="2.1px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;" ng-show="idBattSocMode==='soc'">{{ fBattSoc }}%</text>
-				<text class="etext" x="30" y="51.7" font-size="2.1px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;" ng-show="idBattSocMode==='volt'">{{ fBattVolt | number:1 }} V</text>
+				<text class="etext" y="51.7" font-size="2.1px" text-anchor="middle" style="... font-weight: bold; white-space: pre;" ng-show="idBattSoc != -1" ng-attr-x="{{idBattVolt != -1 ? '27' : '30'}}">{{ fBattSoc }}%</text>
+				<text class="etext" x="33.5" y="51.7" font-size="1.5px" text-anchor="middle" style="... font-weight: normal; white-space: pre;" ng-show="idBattVolt != -1">{{ fBattVolt | number:1 }}V</text>
 				<text class="etext" x="30" y="54" font-size="1.7px" text-anchor="middle" style="font-variant-caps: normal; font-variant-east-asian: normal; font-variant-ligatures: normal; font-variant-numeric: normal; font-weight: bold; white-space: pre;">{{ fActualBattWatt }} Watt</text>
 			</g>
 			<g id="groupSolar" ng-show="idSolar != -1">

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1087,11 +1087,13 @@
 											<td align="right"><label><span data-i18n="Battery SOC"></span>: </label></td>
 											<td><select id="comboEBatterySoc" name="EBatterySoc" style="width:380px" class="combobox ui-corner-all">
 												<option data-i18n="Disabled" value="-1" selected="selected">Disabled</option>
-											</select>
-											&nbsp;<select id="comboEBatterySocMode" name="EBatterySocMode" style="width:110px" class="combobox ui-corner-all">
-												<option value="soc" selected="selected">% (SOC)</option>
-												<option value="volt">V (Voltage)</option>
-											</select></td>
+											</select>&nbsp;%</td>
+										</tr>
+										<tr>
+     										<td align="right"><label><span data-i18n="Battery Voltage"></span>: </label></td>
+     										<td><select id="comboEBatteryVolt" name="EBatteryVolt" style="width:380px" class="combobox ui-corner-all">
+             									<option data-i18n="Disabled" value="-1" selected="selected">Disabled</option>
+         										</select>&nbsp;V</td>
 										</tr>
 										<tr>
 											<td align="right" style="width:200px"><label><span data-i18n="Text Device"></span>: </label></td>

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1087,7 +1087,11 @@
 											<td align="right"><label><span data-i18n="Battery SOC"></span>: </label></td>
 											<td><select id="comboEBatterySoc" name="EBatterySoc" style="width:380px" class="combobox ui-corner-all">
 												<option data-i18n="Disabled" value="-1" selected="selected">Disabled</option>
-											</select>&nbsp;%</td>
+											</select>
+											&nbsp;<select id="comboEBatterySocMode" name="EBatterySocMode" style="width:110px" class="combobox ui-corner-all">
+												<option value="soc" selected="selected">% (SOC)</option>
+												<option value="volt">V (Voltage)</option>
+											</select></td>
 										</tr>
 										<tr>
 											<td align="right" style="width:200px"><label><span data-i18n="Text Device"></span>: </label></td>


### PR DESCRIPTION
## Summary

Added support for displaying **Battery Voltage [V]** as an alternative to **Battery SOC [%]** in the Energy Dashboard. The existing SOC functionality is fully preserved.

## Changes

- **`setup.html`** — added a mode selector (`% SOC` / `V Voltage`) next to the Battery SOC device dropdown
- **`SetupController.js`** — added `General/Voltage` sensor type to the Battery SOC device list; added loading of the new `BatterySocMode` setting
- **`WebServerCmds.cpp`** — added reading and saving of the `BatterySocMode` parameter to `ESettings`
- **`EnergyDashboardController.js`** — added `idBattSocMode` and `fBattVolt` scope variables; updated `handleBattSoc()` to handle both modes; fixed `fBattSoc==100` guard to be mode-aware
- **`energy_dashboard.html`** — battery level bars and SOC text are hidden in voltage mode; voltage value is displayed instead

## How it works

The user selects a Voltage sensor in the existing *Battery SOC* dropdown and switches the new mode selector to `V (Voltage)`. The dashboard then displays the live voltage value (e.g. `48.3 V`) instead of percentage bars. Switching back to `% (SOC)` restores the original behaviour.

No database schema changes — `BatterySocMode` is stored as a new key inside the existing `ESettings` JSON preference. The GET endpoint (`Cmd_GetEnergyDashboardDevices`) required no changes as it returns the full `ESettings` JSON as-is.
