### PR TITLE
fix: chart title position and legend overflow bugs (#6675)

### DIFF
--- a/www/app/UtilityController.js
+++ b/www/app/UtilityController.js
@@ -1202,7 +1202,7 @@
 				}
 			});
 			$("#dialog-edittextdevice").keydown(function (event) {
-				if (event.keyCode == 13) {
+				if (event.keyCode == 13 && !$(event.target).is('textarea')) {
 					$(this).siblings('.ui-dialog-buttonpane').find('button:eq(0)').trigger("click");
 					return false;
 				}

--- a/www/app/log/CounterLog.html
+++ b/www/app/log/CounterLog.html
@@ -15,16 +15,17 @@
         device="::$ctrl.device"></counter-month-chart>
 
 <counter-year-chart
-        class="device-log-chart"
+        class="device-log-chart device-log-chart_lg"
         device="::$ctrl.device"></counter-year-chart>
 
-<counter-calendar-heatmap-chart
-        ng-if="::$ctrl.subtype=='energy-used' || $ctrl.subtype=='energy-generated' || $ctrl.subtype=='p1Energy' || $ctrl.subtype=='gas' || $ctrl.subtype=='water'"
-        class="device-log-chart"
-        style="height: auto"
-        subtype="::$ctrl.subtype"
-        device="::$ctrl.device">
-</counter-calendar-heatmap-chart>
+<div ng-if="::$ctrl.subtype=='energy-used' || $ctrl.subtype=='energy-generated' || $ctrl.subtype=='p1Energy' || $ctrl.subtype=='gas' || $ctrl.subtype=='water'"
+     class="device-log-chart"
+     style="height: auto;">
+    <counter-calendar-heatmap-chart
+            subtype="::$ctrl.subtype"
+            device="::$ctrl.device">
+    </counter-calendar-heatmap-chart>
+</div>
 
 <counter-weekly-heatmap-chart
         ng-if="::$ctrl.subtype=='energy-used' || $ctrl.subtype=='energy-generated' || $ctrl.subtype=='p1Energy' || $ctrl.subtype=='instantAndCounter'"

--- a/www/app/log/RainLog.html
+++ b/www/app/log/RainLog.html
@@ -2,9 +2,8 @@
         device="::$ctrl.device">
 </rain-current-conditions>
 <rain-day-chart
-        class="rain-log-chart"
+        class="device-log-chart"
         device="::$ctrl.device"></rain-day-chart>
-<br/>
 <div style="text-align:center; margin: 10px 0;">
     <a class="btnstyle3" ng-click="$ctrl.toggleAdvancedCharts()">
         <span ng-hide="$ctrl.showAdvancedCharts" data-i18n="Show Advanced Charts">Show Advanced Charts</span>
@@ -16,33 +15,27 @@
     <rain-cumulative-chart
             class="device-log-chart"
             device="::$ctrl.device"></rain-cumulative-chart>
-    <br/>
     <rain-rate-chart
             class="device-log-chart"
             device="::$ctrl.device"></rain-rate-chart>
-    <br/>
     <rain-intensity-chart
             class="device-log-chart"
             device="::$ctrl.device"></rain-intensity-chart>
 </div>
-<br/>
 <rain-week-chart
-        class="rain-log-chart"
+        class="device-log-chart"
         device="::$ctrl.device"
         range="week"></rain-week-chart>
-<br/>
 <rain-long-chart
-        class="rain-log-chart"
+        class="device-log-chart"
         device="::$ctrl.device"
         range="month"></rain-long-chart>
-<br/>
 <rain-long-chart
-        class="rain-log-chart"
+        class="device-log-chart"
         device="::$ctrl.device"
         range="year"></rain-long-chart>
-<br/>
 <rain-compare-chart
-        class="rain-log-chart"
+        class="device-log-chart"
         device="::$ctrl.device"
         degree-type="::$ctrl.degreeType"
         range="compare">

--- a/www/app/log/TemperatureLog.js
+++ b/www/app/log/TemperatureLog.js
@@ -984,10 +984,11 @@ define(['app', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Chart', 'log
         bindings: {
             device: '<'
         },
-        template: '<div id="dewpointchart" style="width:100%; height:300px; margin-top:10px;"></div>',
+        template: customChartTemplate,
         controllerAs: 'vm',
         controller: function ($element, domoticzApi) {
             const self = this;
+            self.chartTitle = $.t('Dew Point');
 
             self.$onInit = function () {
                 if (self.device.Humidity === undefined) {
@@ -1028,10 +1029,9 @@ define(['app', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Chart', 'log
 
                     if (dewPoints.length === 0) return;
 
-                    Highcharts.chart($element[0].firstChild, {
+                    Highcharts.chart($element.find('.chartcontainer')[0], {
                         chart: { type: 'spline', zoomType: 'x' },
-                        title: { text: $.t('Dew Point') },
-                        credits: { enabled: false },
+                        title: { text: null },
                         xAxis: {
                             type: 'datetime'
                         },
@@ -1077,10 +1077,11 @@ define(['app', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Chart', 'log
         bindings: {
             device: '<'
         },
-        template: '<div style="width:100%; height:300px; margin-top:10px;"></div>',
+        template: customChartTemplate,
         controllerAs: 'vm',
         controller: function ($element, domoticzApi) {
             const self = this;
+            self.chartTitle = $.t('Temperature') + ' vs ' + $.t('Humidity');
 
             self.$onInit = function () {
                 if (self.device.Humidity === undefined) {
@@ -1118,15 +1119,12 @@ define(['app', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Chart', 'log
 
                     if (scatterData.length === 0) return;
 
-                    Highcharts.chart($element[0].firstChild, {
+                    Highcharts.chart($element.find('.chartcontainer')[0], {
                         chart: {
                             type: 'scatter',
                             zoomType: 'xy'
                         },
-                        title: {
-                            text: $.t('Temperature') + ' vs ' + $.t('Humidity')
-                        },
-                        credits: { enabled: false },
+                        title: { text: null },
                         xAxis: {
                             title: { text: $.t('Temperature') + ' ' + degreeSuffix },
                             crosshair: true

--- a/www/app/log/WindLog.js
+++ b/www/app/log/WindLog.js
@@ -212,7 +212,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 			bindings: {
 				device: '<'
 			},
-			template: '<div class="chartarea"><div id="winddirectiongraph" style="height: 400px;"></div></div>',
+			template: '<div class="chart noselect"><div class="chart-title-center"><div class="chart-title-container"><h2 ng-bind="vm.chartTitle"></h2></div></div><div class="chartarea"><div id="winddirectiongraph" style="height: 400px;"></div></div></div>',
 			controllerAs: 'vm',
 			controller: function ($element, domoticzApi) {
 				const self = this;
@@ -220,14 +220,14 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 				self.$onInit = function () {
 					var chartElement = $element.find('#winddirectiongraph');
 
+					self.chartTitle = $.t('Wind') + ' ' + $.t('Direction') + ' ' + Get5MinuteHistoryDaysGraphTitle();
+
 					chartElement.highcharts({
 						chart: {
 							polar: true,
 							type: 'column'
 						},
-						title: {
-							text: $.t('Wind') + ' ' + $.t('Direction') + ' ' + Get5MinuteHistoryDaysGraphTitle()
-						},
+						title: null,
 						pane: {
 							size: '85%'
 						},
@@ -315,7 +315,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 			bindings: {
 				device: '<'
 			},
-			template: '<div class="chartarea"><div id="windspeedfreqgraph" style="height: 400px;"></div></div>',
+			template: '<div class="chart noselect"><div class="chart-title-center"><div class="chart-title-container"><h2 ng-bind="vm.chartTitle"></h2></div></div><div class="chartarea"><div id="windspeedfreqgraph" style="height: 400px;"></div></div></div>',
 			controllerAs: 'vm',
 			controller: function ($element, domoticzApi) {
 				const self = this;
@@ -323,6 +323,8 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 				self.$onInit = function () {
 					var chartElement = $element.find('#windspeedfreqgraph');
 					var unit = self.device.getUnit();
+
+					self.chartTitle = $.t('Wind Speed Frequency') + ' ' + Get5MinuteHistoryDaysGraphTitle();
 
 					domoticzApi.sendCommand('graph', {
 						sensor: 'wind',
@@ -383,9 +385,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
 							chart: {
 								type: 'column'
 							},
-							title: {
-								text: $.t('Wind Speed Frequency') + ' ' + Get5MinuteHistoryDaysGraphTitle()
-							},
+							title: null,
 							xAxis: {
 								categories: categories,
 								title: {

--- a/www/app/log/components/CounterCalendarHeatmapChart.js
+++ b/www/app/log/components/CounterCalendarHeatmapChart.js
@@ -47,10 +47,11 @@ define(['app'], function (app) {
             var isGenerated = (deviceType === 4);
             var label = isGenerated ? $.t('Generated') : $.t('Usage');
             var titleText = isGenerated ? $.t('Generated Last Year') : $.t('Usage Last Year');
+            self.chartTitle = titleText;
             var unit = unitForSubtype(self.subtype);
 
             if (!data || data.length === 0) {
-                self.chartDefinition = { title: { text: titleText }, series: [] };
+                self.chartDefinition = { title: null, series: [] };
                 return;
             }
 
@@ -125,9 +126,7 @@ define(['app'], function (app) {
                     marginTop: 35,
                     marginBottom: 45
                 },
-                title: {
-                    text: titleText
-                },
+                title: null,
                 xAxis: {
                     categories: xAxisCategories,
                     tickPositions: xAxisTickPositions,

--- a/www/app/log/components/CounterCumulativeChart.js
+++ b/www/app/log/components/CounterCumulativeChart.js
@@ -77,6 +77,7 @@ define(['app'], function (app) {
             var titleText = isGenerated ? $.t('Cumulative Energy Generated') :
                 (self.subtype === 'gas' ? $.t('Cumulative Gas') :
                 self.subtype === 'water' ? $.t('Cumulative Water') : $.t('Cumulative Energy'));
+            self.chartTitle = titleText;
             var seriesList = [];
 
             allSeries.forEach(function (s, i) {
@@ -100,7 +101,7 @@ define(['app'], function (app) {
 
             self.chartDefinition = {
                 chart: { type: 'spline' },
-                title: { text: titleText },
+                title: null,
                 xAxis: {
                     min: 1,
                     max: leap ? 366 : 365,

--- a/www/app/log/components/CounterStatChart.js
+++ b/www/app/log/components/CounterStatChart.js
@@ -65,11 +65,10 @@ define(['app', 'luxon'], function (app, luxon) {
 		}
 
 		$scope.chartDefinitionDay = {};
+		$scope.chartTitle = '';
 
 		$scope.chartDefinitionBase = {
-			title: {
-				text: 'Hourly Energy Usage'
-			},
+			title: null,
 			xAxis: {
 				type: 'datetime',
 				labels: {
@@ -175,13 +174,13 @@ define(['app', 'luxon'], function (app, luxon) {
 			$scope.actDay = actDay;
 			if ($scope.actDay >= 0) {
 				var dayName = $scope.chartDefinitionWeek.series[0].data[actDay][0];
-				$scope.chartDefinitionDay.title.text = dayName + ' ' + $.t('Hourly Energy') + ' ' + $scope.energyLabel;
+				$scope.chartTitle = dayName + ' ' + $.t('Hourly Energy') + ' ' + $scope.energyLabel;
 				$scope.chartDefinitionDay.tooltip.headerFormat = '<span style="font-size: 10px">' + dayName + ' {point.x:%H:%M}</span><br/>';
 				$scope.chart_weekday_hour_kwh = JSON.parse(JSON.stringify($scope.weekday_hour_kwh[actDay]));
 				$scope.chartDefinitionDay.series[0].data = $scope.chart_weekday_hour_kwh;
 			} else {
 				if ($scope.actDay == -1) {
-					$scope.chartDefinitionDay.title.text = $.t('Hourly Energy') + ' ' + $scope.energyLabel;
+					$scope.chartTitle = $.t('Hourly Energy') + ' ' + $scope.energyLabel;
 					$scope.chartDefinitionDay.tooltip.headerFormat = '<span style="font-size: 10px">{point.x:%H:%M}</span><br/>';
 					$scope.chart_weekday_hour_kwh = JSON.parse(JSON.stringify($scope.daily_hour_kwh));
 					$scope.chartDefinitionDay.series[0].data = $scope.chart_weekday_hour_kwh;
@@ -279,7 +278,7 @@ define(['app', 'luxon'], function (app, luxon) {
 
 			$scope.chartSeriesDailyHour.name = $scope.energyLabel;
 			$scope.chartSeriesWeekday.name = $scope.energyLabel;
-			$scope.chartDefinitionBase.title.text = hourlyTitle;
+			$scope.chartTitle = hourlyTitle;
 			$scope.chartDefinitionBase.yAxis[0].title.text = yAxisTitle;
 			$scope.chartDefinitionWeek.title.text = weeklyTitle;
 			$scope.chartDefinitionWeek.yAxis.title.text = yAxisTitle;

--- a/www/app/log/components/CounterWeeklyHeatmapChart.js
+++ b/www/app/log/components/CounterWeeklyHeatmapChart.js
@@ -33,6 +33,7 @@ define(['app'], function (app) {
 
         function buildChart(weekday_hour_kwh, deviceType) {
             var label = (deviceType === 4) ? $.t('Generated') : $.t('Usage');
+            self.chartTitle = $.t('Weekly') + ' ' + label + ' ' + $.t('Pattern');
             var usageData = [];
             var returnData = [];
             var usageValues = [];
@@ -76,9 +77,7 @@ define(['app'], function (app) {
                     marginTop: 40,
                     marginBottom: 60
                 },
-                title: {
-                    text: $.t('Weekly') + ' ' + label + ' ' + $.t('Pattern')
-                },
+                title: null,
                 xAxis: {
                     categories: hourCategories,
                     title: { text: null }

--- a/www/app/log/components/chart-counter-calendar-heatmap.html
+++ b/www/app/log/components/chart-counter-calendar-heatmap.html
@@ -1,4 +1,9 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
+    <div class="chart-title-center">
+        <div class="chart-title-container">
+            <h2 ng-bind="$ctrl.chartTitle"></h2>
+        </div>
+    </div>
     <div class="chartarea">
         <div class="zoom-buttons-container" ng-if="$ctrl.hasReturn">
             <button class="zoom-button" ng-class="{'zoom-button-active-blue': $ctrl.showUsage}" ng-click="$ctrl.toggleSeries(0)" ng-bind="$ctrl.usageLabel"></button>

--- a/www/app/log/components/chart-counter-cumulative.html
+++ b/www/app/log/components/chart-counter-cumulative.html
@@ -1,4 +1,9 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
+    <div class="chart-title-center">
+        <div class="chart-title-container">
+            <h2 ng-bind="$ctrl.chartTitle"></h2>
+        </div>
+    </div>
     <div class="chartarea">
         <highchart id="chart-{{$ctrl.device.idx}}-cumulative" config="$ctrl.chartDefinition" style="display: block; width: 100%; height: 300px;"></highchart>
     </div>

--- a/www/app/log/components/chart-counter-stat.html
+++ b/www/app/log/components/chart-counter-stat.html
@@ -1,4 +1,9 @@
 <div class="chart noselect">
+    <div class="chart-title-center">
+        <div class="chart-title-container">
+            <h2 ng-bind="chartTitle"></h2>
+        </div>
+    </div>
     <div class="chartarea">
         <div class="zoom-buttons-container">
             <button class="zoom-button" ng-class="isActDay(6)"><span data-i18n="Sat" ng-click="setWeekday(6)"></span></button>

--- a/www/app/log/components/chart-counter-weekly-heatmap.html
+++ b/www/app/log/components/chart-counter-weekly-heatmap.html
@@ -1,4 +1,9 @@
 <div class="chart noselect" ng-if="$ctrl.chartDefinition">
+    <div class="chart-title-center">
+        <div class="chart-title-container">
+            <h2 ng-bind="$ctrl.chartTitle"></h2>
+        </div>
+    </div>
     <div class="chartarea">
         <div class="zoom-buttons-container" ng-if="$ctrl.hasReturn">
             <button class="zoom-button" ng-class="{'zoom-button-active-blue': $ctrl.showUsage}" ng-click="$ctrl.toggleSeries(0)" ng-bind="$ctrl.usageLabel"></button>

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2420,7 +2420,6 @@ tspan {
 
 .device-log-chart {
 	display: block;
-	height: 300px;
 	margin-bottom: 38px;
 }
 device-light-log, .device-log-chart:first-child {
@@ -2435,9 +2434,6 @@ device-light-log, .device-log-chart:first-child {
 	height: 200px;
 }
 
-.device-log-chart_lg {
-	height: 380px;
-}
 .device-log-chart_lg .chartarea .chartcontainer {
 	height: 380px;
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -2435,6 +2435,14 @@ device-light-log, .device-log-chart:first-child {
 	height: 200px;
 }
 
+.device-log-chart_lg {
+	height: 380px;
+}
+.device-log-chart_lg .chartarea .chartcontainer {
+	height: 380px;
+}
+
+
 .wind-chart-container {
 	background-color: transparent !important;
 	padding: 0 !important;


### PR DESCRIPTION
## Summary

- Move chart titles from inside Highcharts SVG to external `<h2>` elements for all affected components (counter calendar heatmap, weekly heatmap, cumulative, stat, temperature dew point, temperature vs humidity, wind direction, wind speed frequency) — matches the pattern used by day/month/year/compare charts and fixes title overlap with zoom buttons on mobile
- Fix legend overflow in the default theme: remove the fixed `height: 300px` from `.device-log-chart` so the card auto-sizes to its content. On desktop the title is `position: absolute` (zero flow height) so the card stays 300px; on mobile the title switches to `position: relative` (~50px) and the card expands naturally, eliminating the overflow
- Add `device-log-chart_lg` modifier (380px chartcontainer) for the year chart to accommodate its 7 legend entries
- Wrap `counter-calendar-heatmap-chart` in a standard div in `CounterLog.html` for reliable `margin-bottom` spacing
- Fix rain log charts using undefined `rain-log-chart` CSS class; replace with `device-log-chart` and remove redundant `<br>` spacers

## Test plan

- [ ] Default theme, mobile: chart legends no longer overflow the card boundary
- [ ] Default theme, desktop: chart panel height unchanged (300px)
- [ ] Simple-blue theme: no regression
- [ ] P1 log: all charts (day, month, year, calendar heatmap, weekly heatmap, cumulative, stat, compare) show title above chart as `<h2>`
- [ ] P1 log, mobile: weekday buttons in stat chart do not overlap title
- [ ] Temperature log: dew point and temperature vs humidity charts show external title (only visible on temp+humidity devices)
- [ ] Wind log: wind direction and wind speed frequency charts show external title
- [ ] Rain log: all charts have styled panel background (day, week, month, year, compare)
- [ ] Year chart (P1): 380px height accommodates 7 legend entries without overflow