### PR TITLE
Fix spelling error Minumum => Minimum in OpenWeatherMap.cpp

### DIFF
--- a/hardware/OpenWeatherMap.cpp
+++ b/hardware/OpenWeatherMap.cpp
@@ -584,7 +584,7 @@ bool COpenWeatherMap::ProcessForecast(Json::Value &forecast, const std::string &
 			NodeID++;
 			sName.str("");
 			sName.clear();
-			sName << "Minumum Temperature " << period << " " << (count + 0);
+			sName << "Minimum Temperature " << period << " " << (count + 0);
 			if (mintemp != -999.9F)
 			{
 				SendTempSensor(NodeID, 255, mintemp, sName.str());


### PR DESCRIPTION
Corrected spelling of word 'Minumum' in OpenWeatherMap device names to be: 'Minimum Temperature ....'