### PR TITLE
Release notes path in docker is broken

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -2704,6 +2704,10 @@ namespace http
 			root["title"] = "GetActualHistory";
 
 			std::string historyfile = szUserDataFolder + "History.txt";
+			if (szStartupFolder != szUserDataFolder)
+			{
+				historyfile = szStartupFolder + "History.txt";
+			}
 
 			std::ifstream infile;
 			int ii = 0;


### PR DESCRIPTION
The release notes path in Docker is broken: 
the page does not show anything because History.txt resides in wrong path and domoticz only looks in szUserDataFolder (which differs in Docker due to the -userdata flag). 

The fix applies a similar logic to what has been already done in OpenZWave.cpp.