### PR TITLE
fix: correct protocol bugs and add new field support in MitsubishiWF driver

### DIFF
--- a/hardware/MitsubishiWF.cpp
+++ b/hardware/MitsubishiWF.cpp
@@ -296,6 +296,16 @@ bool MitsubishiWF::HandleAircoStatus(const std::string& sResult)
 	//Base64 decode
 	szDecoded = base64_decode(sAircoStat);
 
+	m_AircoStatus.ConsumptionJson = -1.0;
+	m_AircoStatus.LedStat = 0;
+	m_AircoStatus.AutoHeating = 0;
+	if (!root["contents"]["consumption"].empty())
+		m_AircoStatus.ConsumptionJson = root["contents"]["consumption"].asDouble();
+	if (!root["contents"]["ledStat"].empty())
+		m_AircoStatus.LedStat = root["contents"]["ledStat"].asInt();
+	if (!root["contents"]["autoHeating"].empty())
+		m_AircoStatus.AutoHeating = root["contents"]["autoHeating"].asInt();
+
 	TranslateAirconStat(szDecoded, m_AircoStatus);
 	if (m_AircoStatus.PresetTemp != 0)
 	{
@@ -889,16 +899,23 @@ void MitsubishiWF::TranslateAirconStat(const std::string& szStat, _tAircoStatus&
 	aircoStatus.Entrust = 4 == (12 & content[12]);
 	aircoStatus.CoolHotJudge = (content[8] & 8) <= 0;
 
-	int8_t modelMatrix[] = { 0, 1, 2 };
-	aircoStatus.ModelNr = find_match(content[0] & 127, modelMatrix, sizeof(modelMatrix));
+	{
+		uint8_t rawModel = static_cast<uint8_t>(content[0]) & 0x7F;
+		if (rawModel == 1 || rawModel == 2 || rawModel == 3 || rawModel == 64)
+			aircoStatus.ModelNr = rawModel;
+		else
+			aircoStatus.ModelNr = 0;
+	}
 
 	aircoStatus.Vacant = content[10] & 1;
 
 	aircoStatus.code = content[6] & 127;
 
+	aircoStatus.IsPresetTempAuto = (static_cast<uint8_t>(content[7]) & 0x80) != 0;
+
 	if (aircoStatus.code == 0)
 		aircoStatus.szErrorCode = "00";
-	else if ((content[6] & -128) <= 0)
+	else if (content[6] < 0)  // int8_t negative means bit 7 set = M-type error
 		aircoStatus.szErrorCode = "M" + std::to_string(aircoStatus.code);
 	else
 		aircoStatus.szErrorCode = "E" + std::to_string(aircoStatus.code);
@@ -1007,6 +1024,11 @@ void MitsubishiWF::ParseAirconStat(const _tAircoStatus& aircoStatus)
 	{
 		double mtotal = m_kWhCounter.CheckTotalCounter(this, 1, 1, 1, aircoStatus.Electric_kWh_Used);
 		SendKwhMeter(1, 1, 255, 0, mtotal, "Electricity used");
+		if (aircoStatus.ConsumptionJson >= 0.0)
+		{
+			Log(LOG_STATUS, "Energy: binary=%.2f kWh, JSON consumption=%.4f",
+				aircoStatus.Electric_kWh_Used, aircoStatus.ConsumptionJson);
+		}
 	}
 }
 
@@ -1215,6 +1237,9 @@ bool MitsubishiWF::command_to_byte(const _tAircoStatus& aircon_stat, std::string
 	double preset_temp = (aircon_stat.OperationMode == 3) ? 25.0 : aircon_stat.PresetTemp;
 	stat_byte[4] |= int(preset_temp / 0.5) + 128;
 
+	if (aircon_stat.IsPresetTempAuto)
+		stat_byte[9] |= 1;
+
 	// entrust
 	if (aircon_stat.Entrust == 0)
 		stat_byte[12] |= 8;
@@ -1230,18 +1255,15 @@ bool MitsubishiWF::command_to_byte(const _tAircoStatus& aircon_stat, std::string
 			stat_byte[10] |= 1;
 	}
 
-	if (aircon_stat.ModelNr != 1 && aircon_stat.ModelNr != 2)
-	{
-	}
-	else
+	if (aircon_stat.ModelNr == 1 || aircon_stat.ModelNr == 2 || aircon_stat.ModelNr == 3)
 	{
 		if (aircon_stat.IsSelfCleanReset)
 			stat_byte[10] |= 4;
 
 		if (aircon_stat.IsSelfCleanOperation)
-			stat_byte[10] |= 144;
+			stat_byte[12] |= 144;
 		else
-			stat_byte[10] |= 128;
+			stat_byte[12] |= 128;
 	}
 
 	uint16_t crc = crc16ccitt((const uint8_t*)stat_byte, sizeof(stat_byte) - 2);
@@ -1315,6 +1337,9 @@ bool MitsubishiWF::recieve_to_bytes(const _tAircoStatus& aircon_stat, std::strin
 	double preset_temp = (aircon_stat.OperationMode == 3) ? 25.0 : aircon_stat.PresetTemp;
 	stat_byte[4] |= int(preset_temp / 0.5);
 
+	if (aircon_stat.IsPresetTempAuto)
+		stat_byte[7] |= 128;
+
 	// entrust
 	if (aircon_stat.Entrust)
 		stat_byte[12] |= 4;
@@ -1322,10 +1347,7 @@ bool MitsubishiWF::recieve_to_bytes(const _tAircoStatus& aircon_stat, std::strin
 	if (!aircon_stat.CoolHotJudge)
 		stat_byte[8] |= 8;
 
-	if (aircon_stat.ModelNr == 1)
-		stat_byte[0] |= 1;
-	else if (aircon_stat.ModelNr == 2)
-		stat_byte[0] |= 2;
+	stat_byte[0] |= (aircon_stat.ModelNr & 0x7F);
 
 	if (aircon_stat.ModelNr == 1)
 	{
@@ -1333,10 +1355,7 @@ bool MitsubishiWF::recieve_to_bytes(const _tAircoStatus& aircon_stat, std::strin
 			stat_byte[10] |= 1;
 	}
 
-	if (aircon_stat.ModelNr != 1 && aircon_stat.ModelNr != 2)
-	{
-	}
-	else
+	if (aircon_stat.ModelNr == 1 || aircon_stat.ModelNr == 2 || aircon_stat.ModelNr == 3)
 	{
 		if (aircon_stat.IsSelfCleanOperation)
 			stat_byte[15] |= 1;

--- a/hardware/MitsubishiWF.h
+++ b/hardware/MitsubishiWF.h
@@ -21,7 +21,7 @@ class MitsubishiWF : public CDomoticzHardwareBase
 		uint8_t WindDirectionLR = 3; //center-center
 		uint8_t Entrust = 0;
 		bool CoolHotJudge = false;
-		uint8_t ModelNr = 1;
+		uint8_t ModelNr = 1;   // raw model number: 0=Sep2021, 1=Global2022, 2=HiEnd2023, 3=ZT2025, 64=FDT2023
 		bool Vacant = false;
 		uint8_t code = 0;
 
@@ -37,6 +37,11 @@ class MitsubishiWF : public CDomoticzHardwareBase
 
 		bool IsSelfCleanReset = false;
 		bool IsSelfCleanOperation = false;
+
+		double ConsumptionJson = -1.0;  // -1.0 = not present in response
+		int LedStat = 0;               // 0=off, 1=on
+		int AutoHeating = 0;           // 0=off, 1=on
+		bool IsPresetTempAuto = false;
 	};
 
 public:


### PR DESCRIPTION
## Summary

- Fix E-type error codes always reported as M-type due to C++ sign extension in `TranslateAirconStat`
- Fix self-clean operation bits written to wrong byte index (10 → 12) in `command_to_byte`
- Fix `ModelNr` parsing missing models 3 (ZT-2025) and 64 (FDT-2023); now stores raw byte value and extends self-clean guards to include model 3
- Add `IsPresetTempAuto` flag decode/encode (receive byte[7] bit 7 / command byte[9] bit 0) — internal only
- Parse `contents.consumption`, `contents.ledStat`, `contents.autoHeating` from JSON response — internal only, with stale-state reset on each poll cycle

All changes derived from reverse-engineering the Smart M-Air v1.4.005 Android APK (`AirconStatCoder.java`, `ResponseSetAirconStatToWifiEntity.java`).

## Test plan

- [ ] Verify E-type fault is logged as `E<n>`, not `M<n>`
- [ ] Capture self-clean command base64 and confirm byte[12] carries the operation bits
- [ ] Confirm `ModelNr` is correctly identified for existing unit; no errors on startup
- [ ] Full poll cycle completes without errors; normal on/off and mode changes unaffected
- [ ] If `consumption` is present in API response, log line appears comparing binary vs JSON kWh values