### PR TITLE
fix: don't show barometric forecast in temperature section

### DIFF
--- a/www/views/dashboard_desktop.html
+++ b/www/views/dashboard_desktop.html
@@ -106,7 +106,7 @@
 								<td id="status" class="status"><span>
 									<span ng-if="device.HumidityStatus">{{device.HumidityStatus}}</span>
 									<span ng-if="device.DewPoint != undefined"><span ng-if="device.HumidityStatus">, </span><span data-i18n="Dew Point">Dew Point</span>: {{device.DewPoint | number:2}}&deg;</span>
-									<span ng-if="device.ForecastStr != undefined"><br>{{device.ForecastStr}}</span>
+									<span ng-if="device.ForecastStr != undefined && device.Barometer == undefined"><br>{{device.ForecastStr}}</span>
 								</span></td>
 								<td id="lastupdate" class="lastupdate"><span data-i18n="Last Seen" style="font-style: italic">Last Seen</span>: <span>{{device.LastUpdate}}</span></td>
 							</tr>
@@ -149,7 +149,7 @@
 										<img ng-if="device.CustomImage == 0 && device.Direction != undefined" ng-src="images/Wind{{device.DirectionStr}}.png" height="40" width="40" class="lcursor">
 									</a>
 								</td>
-								<td id="status"></td>
+								<td id="status"><span ng-if="device.ForecastStr != undefined">{{device.ForecastStr}}</span></td>
 								<td id="lastupdate"><span data-i18n="Last Seen" style="font-style: italic">Last Seen</span>: {{device.LastUpdate}}</td>
 							</tr>
 						</table>

--- a/www/views/dashboard_mobile.html
+++ b/www/views/dashboard_mobile.html
@@ -450,7 +450,7 @@
 						<span ng-if="(item.SetPoint !== undefined || item.Temp !== undefined || item.Chill !== undefined) && item.Humidity !== undefined">, </span>
 						<span ng-if="item.Humidity !== undefined">{{item.Humidity}} %</span>
 						<span ng-if="item.HumidityStatus !== undefined"> ({{item.HumidityStatus}})</span>
-						<span ng-if="item.ForecastStr !== undefined"> ({{item.ForecastStr}})</span>
+						<span ng-if="item.ForecastStr !== undefined && item.Barometer === undefined"> ({{item.ForecastStr}})</span>
 						<!-- Dew Point -->
 						<span ng-if="item.DewPoint !== undefined"><br><span data-i18n="Dew Point">Dew Point</span>: {{item.DewPoint | number:2}}&deg; {{$parent.config.TempSign}}</span>
 					</td>


### PR DESCRIPTION
## Summary

- Temperature section (desktop & mobile): barometric forecast (`ForecastStr`) is no longer shown for sensors that have a barometer field
- Weather section (desktop): `ForecastStr` is now displayed in the status column for weather/barometer devices
- Mobile dashboard weather section already handled this correctly (forecast shown inside the barometer block)