### PR TITLE
Add Domoticz.SendNotification() native Python plugin API

### DIFF
--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -375,6 +375,55 @@ namespace Plugins
 		Py_RETURN_NONE;
 	}
 
+	static PyObject *PyDomoticz_SendNotification(PyObject *self, PyObject *args, PyObject *kwds)
+	{
+		module_state *pModState = CPlugin::FindModule();
+		if (!pModState)
+		{
+			Py_RETURN_NONE;
+		}
+		else if (!pModState->pPlugin)
+		{
+			_log.Log(LOG_ERROR, "CPlugin:%s, illegal operation, Plugin has not started yet.", __func__);
+			Py_RETURN_NONE;
+		}
+
+		const char *Subject = nullptr;
+		const char *Body = nullptr;
+		int Priority = 0;
+		const char *Sound = "";
+		const char *ExtraData = "";
+		const char *SubSystem = "";
+		int Delay = 0;
+		static char *kwlist[] = { "subject", "body", "priority", "sound", "extradata", "subsystem", "delay", nullptr };
+
+		if (!PyArg_ParseTupleAndNormalizedKeywords(args, kwds, "s|sisssi", kwlist, &Subject, &Body, &Priority, &Sound, &ExtraData, &SubSystem, &Delay))
+		{
+			pModState->pPlugin->Log(LOG_ERROR, "%s: Failed to parse parameters, expected subject and optional body/priority/sound/extradata/subsystem/delay.", __func__);
+			pModState->pPlugin->LogPythonException(std::string(__func__));
+			Py_RETURN_NONE;
+		}
+
+		if (!Subject || !Subject[0])
+		{
+			pModState->pPlugin->Log(LOG_ERROR, "%s: Empty subject is not allowed.", __func__);
+			Py_RETURN_NONE;
+		}
+
+		if (Delay < 0)
+		{
+			pModState->pPlugin->Log(LOG_ERROR, "%s: Negative delay (%d) is not supported, using 0 seconds.", __func__, Delay);
+			Delay = 0;
+		}
+
+		std::string sSubject = Subject;
+		std::string sBody = (Body && Body[0]) ? Body : sSubject;
+
+		m_sql.AddTaskItem(_tTaskItem::SendNotification(static_cast<float>(Delay), sSubject, sBody, ExtraData, Priority, Sound, SubSystem));
+
+		Py_RETURN_NONE;
+	}
+
 	static PyObject *PyDomoticz_Trace(PyObject *self, PyObject *args)
 	{
 		module_state *pModState = CPlugin::FindModule();
@@ -586,6 +635,8 @@ namespace Plugins
 						 { "Debugging", PyDomoticz_Debugging, METH_VARARGS, "Set logging level. 1 set verbose logging, all other values use default level" },
 						 { "Heartbeat", PyDomoticz_Heartbeat, METH_VARARGS, "Set the heartbeat interval, default 10 seconds." },
 						 { "Notifier", PyDomoticz_Notifier, METH_VARARGS, "Enable notification handling with supplied name." },
+						 { "SendNotification", (PyCFunction)PyDomoticz_SendNotification, METH_VARARGS | METH_KEYWORDS,
+										   "Send a notification: Subject, optional Body/Priority/Sound/ExtraData/SubSystem/Delay." },
 						 { "Trace", PyDomoticz_Trace, METH_VARARGS, "Enable/Disable line level Python tracing." },
 						 { "Configuration", (PyCFunction)PyDomoticz_Configuration, METH_VARARGS | METH_KEYWORDS, "Retrieve and Store structured plugin configuration." },
 						 { "Register", (PyCFunction)PyDomoticz_Register, METH_VARARGS | METH_KEYWORDS, "Register Device override class." },


### PR DESCRIPTION
## Summary

Add a new module-level function `Domoticz.SendNotification()` for Python plugins (both legacy `Domoticz` and new `DomoticzEx` systems) that queues notifications through the internal C++ task system, eliminating the need for HTTP loopback requests to `/json.htm?param=sendnotification`.

This follows the same internal path used by dzVents `domoticz.notify()` and Lua `SendNotification`: `_tTaskItem::SendNotification` → `m_notifications.SendMessageEx`.

## Signature

```python
Domoticz.SendNotification(
    subject,              # str, required
    body=None,            # str, optional — defaults to subject
    priority=0,           # int, optional
    sound="",             # str, optional
    extradata="",         # str, optional
    subsystem="",         # str, optional (e.g. "telegram")
    delay=0               # int, optional — seconds, negative clamped to 0
)
```

All keyword arguments are **case-insensitive** (via the existing `PyArg_ParseTupleAndNormalizedKeywords` wrapper used throughout the plugin system).

## Motivation

Python plugins previously had no native way to send notifications. The only option was to open an HTTP connection back to Domoticz's own web server (`127.0.0.1/json.htm`), which:

- Required plugins to detect the HTTP port at startup
- Needed a full TCP connection + HTTP request/response cycle per notification
- Triggered credential injection issues for loopback requests (see #6603)
- Added ~65 lines of connection management boilerplate per plugin

With this change, sending a notification is a single line:
```python
Domoticz.SendNotification(subject="Alert", body="Something happened", subsystem="telegram")
```

## Implementation

- Single new function `PyDomoticz_SendNotification` in `Plugins.cpp`
- Registered in `DomoticzMethods[]` which is shared by both `DomoticzModuleDef` and `DomoticzExModuleDef`, so it is available in both plugin systems
- Queues directly via `m_sql.AddTaskItem(_tTaskItem::SendNotification(...))` — zero network overhead

## Testing

- Built and deployed on Raspberry Pi 5 (arm64, Debian Trixie)
- Verified with OpenDTU plugin sending Telegram notifications on solar production start
- Log confirms: `Notification: OpenDTU Alert` → `Notification sent (telegram) => Success`
- Zero errors at startup

Supersedes #6603 (loopback credential skip) — plugins no longer need HTTP loopback for notifications.