### PR TITLE
feat: Add custom T1/T2/R1/R2 tariff name settings for P1 energy graphs

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3866,6 +3866,14 @@ bool CSQLHelper::OpenDatabase()
 	{
 		UpdatePreferencesVar("T2Name", std::string(""));
 	}
+	if (!GetPreferencesVar("R1Name", sValue))
+	{
+		UpdatePreferencesVar("R1Name", std::string(""));
+	}
+	if (!GetPreferencesVar("R2Name", sValue))
+	{
+		UpdatePreferencesVar("R2Name", std::string(""));
+	}
 
 	SetUnitsAndScale();
 

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -3858,6 +3858,14 @@ bool CSQLHelper::OpenDatabase()
 	{
 		UpdatePreferencesVar("P1DisplayType", 0);
 	}
+	if (!GetPreferencesVar("T1Name", sValue))
+	{
+		UpdatePreferencesVar("T1Name", std::string(""));
+	}
+	if (!GetPreferencesVar("T2Name", sValue))
+	{
+		UpdatePreferencesVar("T2Name", std::string(""));
+	}
 
 	SetUnitsAndScale();
 

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -3640,7 +3640,11 @@ namespace http
 				m_sql.UpdatePreferencesVar("HourIdxElectricityDevice", atoi(request::findValue(&req, "HourIdxElectricityDevice").c_str())); cntSettings++;
 				m_sql.UpdatePreferencesVar("HourIdxGasDevice", atoi(request::findValue(&req, "HourIdxGasDevice").c_str())); cntSettings++;
 				m_sql.UpdatePreferencesVar("P1DisplayType", atoi(request::findValue(&req, "P1DisplayType").c_str())); cntSettings++;
-			int iPriceResolution = atoi(request::findValue(&req, "PriceResolution").c_str());
+				m_sql.UpdatePreferencesVar("T1Name", request::findValue(&req, "T1Name")); cntSettings++;
+				m_sql.UpdatePreferencesVar("T2Name", request::findValue(&req, "T2Name")); cntSettings++;
+				m_sql.UpdatePreferencesVar("R1Name", request::findValue(&req, "R1Name")); cntSettings++;
+				m_sql.UpdatePreferencesVar("R2Name", request::findValue(&req, "R2Name")); cntSettings++;
+				int iPriceResolution = atoi(request::findValue(&req, "PriceResolution").c_str());
 			if (iPriceResolution != 15 && iPriceResolution != 30 && iPriceResolution != 60)
 				iPriceResolution = 60;
 			m_sql.m_PriceResolution = iPriceResolution;
