### PR TITLE
feat(hue): Philips Hue V2 API with SSE, auto-detection, and new sensor types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ hardware/PhilipsHue/PhilipsHue.cpp
 hardware/PhilipsHue/PhilipsHueHelper.cpp
 hardware/PhilipsHue/PhilipsHueSensors.cpp
 hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
+hardware/PhilipsHue/PhilipsHueSSE.cpp
 hardware/PiFace.cpp
 hardware/Pinger.cpp
 hardware/PVOutput_Input.cpp

--- a/History.txt
+++ b/History.txt
@@ -8,8 +8,13 @@ Version 2026.xxxx
 - Added: MCP, domoticz://sensor-types resource listing all available virtual sensor types with mapped values
 - Added: MCP, get_sensor_history tool with daily calendar data for all sensor types and event log for switches/scenes
 - Added: MCP, new prompts: battery_status, climate_overview, create_automation, daily_report, energy_report, hardware_health, scene_optimizer, security_check
+- Added: PhilipsHue, automatic bridge version detection (V2 HTTPS/443, V1 HTTPS/443, V1 HTTP/80); port no longer needs manual configuration
+- Added: PhilipsHue V2, real-time sensor updates via Server-Sent Events (SSE); instant state changes without waiting for the next poll cycle
+- Added: PhilipsHue V2, new sensor types: grouped motion, grouped light level, camera motion, security area motion, button remotes, and bell button (doorbell)
 - Fixed: Contact and DoorContact switches now show correct Open/Closed icon state in the dashboard
 - Fixed: MCP, server is now enabled by default; use -nomcp flag to disable (previously required -llmmcp flag to enable)
+- Fixed: PhilipsHue SSE, application shutdown hang when event stream was idle
+- Fixed: PhilipsHue V2, battery level for motion/temperature/light level sensors reported as 255 instead of actual level
 - Fixed: PhilipsHue v2, thread-safety race condition causing concurrent API call errors
 - Fixed: Python plugin framework, spurious NullStream initialization errors on Python < 3.13 (#6688)
 - Fixed: Text device utility widget now preserves HTML style attributes (color, font-size, etc.)

--- a/hardware/PhilipsHue/PhilipsHue.cpp
+++ b/hardware/PhilipsHue/PhilipsHue.cpp
@@ -12,11 +12,11 @@
 #include "../../httpclient/HTTPClient.h"
 #include "../../main/json_helper.h"
 #include "../hardwaretypes.h"
+#include <curl/curl.h>
 
 #define HUE_DEFAULT_POLL_INTERVAL 10
 #define HUE_NOT_ADD_GROUPS 0x01
 #define HUE_NOT_ADD_SCENES 0x02
-#define HUE_USE_V2_SENSORS 0x04
 
 #define SensorTypeDaylight "Daylight"
 #define SensorTypeZGPSwitch "ZGPSwitch"
@@ -93,54 +93,117 @@ CPhilipsHue::CPhilipsHue(const int ID, const std::string& IPAddress, const unsig
 		Log(LOG_STATUS, "Using poll interval of %d seconds.", m_poll_interval);
 	}
 
-	// Force-enable V2 sensors by default by OR-ing the option in here.
-	// This keeps callers unchanged but makes the behavior default-on.
-	int effectiveOptions = Options | HUE_USE_V2_SENSORS;
-
-	m_add_groups = (effectiveOptions & HUE_NOT_ADD_GROUPS) != 0;
-	m_add_scenes = (effectiveOptions & HUE_NOT_ADD_SCENES) != 0;
-
-	m_use_v2_sensors = (effectiveOptions & HUE_USE_V2_SENSORS) != 0;
-
-	if (Port == 443)
-		m_html_schema = "https";
-	else
-		m_html_schema = "http";
-
-	Init();
+	m_add_groups = (Options & HUE_NOT_ADD_GROUPS) != 0;
+	m_add_scenes = (Options & HUE_NOT_ADD_SCENES) != 0;
 }
 
-void CPhilipsHue::Init()
+bool CPhilipsHue::CheckIsV2Bridge()
 {
-	// instantiate V2 sensors helper when Port is 443 (HTTPS) and if enabled
-	if (m_Port == 443) {
-		if (m_use_v2_sensors) {
-			// Use m_UserName as hue-application-key for now (same field used for v1 username).
-			try {
-				m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
-				Log(LOG_STATUS, "PhilipsHue: v2 sensors support enabled (Port==443).");
-			}
-			catch (const std::exception& e) {
-				Log(LOG_ERROR, "PhilipsHue: failed to create v2 sensors helper: %s", e.what());
-				m_use_v2_sensors = false;
-			}
-		} else {
-			// no v2 sensors when disabled/false
-			Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled.");
+	std::string url = "https://" + m_IPAddress + "/clip/v2/resource";
+	CURL* curl = curl_easy_init();
+	if (!curl)
+		return false;
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 3L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+	curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+	CURLcode res = curl_easy_perform(curl);
+	long httpCode = 0;
+	if (res == CURLE_OK)
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+	curl_easy_cleanup(curl);
+	_log.Debug(DEBUG_HARDWARE, "PhilipsHue: CheckIsV2Bridge HTTP %ld from %s (403 = V2)", httpCode, url.c_str());
+	return (httpCode == 403);
+}
+
+bool CPhilipsHue::CheckV1Bridge(int port)
+{
+	const std::string schema = (port == 443) ? "https" : "http";
+	std::string url = schema + "://" + m_IPAddress + ":" + std::to_string(port) + "/api/";
+	CURL* curl = curl_easy_init();
+	if (!curl)
+		return false;
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 3L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 5L);
+	curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
+	CURLcode res = curl_easy_perform(curl);
+	long httpCode = 0;
+	if (res == CURLE_OK)
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
+	curl_easy_cleanup(curl);
+	_log.Debug(DEBUG_HARDWARE, "PhilipsHue: CheckV1Bridge port %d HTTP %ld (200/405 = V1)", port, httpCode);
+	return (httpCode == 200 || httpCode == 405);
+}
+
+bool CPhilipsHue::Init()
+{
+	m_use_v2_sensors = false;
+	m_html_schema = "http";
+
+	if (CheckIsV2Bridge())
+	{
+		m_html_schema = "https";
+		m_Port = 443;
+		try {
+			m_v2sensors = std::make_unique<CPhilipsHueV2Sensors>(m_html_schema, m_IPAddress, std::to_string(m_Port), m_UserName);
+			m_use_v2_sensors = true;
+			Log(LOG_STATUS, "V2 bridge detected, using V2 API.");
 		}
-	} else {
-		// no v2 sensors on non-HTTPS connections
-		Log(LOG_STATUS, "PhilipsHue: v2 sensors support disabled (Port<>443).");
-		m_use_v2_sensors = false;
+		catch (const std::exception& e) {
+			Log(LOG_ERROR, "Failed to create V2 sensors helper: %s", e.what());
+			return false;
+		}
+		return true;
 	}
+
+	if (CheckV1Bridge(443))
+	{
+		m_html_schema = "https";
+		m_Port = 443;
+		Log(LOG_STATUS, "V1 bridge detected on port 443 (HTTPS).");
+		return true;
+	}
+
+	if (CheckV1Bridge(80))
+	{
+		m_html_schema = "http";
+		m_Port = 80;
+		Log(LOG_STATUS, "V1 bridge detected on port 80 (HTTP).");
+		return true;
+	}
+
+	Log(LOG_ERROR, "No Philips Hue bridge found at %s (tried V2 HTTPS/443, V1 HTTPS/443, V1 HTTP/80). Check IP address and network connectivity.", m_IPAddress.c_str());
+	return false;
 }
 
 bool CPhilipsHue::StartHardware()
 {
 	RequestStart();
 
-	Init();
-	//Start worker thread
+	if (!Init())
+		return false;
+
+	if (m_use_v2_sensors && m_v2sensors)
+	{
+		{
+			std::lock_guard<std::mutex> lock(m_http_mutex);
+			GetV2Sensors();
+		}
+
+		m_sse = std::make_unique<CPhilipsHueSSE>(
+			m_IPAddress,
+			std::to_string(m_Port),
+			m_UserName,
+			[this](const std::string& data) { OnSSEEvent(data); }
+		);
+		m_sse->Start();
+	}
+
 	m_thread = std::make_shared<std::thread>([this] { Do_Work(); });
 	SetThreadNameInt(m_thread->native_handle());
 	m_bIsStarted = true;
@@ -150,6 +213,11 @@ bool CPhilipsHue::StartHardware()
 
 bool CPhilipsHue::StopHardware()
 {
+	if (m_sse)
+	{
+		m_sse->Stop();
+		m_sse.reset();
+	}
 	if (m_thread)
 	{
 		RequestStop();
@@ -178,6 +246,11 @@ void CPhilipsHue::Do_Work()
 			{
 				m_LastHeartbeat = mytime(nullptr);
 				GetStates();
+			}
+			if (m_use_v2_sensors && m_v2sensors && sec_counter % 600 == 0)
+			{
+				std::lock_guard<std::mutex> lock(m_http_mutex);
+				GetV2Sensors();
 			}
 		}
 	}
@@ -894,14 +967,17 @@ bool CPhilipsHue::GetStates()
 	{
 		Log(LOG_ERROR, "Error processing Sensors: %s", e.what());
 	}
-	try
+	if (m_use_v2_sensors && m_v2sensors && (!m_sse || !m_sse->IsConnected()))
 	{
-		std::lock_guard<std::mutex> lock(m_http_mutex);
-		GetV2Sensors();
-	}
-	catch (const std::exception& e)
-	{
-		Log(LOG_ERROR, "Error processing V2 Sensors: %s", e.what());
+		try
+		{
+			std::lock_guard<std::mutex> lock(m_http_mutex);
+			GetV2Sensors();
+		}
+		catch (const std::exception& e)
+		{
+			Log(LOG_ERROR, "Error processing V2 Sensors: %s", e.what());
+		}
 	}
 
 	return true;
@@ -1090,6 +1166,12 @@ bool CPhilipsHue::GetGroups(const Json::Value& root)
 			if (bDoSend)
 			{
 				std::string oname = (!group["name"].empty()) ? group["name"].asString() : "??";
+				if (m_use_v2_sensors && m_v2sensors && (oname.empty() || oname == "??" || oname.rfind("Group", 0) == 0))
+				{
+					std::string v2name = m_v2sensors->GetRoomNameByV1GroupId(gID);
+					if (!v2name.empty())
+						oname = v2name;
+				}
 				std::string Name = "Group " + oname;
 				{
 					std::lock_guard<std::mutex> lock(m_mutex);
@@ -1268,6 +1350,28 @@ bool CPhilipsHue::GetScenes(const Json::Value& root)
 	return true;
 }
 
+static int ParseV1NumericId(const std::string& id_v1)
+{
+	if (id_v1.empty())
+		return -1;
+	auto pos = id_v1.rfind('/');
+	if (pos == std::string::npos || pos + 1 >= id_v1.size())
+		return -1;
+	try { return std::stoi(id_v1.substr(pos + 1)); }
+	catch (...) { return -1; }
+}
+
+void CPhilipsHue::LogV2MigrationWarning(const std::string& ownerRid, int v1NodeID, int hashNodeID, const std::string& friendlyName)
+{
+	if (v1NodeID == hashNodeID)
+		return;
+	if (m_v2_migration_warned.find(ownerRid) != m_v2_migration_warned.end())
+		return;
+	Log(LOG_STATUS, "PhilipsHue: Sensor '%s' now uses V1-compatible ID %d (was %d). Old device can be removed from Settings > Devices.",
+		friendlyName.c_str(), v1NodeID, hashNodeID);
+	m_v2_migration_warned.insert(ownerRid);
+}
+
 bool CPhilipsHue::GetV2Sensors()
 {
 	// call v2 sensors UpdateAll() and map to Domoticz devices (change-aware)
@@ -1365,6 +1469,8 @@ bool CPhilipsHue::GetV2Sensors()
 			}
 
 			// Map device_power to battery updates; only update existing devices and only when battery level changed
+			// Note: m_v2_battery_level is always accessed under m_http_mutex (held by all callers of GetV2Sensors
+			// and by OnSSEEvent before dispatching SSE handlers), so no additional lock is needed here.
 			for (const auto& p : m_v2sensors->GetDevicePowers())
 			{
 				const std::string ownerRid = p.owner_rid;
@@ -1395,6 +1501,7 @@ bool CPhilipsHue::GetV2Sensors()
 					batteryLevel = 100;
 				if (batteryLevel == 255)
 					continue;
+				m_v2_battery_level[ownerRid] = batteryLevel;
 
 				// Determine the Domoticz node IDs (owner-based)
 				int baseNode = NodeIDFromRid(ownerRid);
@@ -1405,7 +1512,7 @@ bool CPhilipsHue::GetV2Sensors()
 				char szID[16];
 				std::vector<std::vector<std::string>> result;
 
-				sprintf(szID, "%08X", domoticzNodeID_contact);
+				snprintf(szID, sizeof(szID), "%08X", domoticzNodeID_contact);
 				result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
 					m_HwdID, szID, 1);
 				if (!result.empty())
@@ -1428,7 +1535,7 @@ bool CPhilipsHue::GetV2Sensors()
 				}
 
 				// Tamper device (same approach)
-				sprintf(szID, "%08X", domoticzNodeID_tamper);
+				snprintf(szID, sizeof(szID), "%08X", domoticzNodeID_tamper);
 				result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
 					m_HwdID, szID, 1);
 				if (!result.empty())
@@ -1448,6 +1555,215 @@ bool CPhilipsHue::GetV2Sensors()
 						m_v2_battery_level[ownerRid] = batteryLevel;
 					}
 				}
