### PR TITLE
fix: resolve lowercase custom icon names and navbar/barometer UI issues

### DIFF
--- a/www/app/log/BarometerLog.html
+++ b/www/app/log/BarometerLog.html
@@ -36,14 +36,6 @@
     <barometer-volatility-chart
             class="device-log-chart"
             device="::$ctrl.device"></barometer-volatility-chart>
-    <br/>
-    <barometer-dewpoint-chart
-            class="device-log-chart"
-            device="::$ctrl.device"></barometer-dewpoint-chart>
-    <br/>
-    <barometer-heatindex-chart
-            class="device-log-chart"
-            device="::$ctrl.device"></barometer-heatindex-chart>
 </div>
 <br/>
 <barometer-long-chart

--- a/www/app/widgets/dzLightWidget.js
+++ b/www/app/widgets/dzLightWidget.js
@@ -407,7 +407,9 @@ define(['app'], function (app) {
                     // Door Lock / Door Lock Inverted use InternalState (not Status) to pick icon
                     if (device.SwitchType == 'Door Lock' || device.SwitchType == 'Door Lock Inverted') {
                         var lockImage = device.Image || 'Light';
-                        lockImage = lockImage.charAt(0).toUpperCase() + lockImage.slice(1);
+                        if (device.CustomImage == 0) {
+                            lockImage = lockImage.charAt(0).toUpperCase() + lockImage.slice(1);
+                        }
                         var isUnlocked = device.InternalState == 'Unlocked';
                         return 'images/' + lockImage + '48_' + (isUnlocked ? 'On' : 'Off') + '.png';
                     }
@@ -418,8 +420,10 @@ define(['app'], function (app) {
                     if (!image) {
                         image = 'Light';
                     }
-                    // Capitalize first letter to match file naming convention
-                    image = image.charAt(0).toUpperCase() + image.slice(1);
+                    // Only capitalize for built-in icons; custom icons must preserve their original casing
+                    if (device.CustomImage == 0) {
+                        image = image.charAt(0).toUpperCase() + image.slice(1);
+                    }
 
                     // RGB/LED dimmers with default image use RGB icon
                     if (ctrl.isDimmer() && ctrl.isRGB() && device.CustomImage == 0) {
@@ -583,7 +587,9 @@ define(['app'], function (app) {
                 ctrl.getMediaPlayerIcon = function () {
                     var image = device.CustomImage == 0 ? device.TypeImg : device.Image;
                     if (!image) image = 'Light';
-                    image = image.charAt(0).toUpperCase() + image.slice(1);
+                    if (device.CustomImage == 0) {
+                        image = image.charAt(0).toUpperCase() + image.slice(1);
+                    }
                     if (device.Status !== 'Off' && device.Status !== '0' && device.Status !== 'Disconnected') {
                         return 'images/' + image + '48_On.png';
                     }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -947,6 +947,7 @@ table.mobileitem {
 
 .navbar .nav > li {
 	margin-top: 2px;
+	margin-left: 3px;
 }
 
 .navbar .nav li a {

--- a/www/index.html
+++ b/www/index.html
@@ -1258,26 +1258,17 @@ $(document).ready(function() {
 			<div class="container">
 				<a class="brand hidden-phone" id="version" href="#Dashboard"><img src="images/logo/57.png"><h1>Domoticz</h1> <h2 id="appversion" tooltip-html="{{config.versiontooltip}}" tooltip-placement="right" class="version-tooltip">*</h2></a>
 				<ul class="nav" id="appnavbar">
-					<li ng-show="config.EnableTabDashboard" class="divider-vertical clDashboard"></li>
 					<li ng-show="config.EnableTabDashboard" ng-class="{'current_page_item':getClass('/Dashboard')}" class="clDashboard"><a id="cDashboard" href="#Dashboard"><img src="images/desktop.png"> <span class="hidden-phone hidden-tablet" data-i18n="Dashboard">Dashboard</span></a></li>
-					<li ng-show="config.EnableTabFloorplans" class="divider-vertical clFloorplans"></li>
 					<li ng-show="config.EnableTabFloorplans" ng-class="{'current_page_item':getClass('/Floorplans')}" class="clFloorplans"><a id="cFloorplans" href="#Floorplans"><img src="images/house.png"> <span class="hidden-phone hidden-tablet" data-i18n="Floorplan">Floorplan</span></a></li>
-					<li ng-show="config.EnableTabLights" class="divider-vertical clLightSwitches"></li>
 					<li ng-show="config.EnableTabLights" ng-class="{'current_page_item':getClass('/LightSwitches')}" class="clLightSwitches"><a id="cLightSwitches" href="#LightSwitches"><img src="images/lightbulb.png"> <span class="hidden-phone hidden-tablet" data-i18n="Switches">Switches</span></a></li>
-					<li ng-show="config.EnableTabScenes" class="divider-vertical clScenes"></li>
 					<li ng-show="config.EnableTabScenes" ng-class="{'current_page_item':getClass('/Scenes')}" class="clScenes"><a id="cScenes" href="#Scenes"><img src="images/scenes.png"> <span class="hidden-phone hidden-tablet" data-i18n="Scenes">Scenes</span></a></li>
-					<li ng-show="config.EnableTabTemp" class="divider-vertical clTemperature"></li>
 					<li ng-show="config.EnableTabTemp" ng-class="{'current_page_item':getClass('/Temperature')}" class="clTemperature"><a id="cTemperature" href="#Temperature"><img src="images/temperature.png"> <span class="hidden-phone hidden-tablet" data-i18n="Temperature">Temperature</span></a></li>
-					<li ng-show="config.EnableTabWeather" class="divider-vertical clWeather"></li>
 					<li ng-show="config.EnableTabWeather" ng-class="{'current_page_item':getClass('/Weather')}" class="clWeather"><a id="cWeather" href="#Weather"><img src="images/rain.png"> <span class="hidden-phone hidden-tablet" data-i18n="Weather">Weather</span></a></li>
-					<li ng-show="config.EnableTabUtility" class="divider-vertical clUtility"></li>
 					<li ng-show="config.EnableTabUtility" ng-class="{'current_page_item':getClass('/Utility')}" class="clUtility"><a id="cUtility" href="#Utility"><img src="images/utility.png"> <span class="hidden-phone hidden-tablet" data-i18n="Utility">Utility</span></a></li>
-					<li ng-show="config.EnableTabCustom" class="divider-vertical clcustommenu"></li>
 					<li ng-show="config.EnableTabCustom" class="dropdown clcustommenu">
 						<a class="dropdown-toggle lcursor" data-toggle="dropdown"><img src="images/devices.png"> <span class="hidden-phone hidden-tablet" data-i18n="Custom">Custom</span> <b class="caret hidden-phone hidden-tablet"></b></a>
 						<ul class="dropdown-menu pull-right" id="custommenu"></ul>
 					</li>
-					<li class="divider-vertical" style="display: none;" has-permission="Admin"></li>
 					<li class="dropdown" style="display: none;" has-permission="Admin">
 						<a class="dropdown-toggle lcursor" data-toggle="dropdown"><img src="images/setup.png"> <span class="hidden-phone hidden-tablet" data-i18n="Setup">Setup</span> <b class="caret hidden-phone hidden-tablet"></b></a>
 						<ul class="dropdown-menu pull-right">
@@ -1338,7 +1329,6 @@ $(document).ready(function() {
 							<li id="mLogoutSetup" style="display: none;" can-Logout=true><a id="cLogout" href="#Logout"><img src="images/logout.png"> <span data-i18n="Logout">Logout</span></a></li>
 						</ul>
 					</li>
-					<li id="dLogout" class="divider-vertical" style="display: none;" has-Login-No-Admin=true></li>
 					<li id="mLogout" style="display: none;" has-Login-No-Admin=true>
 						<a class="dropdown-toggle lcursor" data-toggle="dropdown"><img src="images/users.png"> <span class="hidden-phone hidden-tablet" data-i18n="Other">Other</span> <b class="caret hidden-phone hidden-tablet"></b></a>
 						<ul class="dropdown-menu pull-right">


### PR DESCRIPTION
## Summary

- **fix(icons):** Preserve case of custom icon filenames — only capitalize built-in icons (`CustomImage==0`). This fixes 404 errors for custom icons whose filename starts with a lowercase letter (closes #6648)
- **fix(navbar):** Remove `divider-vertical` separator elements and add 3px spacing between menu buttons for a cleaner look
- **fix(barometer-log):** Remove non-existent `barometer-dewpoint-chart` and `barometer-heatindex-chart` components that caused a large empty space between the advanced charts and the last-month graph

## Test plan

- [ ] Verify custom icons with lowercase filenames (e.g. `xfrpimonitor48_On.png`) display correctly on the switches/devices page
- [ ] Verify built-in icons still display correctly
- [ ] Check navbar buttons have small spacing and no vertical separator lines
- [ ] Open barometer log, toggle advanced charts — confirm no empty space before "Last Month" graph