### PR TITLE
fix race condition that prevents switchtype from beeing set

### DIFF
--- a/hardware/Matter.cpp
+++ b/hardware/Matter.cpp
@@ -926,8 +926,8 @@ void CMatter::SendGeneralSwitchInt(int domoticzID, int unit, int battery, int va
 	char szDevID[16];
 	snprintf(szDevID, sizeof(szDevID), "%08X", (unsigned int)domoticzID);
 	bool isNew = m_sql.safe_query(
-		"SELECT ID FROM DeviceStatus WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d",
-		m_HwdID, szDevID, unit).empty();
+		"SELECT ID FROM DeviceStatus WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d AND SwitchType=%d",
+		m_HwdID, szDevID, unit, switchType).empty();
 
 	SendGeneralSwitch(domoticzID, unit, battery, value, level, label, "");
 	_ApplySwitchTypeOnCreate(domoticzID, unit, isNew, switchType);


### PR DESCRIPTION
This is a quick fix for issue #6776 and I don't know if you would want it this way.
But it definitly solves the issue.
The problem:
When a new switch device was created there was a race condition between creation and setting of switchtype, which led to the switchtype not being set. Creation is asynchronous and the device might not be created when switchtype is updated.
With this fix the switchtype is also checked and is set on a later call of `SendGeneralSwitchInt()`.

Another way would be to wait for the actual creation and then set the switchtype.