### PR TITLE
Add Daikin Heat pump devices (via Modbus TCP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,7 @@ hardware/CurrentCostMeterBase.cpp
 hardware/CurrentCostMeterSerial.cpp
 hardware/CurrentCostMeterTCP.cpp
 hardware/Daikin.cpp
+hardware/DaikinModbus.cpp
 hardware/DarkSky.cpp
 hardware/DavisLoggerSerial.cpp
 hardware/DenkoviDevices.cpp
@@ -472,7 +473,7 @@ ELSE(LUA_LIBRARIES AND LUA_INCLUDE_DIRS)
   IF(LUA_FOUND)
     MESSAGE(STATUS "LUA library found at  : ${LUA_LIBRARIES}")
     MESSAGE(STATUS "LUA includes found at : ${LUA_INCLUDE_DIR}")
-    INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR}) 
+    INCLUDE_DIRECTORIES(${LUA_INCLUDE_DIR})
   ELSE(LUA_FOUND)
     MESSAGE(FATAL_ERROR "LUA 5.3 not found! use sudo apt-get install liblua5.3-dev")
   ENDIF(LUA_FOUND)
@@ -577,7 +578,7 @@ ELSE(USE_BUILTIN_JSONCPP)
     MESSAGE(FATAL_ERROR "JSONCPP not found on your system! try 'sudo apt-get install jsoncpp-dev'")
   ENDIF(JSONCPP_FOUND)
 ENDIF(USE_BUILTIN_JSONCPP)
- 
+
 # mosquitto
 find_library(MQTT_LIBRARIES NAMES libmosquitto.so)
 find_path(MQTT_INCLUDE_DIRS NAMES mosquitto.h)
@@ -587,7 +588,7 @@ IF(MQTT_LIBRARIES AND MQTT_INCLUDE_DIRS)
 ELSE(MQTT_LIBRARIES AND MQTT_INCLUDE_DIRS)
   MESSAGE(FATAL_ERROR "Mosquitto library not found on your system, see install.txt how to get them installed. (for example 'sudo apt-get install libmosquitto-dev')")
 ENDIF(MQTT_LIBRARIES AND MQTT_INCLUDE_DIRS)
- 
+
 # sqlite3
 IF(USE_BUILTIN_SQLITE)
   MESSAGE(STATUS "Using builtin SQLite library")