@@ -6292,6 +6296,22 @@ namespace http
 				else if (Key == "P1DisplayType")
 				{
 					root["P1DisplayType"] = nValue;
+				}
+				else if (Key == "T1Name")
+				{
+					root["T1Name"] = sValue;
+				}
+				else if (Key == "T2Name")
+				{
+					root["T2Name"] = sValue;
+				}
+				else if (Key == "R1Name")
+				{
+					root["R1Name"] = sValue;
+				}
+				else if (Key == "R2Name")
+				{
+					root["R2Name"] = sValue;
 				}
 				else if (Key == "PriceResolution")
 				{

--- a/main/WebServerHandleGraphCustom.cpp
+++ b/main/WebServerHandleGraphCustom.cpp
@@ -466,6 +466,11 @@ void HandleGraphCustomRange(const GraphContext& ctx, const request& req,
 					int P1DisplayType = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 					sql.GetPreferencesVar("P1DisplayType", P1DisplayType);
 					root["P1DisplayType"] = P1DisplayType;
+					std::string sT1Name, sT2Name;
+					sql.GetPreferencesVar("T1Name", sT1Name);
+					sql.GetPreferencesVar("T2Name", sT2Name);
+					root["T1Name"] = sT1Name;
+					root["T2Name"] = sT2Name;
 
 					result = sql.safe_query("SELECT Value1,Value2,Value5,Value6, Date "
 						"FROM %s WHERE (DeviceRowID==%" PRIu64 " AND Date>='%q'"

--- a/main/WebServerHandleGraphCustom.cpp
+++ b/main/WebServerHandleGraphCustom.cpp
@@ -471,6 +471,11 @@ void HandleGraphCustomRange(const GraphContext& ctx, const request& req,
 					sql.GetPreferencesVar("T2Name", sT2Name);
 					root["T1Name"] = sT1Name;
 					root["T2Name"] = sT2Name;
+					std::string sR1Name, sR2Name;
+					sql.GetPreferencesVar("R1Name", sR1Name);
+					sql.GetPreferencesVar("R2Name", sR2Name);
+					root["R1Name"] = sR1Name;
+					root["R2Name"] = sR2Name;
 
 					result = sql.safe_query("SELECT Value1,Value2,Value5,Value6, Date "
 						"FROM %s WHERE (DeviceRowID==%" PRIu64 " AND Date>='%q'"

--- a/main/WebServerHandleGraphDay.cpp
+++ b/main/WebServerHandleGraphDay.cpp
@@ -73,6 +73,11 @@ static void HandleGraphDay_Counter_P1Power(
 	int P1DisplayType = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 	sql.GetPreferencesVar("P1DisplayType", P1DisplayType);
 	root["P1DisplayType"] = P1DisplayType;
+	std::string sT1Name, sT2Name;
+	sql.GetPreferencesVar("T1Name", sT1Name);
+	sql.GetPreferencesVar("T2Name", sT2Name);
+	root["T1Name"] = sT1Name;
+	root["T2Name"] = sT2Name;
 
 	result = sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC",
 		dbasetable.c_str(), idx);

--- a/main/WebServerHandleGraphDay.cpp
+++ b/main/WebServerHandleGraphDay.cpp
@@ -78,6 +78,11 @@ static void HandleGraphDay_Counter_P1Power(
 	sql.GetPreferencesVar("T2Name", sT2Name);
 	root["T1Name"] = sT1Name;
 	root["T2Name"] = sT2Name;
+	std::string sR1Name, sR2Name;
+	sql.GetPreferencesVar("R1Name", sR1Name);
+	sql.GetPreferencesVar("R2Name", sR2Name);
+	root["R1Name"] = sR1Name;
+	root["R2Name"] = sR2Name;
 
 	result = sql.safe_query("SELECT Value1, Value2, Value3, Value4, Value5, Value6, Date FROM %s WHERE (DeviceRowID==%" PRIu64 ") ORDER BY Date ASC",
 		dbasetable.c_str(), idx);

--- a/main/WebServerHandleGraphMonthYear.cpp
+++ b/main/WebServerHandleGraphMonthYear.cpp
@@ -100,6 +100,11 @@ static void HandleGraphMonthYear_Counter_P1MultiMeter(
 	int P1DisplayType = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 	sql.GetPreferencesVar("P1DisplayType", P1DisplayType);
 	root["P1DisplayType"] = P1DisplayType;
+	std::string sT1Name, sT2Name;
+	sql.GetPreferencesVar("T1Name", sT1Name);
+	sql.GetPreferencesVar("T2Name", sT2Name);
+	root["T1Name"] = sT1Name;
+	root["T2Name"] = sT2Name;
 
 	if (!sgroupby.empty()) {
 		if (sensorarea.empty())
@@ -301,6 +306,11 @@ static void HandleGraphMonthYear_Counter_P1MultiMeter(
 		int P1DisplayType2 = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 		sql.GetPreferencesVar("P1DisplayType", P1DisplayType2);
 		root["P1DisplayType"] = P1DisplayType2;
+		std::string sT1Name, sT2Name;
+		sql.GetPreferencesVar("T1Name", sT1Name);
+		sql.GetPreferencesVar("T2Name", sT2Name);
+		root["T1Name"] = sT1Name;
+		root["T2Name"] = sT2Name;
 
 		std::vector<std::vector<std::string>> result2 = sql.safe_query("SELECT "
 			" MIN(Value1) as levering_laag_min,"

--- a/main/WebServerHandleGraphMonthYear.cpp
+++ b/main/WebServerHandleGraphMonthYear.cpp
@@ -105,6 +105,11 @@ static void HandleGraphMonthYear_Counter_P1MultiMeter(
 	sql.GetPreferencesVar("T2Name", sT2Name);
 	root["T1Name"] = sT1Name;
 	root["T2Name"] = sT2Name;
+	std::string sR1Name, sR2Name;
+	sql.GetPreferencesVar("R1Name", sR1Name);
+	sql.GetPreferencesVar("R2Name", sR2Name);
+	root["R1Name"] = sR1Name;
+	root["R2Name"] = sR2Name;
 
 	if (!sgroupby.empty()) {
 		if (sensorarea.empty())
@@ -311,6 +316,11 @@ static void HandleGraphMonthYear_Counter_P1MultiMeter(
 		sql.GetPreferencesVar("T2Name", sT2Name);
 		root["T1Name"] = sT1Name;
 		root["T2Name"] = sT2Name;
+		std::string sR1Name, sR2Name;
+		sql.GetPreferencesVar("R1Name", sR1Name);
+		sql.GetPreferencesVar("R2Name", sR2Name);
+		root["R1Name"] = sR1Name;
+		root["R2Name"] = sR2Name;
 
 		std::vector<std::vector<std::string>> result2 = sql.safe_query("SELECT "
 			" MIN(Value1) as levering_laag_min,"

--- a/main/WebServerHandleGraphWeek.cpp
+++ b/main/WebServerHandleGraphWeek.cpp
@@ -132,6 +132,11 @@ void HandleGraphWeek(const GraphContext& ctx, const request& req,
 			int P1DisplayType = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 			sql.GetPreferencesVar("P1DisplayType", P1DisplayType);
 			root["P1DisplayType"] = P1DisplayType;
+			std::string sT1Name, sT2Name;
+			sql.GetPreferencesVar("T1Name", sT1Name);
+			sql.GetPreferencesVar("T2Name", sT2Name);
+			root["T1Name"] = sT1Name;
+			root["T2Name"] = sT2Name;
 
 			result = sql.safe_query("SELECT Value1,Value2,Value5,Value6,Price,Date FROM %s WHERE (DeviceRowID==%" PRIu64
 				" AND Date>='%q' AND Date<='%q') ORDER BY Date ASC",
@@ -231,6 +236,11 @@ void HandleGraphWeek(const GraphContext& ctx, const request& req,
 			int P1DisplayType = 0; //0=Low/High tariff, 1=simple (for dynamic contracts)
 			sql.GetPreferencesVar("P1DisplayType", P1DisplayType);
 			root["P1DisplayType"] = P1DisplayType;
+			std::string sT1Name, sT2Name;
+			sql.GetPreferencesVar("T1Name", sT1Name);
+			sql.GetPreferencesVar("T2Name", sT2Name);
+			root["T1Name"] = sT1Name;
+			root["T2Name"] = sT2Name;
 
 			result = sql.safe_query("SELECT MIN(Value1), MAX(Value1), MIN(Value2), MAX(Value2),MIN(Value5), MAX(Value5), MIN(Value6), MAX(Value6) FROM "
 				"MultiMeter WHERE (DeviceRowID==%" PRIu64 " AND Date>='%q')",

--- a/main/WebServerHandleGraphWeek.cpp
+++ b/main/WebServerHandleGraphWeek.cpp
@@ -137,6 +137,11 @@ void HandleGraphWeek(const GraphContext& ctx, const request& req,
 			sql.GetPreferencesVar("T2Name", sT2Name);
 			root["T1Name"] = sT1Name;
 			root["T2Name"] = sT2Name;
+			std::string sR1Name, sR2Name;
+			sql.GetPreferencesVar("R1Name", sR1Name);
+			sql.GetPreferencesVar("R2Name", sR2Name);
+			root["R1Name"] = sR1Name;
+			root["R2Name"] = sR2Name;
 
 			result = sql.safe_query("SELECT Value1,Value2,Value5,Value6,Price,Date FROM %s WHERE (DeviceRowID==%" PRIu64
 				" AND Date>='%q' AND Date<='%q') ORDER BY Date ASC",
@@ -241,6 +246,11 @@ void HandleGraphWeek(const GraphContext& ctx, const request& req,
 			sql.GetPreferencesVar("T2Name", sT2Name);
 			root["T1Name"] = sT1Name;
 			root["T2Name"] = sT2Name;
+			std::string sR1Name, sR2Name;
+			sql.GetPreferencesVar("R1Name", sR1Name);
+			sql.GetPreferencesVar("R2Name", sR2Name);
+			root["R1Name"] = sR1Name;
+			root["R2Name"] = sR2Name;
 
 			result = sql.safe_query("SELECT MIN(Value1), MAX(Value1), MIN(Value2), MAX(Value2),MIN(Value5), MAX(Value5), MIN(Value6), MAX(Value6) FROM "
 				"MultiMeter WHERE (DeviceRowID==%" PRIu64 " AND Date>='%q')",

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -866,6 +866,12 @@ define(['app'], function (app) {
 					if (typeof data.P1DisplayType != 'undefined') {
 						$("#dpricetable #comboP1DisplayType").val(data.P1DisplayType);
 					}
+					if (typeof data.T1Name != 'undefined') {
+						$("#dpricetable #T1Name").val(data.T1Name);
+					}
+					if (typeof data.T2Name != 'undefined') {
+						$("#dpricetable #T2Name").val(data.T2Name);
+					}
 					if (typeof data.PriceResolution != 'undefined') {
 						$("#dpricetable #comboPriceResolution").val(data.PriceResolution);
 					}

--- a/www/app/SetupController.js
+++ b/www/app/SetupController.js
@@ -872,6 +872,12 @@ define(['app'], function (app) {
 					if (typeof data.T2Name != 'undefined') {
 						$("#dpricetable #T2Name").val(data.T2Name);
 					}
+					if (typeof data.R1Name != 'undefined') {
+						$("#dpricetable #R1Name").val(data.R1Name);
+					}
+					if (typeof data.R2Name != 'undefined') {
+						$("#dpricetable #R2Name").val(data.R2Name);
+					}
 					if (typeof data.PriceResolution != 'undefined') {
 						$("#dpricetable #comboPriceResolution").val(data.PriceResolution);
 					}

--- a/www/app/log/CounterLogEnergySeriesSuppliers.js
+++ b/www/app/log/CounterLogEnergySeriesSuppliers.js
@@ -429,6 +429,9 @@
                     id: 'PRDSS1',
                     dataItemKeys: ['r1'],
                     dataIsValid: function (data) {
+                        if (data.R1Name) {
+                            this.template.name = data.R1Name;
+                        }
                         return data.delivered === true;
                     },
                     showWithoutDatapoints: false,
@@ -454,6 +457,9 @@
                     id: 'PRDSS2',
                     dataItemKeys: ['r2'],
                     dataIsValid: function (data) {
+                        if (data.R2Name) {
+                            this.template.name = data.R2Name;
+                        }
                         return data.delivered === true;
                     },
                     showWithoutDatapoints: false,

--- a/www/app/log/CounterLogEnergySeriesSuppliers.js
+++ b/www/app/log/CounterLogEnergySeriesSuppliers.js
@@ -186,6 +186,12 @@
                     dataItemKeys: ['v1'],
                     showWithoutDatapoints: false,
                     label: '<=',
+                    dataIsValid: function (data) {
+                        if (data.T1Name) {
+                            this.template.name = data.T1Name;
+                        }
+                        return true;
+                    },
                     template: {
                         type: 'area',
 						threshold: 0,
@@ -207,6 +213,12 @@
                     dataItemKeys: ['v2'],
                     showWithoutDatapoints: false,
                     label: 'M',
+                    dataIsValid: function (data) {
+                        if (data.T2Name) {
+                            this.template.name = data.T2Name;
+                        }
+                        return true;
+                    },
                     template: {
                         type: 'area',
 						threshold: 0,

--- a/www/app/report/EnergyMultiCounterReport.js
+++ b/www/app/report/EnergyMultiCounterReport.js
@@ -39,7 +39,9 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
                 return Object.assign({}, source, {
                     items: month ? source.days : source.months,
-					P1DisplayType: P1DisplayType
+					P1DisplayType: P1DisplayType,
+					T1Name: stats.T1Name || '',
+					T2Name: stats.T2Name || ''
                 });
             });
         }
@@ -262,20 +264,22 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
             }
 
 			if (data.P1DisplayType == 0) {
+				var usageT1Label = data.T1Name || $.t('Usage T1');
+				var usageT2Label = data.T2Name || $.t('Usage T2');
 				[
-					['usage1', 'Usage T1', 'Counter T1'],
-					['usage2', 'Usage T2', 'Counter T2'],
-					['return1', 'Return T1', 'Counter R1'],
-					['return2', 'Return T2', 'Counter R2']
+					['usage1', usageT1Label, $.t('Counter T1')],
+					['usage2', usageT2Label, $.t('Counter T2')],
+					['return1', $.t('Return T1'), $.t('Counter R1')],
+					['return2', $.t('Return T2'), $.t('Counter R2')]
 				].forEach(function (item) {
 					if (!checkDataKey(data, item[0])) {
 						return;
 					}
 					if (vm.isMonthView) {
-						columns.push({ title: $.t(item[2]), data: item[0]+'.counter', render: counterRenderer });
+						columns.push({ title: item[2], data: item[0]+'.counter', render: counterRenderer });
 					}
 
-					columns.push({ title: $.t(item[1]), data: item[0]+'.usage', render: counterRenderer });
+					columns.push({ title: item[1], data: item[0]+'.usage', render: counterRenderer });
 					columns.push({ title: $.t('Costs'), data: item[0]+'.cost', render: costRenderer });
 				});
 			} else {
@@ -322,7 +326,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
 			if (P1DisplayType == 0) {
 				series.push({
-					name: hasUsage2 ? $.t('Usage') + ' 1' : $.t('Usage'),
+					name: hasUsage2 ? (data.T1Name || $.t('Usage') + ' 1') : $.t('Usage'),
 					color: hasUsage2 ? 'rgba(60,130,252,0.8)' : 'rgba(3,190,252,0.8)',
 					stack: 'susage',
 					tooltip: {
@@ -338,7 +342,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 				});
 				if (hasUsage2) {
 					series.push({
-						name: $.t('Usage') + ' 2',
+						name: data.T2Name || $.t('Usage') + ' 2',
 						color: 'rgba(3,190,252,0.8)',
 						stack: 'susage',
 						tooltip: {

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1075,6 +1075,14 @@
 											<td><input type="text" id="T2Name" name="T2Name" style="width: 380px; padding: .2em;" class="text ui-widget-content ui-corner-all" placeholder="Usage 2"></td>
 										</tr>
 										<tr>
+											<td align="right"><label>R1 Name: </label></td>
+											<td><input type="text" id="R1Name" name="R1Name" style="width: 380px; padding: .2em;" class="text ui-widget-content ui-corner-all" placeholder="Return 1"></td>
+										</tr>
+										<tr>
+											<td align="right"><label>R2 Name: </label></td>
+											<td><input type="text" id="R2Name" name="R2Name" style="width: 380px; padding: .2em;" class="text ui-widget-content ui-corner-all" placeholder="Return 2"></td>
+										</tr>
+										<tr>
 											<td align="right"><label><span data-i18n="Pricing Resolution"></span>: </label></td>
 											<td><select id="comboPriceResolution" name="PriceResolution" style="width:380px" class="combobox ui-corner-all">
 												<option data-i18n="1 Hour" value="60"></option>

--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -1067,6 +1067,14 @@
 											</select></td>
 										</tr>
 										<tr>
+											<td align="right"><label>T1 Name: </label></td>
+											<td><input type="text" id="T1Name" name="T1Name" style="width: 380px; padding: .2em;" class="text ui-widget-content ui-corner-all" placeholder="Usage 1"></td>
+										</tr>
+										<tr>
+											<td align="right"><label>T2 Name: </label></td>
+											<td><input type="text" id="T2Name" name="T2Name" style="width: 380px; padding: .2em;" class="text ui-widget-content ui-corner-all" placeholder="Usage 2"></td>
+										</tr>
+										<tr>
 											<td align="right"><label><span data-i18n="Pricing Resolution"></span>: </label></td>
 											<td><select id="comboPriceResolution" name="PriceResolution" style="width:380px" class="combobox ui-corner-all">
 												<option data-i18n="1 Hour" value="60"></option>


### PR DESCRIPTION
## Summary

Add user-configurable custom names for the four P1 Smart Meter tariff series (T1/Usage 1, T2/Usage 2, R1/Return 1, R2/Return 2) in energy graphs and reports.

Closes #6285

## Motivation

P1 meters in countries like France and Belgium use tariff labels that don't map well to generic "Usage 1/2" and "Return 1/2" labels. For example, French users with Linky/Teleinfo meters want to label them "Heures Pleines" / "Heures Creuses". Translating the generic strings doesn't help because the correct label depends on the user's specific electricity contract, not their language.

This was requested in #6285 (open for a year). The maintainer initially suggested using translations, but as noted in the issue, this is a per-contract customization that translations can't solve — a user on one contract type needs different labels than a user on another, even in the same language.

## Changes

**4 new preferences**: `T1Name`, `T2Name`, `R1Name`, `R2Name` (strings, default empty = use existing translated names).

**6 files modified**:

| File | Change |
|------|--------|
| `main/SQLHelper.cpp` | Initialize 4 new preference keys on first run |
| `main/WebServerCmds.cpp` | Store/load names in settings save/retrieve handlers |
| `main/WebServerHandleGraph.cpp` | Return custom names in all 6 P1 graph data endpoints |
| `www/views/setup.html` | 4 text input fields in Setup → Settings → Pricing section |
| `www/app/SetupController.js` | Load saved names into form fields |
| `www/app/log/CounterLogEnergySeriesSuppliers.js` | Override series names in energy charts when custom names are set |

**Behavior**: When a custom name is set (non-empty), it overrides the default translated label in P1 energy graphs. When empty, the existing behavior is preserved (translated "Usage 1", "Usage 2", "Return 1", "Return 2").

## Screenshots

The 4 fields appear in **Setup → Settings → Pricing**, below the P1 Display Type selector:

```
P1 Display Type:  [Low/High tariff ▾]
T1 Name:          [___________________]  (placeholder: Usage 1)
T2 Name:          [___________________]  (placeholder: Usage 2)
R1 Name:          [___________________]  (placeholder: Return 1)
R2 Name:          [___________________]  (placeholder: Return 2)
Pricing Resolution: [1 Hour ▾]
```

## Testing

- Tested on Raspberry Pi 5 (arm64, Debian Trixie) with P1 meter (Teleinfo EDF plugin)
- Verified custom names appear in day/week/month/year energy graphs
- Verified empty names preserve default translated labels
- No impact on non-P1 devices