+			}
+
+			for (const auto& mo : m_v2sensors->GetMotions())
+			{
+				const std::string& ownerRid = mo.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int v1Num = ParseV1NumericId(mo.id_v1);
+				int nodeID;
+				if (v1Num >= 0)
+					nodeID = v1Num + 3000;
+				else
+					nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+				std::string name;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					name = dit->second.name + " (Motion)";
+				else
+					name = "Hue Motion";
+
+				if (v1Num >= 0)
+					LogV2MigrationWarning(ownerRid, nodeID, NodeIDFromRid(ownerRid) + 3000, name);
+
+				uint8_t motBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Motion, mo.motion, name, motBattery);
+			}
+
+			for (const auto& te : m_v2sensors->GetTemperatures())
+			{
+				const std::string& ownerRid = te.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int v1Num = ParseV1NumericId(te.id_v1);
+				int nodeID;
+				if (v1Num >= 0)
+					nodeID = v1Num + 3000;
+				else
+					nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+				std::string name;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					name = dit->second.name + " (Temp)";
+				else
+					name = "Hue Temperature";
+
+				if (v1Num >= 0)
+					LogV2MigrationWarning(ownerRid, nodeID, NodeIDFromRid(ownerRid) + 3000, name);
+
+				uint8_t tempBattery = GetBatteryForOwner(ownerRid);
+				SendTempSensor(nodeID, tempBattery, te.temperature, name);
+			}
+
+			for (const auto& ll : m_v2sensors->GetLightLevels())
+			{
+				const std::string& ownerRid = ll.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int v1Num = ParseV1NumericId(ll.id_v1);
+				int nodeID;
+				if (v1Num >= 0)
+					nodeID = v1Num + 3000;
+				else
+					nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+				if (v1Num >= 0)
+				{
+					std::string friendlyName;
+					auto wdit = deviceById.find(ownerRid);
+					if (wdit != deviceById.end() && !wdit->second.name.empty())
+						friendlyName = wdit->second.name;
+					else
+						friendlyName = ownerRid;
+					LogV2MigrationWarning(ownerRid, nodeID, NodeIDFromRid(ownerRid) + 3000, friendlyName);
+				}
+
+				std::string darkName;
+				std::string luxName;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+				{
+					darkName = dit->second.name + " (Dark)";
+					luxName = dit->second.name + " Lux";
+				}
+				else
+				{
+					darkName = "Hue LightLevel";
+					luxName = "Hue LightLevel Lux";
+				}
+
+				uint8_t llBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Dusk, ll.dark, darkName, llBattery);
+
+				double lux = 0.00001;
+				if (ll.lightlevel != 0)
+				{
+					double convertedLightLevel = (double)(ll.lightlevel - 1) / 10000.0;
+					lux = pow(10.0, convertedLightLevel);
+				}
+				SendLuxSensor(nodeID, 0, llBattery, (const float)lux, luxName);
+			}
+
+			for (const auto& gm : m_v2sensors->GetGroupedMotions())
+			{
+				const std::string& ownerRid = gm.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int nodeID = NodeIDFromRid(ownerRid) + 5000;
+
+				std::string name;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					name = dit->second.name + " (Group Motion)";
+				else
+				{
+					for (const auto& room : m_v2sensors->GetRooms())
+					{
+						if (room.id == ownerRid)
+						{
+							name = room.name + " (Group Motion)";
+							break;
+						}
+					}
+					if (name.empty())
+						name = "Hue Group Motion";
+				}
+
+				uint8_t motBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Motion, gm.motion, name, motBattery);
+			}
+
+			for (const auto& gl : m_v2sensors->GetGroupedLightLevels())
+			{
+				const std::string& ownerRid = gl.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int nodeID = NodeIDFromRid(ownerRid) + 6000;
+
+				std::string darkName;
+				std::string luxName;
+				for (const auto& room : m_v2sensors->GetRooms())
+				{
+					if (room.id == ownerRid)
+					{
+						darkName = room.name + " Group (Dark)";
+						luxName = room.name + " Group Lux";
+						break;
+					}
+				}
+				if (darkName.empty())
+				{
+					darkName = "Hue Group LightLevel";
+					luxName = "Hue Group LightLevel Lux";
+				}
+
+				uint8_t llBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Dusk, gl.dark, darkName, llBattery);
+
+				double lux = 0.00001;
+				if (gl.lightlevel != 0)
+				{
+					double convertedLightLevel = (double)(gl.lightlevel - 1) / 10000.0;
+					lux = pow(10.0, convertedLightLevel);
+				}
+				SendLuxSensor(nodeID, 0, llBattery, (const float)lux, luxName);
+			}
+
+			for (const auto& cm : m_v2sensors->GetCameraMotions())
+			{
+				const std::string& ownerRid = cm.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int nodeID = NodeIDFromRid(ownerRid) + 7000;
+
+				std::string name;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					name = dit->second.name + " (Camera Motion)";
+				else
+					name = "Hue Camera Motion";
+
+				uint8_t motBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Motion, cm.motion, name, motBattery);
+			}
+
+			for (const auto& sam : m_v2sensors->GetSecurityAreaMotions())
+			{
+				const std::string& ownerRid = sam.owner_rid;
+				if (ownerRid.empty())
+					continue;
+
+				int nodeID = NodeIDFromRid(ownerRid) + 9000;
+
+				std::string name;
+				auto dit = deviceById.find(ownerRid);
+				if (dit != deviceById.end() && !dit->second.name.empty())
+					name = dit->second.name + " (Security Motion)";
+				else
+					name = "Hue Security Motion";
+
+				uint8_t motBattery = GetBatteryForOwner(ownerRid);
+				InsertUpdateSwitch(nodeID, 1, STYPE_Motion, sam.motion, name, motBattery);
 			}
 		}
 		else
@@ -1554,8 +1870,8 @@ bool CPhilipsHue::GetSensors(const Json::Value& root)
 				double lux = 0.00001;
 				if (current_sensor.m_state.m_lightlevel != 0)
 				{
-					float convertedLightLevel = float((current_sensor.m_state.m_lightlevel - 1) / 10000.00F);
-					lux = pow(10, convertedLightLevel);
+					double convertedLightLevel = (double)(current_sensor.m_state.m_lightlevel - 1) / 10000.0;
+					lux = pow(10.0, convertedLightLevel);
 				}
 				SendLuxSensor(sID, 0, current_sensor.m_config.m_battery, (const float)lux, current_sensor.m_type + " Lux " + current_sensor.m_name);
 			}
@@ -1630,6 +1946,652 @@ void CPhilipsHue::SetSwitchOptions(const int NodeID, const uint8_t Unitcode, con
 	}
 }
 
