### PR TITLE
Fix JWT token generation for external app

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -179,6 +179,7 @@ Key configuration options:
 **Developer Options:**
 - `USE_PRECOMPILED_HEADER` - Speed up build time (default: YES)
 - `GIT_SUBMODULE` - Check submodules during build (default: ON)
+- `ENABLE_ASAN` - Build with address sanitizer (not supported by MSVC compiler) (default: NO)
 
 ## Common Dependencies
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ ENDIF()
 option(USE_PRECOMPILED_HEADER "Use precompiled header feature to speed up build time " YES)
 option(GIT_SUBMODULE "Check submodules during build" ON)
 
+option(ENABLE_ASAN "Build with address sanitizer" NO)
+IF(ENABLE_ASAN)
+add_compile_options(-fsanitize=address)
+add_link_options(-fsanitize=address)
+ENDIF()
 
 ### COMPILER SETTINGS
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,12 @@ option(GIT_SUBMODULE "Check submodules during build" ON)
 
 option(ENABLE_ASAN "Build with address sanitizer" NO)
 IF(ENABLE_ASAN)
-add_compile_options(-fsanitize=address)
-add_link_options(-fsanitize=address)
+  IF(NOT MSVC)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+   ELSE()
+     message(WARNING "ASAN is not supported with MSVC compiler")
+  ENDIF()
 ENDIF()
 
 ### COMPILER SETTINGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,7 @@ ENDIF()
 # Developer-oriented options
 option(USE_PRECOMPILED_HEADER "Use precompiled header feature to speed up build time " YES)
 option(GIT_SUBMODULE "Check submodules during build" ON)
-
 option(ENABLE_ASAN "Build with address sanitizer" NO)
-IF(ENABLE_ASAN)
-  IF(NOT MSVC)
-    add_compile_options(-fsanitize=address)
-    add_link_options(-fsanitize=address)
-   ELSE()
-     message(WARNING "ASAN is not supported with MSVC compiler")
-  ENDIF()
-ENDIF()
 
 ### COMPILER SETTINGS
 #
@@ -82,6 +73,14 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
   #ADD_DEFINITIONS( -Wall -O0 -ggdb )
   #ADD_DEFINITIONS( -Wfatal-errors -Wformat=2 -Werror=format-security )
   ADD_DEFINITIONS( -D_FILE_OFFSET_BITS=64 )
+ENDIF()
+IF(ENABLE_ASAN)
+  IF(NOT MSVC)
+    add_compile_options(-fsanitize=address)
+    add_link_options(-fsanitize=address)
+   ELSE()
+     message(WARNING "ASAN is not supported with MSVC compiler")
+  ENDIF()
 ENDIF()
 
 ### VERSIONING SUPPORT

--- a/hardware/EnphaseAPI.cpp
+++ b/hardware/EnphaseAPI.cpp
@@ -1705,7 +1705,7 @@ bool EnphaseAPI::getInverterDetails()
 			// Update
 			UpdateValueInt(szDeviceID.c_str(), 1, devType, subType, 12, 255, nValue, sValue.c_str(), result[0][0]);
 		}
-		}
+	}
 	return true;
 }
 

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5533,6 +5533,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 	int nValueBeforeUpdate = -1;
 	std::string sValueBeforeUpdate;
 	_eSwitchType stype = STYPE_OnOff;
