### PR TITLE
feat(report): add custom contract-year date range to P1 energy report

### DIFF
--- a/main/WebServerHandleGraphMonthYear.cpp
+++ b/main/WebServerHandleGraphMonthYear.cpp
@@ -2413,54 +2413,12 @@ void HandleGraphMonthYear(const GraphContext& ctx, const request& req,
 
 	std::string szDateStart, szDateEnd, szDateStartPrev, szDateEndPrev;
 
-			std::string sactmonth = request::findValue(&req, "actmonth");
-			std::string sactyear = request::findValue(&req, "actyear");
-
-			int actMonth = atoi(sactmonth.c_str());
-			int actYear = atoi(sactyear.c_str());
-
-			if ((!sactmonth.empty()) && (!sactyear.empty()))
 			{
-				szDateStart = FormatDate(actYear, actMonth, 1);
-				szDateStartPrev = FormatDate(actYear - 1, actMonth, 1);
-				actMonth++;
-				if (actMonth == 13)
-				{
-					actMonth = 1;
-					actYear++;
-				}
-				szDateEnd = FormatDate(actYear, actMonth, 1);
-				szDateEndPrev = FormatDate(actYear - 1, actMonth, 1);
-			}
-			else if (!sactyear.empty())
-			{
-				szDateStart = FormatDate(actYear, 1, 1);
-				szDateStartPrev = FormatDate(actYear - 1, 1, 1);
-				actYear++;
-				szDateEnd = FormatDate(actYear, 1, 1);
-				szDateEndPrev = FormatDate(actYear - 1, 1, 1);
-			}
-			else
-			{
-				szDateEnd = FormatDate(tm1.tm_year + 1900, tm1.tm_mon + 1, tm1.tm_mday);
-				szDateEndPrev = FormatDate(tm1.tm_year + 1900 - 1, tm1.tm_mon + 1, tm1.tm_mday);
-
-				struct tm tm2;
-				if (srange == "month")
-				{
-					// Subtract one month
-					time_t monthbefore;
-					getNoon(monthbefore, tm2, tm1.tm_year + 1900, tm1.tm_mon, tm1.tm_mday);
-				}
-				else
-				{
-					// Subtract one year
-					time_t yearbefore;
-					getNoon(yearbefore, tm2, tm1.tm_year + 1900 - 1, tm1.tm_mon + 1, tm1.tm_mday);
-				}
-
-				szDateStart = FormatDate(tm2.tm_year + 1900, tm2.tm_mon + 1, tm2.tm_mday);
-				szDateStartPrev = FormatDate(tm2.tm_year + 1900 - 1, tm2.tm_mon + 1, tm2.tm_mday);
+				const DateRange dr = CalcMonthYearRange(req, tm1, srange);
+				szDateStart     = dr.start;
+				szDateEnd       = dr.end;
+				szDateStartPrev = dr.startPrev;
+				szDateEndPrev   = dr.endPrev;
 			}
 
 			if (

--- a/main/WebServerHandleGraphUtils.cpp
+++ b/main/WebServerHandleGraphUtils.cpp
@@ -116,6 +116,54 @@ DateRange CalcMonthYearRange(const request& req,
 {
     DateRange dr;
 
+    const std::string sactstart = request::findValue(&req, "actstart"); // "YYYY-MM-DD" or empty
+    const std::string sactend   = request::findValue(&req, "actend");   // "YYYY-MM-DD" or empty
+
+    if (!sactstart.empty() && !sactend.empty())
+    {
+        // Validate format YYYY-MM-DD for both strings
+        bool valid = (sactstart.size() == 10 && sactend.size() == 10);
+        if (valid)
+        {
+            // Check digit/dash positions
+            valid = std::isdigit((unsigned char)sactstart[0]) && std::isdigit((unsigned char)sactstart[1]) &&
+                    std::isdigit((unsigned char)sactstart[2]) && std::isdigit((unsigned char)sactstart[3]) &&
+                    sactstart[4] == '-' &&
+                    std::isdigit((unsigned char)sactstart[5]) && std::isdigit((unsigned char)sactstart[6]) &&
+                    sactstart[7] == '-' &&
+                    std::isdigit((unsigned char)sactstart[8]) && std::isdigit((unsigned char)sactstart[9]) &&
+                    std::isdigit((unsigned char)sactend[0])   && std::isdigit((unsigned char)sactend[1]) &&
+                    std::isdigit((unsigned char)sactend[2])   && std::isdigit((unsigned char)sactend[3]) &&
+                    sactend[4] == '-' &&
+                    std::isdigit((unsigned char)sactend[5])   && std::isdigit((unsigned char)sactend[6]) &&
+                    sactend[7] == '-' &&
+                    std::isdigit((unsigned char)sactend[8])   && std::isdigit((unsigned char)sactend[9]);
+        }
+        if (valid)
+        {
+            // Check month (1-12), day (1-31) and year (>= 2000) for both strings
+            int startYear  = std::stoi(sactstart.substr(0, 4));
+            int startMonth = std::stoi(sactstart.substr(5, 2));
+            int startDay   = std::stoi(sactstart.substr(8, 2));
+            int endYear    = std::stoi(sactend.substr(0, 4));
+            int endMonth   = std::stoi(sactend.substr(5, 2));
+            int endDay     = std::stoi(sactend.substr(8, 2));
+
+            int currentYear = tmNow.tm_year + 1900;
+
+            valid = (startMonth >= 1 && startMonth <= 12 && startDay >= 1 && startDay <= 31 &&
+                     startYear  >= 2000 && startYear  <= currentYear + 1 &&
+                     endMonth   >= 1 && endMonth   <= 12 && endDay   >= 1 && endDay   <= 31 &&
+                     endYear    >= 2000 && endYear    <= currentYear + 1);
+        }
+        if (valid)
+        {
+            dr.start = sactstart;
+            dr.end   = sactend;
+            return dr;
+        }
+    }
+
     const std::string sactmonth = request::findValue(&req, "actmonth");
     const std::string sactyear  = request::findValue(&req, "actyear");
 

--- a/www/app/report/CounterReport.html
+++ b/www/app/report/CounterReport.html
@@ -1,10 +1,10 @@
-<div ng-if="::!$ctrl.isMonthView" style="margin-bottom: 12px">
+<div ng-if="::!$ctrl.isMonthView" style="margin-bottom: 12px; user-select: text;">
     <div>{{:: $ctrl.device.SwitchTypeVal == 4 ? 'Total Generated' : 'Total Usage' | translate }}: {{:: $ctrl.data.usage.toFixed($ctrl.data.decimals) }} {{:: $ctrl.unit}}</div>
     <div ng-if="::!$ctrl.isOnlyUsage">{{:: 'Counter' | translate }}: {{:: $ctrl.data.counter.toFixed($ctrl.data.decimals) }} {{:: $ctrl.unit}}</div>
     <div ng-hide="!$ctrl.data.cost">{{:: $ctrl.device.SwitchTypeVal == 4 ? 'Year Earnings' : 'Year Cost' | translate }}: {{:: $ctrl.data.cost.toFixed(2) }}</div>
 </div>
 
-<div ng-if="::$ctrl.isMonthView" style="margin-bottom: 12px">
+<div ng-if="::$ctrl.isMonthView" style="margin-bottom: 12px; user-select: text;">
     <div>{{:: $ctrl.device.SwitchTypeVal == 4 ? 'Total Generated' : 'Total Usage' | translate }}: {{:: $ctrl.data.usage.toFixed($ctrl.data.decimals) }} {{:: $ctrl.unit}}</div>
     <div ng-if="::($ctrl.device.SwitchTypeVal != 3)">{{:: $ctrl.device.SwitchTypeVal == 4 ? 'Monthly Earnings' : 'Monthly Cost' | translate }}: {{:: $ctrl.data.cost.toFixed(2) }}</div>
 </div>
@@ -13,5 +13,16 @@
     {{ ::'No data available' | translate}}
 </div>
 
+<div style="text-align:right; margin:4px 0;">
+    <i class="far fa-file-alt" ng-click="$ctrl.exportExcel()"
+       title="{{ 'Export to Excel' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+    <i class="far fa-file" ng-click="$ctrl.exportCSV()"
+       title="{{ 'Export to CSV' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+    <i class="far fa-clipboard" ng-click="$ctrl.exportClipboard()"
+       title="{{ 'Copy to clipboard' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+</div>
 <table id="reporttable" class="display myrighttable"></table>
 <div id="usagegraph" class="device-log-chart" style="height: 300px;"></div>

--- a/www/app/report/CounterReport.js
+++ b/www/app/report/CounterReport.js
@@ -4,16 +4,85 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
             fetch: fetch
         };
 
-        function fetch(device, year, month) {
-			var costs = domoticzApi.sendCommand('getcosts', { idx: device.idx });
+        function addOneYear(isoDate, direction) {
+            if (!isoDate || !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)) { return null; }
+            var d = new Date(isoDate + 'T00:00:00');
+            if (isNaN(d.getTime())) { return null; }
+            var origMonth = d.getMonth();
+            var origDay   = d.getDate();
+            d.setFullYear(d.getFullYear() + (direction || 1));
+            if (origMonth === 1 && origDay === 29 && d.getMonth() === 2) { d.setDate(28); }
+            return d.getFullYear() + '-'
+                 + String(d.getMonth() + 1).padStart(2, '0') + '-'
+                 + String(d.getDate()).padStart(2, '0');
+        }
 
-            var stats = domoticzApi.sendCommand('graph', {
-                sensor: 'counter',
-                range: 'year',
-                idx: device.idx,
-                actyear: year,
-                actmonth: month
+        function formatContractMonthLabel(start, end) {
+            var monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            var endDay = new Date(end.getTime() - 1); // last ms of previous day
+            return monthNames[start.getMonth()] + ' ' + start.getDate()
+                 + ' \u2013 ' + monthNames[endDay.getMonth()] + ' ' + endDay.getDate()
+                 + ' ' + endDay.getFullYear();
+        }
+
+        function getContractMonthData(rawData, cost, startDateISO) {
+            var base = new Date(startDateISO + 'T00:00:00');
+            var periods = [];
+            for (var i = 0; i < 12; i++) {
+                var pStart = new Date(base.getFullYear(), base.getMonth() + i, base.getDate());
+                var pEnd   = new Date(base.getFullYear(), base.getMonth() + i + 1, base.getDate());
+                periods.push({
+                    start:       pStart,
+                    end:         pEnd,
+                    label:       formatContractMonthLabel(pStart, pEnd),
+                    date:        +pStart,
+                    periodIndex: i + 1,
+                    days:        [],
+                    usage:       0,
+                    cost:        0,
+                    counter:     0
+                });
+            }
+
+            rawData.forEach(function(item) {
+                var d = new Date(item.d.substring(0, 10) + 'T00:00:00');
+                for (var i = 0; i < periods.length; i++) {
+                    if (d >= periods[i].start && d < periods[i].end) {
+                        var dayUsage = parseFloat(item.v) || 0;
+                        var cprice   = parseFloat(item.p);
+                        var dayCost  = (cprice !== 0 && !isNaN(cprice)) ? cprice : dayUsage * cost;
+                        periods[i].days.push({ date: item.d, usage: dayUsage, counter: parseFloat(item.c) || 0, cost: dayCost });
+                        periods[i].usage   += dayUsage;
+                        periods[i].cost    += dayCost;
+                        periods[i].counter  = Math.max(periods[i].counter, parseFloat(item.c) || 0);
+                        break;
+                    }
+                }
             });
+
+            periods = reportHelpers.addTrendData(periods, 'usage');
+
+            return {
+                months:  periods,
+                usage:   periods.reduce(function(s, p) { return s + p.usage; }, 0),
+                cost:    periods.reduce(function(s, p) { return s + p.cost; }, 0),
+                counter: Math.max.apply(null, periods.map(function(p) { return p.counter; }))
+            };
+        }
+
+        function fetch(device, year, month, customStartDate) {
+            if (customStartDate && !/^\d{4}-\d{2}-\d{2}$/.test(customStartDate)) {
+                return $q.resolve(null);
+            }
+            var costs = domoticzApi.sendCommand('getcosts', { idx: device.idx });
+
+            var graphParams = customStartDate
+                ? { sensor: 'counter', range: 'year', idx: device.idx,
+                    actstart: customStartDate, actend: addOneYear(customStartDate) }
+                : { sensor: 'counter', range: 'year', idx: device.idx,
+                    actyear: year, actmonth: month };
+
+            var stats = domoticzApi.sendCommand('graph', graphParams);
 
             return $q.all([costs, stats]).then(function (responses) {
                 var cost = getCost(device, responses[0]);
@@ -24,23 +93,30 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                     return null;
                 }
 
-                var data = getGroupedData(stats.result, cost);
-                var source = month
-                    ? data.years[year].months.find(function (item) {
-                        return (new Date(item.date)).getMonth() + 1 === month;
-                    })
-                    : data.years[year];
+                var source;
+                if (customStartDate) {
+                    var contractData = getContractMonthData(stats.result, cost, customStartDate);
+                    source = contractData;
+                } else {
+                    var data = getGroupedData(stats.result, cost);
+                    source = month
+                        ? data.years[year].months.find(function (item) {
+                            return (new Date(item.date)).getMonth() + 1 === month;
+                          })
+                        : data.years[year];
+                }
 
                 if (!source) {
                     return null;
                 }
-				
+
                 return {
-                    cost: source.cost,
-                    usage: source.usage,
-                    decimals: (device.SwitchTypeVal === 3) ? device.Divider.numDecimalsDiv1() : 3,
-                    counter: month ? source.counter : parseFloat(stats.counter),
-                    items: month ? source.days : source.months
+                    cost:            source.cost,
+                    usage:           source.usage,
+                    decimals:        (device.SwitchTypeVal === 3) ? device.Divider.numDecimalsDiv1() : 3,
+                    counter:         month ? source.counter : parseFloat(stats.counter),
+                    items:           customStartDate ? source.months : (month ? source.days : source.months),
+                    customStartDate: customStartDate
                 };
             });
         }
@@ -89,8 +165,6 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                     cost: (cprice) != 0 ? cprice : parseFloat(item.v) * cost
                 }
             });
-			console.log(result);
-
             Object.keys(result.years).forEach(function (year) {
                 var yearsData = result.years[year];
                 yearsData.months = Object.values(yearsData.months);
@@ -135,19 +209,24 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
     app.component('deviceCounterReport', {
         bindings: {
-            device: '<',
-            selectedYear: '<',
-            selectedMonth: '<',
-            isOnlyUsage: '<',
+            device:          '<',
+            selectedYear:    '<',
+            selectedMonth:   '<',
+            isOnlyUsage:     '<',
+            customStartDate: '<'
         },
         templateUrl: 'app/report/CounterReport.html',
         controller: DeviceCounterReportController
     });
 
 
-    function DeviceCounterReportController($element, DeviceCounterReportData, dataTableDefaultSettings) {
+    function DeviceCounterReportController($element, $scope, DeviceCounterReportData, dataTableDefaultSettings) {
         var vm = this;
         vm.$onInit = init;
+
+        vm.exportExcel     = function () { exportTableToExcel(vm.device.Name + '_report.xls'); };
+        vm.exportCSV       = function () { exportTableToCSV(vm.device.Name + '_report.csv'); };
+        vm.exportClipboard = function () { exportTableToClipboard(); };
 
         function init() {
             vm.unit = vm.device.getUnit();
@@ -156,13 +235,20 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
 			$.devIdx = vm.device.idx;
 
+            var deregisterWatch = $scope.$watch(function() { return vm.customStartDate; }, function(newVal, oldVal) {
+                if (newVal !== oldVal && /^\d{4}-\d{2}-\d{2}$/.test(newVal || '')) {
+                    getData();
+                }
+            });
+            $scope.$on('$destroy', deregisterWatch);
+
             getData();
         }
-        
-       
+
+
         function getData() {
             DeviceCounterReportData
-                .fetch(vm.device, vm.selectedYear, vm.selectedMonth)
+                .fetch(vm.device, vm.selectedYear, vm.selectedMonth, vm.customStartDate)
                 .then(function (data) {
                     if (!data) {
                         vm.noDataAvailable = true;
@@ -177,6 +263,11 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
         function showTable(data) {
             var table = $element.find('#reporttable');
+            // Destroy existing DataTable instance if present
+            if ($.fn.dataTable.isDataTable(table)) {
+                table.dataTable().api().destroy();
+                table.empty();
+            }
             var columns = [];
 
             var counterRendererDecimals = function (data) {
@@ -208,9 +299,16 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                 });
             } else {
                 columns.push({
-                    title: $.t('Month'),
+                    title: $.t(vm.data && vm.data.customStartDate ? 'Period' : 'Month'),
                     data: 'date',
-                    render: function (data) {
+                    render: function (data, type, row) {
+                        if (type === 'sort' || type === 'type') { return data; }  // sort by raw timestamp
+                        if (vm.data && vm.data.customStartDate) {
+                            var link = '<a href="#/Devices/' + vm.device.idx + '/Report/'
+                                     + 'custom-' + vm.data.customStartDate + '/' + (row.periodIndex || '')
+                                     + '"><img src="images/next.png" /></a>';
+                            return (row.label || '') + ' ' + link;
+                        }
                         var date = new Date(data);
                         var link = '<a href="#/Devices/' + vm.device.idx + '/Report/' + vm.selectedYear + '/' + (date.getMonth() + 1) + '"><img src="images/next.png" /></a>';
                         return dateFormat(data, 'mm. mmmm') + ' ' + link;
@@ -249,11 +347,112 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
             table.dataTable().api().rows
                 .add(data.items)
                 .draw();
+
+            // Grand-total footer row
+            var items = data.items;
+            var totalUsage = items.reduce(function (s, r) { return s + (r.usage || 0); }, 0);
+            var totalCost  = items.reduce(function (s, r) { return s + (r.cost  || 0); }, 0);
+            var maxCounter = items.reduce(function (m, r) { return Math.max(m, r.counter || 0); }, 0);
+
+            var cells = [];
+            if (vm.isMonthView) {
+                cells.push('<td style="font-weight:bold">' + $.t('Total') + '</td>');
+                cells.push('<td></td>');
+                if (!vm.isOnlyUsage) {
+                    cells.push('<td style="font-weight:bold">' +
+                        ((vm.device.SwitchTypeVal === 3) ? counterRenderer(maxCounter) : counterRendererDecimals(maxCounter)) +
+                        '</td>');
+                }
+            } else {
+                cells.push('<td style="font-weight:bold">' + $.t('Total') + '</td>');
+            }
+
+            cells.push('<td style="font-weight:bold">' +
+                ((vm.device.SwitchTypeVal === 3) ? counterRenderer(totalUsage) : counterRendererDecimals(totalUsage)) +
+                '</td>');
+
+            if (vm.device.SwitchTypeVal !== 3) {
+                cells.push('<td style="font-weight:bold">' + costRenderer(totalCost) + '</td>');
+            }
+
+            cells.push('<td></td>');
+
+            var tfoot = $('<tfoot><tr style="font-weight:bold; background:var(--dz-accent-color,#337ab7); color:var(--dz-body-text,#fff);">' + cells.join('') + '</tr></tfoot>');
+            table.append(tfoot);
         }
 
 		function reloadPage() {
 			window.location.reload();
 		}
+
+        function exportTableToCSV(filename) {
+            var rows = [];
+            var headers = [];
+            $element.find('#reporttable thead th').each(function () { headers.push($(this).text()); });
+            rows.push(headers.join(','));
+            $element.find('#reporttable tbody tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () { cols.push('"' + $(this).text().replace(/"/g, '""') + '"'); });
+                rows.push(cols.join(','));
+            });
+            $element.find('#reporttable tfoot tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () { cols.push('"' + $(this).text().replace(/"/g, '""') + '"'); });
+                rows.push(cols.join(','));
+            });
+            var blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a'); a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+        }
+
+        function exportTableToExcel(filename) {
+            function escXml(s) {
+                return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+            }
+            function xmlCell(text) {
+                var t = text.trim();
+                var isNum = /^-?\d+(\.\d+)?$/.test(t);
+                return '<Cell><Data ss:Type="' + (isNum ? 'Number' : 'String') + '">' + escXml(t) + '</Data></Cell>';
+            }
+            var xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + '<?mso-application progid="Excel.Sheet"?>\n'
+                + '<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"'
+                + ' xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">\n'
+                + '<Worksheet ss:Name="Report"><Table>\n';
+            xml += '<Row>';
+            $element.find('#reporttable thead th').each(function () { xml += xmlCell($(this).text()); });
+            xml += '</Row>\n';
+            $element.find('#reporttable tbody tr, #reporttable tfoot tr').each(function () {
+                xml += '<Row>';
+                $(this).find('td').each(function () { xml += xmlCell($(this).text()); });
+                xml += '</Row>\n';
+            });
+            xml += '</Table></Worksheet></Workbook>';
+            var blob = new Blob([xml], { type: 'application/vnd.ms-excel' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a'); a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+        }
+
+        function exportTableToClipboard() {
+            var rows = [];
+            var headers = [];
+            $element.find('#reporttable thead th').each(function () { headers.push($(this).text()); });
+            rows.push(headers.join('\t'));
+            $element.find('#reporttable tbody tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () { cols.push($(this).text()); });
+                rows.push(cols.join('\t'));
+            });
+            $element.find('#reporttable tfoot tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () { cols.push($(this).text()); });
+                rows.push(cols.join('\t'));
+            });
+            navigator.clipboard.writeText(rows.join('\n'));
+        }
 
         function showUsageChart(data) {
             var chartElement = $element.find('#usagegraph');

--- a/www/app/report/DeviceReport.html
+++ b/www/app/report/DeviceReport.html
@@ -6,28 +6,38 @@
 
     <div class="pull-right">
         <label for="comboyear" data-i18n="Year"></label>:
-        <select
-                id="comboyear"
-                class="combobox ui-corner-all"
-                style="width:64px"
+        <select id="comboyear" class="combobox ui-corner-all"
+                style="width:80px"
                 ng-model="vm.selectedYear"
                 ng-change="vm.selectYear()"
-                ng-options="year for year in ::vm.getYearsOptions()">
+                ng-options="y.value as y.label for y in vm.yearsOptions">
         </select>
+        <span ng-show="vm.isCustomYear()" style="margin-left:8px;">
+            <label data-i18n="Start date"></label>:
+            <input type="date"
+                   class="ui-corner-all"
+                   style="padding:2px 4px;"
+                   ng-model="vm._datePickerModel"
+                   min="2012-01-01"
+                   max="{{ ::vm.maxDate }}">
+            <button class="btnstyle3" style="margin-left:4px;" ng-click="vm.applyCustomDate()" data-i18n="Set"></button>
+        </span>
     </div>
 
     <device-counter-report
             ng-if="::vm.isCounterReport()"
             device="::vm.device"
-            selected-year="::vm.selectedYear"
+            selected-year="vm.selectedYear"
             selected-month="::vm.selectedMonth"
-            is-only-usage="::vm.isOnlyUsage()"></device-counter-report>
+            is-only-usage="::vm.isOnlyUsage()"
+            custom-start-date="vm.customStartDate"></device-counter-report>
 
     <device-energy-multi-counter-report
             ng-if="::vm.isEnergyMultiCounterReport()"
             device="::vm.device"
-            selected-year="::vm.selectedYear"
-            selected-month="::vm.selectedMonth"></device-energy-multi-counter-report>
+            selected-year="vm.selectedYear"
+            selected-month="::vm.selectedMonth"
+            custom-start-date="vm.customStartDate"></device-energy-multi-counter-report>
 
     <device-temperature-report
             ng-if="::vm.isTemperatureReport()"

--- a/www/app/report/DeviceReport.js
+++ b/www/app/report/DeviceReport.js
@@ -8,15 +8,78 @@ define(['app', 'report/CounterReport', 'report/TemperatureReport', 'report/Energ
         vm.isRainReport = isRainReport;
         vm.isWindReport = isWindReport;
         vm.isNoReport = isNoReport;
-        vm.getYearsOptions = getYearsOptions;
         vm.selectYear = selectYear;
+        vm.isCustomYear = function () { return vm.selectedYear === 'custom'; };
+        vm.applyCustomDate = function () {
+            var val = vm._datePickerModel;
+            if (val instanceof Date && !isNaN(val.getTime())) {
+                val = localDateISO(val);
+            }
+            if (!val || !/^\d{4}-\d{2}-\d{2}$/.test(val)) { return; }
+            vm.customStartDate = val;
+            localStorage.setItem('dz_report_custom_start_' + vm.deviceIdx, val);
+            $route.updateParams({ year: 'custom-' + val });
+            $location.replace();
+        };
+
+        function localDateISO(d) {
+            var y  = d.getFullYear();
+            var mo = String(d.getMonth() + 1).padStart(2, '0');
+            var dy = String(d.getDate()).padStart(2, '0');
+            return y + '-' + mo + '-' + dy;
+        }
 
         init();
 
+        function formatDateDisplay(isoDate) {
+            if (!isoDate || isoDate.length < 10) { return isoDate; }
+            var p = isoDate.split('-');
+            var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+            return p[2] + ' ' + $.t(months[parseInt(p[1], 10) - 1]) + ' ' + p[0];
+        }
+
+        function addOneYear(dateStr) {
+            var d = new Date(dateStr + 'T00:00:00');
+            var origMonth = d.getMonth();
+            var origDay   = d.getDate();
+            d.setFullYear(d.getFullYear() + 1);
+            if (origMonth === 1 && origDay === 29 && d.getMonth() === 2) {
+                d.setDate(28);
+            }
+            return d.getFullYear() + '-'
+                 + String(d.getMonth() + 1).padStart(2, '0') + '-'
+                 + String(d.getDate()).padStart(2, '0');
+        }
+
         function init() {
+            vm.yearsOptions = getYearsOptions();
+            vm.maxDate = new Date().toISOString().slice(0, 10);
+
             vm.deviceIdx = $routeParams.id;
 
-            vm.selectedYear = parseInt($routeParams.year) || ((new Date()).getFullYear());
+            var yearParam = $routeParams.year || '';
+            if (yearParam.indexOf('custom-') === 0) {
+                var dateStr = yearParam.slice(7);
+                if (/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) {
+                    vm.selectedYear      = 'custom';
+                    vm.customStartDate   = dateStr;
+                    vm._datePickerModel  = new Date(dateStr + 'T00:00:00Z');  // UTC midnight — matches what AngularJS date input expects
+                    localStorage.setItem('dz_report_custom_start_' + vm.deviceIdx, dateStr);
+                } else {
+                    vm.selectedYear      = (new Date()).getFullYear();
+                    vm.customStartDate   = '';
+                    vm._datePickerModel  = null;
+                }
+            } else {
+                vm.selectedYear      = parseInt(yearParam) || (new Date()).getFullYear();
+                vm.customStartDate   = '';
+                vm._datePickerModel  = null;
+                var stored = localStorage.getItem('dz_report_custom_start_' + vm.deviceIdx);
+                if (stored && /^\d{4}-\d{2}-\d{2}$/.test(stored)) {
+                    vm._datePickerModel = new Date(stored + 'T00:00:00Z');
+                    // Don't auto-navigate — user must press Set
+                }
+            }
             vm.selectedMonth = parseInt($routeParams.month) || undefined;
             vm.isMonthView = vm.selectedMonth > 0;
 
@@ -26,25 +89,35 @@ define(['app', 'report/CounterReport', 'report/TemperatureReport', 'report/Energ
 
                 vm.device = device;
 
+                var csDate = vm.customStartDate instanceof Date
+                    ? localDateISO(vm.customStartDate)
+                    : vm.customStartDate;
                 vm.pageName = vm.isMonthView
                     ? vm.device.Name + ', ' + $.t(monthNames[vm.selectedMonth - 1]) + ' ' + vm.selectedYear
-                    : vm.device.Name + ' ' + vm.selectedYear;
+                    : (csDate
+                        ? vm.device.Name + ' ' + formatDateDisplay(csDate) + ' \u2013 ' + formatDateDisplay(addOneYear(csDate))
+                        : vm.device.Name + ' ' + vm.selectedYear);
             });
         }
 
         function selectYear() {
-            $route.updateParams({ year: vm.selectedYear });
+            if (vm.selectedYear === 'custom') {
+                var val = vm.customStartDate;
+                if (val instanceof Date) { val = localDateISO(val); }
+                if (!val) { return; }
+                $route.updateParams({ year: 'custom-' + val });
+            } else {
+                $route.updateParams({ year: vm.selectedYear });
+            }
             $location.replace();
         }
 
         function getYearsOptions() {
-            var currentYear = ((new Date()).getFullYear());
-            var years = [];
-
-            for (var i = 2012; i <= currentYear; i++) {
-                years.push(i);
+            var currentYear = (new Date()).getFullYear();
+            var years = [{ label: 'Custom', value: 'custom' }];
+            for (var i = currentYear; i >= 2012; i--) {
+                years.push({ label: String(i), value: i });
             }
-
             return years;
         }
 

--- a/www/app/report/EnergyMultiCounterReport.html
+++ b/www/app/report/EnergyMultiCounterReport.html
@@ -1,4 +1,17 @@
-<div ng-if="::!$ctrl.isMonthView" style="margin-bottom: 12px">
+<style>
+.report-forecast-row td {
+    opacity: 0.65;
+    font-style: italic;
+}
+.report-forecast-warning {
+    color: var(--dz-widget-amber, #f0a500);
+    margin-left: 4px;
+    cursor: help;
+    font-style: normal;
+}
+</style>
+
+<div ng-if="::!$ctrl.isMonthView" style="margin-bottom: 12px; user-select: text;">
     <div>{{:: 'Total Usage' | translate }}:
 	<div ng-show="$ctrl.P1DisplayType==0">
         {{:: 'T1' | translate }}: <b>{{:: $ctrl.data.usage1.usage.toFixed(3) }}</b> {{:: $ctrl.unit}}<span ng-if="$ctrl.data.totalUsage"> ({{ ((100.0 / $ctrl.data.totalUsage)*$ctrl.data.usage1.usage).toFixed(0) }}%)</span>,
@@ -20,10 +33,25 @@
         {{:: 'R2' | translate }}: <b>{{:: $ctrl.data.return2.counter.toFixed(3) }}</b>
     </div>
 	<div>{{:: 'Total nett usage' | translate }}: <b>{{$ctrl.data.usage.toFixed(3) }}</b> {{:: $ctrl.unit}}</div>
-    	<div>{{:: 'Year Cost' | translate }}: <b>{{:: $ctrl.data.cost.toFixed(2) }}</b></div>
+    	<div>{{ ($ctrl.data.customStartDate ? 'Period Cost' : 'Year Cost') | translate }}: <b>{{$ctrl.data.cost.toFixed(2) }}</b> {{:: $ctrl.currencySign}}</div>
+
+    <!-- Forecast summary block (custom contract year only) -->
+    <div ng-if="$ctrl.data.customStartDate && $ctrl.forecastFullYear">
+        {{'Forecast full year' | translate }}:
+        <b>~ {{($ctrl.forecastFullYear.total).toFixed(3)}}</b> {{:: $ctrl.unit}}
+        <span ng-if="$ctrl.forecastWarning" class="report-forecast-warning" title="{{$ctrl.forecastWarning}}">&#9888;</span>
+    </div>
+    <div ng-if="$ctrl.data.customStartDate && $ctrl.forecastFullYear">
+        {{'Forecast year cost' | translate }}:
+        <b>~ {{$ctrl.forecastFullYear.forecastCost.toFixed(2)}}</b> {{:: $ctrl.currencySign}}
+        <span ng-if="$ctrl.forecastWarning" class="report-forecast-warning" title="{{$ctrl.forecastWarning}}">&#9888;</span>
+    </div>
+    <div ng-if="$ctrl.data.customStartDate && $ctrl.noForecastHistory" style="color:#888; font-style:italic">
+        {{'Forecast full year' | translate }}: &mdash; ({{'No previous year data available' | translate}})
+    </div>
 </div>
 
-<div ng-if="::$ctrl.isMonthView" style="margin-bottom: 12px">
+<div ng-if="::$ctrl.isMonthView" style="margin-bottom: 12px; user-select: text;">
     <div>{{:: 'Total Usage' | translate }}:
         {{:: 'T1' | translate }}: {{:: $ctrl.data.usage1.usage.toFixed(3) }} {{:: $ctrl.unit}},
         {{:: 'T2' | translate }}: {{:: $ctrl.data.usage2.usage.toFixed(3) }} {{:: $ctrl.unit}},
@@ -40,12 +68,29 @@
 	    {{:: 'Total' | translate }}: {{$ctrl.data.usage.toFixed(3) }} {{:: $ctrl.unit}}
     </div>
 
-    <div>{{:: 'Monthly Cost' | translate }}: {{:: $ctrl.data.cost.toFixed(2) }}</div>
+    <div>{{:: 'Monthly Cost' | translate }}: {{:: $ctrl.data.cost.toFixed(2) }} {{:: $ctrl.currencySign}}</div>
+</div>
+
+<!-- Meter-replaced forecast warning banner -->
+<div ng-if="$ctrl.forecastWarning" style="margin-bottom:8px; padding:6px 10px; background:#fff3cd; border:1px solid #ffc107; border-radius:4px; color:#856404;">
+    <span class="report-forecast-warning">&#9888;</span>
+    {{$ctrl.forecastWarning}}
 </div>
 
 <div ng-if="::$ctrl.noDataAvailable" class="no-data">
     {{ ::'No data available' | translate}}
 </div>
 
-<table class="display myrighttable"></table>
+<div style="text-align:right; margin:4px 0;">
+    <i class="far fa-file-alt" ng-click="$ctrl.exportExcel()"
+       title="{{ 'Export to Excel' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+    <i class="far fa-file" ng-click="$ctrl.exportCSV()"
+       title="{{ 'Export to CSV' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+    <i class="far fa-clipboard" ng-click="$ctrl.exportClipboard()"
+       title="{{ 'Copy to clipboard' | translate }}"
+       style="cursor:pointer; font-size:1.1em; margin-left:5px;"></i>
+</div>
+<table id="reporttable" class="display myrighttable"></table>
 <div id="usagegraph" class="device-log-chart" style="height: 300px;"></div>

--- a/www/app/report/EnergyMultiCounterReport.js
+++ b/www/app/report/EnergyMultiCounterReport.js
@@ -4,44 +4,322 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
             fetch: fetch
         };
 
-        function fetch(deviceIdx, year, month) {
+        function fetch(deviceIdx, year, month, customStartDate) {
+            if (customStartDate && !/^\d{4}-\d{2}-\d{2}$/.test(customStartDate)) {
+                return $q.resolve(null);
+            }
             var costs = domoticzApi.sendCommand('getcosts', { idx: deviceIdx });
 
-            var stats = domoticzApi.sendCommand('graph', {
-                sensor: 'counter',
-                range: 'year',
-                idx: deviceIdx,
-                actyear: year,
-                actmonth: month
-            });
-			
-            return $q.all([costs, stats]).then(function (responses) {
+            var graphParams;
+            if (customStartDate) {
+                var actend = reportHelpers.addOneYear(customStartDate);
+                if (!actend) { return $q.resolve(null); }
+                graphParams = { sensor: 'counter', range: 'year', idx: deviceIdx,
+                    actstart: customStartDate, actend: actend };
+            } else {
+                graphParams = { sensor: 'counter', range: 'year', idx: deviceIdx,
+                    actyear: year, actmonth: month };
+            }
+
+            var stats = domoticzApi.sendCommand('graph', graphParams);
+
+            var allPromises;
+            if (customStartDate) {
+                var prevStart = reportHelpers.addOneYear(customStartDate, -1);
+                if (!prevStart) { return $q.resolve(null); }
+                var prevStats = domoticzApi.sendCommand('graph', {
+                    sensor: 'counter', range: 'year', idx: deviceIdx,
+                    actstart: prevStart, actend: customStartDate
+                });
+                allPromises = $q.all([costs, stats, prevStats]);
+            } else {
+                allPromises = $q.all([costs, stats]);
+            }
+
+            return allPromises.then(function (responses) {
                 var costs = responses[0];
                 var stats = responses[1];
+                var prevStats = responses[2] || null;
 
                 if (!stats.result || !stats.result.length) {
                     return null;
                 }
 
                 var includeReturn = typeof stats.delivered !== 'undefined';
-                var data = getGroupedData(stats.result, costs, includeReturn);
-				var P1DisplayType = stats.P1DisplayType;
-			
-                var source = month
-                    ? data.years[year].months.find(function (item) {
-                        return (new Date(item.date)).getMonth() + 1 === month;
-                    })
-                    : data.years[year];
+                var P1DisplayType = stats.P1DisplayType;
+
+                var source;
+                if (customStartDate) {
+                    var prevYearData = (prevStats && prevStats.result && prevStats.result.length)
+                        ? prevStats.result
+                        : null;
+                    source = getContractMonthData(stats.result, costs, includeReturn, customStartDate, prevYearData);
+                } else {
+                    var data = getGroupedData(stats.result, costs, includeReturn);
+                    source = month
+                        ? data.years[year].months.find(function (item) {
+                            return (new Date(item.date)).getMonth() + 1 === month;
+                          })
+                        : data.years[year];
+                }
 
                 if (!source) {
                     return null;
                 }
 
                 return Object.assign({}, source, {
-                    items: month ? source.days : source.months,
-					P1DisplayType: P1DisplayType
+                    items: customStartDate ? source.months : (month ? source.days : source.months),
+                    P1DisplayType: P1DisplayType,
+                    customStartDate: customStartDate
                 });
             });
+        }
+
+        function buildDayRecord(item, costs, includeReturn) {
+            var dayRecord = {
+                date: item.d,
+                usage: {
+                    usage: parseFloat(item.v),
+                    cost: parseFloat(item.v) * costs.CostEnergy / 10000,
+                    counter: parseFloat(item.c1) || 0
+                },
+                usage1: {
+                    usage: parseFloat(item.v1),
+                    cost: parseFloat(item.v1) * costs.CostEnergy / 10000,
+                    counter: parseFloat(item.c1) || 0
+                },
+                usage2: {
+                    usage: parseFloat(item.v2),
+                    cost: parseFloat(item.v2) * costs.CostEnergyT2 / 10000,
+                    counter: parseFloat(item.c3) || 0
+                },
+                price: parseFloat(item.p)
+            };
+
+            if (includeReturn) {
+                dayRecord.return = {
+                    usage: parseFloat(item.r),
+                    cost: parseFloat(item.r) * costs.CostEnergyR1 / 10000,
+                    counter: parseFloat(item.c2) || 0,
+                };
+                dayRecord.return1 = {
+                    usage: parseFloat(item.r1),
+                    cost: parseFloat(item.r1) * costs.CostEnergyR1 / 10000,
+                    counter: parseFloat(item.c2) || 0
+                };
+                dayRecord.return2 = {
+                    usage: parseFloat(item.r2),
+                    cost: parseFloat(item.r2) * costs.CostEnergyR2 / 10000,
+                    counter: parseFloat(item.c4) || 0
+                };
+
+                dayRecord.totalReturn = dayRecord.return1.usage + dayRecord.return2.usage;
+            }
+
+            dayRecord.totalUsage = dayRecord.usage1.usage + dayRecord.usage2.usage;
+            dayRecord.usage = dayRecord.totalUsage -
+                (includeReturn ? dayRecord.totalReturn : 0);
+            dayRecord.cost = (dayRecord.price != 0) ? dayRecord.price : (dayRecord.usage1.cost + dayRecord.usage2.cost -
+                (includeReturn ? (dayRecord.return1.cost + dayRecord.return2.cost) : 0));
+
+            return dayRecord;
+        }
+
+        function getContractMonthData(rawData, costs, includeReturn, startDateISO, prevYearData) {
+            var base = new Date(startDateISO + 'T00:00:00');
+            var subKeys = ['usage1', 'usage2'];
+            if (includeReturn) { subKeys = subKeys.concat(['return1', 'return2']); }
+
+            var today = new Date();
+            today.setHours(0, 0, 0, 0);
+
+            var periods = [];
+            for (var i = 0; i < 12; i++) {
+                var pStart = new Date(base.getFullYear(), base.getMonth() + i, base.getDate());
+                var pEnd   = new Date(base.getFullYear(), base.getMonth() + i + 1, base.getDate());
+                // Clamp pEnd if month overflowed (e.g. Jan 31 → Mar 3 instead of Feb 28)
+                var expectedEndMonth = (base.getMonth() + i + 1) % 12;
+                if (pEnd.getMonth() !== expectedEndMonth) {
+                    pEnd = new Date(base.getFullYear(), base.getMonth() + i + 2, 0);
+                }
+                var p = {
+                    start: pStart, end: pEnd,
+                    label: reportHelpers.formatContractMonthLabel(pStart, pEnd),
+                    date: +pStart, periodIndex: i + 1,
+                    days: [], totalUsage: 0, totalReturn: 0, usage: 0, cost: 0,
+                    forecast: false
+                };
+                subKeys.forEach(function(k) { p[k] = { usage: 0, cost: 0, counter: 0 }; });
+                periods.push(p);
+            }
+
+            rawData.forEach(function(item) {
+                var d = new Date(item.d.substring(0, 10) + 'T00:00:00');
+                for (var i = 0; i < periods.length; i++) {
+                    if (d >= periods[i].start && d < periods[i].end) {
+                        var dayRecord = buildDayRecord(item, costs, includeReturn);
+                        periods[i].days.push(dayRecord);
+                        subKeys.forEach(function(k) {
+                            if (dayRecord[k]) {
+                                periods[i][k].usage  += dayRecord[k].usage;
+                                periods[i][k].cost   += dayRecord[k].cost;
+                                periods[i][k].counter = Math.max(periods[i][k].counter, dayRecord[k].counter);
+                            }
+                        });
+                        periods[i].totalUsage  += dayRecord.totalUsage || 0;
+                        periods[i].totalReturn += dayRecord.totalReturn || 0;
+                        periods[i].usage       += dayRecord.usage || 0;
+                        periods[i].cost        += dayRecord.cost || 0;
+                        break;
+                    }
+                }
+            });
+
+            // Determine which periods are entirely in the future
+            var futurePeriods = periods.filter(function(p) { return p.start >= today; });
+            var hasFuturePeriods = futurePeriods.length > 0;
+
+            // TODO: implement meter replacement detection
+            // Currently always false; counter-reset detection was removed when switching
+            // to the daily-sum approach. As a result, the meterReplaced warning banner
+            // and the '~value ⚠' display in table cells will never show.
+            var meterReplaced = false;
+            var noHistory = false;
+            var forecastFullYear = null;   // { t1, t2, r1, r2, total }
+            var prevMonthBuckets = null;
+
+            if (hasFuturePeriods && prevYearData) {
+                var prevStartISO = reportHelpers.addOneYear(startDateISO, -1);
+
+                // Sum daily v1/v2/r1/r2 values from the previous year — this is
+                // robust against the "today-partial" record appended by the backend
+                // (that record's c1/c3 reflect the current live counter, not the
+                // counter at actend, which would corrupt any counter-delta approach).
+                // Intentionally one level of recursion: this (current-year) call passes
+                // prevYearData, but that recursive call receives no prevYearData so it
+                // will not recurse further. prevYearData contains raw API records (no
+                // forecast flags), making it safe to aggregate directly.
+                var prevAgg = getContractMonthData(prevYearData, costs, includeReturn, prevStartISO);
+                var delta = {
+                    t1: prevAgg.usage1 ? prevAgg.usage1.usage : 0,
+                    t2: prevAgg.usage2 ? prevAgg.usage2.usage : 0,
+                    r1: (includeReturn && prevAgg.return1) ? prevAgg.return1.usage : 0,
+                    r2: (includeReturn && prevAgg.return2) ? prevAgg.return2.usage : 0
+                };
+                delta.total = delta.t1 + delta.t2;
+                prevMonthBuckets = prevAgg.months;
+
+                // Less than 50 kWh for a full year suggests missing/incomplete previous
+                // year data rather than actual consumption — disable forecast in that case.
+                var MIN_YEARLY_KWH = 50;
+                if (delta.total < MIN_YEARLY_KWH) {
+                    noHistory = true;
+                } else {
+                    // Pre-compute forecast full-year cost from tariff rates
+                    delta.forecastCost = delta.t1 * costs.CostEnergy / 10000
+                                       + delta.t2 * costs.CostEnergyT2 / 10000
+                                       - (includeReturn
+                                           ? (delta.r1 * costs.CostEnergyR1 / 10000
+                                              + delta.r2 * costs.CostEnergyR2 / 10000)
+                                           : 0);
+
+                    forecastFullYear = delta;
+
+                    // Apply forecast to future periods
+                    var prevTotal = delta.total;
+
+                    futurePeriods.forEach(function(p) {
+                        var periodIdx = periods.indexOf(p);
+                        var prevBucket = (prevMonthBuckets && prevMonthBuckets[periodIdx]) || null;
+                        var share = (prevBucket && prevTotal > 0)
+                            ? prevBucket.totalUsage / prevTotal
+                            : 1 / 12;
+
+                        p.forecast = true;
+                        p.meterReplaced = meterReplaced;
+
+                        // Forecast usage values
+                        p.usage1 = {
+                            usage: delta.t1 * share,
+                            cost:  delta.t1 * share * costs.CostEnergy / 10000,
+                            counter: 0
+                        };
+                        p.usage2 = {
+                            usage: delta.t2 * share,
+                            cost:  delta.t2 * share * costs.CostEnergyT2 / 10000,
+                            counter: 0
+                        };
+                        p.totalUsage = p.usage1.usage + p.usage2.usage;
+
+                        if (includeReturn) {
+                            p.return1 = {
+                                usage: delta.r1 * share,
+                                cost:  delta.r1 * share * costs.CostEnergyR1 / 10000,
+                                counter: 0
+                            };
+                            p.return2 = {
+                                usage: delta.r2 * share,
+                                cost:  delta.r2 * share * costs.CostEnergyR2 / 10000,
+                                counter: 0
+                            };
+                            p.totalReturn = p.return1.usage + p.return2.usage;
+                        } else {
+                            p.totalReturn = 0;
+                        }
+
+                        p.usage = p.totalUsage - p.totalReturn;
+                        p.cost  = p.usage1.cost + p.usage2.cost
+                                - (includeReturn ? (p.return1.cost + p.return2.cost) : 0);
+                    });
+                }
+            } else if (hasFuturePeriods && !prevYearData) {
+                noHistory = true;
+            }
+
+            periods = reportHelpers.addTrendData(periods, 'usage');
+
+            var agg = {
+                months: periods,
+                meterReplaced: meterReplaced,
+                noHistory: noHistory && hasFuturePeriods,
+                forecastFullYear: forecastFullYear
+            };
+            subKeys.forEach(function(k) { agg[k] = { usage: 0, cost: 0, counter: 0 }; });
+
+            // Aggregate only actual (non-forecast) periods for the summary block
+            periods.forEach(function(p) {
+                if (!p.forecast) {
+                    subKeys.forEach(function(k) {
+                        agg[k].usage  += p[k].usage;
+                        agg[k].cost   += p[k].cost;
+                        agg[k].counter = Math.max(agg[k].counter, p[k].counter);
+                    });
+                    agg.totalUsage  = (agg.totalUsage  || 0) + p.totalUsage;
+                    agg.totalReturn = (agg.totalReturn || 0) + p.totalReturn;
+                    agg.usage       = (agg.usage       || 0) + p.usage;
+                    agg.cost        = (agg.cost        || 0) + p.cost;
+                } else {
+                    // Still initialise the accumulators if not yet set (all-forecast edge case)
+                    subKeys.forEach(function(k) {
+                        if (!agg[k]) { agg[k] = { usage: 0, cost: 0, counter: 0 }; }
+                    });
+                    if (agg.totalUsage  === undefined) { agg.totalUsage  = 0; }
+                    if (agg.totalReturn === undefined) { agg.totalReturn = 0; }
+                    if (agg.usage       === undefined) { agg.usage       = 0; }
+                    if (agg.cost        === undefined) { agg.cost        = 0; }
+                }
+            });
+
+            // Update forecast summary: actual to-date + sum of forecast remaining months
+            // (rather than showing just last year's total as the full-year estimate)
+            if (forecastFullYear && futurePeriods.length > 0) {
+                var fUsage = futurePeriods.reduce(function(s, p) { return s + (p.totalUsage || 0); }, 0);
+                var fCost  = futurePeriods.reduce(function(s, p) { return s + (p.cost  || 0); }, 0);
+                forecastFullYear.total       = (agg.totalUsage || 0) + fUsage;
+                forecastFullYear.forecastCost = (agg.cost || 0) + fCost;
+            }
+
+            return agg;
         }
 
         function getGroupedData(data, costs, includeReturn) {
@@ -67,52 +345,8 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                     }
                 }
 
-                var dayRecord = {
-                    date: item.d,
-                    usage: {
-                        usage: parseFloat(item.v),
-                        cost: parseFloat(item.v) * costs.CostEnergy / 10000,
-                        counter: parseFloat(item.c1) || 0
-                    },
-                    usage1: {
-                        usage: parseFloat(item.v1),
-                        cost: parseFloat(item.v1) * costs.CostEnergy / 10000,
-                        counter: parseFloat(item.c1) || 0
-                    },
-                    usage2: {
-                        usage: parseFloat(item.v2),
-                        cost: parseFloat(item.v2) * costs.CostEnergyT2 / 10000,
-                        counter: parseFloat(item.c3) || 0
-                    },
-					price: parseFloat(item.p)
-                };
-
-                if (includeReturn) {
-                    dayRecord.return = {
-                        usage: parseFloat(item.r),
-                        cost: parseFloat(item.r) * costs.CostEnergyR1 / 10000,
-                        counter: parseFloat(item.c2) || 0,
-                    };
-                    dayRecord.return1 = {
-                        usage: parseFloat(item.r1),
-                        cost: parseFloat(item.r1) * costs.CostEnergyR1 / 10000,
-                        counter: parseFloat(item.c2) || 0
-                    };
-                    dayRecord.return2 = {
-                        usage: parseFloat(item.r2),
-                        cost: parseFloat(item.r2) * costs.CostEnergyR2 / 10000,
-                        counter: parseFloat(item.c4) || 0
-                    };
-
-                    dayRecord.totalReturn = dayRecord.return1.usage + dayRecord.return2.usage;
-                }
-
-                dayRecord.totalUsage = dayRecord.usage1.usage + dayRecord.usage2.usage;
-                dayRecord.usage = dayRecord.totalUsage -
-                    (includeReturn ? dayRecord.totalReturn : 0);
-                dayRecord.cost = (dayRecord.price!=0) ? dayRecord.price : (dayRecord.usage1.cost + dayRecord.usage2.cost -
-                    (includeReturn ? (dayRecord.return1.cost + dayRecord.return2.cost) : 0));
-                result.years[year].months[month].days[day] = dayRecord
+                var dayRecord = buildDayRecord(item, costs, includeReturn);
+                result.years[year].months[month].days[day] = dayRecord;
             });
 
             Object.keys(result.years).forEach(function (year) {
@@ -172,32 +406,45 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
     app.component('deviceEnergyMultiCounterReport', {
         bindings: {
-            device: '<',
-            selectedYear: '<',
-            selectedMonth: '<'
+            device:          '<',
+            selectedYear:    '<',
+            selectedMonth:   '<',
+            customStartDate: '<'
         },
         templateUrl: 'app/report/EnergyMultiCounterReport.html',
         controller: DeviceCounterReportController
     });
 
 
-    function DeviceCounterReportController($element, DeviceEnergyMultiCounterReportData, dataTableDefaultSettings) {
+    function DeviceCounterReportController($element, $scope, DeviceEnergyMultiCounterReportData, dataTableDefaultSettings) {
         var vm = this;
         vm.$onInit = init;
 
+        vm.exportExcel     = function () { exportTableToExcel(vm.device.Name + '_report.xls'); };
+        vm.exportCSV       = function () { exportTableToCSV(vm.device.Name + '_report.csv'); };
+        vm.exportClipboard = function () { exportTableToClipboard(); };
+
         function init() {
             vm.unit = vm.device.getUnit();
+            vm.currencySign = ($.myglobals.currencysign || '').replace(/[<>"'&]/g, '');
             vm.isMonthView = vm.selectedMonth > 0;
             vm.degreeType = $.myglobals.tempsign;
 
-			$.devIdx = vm.device.idx;
+            $.devIdx = vm.device.idx;
 
             getData();
+
+            var deregisterWatch = $scope.$watch(function() { return vm.customStartDate; }, function(newVal, oldVal) {
+                if (newVal !== oldVal && /^\d{4}-\d{2}-\d{2}$/.test(newVal || '')) {
+                    getData();
+                }
+            });
+            $scope.$on('$destroy', deregisterWatch);
         }
 
         function getData() {
             DeviceEnergyMultiCounterReportData
-                .fetch(vm.device.idx, vm.selectedYear, vm.selectedMonth)
+                .fetch(vm.device.idx, vm.selectedYear, vm.selectedMonth, vm.customStartDate)
                 .then(function (data) {
                     if (!data) {
                         vm.noDataAvailable = true;
@@ -207,6 +454,11 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                     vm.data = data;
                     vm.hasReturn = checkDataKey(data, 'return1');
 					vm.P1DisplayType = data.P1DisplayType;
+                    vm.forecastWarning = data.meterReplaced
+                        ? $.t('Previous meter was replaced — forecast based on partial data. Actual values may differ.')
+                        : null;
+                    vm.noForecastHistory = data.noHistory || false;
+                    vm.forecastFullYear = data.forecastFullYear || null;
 
                     showTable(data);
                     showUsageChart(data)
@@ -221,7 +473,12 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 
         function showTable(data) {
 			//console.log(data);
-            var table = $element.find('table');
+            var table = $element.find('#reporttable');
+            // Destroy existing DataTable instance if present
+            if ($.fn.dataTable.isDataTable(table)) {
+                table.dataTable().api().destroy();
+                table.empty();
+            }
             var columns = [];
 
             var counterRenderer = function (data) {
@@ -253,7 +510,11 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                     title: $.t('Month'),
                     width: 150,
                     data: 'date',
-                    render: function (data) {
+                    render: function (data, type, row) {
+                        if (type === 'sort' || type === 'type') { return data; }  // sort by raw timestamp
+                        if (vm.customStartDate) {
+                            return row.label || '';
+                        }
                         var date = new Date(data);
                         var link = '<a href="#/Devices/' + vm.device.idx + '/Report/' + vm.selectedYear + '/' + (date.getMonth() + 1) + '"><img src="images/next.png" /></a>';
                         return dateFormat(data, 'mm. mmmm') + ' ' + link;
@@ -272,20 +533,91 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 						return;
 					}
 					if (vm.isMonthView) {
-						columns.push({ title: $.t(item[2]), data: item[0]+'.counter', render: counterRenderer });
+						columns.push({
+							title: $.t(item[2]),
+							data: item[0]+'.counter',
+							render: function(counterRenderer) {
+								return function(data, type, row) {
+									if (row.forecast) { return '&mdash;'; }
+									return counterRenderer(data);
+								};
+							}(counterRenderer)
+						});
 					}
 
-					columns.push({ title: $.t(item[1]), data: item[0]+'.usage', render: counterRenderer });
-					columns.push({ title: $.t('Costs'), data: item[0]+'.cost', render: costRenderer });
+					columns.push({
+						title: $.t(item[1]),
+						data: item[0]+'.usage',
+						render: function (counterRenderer) {
+							return function (val, type, row) {
+								if (row.forecast) {
+									return row.meterReplaced
+										? '~' + counterRenderer(val) + ' <span class="report-forecast-warning" title="' + $.t('Meter replaced') + '">\u26a0</span>'
+										: '~' + counterRenderer(val);
+								}
+								return counterRenderer(val);
+							};
+						}(counterRenderer)
+					});
+					columns.push({
+						title: $.t('Costs'),
+						data: item[0]+'.cost',
+						render: function (costRenderer) {
+							return function (val, type, row) {
+								if (row.forecast) {
+									return row.meterReplaced
+										? '~' + costRenderer(val) + ' <span class="report-forecast-warning" title="' + $.t('Meter replaced') + '">\u26a0</span>'
+										: '~' + costRenderer(val);
+								}
+								return costRenderer(val);
+							};
+						}(costRenderer)
+					});
 				});
 			} else {
-				columns.push({ title: $.t("Usage"), data: 'totalUsage', render: counterRenderer });
-				columns.push({ title: $.t("Return"), data: 'totalReturn', render: counterRenderer });
-				columns.push({ title: $.t("Total"), data: 'usage', render: counterRenderer });
+				columns.push({
+					title: $.t('Usage'),
+					data: 'totalUsage',
+					render: function (val, type, row) {
+						if (row.forecast) {
+							return row.meterReplaced
+								? '~' + val.toFixed(3) + ' <span class="report-forecast-warning" title="' + $.t('Meter replaced') + '">\u26a0</span>'
+								: '~' + val.toFixed(3);
+						}
+						return val.toFixed(3);
+					}
+				});
+				columns.push({
+					title: $.t('Return'),
+					data: 'totalReturn',
+					render: function (val, type, row) {
+						if (row.forecast) { return '~' + val.toFixed(3); }
+						return val.toFixed(3);
+					}
+				});
+				columns.push({
+					title: $.t('Total'),
+					data: 'usage',
+					render: function (val, type, row) {
+						if (row.forecast) { return '~' + val.toFixed(3); }
+						return val.toFixed(3);
+					}
+				});
 			}
 
 
-            columns.push({ title: $.t('Costs'), data: 'cost', render: costRenderer });
+            columns.push({
+                title: $.t('Costs'),
+                data: 'cost',
+                render: function (val, type, row) {
+                    if (row.forecast) {
+                        return row.meterReplaced
+                            ? '~' + costRenderer(val) + ' <span class="report-forecast-warning" title="' + $.t('Meter replaced') + '">\u26a0</span>'
+                            : '~' + costRenderer(val);
+                    }
+                    return costRenderer(val);
+                }
+            });
 
             columns.push({
                 title: '<>',
@@ -300,25 +632,174 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
                 sDom: '<"H"rC>t<"F">',
                 columns: columns,
                 pageLength: 50,
-                order: [[0, 'asc']]
+                order: [[0, 'asc']],
+                createdRow: function (row, rowData) {
+                    if (rowData.forecast) {
+                        $(row).addClass('report-forecast-row');
+                    }
+                }
             }));
 
             table.dataTable().api().rows
                 .add(data.items)
                 .draw();
+
+            // Grand-total footer row — only actual (non-forecast) items
+            var actualItems = data.items.filter(function(r) { return !r.forecast; });
+            var items = actualItems.length ? actualItems : data.items;
+
+            function sumKey(items, key) {
+                return items.reduce(function (s, r) {
+                    var val = key.split('.').reduce(function (o, k) { return o && o[k]; }, r);
+                    return s + (parseFloat(val) || 0);
+                }, 0);
+            }
+
+            var cells = [];
+
+            if (vm.isMonthView) {
+                cells.push('<td style="font-weight:bold">' + $.t('Total') + '</td>');
+                cells.push('<td></td>');
+            } else {
+                cells.push('<td style="font-weight:bold">' + $.t('Total') + '</td>');
+            }
+
+            if (data.P1DisplayType == 0) {
+                var detailKeys = [
+                    ['usage1', 'Usage T1', 'Counter T1'],
+                    ['usage2', 'Usage T2', 'Counter T2'],
+                    ['return1', 'Return T1', 'Counter R1'],
+                    ['return2', 'Return T2', 'Counter R2']
+                ];
+                detailKeys.forEach(function (item) {
+                    if (!checkDataKey(data, item[0])) {
+                        return;
+                    }
+                    if (vm.isMonthView) {
+                        var maxCounter = items.reduce(function (m, r) {
+                            return Math.max(m, (r[item[0]] && r[item[0]].counter) || 0);
+                        }, 0);
+                        cells.push('<td style="font-weight:bold">' + counterRenderer(maxCounter) + '</td>');
+                    }
+                    cells.push('<td style="font-weight:bold">' + counterRenderer(sumKey(items, item[0] + '.usage')) + '</td>');
+                    cells.push('<td style="font-weight:bold">' + costRenderer(sumKey(items, item[0] + '.cost')) + '</td>');
+                });
+            } else {
+                cells.push('<td style="font-weight:bold">' + counterRenderer(sumKey(items, 'totalUsage')) + '</td>');
+                cells.push('<td style="font-weight:bold">' + counterRenderer(sumKey(items, 'totalReturn')) + '</td>');
+                cells.push('<td style="font-weight:bold">' + counterRenderer(sumKey(items, 'usage')) + '</td>');
+            }
+
+            cells.push('<td style="font-weight:bold">' + costRenderer(sumKey(items, 'cost')) + '</td>');
+            cells.push('<td></td>');
+
+            var tfoot = $('<tfoot><tr style="font-weight:bold; background:var(--dz-accent-color,#337ab7); color:var(--dz-body-text,#fff);">' + cells.join('') + '</tr></tfoot>');
+            table.append(tfoot);
         }
 
 		function reloadPage() {
 			window.location.reload();
 		}
 
+        function exportTableToCSV(filename) {
+            var rows = [];
+            var headers = [];
+            $element.find('#reporttable thead th').each(function () { headers.push($(this).text()); });
+            rows.push(headers.join(','));
+            $element.find('#reporttable tbody tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () {
+                    var val = $(this).text().replace(/"/g, '""');
+                    // Prevent formula injection in spreadsheet applications
+                    if (/^[=+\-@]/.test(val)) { val = "'" + val; }
+                    cols.push('"' + val + '"');
+                });
+                rows.push(cols.join(','));
+            });
+            $element.find('#reporttable tfoot tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () {
+                    var val = $(this).text().replace(/"/g, '""');
+                    // Prevent formula injection in spreadsheet applications
+                    if (/^[=+\-@]/.test(val)) { val = "'" + val; }
+                    cols.push('"' + val + '"');
+                });
+                rows.push(cols.join(','));
+            });
+            var blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a'); a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+        }
+
+        function exportTableToExcel(filename) {
+            function escXml(s) {
+                return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                        .replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+            }
+            function xmlCell(text) {
+                var t = text.trim();
+                var isNum = /^-?\d+(\.\d+)?$/.test(t);
+                return '<Cell><Data ss:Type="' + (isNum ? 'Number' : 'String') + '">' + escXml(t) + '</Data></Cell>';
+            }
+            var xml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+                + '<?mso-application progid="Excel.Sheet"?>\n'
+                + '<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"'
+                + ' xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet">\n'
+                + '<Worksheet ss:Name="Report"><Table>\n';
+            xml += '<Row>';
+            $element.find('#reporttable thead th').each(function () { xml += xmlCell($(this).text()); });
+            xml += '</Row>\n';
+            $element.find('#reporttable tbody tr, #reporttable tfoot tr').each(function () {
+                xml += '<Row>';
+                $(this).find('td').each(function () { xml += xmlCell($(this).text()); });
+                xml += '</Row>\n';
+            });
+            xml += '</Table></Worksheet></Workbook>';
+            var blob = new Blob([xml], { type: 'application/vnd.ms-excel' });
+            var url = URL.createObjectURL(blob);
+            var a = document.createElement('a'); a.href = url; a.download = filename; a.click();
+            URL.revokeObjectURL(url);
+        }
+
+        function exportTableToClipboard() {
+            var rows = [];
+            var headers = [];
+            $element.find('#reporttable thead th').each(function () { headers.push($(this).text()); });
+            rows.push(headers.join('\t'));
+            $element.find('#reporttable tbody tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () {
+                    var val = $(this).text();
+                    // Prevent formula injection in spreadsheet applications
+                    if (/^[=+\-@]/.test(val)) { val = "'" + val; }
+                    cols.push(val);
+                });
+                rows.push(cols.join('\t'));
+            });
+            $element.find('#reporttable tfoot tr').each(function () {
+                var cols = [];
+                $(this).find('td').each(function () {
+                    var val = $(this).text();
+                    // Prevent formula injection in spreadsheet applications
+                    if (/^[=+\-@]/.test(val)) { val = "'" + val; }
+                    cols.push(val);
+                });
+                rows.push(cols.join('\t'));
+            });
+            navigator.clipboard.writeText(rows.join('\n'));
+        }
+
         function showUsageChart(data) {
-			console.log(data);
 			let P1DisplayType = data.P1DisplayType;
             var chartElement = $element.find('#usagegraph');
             var hasUsage2 = checkDataKey(data, 'usage2');
 
             var series = [];
+
+            // Separate actual vs forecast items for the chart
+            var actualItems   = data.items.filter(function(r) { return !r.forecast; });
+            var forecastItems = data.items.filter(function(r) { return  r.forecast; });
 
 			if (P1DisplayType == 0) {
 				series.push({
@@ -329,7 +810,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 						valueSuffix: 'kWh'
 					},
 					yAxis: 0,
-					data: data.items.map(function (item) {
+					data: actualItems.map(function (item) {
 						return {
 							x: +(new Date(item.date)),
 							y: item.usage1.usage
@@ -345,7 +826,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 							valueSuffix: 'kWh'
 						},
 						yAxis: 0,
-						data: data.items.map(function (item) {
+						data: actualItems.map(function (item) {
 							return {
 								x: +(new Date(item.date)),
 								y: item.usage2.usage
@@ -362,7 +843,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 							valueSuffix: 'kWh'
 						},
 						yAxis: 0,
-						data: data.items.map(function (item) {
+						data: actualItems.map(function (item) {
 							return {
 								x: +(new Date(item.date)),
 								y: -item.return1.usage
@@ -379,7 +860,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 							valueSuffix: 'kWh'
 						},
 						yAxis: 0,
-						data: data.items.map(function (item) {
+						data: actualItems.map(function (item) {
 							return {
 								x: +(new Date(item.date)),
 								y: -item.return2.usage
@@ -387,6 +868,68 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 						})
 					});
 				}
+
+                // Forecast series (dashed/lower opacity)
+                if (forecastItems.length) {
+                    series.push({
+                        name: $.t('Usage') + ' 1 (' + $.t('Forecast') + ')',
+                        color: 'rgba(60,130,252,0.35)',
+                        stack: 'susage',
+                        dashStyle: 'Dash',
+                        borderWidth: 1,
+                        borderColor: 'rgba(60,130,252,0.7)',
+                        tooltip: { valueSuffix: 'kWh' },
+                        yAxis: 0,
+                        data: forecastItems.map(function(item) {
+                            return { x: +(new Date(item.date)), y: item.usage1.usage };
+                        })
+                    });
+                    if (hasUsage2) {
+                        series.push({
+                            name: $.t('Usage') + ' 2 (' + $.t('Forecast') + ')',
+                            color: 'rgba(3,190,252,0.35)',
+                            stack: 'susage',
+                            dashStyle: 'Dash',
+                            borderWidth: 1,
+                            borderColor: 'rgba(3,190,252,0.7)',
+                            tooltip: { valueSuffix: 'kWh' },
+                            yAxis: 0,
+                            data: forecastItems.map(function(item) {
+                                return { x: +(new Date(item.date)), y: item.usage2.usage };
+                            })
+                        });
+                    }
+                    if (checkDataKey(data, 'return1')) {
+                        series.push({
+                            name: $.t('Return') + ' 1 (' + $.t('Forecast') + ')',
+                            color: 'rgba(30,242,110,0.35)',
+                            stack: 'susage',
+                            dashStyle: 'Dash',
+                            borderWidth: 1,
+                            borderColor: 'rgba(30,242,110,0.7)',
+                            tooltip: { valueSuffix: 'kWh' },
+                            yAxis: 0,
+                            data: forecastItems.map(function(item) {
+                                return { x: +(new Date(item.date)), y: -item.return1.usage };
+                            })
+                        });
+                    }
+                    if (checkDataKey(data, 'return2')) {
+                        series.push({
+                            name: $.t('Return') + ' 2 (' + $.t('Forecast') + ')',
+                            color: 'rgba(3,252,190,0.35)',
+                            stack: 'susage',
+                            dashStyle: 'Dash',
+                            borderWidth: 1,
+                            borderColor: 'rgba(3,252,190,0.7)',
+                            tooltip: { valueSuffix: 'kWh' },
+                            yAxis: 0,
+                            data: forecastItems.map(function(item) {
+                                return { x: +(new Date(item.date)), y: -item.return2.usage };
+                            })
+                        });
+                    }
+                }
 			} else {
 				series.push({
 					name: $.t('Usage'),
@@ -396,7 +939,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 						valueSuffix: 'kWh'
 					},
 					yAxis: 0,
-					data: data.items.map(function (item) {
+					data: actualItems.map(function (item) {
 						return {
 							x: +(new Date(item.date)),
 							y: item.totalUsage
@@ -412,7 +955,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 							valueSuffix: 'kWh'
 						},
 						yAxis: 0,
-						data: data.items.map(function (item) {
+						data: actualItems.map(function (item) {
 							return {
 								x: +(new Date(item.date)),
 								y: -item.totalReturn
@@ -420,6 +963,36 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 						})
 					});
 				}
+                if (forecastItems.length) {
+                    series.push({
+                        name: $.t('Usage') + ' (' + $.t('Forecast') + ')',
+                        color: 'rgba(3,190,252,0.35)',
+                        stack: 'susage',
+                        dashStyle: 'Dash',
+                        borderWidth: 1,
+                        borderColor: 'rgba(3,190,252,0.7)',
+                        tooltip: { valueSuffix: 'kWh' },
+                        yAxis: 0,
+                        data: forecastItems.map(function(item) {
+                            return { x: +(new Date(item.date)), y: item.totalUsage };
+                        })
+                    });
+                    if (checkDataKey(data, 'return1')) {
+                        series.push({
+                            name: $.t('Return') + ' (' + $.t('Forecast') + ')',
+                            color: 'rgba(3,252,190,0.35)',
+                            stack: 'susage',
+                            dashStyle: 'Dash',
+                            borderWidth: 1,
+                            borderColor: 'rgba(3,252,190,0.7)',
+                            tooltip: { valueSuffix: 'kWh' },
+                            yAxis: 0,
+                            data: forecastItems.map(function(item) {
+                                return { x: +(new Date(item.date)), y: -item.totalReturn };
+                            })
+                        });
+                    }
+                }
 			}
 
 			series.push({
@@ -441,7 +1014,7 @@ define(['app', 'report/helpers'], function (app, reportHelpers) {
 				convertZeroToNull: true,
 				showWithoutDatapoints: false,
 				yAxis: 1,
-				data: data.items.map(function (item) {
+				data: actualItems.map(function (item) {
 					return {
 						x: +(new Date(item.date)),
 						y: item.cost

--- a/www/app/report/helpers.js
+++ b/www/app/report/helpers.js
@@ -1,7 +1,30 @@
 define(function() {
     return {
-        addTrendData: addTrendData
+        addTrendData: addTrendData,
+        addOneYear: addOneYear,
+        formatContractMonthLabel: formatContractMonthLabel
     };
+
+    function addOneYear(isoDate, direction) {
+        if (!isoDate || !/^\d{4}-\d{2}-\d{2}$/.test(isoDate)) { return null; }
+        var d = new Date(isoDate + 'T00:00:00');
+        if (isNaN(d.getTime())) { return null; }
+        var origMonth = d.getMonth();
+        var origDay   = d.getDate();
+        d.setFullYear(d.getFullYear() + (direction || 1));
+        if (origMonth === 1 && origDay === 29 && d.getMonth() === 2) { d.setDate(28); }
+        return d.getFullYear() + '-'
+             + String(d.getMonth() + 1).padStart(2, '0') + '-'
+             + String(d.getDate()).padStart(2, '0');
+    }
+
+    function formatContractMonthLabel(start, end) {
+        var monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        var endDay = new Date(end.getTime() - 1);
+        return monthNames[start.getMonth()] + ' ' + start.getDate()
+             + ' \u2013 ' + monthNames[endDay.getMonth()] + ' ' + endDay.getDate()
+             + ' ' + endDay.getFullYear();
+    }
 
     function addTrendData(items, key) {
         return items.map(function (item, index) {

--- a/www/index.html
+++ b/www/index.html
@@ -85,6 +85,7 @@
 		<link rel="stylesheet" href="css/jquery.uix.multiselect.css">
 		<link rel="stylesheet" href="font-awesome/css/fontawesome.min.css">
 		<link rel="stylesheet" href="font-awesome/css/solid.min.css">
+		<link rel="stylesheet" href="font-awesome/css/regular.min.css">
 		<link rel="stylesheet" href="css/style.css">
 		<link rel="stylesheet" href="css/weather.css">
 		<link rel="stylesheet" href="css/colpick.css">


### PR DESCRIPTION
## Summary

- Adds a **Custom** option to the year dropdown on the device report page, letting users enter a contract start date and view 12 rolling contract months (e.g. 14 Jul 2025 – 13 Jul 2026)
- Forecast for remaining months is based on the previous year's same periods (actual-to-date + remaining forecast = full-year estimate)
- Export to Excel (SpreadsheetML, no format-mismatch warning), CSV, and clipboard
- Currency sign shown after all cost fields; month abbreviations use the translation system

## Key changes

- `DeviceReport.js/html`: custom year picker, date input, localStorage persistence per device, human-readable date range in page title
- `EnergyMultiCounterReport.js`: `getContractMonthData()` groups raw daily records into rolling 12 contract periods; forecast uses sum of previous year daily values (robust against backend today-partial counter artifact); `forecastFullYear.total` = actual-to-date + remaining forecast months
- `CounterReport.js`: DataTables reinit fix, tfoot accent-colour style, export functions, month-sort fix
- `helpers.js`: `addOneYear()` with local-date getters, `formatContractMonthLabel()`
- `WebServerHandleGraphUtils.cpp`: `CalcMonthYearRange()` validates and applies `actstart`/`actend` query parameters
- `WebServerHandleGraphMonthYear.cpp`: passes `actstart`/`actend` through to the calendar query
- `www/index.html`: load Font Awesome `regular.min.css` for outline export icons

## Test plan

- [ ] Select **Custom** year, pick a contract start date, verify 12 rolling months appear
- [ ] Verify forecast rows (italic) show for future months, totals match actual + forecast
- [ ] Verify Forecast full year = sum of all rows in table
- [ ] Export to Excel opens without format-mismatch warning
- [ ] Export to CSV and clipboard work correctly
- [ ] Switch back to a calendar year — report works as before
- [ ] Test in dark theme — tfoot row uses accent colour correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)