+
+uint8_t CPhilipsHue::GetBatteryForOwner(const std::string& ownerRid) const
+{
+	auto bit = m_v2_battery_level.find(ownerRid);
+	if (bit != m_v2_battery_level.end())
+		return (uint8_t)bit->second;
+	return 255;
+}
+
+std::string CPhilipsHue::GetV2DeviceName(const std::string& ownerRid) const
+{
+	if (!m_v2sensors)
+		return "";
+	for (const auto& d : m_v2sensors->GetDevices())
+	{
+		if (d.id == ownerRid)
+			return d.name;
+	}
+	return "";
+}
+
+void CPhilipsHue::OnSSEEvent(const std::string& jsonData)
+{
+	Json::Value events;
+	if (!ParseJSon(jsonData, events) || !events.isArray())
+		return;
+
+	std::lock_guard<std::mutex> lock(m_mutex);
+	std::lock_guard<std::mutex> httpLock(m_http_mutex);
+
+	for (const auto& event : events)
+	{
+		if (!event.isObject())
+			continue;
+		std::string eventType = event["type"].asString();
+		if (eventType != "update" && eventType != "add")
+			continue;
+
+		const auto& dataArr = event["data"];
+		if (!dataArr.isArray())
+			continue;
+
+		for (const auto& resource : dataArr)
+		{
+			if (!resource.isObject())
+				continue;
+			std::string rtype = resource["type"].asString();
+			DispatchSSEResource(rtype, resource);
+		}
+	}
+}
+
+void CPhilipsHue::DispatchSSEResource(const std::string& rtype, const Json::Value& resource)
+{
+	if (rtype == "contact")
+		HandleSSEContact(resource);
+	else if (rtype == "tamper")
+		HandleSSETamper(resource);
+	else if (rtype == "motion")
+		HandleSSEMotion(resource);
+	else if (rtype == "temperature")
+		HandleSSETemperature(resource);
+	else if (rtype == "light_level")
+		HandleSSELightLevel(resource);
+	else if (rtype == "grouped_motion")
+		HandleSSEGroupedMotion(resource);
+	else if (rtype == "grouped_light_level")
+		HandleSSEGroupedLightLevel(resource);
+	else if (rtype == "camera_motion")
+		HandleSSECameraMotion(resource);
+	else if (rtype == "security_area_motion")
+		HandleSSESecurityAreaMotion(resource);
+	else if (rtype == "bell_button")
+		HandleSSEBellButton(resource);
+	else if (rtype == "button")
+		HandleSSEButton(resource);
+	else if (rtype == "device_power")
+		HandleSSEDevicePower(resource);
+}
+
+void CPhilipsHue::HandleSSEContact(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("contact_report"))
+		return;
+
+	const auto& report = r["contact_report"];
+	std::string state;
+	std::string changed;
+	if (report.isMember("state"))
+		state = report["state"].asString();
+	if (report.isMember("changed"))
+		changed = report["changed"].asString();
+
+	if (state.empty() || changed.empty())
+		return;
+
+	auto itCState = m_v2_contact_state.find(ownerRid);
+	auto itCChanged = m_v2_contact_changed.find(ownerRid);
+	if (itCState != m_v2_contact_state.end() && itCChanged != m_v2_contact_changed.end())
+		if (itCState->second == state && itCChanged->second == changed)
+			return;
+
+	int nodeID = NodeIDFromRid(ownerRid) + 3000;
+	bool isOpen = (state == "no_contact");
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Contact)") : "Hue V2 Contact";
+
+	InsertUpdateSwitch(nodeID, 1, STYPE_DoorContact, isOpen, name, 0);
+
+	m_v2_contact_state[ownerRid] = state;
+	m_v2_contact_changed[ownerRid] = changed;
+}
+
+void CPhilipsHue::HandleSSETamper(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("tamper_reports"))
+		return;
+
+	const auto& reports = r["tamper_reports"];
+	if (!reports.isArray() || reports.empty())
+		return;
+
+	const auto& report = reports[0];
+	std::string state;
+	std::string changed;
+	if (report.isMember("state"))
+		state = report["state"].asString();
+	if (report.isMember("changed"))
+		changed = report["changed"].asString();
+
+	if (state.empty() || changed.empty())
+		return;
+
+	auto itTState = m_v2_tamper_state.find(ownerRid);
+	auto itTChanged = m_v2_tamper_changed.find(ownerRid);
+	if (itTState != m_v2_tamper_state.end() && itTChanged != m_v2_tamper_changed.end())
+		if (itTState->second == state && itTChanged->second == changed)
+			return;
+
+	int nodeID = NodeIDFromRid(ownerRid) + 4000;
+	bool isTampered = (state == "tampered");
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Tamper)") : "Hue V2 Tamper";
+
+	InsertUpdateSwitch(nodeID, 1, STYPE_OnOff, isTampered, name, 0);
+
+	m_v2_tamper_state[ownerRid] = state;
+	m_v2_tamper_changed[ownerRid] = changed;
+}
+
+void CPhilipsHue::HandleSSEMotion(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("motion") || !r["motion"].isObject())
+		return;
+
+	const auto& motObj = r["motion"];
+	bool motion = false;
+	if (motObj.isMember("motion"))
+		motion = motObj["motion"].asBool();
+
+	std::string id_v1;
+	if (r.isMember("id_v1"))
+		id_v1 = r["id_v1"].asString();
+
+	int v1Num = ParseV1NumericId(id_v1);
+	int nodeID;
+	if (v1Num >= 0)
+		nodeID = v1Num + 3000;
+	else
+		nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Motion)") : "Hue Motion";
+
+	uint8_t motBattery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Motion, motion, name, motBattery);
+}
+
+void CPhilipsHue::HandleSSETemperature(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("temperature"))
+		return;
+
+	const auto& tempObj = r["temperature"];
+	if (!tempObj.isMember("temperature"))
+		return;
+
+	float temperature = tempObj["temperature"].asFloat();
+
+	std::string id_v1;
+	if (r.isMember("id_v1"))
+		id_v1 = r["id_v1"].asString();
+
+	int v1Num = ParseV1NumericId(id_v1);
+	int nodeID;
+	if (v1Num >= 0)
+		nodeID = v1Num + 3000;
+	else
+		nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Temp)") : "Hue Temperature";
+
+	uint8_t tempBattery = GetBatteryForOwner(ownerRid);
+	SendTempSensor(nodeID, tempBattery, temperature, name);
+}
+
+void CPhilipsHue::HandleSSELightLevel(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("light"))
+		return;
+
+	const auto& lightObj = r["light"];
+	if (!lightObj.isMember("light_level"))
+		return;
+
+	int lightlevel = lightObj["light_level"].asInt();
+	bool dark = false;
+	if (lightObj.isMember("dark"))
+		dark = lightObj["dark"].asBool();
+
+	std::string id_v1;
+	if (r.isMember("id_v1"))
+		id_v1 = r["id_v1"].asString();
+
+	int v1Num = ParseV1NumericId(id_v1);
+	int nodeID;
+	if (v1Num >= 0)
+		nodeID = v1Num + 3000;
+	else
+		nodeID = NodeIDFromRid(ownerRid) + 3000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string darkName;
+	std::string luxName;
+	if (!deviceName.empty())
+	{
+		darkName = deviceName + " (Dark)";
+		luxName = deviceName + " Lux";
+	}
+	else
+	{
+		darkName = "Hue LightLevel";
+		luxName = "Hue LightLevel Lux";
+	}
+
+	uint8_t llBattery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Dusk, dark, darkName, llBattery);
+
+	double lux = 0.00001;
+	if (lightlevel != 0)
+	{
+		double convertedLightLevel = (double)(lightlevel - 1) / 10000.0;
+		lux = pow(10.0, convertedLightLevel);
+	}
+	SendLuxSensor(nodeID, 0, llBattery, (const float)lux, luxName);
+}
+
+void CPhilipsHue::HandleSSEGroupedMotion(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("motion") || !r["motion"].isObject())
+		return;
+
+	const auto& motObj = r["motion"];
+	bool motion = false;
+	if (motObj.isMember("motion"))
+		motion = motObj["motion"].asBool();
+
+	int nodeID = NodeIDFromRid(ownerRid) + 5000;
+
+	std::string name;
+	for (const auto& room : m_v2sensors->GetRooms())
+	{
+		if (room.id == ownerRid)
+		{
+			name = room.name + " (Group Motion)";
+			break;
+		}
+	}
+	if (name.empty())
+		name = "Hue Group Motion";
+
+	uint8_t motBattery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Motion, motion, name, motBattery);
+}
+
+void CPhilipsHue::HandleSSEGroupedLightLevel(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("light"))
+		return;
+
+	const auto& lightObj = r["light"];
+	if (!lightObj.isMember("light_level"))
+		return;
+
+	int lightlevel = lightObj["light_level"].asInt();
+	bool dark = false;
+	if (lightObj.isMember("dark"))
+		dark = lightObj["dark"].asBool();
+
+	int nodeID = NodeIDFromRid(ownerRid) + 6000;
+
+	std::string darkName;
+	std::string luxName;
+	for (const auto& room : m_v2sensors->GetRooms())
+	{
+		if (room.id == ownerRid)
+		{
+			darkName = room.name + " Group (Dark)";
+			luxName = room.name + " Group Lux";
+			break;
+		}
+	}
+	if (darkName.empty())
+	{
+		darkName = "Hue Group LightLevel";
+		luxName = "Hue Group LightLevel Lux";
+	}
+
+	uint8_t llBattery = GetBatteryForOwner(ownerRid);
+
+	InsertUpdateSwitch(nodeID, 1, STYPE_Dusk, dark, darkName, llBattery);
+
+	double lux = 0.00001;
+	if (lightlevel != 0)
+	{
+		double convertedLightLevel = (double)(lightlevel - 1) / 10000.0;
+		lux = pow(10.0, convertedLightLevel);
+	}
+	SendLuxSensor(nodeID, 0, llBattery, (const float)lux, luxName);
+}
+
+void CPhilipsHue::HandleSSECameraMotion(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("motion") || !r["motion"].isObject())
+		return;
+
+	const auto& motObj = r["motion"];
+	bool motion = false;
+	if (motObj.isMember("motion"))
+		motion = motObj["motion"].asBool();
+
+	int nodeID = NodeIDFromRid(ownerRid) + 7000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Camera Motion)") : "Hue Camera Motion";
+
+	uint8_t motBattery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Motion, motion, name, motBattery);
+}
+
+void CPhilipsHue::HandleSSESecurityAreaMotion(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("motion") || !r["motion"].isObject())
+		return;
+
+	const auto& motObj = r["motion"];
+	bool motion = false;
+	if (motObj.isMember("motion"))
+		motion = motObj["motion"].asBool();
+
+	int nodeID = NodeIDFromRid(ownerRid) + 9000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Security Motion)") : "Hue Security Motion";
+
+	uint8_t motBattery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Motion, motion, name, motBattery);
+}
+
+void CPhilipsHue::HandleSSEBellButton(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("bell") || !r["bell"].isObject())
+		return;
+
+	const auto& bellObj = r["bell"];
+	std::string event;
+	if (bellObj.isMember("bell_report") && bellObj["bell_report"].isObject())
+	{
+		if (bellObj["bell_report"].isMember("event"))
+			event = bellObj["bell_report"]["event"].asString();
+	}
+	if (event.empty() && bellObj.isMember("last_event"))
+		event = bellObj["last_event"].asString();
+
+	if (event != "ring")
+		return;
+
+	int nodeID = NodeIDFromRid(ownerRid) + 10000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? (deviceName + " (Bell)") : "Hue Bell";
+
+	uint8_t battery = GetBatteryForOwner(ownerRid);
+	InsertUpdateSwitch(nodeID, 1, STYPE_Doorbell, true, name, battery);
+}
+
+void CPhilipsHue::HandleSSEButton(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("button") || !r["button"].isObject())
+		return;
+
+	const auto& btnObj = r["button"];
+	std::string event;
+	if (btnObj.isMember("button_report") && btnObj["button_report"].isObject())
+	{
+		if (btnObj["button_report"].isMember("event"))
+			event = btnObj["button_report"]["event"].asString();
+	}
+	if (event.empty() && btnObj.isMember("last_event"))
+		event = btnObj["last_event"].asString();
+
+	if (event == "initial_press" || event == "repeat" || event == "long_press" || event.empty())
+		return;
+
+	int control_id = 0;
+	if (r.isMember("metadata") && r["metadata"].isMember("control_id"))
+		control_id = r["metadata"]["control_id"].asInt();
+
+	if (!m_v2sensors)
+		return;
+
+	const auto& allButtons = m_v2sensors->GetButtons();
+	int button_count = 0;
+	bool any_long_press = false;
+	std::string base_id_v1;
+	int lowest_ctrl = INT_MAX;
+
+	for (const auto& btn : allButtons)
+	{
+		if (btn.owner_rid != ownerRid)
+			continue;
+		button_count++;
+		if (btn.supports_long_press)
+			any_long_press = true;
+		if (btn.control_id < lowest_ctrl && !btn.id_v1.empty())
+		{
+			lowest_ctrl = btn.control_id;
+			base_id_v1 = btn.id_v1;
+		}
+	}
+
+	if (button_count == 0)
+		button_count = 1;
+
+	int v1Num = ParseV1NumericId(base_id_v1);
+	int nodeID = (v1Num >= 0) ? (v1Num + 3000) : (NodeIDFromRid(ownerRid) + 8000);
+
+	int button_nr = (control_id > 0) ? (control_id - 1) : 0;
+	if (button_nr > 255)
+	{
+		Log(LOG_ERROR, "PhilipsHue: button control_id out of range: %d", control_id);
+		return;
+	}
+	int selectorLevel = button_nr * 10;
+	if (any_long_press)
+		selectorLevel *= 2;
+	selectorLevel += 10;
+	if (event == "long_release")
+		selectorLevel += 10;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	std::string name = !deviceName.empty() ? deviceName : "Hue Switch";
+
+	uint8_t battery = GetBatteryForOwner(ownerRid);
+
+	if (selectorLevel > 255) selectorLevel = 255;
+	bool isNew = InsertUpdateSelectorSwitch(nodeID, 1, (uint8_t)selectorLevel, name, battery);
+	if (isNew)
+	{
+		std::map<std::string, std::string> options;
+		options["SelectorStyle"] = "1";
+		options["LevelOffHidden"] = "true";
+		options["LevelNames"] = "Off";
+		for (int b = 0; b < button_count; b++)
+		{
+			if (any_long_press)
+			{
+				options["LevelNames"] += "|Button " + std::to_string(b + 1) + " short";
+				options["LevelNames"] += "|Button " + std::to_string(b + 1) + " long";
+			}
+			else
+			{
+				options["LevelNames"] += "|Button " + std::to_string(b + 1);
+			}
+		}
+		SetSwitchOptions(nodeID, 1, options);
+	}
+}
+
+void CPhilipsHue::HandleSSEDevicePower(const Json::Value& r)
+{
+	std::string ownerRid;
+	if (r.isMember("owner") && r["owner"].isMember("rid"))
+		ownerRid = r["owner"]["rid"].asString();
+	if (ownerRid.empty())
+		return;
+
+	if (!r.isMember("power_state"))
+		return;
+
+	const auto& powerObj = r["power_state"];
+
+	int batteryLevel = -1;
+	if (powerObj.isMember("battery_level"))
+		batteryLevel = powerObj["battery_level"].asInt();
+
+	if (batteryLevel < 0 && powerObj.isMember("battery_state"))
+	{
+		const std::string bstate = powerObj["battery_state"].asString();
+		if (bstate == "full" || bstate == "normal")
+			batteryLevel = 100;
+		else if (bstate == "high")
+			batteryLevel = 90;
+		else if (bstate == "low")
+			batteryLevel = 20;
+		else if (bstate == "critical")
+			batteryLevel = 5;
+		else
+			batteryLevel = 255;
+	}
+
+	if (batteryLevel < 0 || batteryLevel == 255)
+		return;
+	if (batteryLevel > 100)
+		batteryLevel = 100;
+
+	m_v2_battery_level[ownerRid] = batteryLevel;
+	int baseNode = NodeIDFromRid(ownerRid);
+	int domoticzNodeID_contact = baseNode + 3000;
+	int domoticzNodeID_tamper = baseNode + 4000;
+
+	std::string deviceName = GetV2DeviceName(ownerRid);
+	char szID[16];
+	std::vector<std::vector<std::string>> result;
+
+	snprintf(szID, sizeof(szID), "%08X", domoticzNodeID_contact);
+	result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+		m_HwdID, szID, 1);
+	if (!result.empty())
+	{
+		int deviceRowId = atoi(result[0][0].c_str());
+		int prevBattery = atoi(result[0][1].c_str());
+		if (prevBattery != batteryLevel)
+		{
+			int nValue = 0;
+			auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+			if (!res2.empty())
+				nValue = atoi(res2[0][0].c_str());
+			bool contactIsOn = (nValue != 0);
+			std::string contactName = !deviceName.empty() ? (deviceName + " (Contact)") : "Hue V2 Contact";
+			InsertUpdateSwitch(domoticzNodeID_contact, 1, STYPE_DoorContact, contactIsOn, contactName, (uint8_t)batteryLevel);
+			m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+			m_v2_battery_level[ownerRid] = batteryLevel;
+		}
+	}
+
+	snprintf(szID, sizeof(szID), "%08X", domoticzNodeID_tamper);
+	result = m_sql.safe_query("SELECT ID, BatteryLevel FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit == %d)",
+		m_HwdID, szID, 1);
+	if (!result.empty())
+	{
+		int deviceRowId = atoi(result[0][0].c_str());
+		int prevBattery = atoi(result[0][1].c_str());
+		if (prevBattery != batteryLevel)
+		{
+			int nValue = 0;
+			auto res2 = m_sql.safe_query("SELECT nValue FROM DeviceStatus WHERE ID=%d", deviceRowId);
+			if (!res2.empty())
+				nValue = atoi(res2[0][0].c_str());
+			bool tamperIsOn = (nValue != 0);
+			std::string tamperName = !deviceName.empty() ? (deviceName + " (Tamper)") : "Hue V2 Tamper";
+			InsertUpdateSwitch(domoticzNodeID_tamper, 1, STYPE_OnOff, tamperIsOn, tamperName, (uint8_t)batteryLevel);
+			m_sql.safe_query("UPDATE DeviceStatus SET BatteryLevel=%d, LastUpdate=datetime('now','localtime') WHERE ID=%d", batteryLevel, deviceRowId);
+			m_v2_battery_level[ownerRid] = batteryLevel;
+		}
+	}
+}
 
 //Webserver helpers
 namespace http {

--- a/hardware/PhilipsHue/PhilipsHue.h
+++ b/hardware/PhilipsHue/PhilipsHue.h
@@ -2,9 +2,11 @@
 
 #include <memory>
 #include <mutex>
+#include <set>
 #include "../DomoticzHardware.h"
 #include "PhilipsHueSensors.h"
 #include "PhilipsHueV2Sensors.h" // NEW: include V2 helper
+#include "PhilipsHueSSE.h"
 
 namespace Json
 {
@@ -61,7 +63,9 @@ public:
 	static std::string RegisterUser(const std::string& IPAddress, unsigned short Port, const std::string& username);
 
 private:
-	void Init();
+	bool CheckIsV2Bridge();
+	bool CheckV1Bridge(int port);
+	bool Init();
 	bool StartHardware() override;
 	bool StopHardware() override;
 	void Do_Work();
@@ -83,6 +87,27 @@ private:
 
 	// Helper: generate deterministic numeric NodeID from a v2 UUID/rid
 	static int NodeIDFromRid(const std::string& rid);
+	void LogV2MigrationWarning(const std::string& ownerRid, int v1NodeID, int hashNodeID, const std::string& friendlyName);
+
+	// SSE event dispatch
+	void OnSSEEvent(const std::string& jsonData);
+	void DispatchSSEResource(const std::string& rtype, const Json::Value& resource);
+	void HandleSSEContact(const Json::Value& r);
+	void HandleSSETamper(const Json::Value& r);
+	void HandleSSEMotion(const Json::Value& r);
+	void HandleSSETemperature(const Json::Value& r);
+	void HandleSSELightLevel(const Json::Value& r);
+	void HandleSSEDevicePower(const Json::Value& r);
+	void HandleSSEGroupedMotion(const Json::Value& r);
+	void HandleSSEGroupedLightLevel(const Json::Value& r);
+	void HandleSSECameraMotion(const Json::Value& r);
+	void HandleSSESecurityAreaMotion(const Json::Value& r);
+	void HandleSSEBellButton(const Json::Value& r);
+	void HandleSSEButton(const Json::Value& r);
+
+	// Look up a cached V2 device name by owner RID
+	std::string GetV2DeviceName(const std::string& ownerRid) const;
+	uint8_t GetBatteryForOwner(const std::string& ownerRid) const;
 
 private:
 	int m_poll_interval;
@@ -103,10 +128,12 @@ private:
 private:
 	bool m_use_v2_sensors = false;
 	std::unique_ptr<CPhilipsHueV2Sensors> m_v2sensors; // constructed when enabled
+	std::unique_ptr<CPhilipsHueSSE> m_sse;
 	// v2 state caches to avoid updating Domoticz every poll when nothing changed
 	std::map<std::string, std::string> m_v2_contact_state;    // owner_rid -> last seen contact state (e.g. "contact"/"no_contact")
 	std::map<std::string, std::string> m_v2_contact_changed;  // owner_rid -> last seen changed timestamp
 	std::map<std::string, std::string> m_v2_tamper_state;     // owner_rid -> last seen tamper state
 	std::map<std::string, std::string> m_v2_tamper_changed;   // owner_rid -> last seen tamper changed timestamp
 	std::map<std::string, int> m_v2_battery_level;            // owner_rid -> last known battery level (0..100), 255=unknown/not-set
+	std::set<std::string> m_v2_migration_warned;              // owner_rids already warned about NodeID change
 };

--- a/hardware/PhilipsHue/PhilipsHueSSE.cpp
+++ b/hardware/PhilipsHue/PhilipsHueSSE.cpp
@@ -1,0 +1,210 @@
+#include "stdafx.h"
+#include "PhilipsHueSSE.h"
+#include "../../main/Logger.h"
+#include <curl/curl.h>
+#include <string>
+#include <thread>
+#include <chrono>
+#include <fstream>
+#include <algorithm>
+#include <memory>
+
+#ifdef _DEBUG
+//#define DEBUG_PhilipsHue_R
+//#define DEBUG_PhilipsHue_W
+#endif
+
+#ifdef DEBUG_PhilipsHue_W
+extern void SaveString2Disk(std::string str, std::string filename);
+#endif
+
+extern std::string urlToFilename(const std::string& prefix, const std::string& url);
+
+struct SSEContext
+{
+	std::string lineBuf;
+	std::string currentData;
+	SSEEventCallback callback;
+	std::atomic<bool>* stop;
+};
+
+static int SSEProgressCallback(void* clientp, curl_off_t /*dltotal*/, curl_off_t /*dlnow*/, curl_off_t /*ultotal*/, curl_off_t /*ulnow*/)
+{
+	auto* stop = static_cast<std::atomic<bool>*>(clientp);
+	return stop->load() ? 1 : 0;
+}
+
+static size_t SSEWriteCallback(char* ptr, size_t size, size_t nmemb, void* userdata)
+{
+	if (!ptr || !userdata)
+		return 0;
+	auto* ctx = static_cast<SSEContext*>(userdata);
+	if (ctx->stop->load())
+		return 0;
+
+	size_t total = size * nmemb;
+	ctx->lineBuf.append(ptr, total);
+
+	size_t pos;
+	while ((pos = ctx->lineBuf.find('\n')) != std::string::npos)
+	{
+		std::string line = ctx->lineBuf.substr(0, pos);
+		ctx->lineBuf.erase(0, pos + 1);
+		if (!line.empty() && line.back() == '\r')
+			line.pop_back();
+
+		if (line.empty())
+		{
+			if (!ctx->currentData.empty())
+			{
+				try { ctx->callback(ctx->currentData); }
+				catch (const std::exception& e) {
+					_log.Log(LOG_ERROR, "PhilipsHue SSE: event callback exception: %s", e.what());
+				}
+#ifdef DEBUG_PhilipsHue_W
+				SaveString2Disk("data: " + ctx->currentData + "\n\n",
+					urlToFilename("PhilipsHue", "eventstream_clip_v2"));
+#endif
+				ctx->currentData.clear();
+			}
+		}
+		else if (line.rfind("data:", 0) == 0)
+		{
+			std::string data = line.substr(5);
+			if (!data.empty() && data[0] == ' ')
+				data.erase(0, 1);
+			if (!ctx->currentData.empty())
+				ctx->currentData += '\n';
+			ctx->currentData += data;
+		}
+		// Ignore "id:" and "event:" lines
+	}
+	return total;
+}
+
+CPhilipsHueSSE::CPhilipsHueSSE(const std::string& ipAddress,
+	const std::string& port,
+	const std::string& applicationKey,
+	SSEEventCallback callback)
+	: m_IPAddress(ipAddress)
+	, m_Port(port)
+	, m_ApplicationKey(applicationKey)
+	, m_callback(callback)
+{
+}
+
+CPhilipsHueSSE::~CPhilipsHueSSE()
+{
+	Stop();
+}
+
+void CPhilipsHueSSE::Start()
+{
+	m_stop = false;
+	m_thread = std::make_shared<std::thread>(&CPhilipsHueSSE::ReaderThread, this);
+}
+
+void CPhilipsHueSSE::Stop()
+{
+	m_stop = true;
+	if (m_thread && m_thread->joinable())
+		m_thread->join();
+	m_thread.reset();
+}
+
+bool CPhilipsHueSSE::IsConnected() const
+{
+	return m_connected.load();
+}
+
+bool CPhilipsHueSSE::ConnectAndRead()
+{
+#ifdef DEBUG_PhilipsHue_R
+	{
+		std::string filename = urlToFilename("PhilipsHue", "eventstream_clip_v2");
+		std::ifstream f(filename);
+		if (!f.is_open())
+		{
+			_log.Log(LOG_ERROR, "PhilipsHue SSE: DEBUG_PhilipsHue_R: failed to open %s", filename.c_str());
+			return false;
+		}
+		std::string line, currentData;
+		while (std::getline(f, line))
+		{
+			if (!line.empty() && line.back() == '\r')
+				line.pop_back();
+			if (line.rfind("data:", 0) == 0)
+			{
+				currentData = line.substr(5);
+				if (!currentData.empty() && currentData[0] == ' ')
+					currentData.erase(0, 1);
+			}
+			else if (line.empty() && !currentData.empty())
+			{
+				try { m_callback(currentData); }
+				catch (const std::exception& e) {
+					_log.Log(LOG_ERROR, "PhilipsHue SSE: event callback exception: %s", e.what());
+				}
+				currentData.clear();
+			}
+		}
+		return false;
+	}
+#endif
+
+	CURL* curl = curl_easy_init();
+	if (!curl)
+		return true;
+
+	std::string url = "https://" + m_IPAddress + ":" + m_Port + "/eventstream/clip/v2";
+
+	SSEContext ctx;
+	ctx.callback = m_callback;
+	ctx.stop = &m_stop;
+
+	struct curl_slist* headers = nullptr;
+	headers = curl_slist_append(headers, ("hue-application-key: " + m_ApplicationKey).c_str());
+	headers = curl_slist_append(headers, "Accept: text/event-stream");
+
+	curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+	curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+	curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, SSEWriteCallback);
+	curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ctx);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+	curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+	curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 10L);
+	curl_easy_setopt(curl, CURLOPT_TIMEOUT, 0L);
+	curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, SSEProgressCallback);
+	curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &m_stop);
+	curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+
+	m_connected = true;
+	_log.Log(LOG_STATUS, "PhilipsHue SSE: connected to event stream");
+	CURLcode res = curl_easy_perform(curl);
+	m_connected = false;
+
+	curl_slist_free_all(headers);
+	curl_easy_cleanup(curl);
+
+	if (m_stop.load())
+		return false;
+
+	_log.Log(LOG_STATUS, "PhilipsHue SSE: disconnected (%s), reconnecting...",
+		curl_easy_strerror(res));
+	return true;
+}
+
+void CPhilipsHueSSE::ReaderThread()
+{
+	int reconnectDelay = 1;
+	while (!m_stop.load())
+	{
+		bool shouldReconnect = ConnectAndRead();
+		if (!shouldReconnect || m_stop.load())
+			break;
+		for (int i = 0; i < reconnectDelay * 10 && !m_stop.load(); ++i)
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		reconnectDelay = std::min(reconnectDelay * 2, 60);
+	}
+}

