### PR TITLE
feat(roomplan): rebuild Roomplan editor with drag-reorder, multi-select and disabled hardware fix

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -2225,8 +2225,9 @@ namespace http
 
 			std::vector<std::vector<std::string>> result;
 			std::vector<std::vector<std::string>> result2;
+			// Include all used devices, plus devices from disabled hardware (which may have Used=0)
 			result = m_sql.safe_query("SELECT T1.[ID], T1.[Name], T1.[Type], T1.[SubType], T2.[Name] AS HardwareName FROM DeviceStatus as T1, Hardware as T2 "
-				"WHERE (T1.[Used]==1) AND (T2.[ID]==T1.[HardwareID]) ORDER BY T2.[Name], T1.[Name]");
+				"WHERE (T2.[ID]==T1.[HardwareID]) AND (T1.[Used]==1 OR (T2.[Enabled]==0)) ORDER BY T2.[Name], T1.[Name]");
 			if (!result.empty())
 			{
 				for (const auto& sd : result)

--- a/www/app/plans/RoomPlans.html
+++ b/www/app/plans/RoomPlans.html
@@ -110,14 +110,16 @@
 		<room-plan-device-selector
 				ng-if="::$ctrl.devices"
 				devices="::$ctrl.devices"
-				on-select="$ctrl.selectDevice(device)"></room-plan-device-selector>
+				on-select="$ctrl.onDevicesSelected(devices)"></room-plan-device-selector>
 	</div>
 	<div class="modal-footer">
 		<button type="button"
 				class="btn btn-primary"
-				data-i18n="Add"
-				ng-disabled="!$ctrl.selectedDevice"
-				ng-click="$close($ctrl.selectedDevice)"></button>
+				ng-click="$close($ctrl.selectedDevices)"
+				ng-disabled="!$ctrl.selectedDevices.length">
+			<span data-i18n="Add"></span>
+			<span ng-if="$ctrl.selectedDevices.length > 0">&nbsp;({{ $ctrl.selectedDevices.length }})</span>
+		</button>
 
 		<button type="button"
 				class="btn btn-default"
@@ -146,7 +148,7 @@
 			<room-plans-device-selector-table
 					class="device-selector-group"
 					devices="$ctrl.filteredDevices"
-					on-select="$ctrl.selectDevice(value)"></room-plans-device-selector-table>
+					on-select="$ctrl.selectDevices(values)"></room-plans-device-selector-table>
 		</section>
 	</div>
 </script>

--- a/www/app/plans/RoomPlans.js
+++ b/www/app/plans/RoomPlans.js
@@ -106,12 +106,11 @@ define(['app'], function (app) {
 			});
 		}
 
-		function changeDeviceOrder(order, planId, deviceId) {
+		function changeDeviceOrder(planId, orderedIds) {
 			return dzApiHelper.checkAdminPermissions().then(function () {
 				return domoticzApi.sendCommand('changeplandeviceorder', {
-					idx: deviceId,
 					planid: planId,
-					way: order
+					order: orderedIds.join(',')
 				});
 			});
 		}
@@ -172,17 +171,21 @@ define(['app'], function (app) {
 
 					$ctrl.devices = devices.map(function (device) {
 						var result = regex.exec(device.Name);
-
+						if (!result) {
+							return Object.assign({}, device, { Hardware: '(unknown)', Name: device.Name });
+						}
 						return Object.assign({}, device, {
 							Hardware: result[1],
 							Name: result[2],
-						})
+						});
 					});
 				})
 			}
 
-			$ctrl.selectDevice = function(device) {
-				$ctrl.selectedDevice = device;
+			$ctrl.selectedDevices = [];
+
+			$ctrl.onDevicesSelected = function(devices) {
+				$ctrl.selectedDevices = devices || [];
 			};
 		}
 	};