--- a/hardware/DaikinModbus.cpp
+++ b/hardware/DaikinModbus.cpp
@@ -1,0 +1,432 @@
+/*
+ Domoticz, Open Source Home Automation System
+
+ Copyright (C) 2012,2026 Rob Peters (GizMoCuz)
+
+ Domoticz is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Domoticz is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Domoticz.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "stdafx.h"
+#include "DaikinModbus.h"
+#include "../main/Helper.h"
+#include "../main/Logger.h"
+#include "hardwaretypes.h"
+#include "../main/mainworker.h"
+
+CDaikinModbus::CDaikinModbus(int ID, const std::string& IPAddress, unsigned short usIPPort, int iPollInterval, bool bIsAirToAir, int iUnitID)
+	: ASyncTCP(false) // MODBUS TCP is NOT secure (no SSL)
+	, m_szIPAddress(IPAddress)
+	, m_iPollInterval(iPollInterval)
+	, m_bIsAirToAir(bIsAirToAir)
+	, m_iUnitID(iUnitID)
+{
+	m_HwdID = ID;
+	m_usIPPort = usIPPort;
+	if (m_iPollInterval < 5)
+		m_iPollInterval = 30;
+	m_TransactionID = 0;
+
+	_log.Log(LOG_STATUS, "DaikinModbus: Initializing (ID: %d, IP: %s, Port: %d, Poll: %d, Unit: %d, Model: %s)",
+		m_HwdID, m_szIPAddress.c_str(), m_usIPPort, m_iPollInterval, m_iUnitID, m_bIsAirToAir ? "Air-to-Air" : "Altherma 3");
+}
+
+CDaikinModbus::~CDaikinModbus()
+{
+	StopHardware();
+}
+
+bool CDaikinModbus::StartHardware()
+{
+	m_bIsStarted = true;
+	this->CDomoticzHardwareBase::RequestStart();
+
+	// Set a reasonable reconnect delay (10 seconds)
+	SetReconnectDelay(10);
+
+	// Initiate connection
+	connect(m_szIPAddress, m_usIPPort);
+
+	m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
+	SetThreadNameInt(m_thread->native_handle());
+
+	sOnConnected(this);
+	return true;
+}
+
+bool CDaikinModbus::StopHardware()
+{
+	m_bIsStarted = false;
+	this->CDomoticzHardwareBase::RequestStop();
+	terminate();
+	if (m_thread)
+	{
+		if (m_thread->joinable())
+			m_thread->join();
+		m_thread.reset();
+	}
+	return true;
+}
+
+void CDaikinModbus::Do_Work()
+{
+	_log.Log(LOG_STATUS, "DaikinModbus: Worker thread started...");
+
+	int iSecCounter = 0;
+	int iPollCounter = m_iPollInterval; // Trigger poll immediately once connected
+
+	while (!this->CDomoticzHardwareBase::IsStopRequested(1000))
+	{
+		// Always update heartbeat to satisfy watchdog
+		mytime(&m_LastHeartbeat);
+
+		if (!m_bIsStarted)
+			continue;
+
+		if (!isConnected())
+		{
+			iSecCounter++;
+			if (iSecCounter % 30 == 0)
+				_log.Log(LOG_STATUS, "DaikinModbus: Waiting for connection...");
+
+			// We reset the poll counter so we poll immediately upon reconnection
+			iPollCounter = m_iPollInterval;
+			continue;
+		}
+
+		iSecCounter = 0;
+		iPollCounter++;
+		if (iPollCounter >= m_iPollInterval)
+		{
+			iPollCounter = 0;
+			try
+			{
+				_log.Debug(DEBUG_HARDWARE, "DaikinModbus: Polling registers...");
+				if (m_bIsAirToAir)
+				{
+					// Homehub / Air-to-Air: Holding Registers 1000, count 2
+					SendReadRegisters(0x03, 1000, 2);
+				}
+				else
+				{
+					// Altherma 3: Holding Registers 1-60
+					SendReadRegisters(0x03, 1, 60);
+
+					// Slight wait between blocks, but check for stop
+					if (this->CDomoticzHardwareBase::IsStopRequested(200))
+						break;
+
+					// Altherma 3: Input Registers 21-61 (Start 21, count 41)
+					SendReadRegisters(0x04, 21, 41);
+				}
+			}
+			catch (const std::exception& e)
+			{
+				_log.Log(LOG_ERROR, "DaikinModbus: Exception in worker thread: %s", e.what());
+			}
+		}
+	}
+
+	_log.Log(LOG_STATUS, "DaikinModbus: Worker thread stopped.");
+}
+
+void CDaikinModbus::SendReadRegisters(uint8_t function_code, uint16_t start_reg, uint16_t count)
+{
+	uint16_t tid = ++m_TransactionID;
+
+	_log.Debug(DEBUG_HARDWARE, "DaikinModbus: Sending Read Request (FC: 0x%02X, Start: %u, Count: %u, TID: %u, Unit: %d)", function_code, start_reg, count, tid, m_iUnitID);
+
+	uint8_t req[12];
+	req[0] = (tid >> 8) & 0xFF;
+	req[1] = tid & 0xFF;
+	req[2] = 0;
+	req[3] = 0;
+	req[4] = 0;
+	req[5] = 6;
+	req[6] = (uint8_t)m_iUnitID;
+	req[7] = function_code;
+	req[8] = ((start_reg - 1) >> 8) & 0xFF;
+	req[9] = (start_reg - 1) & 0xFF;
+	req[10] = (count >> 8) & 0xFF;
+	req[11] = count & 0xFF;
+
+	write(req, sizeof(req));
+}
+
+void CDaikinModbus::SendWriteRegister(uint16_t reg, uint16_t value)
+{
+	uint16_t tid = ++m_TransactionID;
+
+	_log.Log(LOG_STATUS, "DaikinModbus: Sending Write Request (Reg: %u, Value: %u, TID: %u, Unit: %d)", reg, value, tid, m_iUnitID);
+
+	uint8_t req[12];
+	req[0] = (tid >> 8) & 0xFF;
+	req[1] = tid & 0xFF;
+	req[2] = 0;
+	req[3] = 0;
+	req[4] = 0;
+	req[5] = 6;
+	req[6] = (uint8_t)m_iUnitID;
+	req[7] = 0x06;
+	req[8] = ((reg - 1) >> 8) & 0xFF;
+	req[9] = (reg - 1) & 0xFF;
+	req[10] = (value >> 8) & 0xFF;
+	req[11] = value & 0xFF;
+
+	write(req, sizeof(req));
+}
+
+bool CDaikinModbus::WriteToHardware(const char* pdata, unsigned char length)
+{
+	const tRBUF* prb = (const tRBUF*)pdata;
+
+	if (prb->ICMND.packettype == pTypeSetpoint)
+	{
+		uint16_t childid = prb->RADIATOR1.id4;
+		float setpoint = (float)prb->RADIATOR1.temperature + ((float)prb->RADIATOR1.tempPoint5 / 10.0f);
+
+		uint16_t modbus_reg = 0;
+		uint16_t modbus_val = 0;
+
+		if (childid == 201) { modbus_reg = 1; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 202) { modbus_reg = 2; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 206) { modbus_reg = 6; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 207) { modbus_reg = 7; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 210) { modbus_reg = 10; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 254) { modbus_reg = 54; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		else if (childid == 255) { modbus_reg = 55; modbus_val = (uint16_t)(setpoint * 100.0f); }
+
+		if (modbus_reg > 0)
+		{
+			SendWriteRegister(modbus_reg, modbus_val);
+			return true;
+		}
+	}
+	else if (prb->ICMND.packettype == pTypeGeneralSwitch)
+	{
+		uint16_t childid = prb->LIGHTING5.unitcode;
+		uint16_t value = prb->LIGHTING5.level;
+
+		uint16_t modbus_reg = 0;
+		uint16_t modbus_val = 0;
+
+		if (childid == 203) { modbus_reg = 3; modbus_val = value / 10; }
+		else if (childid == 204) { modbus_reg = 4; modbus_val = (prb->LIGHTING5.cmnd == light5_sOn) ? 1 : 0; }
+		else if (childid == 209) { modbus_reg = 9; modbus_val = value / 10; }
+		else if (childid == 212) { modbus_reg = 12; modbus_val = (prb->LIGHTING5.cmnd == light5_sOn) ? 1 : 0; }
+		else if (childid == 213) { modbus_reg = 13; modbus_val = (prb->LIGHTING5.cmnd == light5_sOn) ? 1 : 0; }
+		else if (childid == 253) { modbus_reg = 53; modbus_val = value / 10; }
+		else if (childid == 256) { modbus_reg = 56; modbus_val = value / 10; }
+		else if (childid == 259) { modbus_reg = 59; modbus_val = (prb->LIGHTING5.cmnd == light5_sOn) ? 1 : 0; }
+		else if (m_bIsAirToAir && childid == 1000) { modbus_reg = 1000; modbus_val = value / 10; }
+
+		if (modbus_reg > 0)
+		{
+			SendWriteRegister(modbus_reg, modbus_val);
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void CDaikinModbus::OnConnect()
+{
+	_log.Log(LOG_STATUS, "DaikinModbus: Connected to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	std::lock_guard<std::mutex> lock(m_rbufferMutex);
+	m_vRBuffer.clear();
+}
+
+void CDaikinModbus::OnDisconnect()
+{
+	_log.Log(LOG_STATUS, "DaikinModbus: Disconnected from %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+}
+
+void CDaikinModbus::OnError(const boost::system::error_code& error)
+{
+	_log.Log(LOG_ERROR, "DaikinModbus: TCP Error: %s", error.message().c_str());
+}
+
+void CDaikinModbus::OnData(const uint8_t* pData, size_t length)
+{
+	std::lock_guard<std::mutex> lock(m_rbufferMutex);
+	m_vRBuffer.insert(m_vRBuffer.end(), pData, pData + length);
+
+	while (m_vRBuffer.size() >= 7)
+	{
+		uint16_t payload_len = (m_vRBuffer[4] << 8) | m_vRBuffer[5];
+		size_t total_expected = 6 + payload_len;
+
+		if (payload_len < 2)
+		{
+			m_vRBuffer.erase(m_vRBuffer.begin());
+			continue;
+		}
+
+		if (m_vRBuffer.size() < total_expected)
+			break;
+
+		uint8_t fc = m_vRBuffer[7];
+
+		SetHeartbeatReceived();
+
+		if (fc == 0x03 && payload_len >= 3)
+		{
+			uint8_t byte_count = m_vRBuffer[8];
+			if (payload_len >= (size_t)(3 + byte_count))
+				ProcessHoldingRegisters(m_vRBuffer.data() + 9, byte_count);
+		}
+		else if (fc == 0x04 && payload_len >= 3)
+		{
+			uint8_t byte_count = m_vRBuffer[8];
+			if (payload_len >= (size_t)(3 + byte_count))
+				ProcessInputRegisters(m_vRBuffer.data() + 9, byte_count);
+		}
+
+		m_vRBuffer.erase(m_vRBuffer.begin(), m_vRBuffer.begin() + total_expected);
+	}
+}
+
+void CDaikinModbus::ProcessInputRegisters(const uint8_t* pData, size_t length)
+{
+	auto getReg = [&](int reg) -> int16_t {
+		int idx = (reg - 21) * 2;
+		if (idx < 0 || idx + 1 >= (int)length) return 0x7FFF;
+		return (int16_t)((pData[idx] << 8) | pData[idx + 1]);
+	};
+
+	if (m_bIsAirToAir) return;
+
+	int16_t val;
+
+	// Combined Alert for Unit Error (Reg 21 and 23)
+	int16_t err = getReg(21);
+	int16_t suberr = getReg(23);
+	if (err != 0x7FFF)
+	{
+		int alertLevel = (err == 0) ? 1 : 4; // 1=Green (OK), 4=Red (Error)
+		std::string msg = (err == 0) ? "Unit Status: OK" : "Unit Error: " + std::to_string(err) + " (Sub: " + std::to_string(suberr) + ")";
+		UpdateAlertSensor(121, alertLevel, msg, "Unit Status");
+	}
+
+	// Binary States (30-37, 52, 53)
+	if ((val = getReg(30)) != 0x7FFF && val != 32766) UpdateSwitch(130, val != 0, "Circulation Pump");
+	if ((val = getReg(31)) != 0x7FFF && val != 32766) UpdateSwitch(131, val != 0, "Compressor");
+	if ((val = getReg(32)) != 0x7FFF && val != 32766) UpdateSwitch(132, val != 0, "Booster Heater");
+	if ((val = getReg(33)) != 0x7FFF && val != 32766) UpdateSwitch(133, val != 0, "Disinfection");
+	if ((val = getReg(35)) != 0x7FFF && val != 32766) UpdateSwitch(135, val != 0, "Defrost/Startup");
+	if ((val = getReg(36)) != 0x7FFF && val != 32766) UpdateSwitch(136, val != 0, "Hot Start");
+	if ((val = getReg(37)) != 0x7FFF && val != 32766) UpdateSwitch(137, val != 0, "3-way Valve");
+	if ((val = getReg(52)) != 0x7FFF && val != 32766) UpdateSwitch(152, val != 0, "DHW Normal Op");
+	if ((val = getReg(53)) != 0x7FFF && val != 32766) UpdateSwitch(153, val != 0, "Heating/Cooling Normal Op");
+
+	// Temperatures (40-45, 50) - Scale 0.01
+	if ((val = getReg(40)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(140, val / 100.0f, "LWT PHE");
+	if ((val = getReg(41)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(141, val / 100.0f, "LWT BUH");
+	if ((val = getReg(42)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(142, val / 100.0f, "Return Water Temp");
+	if ((val = getReg(43)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(143, val / 100.0f, "DHW Temp");
+	if ((val = getReg(44)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(144, val / 100.0f, "Outside Temp");
+	if ((val = getReg(45)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(145, val / 100.0f, "Refrigerant Temp");
+	if ((val = getReg(50)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(150, val / 100.0f, "Room Temp");
+
+	// Limits (54-57) - Scale 0.01
+	if ((val = getReg(54)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(154, val / 100.0f, "LWT Heating Lower Limit");
+	if ((val = getReg(55)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(155, val / 100.0f, "LWT Heating Upper Limit");
+	if ((val = getReg(56)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(156, val / 100.0f, "LWT Cooling Lower Limit");
+	if ((val = getReg(57)) != 0x7FFF && val != 32766) UpdateTemperatureSensor(157, val / 100.0f, "LWT Cooling Upper Limit");
+
+	// Sensors (49, 51)
+	if ((val = getReg(49)) != 0x7FFF && val != 32766) UpdateWaterflowSensor(149, val / 100.0f, "Flow Rate");
+	if ((val = getReg(51)) != 0x7FFF && val != 32766) UpdateCustomSensor(151, (val / 100.0f) * 1000.0f, "Power Consumption", "W");
+}
+
+void CDaikinModbus::ProcessHoldingRegisters(const uint8_t* pData, size_t length)
+{
+	if (m_bIsAirToAir)
+	{
+		auto getReg = [&](int reg) -> int16_t {
+			int idx = (reg - 1000) * 2;
+			if (idx < 0 || idx + 1 >= (int)length) return 0x7FFF;
+			return (int16_t)((pData[idx] << 8) | pData[idx + 1]);
+		};
+
+		int16_t val;
+		if ((val = getReg(1000)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(1000, val * 10, "Smart Grid Mode", "Free|Forced off|Recommended on|Forced on");
+		if ((val = getReg(1001)) != 0x7FFF && val != 32766) UpdateCustomSensor(1001, (val / 100.0f) * 1000.0f, "Power Limit", "W");
+		return;
+	}
+
+	auto getReg = [&](int reg) -> int16_t {
+		int idx = (reg - 1) * 2;
+		if (idx < 0 || idx + 1 >= (int)length) return 0x7FFF;
+		return (int16_t)((pData[idx] << 8) | pData[idx + 1]);
+	};
+
+	int16_t val;
+	// Setpoints (1, 2, 6, 7, 10)
+	if ((val = getReg(1)) != 0x7FFF && val != 32766) UpdateSetpointDevice(201, val / 100.0f, "LWT Heating Setpoint");
+	if ((val = getReg(2)) != 0x7FFF && val != 32766) UpdateSetpointDevice(202, val / 100.0f, "LWT Cooling Setpoint");
+	if ((val = getReg(6)) != 0x7FFF && val != 32766) UpdateSetpointDevice(206, val / 100.0f, "Room Heating Setpoint");
+	if ((val = getReg(7)) != 0x7FFF && val != 32766) UpdateSetpointDevice(207, val / 100.0f, "Room Cooling Setpoint");
+	if ((val = getReg(10)) != 0x7FFF && val != 32766) UpdateSetpointDevice(210, val / 100.0f, "DHW Reheat Setpoint");
+
+	// Modes and Other (3, 4, 9, 12, 13, 53, 54, 55, 56, 58, 59)
+	if ((val = getReg(3)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(203, val * 10, "Operation Mode", "Auto|Heating|Cooling");
+	if ((val = getReg(4)) != 0x7FFF && val != 32766) UpdateSwitch(204, val != 0, "Space Heating/Cooling");
+	if ((val = getReg(9)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(209, val * 10, "Quiet Mode", "Off|On (Auto)|On (Manual)");
+	if ((val = getReg(12)) != 0x7FFF && val != 32766) UpdateSwitch(212, val != 0, "DHW Reheat");
+	if ((val = getReg(13)) != 0x7FFF && val != 32766) UpdateSwitch(213, val != 0, "DHW Booster");
+	if ((val = getReg(53)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(253, val * 10, "Weather Dependent Mode", "Fixed|Weather Dependent|Fixed+Scheduled|Weather Dependent+Scheduled");
+	if ((val = getReg(54)) != 0x7FFF && val != 32766) UpdateSetpointDevice(254, val / 100.0f, "Weather Dependent Heating Offset");
+	if ((val = getReg(55)) != 0x7FFF && val != 32766) UpdateSetpointDevice(255, val / 100.0f, "Weather Dependent Cooling Offset");
+	if ((val = getReg(56)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(256, val * 10, "Smart Grid", "Free|Forced off|Recommended on|Forced on");
+	if ((val = getReg(58)) != 0x7FFF && val != 32766) UpdateCustomSensor(258, (val / 100.0f) * 1000.0f, "General Power Limit", "W");
+	if ((val = getReg(59)) != 0x7FFF && val != 32766) UpdateSwitch(259, val != 0, "Thermostat Main Input A");
+}
+
+void CDaikinModbus::UpdateTemperatureSensor(int ChildID, float temperature, const std::string& szDefaultName)
+{
+	// Important: Use unique ChildID as NodeID to prevent overwriting
+	SendTempSensor(ChildID, 255, temperature, szDefaultName);
+}
+
+void CDaikinModbus::UpdateSwitch(int ChildID, bool bOn, const std::string& szDefaultName)
+{
+	SendGeneralSwitch(m_HwdID, ChildID, 255, bOn ? 1 : 0, 0, szDefaultName, "");
+}
+
+void CDaikinModbus::UpdateSetpointDevice(int ChildID, float temperature, const std::string& szDefaultName)
+{
+	// NodeID 0, ChildID as ID4
+	SendSetPointSensor(0, 0, 0, (uint8_t)ChildID, 1, 255, temperature, szDefaultName);
+}
+
+void CDaikinModbus::UpdateWaterflowSensor(int ChildID, float flow, const std::string& szDefaultName)
+{
+	SendWaterflowSensor(m_HwdID, (uint8_t)ChildID, 255, flow, szDefaultName);
+}
+
+void CDaikinModbus::UpdateSelectorSwitch(int ChildID, int level, const std::string& szDefaultName, const std::string& szLevelNames)
+{
+	SendSelectorSwitch(m_HwdID, (uint8_t)ChildID, std::to_string(level), szDefaultName, 0, false, szLevelNames, "", false, "");
+}
+
+void CDaikinModbus::UpdateAlertSensor(int ChildID, int alertLevel, const std::string& szMessage, const std::string& szDefaultName)
+{
+	SendAlertSensor(ChildID, 255, alertLevel, szMessage, szDefaultName);
+}
+
+void CDaikinModbus::UpdateCustomSensor(int ChildID, float fValue, const std::string& szDefaultName, const std::string& szLabel)
+{
+	SendCustomSensor(m_HwdID, (uint8_t)ChildID, 255, fValue, szDefaultName, szLabel);
+}

--- a/hardware/DaikinModbus.cpp
+++ b/hardware/DaikinModbus.cpp
@@ -36,9 +36,6 @@ CDaikinModbus::CDaikinModbus(int ID, const std::string& IPAddress, unsigned shor
 	if (m_iPollInterval < 5)
 		m_iPollInterval = 30;
 	m_TransactionID = 0;
-
-	_log.Log(LOG_STATUS, "DaikinModbus: Initializing (ID: %d, IP: %s, Port: %d, Poll: %d, Unit: %d, Model: %s)",
-		m_HwdID, m_szIPAddress.c_str(), m_usIPPort, m_iPollInterval, m_iUnitID, m_bIsAirToAir ? "Air-to-Air" : "Altherma 3");
 }
 
 CDaikinModbus::~CDaikinModbus()
@@ -48,6 +45,9 @@ CDaikinModbus::~CDaikinModbus()
 
 bool CDaikinModbus::StartHardware()
 {
+	Log(LOG_STATUS, "Initializing (ID: %d, IP: %s, Port: %d, Poll: %d, Unit: %d, Model: %s)",
+		m_HwdID, m_szIPAddress.c_str(), m_usIPPort, m_iPollInterval, m_iUnitID, m_bIsAirToAir ? "Air-to-Air" : "Altherma 3");
+
 	m_bIsStarted = true;
 	this->CDomoticzHardwareBase::RequestStart();
 
@@ -80,7 +80,7 @@ bool CDaikinModbus::StopHardware()
 
 void CDaikinModbus::Do_Work()
 {
-	_log.Log(LOG_STATUS, "DaikinModbus: Worker thread started...");
+	Log(LOG_STATUS, "Worker thread started...");
 
 	int iSecCounter = 0;
 	int iPollCounter = m_iPollInterval; // Trigger poll immediately once connected
@@ -97,7 +97,7 @@ void CDaikinModbus::Do_Work()
 		{
 			iSecCounter++;
 			if (iSecCounter % 30 == 0)
-				_log.Log(LOG_STATUS, "DaikinModbus: Waiting for connection...");
+				Log(LOG_STATUS, "Waiting for connection...");
 
 			// We reset the poll counter so we poll immediately upon reconnection
 			iPollCounter = m_iPollInterval;
@@ -111,7 +111,7 @@ void CDaikinModbus::Do_Work()
 			iPollCounter = 0;
 			try
 			{
-				_log.Debug(DEBUG_HARDWARE, "DaikinModbus: Polling registers...");
+				Debug(DEBUG_HARDWARE, "Polling registers...");
 				if (m_bIsAirToAir)
 				{
 					// Homehub / Air-to-Air: Holding Registers 1000, count 2
@@ -132,19 +132,19 @@ void CDaikinModbus::Do_Work()
 			}
 			catch (const std::exception& e)
 			{
-				_log.Log(LOG_ERROR, "DaikinModbus: Exception in worker thread: %s", e.what());
+				Log(LOG_ERROR, "Exception in worker thread: %s", e.what());
 			}
 		}
 	}
 
-	_log.Log(LOG_STATUS, "DaikinModbus: Worker thread stopped.");
+	Log(LOG_STATUS, "Worker thread stopped.");
 }
 
 void CDaikinModbus::SendReadRegisters(uint8_t function_code, uint16_t start_reg, uint16_t count)
 {
 	uint16_t tid = ++m_TransactionID;
 
-	_log.Debug(DEBUG_HARDWARE, "DaikinModbus: Sending Read Request (FC: 0x%02X, Start: %u, Count: %u, TID: %u, Unit: %d)", function_code, start_reg, count, tid, m_iUnitID);
+	Debug(DEBUG_HARDWARE, "Sending Read Request (FC: 0x%02X, Start: %u, Count: %u, TID: %u, Unit: %d)", function_code, start_reg, count, tid, m_iUnitID);
 
 	uint8_t req[12];
 	req[0] = (tid >> 8) & 0xFF;
@@ -167,7 +167,7 @@ void CDaikinModbus::SendWriteRegister(uint16_t reg, uint16_t value)
 {
 	uint16_t tid = ++m_TransactionID;
 
-	_log.Log(LOG_STATUS, "DaikinModbus: Sending Write Request (Reg: %u, Value: %u, TID: %u, Unit: %d)", reg, value, tid, m_iUnitID);
+	Debug(DEBUG_HARDWARE, "Sending Write Request (Reg: %u, Value: %u, TID: %u, Unit: %d)", reg, value, tid, m_iUnitID);
 
 	uint8_t req[12];
 	req[0] = (tid >> 8) & 0xFF;
@@ -242,19 +242,19 @@ bool CDaikinModbus::WriteToHardware(const char* pdata, unsigned char length)
 
 void CDaikinModbus::OnConnect()
 {
-	_log.Log(LOG_STATUS, "DaikinModbus: Connected to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	Log(LOG_STATUS, "Connected to %s:%d", m_szIPAddress.c_str(), m_usIPPort);
 	std::lock_guard<std::mutex> lock(m_rbufferMutex);
 	m_vRBuffer.clear();
 }
 
 void CDaikinModbus::OnDisconnect()
 {
-	_log.Log(LOG_STATUS, "DaikinModbus: Disconnected from %s:%d", m_szIPAddress.c_str(), m_usIPPort);
+	Log(LOG_STATUS, "Disconnected from %s:%d", m_szIPAddress.c_str(), m_usIPPort);
 }
 
 void CDaikinModbus::OnError(const boost::system::error_code& error)
 {
-	_log.Log(LOG_ERROR, "DaikinModbus: TCP Error: %s", error.message().c_str());
+	Log(LOG_ERROR, "TCP Error: %s", error.message().c_str());
 }
 
 void CDaikinModbus::OnData(const uint8_t* pData, size_t length)

--- a/hardware/DaikinModbus.cpp
+++ b/hardware/DaikinModbus.cpp
@@ -192,19 +192,20 @@ bool CDaikinModbus::WriteToHardware(const char* pdata, unsigned char length)
 
 	if (prb->ICMND.packettype == pTypeSetpoint)
 	{
-		uint16_t childid = prb->RADIATOR1.id4;
-		float setpoint = (float)prb->RADIATOR1.temperature + ((float)prb->RADIATOR1.tempPoint5 / 10.0f);
+		const _tSetpoint* pSetpoint = reinterpret_cast<const _tSetpoint*>(prb);
+		uint16_t childid = pSetpoint->id4;
+		float setpoint = pSetpoint->value;
 
 		uint16_t modbus_reg = 0;
 		uint16_t modbus_val = 0;
 
-		if (childid == 201) { modbus_reg = 1; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 202) { modbus_reg = 2; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 206) { modbus_reg = 6; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 207) { modbus_reg = 7; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 210) { modbus_reg = 10; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 254) { modbus_reg = 54; modbus_val = (uint16_t)(setpoint * 100.0f); }
-		else if (childid == 255) { modbus_reg = 55; modbus_val = (uint16_t)(setpoint * 100.0f); }
+		if (childid == 201) { modbus_reg = 1; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 202) { modbus_reg = 2; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 206) { modbus_reg = 6; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 207) { modbus_reg = 7; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 210) { modbus_reg = 10; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 254) { modbus_reg = 54; modbus_val = (uint16_t)setpoint; }
+		else if (childid == 255) { modbus_reg = 55; modbus_val = (uint16_t)setpoint; }
 
 		if (modbus_reg > 0)
 		{
@@ -374,11 +375,11 @@ void CDaikinModbus::ProcessHoldingRegisters(const uint8_t* pData, size_t length)
 
 	int16_t val;
 	// Setpoints (1, 2, 6, 7, 10)
-	if ((val = getReg(1)) != 0x7FFF && val != 32766) UpdateSetpointDevice(201, val / 100.0f, "LWT Heating Setpoint");
-	if ((val = getReg(2)) != 0x7FFF && val != 32766) UpdateSetpointDevice(202, val / 100.0f, "LWT Cooling Setpoint");
-	if ((val = getReg(6)) != 0x7FFF && val != 32766) UpdateSetpointDevice(206, val / 100.0f, "Room Heating Setpoint");
-	if ((val = getReg(7)) != 0x7FFF && val != 32766) UpdateSetpointDevice(207, val / 100.0f, "Room Cooling Setpoint");
-	if ((val = getReg(10)) != 0x7FFF && val != 32766) UpdateSetpointDevice(210, val / 100.0f, "DHW Reheat Setpoint");
+	if ((val = getReg(1)) != 0x7FFF && val != 32766) UpdateSetpointDevice(201, (float)val, "LWT Heating Setpoint");
+	if ((val = getReg(2)) != 0x7FFF && val != 32766) UpdateSetpointDevice(202, (float)val, "LWT Cooling Setpoint");
+	if ((val = getReg(6)) != 0x7FFF && val != 32766) UpdateSetpointDevice(206, (float)val, "Room Heating Setpoint");
+	if ((val = getReg(7)) != 0x7FFF && val != 32766) UpdateSetpointDevice(207, (float)val, "Room Cooling Setpoint");
+	if ((val = getReg(10)) != 0x7FFF && val != 32766) UpdateSetpointDevice(210, (float)val, "DHW Reheat Setpoint");
 
 	// Modes and Other (3, 4, 9, 12, 13, 53, 54, 55, 56, 58, 59)
 	if ((val = getReg(3)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(203, val * 10, "Operation Mode", "Auto|Heating|Cooling");
@@ -387,8 +388,8 @@ void CDaikinModbus::ProcessHoldingRegisters(const uint8_t* pData, size_t length)
 	if ((val = getReg(12)) != 0x7FFF && val != 32766) UpdateSwitch(212, val != 0, "DHW Reheat");
 	if ((val = getReg(13)) != 0x7FFF && val != 32766) UpdateSwitch(213, val != 0, "DHW Booster");
 	if ((val = getReg(53)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(253, val * 10, "Weather Dependent Mode", "Fixed|Weather Dependent|Fixed+Scheduled|Weather Dependent+Scheduled");
-	if ((val = getReg(54)) != 0x7FFF && val != 32766) UpdateSetpointDevice(254, val / 100.0f, "Weather Dependent Heating Offset");
-	if ((val = getReg(55)) != 0x7FFF && val != 32766) UpdateSetpointDevice(255, val / 100.0f, "Weather Dependent Cooling Offset");
+	if ((val = getReg(54)) != 0x7FFF && val != 32766) UpdateSetpointDevice(254, (float)val, "Weather Dependent Heating Offset");
+	if ((val = getReg(55)) != 0x7FFF && val != 32766) UpdateSetpointDevice(255, (float)val, "Weather Dependent Cooling Offset");
 	if ((val = getReg(56)) != 0x7FFF && val != 32766) UpdateSelectorSwitch(256, val * 10, "Smart Grid", "Free|Forced off|Recommended on|Forced on");
 	if ((val = getReg(58)) != 0x7FFF && val != 32766) UpdateCustomSensor(258, (val / 100.0f) * 1000.0f, "General Power Limit", "W");
 	if ((val = getReg(59)) != 0x7FFF && val != 32766) UpdateSwitch(259, val != 0, "Thermostat Main Input A");

--- a/hardware/DaikinModbus.h
+++ b/hardware/DaikinModbus.h
@@ -1,0 +1,69 @@
+/*
+ Domoticz, Open Source Home Automation System
+
+ Copyright (C) 2012,2026 Rob Peters (GizMoCuz)
+
+ Domoticz is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Domoticz is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Domoticz.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "DomoticzHardware.h"
+#include "ASyncTCP.h"
+#include <atomic>
+
+class CDaikinModbus : public CDomoticzHardwareBase, ASyncTCP
+{
+public:
+	CDaikinModbus(int ID, const std::string& IPAddress, unsigned short usIPPort, int iPollInterval, bool bIsAirToAir, int iUnitID);
+	~CDaikinModbus() override;
+
+	bool StartHardware() override;
+	bool StopHardware() override;
+	bool WriteToHardware(const char* pdata, unsigned char length) override;
+
+private:
+	void Do_Work();
+
+	void SendReadRegisters(uint8_t function_code, uint16_t start_reg, uint16_t count);
+	void SendWriteRegister(uint16_t reg, uint16_t value);
+	void ProcessInputRegisters(const uint8_t* pData, size_t length);
+	void ProcessHoldingRegisters(const uint8_t* pData, size_t length);
+
+	// Device creation/update helpers
+	void UpdateTemperatureSensor(int ChildID, float temperature, const std::string& szDefaultName);
+	void UpdateSwitch(int ChildID, bool bOn, const std::string& szDefaultName);
+	void UpdateSetpointDevice(int ChildID, float temperature, const std::string& szDefaultName);
+	void UpdateUsageSensor(int ChildID, float usage, const std::string& szDefaultName);
+	void UpdateWaterflowSensor(int ChildID, float flow, const std::string& szDefaultName);
+	void UpdateSelectorSwitch(int ChildID, int level, const std::string& szDefaultName, const std::string& szLevelNames);
+	void UpdateAlertSensor(int ChildID, int alertLevel, const std::string& szMessage, const std::string& szDefaultName);
+	void UpdateCustomSensor(int ChildID, float fValue, const std::string& szDefaultName, const std::string& szLabel);
+
+	// ASyncTCP callbacks
+	void OnConnect() override;
+	void OnDisconnect() override;
+	void OnData(const uint8_t* pData, size_t length) override;
+	void OnError(const boost::system::error_code& error) override;
+
+	std::string m_szIPAddress;
+	unsigned short m_usIPPort;
+	int m_iPollInterval;
+	bool m_bIsAirToAir;
+	int m_iUnitID;
+	std::atomic<uint16_t> m_TransactionID;
+	std::vector<uint8_t> m_vRBuffer;
+	std::mutex m_rbufferMutex;
+	std::shared_ptr<std::thread> m_thread;
+};

--- a/main/RFXNames.cpp
+++ b/main/RFXNames.cpp
@@ -278,6 +278,7 @@ static const STR_TABLE_SINGLE HardwareTypeTable[] = {
 	{ HTYPE_MQTTAutoDiscovery, "MQTT Auto Discovery Client Gateway with LAN interface", "MQTT-AD" },
 	{ HTYPE_RFLINKMQTT, "RFLink Gateway MQTT", "RFLink" },
 	{ HTYPE_MitsubishiWF, "Mitsubishi WF RAC Airco with LAN (HTTP) interface", "MitsubishiWF" },
+	{ HTYPE_DaikinModbus, "Daikin Altherma (Modbus TCP via Homehub)", "DaikinHH" },
 	{ HTYPE_OpenMeteo, "Open-Meteo (Weather Lookup)", "OpenMeteo" },
 	{ 0, nullptr, nullptr },
 };
@@ -1738,7 +1739,7 @@ void GetLightStatus(
 			break;
 		case curtain_sClose:
 			lstatus = "Close";
-			break; 
+			break;
 		case curtain_sStop:
 			lstatus = "Stop";
 			break;

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -121,7 +121,7 @@ enum _eHardwareTypes {
 	HTYPE_System,				//23
 	HTYPE_EnOceanESP2,			//24
 	HTYPE_DarkSky,				//25
-	HTYPE_FREE2USE,				//26 (Old deprecated hardware, use this enum for your next project if you want to have a free to use hardware type for your plugin)
+	HTYPE_DaikinModbus,			//26
 	HTYPE_SBFSpot,				//27
 	HTYPE_ICYTHERMOSTAT,		//28
 	HTYPE_WOL,					//29
@@ -224,7 +224,6 @@ enum _eHardwareTypes {
 	HTYPE_RFLINKMQTT,			//126
 	HTYPE_VisualCrossing,		//127
 	HTYPE_MitsubishiWF,			//128
-	HTYPE_DaikinModbus,			//129
 	HTYPE_END
 };
 

--- a/main/RFXNames.h
+++ b/main/RFXNames.h
@@ -224,6 +224,7 @@ enum _eHardwareTypes {
 	HTYPE_RFLINKMQTT,			//126
 	HTYPE_VisualCrossing,		//127
 	HTYPE_MitsubishiWF,			//128
+	HTYPE_DaikinModbus,			//129
 	HTYPE_END
 };
 

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -1496,7 +1496,7 @@ namespace http
 					|| (htype == HTYPE_EVOHOME_SCRIPT) || (htype == HTYPE_EVOHOME_SERIAL) || (htype == HTYPE_EVOHOME_WEB) || (htype == HTYPE_EVOHOME_TCP)
 					|| (htype == HTYPE_PiFace) || (htype == HTYPE_HTTPPOLLER) || (htype == HTYPE_BleBox) || (htype == HTYPE_HEOS) || (htype == HTYPE_Yeelight) || (htype == HTYPE_XiaomiGateway)
 					|| (htype == HTYPE_Arilux) || (htype == HTYPE_USBtinGateway) || (htype == HTYPE_BuienRadar) || (htype == HTYPE_Honeywell) ||(htype == HTYPE_RaspberryGPIO)
-					|| (htype == HTYPE_SysfsGpio) || (htype == HTYPE_OpenWebNetTCP) || (htype == HTYPE_Daikin) || (htype == HTYPE_PythonPlugin) || (htype == HTYPE_RaspberryPCF8574)
+					|| (htype == HTYPE_SysfsGpio) || (htype == HTYPE_OpenWebNetTCP) || (htype == HTYPE_Daikin) || (htype == HTYPE_DaikinModbus) || (htype == HTYPE_PythonPlugin) || (htype == HTYPE_RaspberryPCF8574)
 					|| (htype == HTYPE_OpenWebNetUSB) || (htype == HTYPE_IntergasInComfortLAN2RF) || (htype == HTYPE_EnphaseAPI) || (htype == HTYPE_EcoCompteur) || (htype == HTYPE_Meteorologisk) || (htype == HTYPE_OpenMeteo)
 					|| (htype == HTYPE_AirconWithMe) || (htype == HTYPE_EneverPriceFeeds) || (htype == HTYPE_Tado))
 			{
@@ -1813,7 +1813,7 @@ namespace http
 				}
 				else if ((htype == HTYPE_RFXtrx433) || (htype == HTYPE_RFXtrx868))
 				{
-					// No Extra field here, handled in CWebServer::SetRFXCOMMode 
+					// No Extra field here, handled in CWebServer::SetRFXCOMMode
 					m_sql.safe_query("UPDATE Hardware SET Name='%q', Enabled=%d, Type=%d, LogLevel=%d, Address='%q', Port=%d, SerialPort='%q', Username='%q', Password='%q', "
 						"Mode1=%d, Mode2=%d, Mode3=%d, Mode4=%d, Mode5=%d, Mode6=%d, DataTimeout=%d WHERE (ID == '%q')",
 						name.c_str(), (bEnabled == true) ? 1 : 0, htype, iLogLevelEnabled, address.c_str(), port, sport.c_str(), username.c_str(), password.c_str(),

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -126,6 +126,7 @@
 #include "../hardware/Ec3kMeterTCP.h"
 #include "../hardware/OpenWeatherMap.h"
 #include "../hardware/Daikin.h"
+#include "../hardware/DaikinModbus.h"
 #include "../hardware/HEOS.h"
 #include "../hardware/MultiFun.h"
 #include "../hardware/ZiBlueSerial.h"
@@ -920,6 +921,9 @@ bool MainWorker::AddHardwareFromParams(
 		break;
 	case HTYPE_Daikin:
 		pHardware = new CDaikin(ID, Address, Port, Username, Password, Mode1);
+		break;
+	case HTYPE_DaikinModbus:
+		pHardware = new CDaikinModbus(ID, Address, Port, Mode1, Mode2 != 0, Mode3);
 		break;
 	case HTYPE_SBFSpot:
 		pHardware = new CSBFSpot(ID, Username);
@@ -2331,7 +2335,7 @@ void MainWorker::ProcessRXMessage(const CDomoticzHardwareBase* pHardware, const 
 	if ((BatteryLevel != -1) && (procResult.bProcessBatteryValue))
 	{
 		m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d WHERE (ID==%" PRIu64 ")", BatteryLevel, DeviceRowIdx);
-		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily... 
+		m_eventsystem.UpdateBatteryLevel(DeviceRowIdx, BatteryLevel); //GizMoCuz, temporarily...
 	}
 
 	if ((defaultName != nullptr) && ((DeviceName == "Unknown") || (DeviceName.empty())))
@@ -14302,7 +14306,7 @@ void MainWorker::HeartbeatCheck()
 				if (diff > 60)
 				{
 					_log.Log(LOG_ERROR, "%s hardware (%d) thread seems to have ended unexpectedly", pHardware->m_Name.c_str(), pHardware->m_HwdID);
-					
+
 				}
 			}
 

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -6,6 +6,7 @@ define(['app'], function (app) {
 	 */
 	let extraHWTable = {
 		'Daikin Airconditioning with LAN (HTTP) interface': 'DaikinParams',
+		'Daikin Altherma (Modbus TCP via Homehub)': 'DaikinModbusParams',
 		'MQTT Client Gateway with LAN interface': ['MQTTParams', 0],
 		'OctoPrint (MQTT/Gina Haussge) with LAN interface': ['MQTTParams', 1],
 		'The Things Network (MQTT/CayenneLPP) with LAN interface': ['MQTTParams', 2],
@@ -1318,7 +1319,7 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&extra=" + extra +
 					"&Mode1=" + defaultinterval +
-					"&Mode2=" + activeinterval + 
+					"&Mode2=" + activeinterval +
 					"&Mode3=" + allowwakeup,
 					async: false,
 					dataType: 'json',
@@ -1354,7 +1355,7 @@ define(['app'], function (app) {
 					"&datatimeout=" + datatimeout +
 					"&extra=" + vinnr +
 					"&Mode1=" + defaultinterval +
-					"&Mode2=" + activeinterval + 
+					"&Mode2=" + activeinterval +
 					"&Mode3=" + allowwakeup,
 					async: false,
 					dataType: 'json',
@@ -1684,7 +1685,7 @@ define(['app'], function (app) {
 					}
 				});
 			}
-			else if (text.indexOf("AirconWithMe") >= 0) 
+			else if (text.indexOf("AirconWithMe") >= 0)
 			{
 				var address = $("#hardwarecontent #divremote #tcpaddress").val();
 				if (address == "") {
@@ -2650,9 +2651,9 @@ define(['app'], function (app) {
 				var useowmforecast = $("#hardwarecontent #divopenweathermap #useowmforecast").prop("checked") ? 1 : 0;
 				var apiversion = $("#hardwarecontent #divopenweathermap #comboapiversion").val();
 				$.ajax({
-					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype + 
+					url: "json.htm?type=command&param=addhardware&htype=" + hardwaretype +
 					"&loglevel=" + logLevel +
-					"&username=" + encodeURIComponent(apikey) + "&password=" + encodeURIComponent(location) + 
+					"&username=" + encodeURIComponent(apikey) + "&password=" + encodeURIComponent(location) +
 					"&name=" + encodeURIComponent(name) + "&enabled=" + bEnabled + "&datatimeout=" + datatimeout +
 					"&Mode1=" + adddayforecast + "&Mode2=" + addhourforecast +
 					"&Mode3=" + adddescdev + "&Mode4=" + useowmforecast +
@@ -3141,7 +3142,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("AirconWithMe") >= 0) {
 				var address = $("#hardwarecontent #divremote #tcpaddress").val();
-				if (address == "") 
+				if (address == "")
 				{
 					ShowNotify($.t('Please enter an Address!'), 2500, true);
 					return;
@@ -4939,7 +4940,7 @@ define(['app'], function (app) {
 
 		expandScope = function (scopeArray, separator) {
 			//Netatmo Scopes
-			var scopeGroups = { 
+			var scopeGroups = {
 				station_R :					'read_station',
 				thermostat_RW :				'read_thermostat write_thermostat',
 				camera_RWA :				'read_camera write_camera access_camera',
@@ -5418,7 +5419,7 @@ define(['app'], function (app) {
 				text.indexOf("Eco Devices") >= 0 ||
 				text.indexOf("Intergas InComfort") >= 0 ||
 				text.indexOf("MySensors Gateway with MQTT") >= 0) &&
-				text.indexOf("YouLess") == -1 && 
+				text.indexOf("YouLess") == -1 &&
 				text.indexOf("Denkovi") == -1 &&
 				text.indexOf("Relay-Net") == -1 &&
 				text.indexOf("Satel Integra") == -1 &&

--- a/www/app/hardware/extra/DaikinModbusParams.html
+++ b/www/app/hardware/extra/DaikinModbusParams.html
@@ -1,0 +1,32 @@
+<br>
+<p><i>Note: This plugin requires the <b>Daikin Homehub (EKRHH)</b> gateway configured for Modbus TCP.</i></p>
+<table class="display" id="hardwareparamsdaikinmodbus" border="0" cellpadding="0" cellspacing="20">
+	<tr valign="top">
+		<td align="right" style="width:110px">
+			<label id="lblmodeldaikinmodbus"><span data-i18n="Model">Model</span>: </label>
+		</td>
+		<td>
+			<select id="modeldaikinmodbus" class="combobox ui-corner-all">
+				<option value="0">Altherma 3 (Air-to-Water)</option>
+				<option value="1">Air-to-Air (AC units)</option>
+			</select>
+		</td>
+	</tr>
+	<tr valign="top">
+		<td align="right" style="width:110px">
+			<label id="lblunitiddaikinmodbus"><span data-i18n="Unit ID">Unit ID</span>: </label>
+		</td>
+		<td>
+			<input type="text" id="unitiddaikinmodbus" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="1"><br>
+		</td>
+	</tr>
+	<tr valign="top">
+		<td align="right" style="width:110px">
+			<label id="lblupdfreqdaikinmodbus"><span data-i18n="Poll Interval">Poll Interval</span>: </label>
+		</td>
+		<td>
+			<input type="text" id="updatefrequencydaikinmodbus" style="width: 50px; padding: .2em;" class="text ui-widget-content ui-corner-all" value="30">&nbsp;<span data-i18n="(Seconds)">(Seconds)</span><br>
+			<span data-i18n="This sets the polling interval for status updates.">This sets the polling interval for status updates.</span><br>
+		</td>
+	</tr>
+</table>

--- a/www/app/hardware/extra/DaikinModbusParams.js
+++ b/www/app/hardware/extra/DaikinModbusParams.js
@@ -1,0 +1,42 @@
+
+extraHWValidateParams = function (data, validators) {
+	var address = $("#hardwarecontent #tcpaddress").val();
+	var port = $("#hardwarecontent #tcpport").val();
+
+	if (!validators["String"](address, "Remote Address")) return false;
+	if (!validators["Integer"](port, 1, 65535, "Port")) return false;
+	if (!validators["Integer"](data["Mode3"], 1, 255, "Unit ID")) return false;
+	return validators["Integer"](data["Mode1"], 5, 3600, " Poll Interval");
+}
+
+extraHWInitParams = function (data) {
+	if (data["Mode1"] == "")
+		data["Mode1"] = 30;
+	$('#hardwarecontent #divextrahwparams #updatefrequencydaikinmodbus').val(data["Mode1"]);
+
+	if (data["Mode2"] == "")
+		data["Mode2"] = "0";
+	$('#hardwarecontent #divextrahwparams #modeldaikinmodbus').val(data["Mode2"]);
+
+	if (data["Mode3"] == "")
+		data["Mode3"] = "1";
+	$('#hardwarecontent #divextrahwparams #unitiddaikinmodbus').val(data["Mode3"]);
+
+	if (data["Port"] == "" || data["Port"] == "0")
+		data["Port"] = "502";
+
+	if (data["Address"])
+		$("#hardwarecontent #tcpaddress").val(data["Address"]);
+
+	$("#hardwarecontent #divremote").show();
+}
+
+extraHWUpdateParams = function(validators) {
+    var data = {};
+    data["Mode1"] = $("#hardwarecontent #divextrahwparams #updatefrequencydaikinmodbus").val();
+    data["Mode2"] = $("#hardwarecontent #divextrahwparams #modeldaikinmodbus").val();
+    data["Mode3"] = $("#hardwarecontent #divextrahwparams #unitiddaikinmodbus").val();
+    if(!extraHWValidateParams(data, validators))
+        return false;
+    return data;
+}


### PR DESCRIPTION
Daikin has a nice system called the HomeHub. This is meant to manage Daikin Heatpumps via modbus.
This plugin intends to implement management of a Daikin Altherma 3 (and daikin air conditioner) via homehub.
Fully local, no internet connection required.

Please provide feedback, or merge if you're happy. :-D

I also found some warning during the build and added a fix for them. Not sure if I should put that into the same pull request... but the intention is good. :-D