--- a/hardware/PhilipsHue/PhilipsHueSSE.h
+++ b/hardware/PhilipsHue/PhilipsHueSSE.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <string>
+#include <functional>
+#include <memory>
+#include <thread>
+#include <atomic>
+
+using SSEEventCallback = std::function<void(const std::string& jsonData)>;
+
+class CPhilipsHueSSE
+{
+public:
+	CPhilipsHueSSE(const std::string& ipAddress,
+		const std::string& port,
+		const std::string& applicationKey,
+		SSEEventCallback callback);
+	~CPhilipsHueSSE();
+
+	void Start();
+	void Stop();
+	bool IsConnected() const;
+
+	CPhilipsHueSSE(const CPhilipsHueSSE&) = delete;
+	CPhilipsHueSSE& operator=(const CPhilipsHueSSE&) = delete;
+
+private:
+	void ReaderThread();
+	bool ConnectAndRead();
+
+	std::string m_IPAddress;
+	std::string m_Port;
+	std::string m_ApplicationKey;
+	SSEEventCallback m_callback;
+
+	std::shared_ptr<std::thread> m_thread;
+	std::atomic<bool> m_stop{ false };
+	std::atomic<bool> m_connected{ false };
+};

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.cpp
@@ -11,11 +11,23 @@
 #ifdef _DEBUG
 //should be the same as in the main class!
 //#define DEBUG_PhilipsHue_R
