### PR TITLE
Plot energy return under the horizontal axis

### DIFF
--- a/www/app/log/CounterLogEnergySeriesSuppliers.js
+++ b/www/app/log/CounterLogEnergySeriesSuppliers.js
@@ -328,6 +328,7 @@
                     dataIsValid: function (data) {
                         return data.delivered === true;
                     },
+					postprocessDatapoints: negateDatapoints,
 					label: 'C',
 					series: {
 						type: 'column',
@@ -384,7 +385,6 @@
                     },
                     showWithoutDatapoints: false,
                     //convertZeroToNull: true,
-                    postprocessDatapoints: negateDatapoints,
                     label: 'R',
                     template: {
 						type: 'area',
@@ -419,7 +419,6 @@
                         return data.delivered === true;
                     },
                     showWithoutDatapoints: false,
-                    postprocessDatapoints: negateDatapoints,
                     label: 'R',
                     template: {
 						type: 'area',
@@ -444,7 +443,6 @@
                         return data.delivered === true;
                     },
                     showWithoutDatapoints: false,
-                    postprocessDatapoints: negateDatapoints,
                     label: 'S',
                     template: {
 						type: 'area',

--- a/www/app/log/CounterLogP1Energy.js
+++ b/www/app/log/CounterLogP1Energy.js
@@ -85,7 +85,6 @@ define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesS
                         title: {
                             text: $.t('Power') + ' (' + chart.valueUnits.power(chart.valueMultipliers.m1) + ')'
                         },
-                        min: 0,
                         opposite: true
                     }
                 ];
@@ -95,8 +94,7 @@ define(['app', 'log/Chart', 'log/CounterLogParams', 'log/CounterLogEnergySeriesS
                     {
                         title: {
                             text: $.t('Energy') + ' (' + chart.valueUnits.energy(chart.valueMultipliers.m1) + ')'
-                        },
-						min: 0
+                        }
                     },
                     {
                         title: {


### PR DESCRIPTION
In the Usage Last Month and Usage Last Year charts, returned energy was already plotted as negative values. This commit does the same for the Usage / Hour and Usage Last 7 Days charts.

For the 'day' range API, the power (r, r1, r2) is returned as already-negative values. The negateDatapoints call was flipping them back to positive, so that had to be removed.