+	char sValueUpdate[100];
 
 	if (result.empty())
 	{
@@ -5602,7 +5603,6 @@ uint64_t CSQLHelper::UpdateValueInt(
 			if (!powerAndEnergyUpdate.empty())
 			{
 				const char* powerUpdate = powerAndEnergyUpdate[0].c_str();
-				char sValueUpdate[100];
 				sprintf(sValueUpdate, "%s;%.4f", powerUpdate, energyAfterInterval);
 				sValue = sValueUpdate;
 			}

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -5533,7 +5533,7 @@ uint64_t CSQLHelper::UpdateValueInt(
 	int nValueBeforeUpdate = -1;
 	std::string sValueBeforeUpdate;
 	_eSwitchType stype = STYPE_OnOff;
-	char sValueUpdate[100];
+	std::string sValueUpdate;
 
 	if (result.empty())
 	{
@@ -5603,8 +5603,8 @@ uint64_t CSQLHelper::UpdateValueInt(
 			if (!powerAndEnergyUpdate.empty())
 			{
 				const char* powerUpdate = powerAndEnergyUpdate[0].c_str();
-				sprintf(sValueUpdate, "%s;%.4f", powerUpdate, energyAfterInterval);
-				sValue = sValueUpdate;
+				sValueUpdate = std_format("%s;%.4f", powerUpdate, energyAfterInterval);
+				sValue = sValueUpdate.c_str();
 			}
 			else
 			{

--- a/notifications/NotificationFCM.cpp
+++ b/notifications/NotificationFCM.cpp
@@ -6,7 +6,7 @@
 #include "../main/json_helper.h"
 
 #define JWT_DISABLE_BASE64
-#include <jwt-cpp/jwt.h>
+#include <jwt-cpp/traits/open-source-parsers-jsoncpp/defaults.h>
 #include <libwebem/Base64.h>
 
 #define GAPI_FCM_POST_URL_BASE "https://fcm.googleapis.com/v1/projects/##PROJECTID##/messages:send"


### PR DESCRIPTION
This PR fixes 2 issues:

- JWT token generation: it was broken by the externalization of libwebem because it was using a different JSON implementation, causing a crash
- Stack use after out of scope in SQLHelper in some cases

I found these 2 issues with address sanitizer, so this PR also adds the possibility to build with ASAN enabled (disabled by default)

Stack trace of the `jwt::create()` for reference:

```
==4130669==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7bf6a1633918 at pc 0x5614d385d58a bp 0x7bf6a22c46e0 sp 0x7bf6a22c46d8
WRITE of size 8 at 0x7bf6a1633918 thread T8
    #0 0x5614d385d589 in std::_Rb_tree_header::_M_reset() /usr/include/c++/15/bits/stl_tree.h:209
    #1 0x5614d385d4c2 in std::_Rb_tree_header::_Rb_tree_header() /usr/include/c++/15/bits/stl_tree.h:174
    #2 0x5614d4894fb5 in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value> > >::_Rb_tree_impl<std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, true>::_Rb_tree_impl() /usr/include/c++/15/bits/stl_tree.h:1314
    #3 0x5614d488f3c3 in std::_Rb_tree<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value>, std::_Select1st<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value> > >::_Rb_tree() /usr/include/c++/15/bits/stl_tree.h:1553
    #4 0x5614d488f3df in std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, picojson::value, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, picojson::value> > >::map() /usr/include/c++/15/bits/stl_map.h:200
    #5 0x5614d48976e4 in jwt::builder<jwt::default_clock, jwt::traits::kazuho_picojson>::builder(jwt::default_clock) /home/arya/domoticz/extern/jwtcpp/include/jwt-cpp/jwt.h:3139
    #6 0x5614d4894e42 in jwt::create() /home/arya/domoticz/extern/jwtcpp/include/jwt-cpp/traits/open-source-parsers-jsoncpp/defaults.h:32
    #7 0x5614d49554ee in http::server::cWebem::GenerateJwtToken(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, unsigned int, Json::Value, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/arya/domoticz/extern/libwebem/src/cWebem.cpp:1634
    #8 0x5614d3eb74e2 in http::server::CWebServer::PostOauth2AccessToken(http::server::_tWebEmSession&, http::server::request const&, http::server::reply&) /home/arya/domoticz/iamserver/IamService.cpp:377
    #9 0x5614d3c6a8f5 in operator()<http::server::_tWebEmSession&, const http::server::request&, http::server::reply&> /home/arya/domoticz/main/WebServer.cpp:264
    #10 0x5614d3d2f927 in __invoke_impl<void, http::server::CWebServer::StartServer(http::server::server_settings&, const std::string&, bool)::<lambda(auto:36&&, auto:37&&, auto:38&&)>&, http::server::_tWebEmSession&, const http::server::request&, http::server::reply&> /usr/include/c++/15/bits/invoke.h:63
    #11 0x5614d3d09b1e in __invoke_r<void, http::server::CWebServer::StartServer(http::server::server_settings&, const std::string&, bool)::<lambda(auto:36&&, auto:37&&, auto:38&&)>&, http::server::_tWebEmSession&, const http::server::request&, http::server::reply&> /usr/include/c++/15/bits/invoke.h:113
    #12 0x5614d3cf1406 in _M_invoke /usr/include/c++/15/bits/std_function.h:292
    #13 0x5614d49781a4 in std::function<void (http::server::_tWebEmSession&, http::server::request const&, http::server::reply&)>::operator()(http::server::_tWebEmSession&, http::server::request const&, http::server::reply&) const /usr/include/c++/15/bits/std_function.h:593
    #14 0x5614d4947eef in http::server::cWebem::CheckForPageOverride(http::server::_tWebEmSession&, http::server::request&, http::server::reply&) /home/arya/domoticz/extern/libwebem/src/cWebem.cpp:681
    #15 0x5614d4962588 in http::server::cWebemRequestHandler::handle_request(http::server::request const&, http::server::reply&) /home/arya/domoticz/extern/libwebem/src/cWebem.cpp:2511
    #16 0x5614d49f5560 in http::server::connection::handle_read(boost::system::error_code const&, unsigned long) /home/arya/domoticz/extern/libwebem/src/connection.cpp:451
    #17 0x5614d49fc257 in operator()<const boost::system::error_code&, long unsigned int> /home/arya/domoticz/extern/libwebem/src/connection.cpp:221
    #18 0x5614d4a07058 in call_handler<http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> > /usr/include/boost/asio/ssl/detail/read_op.hpp:60
    #19 0x5614d4a03fe4 in operator() /usr/include/boost/asio/ssl/detail/io.hpp:309
    #20 0x5614d4a33ff7 in operator() /usr/include/boost/asio/detail/bind_handler.hpp:289
    #21 0x5614d4a2d0a7 in asio_handler_invoke<boost::asio::detail::binder2<boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> >, boost::system::error_code, long unsigned int> > /usr/include/boost/asio/handler_invoke_hook.hpp:88
    #22 0x5614d4a27e86 in invoke<boost::asio::detail::binder2<boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> >, boost::system::error_code, long unsigned int>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> > /usr/include/boost/asio/detail/handler_invoke_helpers.hpp:54
    #23 0x5614d4a23842 in asio_handler_invoke<boost::asio::detail::binder2<boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> >, boost::system::error_code, long unsigned int>, boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> > /usr/include/boost/asio/ssl/detail/io.hpp:374
    #24 0x5614d4a204b2 in invoke<boost::asio::detail::binder2<boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> >, boost::system::error_code, long unsigned int>, boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> > > /usr/include/boost/asio/detail/handler_invoke_helpers.hpp:54
    #25 0x5614d4a1e9c1 in complete<boost::asio::detail::binder2<boost::asio::ssl::detail::io_op<boost::asio::basic_stream_socket<boost::asio::ip::tcp>, boost::asio::ssl::detail::read_op<boost::asio::mutable_buffers_1>, http::server::connection::read_more()::<lambda(auto:38&&, auto:39)> >, boost::system::error_code, long unsigned int> > /usr/include/boost/asio/detail/handler_work.hpp:524
    #26 0x5614d4a19322 in do_complete /usr/include/boost/asio/detail/reactive_socket_recv_op.hpp:152
    #27 0x5614d3fbbaf6 in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /usr/include/boost/asio/detail/scheduler_operation.hpp:40
    #28 0x5614d3fc4159 in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /usr/include/boost/asio/detail/impl/scheduler.ipp:493
    #29 0x5614d3fc34ce in boost::asio::detail::scheduler::run(boost::system::error_code&) /usr/include/boost/asio/detail/impl/scheduler.ipp:210
    #30 0x5614d3ff646a in boost::asio::io_context::run() /usr/include/boost/asio/impl/io_context.ipp:64
    #31 0x5614d49bf8b8 in http::server::server_base::run() /home/arya/domoticz/extern/libwebem/src/server.cpp:68
    #32 0x5614d49419e8 in http::server::cWebem::Run() /home/arya/domoticz/extern/libwebem/src/cWebem.cpp:95
    #33 0x5614d3c6a4dd in http::server::CWebServer::Do_Work() /home/arya/domoticz/main/WebServer.cpp:110
    #34 0x5614d3c70765 in operator() /home/arya/domoticz/main/WebServer.cpp:690
    #35 0x5614d3d49815 in __invoke_impl<void, http::server::CWebServer::StartServer(http::server::server_settings&, const std::string&, bool)::<lambda()> > /usr/include/c++/15/bits/invoke.h:63
    #36 0x5614d3d497d8 in __invoke<http::server::CWebServer::StartServer(http::server::server_settings&, const std::string&, bool)::<lambda()> > /usr/include/c++/15/bits/invoke.h:98
    #37 0x5614d3d49793 in _M_invoke<0> /usr/include/c++/15/bits/std_thread.h:303
    #38 0x5614d3d49767 in operator() /usr/include/c++/15/bits/std_thread.h:310
    #39 0x5614d3d4974b in _M_run /usr/include/c++/15/bits/std_thread.h:255
    #40 0x5614d4b4f7e3 in execute_native_thread_routine (/home/arya/domoticz/build/domoticz+0x1e107e3) (BuildId: d056d7f14facd763c5e63bd0eb0870e24c1513a2)
    #41 0x7ff6b025c0f5 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:239
    #42 0x7ff6af68b468 in start_thread nptl/pthread_create.c:448
    #43 0x7ff6af709cf7 in __clone3 ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```