### PR TITLE
fix: attribute dzVents device log entries to the correct script name

### DIFF
--- a/dzVents/runtime/Domoticz.lua
+++ b/dzVents/runtime/Domoticz.lua
@@ -78,7 +78,11 @@ local function Domoticz(settings)
 		if delay and tonumber(delay) then
 			self.emitEvent('___' .. command .. '__' , value ).afterSec(delay)
 		else
-			table.insert(self.commandArray, { [command] = value })
+			local entry = { [command] = value }
+			if _G.currentDzVentsScriptName then
+				entry._scriptName = _G.currentDzVentsScriptName
+			end
+			table.insert(self.commandArray, entry)
 		end
 		-- return a reference to the newly added item
 		return self.commandArray[#self.commandArray], command, value, delay

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -3344,7 +3344,16 @@ bool CEventSystem::iterateLuaTable(lua_State *lua_state, const int tIndex, const
 		}
 		else if ((std::string(luaL_typename(lua_state, -2)) == "number") && lua_istable(lua_state, -1))
 		{
-			scriptTrue = iterateLuaTable(lua_state, tIndex + 2, filename);
+			std::string commandFilename = filename;
+			lua_getfield(lua_state, -1, "_scriptName");
+			if (lua_isstring(lua_state, -1))
+			{
+				const char* sn = lua_tostring(lua_state, -1);
+				if (sn && *sn)
+					commandFilename = std::string(sn);
+			}
+			lua_pop(lua_state, 1);
+			scriptTrue = iterateLuaTable(lua_state, tIndex + 2, commandFilename);
 		}
 		else if (!m_sql.m_bDisableDzVentsSystem && lua_istable(lua_state, -1) && std::string(luaL_typename(lua_state, -2)) == "string")
 		{
@@ -3377,16 +3386,10 @@ bool CEventSystem::processLuaCommand(lua_State *lua_state, const std::string &fi
 	bool scriptTrue = false;
 	std::string lCommand = std::string(lua_tostring(lua_state, -2));
 
-	// Try to get the actual dzVents script name from the global variable
-	std::string scriptName = filename;
-	lua_getglobal(lua_state, "currentDzVentsScriptName");
-	if (lua_isstring(lua_state, -1))
-	{
-		const char* scriptNamePtr = lua_tostring(lua_state, -1);
-		if (scriptNamePtr != nullptr)
-			scriptName = std::string(scriptNamePtr);
-	}
-	lua_pop(lua_state, 1); // pop the global variable
+	if (!lCommand.empty() && lCommand.front() == '_')
+		return false;
+
+	const std::string& scriptName = filename;
 	if (lCommand == "SendNotification") {
 		std::string luaString = lua_tostring(lua_state, -1);
 		std::string subject, body, priority("0"), sound, subsystem;

--- a/main/dzVents.cpp
+++ b/main/dzVents.cpp
@@ -558,7 +558,8 @@ bool CdzVents::UpdateDevice(lua_State* lua_state, const std::vector<_tLuaTableVa
 	if (idx == -1)
 		return false;
 
-	m_sql.AddTaskItem(_tTaskItem::UpdateDevice(delayTime, idx, nValue, sValue, Protected, bEventTrigger, "dzVents/" + eventName), false);
+	const std::string attribution = eventName.empty() ? "dzVents.lua" : eventName;
+	m_sql.AddTaskItem(_tTaskItem::UpdateDevice(delayTime, idx, nValue, sValue, Protected, bEventTrigger, "dzVents/" + attribution), false);
 	return true;
 }
 
@@ -662,7 +663,8 @@ bool CdzVents::CancelItem(lua_State* lua_state, const std::vector<_tLuaTableValu
 	_tTaskItem tItem;
 	tItem._idx = idx;
 	tItem._DelayTime = 0;
-	tItem._sUser = "dzVents/" + eventName;
+	const std::string attribution = eventName.empty() ? "dzVents.lua" : eventName;
+	tItem._sUser = "dzVents/" + attribution;
 	if (type == "device")
 	{
 		tItem._ItemType = TITEM_SWITCHCMD_EVENT;

--- a/www/app/events/EventViewer.js
+++ b/www/app/events/EventViewer.js
@@ -297,6 +297,7 @@ define(['app', 'events/factories'], function (app) {
                     element.parentNode.appendChild(statusBarEl);
                     element.style.bottom = '21px';
                     new StatusBar(aceEditor, statusBarEl);
+                    $timeout(function () { aceEditor.resize(); }, 0);
 
                     // Debounced change handler
                     aceEditor.on('change', function () {


### PR DESCRIPTION
## Summary

Fixes #6670 — when multiple dzVents scripts execute in the same event cycle, all device log entries were attributed to the last script that ran instead of the actual originating script.

- Inject `_scriptName` into every `commandArray` entry via `sendCommand` in `Domoticz.lua` at command creation time
- Extract `_scriptName` per-entry in `iterateLuaTable` (`EventSystem.cpp`) and pass it to both command processing paths
- Remove the stale `_G.currentDzVentsScriptName` global read from `processLuaCommand` (always reflected the last script)
- Use the correct per-command name in `CdzVents::UpdateDevice` and `CancelItem` (`dzVents.cpp`)
- Fix ACE editor rendering at half height on initial load in the event viewer (`EventViewer.js`)

## Test plan

- Create two dzVents scripts triggered by the same timer
- Each script updates a different device
- Verify each device log entry attributes to its own script, not the last one that ran
- Verify plain (non-dzVents) Lua scripts still attribute correctly