### PR TITLE
fix: prevent thread resource errors from WebSocket handler lifecycle

### DIFF
--- a/main/DomoticzWebsocketHandler.cpp
+++ b/main/DomoticzWebsocketHandler.cpp
@@ -22,6 +22,7 @@ namespace http {
 
 		CDomoticzWebsocketHandler::~CDomoticzWebsocketHandler()
 		{
+			_log.Debug(DEBUG_WEBSERVER, "WebSocket: handler destroyed");
 			Stop();
 		}
 
@@ -33,10 +34,12 @@ namespace http {
 
 			//Start worker thread
 			m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
+			_log.Debug(DEBUG_WEBSERVER, "WebSocket: handler started");
 		}
 
 		void CDomoticzWebsocketHandler::Stop()
 		{
+			_log.Debug(DEBUG_WEBSERVER, "WebSocket: handler stopping");
 			m_Push.Stop();
 			if (m_thread)
 			{
@@ -44,6 +47,7 @@ namespace http {
 				m_thread->join();
 				m_thread.reset();
 			}
+			_log.Debug(DEBUG_WEBSERVER, "WebSocket: handler stopped");
 		}
 
 		void CDomoticzWebsocketHandler::Do_Work()

--- a/main/Logger.cpp
+++ b/main/Logger.cpp
@@ -40,7 +40,7 @@ CLogger::CLogger()
 	m_bEnableErrorsToNotificationSystem = false;
 	m_LastLogNotificationsSend = 0;
 	SetLogFlags(LOG_NORM | LOG_STATUS | LOG_ERROR);
-	SetDebugFlags(DEBUG_NORM);
+	SetDebugFlags(0);
 }
 
 CLogger::~CLogger()
@@ -89,7 +89,12 @@ bool CLogger::SetLogFlags(const std::string &sFlags)
 
 void CLogger::SetLogFlags(const uint32_t iFlags)
 {
-	m_log_flags = iFlags;
+	m_log_flags.store(iFlags, std::memory_order_relaxed);
+}
+
+uint32_t CLogger::GetLogFlags() const
+{
+	return m_log_flags.load(std::memory_order_relaxed);
 }
 
 // Supported flags: all,normal,hardware,received,webserver,eventsystem,python,thread_id,sql,auth
@@ -137,7 +142,7 @@ bool CLogger::SetDebugFlags(const std::string &sFlags)
 	SetDebugFlags(iFlags);
 	if (iFlags && !IsLogLevelEnabled(LOG_DEBUG_INT))
 	{
-		m_log_flags |= LOG_DEBUG_INT;
+		m_log_flags.store(m_log_flags.load(std::memory_order_relaxed) | LOG_DEBUG_INT, std::memory_order_relaxed);
 		Log(LOG_STATUS, "Enabling Debug logging!");
 	}
 	if(IsDebugLevelEnabled(DEBUG_WEBSERVER))
@@ -147,7 +152,12 @@ bool CLogger::SetDebugFlags(const std::string &sFlags)
 
 void CLogger::SetDebugFlags(const uint32_t iFlags)
 {
-	m_debug_flags = iFlags;
+	m_debug_flags.store(iFlags, std::memory_order_relaxed);
+}
+
+uint32_t CLogger::GetDebugFlags() const
+{
+	return m_debug_flags.load(std::memory_order_relaxed);
 }
 
 void CLogger::SetACLFlogFlags(const uint8_t iFlags)
@@ -157,14 +167,14 @@ void CLogger::SetACLFlogFlags(const uint8_t iFlags)
 
 bool CLogger::IsLogLevelEnabled(const _eLogLevel level)
 {
-	return (m_log_flags & level);
+	return (m_log_flags.load(std::memory_order_relaxed) & level);
 }
 
 bool CLogger::IsDebugLevelEnabled(const _eDebugLevel level)
 {
-	if (!(m_log_flags & LOG_DEBUG_INT))
+	if (!(m_log_flags.load(std::memory_order_relaxed) & LOG_DEBUG_INT))
 		return false;
-	return (m_debug_flags & level);
+	return (m_debug_flags.load(std::memory_order_relaxed) & level);
 }
 
 bool CLogger::IsACLFlogEnabled()
@@ -255,7 +265,7 @@ void CLogger::Log(const _eLogLevel level, const std::string &sLogline)
 
 void CLogger::Log(const _eLogLevel level, const char *logline, ...)
 {
-	if (!(m_log_flags & level))
+	if (!(m_log_flags.load(std::memory_order_relaxed) & level))
 		return; // This log level is not enabled!
 
 	va_list argList;
@@ -281,7 +291,7 @@ void CLogger::Log(const _eLogLevel level, const char *logline, ...)
 	if (m_bEnableLogTimestamps)
 		sstr << TimeToString(nullptr, TF_DateTimeMs) << "  ";
 
-	if ((m_log_flags & LOG_DEBUG_INT) && (m_debug_flags & DEBUG_THREADIDS))
+	if ((m_log_flags.load(std::memory_order_relaxed) & LOG_DEBUG_INT) && (m_debug_flags.load(std::memory_order_relaxed) & DEBUG_THREADIDS))
 	{
 #ifdef WIN32
 		sstr << "[" << std::setfill('0') << std::setw(4) << std::hex << ::GetCurrentThreadId() << "] ";

--- a/main/Logger.h
+++ b/main/Logger.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <deque>
 #include <list>
 #include <string>
@@ -53,10 +54,12 @@ public:
 
 	bool SetLogFlags(const std::string& sFlags);
 	void SetLogFlags(const uint32_t iFlags);
+	uint32_t GetLogFlags() const;
 	bool IsLogLevelEnabled(const _eLogLevel level);
 
 	bool SetDebugFlags(const std::string& sFlags);
 	void SetDebugFlags(const uint32_t iFlags);
+	uint32_t GetDebugFlags() const;
 	bool IsDebugLevelEnabled(const _eDebugLevel level);
 
 	void SetACLFlogFlags(const uint8_t iFlags);
@@ -100,8 +103,8 @@ public:
 	bool NotificationLogsEnabled();
 
 private:
-	uint32_t m_log_flags = 0;
-	uint32_t m_debug_flags = 0;
+	std::atomic<uint32_t> m_log_flags{0};
+	std::atomic<uint32_t> m_debug_flags{0};
 	uint8_t m_aclf_flags = 0;
 	uint32_t m_aclf_loggedlinescnt = 0;
 

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -4358,7 +4358,7 @@ void CSQLHelper::Do_Work()
 
 		for (const auto &itt : _items2do)
 		{
-			_log.Debug(DEBUG_NORM, "SQLH: Do Task ItemType: %d Cmd: %s Value: %s", itt._ItemType, itt._command.c_str(), itt._sValue.c_str());
+			_log.Debug(DEBUG_SQL, "SQLH: Do Task ItemType: %d Cmd: %s Value: %s", itt._ItemType, itt._command.c_str(), itt._sValue.c_str());
 
 			if (itt._ItemType == TITEM_SWITCHCMD)
 			{
@@ -5541,7 +5541,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 		//TODO: Plugins should perhaps be blocked from implicitly adding a device by update? It's most likely a bug due to updating a removed device..
 		if (pHardware != nullptr && pHardware->HwdType == HTYPE_PythonPlugin)
 		{
-			_log.Debug(DEBUG_NORM, "CSQLHelper::UpdateValueInt: Notifying plugin %u about creation of device %u", HardwareID, unit);
+			_log.Debug(DEBUG_SQL, "CSQLHelper::UpdateValueInt: Notifying plugin %u about creation of device %u", HardwareID, unit);
 			Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)pHardware;
 			pPlugin->DeviceAdded(ID, unit);
 		}
@@ -5957,7 +5957,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 		break;
 	}
 
-	_log.Debug(DEBUG_NORM, "SQLH UpdateValueInt %s HwID:%d  DevID:%s Type:%d  sType:%d nValue:%d sValue:%s IDX: %" PRIu64, devname.c_str(), HardwareID, ID, devType, subType, nValue, sValue, ulID);
+	_log.Debug(DEBUG_SQL, "SQLH UpdateValueInt %s HwID:%d  DevID:%s Type:%d  sType:%d nValue:%d sValue:%s IDX: %" PRIu64, devname.c_str(), HardwareID, ID, devType, subType, nValue, sValue, ulID);
 
 	if (bDeviceUsed)
 	{
@@ -8477,7 +8477,7 @@ void CSQLHelper::DeleteDevices(const std::string& idx)
 #ifdef ENABLE_PYTHON
 	for (const auto &str : _idx)
 	{
-		_log.Debug(DEBUG_NORM, "CSQLHelper::DeleteDevices: ID: %s", str.c_str());
+		_log.Debug(DEBUG_SQL, "CSQLHelper::DeleteDevices: ID: %s", str.c_str());
 		std::vector<std::vector<std::string> > result;
 		result = safe_query("SELECT HardwareID, DeviceID, Unit FROM DeviceStatus WHERE (ID == '%q')", str.c_str());
 		if (!result.empty())
@@ -8550,7 +8550,7 @@ void CSQLHelper::DeleteDevices(const std::string& idx)
 		CDomoticzHardwareBase* pHardware = m_mainworker.GetHardware(HwID);
 		if (pHardware != nullptr && pHardware->HwdType == HTYPE_PythonPlugin)
 		{
-			_log.Debug(DEBUG_NORM, "CSQLHelper::DeleteDevices: Notifying plugin %u about deletion of device %u", HwID, Unit);
+			_log.Debug(DEBUG_SQL, "CSQLHelper::DeleteDevices: Notifying plugin %u about deletion of device %u", HwID, Unit);
 			Plugins::CPlugin* pPlugin = (Plugins::CPlugin*)pHardware;
 			pPlugin->DeviceRemoved(DeviceID, Unit);
 		}
@@ -8762,7 +8762,7 @@ void CSQLHelper::DeleteDateRange(const char *ID, const std::string &fromDate, co
 	for (const auto &historyTable : historyTables)
 	{
 		safe_query("DELETE FROM %q WHERE (DeviceRowID=='%q') AND (Date>='%q') AND (Date<='%q')", historyTable.c_str(), ID, fromDate.c_str(), toDate.c_str() );
-		_log.Debug(DEBUG_NORM, "CSQLHelper::DeleteDateRange; delete from %s with idx: %s and Date >= %s and date <= %s" , historyTable.c_str(), std::string(ID).c_str(), fromDate.c_str(), toDate.c_str() );
+		_log.Debug(DEBUG_SQL, "CSQLHelper::DeleteDateRange; delete from %s with idx: %s and Date >= %s and date <= %s" , historyTable.c_str(), std::string(ID).c_str(), fromDate.c_str(), toDate.c_str() );
 	}
 }
 
@@ -8788,7 +8788,7 @@ void CSQLHelper::AddTaskItem(const _tTaskItem& tItem, const bool cancelItem)
 	std::lock_guard<std::mutex> l(m_background_task_mutex);
 
 	// Check if an event for the same device is already in queue, and if so, replace it
-	_log.Debug(DEBUG_NORM, "SQLH AddTask: Request to add task: idx=%" PRIu64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", tItem._idx, tItem._DelayTime, tItem._command.c_str(), tItem._level, tItem._Color.toString().c_str(), tItem._relatedEvent.c_str());
+	_log.Debug(DEBUG_SQL, "SQLH AddTask: Request to add task: idx=%" PRIu64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", tItem._idx, tItem._DelayTime, tItem._command.c_str(), tItem._level, tItem._Color.toString().c_str(), tItem._relatedEvent.c_str());
 	// Remove any previous task linked to the same device
 
 	if (
@@ -8801,13 +8801,13 @@ void CSQLHelper::AddTaskItem(const _tTaskItem& tItem, const bool cancelItem)
 		auto itt = m_background_task_queue.begin();
 		while (itt != m_background_task_queue.end())
 		{
-			_log.Debug(DEBUG_NORM, "SQLH AddTask: Comparing with item in queue: idx=%" PRIu64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", itt->_idx, itt->_DelayTime, itt->_command.c_str(), itt->_level, itt->_Color.toString().c_str(), itt->_relatedEvent.c_str());
+			_log.Debug(DEBUG_SQL, "SQLH AddTask: Comparing with item in queue: idx=%" PRIu64 ", DelayTime=%f, Command='%s', Level=%d, Color='%s', RelatedEvent='%s'", itt->_idx, itt->_DelayTime, itt->_command.c_str(), itt->_level, itt->_Color.toString().c_str(), itt->_relatedEvent.c_str());
 			if (itt->_idx == tItem._idx && itt->_ItemType == tItem._ItemType)
 			{
 				float iDelayDiff = tItem._DelayTime - itt->_DelayTime;
 				if (iDelayDiff < (1. / timer_resolution_hz / 2))
 				{
-					_log.Debug(DEBUG_NORM, "SQLH AddTask: => Already present. Cancelling previous task item");
+					_log.Debug(DEBUG_SQL, "SQLH AddTask: => Already present. Cancelling previous task item");
 					itt = m_background_task_queue.erase(itt);
 				}
 				else
@@ -9280,9 +9280,9 @@ void CSQLHelper::SetUnitsAndScale()
 bool CSQLHelper::HandleOnOffAction(const bool bIsOn, const std::string& OnAction, const std::string& OffAction)
 {
 	if (bIsOn)
-		_log.Debug(DEBUG_NORM, "SQLH HandleOnOffAction: OnAction:%s", OnAction.c_str());
+		_log.Debug(DEBUG_SQL, "SQLH HandleOnOffAction: OnAction:%s", OnAction.c_str());
 	else
-		_log.Debug(DEBUG_NORM, "SQLH HandleOnOffAction: OffAction:%s", OffAction.c_str());
+		_log.Debug(DEBUG_SQL, "SQLH HandleOnOffAction: OffAction:%s", OffAction.c_str());
 
 	if (bIsOn)
 	{

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -3908,6 +3908,25 @@ namespace http
 				// Signal plugins to update Settings dictionary
 				PluginLoadConfig();
 #endif
+
+				std::string sDebugLevel = request::findValue(&req, "DebugLevel");
+				if (!sDebugLevel.empty())
+				{
+					uint32_t iDebugLevel = static_cast<uint32_t>(atoi(sDebugLevel.c_str()));
+					_log.SetDebugFlags(iDebugLevel);
+					if (iDebugLevel != 0)
+					{
+						// Enable debug log level when any debug flags are set
+						_log.SetLogFlags(_log.GetLogFlags() | LOG_DEBUG_INT);
+					}
+					else
+					{
+						// Disable debug log level when no debug flags are set
+						_log.SetLogFlags(_log.GetLogFlags() & ~LOG_DEBUG_INT);
+					}
+					cntSettings++;
+				}
+
 				root["status"] = "OK";
 			}
 			catch (const std::exception& e)
@@ -6132,6 +6151,7 @@ namespace http
 					root["PriceResolution"] = nValue;
 				}
 			}
+			root["DebugLevel"] = static_cast<int>(_log.GetDebugFlags());
 		}
 
 		void CWebServer::Cmd_GetLightLog(WebEmSession& session, const request& req, Json::Value& root)

--- a/push/WebsocketPush.cpp
+++ b/push/WebsocketPush.cpp
@@ -13,6 +13,11 @@ CWebSocketPush::CWebSocketPush(http::server::CDomoticzWebsocketHandler *sock)
 	isStarted = false;
 }
 
+CWebSocketPush::~CWebSocketPush()
+{
+	Stop();
+}
+
 void CWebSocketPush::Start()
 {
 	if (isStarted) {
@@ -54,41 +59,42 @@ void CWebSocketPush::Stop()
 
 void CWebSocketPush::OnDeviceReceived(const int HwdID, const uint64_t DeviceRowIdx, const std::string &DeviceName, const unsigned char *pRXCommand)
 {
-	std::unique_lock<std::mutex> lock(handlerMutex);
-	if (!isStarted) {
-		return;
+	{
+		std::unique_lock<std::mutex> lock(handlerMutex);
+		if (!isStarted)
+			return;
 	}
-
+	// Called outside the lock to prevent deadlock: OnDeviceChanged -> Handle -> Log -> sOnLogMessage -> OnLogMessage -> handlerMutex
 	m_sock->OnDeviceChanged(DeviceRowIdx);
 }
 
 void CWebSocketPush::OnDeviceUpdate(const int m_HwdID, const uint64_t DeviceRowIdx)
 {
-	std::unique_lock<std::mutex> lock(handlerMutex);
-	if (!isStarted) {
-		return;
+	{
+		std::unique_lock<std::mutex> lock(handlerMutex);
+		if (!isStarted)
+			return;
 	}
-
 	m_sock->OnDeviceChanged(DeviceRowIdx);
 }
 
 void CWebSocketPush::OnSceneChange(const uint64_t SceneRowIdx, const std::string& SceneName)
 {
-	std::unique_lock<std::mutex> lock(handlerMutex);
-	if (!isStarted) {
-		return;
+	{
+		std::unique_lock<std::mutex> lock(handlerMutex);
+		if (!isStarted)
+			return;
 	}
 	m_sock->OnSceneChanged(SceneRowIdx);
 }
 
 void CWebSocketPush::OnNotificationReceived(const std::string & Subject, const std::string & Text, const std::string & ExtraData, const int Priority, const std::string & Sound, const bool bFromNotification)
 {
-	std::unique_lock<std::mutex> lock(handlerMutex);
-	if (!isStarted) {
-		return;
+	{
+		std::unique_lock<std::mutex> lock(handlerMutex);
+		if (!isStarted)
+			return;
 	}
-
-	// push message to websocket
 	m_sock->SendNotification(Subject, Text, ExtraData, Priority, Sound, bFromNotification);
 }
 

--- a/push/WebsocketPush.h
+++ b/push/WebsocketPush.h
@@ -16,6 +16,7 @@ class CWebSocketPush : public CBasePush, public StoppableTask
 {
 public:
 	explicit CWebSocketPush(http::server::CDomoticzWebsocketHandler *sock);
+	~CWebSocketPush();
 	void Start();
 	void Stop();
 	void onDeviceTableChanged(); // device added, or deleted

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -590,6 +590,18 @@ define(['app'], function (app) {
 					if (typeof data.ShortLogInterval != 'undefined') {
 						$scope.ShortLogInterval = data.ShortLogInterval;
 					}
+					if (typeof data.DebugLevel != 'undefined') {
+						var dl = data.DebugLevel;
+						$("#debugleveltable #DebugNormal").prop('checked', (dl & 0x01) != 0);
+						$("#debugleveltable #DebugHardware").prop('checked', (dl & 0x02) != 0);
+						$("#debugleveltable #DebugReceived").prop('checked', (dl & 0x04) != 0);
+						$("#debugleveltable #DebugWebServer").prop('checked', (dl & 0x08) != 0);
+						$("#debugleveltable #DebugEventSystem").prop('checked', (dl & 0x10) != 0);
+						$("#debugleveltable #DebugPython").prop('checked', (dl & 0x20) != 0);
+						$("#debugleveltable #DebugThreadIDs").prop('checked', (dl & 0x40) != 0);
+						$("#debugleveltable #DebugSQL").prop('checked', (dl & 0x80) != 0);
+						$("#debugleveltable #DebugAuth").prop('checked', (dl & 0x100) != 0);
+					}
 					if (typeof data.DashboardType != 'undefined') {
 						$("#settingscontent #combosdashtype").val(data.DashboardType);
 					}
@@ -927,6 +939,18 @@ define(['app'], function (app) {
 			if (!isNaN(priceRes) && !isNaN(shortLogInterval) && priceRes < 60 && shortLogInterval > priceRes) {
 				ShowNotify($.t('Warning: ShortLog Interval is greater than the selected pricing resolution. For accurate pricing, the ShortLog Interval should be ' + priceRes + ' minutes or less.'), 5000, true);
 			}
+
+			var debugLevel = 0;
+			if ($("#debugleveltable #DebugNormal").prop("checked")) debugLevel |= 0x01;
+			if ($("#debugleveltable #DebugHardware").prop("checked")) debugLevel |= 0x02;
+			if ($("#debugleveltable #DebugReceived").prop("checked")) debugLevel |= 0x04;
+			if ($("#debugleveltable #DebugWebServer").prop("checked")) debugLevel |= 0x08;
+			if ($("#debugleveltable #DebugEventSystem").prop("checked")) debugLevel |= 0x10;
+			if ($("#debugleveltable #DebugPython").prop("checked")) debugLevel |= 0x20;
+			if ($("#debugleveltable #DebugThreadIDs").prop("checked")) debugLevel |= 0x40;
+			if ($("#debugleveltable #DebugSQL").prop("checked")) debugLevel |= 0x80;
+			if ($("#debugleveltable #DebugAuth").prop("checked")) debugLevel |= 0x100;
+			$("#settings #DebugLevel").val(debugLevel);
 
 			$http.post('json.htm?type=command&param=storesettings', new FormData(document.querySelector("#settings")), {
 				transformRequest: angular.identity,

--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -1,5 +1,14 @@
 {
+	"Authentication": "Authentication",
 	"Consider enabling 2FA or passkeys for your admin account in User Settings": "Consider enabling 2FA or passkeys for your admin account in User Settings",
+	"Debug Levels": "Debug Levels",
+	"DebugLevelsDescription": "Enable debug logging for specific subsystems. These can also be set via the -debuglevel command line argument.",
+	"Event System": "Event System",
+	"Log": "Log",
+	"Received": "Received",
+	"SQL": "SQL",
 	"Service is restarting, please wait...": "Service is restarting, please wait...",
-	"Waiting for service to restart, please wait...": "Waiting for service to restart, please wait..."
+	"Thread IDs": "Thread IDs",
+	"Waiting for service to restart, please wait...": "Waiting for service to restart, please wait...",
+	"Web Server": "Web Server"
 }

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -38,7 +38,7 @@
 			<div id="content">
 				<ul id="tabs" class="nav nav-tabs sub-tabs" data-tabs="tabs">
 					<li class="active"><a data-target="#tabsystem" data-toggle="tab" data-i18n="System">System</a></li>
-					<li><a data-target="#tablog" data-toggle="tab" data-i18n="Log History"></a></li>
+					<li><a data-target="#tablog" data-toggle="tab" data-i18n="Log"></a></li>
 					<li><a data-target="#tabnotifications" data-toggle="tab" data-i18n="Notifications"></a></li>
 					<li><a data-target="#tabemail" data-toggle="tab" data-i18n="Email">Email</a></li>
 					<li><a data-target="#tabmeters" data-toggle="tab" data-i18n="Meters/Counters">Meters/Counters</a></li>
@@ -239,6 +239,47 @@
 								</div>
 							</div>
 						</section>
+						<br>
+						<section id="debuglevels">
+							<div class="page-header-small">
+								<h1 data-i18n="Debug Levels">Debug Levels</h1>
+							</div>
+							<div class="row-fluid">
+								<div class="span12">
+									<p data-i18n="DebugLevelsDescription">Enable debug logging for specific subsystems. These can also be set via the -debuglevel command line argument.</p>
+									<table class="display" id="debugleveltable" border="0" cellpadding="0" cellspacing="0">
+										<tr>
+											<td><input type="checkbox" id="DebugNormal" name="DebugNormal"> <label for="DebugNormal" data-i18n="Normal">Normal</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugHardware" name="DebugHardware"> <label for="DebugHardware" data-i18n="Hardware">Hardware</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugReceived" name="DebugReceived"> <label for="DebugReceived" data-i18n="Received">Received</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugWebServer" name="DebugWebServer"> <label for="DebugWebServer" data-i18n="Web Server">Web Server</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugEventSystem" name="DebugEventSystem"> <label for="DebugEventSystem" data-i18n="Event System">Event System</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugPython" name="DebugPython"> <label for="DebugPython" data-i18n="Python">Python</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugThreadIDs" name="DebugThreadIDs"> <label for="DebugThreadIDs" data-i18n="Thread IDs">Thread IDs</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugSQL" name="DebugSQL"> <label for="DebugSQL" data-i18n="SQL">SQL</label></td>
+										</tr>
+										<tr>
+											<td><input type="checkbox" id="DebugAuth" name="DebugAuth"> <label for="DebugAuth" data-i18n="Authentication">Authentication</label></td>
+										</tr>
+									</table>
+								</div>
+							</div>
+						</section>
+						<input type="hidden" id="DebugLevel" name="DebugLevel" value="0">
 					</div>
                     <div class="tab-pane" id="tabnotifications">
 						<!-- Notification system


### PR DESCRIPTION
## Summary

- **Async WebSocket handler cleanup**: Moves handler `Stop()` out of the I/O thread via `ScheduleHandlerCleanup()` in libwebem, preventing thread resource errors when WebSocket connections close rapidly
- **Thread-safe Logger flags**: Converts `m_log_flags` and `m_debug_flags` to `std::atomic<uint32_t>` to eliminate data races from concurrent signal handler threads
- **WebsocketPush deadlock fix**: Restructures mutex scoping so `OnDeviceChanged`/`OnSceneChanged`/`OnNotificationReceived` calls happen outside the lock, preventing deadlock through the `Handle -> Log -> sOnLogMessage -> OnLogMessage -> handlerMutex` path
- **Debug Levels UI**: Adds a Debug Levels section to Setup > System for runtime configuration of debug flags (Normal, Hardware, Received, Web Server, Event System, Python, Thread IDs, SQL, Auth)
- **SQL debug category**: Moves SQL-related debug messages from `DEBUG_NORM` to `DEBUG_SQL` to reduce noise when only normal debug logging is enabled

Fixes #6623

## Test plan

- [ ] Open multiple browser tabs, rapidly open/close them — no "thread resource" errors in log
- [ ] Enable/disable debug levels via Setup > System > Debug Levels — verify flags persist and log output matches
- [ ] Verify WebSocket device/scene updates still work across multiple tabs
- [ ] Verify notifications and log messages still push to WebSocket clients
- [ ] Check SQL debug messages only appear when SQL debug flag is enabled