### PR TITLE
MCP: Add get_status tool for system health overview

### DIFF
--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -44,6 +44,10 @@
 
 extern http::server::CWebServerHelper m_webservers;
 extern CLogger _log;
+extern std::string szAppVersion;
+extern std::string szAppHash;
+extern std::string szAppDate;
+extern time_t m_StartTime;
 
 namespace http
 {
@@ -290,6 +294,13 @@ namespace mcp		// Model Context Protocol
 		tool["inputSchema"]["properties"]["floorplan"]["type"] = "string";
 		tool["inputSchema"]["properties"]["floorplan"]["description"] = "The name of the floorplan to retrieve";
 		jsonRPCRep["result"]["tools"].append(tool);
+		// Get Status tool
+		tool.clear();
+		tool["name"] = "get_status";
+		tool["title"] = "Get the system status of Domoticz";
+		tool["description"] = "Retrieve the current system status including version, uptime, sunrise/sunset times and device/hardware counts. Use this tool to check if the Domoticz instance is running and healthy.";
+		tool["inputSchema"]["type"] = "object";
+		jsonRPCRep["result"]["tools"].append(tool);
 	}
 
 	void McpToolsCall(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
@@ -359,6 +370,15 @@ namespace mcp		// Model Context Protocol
 			{
 				jsonRPCRep["error"]["code"] = JSONRPC_INVALID_PARAMETER;
 				jsonRPCRep["error"]["message"] = "Error getting floorplan";
+				return;
+			}
+		}
+		else if (sMethodName == "get_status")
+		{
+			if(!mcp::getStatus(jsonRequest, jsonRPCRep))
+			{
+				jsonRPCRep["error"]["code"] = JSONRPC_INTERNAL_ERROR;
+				jsonRPCRep["error"]["message"] = "Error getting system status";
 				return;
 			}
 		}
@@ -865,6 +885,72 @@ namespace mcp		// Model Context Protocol
 		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
 		jsonRPCRep["result"]["content"].append(tool);
 		jsonRPCRep["result"]["isError"] = !bFound;
+		return true;
+	}
+
+	bool getStatus(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
+	{
+		std::string sResult = "Domoticz System Status\n";
+		sResult += "======================\n";
+
+		// Version info
+		sResult += "Version: " + szAppVersion + "\n";
+		sResult += "Build hash: " + szAppHash + "\n";
+		sResult += "Build time: " + szAppDate + "\n";
+
+		// Server time
+		time_t now = mytime(nullptr);
+		sResult += "Server time: " + TimeToString(&now, TF_DateTime) + "\n";
+
+		// Uptime
+		time_t tuptime = now - m_StartTime;
+		int days = (int)(tuptime / 86400);
+		tuptime -= (days * 86400);
+		int hours = (int)(tuptime / 3600);
+		tuptime -= (hours * 3600);
+		int minutes = (int)(tuptime / 60);
+		tuptime -= (minutes * 60);
+		int seconds = (int)tuptime;
+		sResult += "Uptime: " + std::to_string(days) + "d " + std::to_string(hours) + "h " + std::to_string(minutes) + "m " + std::to_string(seconds) + "s\n";
+
+		// Sunrise/Sunset
+		if (!m_mainworker.m_LastSunriseSet.empty())
+		{
+			std::vector<std::string> strarray;
+			StringSplit(m_mainworker.m_LastSunriseSet, ";", strarray);
+			if (strarray.size() >= 10)
+			{
+				sResult += "Sunrise: " + strarray[0] + "\n";
+				sResult += "Sunset: " + strarray[1] + "\n";
+				sResult += "Day length: " + strarray[9] + "\n";
+			}
+		}
+
+		// Device counts
+		Json::Value jsonDevices;
+		std::string sUsed = "true";
+		m_webservers.GetJSonDevices(jsonDevices, sUsed, "", "", "", "", "", false, false, false, 0, "", "");
+		int iDeviceCount = 0;
+		if (jsonDevices.isObject() && jsonDevices.isMember("result"))
+			iDeviceCount = jsonDevices["result"].size();
+		sResult += "Active devices: " + std::to_string(iDeviceCount) + "\n";
+
+		// Hardware count
+		auto hwResult = m_sql.safe_query("SELECT COUNT(*) FROM Hardware WHERE Enabled=1");
+		if (!hwResult.empty())
+			sResult += "Active hardware: " + hwResult[0][0] + "\n";
+
+		// Scenes count
+		auto scResult = m_sql.safe_query("SELECT COUNT(*) FROM Scenes");
+		if (!scResult.empty())
+			sResult += "Scenes/groups: " + scResult[0][0] + "\n";
+
+		Json::Value tool;
+		tool["type"] = "text";
+		tool["text"] = sResult;
+		jsonRPCRep["result"]["content"] = Json::Value(Json::arrayValue);
+		jsonRPCRep["result"]["content"].append(tool);
+		jsonRPCRep["result"]["isError"] = false;
 		return true;
 	}
 

--- a/mcpserver/McpService.hpp
+++ b/mcpserver/McpService.hpp
@@ -23,6 +23,7 @@ namespace mcp
 
 	bool toggleSwitchState(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 	bool setThermostatSetpoint(const Json::Value& jsonRequest, Json::Value& jsonRPCRep);
+	bool getStatus(const Json::Value &jsonRequest, Json::Value &jsonRPCRep);
 
 	bool getDeviceByName(const std::string &sDeviceName, Json::Value &device);
 


### PR DESCRIPTION
## Summary

Add a `get_status` tool to the MCP (Model Context Protocol) server that returns a system health overview. This gives AI agents a quick way to check if the Domoticz instance is running and healthy.

## What it returns

- **Version info**: version string, build hash, build time
- **Server time**: current server date/time
- **Uptime**: days, hours, minutes, seconds since startup
- **Sunrise/Sunset**: times and day length (when available)
- **Counts**: active devices, enabled hardware, scenes/groups

## Tool definition

```json
{
  "name": "get_status",
  "title": "Get the system status of Domoticz",
  "description": "Retrieve the current system status including version, uptime, sunrise/sunset times and device/hardware counts. Use this tool to check if the Domoticz instance is running and healthy.",
  "inputSchema": { "type": "object" }
}
```

No parameters required — the tool takes no arguments.

## Example response

_(screenshot to be added)_

## Changes

- `mcpserver/McpService.cpp`: Add tool registration in `McpToolsList`, dispatch in `McpToolsCall`, and `getStatus()` implementation
- `mcpserver/McpService.hpp`: Add `getStatus()` declaration

## Testing

Tested on a live Domoticz instance via curl:

```bash
curl -s -X POST http://127.0.0.1/mcp \
  -H "Accept: application/json" \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"get_status","arguments":{}}}'
```
