### PR TITLE
fix(mqtt): prevent discovery message loss during startup burst (#6754)

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -77,14 +77,15 @@ MQTTAutoDiscover::MQTTAutoDiscover(const int ID, const std::string& Name, const 
 
 void MQTTAutoDiscover::on_message(const struct mosquitto_message* message)
 {
+	std::string topic = message->topic;
 	std::lock_guard<std::mutex> lock(m_inc_msg_mutex);
-	if (m_incoming_messages.size() > 1000)
+	if (m_incoming_messages.size() > 10000)
 	{
 		//Prevent flooding
+		Log(LOG_ERROR, "MQTT Auto Discover: Incoming message queue full! Dropping message on topic: %s", topic.c_str());
 		return;
 	}
 
-	std::string topic = message->topic;
 	std::string qMessage;
 	if (message->payload != nullptr && message->payloadlen > 0)
 		qMessage = std::string((char*)message->payload, (char*)message->payload + message->payloadlen);
@@ -6575,7 +6576,7 @@ bool MQTTAutoDiscover::StopHardware()
 
 void MQTTAutoDiscover::Do_Work()
 {
-	while (!IsStopRequested(1000))
+	while (!IsStopRequested(100))
 	{
 		if (m_bDisconnected)
 		{


### PR DESCRIPTION
  This PR fixes the issue where some MQTT devices (especially Zigbee2MQTT lights) wouldn't show up after a restart.

  It turns out there is a hardcoded limit of 1,000 messages in the incoming queue. In larger setups—like the one in #6754 which had ~1,100 discovery messages—the initial burst of retained messages on startup would
  overflow the queue and cause configuration messages to be dropped.

  Changes:
   - Increased the queue limit from 1,000 to 10,000.
   - Reduced the poll interval from 1s to 100ms to drain the queue faster.
   - Added a log warning if the queue ever hits the limit again to make future issues easier to spot.

  Fixes #6754
