### PR TITLE
fix(dashboard): counter/energy charts show UTC instead of local time in dynamic dashboard

### DIFF
--- a/www/app/dashboardDynamic/widgets/ddEnergyChart.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddEnergyChart.widget.js
@@ -296,7 +296,8 @@ define([
                         },
                         legend:    { enabled: false },
                         credits:   { enabled: false },
-                        exporting: { enabled: false }
+                        exporting: { enabled: false },
+                        time:      { useUTC: false }
                     };
                 }
 


### PR DESCRIPTION
## Problem
Counter/Energy chart widgets in the dynamic dashboard display timestamps in UTC instead of the browser's local timezone. Regular chart views outside the dynamic dashboard show correct local time.

## Root Cause
`baseChartOptions()` in `ddEnergyChart.widget.js` does not set `time.useUTC`, so Highcharts defaults to `useUTC: true`. The data points use `parseDateLocal()` which creates local timestamps, but Highcharts interprets them as UTC when rendering the x-axis labels and tooltips.

The regular log page charts handle this correctly in `RefreshingChart.js` via `time: { timezone: Intl.DateTimeFormat().resolvedOptions().timeZone }`.

## Fix
Add `time: { useUTC: false }` to chart options in `baseChartOptions()`. This makes Highcharts interpret the locally-created timestamps as local time, matching the behavior of charts outside the dynamic dashboard.

1 line change, affects all chart types in the Counter/Energy widget (day, week, month, year, shortlog, compare).

Fixes #6770