-//#define DEBUG_PhilipsHue_W
+#define DEBUG_PhilipsHue_W
 #endif
 
 #ifdef DEBUG_PhilipsHue_W
+#ifndef SaveString2Disk
+void SaveString2Disk(std::string str, std::string filename)
+{
+	FILE* fOut = fopen(filename.c_str(), "wb+");
+	if (fOut)
+	{
+		fwrite(str.c_str(), 1, str.size(), fOut);
+		fclose(fOut);
+	}
+}
+#else
 extern void SaveString2Disk(std::string str, std::string filename);
+#endif
 #endif
 #ifdef DEBUG_PhilipsHue_R
 std::string ReadFile(std::string filename)
@@ -54,17 +66,28 @@ void CPhilipsHueV2Sensors::SetBaseURLv2FromParts()
 // High-level update: attempt all endpoints; partial success still returns true if any succeeded
 bool CPhilipsHueV2Sensors::UpdateAll()
 {
+	bool ok0 = FetchRooms();
 	bool ok1 = FetchDevices();
-	bool ok2 = FetchLights();
-	bool ok3 = FetchContacts();
-	bool ok4 = FetchTamper();
-	bool ok5 = FetchDevicePower();
-	return ok1 || ok2 || ok3 || ok4 || ok5;
+	bool ok2 = FetchMotion();
+	bool ok3 = FetchTemperature();
+	bool ok4 = FetchLightLevel();
+	bool ok5 = FetchLights();
+	bool ok6 = FetchContacts();
+	bool ok7 = FetchTamper();
+	bool ok8 = FetchDevicePower();
+	FetchGroupedMotion();
+	FetchGroupedLightLevel();
+	FetchCameraMotion();
+	FetchSecurityAreaMotion();
+	FetchBellButtons();
+	FetchButtons();
+	return ok0 || ok1 || ok2 || ok3 || ok4 || ok5 || ok6 || ok7 || ok8;
 }
 
 // Helper: GET with hue-application-key header using project HTTPClient
 bool CPhilipsHueV2Sensors::http_get_v2_with_key(const std::string& api_endpoint, const std::string& appKey, std::string& outBody)
 {
+	std::string url = m_BaseURLv2.str() + api_endpoint;
 #ifdef DEBUG_PhilipsHue_R
 	outBody = ReadFile(urlToFilename("PhilipsHue", url));
 #endif
@@ -74,12 +97,140 @@ bool CPhilipsHueV2Sensors::http_get_v2_with_key(const std::string& api_endpoint,
 	{
 		ExtraHeaders.push_back(std::string("hue-application-key: ") + appKey);
 	}
-	std::string url = m_BaseURLv2.str() + api_endpoint;
 	bool ret = HTTPClient::GET(url, ExtraHeaders, outBody);
 #ifdef DEBUG_PhilipsHue_W
 	SaveString2Disk(outBody, urlToFilename("PhilipsHue", url));
 #endif
 	return ret;
+}
+
+// Fetch /clip/v2/resource/room and /clip/v2/resource/zone
+bool CPhilipsHueV2Sensors::FetchRooms()
+{
+	m_rooms.clear();
+	m_roomNameByV1GroupId.clear();
+	std::string sResult;
+	if (http_get_v2_with_key("room", m_ApplicationKey, sResult))
+	{
+		Json::Value root;
+		if (ParseJSon(sResult, root) && sResult.find("\"error\":") == std::string::npos)
+			parseRoomJson(root);
+		else
+			_log.Log(LOG_ERROR, "PhilipsHueV2: FetchRooms (room) parse/error failure");
+	}
+	else
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchRooms (room) HTTP GET failed");
+
+	if (http_get_v2_with_key("zone", m_ApplicationKey, sResult))
+	{
+		Json::Value root;
+		if (ParseJSon(sResult, root) && sResult.find("\"error\":") == std::string::npos)
+			parseRoomJson(root);
+		else
+			_log.Log(LOG_ERROR, "PhilipsHueV2: FetchRooms (zone) parse/error failure");
+	}
+	else
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchRooms (zone) HTTP GET failed");
+
+	if (!m_rooms.empty())
+	{
+		if (http_get_v2_with_key("grouped_light", m_ApplicationKey, sResult))
+		{
+			Json::Value root;
+			if (ParseJSon(sResult, root) && sResult.find("\"error\":") == std::string::npos)
+			{
+				std::map<std::string, int> ridToV1Id;
+				if (parseGroupedLightV1Ids(root, ridToV1Id))
+				{
+					for (const auto& room : m_rooms)
+					{
+						if (room.grouped_light_rid.empty() || room.name.empty())
+							continue;
+						auto it = ridToV1Id.find(room.grouped_light_rid);
+						if (it != ridToV1Id.end())
+							m_roomNameByV1GroupId[it->second] = room.name;
+					}
+				}
+			}
+			else
+				_log.Log(LOG_ERROR, "PhilipsHueV2: FetchRooms (grouped_light) parse/error failure");
+		}
+		else
+			_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchRooms (grouped_light) HTTP GET failed");
+	}
+
+	return !m_rooms.empty();
+}
+
+// parse /clip/v2/resource/room or /clip/v2/resource/zone (same structure)
+bool CPhilipsHueV2Sensors::parseRoomJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseRoomJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject())
+			continue;
+		HueV2Room r;
+		if (item.isMember("id"))
+			r.id = item["id"].asString();
+		if (item.isMember("metadata") && item["metadata"].isObject() && item["metadata"].isMember("name"))
+			r.name = item["metadata"]["name"].asString();
+		if (item.isMember("services") && item["services"].isArray())
+		{
+			for (const auto& srv : item["services"])
+			{
+				if (srv.isObject() && srv.isMember("rtype") && srv["rtype"].asString() == "grouped_light")
+				{
+					if (srv.isMember("rid"))
+						r.grouped_light_rid = srv["rid"].asString();
+					break;
+				}
+			}
+		}
+		m_rooms.push_back(r);
+	}
+	return true;
+}
+
+// Parse /clip/v2/resource/grouped_light to extract UUID -> V1 group number mappings
+bool CPhilipsHueV2Sensors::parseGroupedLightV1Ids(const Json::Value& root, std::map<std::string, int>& outRidToV1Id)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+		return false;
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject())
+			continue;
+		if (!item.isMember("id") || !item.isMember("id_v1"))
+			continue;
+		const std::string rid = item["id"].asString();
+		const std::string id_v1 = item["id_v1"].asString();
+		const std::string prefix = "/groups/";
+		if (id_v1.size() <= prefix.size() || id_v1.substr(0, prefix.size()) != prefix)
+			continue;
+		const std::string numStr = id_v1.substr(prefix.size());
+		if (numStr.empty())
+			continue;
+		try {
+			int groupNum = std::stoi(numStr);
+			outRidToV1Id[rid] = groupNum;
+		}
+		catch (...) {}
+	}
+	return !outRidToV1Id.empty();
+}
+
+// Return room/zone name for a V1 group integer ID, empty string if not available
+std::string CPhilipsHueV2Sensors::GetRoomNameByV1GroupId(int groupId) const
+{
+	auto it = m_roomNameByV1GroupId.find(groupId);
+	if (it != m_roomNameByV1GroupId.end())
+		return it->second;
+	return {};
 }
 
 // Fetch /clip/v2/resource/device
