### PR TITLE
fix: correct AirQuality compare-view divisor from 10 to 1

### DIFF
--- a/main/WebServerHandleGraphMonthYear.cpp
+++ b/main/WebServerHandleGraphMonthYear.cpp
@@ -1871,7 +1871,7 @@ static void HandleGraphMonthYear_Counter(
 		if (!sgroupby.empty())
 		{
 			root["title"] = "Comparing " + sensor;
-			webserver.MakeCompareDataSensor(root, sgroupby, dbasetable, idx, "Value3", 10.0);
+			webserver.MakeCompareDataSensor(root, sgroupby, dbasetable, idx, "Value3", 1.0);
 			if (sql.m_weightscale != 1.0)
 			{
 				for (auto& itt : root["result"])


### PR DESCRIPTION
MakeCompareDataSensor was called with divisor 10.0 for pTypeAirQuality, causing monthly averages in the bottom compare panel to be 10x too low (e.g. 1000 ppb shown as 100 ppb). Unlike pTypeWEIGHT which stores values scaled by 10 internally, VOC/AirQuality stores raw integer readings that need no scaling.