### PR TITLE
fix(kwh): auto-detect spike threshold in FixKwhCounterSpikes

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -8628,7 +8628,7 @@ bool CSQLHelper::FixKwhCounterSpikes(uint64_t idx, double max_daily_kwh, bool dr
 		{
 			std::sort(positive_values.begin(), positive_values.end());
 			int64_t median_wh = positive_values[positive_values.size() / 2];
-			int64_t auto_threshold_wh = std::max(median_wh * 100LL, int64_t(1000)); // floor: 1 kWh
+			int64_t auto_threshold_wh = std::max(median_wh * int64_t(100), int64_t(1000)); // floor: 1 kWh
 			max_daily_kwh = auto_threshold_wh / 1000.0;
 			results.push_back(std_format("Auto-detected threshold: %.1f kWh (100x median daily usage of %.3f kWh)",
 				max_daily_kwh, median_wh / 1000.0));

--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -8599,14 +8599,49 @@ bool CSQLHelper::FixKwhCounterSpikes(uint64_t idx, double max_daily_kwh, bool dr
 		return false;
 	}
 
-	double clamped_threshold = std::min(max_daily_kwh, 1e9);
-	int64_t threshold_wh = static_cast<int64_t>(clamped_threshold * 1000.0);
-
 	// --- Phase 1: Detect anomalous days in Meter_Calendar ---
 	//   Positive spike: Value > threshold  — false counter jump upward (e.g. reset artefact)
 	//   Negative spike: Value < -threshold — counter reset stored without offset correction
 	auto calresult = safe_query(
 		"SELECT Date, Value FROM Meter_Calendar WHERE (DeviceRowID='%" PRIu64 "') ORDER BY Date ASC", idx);
+
+	// Auto-detect threshold when max_daily_kwh <= 0:
+	// Compute the median of positive daily values, then use 100x as the spike threshold.
+	// Using the median (not the mean) ensures that a small number of spike days cannot
+	// inflate the baseline and hide themselves from detection.
+	// This scales correctly for all device types:
+	//   - Low-power sensor  (median ~0.45 kWh) → threshold ~45 kWh
+	//   - EV charger        (median ~50 kWh)   → threshold ~5000 kWh  (300 kWh real peaks not flagged)
+	//   - Heavy power user  (median ~1000 kWh) → threshold ~100000 kWh (large-but-real days not flagged)
+	if (max_daily_kwh <= 0.0)
+	{
+		std::vector<int64_t> positive_values;
+		positive_values.reserve(calresult.size());
+		for (const auto& row : calresult)
+		{
+			int64_t v = 0;
+			try { v = std::stoll(row[1]); } catch (...) { continue; }
+			if (v > 0)
+				positive_values.push_back(v);
+		}
+		if (positive_values.size() >= 5)
+		{
+			std::sort(positive_values.begin(), positive_values.end());
+			int64_t median_wh = positive_values[positive_values.size() / 2];
+			int64_t auto_threshold_wh = std::max(median_wh * 100LL, int64_t(1000)); // floor: 1 kWh
+			max_daily_kwh = auto_threshold_wh / 1000.0;
+			results.push_back(std_format("Auto-detected threshold: %.1f kWh (100x median daily usage of %.3f kWh)",
+				max_daily_kwh, median_wh / 1000.0));
+		}
+		else
+		{
+			max_daily_kwh = 1000.0; // not enough history, fall back to safe default
+			results.push_back("Not enough history for auto-detection; using default 1000 kWh threshold");
+		}
+	}
+
+	double clamped_threshold = std::min(max_daily_kwh, 1e9);
+	int64_t threshold_wh = static_cast<int64_t>(clamped_threshold * 1000.0);
 
 	struct SpikeDay
 	{

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -5451,7 +5451,7 @@ namespace http
 			}
 
 			std::string sthreshold = request::findValue(&req, "threshold");
-			double max_daily_kwh = 1000.0;
+			double max_daily_kwh = 0.0; // 0 = auto-detect from device history
 			if (!sthreshold.empty())
 			{
 				char* endptr = nullptr;
@@ -6852,11 +6852,24 @@ namespace http
 				return;
 			uint64_t idx = std::stoull(request::findValue(&req, "idx"));
 
+			// Fix actual counter spikes in Meter_Calendar / Meter (kWh devices only).
+			// Uses auto-detected threshold (0.0 = 100x median daily usage).
+			// Non-kWh devices are silently skipped by FixKwhCounterSpikes.
+			std::vector<std::string> spikeResults;
+			m_sql.FixKwhCounterSpikes(idx, 0.0, false, spikeResults);
+			int spikesFixed = 0;
+			for (const auto& line : spikeResults)
+			{
+				if (line.rfind("Positive spike", 0) == 0 || line.rfind("Negative spike", 0) == 0)
+					spikesFixed++;
+			}
+
 			bool changed = CKWHStats::RemoveSpikeStats(idx);
 			int pricesFixed = m_sql.SanitizeCalendarData(idx);
-			root["changed"] = changed || (pricesFixed > 0);
+			root["changed"] = changed || (pricesFixed > 0) || (spikesFixed > 0);
 			root["kwhStatsFixed"] = changed;
 			root["pricesFixed"] = pricesFixed;
+			root["spikesFixed"] = spikesFixed;
 			root["status"] = "OK";
 			root["title"] = "FixCounterPrices";
 		}

--- a/www/app/log/CounterLog.js
+++ b/www/app/log/CounterLog.js
@@ -222,6 +222,7 @@ define(['app', 'lodash', 'RefreshingChart', 'DataLoader', 'ChartLoader', 'log/Ch
                         $.ajax({ url: 'json.htm?type=command&param=fixcounterprices&idx=' + deviceIdx })
                             .then(function (data) {
                                 var parts = [];
+                                if (data && data.spikesFixed > 0) parts.push($.t('Fixed') + ' ' + data.spikesFixed + ' ' + $.t('counter spike(s).'));
                                 if (data && data.kwhStatsFixed) parts.push($.t('Weekly pattern fixed.'));
                                 if (data && data.pricesFixed > 0) parts.push($.t('Repaired') + ' ' + data.pricesFixed + ' ' + $.t('daily rows') + '.');
                                 var msg = parts.length > 0 ? parts.join('\n') : $.t('No issues found.');

--- a/www/app/log/RefreshingChart.js
+++ b/www/app/log/RefreshingChart.js
@@ -1068,6 +1068,7 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
                     $.ajax({ url: 'json.htm?type=command&param=fixcounterprices&idx=' + self.device.idx })
                         .then(function (data) {
                             var parts = [];
+                            if (data && data.spikesFixed > 0) parts.push($.t('Fixed') + ' ' + data.spikesFixed + ' ' + $.t('counter spike(s).'));
                             if (data && data.kwhStatsFixed) parts.push($.t('Weekly pattern fixed.'));
                             if (data && data.pricesFixed > 0) parts.push($.t('Repaired') + ' ' + data.pricesFixed + ' ' + $.t('daily rows') + '.');
                             var msg = parts.length > 0 ? parts.join('\n') : $.t('No issues found.');


### PR DESCRIPTION
## Summary

- **Auto-detect spike threshold** in `FixKwhCounterSpikes`: replaces the hardcoded 1000 kWh/day default with 100× the median daily usage from `Meter_Calendar`. The median is used (not mean) so existing spike days cannot inflate the baseline and hide themselves. Falls back to 1000 kWh if fewer than 5 history days exist.
- **Wire spike detection into the UI button**: `Cmd_FixCounterPrices` (the `fixcounterprices` endpoint called by the "Fix Counter/Price Spikes" button) previously only cleaned up stats and prices — it never called `FixKwhCounterSpikes`. Now it does, with auto-threshold. Non-kWh devices are silently skipped.
- **Report results in the UI dialog**: `spikesFixed` is added to the JSON response; both `CounterLog.js` and `RefreshingChart.js` now show e.g. "Fixed 2 counter spike(s)." instead of always "No issues found."

## Example

Device with ~0.45 kWh/day median usage had a hardware glitch on 2026-03-28 (counter jumped by 715 kWh). With the old 1000 kWh threshold it was undetected. Auto-detection sets the threshold to 45 kWh and correctly flags and removes the spike.

## Threshold scaling

| Device type | Median daily | Auto-threshold | Real peak safe? |
|---|---|---|---|
| Low-power sensor | 0.45 kWh | 45 kWh | ✓ |
| EV charger | 50 kWh | 5000 kWh | ✓ (300 kWh charge not flagged) |
| Heavy power user | 1000 kWh | 100,000 kWh | ✓ (3000 kWh day not flagged) |

## Test plan

- [ ] Run `fixkwhcounterspikes` directly via API with no `threshold=` param — confirm "Auto-detected threshold" line appears in result
- [ ] Click "Fix Counter/Price Spikes" in device log for a kWh device with a known spike — confirm dialog shows "Fixed N counter spike(s)." and chart reloads corrected
- [ ] Click the button for a device with no spikes — confirm "No issues found." still shown
- [ ] Click the button for a non-kWh device (gas, water) — confirm no crash, normal behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)