### PR TITLE
fix(solaredge): add missing return statements in isDaylightWindow()

### DIFF
--- a/hardware/SolarEdgeAPI.cpp
+++ b/hardware/SolarEdgeAPI.cpp
@@ -252,9 +252,9 @@ bool SolarEdgeAPI::isDaylightWindow()
 	int sunRise = getSunRiseSunSetMinutes(true);
 	int sunSet = getSunRiseSunSetMinutes(false);
 	if (ActHourMin + 60 < sunRise)
-		false;
+		return false;
 	if (ActHourMin - 60 > sunSet)
-		false;
+		return false;
 	return true;
 }
 


### PR DESCRIPTION
## Root Cause

`isDaylightWindow()` in `SolarEdgeAPI.cpp` had two bare `false;` expressions instead of `return false;` statements. These no-op expressions meant the function always returned `true`, regardless of time of day.

## Impact

Because the daylight window check never actually worked:
- Optimizer data was polled during nighttime hours, keeping stale power readings displayed after sunset
- Inverter details were fetched at night
- Overview data was polled outside daylight hours

SolarEdge panels with optimizers would show the last received power value indefinitely after sunset instead of zeroing out.

## Fix

Added the missing `return` keyword to both conditions in `isDaylightWindow()`.

Fixes #6774