@@ -131,6 +282,150 @@ bool CPhilipsHueV2Sensors::FetchLights()
 		return false;
 	}
 	return parseLightJson(root);
+}
+
+// Fetch /clip/v2/resource/motion
+bool CPhilipsHueV2Sensors::FetchMotion()
+{
+	m_motions.clear();
+	std::string sResult;
+	if (!http_get_v2_with_key("motion", m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchMotion HTTP GET failed");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchMotion JSON parse failed");
+		return false;
+	}
+	if (sResult.find("\"error\":") != std::string::npos)
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseMotionJson(root);
+}
+
+// Fetch /clip/v2/resource/temperature
+bool CPhilipsHueV2Sensors::FetchTemperature()
+{
+	m_temperatures.clear();
+	std::string sResult;
+	if (!http_get_v2_with_key("temperature", m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchTemperature HTTP GET failed");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchTemperature JSON parse failed");
+		return false;
+	}
+	if (sResult.find("\"error\":") != std::string::npos)
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseTemperatureJson(root);
+}
+
+// Fetch /clip/v2/resource/light_level
+bool CPhilipsHueV2Sensors::FetchLightLevel()
+{
+	m_lightlevels.clear();
+	std::string sResult;
+	if (!http_get_v2_with_key("light_level", m_ApplicationKey, sResult))
+	{
+		_log.Log(LOG_DEBUG_INT, "PhilipsHueV2: FetchLightLevel HTTP GET failed");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(sResult, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: FetchLightLevel JSON parse failed");
+		return false;
+	}
+	if (sResult.find("\"error\":") != std::string::npos)
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseLightLevelJson(root);
+}
+
+// Fetch /clip/v2/resource/grouped_motion
+bool CPhilipsHueV2Sensors::FetchGroupedMotion()
+{
+	m_groupedMotions.clear();
+	std::string body;
+	if (!http_get_v2_with_key("grouped_motion", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch grouped_motion");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse grouped_motion JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseGroupedMotionJson(root);
+}
+
+// Fetch /clip/v2/resource/grouped_light_level
+bool CPhilipsHueV2Sensors::FetchGroupedLightLevel()
+{
+	m_groupedLightLevels.clear();
+	std::string body;
+	if (!http_get_v2_with_key("grouped_light_level", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch grouped_light_level");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse grouped_light_level JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseGroupedLightLevelJson(root);
+}
+
+// Fetch /clip/v2/resource/camera_motion
+bool CPhilipsHueV2Sensors::FetchCameraMotion()
+{
+	m_cameraMotions.clear();
+	std::string body;
+	if (!http_get_v2_with_key("camera_motion", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch camera_motion");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse camera_motion JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseCameraMotionJson(root);
 }
 
 // Fetch /clip/v2/resource/contact
@@ -301,6 +596,393 @@ bool CPhilipsHueV2Sensors::parseLightJson(const Json::Value& root)
 	return true;
 }
 
+// parse /clip/v2/resource/motion
+bool CPhilipsHueV2Sensors::parseMotionJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseMotionJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject())
+			continue;
+		HueV2Motion m;
+		if (item.isMember("id"))
+			m.id = item["id"].asString();
+		if (item.isMember("id_v1") && item["id_v1"].isString())
+			m.id_v1 = item["id_v1"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			m.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled"))
+			m.enabled = item["enabled"].asBool();
+		if (item.isMember("motion") && item["motion"].isObject())
+		{
+			const auto& motObj = item["motion"];
+			if (motObj.isMember("motion"))
+				m.motion = motObj["motion"].asBool();
+			if (motObj.isMember("motion_report") && motObj["motion_report"].isObject())
+			{
+				if (motObj["motion_report"].isMember("changed"))
+					m.motion_changed = motObj["motion_report"]["changed"].asString();
+			}
+		}
+		m_motions.push_back(m);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/temperature
+bool CPhilipsHueV2Sensors::parseTemperatureJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseTemperatureJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject())
+			continue;
+		HueV2Temperature t;
+		if (item.isMember("id"))
+			t.id = item["id"].asString();
+		if (item.isMember("id_v1") && item["id_v1"].isString())
+			t.id_v1 = item["id_v1"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			t.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled"))
+			t.enabled = item["enabled"].asBool();
+		if (item.isMember("temperature") && item["temperature"].isObject())
+		{
+			const auto& temp = item["temperature"];
+			if (temp.isMember("temperature"))
+				t.temperature = temp["temperature"].asFloat();
+			if (temp.isMember("temperature_report") && temp["temperature_report"].isObject())
+			{
+				if (temp["temperature_report"].isMember("changed"))
+					t.temperature_changed = temp["temperature_report"]["changed"].asString();
+			}
+		}
+		m_temperatures.push_back(t);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/light_level
+bool CPhilipsHueV2Sensors::parseLightLevelJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseLightLevelJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject())
+			continue;
+		HueV2LightLevel ll;
+		if (item.isMember("id"))
+			ll.id = item["id"].asString();
+		if (item.isMember("id_v1") && item["id_v1"].isString())
+			ll.id_v1 = item["id_v1"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			ll.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled"))
+			ll.enabled = item["enabled"].asBool();
+		if (item.isMember("light") && item["light"].isObject())
+		{
+			const auto& light = item["light"];
+			if (light.isMember("light_level"))
+				ll.lightlevel = light["light_level"].asInt();
+			if (light.isMember("dark"))
+				ll.dark = light["dark"].asBool();
+			if (light.isMember("light_level_report") && light["light_level_report"].isObject())
+			{
+				if (light["light_level_report"].isMember("changed"))
+					ll.lightlevel_changed = light["light_level_report"]["changed"].asString();
+			}
+		}
+		m_lightlevels.push_back(ll);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/grouped_motion
+bool CPhilipsHueV2Sensors::parseGroupedMotionJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseGroupedMotionJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2GroupedMotion m;
+		if (item.isMember("id")) m.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			m.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled")) m.enabled = item["enabled"].asBool();
+		if (item.isMember("motion") && item["motion"].isObject())
+		{
+			const auto& motObj = item["motion"];
+			if (motObj.isMember("motion"))
+				m.motion = motObj["motion"].asBool();
+			if (motObj.isMember("motion_report") && motObj["motion_report"].isObject())
+				if (motObj["motion_report"].isMember("changed"))
+					m.motion_changed = motObj["motion_report"]["changed"].asString();
+		}
+		if (!m.owner_rid.empty())
+			m_groupedMotions.push_back(m);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/grouped_light_level
+bool CPhilipsHueV2Sensors::parseGroupedLightLevelJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseGroupedLightLevelJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2GroupedLightLevel ll;
+		if (item.isMember("id")) ll.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			ll.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled")) ll.enabled = item["enabled"].asBool();
+		if (item.isMember("light") && item["light"].isObject())
+		{
+			const auto& light = item["light"];
+			if (light.isMember("light_level"))
+				ll.lightlevel = light["light_level"].asInt();
+			if (light.isMember("dark"))
+				ll.dark = light["dark"].asBool();
+			if (light.isMember("light_level_report") && light["light_level_report"].isObject())
+				if (light["light_level_report"].isMember("changed"))
+					ll.lightlevel_changed = light["light_level_report"]["changed"].asString();
+		}
+		if (!ll.owner_rid.empty())
+			m_groupedLightLevels.push_back(ll);
+	}
+	return true;
+}
+
+// parse /clip/v2/resource/camera_motion
+bool CPhilipsHueV2Sensors::parseCameraMotionJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseCameraMotionJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2CameraMotion m;
+		if (item.isMember("id")) m.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			m.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled")) m.enabled = item["enabled"].asBool();
+		if (item.isMember("motion") && item["motion"].isObject())
+		{
+			const auto& motObj = item["motion"];
+			if (motObj.isMember("motion"))
+				m.motion = motObj["motion"].asBool();
+			if (motObj.isMember("motion_report") && motObj["motion_report"].isObject())
+				if (motObj["motion_report"].isMember("changed"))
+					m.motion_changed = motObj["motion_report"]["changed"].asString();
+		}
+		if (!m.owner_rid.empty())
+			m_cameraMotions.push_back(m);
+	}
+	return true;
+}
+
+// Fetch /clip/v2/resource/security_area_motion
+bool CPhilipsHueV2Sensors::FetchSecurityAreaMotion()
+{
+	m_securityAreaMotions.clear();
+	std::string body;
+	if (!http_get_v2_with_key("security_area_motion", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch security_area_motion");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse security_area_motion JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseSecurityAreaMotionJson(root);
+}
+
+// parse /clip/v2/resource/security_area_motion
+bool CPhilipsHueV2Sensors::parseSecurityAreaMotionJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseSecurityAreaMotionJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2SecurityAreaMotion m;
+		if (item.isMember("id")) m.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			m.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("enabled")) m.enabled = item["enabled"].asBool();
+		if (item.isMember("motion") && item["motion"].isObject())
+		{
+			const auto& motObj = item["motion"];
+			if (motObj.isMember("motion"))
+				m.motion = motObj["motion"].asBool();
+		}
+		if (!m.owner_rid.empty())
+			m_securityAreaMotions.push_back(m);
+	}
+	return true;
+}
+
+// Fetch /clip/v2/resource/bell_button
+bool CPhilipsHueV2Sensors::FetchBellButtons()
+{
+	m_bellButtons.clear();
+	std::string body;
+	if (!http_get_v2_with_key("bell_button", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch bell_button");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse bell_button JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseBellButtonJson(root);
+}
+
+// parse /clip/v2/resource/bell_button
+bool CPhilipsHueV2Sensors::parseBellButtonJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseBellButtonJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2BellButton b;
+		if (item.isMember("id")) b.id = item["id"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			b.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("metadata") && item["metadata"].isObject() && item["metadata"].isMember("control_id"))
+		{
+			int parsed = item["metadata"]["control_id"].asInt();
+			if (parsed >= 1 && parsed <= 256)
+				b.control_id = parsed;
+		}
+		if (!b.owner_rid.empty())
+			m_bellButtons.push_back(b);
+	}
+	return true;
+}
+
+// Fetch /clip/v2/resource/button
+bool CPhilipsHueV2Sensors::FetchButtons()
+{
+	m_buttons.clear();
+	std::string body;
+	if (!http_get_v2_with_key("button", m_ApplicationKey, body))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to fetch button");
+		return false;
+	}
+	Json::Value root;
+	if (!ParseJSon(body, root))
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: failed to parse button JSON");
+		return false;
+	}
+	if (root.isMember("errors") && !root["errors"].empty())
+	{
+		_log.Log(LOG_ERROR, "Error received: %s", hue_errorDescription(root).c_str());
+		return false;
+	}
+	return parseButtonJson(root);
+}
+
+// parse /clip/v2/resource/button
+bool CPhilipsHueV2Sensors::parseButtonJson(const Json::Value& root)
+{
+	if (!root.isObject() || !root.isMember("data") || !root["data"].isArray())
+	{
+		_log.Log(LOG_ERROR, "PhilipsHueV2: parseButtonJson unexpected structure");
+		return false;
+	}
+	for (const auto& item : root["data"])
+	{
+		if (!item.isObject()) continue;
+		HueV2Button b;
+		if (item.isMember("id")) b.id = item["id"].asString();
+		if (item.isMember("id_v1")) b.id_v1 = item["id_v1"].asString();
+		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
+			b.owner_rid = item["owner"]["rid"].asString();
+		if (item.isMember("metadata") && item["metadata"].isObject() && item["metadata"].isMember("control_id"))
+		{
+			int parsed = item["metadata"]["control_id"].asInt();
+			if (parsed >= 1 && parsed <= 256)
+				b.control_id = parsed;
+		}
+		if (item.isMember("button") && item["button"].isObject())
+		{
+			const auto& btnObj = item["button"];
+			if (btnObj.isMember("event_values") && btnObj["event_values"].isArray())
+			{
+				for (const auto& ev : btnObj["event_values"])
+				{
+					std::string evStr = ev.asString();
+					if (evStr == "long_release" || evStr == "long_press")
+					{
+						b.supports_long_press = true;
+						break;
+					}
+				}
+			}
+			if (btnObj.isMember("button_report") && btnObj["button_report"].isObject())
+			{
+				const auto& rep = btnObj["button_report"];
+				if (rep.isMember("updated")) b.last_updated = rep["updated"].asString();
+				if (rep.isMember("event")) b.last_event = rep["event"].asString();
+			}
+			if (b.last_event.empty() && btnObj.isMember("last_event"))
+				b.last_event = btnObj["last_event"].asString();
+		}
+		if (!b.owner_rid.empty())
+			m_buttons.push_back(b);
+	}
+	return true;
+}
+
 // parse /clip/v2/resource/contact
 bool CPhilipsHueV2Sensors::parseContactJson(const Json::Value& root)
 {
@@ -343,14 +1025,18 @@ bool CPhilipsHueV2Sensors::parseTamperJson(const Json::Value& root)
 		if (item.isMember("id")) t.id = item["id"].asString();
 		if (item.isMember("owner") && item["owner"].isObject() && item["owner"].isMember("rid"))
 			t.owner_rid = item["owner"]["rid"].asString();
-		// tamper_reports may be empty; pick last if present
 		if (item.isMember("tamper_reports") && item["tamper_reports"].isArray() && item["tamper_reports"].size() > 0)
 		{
 			const auto& arr = item["tamper_reports"];
-			const Json::Value& last = arr[arr.size() - 1];
-			if (last.isMember("state")) t.state = last["state"].asString();
-			if (last.isMember("source")) t.source = last["source"].asString();
-			if (last.isMember("changed")) t.changed = last["changed"].asString();
+			// Use first report, matching HA behavior
+			const Json::Value& first = arr[0];
+			if (first.isMember("state")) t.state = first["state"].asString();
+			if (first.isMember("source")) t.source = first["source"].asString();
+			if (first.isMember("changed")) t.changed = first["changed"].asString();
+		}
+		else
+		{
+			_log.Debug(DEBUG_HARDWARE, "PhilipsHueV2: tamper device %s has no tamper_reports", t.id.c_str());
 		}
 		m_tampers.push_back(t);
 	}