@@ -312,35 +315,38 @@ define(['app'], function (app) {
 			devices: '<',
 			onUpdate: '&',
 		},
-		template:  '<table id="plan-devices-table" class="display" width="100%"></table>',
-		controller: function($element, $scope, bootbox, dzRoomPlanApi, dataTableDefaultSettings) {
+		template: '<div>' +
+		'<div class="btn-panel align-right" ng-show="$ctrl.hasSelection">' +
+			'<button class="btn btn-default js-remove-selected" data-i18n="Remove Selected"></button>' +
+		'</div>' +
+		'<table id="plan-devices-table" class="display" width="100%"></table>' +
+	'</div>',
+		controller: function($element, $scope, $q, bootbox, dzRoomPlanApi, dataTableDefaultSettings) {
 			var $ctrl = this;
 			var table;
+			$ctrl.hasSelection = false;
 
 			$ctrl.$onInit = function () {
 				table = $element.find('table').dataTable(Object.assign({}, dataTableDefaultSettings, {
-					order: [[2, 'asc']],
 					ordering: false,
+					select: { style: 'multi' },
+					createdRow: function(row, data) {
+						$(row).attr('data-idx', data.idx);
+					},
 					columns: [
-						{title: $.t('Idx'), width: '40px', data: 'devidx'},
-						{title: $.t('Name'), data: 'Name'},
-						{title: $.t('Order'), width: '50px', data: 'Order', render: orderRenderer},
+						{ title: '', width: '20px', data: null, orderable: false, render: dragHandleRenderer },
+						{ title: $.t('Idx'), width: '40px', data: 'devidx' },
+						{ title: $.t('Name'), data: 'Name' },
 						{ title: '', className: 'actions-column', width: '40px', data: 'idx', render: actionsRenderer },
 					]
 				}));
 
-				table.on('click', '.js-move-up', function () {
-					var device = table.api().row($(this).closest('tr')).data();
-					dzRoomPlanApi.changeDeviceOrder(0, $ctrl.planId, device.idx).then($ctrl.onUpdate);
-					$scope.$apply();
-					return false;
-				});
+				// Enable drag-to-reorder via jQuery UI Sortable
+				initSortable($element.find('table tbody'));
 
-				table.on('click', '.js-move-down', function () {
-					var device = table.api().row($(this).closest('tr')).data();
-					dzRoomPlanApi.changeDeviceOrder(1, $ctrl.planId, device.idx).then($ctrl.onUpdate);
+				table.on('select.dt deselect.dt', function () {
+					$ctrl.hasSelection = table.api().rows({ selected: true }).count() > 0;
 					$scope.$apply();
-					return false;
 				});
 
 				table.on('click', '.js-remove', function () {
@@ -351,6 +357,27 @@ define(['app'], function (app) {
 							return dzRoomPlanApi.removeDeviceFromPlan(device.idx);
 						})
 						.then($ctrl.onUpdate);
+
+					$scope.$apply();
+					return false;
+				});
+
+				table.on('click', '.js-remove-selected', function () {
+					var selected = table.api().rows({ selected: true }).data().toArray();
+					if (!selected.length) return false;
+
+					bootbox.confirm($.t('Are you sure to delete the selected Active Devices?\n\nThis action can not be undone...?'))
+						.then(function () {
+							return selected.reduce(function(promise, device) {
+								return promise.then(function() {
+									return dzRoomPlanApi.removeDeviceFromPlan(device.idx);
+								});
+							}, $q.when());
+						})
+						.then(function() {
+							$ctrl.hasSelection = false;
+							return $ctrl.onUpdate();
+						});
 
 					$scope.$apply();
 					return false;
@@ -367,27 +394,45 @@ define(['app'], function (app) {
 					table.api().rows
 						.add($ctrl.devices)
 						.draw();
+
+					// Reinitialize sortable after redraw so new rows are draggable
+					var $tbody = $element.find('table tbody');
+					if ($tbody.hasClass('ui-sortable')) {
+						$tbody.sortable('destroy');
+					}
+					initSortable($tbody);
 				}
 			};
 
-			function orderRenderer(value, renderType, plan, record) {
-				var upIcon = '<button class="btn btn-icon js-move-up"><img src="./images/up.png" /></button>';
-				var downIcon = '<button class="btn btn-icon js-move-down"><img src="./images/down.png" /></button>';
-				var emptyIcon = '<img src="./images/empty16.png" width="16" height="16" />';
+			function initSortable($tbody) {
+				$tbody.sortable({
+					axis: 'y',
+					handle: '.drag-handle',
+					helper: function(e, tr) {
+						var $originals = tr.children();
+						var $helper = tr.clone();
+						$helper.children().each(function(index) {
+							$(this).width($originals.eq(index).width());
+						});
+						return $helper;
+					},
+					update: function() {
+						var orderedIds = $element.find('table tbody tr').map(function() {
+							return $(this).attr('data-idx');
+						}).get();
+						dzRoomPlanApi.changeDeviceOrder($ctrl.planId, orderedIds)
+							.then($ctrl.onUpdate);
+						$scope.$apply();
+					}
+				});
+			}
 
-				if (record.row === 0) {
-					return downIcon + emptyIcon;
-				} else if (record.row === $ctrl.devices.length - 1) {
-					return  emptyIcon + upIcon;
-				} else {
-					return downIcon + upIcon;
-				}
+			function dragHandleRenderer() {
+				return '<span class="drag-handle" style="cursor:grab;">&#9776;</span>';
 			}
 
 			function actionsRenderer() {
-				var actions = [];
-				actions.push('<button class="btn btn-icon js-remove" title="' + $.t('Remove') + '"><img src="./images/delete.png" /></button>');
-				return actions.join('&nbsp;');
+				return '<button class="btn btn-icon js-remove" title="' + $.t('Remove') + '"><img src="./images/delete.png" /></button>';
 			}
 		}
 	});
@@ -413,9 +458,9 @@ define(['app'], function (app) {
 				}
 			};
 
-			$ctrl.selectDevice = function(device) {
-				$ctrl.selectedDevice = device;
-				$ctrl.onSelect({device: $ctrl.selectedDevice });
+			$ctrl.selectDevices = function(devices) {
+				$ctrl.selectedDevices = devices;
+				$ctrl.onSelect({ devices: $ctrl.selectedDevices });
 			};
 
 			$ctrl.filterByHardware = function(hardware) {
@@ -448,20 +493,16 @@ define(['app'], function (app) {
 					dom: '<"H"lfrC>t',
 					order: [[1, 'asc']],
 					paging: false,
+					select: { style: 'multi' },
 					columns: [
 						{title: $.t('Idx'), width: '40px', data: 'idx'},
 						{title: $.t('Name'), data: 'Name'},
 					]
 				}));
 
-				table.on('select.dt', function (e, dt, type, indexes) {
-					var item = dt.rows(indexes).data()[0];
-					$ctrl.onSelect({value: item});
-					$scope.$apply();
-				});
-
-				table.on('deselect.dt', function () {
-					$ctrl.onSelect(null);
+				table.on('select.dt deselect.dt', function () {
+					var selected = table.api().rows({ selected: true }).data().toArray();
+					$ctrl.onSelect({ values: selected });
 					$scope.$apply();
 				});
 
@@ -489,7 +530,7 @@ define(['app'], function (app) {
 		}
 	});
 
-	app.controller('RoomPlansController', function ($scope, $uibModal, bootbox, dzRoomPlanApi) {
+	app.controller('RoomPlansController', function ($scope, $uibModal, $q, bootbox, dzRoomPlanApi) {
 		var $ctrl = this;
 
 		$ctrl.addPlan = addPlan;
@@ -539,10 +580,14 @@ define(['app'], function (app) {
 
 			$uibModal
 				.open(Object.assign({ scope: scope }, selectDeviceModal)).result
-				.then(function(selectedDevice) {
-					return dzRoomPlanApi.addDeviceToPlan($ctrl.selectedPlan.idx, selectedDevice.idx, selectedDevice.type)
+				.then(function(selectedDevices) {
+					if (!selectedDevices || !selectedDevices.length) return;
+					return $q.all(selectedDevices.map(function(device) {
+						return dzRoomPlanApi.addDeviceToPlan($ctrl.selectedPlan.idx, device.idx, device.type);
+					}));
 				})
 				.then(refreshPlanDevices)
+				.catch(angular.noop);
 		}
 
 		function refreshPlans() {

--- a/www/css/demo_table_jui.css
+++ b/www/css/demo_table_jui.css
@@ -331,6 +331,15 @@ table.display tr.odd.row_selected td {
 	background-color: #9FAFD1;
 }
 
+/* DataTables Select extension — selected row highlight */
+table.display tr.selected td {
+	background-color: #B0BED9;
+}
+
+table.display tr.odd.selected td {
+	background-color: #9FAFD1;
+}
+
 
 /*
  * Sorting classes for columns


### PR DESCRIPTION
## Summary

- **Fix**: Devices from disabled hardware are now shown in the "Add Device" selector. Previously excluded because `Used=0` when hardware is disabled — fixed by relaxing the SQL filter to include devices from hardware with `Enabled=0`.
- **Feature**: Replace up/down order buttons in the plan devices table with jQuery UI Sortable drag-to-reorder. The `changeplandeviceorder` API was redesigned to accept a full ordered list instead of relative up/down swaps, enabling single-call persistence of any reorder.
- **Feature**: Multi-select in the "Add Device" modal — select multiple devices and add them all at once via `$q.all()`. Multi-select batch-remove in the devices table with a "Remove Selected" toolbar button.
- **Fix**: Added selection highlight CSS for the DataTables Select extension (`.selected` class was unstyled).
- **Fix**: Null-guard added to device name regex parsing to prevent crashes on unexpected name formats.

## Test plan

- [ ] Open Roomplan editor, select a plan — verify devices from **disabled** hardware appear in the "Add Device" selector
- [ ] In the "Add Device" modal, select multiple devices — verify counter shows `Add (N)` and all selected devices are added on confirm
- [ ] In the devices table, select multiple rows — verify "Remove Selected" button appears and removes all selected devices after confirmation
- [ ] Drag a device row up/down in the devices table — verify the new order persists after release
- [ ] Verify row selection is visually highlighted (blue) when clicking rows in both the selector modal and the devices table
- [ ] Cancel the "Add Device" modal — verify no error is thrown and no devices are added