### PR TITLE
fix(log): fix chart series visibility persistence and rain log summary cards

### DIFF
--- a/www/app/log/BarometerLog.js
+++ b/www/app/log/BarometerLog.js
@@ -389,6 +389,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					}
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-change-rate');
 					Highcharts.chart(chartElement[0], {
 						chart: {
 							type: 'column',
@@ -442,11 +443,13 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 						},
 						series: [
 							{
+								id: 'rising',
 								name: $.t('Rising'),
 								color: 'rgba(0,180,0,0.8)',
 								data: positiveData
 							},
 							{
+								id: 'falling',
 								name: $.t('Falling'),
 								color: 'rgba(220,0,0,0.8)',
 								data: negativeData
@@ -530,6 +533,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 
 					var series = [
 						{
+							id: 'pressure',
 							name: $.t('Pressure'),
 							type: 'spline',
 							yAxis: 0,
@@ -542,6 +546,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 
 					if (hasTemp) {
 						series.push({
+							id: 'temperature',
 							name: $.t('Temperature'),
 							type: 'spline',
 							yAxis: 1,
@@ -554,6 +559,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 
 					if (hasHum) {
 						series.push({
+							id: 'humidity',
 							name: $.t('Humidity'),
 							type: 'spline',
 							yAxis: hasTemp ? 2 : 1,
@@ -565,6 +571,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					}
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-weather-overview');
 					Highcharts.chart(chartElement[0], {
 						chart: {
 							zoomType: 'x'
@@ -642,6 +649,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					});
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-vs-temp');
 					Highcharts.chart(chartElement[0], {
 						chart: {
 							type: 'scatter',
@@ -739,6 +747,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					});
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-vs-humidity');
 					Highcharts.chart(chartElement[0], {
 						chart: {
 							type: 'scatter',
@@ -842,6 +851,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					var ma12h = movingAverage(rawData, 12 * 3600000);
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-rolling-avg');
 					Highcharts.chart(chartElement[0], {
 						chart: { zoomType: 'x' },
 						title: { text: null },
@@ -856,6 +866,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 						},
 						series: [
 							{
+								id: 'pressure',
 								name: $.t('Pressure'),
 								type: 'spline',
 								data: rawData,
@@ -863,6 +874,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 								lineWidth: 1
 							},
 							{
+								id: 'ma-3h',
 								name: '3h ' + $.t('Average'),
 								type: 'spline',
 								data: ma3h,
@@ -870,6 +882,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 								lineWidth: 2
 							},
 							{
+								id: 'ma-6h',
 								name: '6h ' + $.t('Average'),
 								type: 'spline',
 								data: ma6h,
@@ -877,6 +890,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 								lineWidth: 2
 							},
 							{
+								id: 'ma-12h',
 								name: '12h ' + $.t('Average'),
 								type: 'spline',
 								data: ma12h,
@@ -947,6 +961,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					var std6h = rollingStdDev(rawData, 6 * 3600000);
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-baro-volatility');
 					Highcharts.chart(chartElement[0], {
 						chart: { zoomType: 'x' },
 						title: { text: null },
@@ -959,6 +974,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 						legend: { enabled: true },
 						series: [
 							{
+								id: 'vol-3h',
 								name: '3h ' + $.t('Volatility'),
 								type: 'area',
 								data: std3h,
@@ -968,6 +984,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 								marker: { enabled: false }
 							},
 							{
+								id: 'vol-6h',
 								name: '6h ' + $.t('Volatility'),
 								type: 'area',
 								data: std6h,

--- a/www/app/log/CounterLog.js
+++ b/www/app/log/CounterLog.js
@@ -381,6 +381,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
             controller: function ($location, $route, $scope, $timeout, $element, domoticzGlobals, domoticzApi, domoticzDataPointApi, chart, counterLogParams, counterLogSubtypeRegistry) {
                 const self = this;
                 self.groupingBy = 'month';
+                self.range = 'compare';
 
                 self.$onInit = function () {
                     const subtype = counterLogSubtypeRegistry.get(self.logCtrl.subtype);

--- a/www/app/log/RainLog.js
+++ b/www/app/log/RainLog.js
@@ -62,26 +62,19 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
                             }
                         }
 
-                        // Total Rain card
-                        if (device.Rain !== undefined) {
-                            var rain = parseFloat(device.Rain);
-                            if (!isNaN(rain)) {
-                                self.cards.push({
-                                    label: $.t('Total'),
-                                    value: rain.toFixed(1) + ' ' + unit,
-                                    delta: '',
-                                    deltaColor: ''
-                                });
-                            }
-                        }
-
-                        // Calculate today's total from graph data
+                        // Calculate today's total from graph data (filter to today only)
                         var result = self.logCtrl.dayGraphData;
                         if (result && result.length > 0) {
+                            var now = new Date();
+                            var todayStr = now.getFullYear() + '-' +
+                                String(now.getMonth() + 1).padStart(2, '0') + '-' +
+                                String(now.getDate()).padStart(2, '0');
                             var todayTotal = 0;
                             for (var i = 0; i < result.length; i++) {
-                                var val = parseFloat(result[i][valueKey]);
-                                if (!isNaN(val)) todayTotal += val;
+                                if (result[i].d.substring(0, 10) === todayStr) {
+                                    var val = parseFloat(result[i][valueKey]);
+                                    if (!isNaN(val)) todayTotal += val;
+                                }
                             }
                             self.cards.push({
                                 label: $.t('Today'),
@@ -103,7 +96,9 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
                         return self.logCtrl.dayGraphData;
                     }, function (result) {
                         if (result && result.length > 0) {
+                            var yearCards = self.cards.splice(self._deviceCardCount);
                             buildDeviceCards();
+                            self.cards.push.apply(self.cards, yearCards);
                         }
                     });
 
@@ -118,7 +113,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
                         }
                     });
 
-                    // Watch for year graph data shared by rainLongChart (range=year)
+                    // Show This Year card when year chart data is available
                     $scope.$watch(function () {
                         return self.logCtrl.yearGraphData;
                     }, function (result) {
@@ -329,6 +324,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					}
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-rain-cumulative');
 					Highcharts.chart(chartElement[0], {
 						chart: { type: 'area', zoomType: 'x' },
 						title: { text: '' },
@@ -405,6 +401,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					}
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-rain-rate');
 					Highcharts.chart(chartElement[0], {
 						chart: { type: 'spline', zoomType: 'x' },
 						title: { text: '' },
@@ -514,6 +511,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 					];
 
 					var chartElement = $element.find('.chartcontainer');
+					chartElement.attr('id', 'chart-' + self.device.idx + '-rain-intensity');
 					self.chartTitle += ' (' + rates.length + ' ' + $.t('rain intervals') + ')';
 
 					Highcharts.chart(chartElement[0], {

--- a/www/app/log/RefreshingChart.js
+++ b/www/app/log/RefreshingChart.js
@@ -24,7 +24,11 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
         self.synchronizeYaxes = params.synchronizeYaxes;
         const chartDefinition = createChartDefinition(params.highchartTemplate);
         chartDefinition.range = params.range;
-        self.chart = self.$element.find('.chartcontainer').highcharts(chartDefinition).highcharts();
+        const containerEl = self.$element.find('.chartcontainer');
+        if (params.device.idx !== undefined && params.device.idx !== null && params.range !== undefined) {
+            containerEl.attr('id', 'chart-' + params.device.idx + '-' + params.range);
+        }
+        self.chart = containerEl.highcharts(chartDefinition).highcharts();
         // Disable the Highcharts Reset Zoom button
         self.chart.showResetZoom = function () {};
         self.autoRefreshIsEnabled = params.autoRefreshIsEnabled;
@@ -324,7 +328,13 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
 
         function synchronizeYaxes(redraw=false) {
             if (self.synchronizeYaxes) {
-                const yAxes = self.chart.series.map(getYaxisForSeries).reduce(collectToSet, []);
+                const visibleSeries = self.chart.series.filter(function (s) { return s.visible; });
+                const yAxes = visibleSeries.map(getYaxisForSeries).reduce(collectToSet, []);
+
+                if (yAxes.length === 0) {
+                    return;
+                }
+
                 yAxes.forEach(function (yAxis) {
                     yAxis.setExtremes(null, null, false);
                 });
@@ -335,6 +345,9 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
 
                 const yAxisMinSynchronized = iMin === Infinity ? null : iMin;
                 const yAxisMaxSynchronized = iMax === -Infinity ? null : iMax;
+
+                if (isNaN(yAxisMinSynchronized) || isNaN(yAxisMaxSynchronized)) return;
+
                 self.consoledebug('Synchronizing yAxes to extremes (' + yAxisMinSynchronized + ', ' + yAxisMaxSynchronized + '):');
                 yAxes.forEach(function (yAxis) {
                     self.consoledebug('    yAxis:' + yAxisToString(yAxis));

--- a/www/app/log/components/chart-counter-calendar-heatmap.html
+++ b/www/app/log/components/chart-counter-calendar-heatmap.html
@@ -1,5 +1,5 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
     <div class="chartarea">
-        <highchart config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 220px;"></highchart>
+        <highchart id="chart-{{$ctrl.device.idx}}-calendar-heatmap" config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 220px;"></highchart>
     </div>
 </div>

--- a/www/app/log/components/chart-counter-cumulative.html
+++ b/www/app/log/components/chart-counter-cumulative.html
@@ -1,5 +1,5 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
     <div class="chartarea">
-        <highchart config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 300px;"></highchart>
+        <highchart id="chart-{{$ctrl.device.idx}}-cumulative" config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 300px;"></highchart>
     </div>
 </div>

--- a/www/app/log/components/chart-counter-stat.html
+++ b/www/app/log/components/chart-counter-stat.html
@@ -10,6 +10,6 @@
             <button class="zoom-button" ng-class="isActDay(0)"><span data-i18n="Sun" ng-click="setWeekday(0)"></span></button>
             <button class="zoom-button" ng-class="isActDay(-1)"><span data-i18n="Days" ng-click="setWeekday(-1)"></span></button>
         </div>
-        <highchart config="chartDefinitionDay" style="display: block; width: 100%; height: 300px;"></highchart>
+        <highchart id="chart-{{$ctrl.device.idx}}-stat-day" config="chartDefinitionDay" style="display: block; width: 100%; height: 300px;"></highchart>
     </div>
 </div>

--- a/www/app/log/components/chart-counter-weekly-heatmap.html
+++ b/www/app/log/components/chart-counter-weekly-heatmap.html
@@ -1,5 +1,5 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
     <div class="chartarea">
-        <highchart config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 300px;"></highchart>
+        <highchart id="chart-{{$ctrl.device.idx}}-weekly-heatmap" config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 300px;"></highchart>
     </div>
 </div>

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -43,8 +43,9 @@ if (typeof (Highcharts) !== 'undefined') {
 				) {
 					fProceed_.apply(this, Array.prototype.slice.call(arguments, 1));
 					try {
-						var sStorageId = 'highcharts_series_visibility_' + $.devIdx;
-						var sStateId = $(this.chart.container).parent().attr('id') + '_' + this.options.id;
+						var sStorageId = 'highcharts_series_visibility';
+						if (!this.chart.renderTo.id) { return; }
+						var sStateId = this.chart.renderTo.id + '_' + this.options.id;
 						var sCurrentState = localStorage.getItem(sStorageId) || '{}';
 						var oCurrentState = JSON.parse(sCurrentState);
 						oCurrentState[sStateId] = this.visible;
@@ -55,12 +56,15 @@ if (typeof (Highcharts) !== 'undefined') {
 
 			H_.wrap(H_.Series.prototype, 'init', function (fProceed_, oChart_, oOptions_) {
 				try {
-					var sStorageId = 'highcharts_series_visibility_' + $.devIdx;
-					var sStateId = $(oChart_.container).parent().attr('id') + '_' + oOptions_.id;
-					var sCurrentState = localStorage.getItem(sStorageId) || '{}';
-					var oCurrentState = JSON.parse(sCurrentState);
-					if (sStateId in oCurrentState) {
-						oOptions_.visible = oCurrentState[sStateId];
+					var sStorageId = 'highcharts_series_visibility';
+					var renderToId = oChart_.renderTo && oChart_.renderTo.id;
+					if (renderToId) {
+						var sStateId = renderToId + '_' + oOptions_.id;
+						var sCurrentState = localStorage.getItem(sStorageId) || '{}';
+						var oCurrentState = JSON.parse(sCurrentState);
+						if (sStateId in oCurrentState) {
+							oOptions_.visible = oCurrentState[sStateId];
+						}
 					}
 				} catch (oException_) { /* too bad, no state */ }
 				fProceed_.apply(this, Array.prototype.slice.call(arguments, 1));


### PR DESCRIPTION
## Summary

Fixes #6101 — kWh (and other) chart becomes empty after toggling a series off in the legend and navigating away/refreshing.

### Root causes fixed

- **Wrong localStorage key**: The series visibility key used `$(container).parent().attr('id')` which returned `undefined` (no id on parent), causing all series on a chart to share the key `undefined_seriesId`. Hiding any one series wrote `false` to that key; on reload all series read it and all became hidden → empty chart.
- **`synchronizeYaxes` NaN**: When a series was hidden, `synchronizeYaxes` included its yAxis in the min/max calculation, producing `NaN` extremes that broke chart rendering.
- **Missing series `id` properties**: Multi-series charts (barometer weather overview, change rate, rolling avg, volatility) had no `id` on each series, so all series in a chart shared `chart-{idx}-{slug}_undefined` as their key — hiding one hid all on reload.

### Changes

**`www/js/domoticz.js`**
- Use `chart.renderTo.id` instead of `$.devIdx` + jQuery parent selector for the localStorage key — stable, device-scoped, no global dependency
- Guard against missing container id (skip persistence silently rather than writing a bad key)

**`www/app/log/RefreshingChart.js`**
- Set a stable `id` on the chart container before initialising Highcharts: `chart-{device.idx}-{range}`
- `synchronizeYaxes`: filter to visible series only; early-return when none visible; guard against NaN extremes

**`www/app/log/CounterLog.js`**
- Add `self.range = 'compare'` to `counterCompareChart` so it gets a proper container id

**`www/app/log/BarometerLog.js`**
- Add unique container ids to all 6 direct-Highcharts charts
- Add explicit `id` to each series in multi-series charts (change-rate, weather-overview, rolling-avg, volatility)

**`www/app/log/RainLog.js`**
- Fix **Today** card: was summing the entire multi-day shortlog; now filters to today's date only
- Fix **This Year** card: was wiped on every auto-refresh (dayGraphData watch called `buildDeviceCards()` which reset the cards array); now saves/restores year cards around each rebuild
- Remove confusing **Total** (raw hardware counter) card

**`www/app/log/components/chart-counter-*.html`**
- Add `id="chart-{{$ctrl.device.idx}}-{slug}"` to `<highchart>` directives so visibility state is correctly scoped per device

## Test plan

- [ ] Open kWh device log (Generic kWh with power, `instantAndCounter` subtype)
- [ ] Hide the Power series via legend click → chart shows only Energy bars
- [ ] Navigate away and back → chart still shows Energy bars (not empty)
- [ ] Re-enable Power series → both visible; navigate away and back → both still visible
- [ ] Open barometer log → hide Temperature in Weather Overview → refresh → remaining series still visible
- [ ] Open rain log → verify Today shows only today's rainfall, This Year appears after page load
- [ ] Verify no regressions on other chart types (temp, humidity, P1 meter)