@@ -409,6 +1095,9 @@ bool CPhilipsHueV2Sensors::parseDevicePowerJson(const Json::Value& root)
 - Example URLs:
 	m_BaseURLv2 << "/clip/v2/resource/device"
 	m_BaseURLv2 << "/clip/v2/resource/light"
+	m_BaseURLv2 << "/clip/v2/resource/motion"
+	m_BaseURLv2 << "/clip/v2/resource/temperature"
+	m_BaseURLv2 << "/clip/v2/resource/light_level"
 	m_BaseURLv2 << "/clip/v2/resource/contact"
 	m_BaseURLv2 << "/clip/v2/resource/tamper"
 	m_BaseURLv2 << "/clip/v2/resource/device_power"

--- a/hardware/PhilipsHue/PhilipsHueV2Sensors.h
+++ b/hardware/PhilipsHue/PhilipsHueV2Sensors.h
@@ -59,6 +59,89 @@ struct HueV2DevicePower {
 	int battery_level = -1;    // 0..100 or -1 if missing
 };
 
+struct HueV2Room {
+	std::string id;                // Room/zone UUID
+	std::string name;              // metadata.name
+	std::string grouped_light_rid; // RID of the grouped_light service for this room
+};
+
+struct HueV2Motion {
+	std::string id;
+	std::string id_v1;           // e.g. "/sensors/4"
+	std::string owner_rid;
+	bool enabled = false;
+	bool motion = false;
+	std::string motion_changed; // ISO timestamp of last change
+};
+
+struct HueV2Temperature {
+	std::string id;
+	std::string id_v1;           // e.g. "/sensors/7"
+	std::string owner_rid;
+	bool enabled = false;
+	float temperature = 0.0f;   // Celsius
+	std::string temperature_changed;
+};
+
+struct HueV2LightLevel {
+	std::string id;
+	std::string id_v1;           // e.g. "/sensors/6"
+	std::string owner_rid;
+	bool enabled = false;
+	int lightlevel = 0;         // raw lux-derived value
+	bool dark = false;
+	std::string lightlevel_changed;
+};
+
+struct HueV2GroupedMotion {
+	std::string id;
+	std::string owner_rid;
+	bool enabled = false;
+	bool motion = false;
+	std::string motion_changed;
+};
+
+struct HueV2GroupedLightLevel {
+	std::string id;
+	std::string owner_rid;
+	bool enabled = false;
+	int lightlevel = 0;
+	bool dark = false;
+	std::string lightlevel_changed;
+};
+
+struct HueV2CameraMotion {
+	std::string id;
+	std::string owner_rid;
+	bool enabled = false;
+	bool motion = false;
+	std::string motion_changed;
+};
+
+struct HueV2SecurityAreaMotion {
+	std::string id;
+	std::string owner_rid;
+	bool enabled = false;
+	bool motion = false;
+	std::string motion_changed;
+};
+
+struct HueV2BellButton {
+	std::string id;
+	std::string owner_rid;
+	int control_id = 0;
+};
+
+struct HueV2Button {
+	std::string id;
+	std::string id_v1;
+	std::string owner_rid;
+	int control_id = 0;
+	bool supports_long_press = false;
+	std::string last_event;
+	std::string last_updated;
+};
+
 class CPhilipsHueV2Sensors {
 public:
 	// html_schema should be "http" or "https" per existing code usage
@@ -79,18 +162,41 @@ public:
 	bool UpdateAll();
 
 	// Individual fetch functions (public for testing)
+	bool FetchRooms();
 	bool FetchDevices();
 	bool FetchLights();
+	bool FetchMotion();
+	bool FetchTemperature();
+	bool FetchLightLevel();
 	bool FetchContacts();
 	bool FetchTamper();
 	bool FetchDevicePower();
+	bool FetchGroupedMotion();
+	bool FetchGroupedLightLevel();
+	bool FetchCameraMotion();
+	bool FetchSecurityAreaMotion();
+	bool FetchBellButtons();
+	bool FetchButtons();
 
 	// Getters
+	const std::vector<HueV2Room>& GetRooms() const { return m_rooms; }
+	// Returns room/zone name for a V1 group integer ID, or empty string if not found
+	std::string GetRoomNameByV1GroupId(int groupId) const;
+
 	const std::vector<HueV2Device>& GetDevices() const { return m_devices; }
 	const std::vector<HueV2Light>& GetLights() const { return m_lights; }
+	const std::vector<HueV2Motion>& GetMotions() const { return m_motions; }
+	const std::vector<HueV2Temperature>& GetTemperatures() const { return m_temperatures; }
+	const std::vector<HueV2LightLevel>& GetLightLevels() const { return m_lightlevels; }
 	const std::vector<HueV2Contact>& GetContacts() const { return m_contacts; }
 	const std::vector<HueV2Tamper>& GetTampers() const { return m_tampers; }
 	const std::vector<HueV2DevicePower>& GetDevicePowers() const { return m_devicePowers; }
+	const std::vector<HueV2GroupedMotion>& GetGroupedMotions() const { return m_groupedMotions; }
+	const std::vector<HueV2GroupedLightLevel>& GetGroupedLightLevels() const { return m_groupedLightLevels; }
+	const std::vector<HueV2CameraMotion>& GetCameraMotions() const { return m_cameraMotions; }
+	const std::vector<HueV2SecurityAreaMotion>& GetSecurityAreaMotions() const { return m_securityAreaMotions; }
+	const std::vector<HueV2BellButton>& GetBellButtons() const { return m_bellButtons; }
+	const std::vector<HueV2Button>& GetButtons() const { return m_buttons; }
 
 	// Simple setters
 	void SetApplicationKey(const std::string& key) { m_ApplicationKey = key; }
@@ -100,11 +206,22 @@ public:
 
 private:
 	// parse helpers
+	bool parseRoomJson(const Json::Value& root);
+	bool parseGroupedLightV1Ids(const Json::Value& root, std::map<std::string, int>& outRidToV1Id);
 	bool parseDeviceJson(const Json::Value& root);
 	bool parseLightJson(const Json::Value& root);
+	bool parseMotionJson(const Json::Value& root);
+	bool parseTemperatureJson(const Json::Value& root);
+	bool parseLightLevelJson(const Json::Value& root);
 	bool parseContactJson(const Json::Value& root);
 	bool parseTamperJson(const Json::Value& root);
 	bool parseDevicePowerJson(const Json::Value& root);
+	bool parseGroupedMotionJson(const Json::Value& root);
+	bool parseGroupedLightLevelJson(const Json::Value& root);
+	bool parseCameraMotionJson(const Json::Value& root);
+	bool parseSecurityAreaMotionJson(const Json::Value& root);
+	bool parseBellButtonJson(const Json::Value& root);
+	bool parseButtonJson(const Json::Value& root);
 
 	bool http_get_v2_with_key(const std::string& api_endpoint, const std::string& appKey, std::string& outBody);
 private:
@@ -114,9 +231,20 @@ private:
 	std::ostringstream m_BaseURLv2; // use stream as requested
 	std::string m_ApplicationKey;
 
+	std::vector<HueV2Room> m_rooms;
+	std::map<int, std::string> m_roomNameByV1GroupId; // V1 group integer -> room/zone name
 	std::vector<HueV2Device> m_devices;
 	std::vector<HueV2Light> m_lights;
+	std::vector<HueV2Motion> m_motions;
+	std::vector<HueV2Temperature> m_temperatures;
+	std::vector<HueV2LightLevel> m_lightlevels;
 	std::vector<HueV2Contact> m_contacts;
 	std::vector<HueV2Tamper> m_tampers;
 	std::vector<HueV2DevicePower> m_devicePowers;
+	std::vector<HueV2GroupedMotion> m_groupedMotions;
+	std::vector<HueV2GroupedLightLevel> m_groupedLightLevels;
+	std::vector<HueV2CameraMotion> m_cameraMotions;
+	std::vector<HueV2SecurityAreaMotion> m_securityAreaMotions;
+	std::vector<HueV2BellButton> m_bellButtons;
+	std::vector<HueV2Button> m_buttons;
 };

