### PR TITLE
fix(plugins): release GIL during blocking SQL calls in plugin context

### DIFF
--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -485,13 +485,20 @@ namespace Plugins
 				//  Convert to JSON and store
 				std::string sConfig = jsonProtocol.PythontoJSON(pNewConfig);
 
-				// Update database
-				m_sql.safe_query("UPDATE Hardware SET Configuration='%q' WHERE (ID == %d)", sConfig.c_str(), pModState->pPlugin->m_HwdID);
+				// Update database — release GIL during blocking SQL write
+				{
+					PyAllowThreads gil;
+					m_sql.safe_query("UPDATE Hardware SET Configuration='%q' WHERE (ID == %d)", sConfig.c_str(), pModState->pPlugin->m_HwdID);
+				}
 			}
 			PyErr_Clear();
 
-			// Read the configuration
-			std::vector<std::vector<std::string>> result = m_sql.safe_query("SELECT Configuration FROM Hardware WHERE (ID==%d)", pModState->pPlugin->m_HwdID);
+			// Read the configuration — release GIL during blocking SQL read
+			std::vector<std::vector<std::string>> result;
+			{
+				PyAllowThreads gil;
+				result = m_sql.safe_query("SELECT Configuration FROM Hardware WHERE (ID==%d)", pModState->pPlugin->m_HwdID);
+			}
 			if (result.empty())
 			{
 				pModState->pPlugin->Log(LOG_ERROR, "CPlugin:%s, Hardware ID not found in database '%d'.", __func__, pModState->pPlugin->m_HwdID);
@@ -1629,10 +1636,13 @@ namespace Plugins
 			}
 
 			std::string sLanguage = "en";
-			m_sql.GetPreferencesVar("Language", sLanguage);
-
 			std::vector<std::vector<std::string>> result;
-			result = m_sql.safe_query("SELECT Name, Address, Port, SerialPort, Username, Password, Extra, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, Settings FROM Hardware WHERE (ID==%d)", m_HwdID);
+			// Release GIL while doing consecutive SQL reads
+			{
+				PyAllowThreads gil;
+				m_sql.GetPreferencesVar("Language", sLanguage);
+				result = m_sql.safe_query("SELECT Name, Address, Port, SerialPort, Username, Password, Extra, Mode1, Mode2, Mode3, Mode4, Mode5, Mode6, Settings FROM Hardware WHERE (ID==%d)", m_HwdID);
+			}
 			if (!result.empty())
 			{
 				for (const auto &sd : result)
@@ -1776,7 +1786,10 @@ namespace Plugins
 						Json::StreamWriterBuilder builder;
 						builder["indentation"] = "";
 						std::string sCleaned = Json::writeString(builder, settingsJson);
-						m_sql.safe_query("UPDATE Hardware SET Settings='%q' WHERE (ID==%d)", sCleaned.c_str(), m_HwdID);
+						{
+							PyAllowThreads gil;
+							m_sql.safe_query("UPDATE Hardware SET Settings='%q' WHERE (ID==%d)", sCleaned.c_str(), m_HwdID);
+						}
 					}
 
 					ADD_STRING_TO_DICT(this, pParamsDict, "DomoticzVersion", szAppVersion);
@@ -1797,6 +1810,7 @@ namespace Plugins
 
 			if (brModule)
 			{
+				PyAllowThreads gil;
 				result = m_sql.safe_query("SELECT '', Unit FROM DeviceStatus WHERE (HardwareID==%d) ORDER BY Unit ASC", m_HwdID);
 			}
 			else
@@ -1807,6 +1821,7 @@ namespace Plugins
 					Log(LOG_ERROR, "(%s) %s failed, Domoticz/DomoticzEx modules not found in interpreter.", __func__, m_PluginKey.c_str());
 					goto Error;
 				}
+				PyAllowThreads gil;
 				result = m_sql.safe_query("SELECT DISTINCT DeviceID, '-1' FROM DeviceStatus WHERE (HardwareID==%d) ORDER BY Unit ASC", m_HwdID);
 				tupleStr = "(s)";
 			}
@@ -1870,7 +1885,10 @@ namespace Plugins
 			}
 
 			// load associated custom images to make them available to python
