### PR TITLE
fix for race condition in device creation

### DIFF
--- a/hardware/Matter.cpp
+++ b/hardware/Matter.cpp
@@ -908,7 +908,7 @@ void CMatter::_DetectAndSendNode(int nodeId)
 // path share identical formatting and SQL.
 void CMatter::_ApplySwitchTypeOnCreate(int domoticzID, int unit, bool wasNew, _eSwitchType switchType)
 {
-	if (!wasNew || switchType == STYPE_OnOff)
+	if (!wasNew || switchType == STYPE_OnOff || !m_sql.m_bAcceptNewHardware)
 		return;
 	char szDevID[16];
 	snprintf(szDevID, sizeof(szDevID), "%08X", (unsigned int)domoticzID);

--- a/hardware/Matter.cpp
+++ b/hardware/Matter.cpp
@@ -921,7 +921,7 @@ void CMatter::_ApplySwitchTypeOnCreate(int domoticzID, int unit, bool wasNew, _e
 			m_HwdID, szDevID, unit);
 		if (!result.empty())
 			break;
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		sleep_milliseconds(50);
 	}
 
 	m_sql.safe_query(

--- a/hardware/Matter.cpp
+++ b/hardware/Matter.cpp
@@ -912,6 +912,18 @@ void CMatter::_ApplySwitchTypeOnCreate(int domoticzID, int unit, bool wasNew, _e
 		return;
 	char szDevID[16];
 	snprintf(szDevID, sizeof(szDevID), "%08X", (unsigned int)domoticzID);
+
+	//check and wait for device creation
+	for (int i = 0; i < 20; i++)
+        {
+            auto result = m_sql.safe_query(
+                "SELECT ID FROM DeviceStatus WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d",
+                m_HwdID, szDevID, unit);
+            if (!result.empty())
+                break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+
 	m_sql.safe_query(
 		"UPDATE DeviceStatus SET SwitchType=%d "
 		"WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d",

--- a/hardware/Matter.cpp
+++ b/hardware/Matter.cpp
@@ -915,14 +915,14 @@ void CMatter::_ApplySwitchTypeOnCreate(int domoticzID, int unit, bool wasNew, _e
 
 	//check and wait for device creation
 	for (int i = 0; i < 20; i++)
-        {
-            auto result = m_sql.safe_query(
-                "SELECT ID FROM DeviceStatus WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d",
-                m_HwdID, szDevID, unit);
-            if (!result.empty())
-                break;
-            std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        }
+	{
+    	auto result = m_sql.safe_query(
+			"SELECT ID FROM DeviceStatus WHERE HardwareID=%d AND DeviceID='%q' AND Unit=%d",
+			m_HwdID, szDevID, unit);
+		if (!result.empty())
+			break;
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
 
 	m_sql.safe_query(
 		"UPDATE DeviceStatus SET SwitchType=%d "


### PR DESCRIPTION
see issue #6776 
There is a race condition in slower systems (rpi 4 in my case) where `_ApplySwitchTypeOnCreate` fails because the device is not created yet. This PR fixes this by introducing a wait loop that loops for a maximum of 20 time and sleeps 5ms each time.
This way it is ensured that the device that is updated already exists in the database.

Without this PR most switches that are newly created have the default switchtype.
With this PR all switches are created correctly.