### PR TITLE
Fix orcon fan in UI

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -5690,6 +5690,7 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 	uint8_t OID3;
 	uint8_t OID4;
 	int LastLevel = 0;
+	int currentNValue = 0;
 	int llevel = 0;
 	int switchType;
 	int nValue;
@@ -5718,7 +5719,7 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 			ID = DIDTmp;
 			SourceID = IDTmp;
 		}
-		result = m_sql.safe_query("SELECT Name, SwitchType, Options, LastLevel, Description FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (SubType==%d)",
+		result = m_sql.safe_query("SELECT Name, SwitchType, Options, LastLevel, Description, nValue FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%q') AND (Unit==%d) AND (Type==%d) AND (SubType==%d)",
 			pHardware->m_HwdID, ID.c_str(), Unit, devType, subType);
 		if (!result.empty())
 		{
@@ -5727,6 +5728,7 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 			switchType = atoi(result[0][1].c_str());
 			std::string optionsStr = result[0][2];
 			LastLevel = atoi(result[0][3].c_str());
+			currentNValue = atoi(result[0][5].c_str());
 			if(SourceID.empty()) {
 				SourceID = result[0][4];
 			}
@@ -5783,9 +5785,22 @@ void MainWorker::decode_Fan(const CDomoticzHardwareBase* pHardware, const tRBUF*
 		}
 		else
 		{
-					nValue = LastLevel;
-					sValue = std::to_string(LastLevel);
-					_log.Debug(DEBUG_HARDWARE, "Orcon: Status '%s' for command %02X not found in selector configuration, using LastLevel=%d", lstatus.c_str(), cmnd, LastLevel);
+			// Ignore "speed" acknowledgment packets sent by the device after level commands
+			// Use the command value directly
+			if (cmnd != fan_Orconspeed)
+			{
+					nValue = cmnd;
+					sValue = std::to_string(cmnd);
+					m_sql.UpdateDeviceValue("LastLevel", cmnd, ID);
+					_log.Debug(DEBUG_HARDWARE, "Orcon: Status command %02X", cmnd);
+			}
+			else
+			{
+					// Use the current DB nValue (not LastLevel)
+					nValue = currentNValue;
+					sValue = std::to_string(currentNValue);
+					_log.Debug(DEBUG_HARDWARE, "Orcon: Ignoring speed acknowledgment, keeping current nValue=%d", currentNValue);
+			}
 		}
 	}
 	else

--- a/www/app/widgets/dzLightWidget.js
+++ b/www/app/widgets/dzLightWidget.js
@@ -382,6 +382,7 @@ define(['app'], function (app) {
                     // Fan subtypes always show Fan48_On.png
                     if (device.SubType && (
                         device.SubType.indexOf('Itho') == 0 ||
+                        device.SubType.indexOf('Orcon') == 0 ||
                         device.SubType.indexOf('Lucci') == 0 ||
                         device.SubType.indexOf('Falmec') == 0 ||
                         device.SubType.indexOf('Westinghouse') == 0
@@ -499,7 +500,7 @@ define(['app'], function (app) {
                     if (!ctrl.isClickable()) return;
 
                     // Fan subtypes - show specialized popups
-                    if (device.SubType && device.SubType.indexOf('Itho') == 0) {
+                    if (device.SubType && (device.SubType.indexOf('Itho') == 0 || device.SubType.indexOf('Orcon') == 0)) {
                         ShowIthoPopup($event || event, device.idx, device.Protected, window.myglobals.ismobile);
                         return;
                     }


### PR DESCRIPTION
Orcon (SubType="Orcon") was missing from the fan-specific UI checks in dzLightWidget.js, causing Orcon devices to fall through to generic icon/click handling instead of showing the fan icon and popup.

### Changes

Fan icon (dzLightWidget.js): added Orcon to the SubType prefix check so Orcon devices always render Fan48_On.png
Click popup (dzLightWidget.js): extended the Itho popup condition to include Orcon

### Why Orcon shares the Itho popup

The Itho popup sends commands '1', '2', '3', 'timer'. The backend GetLightCommand already has a case sTypeOrcon: that maps these identically to fan_Orconlow, fan_Orconmedium, fan_Orconhigh, and fan_Orcontimer1.

Kind Regards