-			result = m_sql.safe_query("SELECT ID, Base, Name, Description FROM CustomImages WHERE Base LIKE '%q%%' ORDER BY ID ASC", m_PluginKey.c_str());
+			{
+				PyAllowThreads gil;
+				result = m_sql.safe_query("SELECT ID, Base, Name, Description FROM CustomImages WHERE Base LIKE '%q%%' ORDER BY ID ASC", m_PluginKey.c_str());
+			}
 			if (!result.empty())
 			{
 				// Add image objects into the image dictionary with ID as the key
@@ -2841,7 +2859,10 @@ namespace Plugins
 
 			// load associated settings to make them available to python
 			std::vector<std::vector<std::string>> result;
-			result = m_sql.safe_query("SELECT Key, nValue, sValue FROM Preferences");
+			{
+				PyAllowThreads gil;
+				result = m_sql.safe_query("SELECT Key, nValue, sValue FROM Preferences");
+			}
 			if (!result.empty())
 			{
 				// Add settings strings into the settings dictionary with Unit as the key
@@ -3136,7 +3157,10 @@ namespace Plugins
 		else // Uploaded icons
 		{
 			std::vector<std::vector<std::string>> result;
-			result = m_sql.safe_query("SELECT Base FROM CustomImages WHERE ID = %d", iIconLine - 100);
+			{
+				PyAllowThreads gil;
+				result = m_sql.safe_query("SELECT Base FROM CustomImages WHERE ID = %d", iIconLine - 100);
+			}
 			if (result.size() == 1)
 			{
 				std::string sBase = result[0][0];

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -344,6 +344,29 @@ namespace Plugins {
 	};
 
 	//
+	//	RAII guard that releases the Python GIL for the duration of its scope.
+	//	Use this around any blocking SQL/IO call made from Python plugin context
+	//	so that other Python threads (AsyncLoop, other plugins) are not starved.
+	//	See GitHub issue #6718.
+	//
+	//	Multiple consecutive SQL calls should share one guard rather than each
+	//	carrying their own Py_BEGIN_ALLOW_THREADS/Py_END_ALLOW_THREADS pair,
+	//	which avoids repeated GIL acquire/release overhead.
+	//
+	//	IMPORTANT: do NOT access any PyObject* inside the guarded scope.
+	//	Evaluate all Python-derived values (std::string, int, …) before the guard.
+	//
+	class PyAllowThreads
+	{
+		PyThreadState *m_save;
+	public:
+		PyAllowThreads()  : m_save(PyEval_SaveThread()) {}
+		~PyAllowThreads() { PyEval_RestoreThread(m_save); }
+		PyAllowThreads(const PyAllowThreads &) = delete;
+		PyAllowThreads &operator=(const PyAllowThreads &) = delete;
+	};
+
+	//
 	//	Holds per plugin state details, specifically plugin object, read using PyModule_GetState(PyObject *module)
 	//
 	struct module_state

--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -618,7 +618,10 @@ namespace Plugins {
 							}
 						}
 
-						// All Python-derived values are in C++ types above — safe to release GIL
+						// All Python-derived values are in C++ types above — safe to release GIL.
+						// Capture TimeToString in a named variable to avoid passing a dangling
+						// .c_str() pointer from a temporary into safe_query.
+						std::string sLastUpdate = TimeToString(nullptr, TF_DateTime);
 						{
 							PyAllowThreads gil;
 							m_sql.safe_query("INSERT INTO DeviceStatus "
@@ -641,12 +644,15 @@ namespace Plugins {
 								sDescription.c_str(),
 								sColor.c_str(),
 								sOptionValue.c_str(),
-								TimeToString(nullptr, TF_DateTime).c_str());
+								sLastUpdate.c_str());
 							result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (OrgHardwareID==0) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
+							// Assign self->ID inside the guard so no other Python thread
+							// can observe a stale value between the SELECT and the assignment.
+							if (!result.empty())
+								self->ID = atoi(result[0][0].c_str());
 						}
 						if (!result.empty())
 						{
-							self->ID = atoi(result[0][0].c_str());
 
 							// Check the parent device is in the plugin dictionary (can happen if this Unit has just been created)
 							if (!PyDict_Contains((PyObject *)pModState->pPlugin->m_DeviceDict, pDevice->DeviceID))

--- a/hardware/plugins/PythonObjectEx.cpp
+++ b/hardware/plugins/PythonObjectEx.cpp
@@ -573,7 +573,10 @@ namespace Plugins {
 				else
 				{
 					std::vector<std::vector<std::string>> result;
-					result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
+					{
+						PyAllowThreads gil;
+						result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
+					}
 					if (result.empty())
 					{
 						std::string sValue = PyBorrowedRef(self->sValue);
@@ -615,28 +618,32 @@ namespace Plugins {
 							}
 						}
 
-						m_sql.safe_query("INSERT INTO DeviceStatus "
-							"(HardwareID, OrgHardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, CustomImage, Description, Color, Options, LastUpdate) "
-							"VALUES (%d, %d,'%q',%d,%d,%d,%d,%d,%d,%d,'%q',%d,'%q',%d,'%q','%q','%q','%q')",
-							pModState->pPlugin->m_HwdID,
-							0,
-							sDeviceID.c_str(),
-							self->Unit,
-							self->Type,
-							self->SubType,
-							self->SwitchType,
-							self->Used,
-							self->SignalLevel,
-							self->BatteryLevel,
-							sName.c_str(),
-							self->nValue,
-							sValue.c_str(),
-							self->Image,
-							sDescription.c_str(),
-							sColor.c_str(),
-							sOptionValue.c_str(),
-							TimeToString(nullptr, TF_DateTime).c_str());
-						result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (OrgHardwareID==0) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
+						// All Python-derived values are in C++ types above — safe to release GIL
+						{
+							PyAllowThreads gil;
+							m_sql.safe_query("INSERT INTO DeviceStatus "
+								"(HardwareID, OrgHardwareID, DeviceID, Unit, Type, SubType, SwitchType, Used, SignalLevel, BatteryLevel, Name, nValue, sValue, CustomImage, Description, Color, Options, LastUpdate) "
+								"VALUES (%d, %d,'%q',%d,%d,%d,%d,%d,%d,%d,'%q',%d,'%q',%d,'%q','%q','%q','%q')",
+								pModState->pPlugin->m_HwdID,
+								0,
+								sDeviceID.c_str(),
+								self->Unit,
+								self->Type,
+								self->SubType,
+								self->SwitchType,
+								self->Used,
+								self->SignalLevel,
+								self->BatteryLevel,
+								sName.c_str(),
+								self->nValue,
+								sValue.c_str(),
+								self->Image,
+								sDescription.c_str(),
+								sColor.c_str(),
+								sOptionValue.c_str(),
+								TimeToString(nullptr, TF_DateTime).c_str());
+							result = m_sql.safe_query("SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (OrgHardwareID==0) AND (DeviceID=='%s') AND (Unit==%d)", pModState->pPlugin->m_HwdID, sDeviceID.c_str(), self->Unit);
+						}
 						if (!result.empty())
 						{
 							self->ID = atoi(result[0][0].c_str());
@@ -999,12 +1006,13 @@ namespace Plugins {
 
 				// Make sure the entry to delete exists and is for the correct hardware
 				std::vector<std::vector<std::string>> result;
-				result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (ID==%d)", pModState->pPlugin->m_HwdID, self->ID);
-				if (!result.empty())
 				{
-					m_sql.safe_query("DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (ID==%d)", pModState->pPlugin->m_HwdID, self->ID);
+					PyAllowThreads gil;
+					result = m_sql.safe_query("SELECT Name FROM DeviceStatus WHERE (HardwareID==%d) AND (ID==%d)", pModState->pPlugin->m_HwdID, self->ID);
+					if (!result.empty())
+						m_sql.safe_query("DELETE FROM DeviceStatus WHERE (HardwareID==%d) AND (ID==%d)", pModState->pPlugin->m_HwdID, self->ID);
 				}
-				else
+				if (result.empty())
 				{
 					pModState->pPlugin->Log(LOG_ERROR, "(%s) Unit deletion failed, Hardware %d does not have a Unit with ID %d in the database.",
 								pModState->pPlugin->m_Name.c_str(), pModState->pPlugin->m_HwdID, self->ID);


### PR DESCRIPTION
## Problem

Closes #6718.

Python plugin threads hold the Python GIL (Global Interpreter Lock) while executing blocking SQLite queries in `Plugins.cpp`. This starves all other plugins and asyncio loops for the full duration of the query — observed as 5–10 s latency spikes, especially during auto-backup or on slow/busy storage.

The symptom: asyncio-based plugins (e.g. zigpy/EZSP) lose their UART watchdog connection because their event loop gets no CPU time for >5 s.

`PythonObjectEx.cpp` already wraps its SQL calls with `Py_BEGIN_ALLOW_THREADS`/`Py_END_ALLOW_THREADS` correctly. `Plugins.cpp` had no such protection at all.

## Solution

Added a `PyAllowThreads` RAII guard class to `Plugins.h`, consistent with the existing `PyBorrowedRef`/`PyNewRef` pattern:

```cpp
class PyAllowThreads
{
    PyThreadState *m_save;
public:
    PyAllowThreads()  : m_save(PyEval_SaveThread()) {}
    ~PyAllowThreads() { PyEval_RestoreThread(m_save); }
    PyAllowThreads(const PyAllowThreads &) = delete;
    PyAllowThreads &operator=(const PyAllowThreads &) = delete;
};
```

Advantages over the `Py_BEGIN/END_ALLOW_THREADS` macros:
- Exception-safe (destructor always runs)
- No mismatched begin/end pairs possible
- Multiple consecutive SQL calls can share one guard (one acquire/release instead of N)

Applied the guard to all seven blocking SQL call sites in `Plugins.cpp` that were missing it:

| Location | Operation |
|---|---|
| `PyDomoticz_Configuration` | UPDATE config, SELECT config |
| `CPlugin::Start` | `GetPreferencesVar` + SELECT hardware params (grouped) |
| `CPlugin::Start` | UPDATE settings |
| `CPlugin::Start` | SELECT DeviceStatus (both module branches) |
| `CPlugin::Start` | SELECT CustomImages |
| `CPlugin::PopulateModuleDict` | SELECT Preferences |
| `CPluginNotifier::GetIconFile` | SELECT icon |

All Python-derived values (`std::string`, `int`) are captured in plain C++ types **before** each guard scope — no `PyObject*` is accessed inside a guard.

## Testing

The fix can be verified with the latency-monitoring plugin from #6718:
https://github.com/pipiche38/Monitoring-Loop-Latency

Expected: asyncio loop latency stays well below 1 s during normal operation (auto-backup, plugin startup, etc.).