--- a/hardware/PhilipsHue/hue.wiki
+++ b/hardware/PhilipsHue/hue.wiki
@@ -1,0 +1,134 @@
+== Philips Hue ==
+
+Domoticz supports the Philips Hue bridge (both V1 and V2) and automatically detects which API version to use.
+
+=== Adding the Hardware ===
+
+Go to '''Setup → Hardware''' and select '''Philips Hue Bridge''' as the hardware type.
+
+Enter:
+* The '''IP Address''' of your Hue bridge (you can also find this in your network router)
+
+'''First time setup (no username yet):'''
+# Leave the '''Username''' field empty
+# Press the '''link button''' on top of the Hue bridge
+# Within 30 seconds, press the '''Register''' button in Domoticz
+# If successful, a username is automatically filled in
+# Press '''Add'''
+
+'''Already registered before:'''
+* If you know the username, enter it and press '''Add'''
+* If you forgot the username, use the first-time procedure above to register again
+
+'''Note:''' To allow Domoticz to create new devices, make sure '''Accept new Hardware Devices''' is enabled under '''Setup → Settings'''.
+
+Domoticz will automatically probe the bridge after adding:
+* Hue V2 bridges (CLIP v2 API) are detected on HTTPS port 443
+* Hue V1 bridges are tried on HTTPS port 443, then HTTP port 80
+* If no bridge is reachable, an error is logged and the hardware is not started
+
+=== Configuration Options ===
+
+{| class="wikitable"
+|-
+! Option !! Description
+|-
+| '''IP Address''' || The local IP address or hostname of your Hue bridge
+|-
+| '''Username''' || The application key used to authenticate with the Hue API
+|-
+| '''Poll Interval''' || For V1 bridges: how often Domoticz polls all device states (seconds, minimum 5, default 10). For V2 bridges: interval between full resyncs; real-time updates arrive instantly via SSE regardless of this setting.
+|-
+| '''Add Groups''' || Whether to expose Hue light groups as Domoticz devices
+|-
+| '''Add Scenes''' || Whether to expose Hue scenes as Domoticz selector switches
+|}
+
+=== Supported Hardware ===
+
+==== Lights ====
+
+All lights connected to the Hue bridge are added as Domoticz devices:
+
+* '''On/Off lights''' — basic switch
+* '''Dimmable lights''' — dimmer switch (brightness 0–100%)
+* '''Color temperature lights''' — dimmer with color temperature control
+* '''Full colour lights (RGB/RGBW)''' — RGB colour device
+
+Lights can be controlled directly from the Domoticz dashboard or via scripts.
+
+==== Groups ====
+
+Light groups configured in the Hue app can be exposed as a single device in Domoticz (enable the '''Add Groups''' option). Controlling the group device turns all lights in the group on/off and adjusts brightness/colour.
+
+==== Scenes ====
+
+Hue scenes (named light configurations) can be exposed as selector switches in Domoticz (enable the '''Add Scenes''' option). Selecting a scene activates it on the bridge.
+
+==== Sensors (V1 API) ====
+
+The following sensor types are supported via the V1 API:
+
+* '''Motion sensors''' (ZLLPresence) — motion/no-motion switch
+* '''Temperature sensors''' (ZLLTemperature) — temperature device (°C)
+* '''Light level sensors''' (ZLLLightLevel) — lux level device
+* '''Switches / Remotes''' (ZLLSwitch, ZGPSwitch) — selector switch with button events
+* '''Daylight sensor''' — on/off based on local sunrise/sunset
+
+==== Sensors (V2 API) ====
+
+When a V2 bridge is detected, the following additional sensor types are supported:
+
+* '''Motion''' — motion sensors (per room or per individual device)
+* '''Temperature''' — temperature sensors attached to motion sensor devices
+* '''Light level''' — ambient light level in lux (per room or per device)
+* '''Contact sensors''' — door/window open/close state
+* '''Tamper alerts''' — tamper detection state
+* '''Camera motion''' — motion detected by Hue camera devices
+* '''Security area motion''' — motion events from security area zones
+* '''Grouped motion''' — aggregated motion state across a room or zone
+* '''Grouped light level''' — aggregated light level for a room or zone
+* '''Buttons / Remotes''' — Hue dimmer switches and tap dial switches; each remote appears as a selector switch with short/long press levels per button
+* '''Bell button''' — Hue doorbell button; triggers a Domoticz doorbell device on ring event
+* '''Device power''' — battery level reported for all battery-powered Hue accessories (0–100%, or 255 if not applicable)
+
+=== V2 API — Server-Sent Events (SSE) ===
+
+When a Hue V2 bridge is detected, Domoticz uses the Hue CLIP v2 event stream (`/eventstream/clip/v2`) in addition to the polling loop.
+
+The SSE stream is a persistent HTTP connection that delivers real-time push notifications from the bridge whenever a device state changes (motion, button press, contact open/close, etc.). This means:
+
+* '''Instant updates''' — device state changes appear in Domoticz within milliseconds, without waiting for the next poll cycle
+* '''Reduced bridge load''' — SSE replaces per-sensor polling for most sensor types
+* '''Automatic reconnect''' — if the SSE connection drops, Domoticz reconnects automatically with exponential backoff (up to 60 seconds between retries)
+
+A full resync (fetching all device states via the REST API) still runs at every poll interval to catch any missed updates.
+
+=== Troubleshooting ===
+
+{| class="wikitable"
+|-
+! Problem !! Solution
+|-
+| Hardware starts but no devices appear || Check the Username/application key. Ensure the Hue bridge is reachable at the configured IP address.
+|-
+| '''No Philips Hue bridge found''' error in log || Verify the IP address. Check that the bridge is online and reachable from the Domoticz host. Firewall rules may block HTTPS (port 443) or HTTP (port 80).
+|-
+| Lights appear but sensors do not || For V1 bridges, sensors must already be paired. For V2 bridges, check that the application key was created on the V2 bridge (not via a V1-only API path).
+|-
+| Battery level shows 255 || The device does not report a battery level (mains-powered) or no battery report has been received yet.
+|-
+| Duplicate devices after bridge upgrade || If you upgraded from a V1 to a V2 bridge and re-added the hardware, sensors may appear as duplicates due to different internal IDs. You can delete the old devices via '''Setup → Devices'''.
+|}
+
+=== Notes ===
+
+* The Hue bridge has a limit of approximately 3 concurrent API connections. The SSE stream counts as one connection. Avoid connecting too many external applications simultaneously.
+* Hue V1 bridges manufactured before 2016 may not support HTTPS. Domoticz will fall back to HTTP port 80 automatically.
+* The Hue V2 CLIP API supports additional sensor and device types not available via V1. Using a V2 bridge is recommended for the best experience.
+
+=== Links ===
+
+* Philips Hue developer portal: https://developers.meethue.com/
+* Hue CLIP v2 API documentation: https://developers.meethue.com/develop/hue-api-v2/
+* Domoticz forum: https://forum.domoticz.com/

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -981,6 +981,7 @@
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueHelper.cpp" />
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueSensors.cpp" />
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.cpp" />
+    <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueSSE.cpp" />
     <ClCompile Include="..\hardware\PiFace.cpp" />
     <ClCompile Include="..\hardware\Pinger.cpp" />
     <ClCompile Include="..\hardware\plugins\DelayedLink.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -1672,6 +1672,9 @@
     <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.h">
       <Filter>Devices\Philips Hue</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\PhilipsHue\PhilipsHueSSE.h">
+      <Filter>Devices\Philips Hue</Filter>
+    </ClInclude>
     <ClInclude Include="..\hardware\EvohomeBase.h">
       <Filter>Devices\EvoHome</Filter>
     </ClInclude>
@@ -2446,6 +2449,9 @@
       <Filter>Devices\Philips Hue</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueV2Sensors.cpp">
+      <Filter>Devices\Philips Hue</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\PhilipsHue\PhilipsHueSSE.cpp">
       <Filter>Devices\Philips Hue</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\EvohomeBase.cpp">

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -951,16 +951,7 @@ define(['app'], function (app) {
 					ShowNotify($.t('Please enter an Address!'), 2500, true);
 					return;
 				}
-				var port = $("#hardwarecontent #divremote #tcpport").val();
-				if (port == "") {
-					ShowNotify($.t('Please enter an Port!'), 2500, true);
-					return;
-				}
-				var intRegex = /^\d+$/;
-				if (!intRegex.test(port)) {
-					ShowNotify($.t('Please enter an Valid Port!'), 2500, true);
-					return;
-				}
+				var port = 443;
 				var username = $("#hardwarecontent #hardwareparamsphilipshue #username").val();
 				if (username == "") {
 					ShowNotify($.t('Please enter a username!'), 2500, true);
@@ -2445,16 +2436,7 @@ define(['app'], function (app) {
 					ShowNotify($.t('Please enter an Address!'), 2500, true);
 					return;
 				}
-				var port = $("#hardwarecontent #divremote #tcpport").val();
-				if (port == "") {
-					ShowNotify($.t('Please enter an Port!'), 2500, true);
-					return;
-				}
-				var intRegex = /^\d+$/;
-				if (!intRegex.test(port)) {
-					ShowNotify($.t('Please enter an Valid Port!'), 2500, true);
-					return;
-				}
+				var port = 443;
 				var username = $("#hardwarecontent #hardwareparamsphilipshue #username").val();
 
 				if (username == "") {
@@ -4763,7 +4745,7 @@ define(['app'], function (app) {
 						}
 						else if (data["Type"].indexOf("Philips Hue") >= 0) {
 							$("#hardwarecontent #hardwareparamsremote #tcpaddress").val(data["Address"]);
-							$("#hardwarecontent #hardwareparamsremote #tcpport").val(data["Port"]);
+							$("#hardwarecontent #divremote #tcpport").closest('tr').hide();
 							$("#hardwarecontent #hardwareparamsphilipshue #username").val(data["Username"]);
 							$("#hardwarecontent #hardwareparamsphilipshue #pollinterval").val(data["Mode1"]);
 							$("#hardwarecontent #hardwareparamsphilipshue #addgroups").prop('checked', (data["Mode2"]&1));
@@ -5602,6 +5584,7 @@ define(['app'], function (app) {
 			}
 			else if (text.indexOf("Philips Hue") >= 0) {
 				$("#hardwarecontent #divremote").show();
+				$("#hardwarecontent #divremote #tcpport").closest('tr').hide();
 				$("#hardwarecontent #divphilipshue").show();
 			}
 			else if (text.indexOf("Yeelight") >= 0) {


### PR DESCRIPTION
## Summary

- Auto-detects bridge version (V2 HTTPS/443 → V1 HTTPS/443 → V1 HTTP/80); port field removed from UI
- Real-time sensor updates via Server-Sent Events (SSE) for V2 bridges; fixes SSE shutdown hang
- New V2 sensor types: grouped motion/light level, camera motion, security area motion, button remotes, bell button (doorbell)
- Fixed battery level propagation (was hardcoded 255 for motion/temp/light sensors)
- Fixed tamper sensor to use first report, matching HA behavior
- Added `hue.wiki` documentation page

## Test plan

- [ ] V2 bridge auto-detected on HTTPS/443; V1 bridge falls back to HTTPS/443 then HTTP/80
- [ ] Error logged and hardware not started when no bridge reachable
- [ ] SSE stream delivers real-time motion/contact/button events without waiting for poll interval
- [ ] Application shuts down cleanly (no hang) when SSE stream is idle
- [ ] Battery level shown correctly (0–100%) on motion/temperature/light level sensors
- [ ] Bell button creates a Doorbell device in Domoticz on ring event
- [ ] Button remotes create selector switch with correct short/long press levels