### PR TITLE
Added PLN (zł) currency option

### DIFF
--- a/www/views/setup.html
+++ b/www/views/setup.html
@@ -138,6 +138,7 @@
 											<option value="₦">₦</option>
 											<option value="KSh">KSh</option>
 											<option value="MKD">MKD</option>
+											<option value="zł">zł</option>
 										</select></td>
 									</tr>
 									</table>


### PR DESCRIPTION
Add Polish Zloty (zł) to the currency selector in the settings view.
Poland is one of the larger EU countries with a significant Domoticz user base, but PLN was missing from the currency list.
