### PR TITLE
feat(plugins): bidirectional plugin-frontend WebSocket channel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,8 @@ hardware/plugins/Plugins.cpp
 hardware/plugins/PluginManager.cpp
 hardware/plugins/PluginProtocols.cpp
 hardware/plugins/PluginTransports.cpp
+hardware/plugins/PluginWebSocketRegistry.cpp
+hardware/plugins/PluginWebSocketBridge.cpp
 hardware/plugins/PythonObjects.cpp
 hardware/plugins/PythonObjectEx.cpp
 notifications/NotificationBase.cpp

--- a/docs/Developing_a_Python_plugin.wiki
+++ b/docs/Developing_a_Python_plugin.wiki
@@ -2034,6 +2034,46 @@ Called just before a device owned by the plugin is being removed, for example by
 
 *Parameters: DeviceID, Unit, Level, Description
 *Can be overidden or Device or Unit objects, see documentation elsewhere in this page
+|-
+|onWebSocketMessage
+|Parameters: Data (String).
+
+Called when a frontend page sends a <code>plugin_command</code> WebSocket message addressed to this plugin.
+<code>Data</code> is always a plain Python <code>str</code>.  When the frontend sent a JavaScript object
+(e.g. <code>livesocket.sendPluginCommand('MyPlugin', {cmd:'toggle'})</code>), it arrives as a JSON string;
+call <code>json.loads(Data)</code> to obtain the dict.
+
+This callback is optional.  If the plugin does not define it, inbound commands are silently dropped.
+An exception raised inside the callback is caught and logged by the framework; it does not crash Domoticz
+or block the WebSocket.
+
+Example:<syntaxhighlight lang="python3">
+import json
+
+class BasePlugin:
+    def onWebSocketMessage(self, Data):
+        try:
+            msg = json.loads(Data)
+        except ValueError:
+            msg = {"raw": Data}
+        Domoticz.Log("Received from frontend: " + str(msg))
+        # Respond to a ping command with a pong; echo everything else back
+        if isinstance(msg, dict) and msg.get("cmd") == "ping":
+            Domoticz.WebSocketSend({
+                "type": "pong",
+                "hwid": Parameters["HardwareID"],
+                "ts": msg.get("ts"),
+            })
+        else:
+            Domoticz.WebSocketSend({"echo": msg})
+</syntaxhighlight>
+
+When the frontend sends <code>{"cmd":"ping","ts":&lt;ms&gt;}</code> the plugin replies with
+<code>{"type":"pong","hwid":&lt;int&gt;,"ts":&lt;ms&gt;}</code> — the <code>ts</code> value is echoed
+back so the caller can measure round-trip latency.  Any other payload produces a generic
+<code>{"echo": ...}</code> response, which remains useful for ad-hoc debugging.
+
+See also: [[#Plugin WebSocket Channel|Plugin WebSocket Channel]] (UI section).
 |}
 
 ==C++ Callable API==
@@ -2303,6 +2343,49 @@ class myDevice(Domoticz.Device):
 
 Domoticz.Register(Device=myDevice, Unit=myUnit)
 </syntaxhighlight>
+|-
+|WebSocketSend
+|Parameters: Payload (String or Dictionary, required).
+
+Push a message to every frontend WebSocket client that is currently subscribed to <code>plugin:&lt;key&gt;</code>,
+where <code>&lt;key&gt;</code> is this plugin's <code>key</code> attribute from its XML definition.
+
+*If Payload is a '''Dictionary''' it is automatically serialised to a JSON string before delivery.
+  Integer values support the full 64-bit range (including JavaScript millisecond timestamps
+  such as <code>Date.now()</code> ≈ 1.7×10<sup>12</sup>) on all platforms; there is no 32-bit truncation.
+*If Payload is a '''String''' it is delivered as a string value in the frame's <code>data</code> field.
+
+The call is non-blocking and returns immediately regardless of the number of connected clients.
+The message is delivered only to clients that have previously called <code>livesocket.subscribePlugin('&lt;key&gt;')</code>.
+
+Each delivered WebSocket frame has the structure:
+<syntaxhighlight lang="json">
+{
+  "event":  "plugin",
+  "plugin": "<key>",
+  "hwid":   <HardwareID>,
+  "data":   <payload>
+}
+</syntaxhighlight>
+
+where <code>hwid</code> identifies the originating hardware instance so the page can distinguish between
+multiple simultaneous instances of the same plugin type.
+
+Usage:<syntaxhighlight lang="python3">
+import Domoticz
+
+class BasePlugin:
+    def onHeartbeat(self):
+        # Send a dict — automatically JSON-encoded
+        Domoticz.WebSocketSend({"counter": self._counter, "status": "ok"})
+        self._counter += 1
+
+    def onWebSocketMessage(self, Data):
+        # React to a command from the page
+        Domoticz.WebSocketSend({"ack": True})
+</syntaxhighlight>
+
+Available in both the legacy <code>Domoticz</code> and extended <code>DomoticzEx</code> plugin frameworks.
 |-
 |Dump
 |Parameters: Object (Optional).
@@ -2602,6 +2685,235 @@ Example of custom page with access to AngularJS and domoticzApi service:<syntaxh
 </script>
 </syntaxhighlight>
 
+===Plugin WebSocket Channel===
+
+Plugins can open a real-time bidirectional channel between the C++ plugin process and any
+browser page that subscribes to it.  No HTTP polling is needed; messages are pushed over the
+same persistent WebSocket connection that Domoticz already uses for device updates.
+
+====Channel key and multi-instance behaviour====
+
+The channel is identified by the '''plugin key''': the <code>key</code> attribute in the plugin's XML
+<code>&lt;plugin&gt;</code> tag.  This is the same value used in <code>Parameters["Key"]</code> inside the plugin.
+
+<blockquote>'''Important — key must match exactly.'''
+The string passed to <code>livesocket.subscribePlugin()</code>, <code>livesocket.sendPluginCommand()</code>,
+and the topic suffix in <code>{"event":"subscribe","topic":"plugin:&lt;key&gt;"}</code> must be the
+''exact'' value of the XML <code>key</code> attribute (also visible as <code>CPlugin::m_PluginKey</code>
+in C++ and in the <code>"plugin"</code> field of every <code>plugin_command_ack</code> frame).
+A mismatch results in silently receiving nothing — the server logs a status line when a
+<code>plugin_command</code> targets a key with no running instances.</blockquote>
+
+Example — plugin XML and the matching frontend call:
+<syntaxhighlight lang="python3">
+# plugin.py  —  the key is "MyPlugin"
+"""
+<plugin key="MyPlugin" name="My Plugin" author="me" version="1.0.0">
+    ...
+</plugin>
+"""
+</syntaxhighlight>
+<syntaxhighlight lang="javascript">
+// custom page — must use the identical string "MyPlugin"
+livesocket.subscribePlugin('MyPlugin');
+livesocket.sendPluginCommand('MyPlugin', { cmd: 'toggle' });
+</syntaxhighlight>
+
+When more than one hardware entry uses the same plugin (i.e. the same <code>key</code>), all
+running instances share the channel:
+
+*'''Outbound (plugin → page):''' A message sent by any instance is delivered to every subscribed
+ page, tagged with the originating <code>hwid</code> (HardwareID integer) so the page can tell
+ instances apart.
+*'''Inbound (page → plugin):''' A <code>plugin_command</code> frame fans out to every running
+ instance unless the page supplies a specific <code>hwid</code> to target one instance only.
+
+====Plugin-side API====
+
+;Push a message from Python to subscribed pages
+:<code>Domoticz.WebSocketSend(payload)</code> — payload may be a <code>dict</code> (auto-JSON) or <code>str</code>.
+
+;Receive a message from a page
+: Implement <code>onWebSocketMessage(self, Data)</code>.  <code>Data</code> is always a <code>str</code>;
+  call <code>json.loads(Data)</code> if the page sent a JSON object.
+
+See [[#C++ Callable API|C++ Callable API]] (WebSocketSend) and [[#Callbacks|Callbacks]] (onWebSocketMessage)
+for full parameter documentation.
+
+====Frontend custom-page snippet====
+
+Place this in your plugin's custom HTML template (shipped in the plugin folder, copied to
+<code>www/templates/</code> by <code>onStart</code>).  The snippet follows the same AngularJS
+controller idiom used by Domoticz's own templates (e.g. <code>www/templates/Forecast.html</code>):
+
+*The root <code>&lt;div&gt;</code> carries <code>ng-app="domoticz" ng-controller="myCtrl"</code>.
+*A temporary module is declared with <code>angular.module(['myApp'], [])</code>.
+*The controller receives <code>livesocket</code> via the standard DI array.
+*All view-bound data lives on <code>$scope.*</code>; the template uses <code>ng-repeat</code> / <code>ng-click</code> — no direct <code>getElementById</code> / <code>textContent</code> writes.
+*Cleanup is done in <code>$scope.$on('$destroy', ...)</code>.
+
+<syntaxhighlight lang="html">
+<style>
+.myplugin-page { padding: 8px 4px; color: var(--dz-text, #ddd); }
+.myplugin-table-wrap {
+  max-height: 320px; overflow-y: auto;
+  border-radius: var(--dz-border-radius, 8px);
+  background: var(--dz-panel-bg, #1e1e1e); margin-top: 8px;
+}
+.myplugin-table { width: 100%; border-collapse: collapse; font-size: 0.88em; font-family: monospace; }
+.myplugin-table th {
+  position: sticky; top: 0; background: var(--dz-panel-bg, #1e1e1e);
+  color: var(--dz-text-muted, #9ab); font-weight: normal;
+  text-align: left; padding: 6px 10px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.myplugin-table td { padding: 4px 10px; border-bottom: 1px solid rgba(255,255,255,0.04); word-break: break-all; }
+.myplugin-time  { white-space: nowrap; color: var(--dz-text-muted, #9ab); }
+.myplugin-empty { text-align: center; padding: 24px; color: var(--dz-text-muted, #9ab); opacity: 0.6; }
+.myplugin-status { color: var(--dz-text-muted, #9ab); font-size: 0.85em; margin-left: 8px; }
+</style>
+
+<div ng-app="domoticz" ng-controller="myCtrl" class="myplugin-page">
+  <a class="btnstylerev" back-button>{{ ::'Back' | translate }}</a>
+  <h2 class="page-header">My Plugin Live Data</h2>
+
+  <div style="margin:8px 0;display:flex;align-items:center;gap:8px;">
+    <button class="btnstyle3" ng-click="sendCommand()">{{ ::'Send command' | translate }}</button>
+    <span class="myplugin-status" ng-if="lastSentAt">{{ ::'Sent' | translate }}: {{lastSentAt}}</span>
+  </div>
+
+  <div class="myplugin-table-wrap" id="myplugin-scroll">
+    <table class="myplugin-table">
+      <thead>
+        <tr>
+          <th class="myplugin-time">{{ ::'Time' | translate }}</th>
+          <th>{{ ::'HW' | translate }}</th>
+          <th>{{ ::'Data' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-if="!messages.length">
+          <td colspan="3" class="myplugin-empty">{{ ::'Waiting for messages…' | translate }}</td>
+        </tr>
+        <tr ng-repeat="m in messages track by m.seq">
+          <td class="myplugin-time">{{m.time}}</td>
+          <td>{{m.hwid}}</td>
+          <td>{{m.display}}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+var app = angular.module(['myApp'], []);
+app.controller('myCtrl', function ($scope, $timeout, livesocket) {
+
+  var PLUGIN = 'MyPlugin';  /* must equal the XML <plugin key="..."> value */
+  var seq    = 0;
+
+  $scope.messages   = [];   /* [{seq, time, hwid, display}] — bound to ng-repeat */
+  $scope.lastSentAt = '';
+
+  function formatData(data) {
+    /* Render both JSON objects and plain strings readably */
+    if (data === null || data === undefined) { return String(data); }
+    if (typeof data === 'string')            { return data; }
+    try { return JSON.stringify(data); } catch (e) { return String(data); }
+  }
+
+  /* Subscribe — auto-restored on WebSocket reconnect */
+  livesocket.subscribePlugin(PLUGIN);
+
+  /* Receive pushed messages from any running instance */
+  var offMessage = livesocket.onPluginMessage(PLUGIN, function (msg) {
+    /* msg = { plugin: 'MyPlugin', hwid: <int>, data: <any> } */
+    seq++;
+    var now = new Date(), pad = function (n) { return n < 10 ? '0' + n : n; };
+    $scope.messages.push({
+      seq:     seq,
+      time:    pad(now.getHours()) + ':' + pad(now.getMinutes()) + ':' + pad(now.getSeconds()),
+      hwid:    msg.hwid,
+      display: formatData(msg.data)
+    });
+    /* Scroll the table to the latest row after ng-repeat renders it */
+    $timeout(function () {
+      var el = document.getElementById('myplugin-scroll');
+      if (el) { el.scrollTop = el.scrollHeight; }
+    }, 0);
+  });
+
+  /* Send a command to all running instances */
+  $scope.sendCommand = function () {
+    livesocket.sendPluginCommand(PLUGIN, { cmd: 'toggle' });
+    $scope.lastSentAt = new Date().toLocaleTimeString();
+  };
+
+  /* Tear down on page leave */
+  $scope.$on('$destroy', function () {
+    if (offMessage) { offMessage(); offMessage = null; }
+    livesocket.unsubscribePlugin(PLUGIN);
+  });
+
+});
+</script>
+</syntaxhighlight>
+
+====Security====
+
+Only WebSocket sessions with at least <code>URIGHTS_SWITCHER</code> rights (the standard switch-permission
+level) may send inbound <code>plugin_command</code> frames.  Unauthenticated or viewer-only sessions
+receive a <code>Forbidden</code> error in the ack frame.  Payloads larger than 64 KiB are rejected
+before they reach the plugin queue.
+
+====Crash and lifecycle safety====
+
+The channel registration is handled automatically by the plugin framework:
+*The instance is registered when the plugin starts and unregistered when it stops or is deleted,
+ even if the plugin has crashed (the framework's own cleanup path removes the entry).
+*A stale registration from a previous run is silently replaced on the next start.
+*All inbound delivery is non-blocking: the WebSocket thread enqueues the message on the plugin's
+ own work queue and returns immediately, so a slow or stuck plugin never stalls the web server.
+
+====Example====
+
+A runnable demonstration is shipped under <code>plugins/examples/WebSocketChannelTest/</code>
+in the Domoticz source tree.  Domoticz scans <code>plugins/&lt;Name&gt;/plugin.py</code>
+directly and does '''not''' scan <code>plugins/examples/</code>, so to use it you must copy
+the folder to <code>plugins/WebSocketChannelTest/</code> (or any <code>plugins/&lt;Name&gt;/</code>)
+and restart Domoticz.  The plugin depth matches <code>plugins/Domoticz-MeshCore-Plugin</code>,
+so <code>domoticz_root</code> is computed with exactly 2×&nbsp;<code>..</code> as MeshCore does.
+It shows a counter pushed from the plugin on every heartbeat, a handler for inbound commands, and
+the matching HTML custom page.  The custom page (<code>wschanneltest.html</code>) follows the same
+AngularJS controller idiom as <code>www/templates/Forecast.html</code>: <code>ng-app</code>/<code>ng-controller</code>
+on the root element, <code>$scope</code>-bound data, <code>ng-repeat</code> for the message list, and
+<code>$scope.$on('$destroy', ...)</code> for teardown — making it a reference example for
+template authors.
+
+====Testing====
+
+An automated end-to-end test script is provided at <code>test/python/test_plugin_websocket.py</code>.
+It connects to a running Domoticz instance over its native WebSocket endpoint, drives the full
+outbound/inbound/fan-out/hwid-targeting/topic-filtering flow and reports PASS/FAIL per check.
+The round-trip checks (B and C) send <code>{"cmd":"ping","ts":&lt;ms&gt;}</code> and verify that the
+plugin replies with <code>{"type":"pong","tag":...,"hwid":...,"ts":&lt;ms&gt;}</code> — asserting both
+correct delivery count and that the <code>ts</code> value is echoed back unchanged.
+
+Prerequisites: the example is tracked at <code>plugins/examples/WebSocketChannelTest/</code>;
+copy that folder to <code>plugins/WebSocketChannelTest/</code> (Domoticz does not scan
+<code>plugins/examples/</code> directly).  Add it twice as hardware (Tag A and Tag B)
+and have Domoticz running, then:
+<syntaxhighlight lang="bash">
+pip install websocket-client
+python test/python/test_plugin_websocket.py [http://host:port]
+</syntaxhighlight>
+
+Environment variables <code>DOMOTICZ_URL</code>, <code>DOMOTICZ_USER</code>, <code>DOMOTICZ_PASS</code>
+override the defaults (<code>http://127.0.0.1:8080</code>, <code>admin</code>, <code>domoticz</code>).
+
+For a manual checklist see the step-by-step procedure in
+<code>Plans/plugin-websocket-channel/F7-test-harness.md</code>.
+
 ==Examples==
 There are a number of examples that are available that show potential usages and patterns that may be useful that can be found [https://github.com/domoticz/domoticz/tree/development/plugins/examples on Github]:
 {| class="wikitable"
@@ -2654,6 +2966,16 @@ There are a number of examples that are available that show potential usages and
 |-
 |Web Socket Client
 |Establishes a Web Socket connection and shows how to send and receive messages
+|-
+|WebSocketChannelTest
+|Demonstrates the bidirectional Plugin WebSocket Channel.
+
+*Pushes a heartbeat counter to subscribed frontend pages using <code>Domoticz.WebSocketSend</code>.
+*Handles inbound commands via <code>onWebSocketMessage</code>: a <code>{"cmd":"ping","ts":&lt;ms&gt;}</code>
+ payload receives a <code>{"type":"pong","tag":...,"hwid":...,"ts":&lt;ms&gt;}</code> reply; any other
+ payload is echoed back as <code>{"type":"echo",...}</code>.
+*Includes a matching custom HTML page showing live data, sent/received message log, and a send-command button.
+*Tracked under <code>plugins/examples/WebSocketChannelTest/</code>; copy to <code>plugins/WebSocketChannelTest/</code> to run (Domoticz does not scan <code>plugins/examples/</code>).
 |-
 |}
 

--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -85,6 +85,7 @@ namespace Plugins {
 		DECLARE_PYTHON_SYMBOL(char*, PyByteArray_AsString, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyLong_FromLong, long);
 		DECLARE_PYTHON_SYMBOL(PY_LONG_LONG, PyLong_AsLongLong, PyObject*);
+		DECLARE_PYTHON_SYMBOL(unsigned PY_LONG_LONG, PyLong_AsUnsignedLongLong, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyModule_GetDict, PyObject*);
 		DECLARE_PYTHON_SYMBOL(PyObject*, PyDict_New, );
 		DECLARE_PYTHON_SYMBOL(void, PyDict_Clear, PyObject *);
@@ -224,6 +225,7 @@ namespace Plugins {
 					RESOLVE_PYTHON_SYMBOL(PyByteArray_AsString);
 					RESOLVE_PYTHON_SYMBOL(PyLong_FromLong);
 					RESOLVE_PYTHON_SYMBOL(PyLong_AsLongLong);
+					RESOLVE_PYTHON_SYMBOL(PyLong_AsUnsignedLongLong);
 					RESOLVE_PYTHON_SYMBOL(PyModule_GetDict);
 					RESOLVE_PYTHON_SYMBOL(PyDict_New);
 					RESOLVE_PYTHON_SYMBOL(PyDict_Contains);
@@ -456,6 +458,7 @@ extern	SharedLibraryProxy* pythonLib;
 #define PyByteArray_AsString	pythonLib->PyByteArray_AsString
 #define PyLong_FromLong			pythonLib->PyLong_FromLong
 #define PyLong_AsLongLong		pythonLib->PyLong_AsLongLong
+#define PyLong_AsUnsignedLongLong	pythonLib->PyLong_AsUnsignedLongLong
 #define PyModule_GetDict		pythonLib->PyModule_GetDict
 #define PyDict_New				pythonLib->PyDict_New
 #define PyDict_Contains			pythonLib->PyDict_Contains

--- a/hardware/plugins/PluginManager.cpp
+++ b/hardware/plugins/PluginManager.cpp
@@ -12,6 +12,7 @@
 #include "Plugins.h"
 #include "PluginMessages.h"
 #include "PluginTransports.h"
+#include "PluginWebSocketRegistry.h"
 
 #include <json/json.h>
 #include "../../main/EventSystem.h"
@@ -296,11 +297,16 @@ namespace Plugins {
 
 	void CPluginSystem::DeregisterPlugin(const int HwdID)
 	{
-		if (m_pPlugins.count(HwdID))
+		// Hold PluginMutex for the entire count+erase sequence to avoid a TOCTOU gap.
+		// Unregister is called after erase so any concurrent lookup by the worker thread
+		// (which holds its own registry mutex) cannot see a partially-torn-down entry.
+		// Callers must invoke DeregisterPlugin only after device->Stop() has joined the
+		// plugin worker thread, guaranteeing Register() cannot race with Unregister().
 		{
 			std::lock_guard<std::mutex> l(PluginMutex);
 			m_pPlugins.erase(HwdID);
 		}
+		CPluginWebSocketRegistry::Get().Unregister(HwdID);
 	}
 
 	void* CPluginSystem::GetPreservedInterpreter(const std::string& pluginKey)

--- a/hardware/plugins/PluginMessages.h
+++ b/hardware/plugins/PluginMessages.h
@@ -7,6 +7,9 @@
 typedef unsigned char byte;
 #endif
 
+#include <boost/signals2.hpp>
+extern boost::signals2::signal<void(const std::string& pluginKey, int hwId, const std::string& jsonPayload)> sOnPluginWebSocketMessage;
+
 namespace Plugins {
 
 	extern struct PyModuleDef DomoticzExModuleDef;
@@ -589,6 +592,22 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 	  };
 	};
 
+	class onWebSocketMessageCallback : public CCallbackBase
+	{
+	public:
+		onWebSocketMessageCallback(const std::string &Data) : CCallbackBase("onWebSocketMessage"), m_Data(Data)
+		{
+			m_Name = __func__;
+		};
+		std::string m_Data;
+	protected:
+		void ProcessLocked(CPlugin* pPlugin) override
+		{
+			PyNewRef pParams = Py_BuildValue("(s)", m_Data.c_str());
+			Callback(pPlugin, pParams);
+		};
+	};
+
 	class onStopCallback : public CCallbackBase
 	{
 	public:
@@ -714,6 +733,28 @@ static std::string get_utf8_from_ansi(const std::string &utf8, int codepage)
 		void ProcessLocked(CPlugin* pPlugin) override
 		{
 			pPlugin->Notifier(m_NotifierName);
+		};
+	};
+
+	class WebSocketSendDirective : public CDirectiveBase
+	{
+	public:
+		WebSocketSendDirective(const std::string& pluginKey, int hwId, const std::string& payload)
+			: CDirectiveBase(), m_PluginKey(pluginKey), m_HwdID(hwId), m_Payload(payload)
+		{
+			m_Name = __func__;
+		};
+		std::string m_PluginKey;
+		int         m_HwdID;
+		std::string m_Payload;
+		void ProcessLocked(CPlugin* pPlugin) override
+		{
+			// Release the GIL before emitting the signal: the connected CWebSocketPush
+			// slots are pure C++ (no Python calls) but may acquire their own mutexes,
+			// and holding the GIL across them risks lock-order issues with the web-server
+			// thread.  PyAllowThreads releases GIL on construction, restores on destruction.
+			PyAllowThreads gil;
+			sOnPluginWebSocketMessage(m_PluginKey, m_HwdID, m_Payload);
 		};
 	};
 

--- a/hardware/plugins/PluginProtocols.cpp
+++ b/hardware/plugins/PluginProtocols.cpp
@@ -309,7 +309,42 @@ namespace Plugins {
 		}
 		else if (pObj.IsLong())
 		{
-			sJson += std::to_string(PyLong_AsLong(pObj));
+			// Use PyLong_AsLongLong to avoid OverflowError on Windows where
+			// C `long` is 32-bit (LLP64) but Python ints can be arbitrarily large
+			// (e.g. JS Date.now() ms timestamps ~1.7e12 > INT32_MAX).
+			long long llv = PyLong_AsLongLong(pObj);
+			if (!PyErr_Occurred())
+			{
+				sJson += std::to_string(llv);
+			}
+			else
+			{
+				// Signed 64-bit overflow — try unsigned 64-bit (values up to 2^64-1)
+				PyErr_Clear();
+				unsigned long long ullv = PyLong_AsUnsignedLongLong(pObj);
+				if (!PyErr_Occurred())
+				{
+					sJson += std::to_string(ullv);
+				}
+				else
+				{
+					// Value exceeds uint64 range; fall back to decimal string
+					// representation so the send never raises/aborts.
+					PyErr_Clear();
+					PyObject* pStr = PyObject_Str(pObj);
+					if (pStr)
+					{
+						const char* sz = PyUnicode_AsUTF8(pStr);
+						sJson += (sz ? sz : "0");
+						Py_DECREF(pStr);
+					}
+					else
+					{
+						PyErr_Clear();
+						sJson += "0";
+					}
+				}
+			}
 		}
 		else if (pObj.IsFloat())
 		{

--- a/hardware/plugins/PluginWebSocketBridge.cpp
+++ b/hardware/plugins/PluginWebSocketBridge.cpp
@@ -1,0 +1,64 @@
+#include "stdafx.h"
+
+#ifdef ENABLE_PYTHON
+
+#include "PluginWebSocketBridge.h"
+#include "PluginManager.h"
+#include "Plugins.h"
+#include "PluginMessages.h"
+#include "../../main/Logger.h"
+
+namespace Plugins
+{
+	// Declared in PluginManager.cpp — guards CPluginSystem::m_pPlugins.
+	extern std::mutex PluginMutex;
+
+	bool EnqueueWebSocketMessage(int hwId, const std::string &data)
+	{
+		CPlugin *pPlugin = nullptr;
+		{
+			CPluginSystem mgr;
+			std::map<int, CDomoticzHardwareBase *> *pPlugins = mgr.GetHardware();
+			std::lock_guard<std::mutex> l(PluginMutex);
+
+			auto it = pPlugins->find(hwId);
+			if (it == pPlugins->end())
+			{
+				_log.Debug(DEBUG_WEBSERVER, "PluginWebSocketBridge: hwId %d not found, dropping message", hwId);
+				return false;
+			}
+
+			pPlugin = dynamic_cast<CPlugin *>(it->second);
+		}
+
+		if (!pPlugin)
+		{
+			_log.Debug(DEBUG_WEBSERVER, "PluginWebSocketBridge: hwId %d is not a CPlugin, dropping message", hwId);
+			return false;
+		}
+
+		// Safe to call onWebSocketMessage() here after releasing PluginMutex: the
+		// method only enqueues onto pPlugin's own m_QueueMutex-guarded queue and
+		// does not touch the Python C-API from this thread.  pPlugin cannot be
+		// deleted while we hold no mutex because device->Stop() in mainworker.cpp
+		// joins the plugin worker thread before DeregisterPlugin() / delete runs
+		// (~lines 326, 401), ensuring the object outlives any concurrent enqueue.
+		pPlugin->onWebSocketMessage(data);
+		return true;
+	}
+
+} // namespace Plugins
+
+#else // !ENABLE_PYTHON
+
+namespace Plugins
+{
+	// No-op fallback: Python support is disabled so no plugin instances exist.
+	bool EnqueueWebSocketMessage(int /*hwId*/, const std::string & /*data*/)
+	{
+		return false;
+	}
+} // namespace Plugins
+
+#endif // ENABLE_PYTHON
+

--- a/hardware/plugins/PluginWebSocketBridge.h
+++ b/hardware/plugins/PluginWebSocketBridge.h
@@ -1,0 +1,30 @@
+#pragma once
+
+//
+// PluginWebSocketBridge
+//
+// Python-header-free interface that lets main/ enqueue an inbound websocket
+// message onto a specific plugin instance's message queue without ever touching
+// the Python C-API from the websocket thread.
+//
+// main/DomoticzWebsocketHandler.cpp includes only this header; the Python-
+// dependent implementation lives in PluginWebSocketBridge.cpp which is compiled
+// as part of the plugins module (ENABLE_PYTHON guard applies there).
+//
+
+#include <string>
+
+namespace Plugins
+{
+	// Enqueue an inbound websocket message for the plugin instance identified by
+	// hwId.  The call is non-blocking: it locks only the plugin's m_QueueMutex
+	// (a short critical section) and returns immediately.
+	//
+	// Returns true if the message was successfully enqueued, false if the plugin
+	// instance was not found or has already stopped (safe to ignore — caller
+	// should count successes for the ack reply).
+	//
+	// data: the JSON-serialised payload string forwarded from the frontend.
+	bool EnqueueWebSocketMessage(int hwId, const std::string &data);
+
+} // namespace Plugins

--- a/hardware/plugins/PluginWebSocketRegistry.cpp
+++ b/hardware/plugins/PluginWebSocketRegistry.cpp
@@ -1,0 +1,96 @@
+#include "stdafx.h"
+
+//
+// CPluginWebSocketRegistry
+//
+// Plugin key used: CPlugin::m_PluginKey (hardware/plugins/Plugins.h line ~124).
+// This is the XML <plugin key="..."> attribute passed to CPlugin's constructor as
+// PluginKey and stored verbatim.  It is constant for all instances of the same plugin
+// type (e.g. "MeshCore"), making it suitable as a fan-out channel key.
+//
+
+#include "PluginWebSocketRegistry.h"
+#include "../../main/Logger.h"
+
+CPluginWebSocketRegistry &CPluginWebSocketRegistry::Get()
+{
+	static CPluginWebSocketRegistry instance;
+	return instance;
+}
+
+void CPluginWebSocketRegistry::Register(const std::string &pluginKey, int hwId)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	// Remove any stale entry for this hwId (may be under a different key if the
+	// hardware was reconfigured, or re-registering after a framework-driven restart).
+	auto itRev = m_hwIdToKey.find(hwId);
+	if (itRev != m_hwIdToKey.end())
+	{
+		const std::string &oldKey = itRev->second;
+		if (oldKey == pluginKey)
+		{
+			// Already present under the same key; expected on a framework-driven restart
+			// where the previous Unregister was skipped (e.g. plugin re-enabled in-place).
+			_log.Log(LOG_STATUS, "PluginWebSocketRegistry: HwdID %d re-registered under '%s' (framework restart).", hwId, pluginKey.c_str());
+			return;
+		}
+		// Stale entry under a different key; clean it up.
+		auto itOld = m_keyToHwIds.find(oldKey);
+		if (itOld != m_keyToHwIds.end())
+		{
+			itOld->second.erase(hwId);
+			if (itOld->second.empty())
+				m_keyToHwIds.erase(itOld);
+		}
+		m_hwIdToKey.erase(itRev);
+		_log.Log(LOG_STATUS, "PluginWebSocketRegistry: HwdID %d re-registered from '%s' to '%s'.", hwId, oldKey.c_str(), pluginKey.c_str());
+	}
+
+	m_keyToHwIds[pluginKey].insert(hwId);
+	m_hwIdToKey[hwId] = pluginKey;
+
+	_log.Log(LOG_STATUS, "PluginWebSocketRegistry: HwdID %d registered under '%s' (%d instance(s)).",
+		hwId, pluginKey.c_str(), (int)m_keyToHwIds[pluginKey].size());
+}
+
+void CPluginWebSocketRegistry::Unregister(int hwId)
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	auto itRev = m_hwIdToKey.find(hwId);
+	if (itRev == m_hwIdToKey.end())
+		return;
+
+	const std::string key = itRev->second;
+	m_hwIdToKey.erase(itRev);
+
+	auto itFwd = m_keyToHwIds.find(key);
+	if (itFwd != m_keyToHwIds.end())
+	{
+		itFwd->second.erase(hwId);
+		if (itFwd->second.empty())
+			m_keyToHwIds.erase(itFwd);
+	}
+
+	_log.Log(LOG_STATUS, "PluginWebSocketRegistry: HwdID %d unregistered from '%s'.", hwId, key.c_str());
+}
+
+std::vector<int> CPluginWebSocketRegistry::GetInstances(const std::string &pluginKey) const
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	std::vector<int> result;
+	auto it = m_keyToHwIds.find(pluginKey);
+	if (it != m_keyToHwIds.end())
+		result.assign(it->second.begin(), it->second.end());
+	return result;
+}
+
+std::string CPluginWebSocketRegistry::GetKeyForHardware(int hwId) const
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+
+	auto it = m_hwIdToKey.find(hwId);
+	return (it != m_hwIdToKey.end()) ? it->second : std::string();
+}

--- a/hardware/plugins/PluginWebSocketRegistry.h
+++ b/hardware/plugins/PluginWebSocketRegistry.h
@@ -1,0 +1,55 @@
+#pragma once
+
+//
+// CPluginWebSocketRegistry
+//
+// Singleton that maps a stable plugin key (CPlugin::m_PluginKey, the XML <plugin key="...">
+// attribute, e.g. "MyPlugin") to the set of currently-running HardwareIDs for that plugin
+// type.  The reverse map lets an Unregister(hwId) call work without knowing the key.
+//
+// Thread-safe: all public methods acquire the internal mutex.
+//
+// Kept Python-header-free so main/ code (F3 inbound routing) can include this without
+// pulling the Python C-API headers.
+//
+
+#include <map>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+class CPluginWebSocketRegistry
+{
+public:
+	static CPluginWebSocketRegistry &Get();
+
+	// Register a running plugin instance.  If hwId is already present under any key
+	// (stale entry from a previous run) it is removed first, then added under pluginKey.
+	void Register(const std::string &pluginKey, int hwId);
+
+	// Remove a plugin instance by HardwareID from whatever key currently holds it.
+	// No-op if hwId is not found; this is expected when Start() failed before reaching
+	// Register() (so the hwId was never registered) or after a clean shutdown.
+	void Unregister(int hwId);
+
+	// Return all HardwareIDs currently registered under pluginKey.
+	std::vector<int> GetInstances(const std::string &pluginKey) const;
+
+	// Return the plugin key that hwId is currently registered under, or "" if not found.
+	std::string GetKeyForHardware(int hwId) const;
+
+private:
+	CPluginWebSocketRegistry() = default;
+	~CPluginWebSocketRegistry() = default;
+	CPluginWebSocketRegistry(const CPluginWebSocketRegistry &) = delete;
+	CPluginWebSocketRegistry &operator=(const CPluginWebSocketRegistry &) = delete;
+
+	mutable std::mutex m_mutex;
+
+	// pluginKey -> set of active HardwareIDs for that plugin type
+	std::map<std::string, std::set<int>> m_keyToHwIds;
+
+	// reverse: HardwareID -> pluginKey
+	std::map<int, std::string> m_hwIdToKey;
+};

--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -11,6 +11,7 @@
 #include "PluginMessages.h"
 #include "PluginProtocols.h"
 #include "PluginTransports.h"
+#include "PluginWebSocketRegistry.h"
 #include "PythonObjects.h"
 #include "PythonPluginUtils.h"
 
@@ -650,6 +651,61 @@ namespace Plugins
 		Py_RETURN_NONE;
 	}
 
+	static PyObject *PyDomoticz_WebSocketSend(PyObject *self, PyObject *args, PyObject *kwds)
+	{
+		module_state *pModState = CPlugin::FindModule();
+		if (!pModState)
+		{
+			Py_RETURN_NONE;
+		}
+		else if (!pModState->pPlugin)
+		{
+			_log.Log(LOG_ERROR, "CPlugin:%s, illegal operation, Plugin has not started yet.", __func__);
+			Py_RETURN_NONE;
+		}
+
+		PyObject *pPayload = nullptr;
+		static char *kwlist[] = { "data", nullptr };
+		if (!PyArg_ParseTupleAndNormalizedKeywords(args, kwds, "O", kwlist, &pPayload))
+		{
+			pModState->pPlugin->Log(LOG_ERROR, "%s: Failed to parse parameters, expected a str or dict.", __func__);
+			pModState->pPlugin->LogPythonException(std::string(__func__));
+			Py_RETURN_NONE;
+		}
+
+		std::string sPayload;
+		PyBorrowedRef brPayload(pPayload);
+		if (brPayload.IsString())
+		{
+			// JSON-encode the Python str as a JSON string literal so that
+			// SendPluginMessage's ParseJSon round-trip always succeeds and
+			// json["data"] receives the correct string value.  Without this,
+			// a bare unquoted string like "raw-string-..." would be passed to
+			// ParseJSon, which fails on it (not valid JSON), and the else-branch
+			// assigns the raw string directly — but only if ParseJSon truly
+			// returns false every time.  Encoding here makes the behaviour
+			// explicit and identical on all jsoncpp build configurations.
+			std::string rawStr = std::string(brPayload);
+			sPayload = Json::valueToQuotedString(rawStr.c_str());
+		}
+		else if (brPayload.IsDict())
+		{
+			CPluginProtocolJSON jsonProtocol;
+			sPayload = jsonProtocol.PythontoJSON(pPayload);
+		}
+		else
+		{
+			pModState->pPlugin->Log(LOG_ERROR, "%s: Parameter must be a str or dict.", __func__);
+			Py_RETURN_NONE;
+		}
+
+		std::string sPluginKey = pModState->pPlugin->m_PluginKey;
+		int hwId = pModState->pPlugin->m_HwdID;
+		pModState->pPlugin->MessagePlugin(new WebSocketSendDirective(sPluginKey, hwId, sPayload));
+
+		Py_RETURN_NONE;
+	}
+
 	static PyMethodDef DomoticzMethods[] = { { "Debug", PyDomoticz_Debug, METH_VARARGS, "Write a message to Domoticz log only if verbose logging is turned on." },
 						 { "Log", PyDomoticz_Log, METH_VARARGS, "Write a message to Domoticz log." },
 						 { "Status", PyDomoticz_Status, METH_VARARGS, "Write a status message to Domoticz log." },
@@ -663,6 +719,8 @@ namespace Plugins
 						 { "Configuration", (PyCFunction)PyDomoticz_Configuration, METH_VARARGS | METH_KEYWORDS, "Retrieve and Store structured plugin configuration." },
 						 { "Register", (PyCFunction)PyDomoticz_Register, METH_VARARGS | METH_KEYWORDS, "Register Device override class." },
 						 { "Dump", (PyCFunction)PyDomoticz_Dump, METH_VARARGS | METH_KEYWORDS, "Dump string values of an object or all locals to the log." },
+						 { "WebSocketSend", (PyCFunction)PyDomoticz_WebSocketSend, METH_VARARGS | METH_KEYWORDS,
+										   "Send a message to frontend pages subscribed to this plugin's websocket channel. Accepts a str (raw text/JSON) or a dict (serialised to JSON)." },
 						 { nullptr, nullptr, 0, nullptr } };
 
 	PyType_Slot ConnectionSlots[] = {
@@ -1921,6 +1979,7 @@ namespace Plugins
 			m_bIsStarted = true;
 			m_bIsStarting = false;
 			m_bIsStopped = false;
+			CPluginWebSocketRegistry::Get().Register(m_PluginKey, m_HwdID);
 			return true;
 		}
 		catch (...)
@@ -2409,6 +2468,15 @@ namespace Plugins
 	{
 		CPluginMessageBase *pMessage = new onDeviceRemovedCallback(DeviceID, Unit);
 		MessagePlugin(pMessage);
+	}
+
+	void CPlugin::onWebSocketMessage(const std::string &Data)
+	{
+		if (m_bDebug & PDM_QUEUE)
+		{
+			Debug(DEBUG_PYTHON, "onWebSocketMessage: queuing message, data length %zu", Data.length());
+		}
+		MessagePlugin(new onWebSocketMessageCallback(Data));
 	}
 
 	void CPlugin::DisconnectEvent(CEventBase *pMess)

--- a/hardware/plugins/Plugins.h
+++ b/hardware/plugins/Plugins.h
@@ -111,6 +111,7 @@ namespace Plugins {
 	  void onDeviceAdded(const std::string DeviceID, int Unit);
 	  void onDeviceModified(const std::string DeviceID, int Unit);
 	  void onDeviceRemoved(const std::string DeviceID, int Unit);
+	  void onWebSocketMessage(const std::string &Data);
 	  void MessagePlugin(CPluginMessageBase *pMessage);
 	  void DeviceAdded(const std::string DeviceID, int Unit);
 	  void DeviceModified(const std::string DeviceID, int Unit);

--- a/main/DomoticzWebsocketHandler.cpp
+++ b/main/DomoticzWebsocketHandler.cpp
@@ -2,11 +2,15 @@
 #include "DomoticzWebsocketHandler.h"
 
 #include <utility>
+#include <algorithm>
 #include "mainworker.h"
 #include "Helper.h"
 #include "json_helper.h"
 #include <libwebem/cWebem.h>
+#include <libwebem/session.h>
 #include "Logger.h"
+#include "../hardware/plugins/PluginWebSocketRegistry.h"
+#include "../hardware/plugins/PluginWebSocketBridge.h"
 
 
 namespace http {
@@ -122,6 +126,11 @@ namespace http {
 				else if (szEvent == "unsubscribe_devices")
 				{
 					if (HandleUnsubscribeDevices(value, outbound))
+						return true;
+				}
+				else if (szEvent == "plugin_command")
+				{
+					if (HandlePluginCommand(value, outbound))
 						return true;
 				}
 			}
@@ -377,6 +386,133 @@ namespace http {
 			json["message"] = szMessage;
 			std::string response = json.toStyledString();
 			MyWrite(response);
+		}
+
+		// Maximum byte length accepted for a plugin_command payload (64 KiB).
+		// DoS protection: caps the per-message allocation on the plugin's queue so
+		// that a misbehaving or compromised frontend cannot exhaust process memory
+		// by flooding large payloads before the plugin worker thread drains them.
+		static constexpr size_t kPluginCommandMaxPayloadBytes = 65536;
+
+		bool CDomoticzWebsocketHandler::HandlePluginCommand(const Json::Value& value, const bool outbound)
+		{
+			// Security: only URIGHTS_SWITCHER or above may send commands.
+			// This mirrors the rights level enforced for device-command operations
+			// (Cmd_UpdateDevice and sSwitcherCommands in WebServerCommands.cpp).
+			// The upper-bound guard rejects URIGHTS_NONE (254) and URIGHTS_CLIENTID (255)
+			// which are numerically above URIGHTS_ADMIN (2) and must not be allowed.
+			if (m_session.rights < URIGHTS_SWITCHER || m_session.rights > URIGHTS_ADMIN)
+			{
+				_log.Log(LOG_ERROR, "WebSocket plugin_command: rejected, insufficient rights (user '%s')", m_session.username.c_str());
+				Json::Value resp;
+				resp["event"] = "plugin_command_ack";
+				resp["error"] = "Forbidden";
+				MyWrite(JSonToFormatString(resp));
+				return true;
+			}
+
+			// Validate required fields.
+			if (!value.isMember("plugin") || !value["plugin"].isString())
+			{
+				_log.Log(LOG_ERROR, "WebSocket plugin_command: missing or non-string 'plugin' field");
+				return false;
+			}
+			const std::string pluginKey = value["plugin"].asString();
+			if (pluginKey.empty())
+			{
+				_log.Log(LOG_ERROR, "WebSocket plugin_command: empty 'plugin' field");
+				return false;
+			}
+			if (!value.isMember("data"))
+			{
+				_log.Log(LOG_ERROR, "WebSocket plugin_command: missing 'data' field");
+				return false;
+			}
+
+			// Serialise the data payload for the plugin queue.
+			std::string dataStr;
+			const Json::Value& dataVal = value["data"];
+			if (dataVal.isString())
+				dataStr = dataVal.asString();
+			else
+				dataStr = JSonToFormatString(dataVal);
+
+			// Reject oversized payloads before touching any plugin state.
+			if (dataStr.size() > kPluginCommandMaxPayloadBytes)
+			{
+				_log.Log(LOG_ERROR, "WebSocket plugin_command: payload too large (%zu bytes, max %zu)", dataStr.size(), kPluginCommandMaxPayloadBytes);
+				Json::Value resp;
+				resp["event"] = "plugin_command_ack";
+				resp["plugin"] = pluginKey;
+				resp["error"] = "Payload too large";
+				resp["delivered"] = 0;
+				MyWrite(JSonToFormatString(resp));
+				return true;
+			}
+
+			// Determine target instance(s).
+			std::vector<int> hwIds = CPluginWebSocketRegistry::Get().GetInstances(pluginKey);
+			if (hwIds.empty())
+			{
+				_log.Debug(DEBUG_WEBSERVER, "WebSocket plugin_command: no running instances for plugin '%s'", pluginKey.c_str());
+				_log.Log(LOG_STATUS, "WebSocket plugin_command: plugin '%s' is not subscribed or not running (check plugin key)", pluginKey.c_str());
+				Json::Value resp;
+				resp["event"] = "plugin_command_ack";
+				resp["plugin"] = pluginKey;
+				resp["delivered"] = 0;
+				MyWrite(JSonToFormatString(resp));
+				return true;
+			}
+
+			// Optional single-instance targeting.
+			if (value.isMember("hwid") && value["hwid"].isInt())
+			{
+				int targetHwId = value["hwid"].asInt();
+				hwIds.erase(
+					std::remove_if(hwIds.begin(), hwIds.end(), [targetHwId](int id) { return id != targetHwId; }),
+					hwIds.end());
+			}
+
+			// Fan out — each call is non-blocking (enqueues onto the plugin's own queue).
+			int delivered = 0;
+			for (int hwId : hwIds)
+			{
+				if (Plugins::EnqueueWebSocketMessage(hwId, dataStr))
+					++delivered;
+			}
+
+			_log.Debug(DEBUG_WEBSERVER, "WebSocket plugin_command: plugin '%s', delivered to %d instance(s)", pluginKey.c_str(), delivered);
+
+			Json::Value resp;
+			resp["event"] = "plugin_command_ack";
+			resp["plugin"] = pluginKey;
+			resp["delivered"] = delivered;
+			MyWrite(JSonToFormatString(resp));
+			return true;
+		}
+
+		void CDomoticzWebsocketHandler::SendPluginMessage(const std::string& pluginKey, int hwId, const std::string& jsonPayload)
+		{
+			if (!isSubscribed("plugin:" + pluginKey))
+				return;
+			try
+			{
+				Json::Value json;
+				json["event"] = "plugin";
+				json["plugin"] = pluginKey;
+				json["hwid"] = hwId;
+				Json::Value data;
+				if (ParseJSon(jsonPayload, data))
+					json["data"] = data;
+				else
+					json["data"] = jsonPayload;
+				std::string response = json.toStyledString();
+				MyWrite(response);
+			}
+			catch (std::exception& e)
+			{
+				_log.Log(LOG_ERROR, "WebsocketHandler::%s Exception: %s", __func__, e.what());
+			}
 		}
 	} // namespace server
 } // namespace http

--- a/main/DomoticzWebsocketHandler.h
+++ b/main/DomoticzWebsocketHandler.h
@@ -38,6 +38,7 @@ namespace http
 			void OnSceneChanged(uint64_t SceneRowIdx);
 			void SendNotification(const std::string& Subject, const std::string& Text, const std::string& ExtraData, int Priority, const std::string& Sound, bool bFromNotification);
 			void SendLogMessage(int iLevel, const std::string& szMessage);
+			void SendPluginMessage(const std::string& pluginKey, int hwId, const std::string& jsonPayload);
 
 			bool subscribeTo(const std::string& szTopic);
 			bool unsubscribeFrom(const std::string& szTopic);
@@ -53,6 +54,7 @@ namespace http
 			bool HandleSubscribe(const std::string& szEvent, const Json::Value& value, bool outbound);
 			bool HandleUnsubscribe(const std::string& szEvent, const Json::Value& value, bool outbound);
 			bool HandleUnsubscribeDevices(const Json::Value& value, bool outbound);
+			bool HandlePluginCommand(const Json::Value& value, bool outbound);
 			bool isSubscribed(const std::string& szTopic);
 			std::map<std::string, bool> m_subscribed_topics;
 			std::map<uint64_t, bool> m_subscribed_devices;

--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -323,10 +323,10 @@ void MainWorker::StopDomoticzHardware()
 
 	for (auto& device : OrgHardwaredevices)
 	{
+		device->Stop(); // joins the plugin worker thread before deregistering
 #ifdef ENABLE_PYTHON
 		m_pluginsystem.DeregisterPlugin(device->m_HwdID);
 #endif
-		device->Stop();
 		delete device;
 	}
 }
@@ -398,10 +398,10 @@ void MainWorker::RemoveDomoticzHardware(int HwdId)
 	int dpos = FindDomoticzHardware(HwdId);
 	if (dpos == -1)
 		return;
+	RemoveDomoticzHardware(m_hardwaredevices[dpos]); // calls Stop() which joins the worker thread
 #ifdef ENABLE_PYTHON
-	m_pluginsystem.DeregisterPlugin(HwdId);
+	m_pluginsystem.DeregisterPlugin(HwdId); // safe: worker is joined before this point
 #endif
-	RemoveDomoticzHardware(m_hardwaredevices[dpos]);
 }
 
 int MainWorker::FindDomoticzHardware(int HwdId)

--- a/msbuild/domoticz.vcxproj
+++ b/msbuild/domoticz.vcxproj
@@ -689,6 +689,8 @@
     <ClInclude Include="..\hardware\plugins\PluginProtocols.h" />
     <ClInclude Include="..\hardware\plugins\Plugins.h" />
     <ClInclude Include="..\hardware\plugins\PluginTransports.h" />
+    <ClInclude Include="..\hardware\plugins\PluginWebSocketRegistry.h" />
+    <ClInclude Include="..\hardware\plugins\PluginWebSocketBridge.h" />
     <ClInclude Include="..\hardware\plugins\PythonObjects.h" />
     <ClInclude Include="..\hardware\plugins\PythonPluginUtils.h" />
     <ClInclude Include="..\hardware\PVOutput_Input.h" />
@@ -995,6 +997,8 @@
     <ClCompile Include="..\hardware\plugins\PluginProtocols.cpp" />
     <ClCompile Include="..\hardware\plugins\Plugins.cpp" />
     <ClCompile Include="..\hardware\plugins\PluginTransports.cpp" />
+    <ClCompile Include="..\hardware\plugins\PluginWebSocketRegistry.cpp" />
+    <ClCompile Include="..\hardware\plugins\PluginWebSocketBridge.cpp" />
     <ClCompile Include="..\hardware\plugins\PythonObjects.cpp" />
     <ClCompile Include="..\hardware\PVOutput_Input.cpp" />
     <ClCompile Include="..\hardware\RAVEn.cpp" />

--- a/msbuild/domoticz.vcxproj.filters
+++ b/msbuild/domoticz.vcxproj.filters
@@ -2167,6 +2167,12 @@
     <ClInclude Include="..\hardware\plugins\PluginTransports.h">
       <Filter>Plugin Framework</Filter>
     </ClInclude>
+    <ClInclude Include="..\hardware\plugins\PluginWebSocketRegistry.h">
+      <Filter>Plugin Framework</Filter>
+    </ClInclude>
+    <ClInclude Include="..\hardware\plugins\PluginWebSocketBridge.h">
+      <Filter>Plugin Framework</Filter>
+    </ClInclude>
     <ClInclude Include="..\hardware\plugins\Plugins.h">
       <Filter>Plugin Framework</Filter>
     </ClInclude>
@@ -2962,6 +2968,12 @@
       <Filter>Plugin Framework</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\plugins\PluginTransports.cpp">
+      <Filter>Plugin Framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\plugins\PluginWebSocketRegistry.cpp">
+      <Filter>Plugin Framework</Filter>
+    </ClCompile>
+    <ClCompile Include="..\hardware\plugins\PluginWebSocketBridge.cpp">
       <Filter>Plugin Framework</Filter>
     </ClCompile>
     <ClCompile Include="..\hardware\plugins\Plugins.cpp">

--- a/notifications/NotificationBrowser.cpp
+++ b/notifications/NotificationBrowser.cpp
@@ -3,6 +3,9 @@
 #include <boost/signals2.hpp>
 
 boost::signals2::signal<void(const std::string &Subject, const std::string &Text, const std::string &ExtraData, const int Priority, const std::string & Sound, const bool bFromNotification)> sOnNotificationReceived;
+// Emitted from the plugin worker thread; all connected slots are protected by
+// each CDomoticzWebsocketHandler's handlerMutex and isStarted guard.
+boost::signals2::signal<void(const std::string &pluginKey, int hwId, const std::string &jsonPayload)> sOnPluginWebSocketMessage;
 
 CNotificationBrowser::CNotificationBrowser() : CNotificationBase(std::string("browser"), 0)
 {

--- a/plugins/examples/WebSocketChannelTest/plugin.py
+++ b/plugins/examples/WebSocketChannelTest/plugin.py
@@ -1,0 +1,158 @@
+"""
+<plugin key="WSChannelTest" name="WebSocket Channel Test" author="domoticz" version="1.0.5">
+    <params>
+        <param field="Mode1" label="Tag" width="120px" default="A"/>
+        <param field="Mode2" label="Web port" width="80px" default="8080"/>
+    </params>
+</plugin>
+
+EXAMPLE PLUGIN — shipping location and run location
+----------------------------------------------------
+The tracked copy of this file lives under:
+    plugins/examples/WebSocketChannelTest/
+
+Domoticz does NOT scan plugins/examples/; it only discovers plugins at
+    plugins/<Name>/plugin.py
+To use this example, copy the entire WebSocketChannelTest/ folder to the
+plugins/ directory (e.g. plugins/WebSocketChannelTest/) and restart Domoticz.
+Any name may be used for <Name>; the plugin key ("WSChannelTest") is what
+matters for the WebSocket channel topic.
+
+This plugin is run from plugins/WebSocketChannelTest/ (two directory levels
+below the Domoticz root, identical depth to plugins/Domoticz-MeshCore-Plugin).
+The domoticz_root computation therefore uses exactly 2x ".." — the same idiom
+MeshCore uses — so that www/templates/ resolves to the correct destination.
+"""
+import Domoticz
+import filecmp
+import json
+import os
+import shutil
+import tempfile
+import urllib.request
+
+
+class BasePlugin:
+    def __init__(self):
+        self.beat = 0
+        self.tag = "A"
+
+    def onStart(self):
+        self.tag = Parameters.get("Mode1", "A")
+        Domoticz.Log("WSChannelTest v%s started, tag=%s hwid=%s" % (PLUGIN_VERSION, self.tag, Parameters["HardwareID"]))
+
+        plugin_dir    = os.path.dirname(os.path.abspath(__file__))
+        template      = os.path.join(plugin_dir, "wschanneltest.html")
+        domoticz_root = os.path.abspath(os.path.join(plugin_dir, "..", ".."))
+        dest_dir      = os.path.join(domoticz_root, "www", "templates")
+        dest          = os.path.join(dest_dir, "wschanneltest.html")
+
+        os.makedirs(dest_dir, exist_ok=True)
+        if os.path.isfile(dest) and filecmp.cmp(template, dest, shallow=False):
+            Domoticz.Log("WSChannelTest: custom page already up to date")
+        else:
+            tmp_path = None
+            try:
+                fd, tmp_path = tempfile.mkstemp(prefix=".wschanneltest-", dir=dest_dir)
+                os.close(fd)
+                shutil.copy2(template, tmp_path)
+                os.replace(tmp_path, dest)
+                tmp_path = None
+                Domoticz.Log("WSChannelTest: custom page installed: %s" % dest)
+            except Exception as e:
+                if tmp_path is not None:
+                    try:
+                        os.remove(tmp_path)
+                    except OSError:
+                        pass
+                if os.path.isfile(dest):
+                    Domoticz.Log("WSChannelTest: concurrent install by sibling, dest present")
+                else:
+                    Domoticz.Error("WSChannelTest: install FAILED, dest missing: %r" % e)
+
+        Domoticz.WebSocketSend({"type": "started", "tag": self.tag})
+
+    def onHeartbeat(self):
+        self.beat += 1
+        Domoticz.WebSocketSend({"type": "tick", "tag": self.tag, "beat": self.beat})
+        # Send the raw-string payload form every 5th heartbeat (~50s cadence) so that
+        # a test client connecting at any point can observe it within a bounded window.
+        if self.beat % 5 == 0:
+            Domoticz.WebSocketSend("raw-string-from-%s-beat%d" % (self.tag, self.beat))
+
+    def onWebSocketMessage(self, Data):
+        Domoticz.Log("WSChannelTest got inbound: %s" % str(Data))
+        try:
+            payload = json.loads(Data) if isinstance(Data, str) else Data
+        except Exception:
+            payload = {"raw": str(Data)}
+        if isinstance(payload, dict) and payload.get("cmd") == "ping":
+            Domoticz.WebSocketSend({
+                "type": "pong",
+                "tag": self.tag,
+                "hwid": Parameters["HardwareID"],
+                "ts": payload.get("ts"),
+            })
+        else:
+            Domoticz.WebSocketSend({"type": "echo", "tag": self.tag, "received": payload})
+
+    def _count_sibling_instances(self):
+        """Query the local Domoticz JSON API and return the number of OTHER enabled
+        instances of this plugin (Type==94, Extra=="WSChannelTest", idx != this hwid).
+
+        Returns -1 if the query fails — callers must treat -1 as "unknown / be safe".
+        """
+        port = Parameters.get("Mode2", "8080") or "8080"
+        this_hwid = str(Parameters["HardwareID"])
+        url = "http://127.0.0.1:%s/json.htm?type=command&param=gethardware" % port
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:
+            Domoticz.Debug("WSChannelTest: could not query hardware list (%s) — skipping template removal to be safe" % exc)
+            return -1
+
+        result = data.get("result", [])
+        siblings = [
+            h for h in result
+            if h.get("Type") == 94
+            and h.get("Extra") == "WSChannelTest"
+            and str(h.get("idx", "")) != this_hwid
+            and h.get("Enabled") in ("true", True)
+        ]
+        return len(siblings)
+
+    def onStop(self):
+        Domoticz.Log("WSChannelTest v%s stopping, tag=%s hwid=%s" % (PLUGIN_VERSION, self.tag, Parameters["HardwareID"]))
+
+        plugin_dir    = os.path.dirname(os.path.abspath(__file__))
+        domoticz_root = os.path.abspath(os.path.join(plugin_dir, "..", ".."))
+        tpl_dir       = os.path.join(domoticz_root, "www", "templates")
+        dest          = os.path.join(tpl_dir, "wschanneltest.html")
+
+        sibling_count = self._count_sibling_instances()
+        if sibling_count < 0:
+            Domoticz.Log("WSChannelTest: sibling query failed, keeping template")
+            return
+        if sibling_count > 0:
+            Domoticz.Log("WSChannelTest: %d sibling(s) still running, keeping template" % sibling_count)
+            return
+
+        try:
+            if os.path.isfile(dest):
+                os.remove(dest)
+                Domoticz.Log("WSChannelTest: custom page removed")
+            else:
+                Domoticz.Log("WSChannelTest: custom page not present, nothing to remove")
+        except Exception as e:
+            Domoticz.Error("WSChannelTest: remove FAILED %s : %r" % (dest, e))
+
+
+PLUGIN_VERSION = "1.0.5"
+_plugin = BasePlugin()
+
+
+def onStart():                    _plugin.onStart()
+def onStop():                     _plugin.onStop()
+def onHeartbeat():                _plugin.onHeartbeat()
+def onWebSocketMessage(Data):     _plugin.onWebSocketMessage(Data)

--- a/plugins/examples/WebSocketChannelTest/wschanneltest.html
+++ b/plugins/examples/WebSocketChannelTest/wschanneltest.html
@@ -1,0 +1,180 @@
+<style>
+.wsct-page { padding: 8px 4px; color: var(--dz-text, #ddd); }
+.wsct-table-wrap {
+  max-height: 340px; overflow-y: auto;
+  border-radius: var(--dz-border-radius, 8px);
+  background: var(--dz-panel-bg, #1e1e1e); margin-top: 8px;
+}
+.wsct-table { width: 100%; border-collapse: collapse; font-size: 0.88em; font-family: monospace; }
+.wsct-table th {
+  position: sticky; top: 0; background: var(--dz-panel-bg, #1e1e1e);
+  color: var(--dz-text-muted, #9ab); font-weight: normal;
+  text-align: left; padding: 6px 10px;
+  border-bottom: 1px solid rgba(255,255,255,0.08);
+}
+.wsct-table td { padding: 4px 10px; border-bottom: 1px solid rgba(255,255,255,0.04); word-break: break-all; }
+.wsct-col-time { white-space: nowrap; color: var(--dz-text-muted, #9ab); }
+.wsct-empty { text-align: center; padding: 24px; color: var(--dz-text-muted, #9ab); opacity: 0.6; }
+.wsct-toolbar { display: flex; align-items: center; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
+.wsct-status { color: var(--dz-text-muted, #9ab); font-size: 0.85em; }
+/* Force text selection on the messages table — this page is a debug/inspection tool.
+   !important is required to override the Domoticz theme and any .noselect / inherited
+   user-select:none rules that cascade from parent layouts (e.g. style.css device tables,
+   Nightglass pages.css command-palette items). Selectors are scoped to .wsct-page so no
+   other Domoticz page is affected. */
+.wsct-page .wsct-table,
+.wsct-page .wsct-table td,
+.wsct-page .wsct-table th {
+  -webkit-user-select: text !important;
+  -moz-user-select:    text !important;
+  -ms-user-select:     text !important;
+  user-select:         text !important;
+}
+.wsct-col-data-value {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+/* Direction badge — scoped to .wsct-page; --dz-* vars only, no hardcoded colours */
+.wsct-dir-badge {
+  display: inline-block;
+  font-size: 0.82em;
+  white-space: nowrap;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.wsct-dir-badge--sent {
+  color: var(--dz-text-muted, #9ab);
+  background: var(--dz-panel-header-bg, rgba(255,255,255,0.06));
+}
+.wsct-dir-badge--recv {
+  color: var(--dz-accent, #5bf);
+  background: var(--dz-accent-muted, rgba(85,187,255,0.12));
+}
+/* Sent rows are visually de-emphasised relative to received rows */
+.wsct-row-sent td {
+  opacity: 0.7;
+}
+</style>
+
+<div ng-app="domoticz" ng-controller="myCtrl" class="wsct-page">
+  <a class="btnstylerev" back-button>{{ ::'Back' | translate }}</a>
+  <h2 class="page-header">WebSocket Channel Test</h2>
+
+  <div class="wsct-toolbar">
+    <button class="btnstyle3" ng-click="sendPing()">{{ ::'Send command to plugin' | translate }}</button>
+    <span class="wsct-status" ng-if="lastSentAt">{{ ::'Sent' | translate }}: {{lastSentAt}}</span>
+  </div>
+
+  <h3>{{ ::'Messages (sent &amp; received)' | translate }}
+    <small ng-if="messages.length" class="wsct-status">&nbsp;({{messages.length}})</small>
+  </h3>
+
+  <div class="wsct-table-wrap" id="wsct-scroll">
+    <table class="wsct-table">
+      <thead>
+        <tr>
+          <th class="wsct-col-time">{{ ::'Time' | translate }}</th>
+          <th class="wsct-col-dir">{{ ::'Dir' | translate }}</th>
+          <th class="wsct-col-hwid">{{ ::'HW' | translate }}</th>
+          <th class="wsct-col-data">{{ ::'Data' | translate }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr ng-if="!messages.length">
+          <td colspan="4" class="wsct-empty">{{ ::'Waiting for messages…' | translate }}</td>
+        </tr>
+        <tr ng-repeat="m in messages track by m.seq"
+            ng-class="{'wsct-row-sent': m.dir === 'sent'}">
+          <td class="wsct-col-time">{{m.time}}</td>
+          <td class="wsct-col-dir">
+            <span class="wsct-dir-badge"
+                  ng-class="m.dir === 'sent' ? 'wsct-dir-badge--sent' : 'wsct-dir-badge--recv'">
+              {{m.dir === 'sent' ? '→ sent' : '← recv'}}
+            </span>
+          </td>
+          <td class="wsct-col-hwid">{{m.hwid}}</td>
+          <td class="wsct-col-data"><span class="wsct-col-data-value">{{m.display}}</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+var app = angular.module(['myApp'], []);
+app.controller('myCtrl', function ($scope, $element, $timeout, livesocket) {
+
+  var PLUGIN   = 'WSChannelTest';
+  var MAX_ROWS = 200;
+  var seq      = 0;
+
+  $scope.messages   = [];   // [{seq, time, hwid, display, dir}]
+  $scope.lastSentAt = '';
+
+  function formatData(data) {
+    if (data === null || data === undefined) { return String(data); }
+    if (typeof data === 'string')            { return data; }
+    try { return JSON.stringify(data); } catch (e) { return String(data); }
+  }
+
+  function nowTime() {
+    var now = new Date();
+    var pad = function (n) { return n < 10 ? '0' + n : n; };
+    return pad(now.getHours()) + ':' + pad(now.getMinutes()) + ':' + pad(now.getSeconds());
+  }
+
+  function trimMessages() {
+    if ($scope.messages.length > MAX_ROWS) {
+      $scope.messages.splice(0, $scope.messages.length - MAX_ROWS);
+    }
+  }
+
+  function scrollToBottom() {
+    $timeout(function () {
+      var el = document.getElementById('wsct-scroll');
+      if (el) { el.scrollTop = el.scrollHeight; }
+    }, 0);
+  }
+
+  // F5: subscribe + receive (verifies F1 outbound + multi-instance + hwid tagging)
+  livesocket.subscribePlugin(PLUGIN);
+
+  var offMessage = livesocket.onPluginMessage(PLUGIN, function (msg) {
+    seq++;
+    $scope.messages.push({
+      seq:     seq,
+      time:    nowTime(),
+      hwid:    msg.hwid,
+      display: formatData(msg.data),
+      dir:     'recv'
+    });
+    trimMessages();
+    scrollToBottom();
+  });
+
+  // F5: send command (verifies F3 inbound + F4 callback + round-trip echo)
+  $scope.sendPing = function () {
+    var payload = { cmd: 'ping', ts: Date.now() };
+    // Push the outgoing row BEFORE sending so it appears above the pong reply.
+    seq++;
+    $scope.messages.push({
+      seq:     seq,
+      time:    nowTime(),
+      hwid:    '(me)',
+      display: formatData(payload),
+      dir:     'sent'
+    });
+    trimMessages();
+    scrollToBottom();
+    livesocket.sendPluginCommand(PLUGIN, payload);
+    $scope.lastSentAt = new Date().toLocaleTimeString();
+  };
+
+  // Cleanup on page leave (mirrors Forecast.html $destroy handler)
+  $scope.$on('$destroy', function () {
+    if (offMessage) { offMessage(); offMessage = null; }
+    livesocket.unsubscribePlugin(PLUGIN);
+  });
+
+});
+</script>

--- a/push/WebsocketPush.cpp
+++ b/push/WebsocketPush.cpp
@@ -5,6 +5,7 @@
 #include "../main/Logger.h"
 
 extern boost::signals2::signal<void(const std::string &Subject, const std::string &Text, const std::string &ExtraData, const int Priority, const std::string & Sound, const bool bFromNotification)> sOnNotificationReceived;
+extern boost::signals2::signal<void(const std::string &pluginKey, int hwId, const std::string &jsonPayload)> sOnPluginWebSocketMessage;
 
 CWebSocketPush::CWebSocketPush(http::server::CDomoticzWebsocketHandler *sock)
 {
@@ -27,6 +28,7 @@ void CWebSocketPush::Start()
 	m_sDeviceUpdate = m_mainworker.sOnDeviceUpdate.connect([this](auto id, auto idx) { OnDeviceUpdate(id, idx); });
 	m_sNotification = sOnNotificationReceived.connect([this](auto &&s, auto &&t, auto &&e, auto p, auto &&sound, auto n) { OnNotificationReceived(s, t, e, p, sound, n); });
 	m_sSceneChanged = m_mainworker.sOnSwitchScene.connect([this](auto idx, auto &&name) { OnSceneChange(idx, name); });
+	m_sPluginWS = sOnPluginWebSocketMessage.connect([this](auto &&key, auto hwId, auto &&payload) { OnPluginWebSocketMessage(key, hwId, payload); });
 
 	_log.sOnLogMessage.connect(this, &CWebSocketPush::OnLogMessage, &m_sLogMessage);
 
@@ -53,6 +55,9 @@ void CWebSocketPush::Stop()
 
 	if (m_sSceneChanged.connected())
 		m_sSceneChanged.disconnect();
+
+	if (m_sPluginWS.connected())
+		m_sPluginWS.disconnect();
 
 	m_sLogMessage.disconnect();
 }
@@ -95,4 +100,12 @@ void CWebSocketPush::OnLogMessage(const _eLogLevel level, const std::string& sLo
 	if (!isStarted)
 		return;
 	m_sock->SendLogMessage(static_cast<int>(level), sLogline);
+}
+
+void CWebSocketPush::OnPluginWebSocketMessage(const std::string& pluginKey, int hwId, const std::string& jsonPayload)
+{
+	std::unique_lock<std::recursive_mutex> lock(handlerMutex);
+	if (!isStarted)
+		return;
+	m_sock->SendPluginMessage(pluginKey, hwId, jsonPayload);
 }

--- a/push/WebsocketPush.h
+++ b/push/WebsocketPush.h
@@ -26,11 +26,13 @@ private:
 	void OnNotificationReceived(const std::string &Subject, const std::string &Text, const std::string &ExtraData, int Priority, const std::string &Sound, bool bFromNotification);
 	void OnSceneChange(uint64_t SceneRowIdx, const std::string &SceneName);
 	void OnLogMessage(const _eLogLevel level, const std::string& sLogline);
+	void OnPluginWebSocketMessage(const std::string& pluginKey, int hwId, const std::string& jsonPayload);
 
 	std::recursive_mutex handlerMutex;
 	http::server::CDomoticzWebsocketHandler *m_sock;
 	bool isStarted;
 
+	boost::signals2::connection m_sPluginWS;
 	lsignal::slot m_sLogMessage;
 
 };

--- a/test/python/test_plugin_websocket.py
+++ b/test/python/test_plugin_websocket.py
@@ -1,0 +1,685 @@
+"""
+End-to-end test for the Plugin WebSocket Channel feature.
+
+Prerequisites
+-------------
+1. Domoticz must be running and reachable (default: http://127.0.0.1:8080).
+2. The WebSocketChannelTest plugin must be present at plugins/WebSocketChannelTest/
+   in the Domoticz source tree (Domoticz scans plugins/<Name>/plugin.py directly;
+   it does NOT scan plugins/examples/).
+   The tracked/example copy lives at plugins/examples/WebSocketChannelTest/; to
+   run the plugin, copy that folder to plugins/WebSocketChannelTest/ (or any
+   plugins/<Name>/) and restart Domoticz.
+   - Restart Domoticz (or reload plugins).
+3. Add the plugin **twice** as hardware:
+   - Instance A: Hardware > Add > Type "WebSocket Channel Test", Tag = "A"
+   - Instance B: Hardware > Add > Type "WebSocket Channel Test", Tag = "B"
+   Both instances must be enabled and running.
+4. A user account with at least Switcher rights is required to send plugin_command
+   frames (default admin/domoticz works).
+
+Dependencies
+------------
+Uses only the Python standard library when possible.  If 'websocket-client' is
+available it is used for the raw WebSocket connection; otherwise the script falls
+back to http.client for a plain-HTTP upgrade (which covers most CI use-cases with
+Python >= 3.11 that include tomllib but not a WS library).
+
+The preferred way is to install websocket-client:
+    pip install websocket-client
+
+Run command
+-----------
+    python test/python/test_plugin_websocket.py
+
+Optional environment variables / argv overrides:
+    DOMOTICZ_URL   Base URL, e.g. http://192.168.1.10:8080   (default: http://127.0.0.1:8080)
+    DOMOTICZ_USER  Username  (default: admin)
+    DOMOTICZ_PASS  Password  (default: domoticz)
+
+Or pass URL as the first positional argument:
+    python test/python/test_plugin_websocket.py http://192.168.1.10:8080
+
+Protocol notes (must match livesocket.js and DomoticzWebsocketHandler.cpp)
+---------------------------------------------------------------------------
+- URL path:       <base>/json   (livesocket.js line: wsURI = ... + location.pathname + 'json')
+- Subprotocol:    "domoticz"    (livesocket.js: protocols: ["domoticz"])
+- Auth:           HTTP Basic auth on the initial HTTP upgrade handshake
+- Subscribe:      {"event":"subscribe","topic":"plugin:<key>","requestid":<n>}
+  Server ack:     {"event":"subscribed","request":"subscribe","requestid":<n>}
+- Plugin push:    {"event":"plugin","plugin":"<key>","hwid":<int>,"data":<any>}
+- Plugin command: {"event":"plugin_command","plugin":"<key>","data":<any>[,"hwid":<int>]}
+  Server ack:     {"event":"plugin_command_ack","plugin":"<key>","delivered":<int>}
+- Unknown plugin ack: delivered==0 (no error field for unknown plugin, just delivered:0)
+"""
+
+import json
+import os
+import sys
+import threading
+import time
+import base64
+import urllib.parse
+from collections import defaultdict
+
+# ---------------------------------------------------------------------------
+# Console encoding: reconfigure stdout/stderr to UTF-8 with replacement so
+# that any stray Unicode in debug output does not crash on cp1252 terminals.
+# ---------------------------------------------------------------------------
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:
+            pass
+
+# ---------------------------------------------------------------------------
+# Configuration from environment / argv
+# ---------------------------------------------------------------------------
+_base_url = os.environ.get("DOMOTICZ_URL", "http://127.0.0.1:8080").rstrip("/")
+if len(sys.argv) > 1 and sys.argv[1].startswith("http"):
+    _base_url = sys.argv[1].rstrip("/")
+
+_user = os.environ.get("DOMOTICZ_USER", "admin")
+_pass = os.environ.get("DOMOTICZ_PASS", "domoticz")
+
+# Derive WebSocket URL from the base HTTP URL.
+# livesocket.js: wsProtocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+#                wsURI = wsProtocol + '//' + location.host + location.pathname + 'json'
+# Since the base URL may have a path component (reverse-proxy sub-path), we keep it.
+def _make_ws_url(base: str) -> str:
+    parsed = urllib.parse.urlparse(base)
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    path = parsed.path.rstrip("/") + "/json"
+    return urllib.parse.urlunparse((scheme, parsed.netloc, path, "", "", ""))
+
+_ws_url = _make_ws_url(_base_url)
+_PLUGIN_KEY = "WSChannelTest"
+# Heartbeat is ~10s; the plugin emits the raw-string form every 5th beat (~50s cadence).
+# RAW_STRING_TIMEOUT must be long enough to catch at least one raw-string emission after
+# the test client connects.  Allow 1.5x the cadence (5 beats * 10s * 1.5) plus slack.
+_HEARTBEAT_SECONDS = 10
+_RAW_STRING_CADENCE_BEATS = 5
+_RAW_STRING_TIMEOUT = int(_RAW_STRING_CADENCE_BEATS * _HEARTBEAT_SECONDS * 1.5) + 5  # ~80s
+_TIMEOUT = 35      # seconds - for most checks (subscribe ack, echo round-trips, etc.)
+_SHORT_TIMEOUT = 4 # seconds for the "should receive nothing" check
+
+# ---------------------------------------------------------------------------
+# WebSocket import - prefer websocket-client, fall back gracefully
+# ---------------------------------------------------------------------------
+try:
+    import websocket as _websocket_client
+    _HAS_WS_CLIENT = True
+except ImportError:
+    _HAS_WS_CLIENT = False
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+_results: list[tuple[str, bool, str]] = []   # (check_name, passed, detail)
+_fail_count = 0
+
+
+def _report(name: str, passed: bool, detail: str = "") -> None:
+    global _fail_count
+    status = "PASS" if passed else "FAIL"
+    line = f"  [{status}] {name}"
+    if detail:
+        line += f" -- {detail}"
+    print(line)
+    _results.append((name, passed, detail))
+    if not passed:
+        _fail_count += 1
+
+
+def _assert(name: str, condition: bool, detail: str = "") -> None:
+    _report(name, condition, detail)
+
+
+# ---------------------------------------------------------------------------
+# WebSocket connection helper
+# ---------------------------------------------------------------------------
+class _WSConn:
+    """
+    Thread-safe WebSocket connection that accumulates received messages in a
+    list and exposes a 'collect' method to drain messages up to a deadline.
+
+    Uses websocket-client (websocket.WebSocketApp) if available.
+    Raises RuntimeError if the library is missing.
+    """
+
+    def __init__(self, url: str, user: str, password: str, label: str = ""):
+        if not _HAS_WS_CLIENT:
+            raise RuntimeError(
+                "websocket-client is not installed.\n"
+                "Install it with:  pip install websocket-client\n"
+                "then re-run the test."
+            )
+        self._url = url
+        self._label = label or url
+        self._lock = threading.Lock()
+        self._messages: list[dict] = []
+        self._open_event = threading.Event()
+        self._auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+
+        header = {
+            "Authorization": f"Basic {self._auth}",
+        }
+
+        self._ws = _websocket_client.WebSocketApp(
+            url,
+            subprotocols=["domoticz"],
+            header=header,
+            on_open=self._on_open,
+            on_message=self._on_message,
+            on_error=self._on_error,
+            on_close=self._on_close,
+        )
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def _run(self):
+        self._ws.run_forever(ping_interval=0)
+
+    def _on_open(self, ws):
+        self._open_event.set()
+
+    def _on_message(self, ws, raw):
+        try:
+            msg = json.loads(raw)
+        except Exception:
+            msg = {"_raw": raw}
+        with self._lock:
+            self._messages.append(msg)
+
+    def _on_error(self, ws, error):
+        pass  # errors are surfaced as missing messages / timeouts
+
+    def _on_close(self, ws, code, reason):
+        pass
+
+    def wait_open(self, timeout: float = 10.0) -> bool:
+        return self._open_event.wait(timeout)
+
+    def send(self, obj: dict) -> None:
+        self._ws.send(json.dumps(obj))
+
+    def collect(self, deadline: float) -> list[dict]:
+        """Return all messages received up to the given deadline (absolute time)."""
+        msgs: list[dict] = []
+        while time.monotonic() < deadline:
+            time.sleep(0.05)
+            with self._lock:
+                msgs.extend(self._messages)
+                self._messages.clear()
+        return msgs
+
+    def drain(self) -> list[dict]:
+        """Return and clear currently queued messages without waiting."""
+        with self._lock:
+            msgs = list(self._messages)
+            self._messages.clear()
+        return msgs
+
+    def close(self) -> None:
+        try:
+            self._ws.close()
+        except Exception:
+            pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+# ---------------------------------------------------------------------------
+# Subscribe helper - sends subscribe frame and waits for ack
+# ---------------------------------------------------------------------------
+_req_counter = 0
+
+def _next_req_id() -> int:
+    global _req_counter
+    _req_counter += 1
+    return _req_counter
+
+
+def _subscribe(conn: _WSConn, topic: str, timeout: float = 5.0) -> bool:
+    """Send a subscribe frame; return True when the ack arrives."""
+    req_id = _next_req_id()
+    conn.send({"event": "subscribe", "topic": topic, "requestid": req_id})
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        msgs = conn.drain()
+        for m in msgs:
+            if m.get("event") == "subscribed" and m.get("requestid") == req_id:
+                return True
+            # Put non-matching messages back
+            with conn._lock:
+                conn._messages.insert(0, m)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Individual checks
+# ---------------------------------------------------------------------------
+
+def check_connect_and_subscribe(conn: _WSConn) -> bool:
+    """Connect and subscribe to plugin:WSChannelTest."""
+    if not conn.wait_open(10.0):
+        _report("connect", False, f"WebSocket did not open within 10s for {_ws_url}")
+        return False
+    _report("connect", True, f"Connected to {_ws_url}")
+
+    ok = _subscribe(conn, f"plugin:{_PLUGIN_KEY}")
+    _report("subscribe", ok,
+            f"topic=plugin:{_PLUGIN_KEY}" + ("" if ok else " -- no ack received"))
+    return ok
+
+
+def check_a_multi_instance_fanout_and_hwid(conn: _WSConn) -> tuple[int, int]:
+    """
+    README req 1 + 2 (multi-instance fan-out + hwid tagging):
+    Within timeout receive tick messages from TWO distinct hwids.
+
+    Returns (hwid_a, hwid_b) or (0, 0) on failure.
+    Also checks for at least one dict payload and one raw-string payload (req data forms).
+
+    The raw-string form is emitted every _RAW_STRING_CADENCE_BEATS heartbeats (~50s),
+    so a client connecting mid-cycle may need to wait up to one full cadence interval.
+    _RAW_STRING_TIMEOUT is set to 1.5x the cadence to give comfortable headroom.
+    """
+    # Phase 1: wait for two distinct hwids and at least one dict payload.
+    # These come every heartbeat so _TIMEOUT is sufficient.
+    phase1_deadline = time.monotonic() + _TIMEOUT
+    hwids: set[int] = set()
+    dict_seen = False
+    string_seen = False
+
+    def _absorb(m: dict) -> None:
+        nonlocal dict_seen, string_seen
+        if m.get("event") != "plugin" or m.get("plugin") != _PLUGIN_KEY:
+            return
+        hwid = m.get("hwid")
+        if isinstance(hwid, int):
+            hwids.add(hwid)
+        data = m.get("data")
+        if isinstance(data, dict):
+            dict_seen = True
+        elif isinstance(data, str):
+            string_seen = True
+
+    while time.monotonic() < phase1_deadline and (len(hwids) < 2 or not dict_seen):
+        time.sleep(0.1)
+        for m in conn.drain():
+            _absorb(m)
+
+    # Phase 2: if raw-string not yet seen, keep listening up to _RAW_STRING_TIMEOUT.
+    # The plugin emits raw-string-from-<tag>-beat<N> every 5th heartbeat (~50s cadence).
+    # _RAW_STRING_TIMEOUT = cadence * 1.5 + slack so we catch it regardless of phase.
+    if not string_seen:
+        raw_deadline = time.monotonic() + _RAW_STRING_TIMEOUT
+        while time.monotonic() < raw_deadline and not string_seen:
+            time.sleep(0.1)
+            for m in conn.drain():
+                _absorb(m)
+
+    got_two = len(hwids) >= 2
+    _assert(
+        "multi-instance fan-out (two distinct hwids in tick messages)",
+        got_two,
+        f"hwids seen: {sorted(hwids)}" + ("" if got_two else f" -- waited {_TIMEOUT}s")
+    )
+    _assert(
+        "dict payload form seen",
+        dict_seen,
+        "at least one 'plugin' frame had data as a JSON object"
+    )
+    _assert(
+        "raw-string payload form seen",
+        string_seen,
+        (
+            "at least one 'plugin' frame had data as a plain string "
+            "(emitted every %d beats, ~%ds cadence; waited up to %ds)"
+            % (_RAW_STRING_CADENCE_BEATS, _RAW_STRING_CADENCE_BEATS * _HEARTBEAT_SECONDS,
+               _RAW_STRING_TIMEOUT)
+        )
+    )
+
+    if got_two:
+        ids = sorted(hwids)
+        return ids[0], ids[1]
+    return 0, 0
+
+
+def check_b_round_trip_fanout(conn: _WSConn) -> None:
+    """
+    README req 3 (inbound fan-out + round-trip F3/F4/F2):
+    Send plugin_command {cmd:'ping',ts:<ms>}; assert delivered>=2 in ack and TWO pong messages,
+    each with the matching ts value.
+
+    The 'ts' value is int(time.time() * 1000) which is a JavaScript-style millisecond
+    timestamp (~1.7e12 as of 2024).  This value exceeds 2^31-1 (2147483647) and therefore
+    exercises the 64-bit integer path in CPluginProtocolJSON::PythontoJSON.  On an
+    unfixed build (PyLong_AsLong on Windows LLP64) this raises:
+        OverflowError: Python int too large to convert to C long
+    The pong-ts assertion below will fail if that regression is reintroduced.
+    """
+    conn.drain()  # clear any buffered messages before the test
+    req_id = _next_req_id()
+    sent_ts = int(time.time() * 1000)
+    # Confirm sent_ts actually exceeds INT32_MAX so this test is a meaningful
+    # regression guard for the 32-bit overflow bug (not just a theoretical check).
+    assert sent_ts > 2147483647, (
+        "sent_ts (%d) must exceed INT32_MAX for the overflow regression check" % sent_ts
+    )
+    cmd_payload = {"cmd": "ping", "ts": sent_ts}
+    conn.send({
+        "event": "plugin_command",
+        "plugin": _PLUGIN_KEY,
+        "data": cmd_payload,
+        "requestid": req_id,
+    })
+
+    deadline = time.monotonic() + _TIMEOUT
+    ack: dict | None = None
+    pong_hwids: set[int] = set()
+    pong_ts_values: list = []
+    buffered: list[dict] = []
+
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        with conn._lock:
+            incoming = list(conn._messages)
+            conn._messages.clear()
+        for m in incoming:
+            if m.get("event") == "plugin_command_ack" and m.get("plugin") == _PLUGIN_KEY:
+                ack = m
+            elif (
+                m.get("event") == "plugin"
+                and m.get("plugin") == _PLUGIN_KEY
+                and isinstance(m.get("data"), dict)
+                and m["data"].get("type") == "pong"
+            ):
+                hwid = m.get("hwid")
+                if isinstance(hwid, int):
+                    pong_hwids.add(hwid)
+                pong_ts_values.append(m["data"].get("ts"))
+            else:
+                buffered.append(m)
+        if ack is not None and len(pong_hwids) >= 2:
+            break
+
+    # Put non-pong, non-ack messages back
+    with conn._lock:
+        conn._messages[:0] = buffered
+
+    _assert(
+        "plugin_command_ack received",
+        ack is not None,
+        str(ack) if ack else "no ack within timeout"
+    )
+    if ack is not None:
+        delivered = ack.get("delivered", -1)
+        _assert(
+            "plugin_command_ack delivered>=2",
+            delivered >= 2,
+            f"delivered={delivered}"
+        )
+
+    _assert(
+        "pong messages from two instances (round-trip)",
+        len(pong_hwids) >= 2,
+        f"pong hwids: {sorted(pong_hwids)}" + ("" if len(pong_hwids) >= 2 else f" -- waited {_TIMEOUT}s")
+    )
+    # This assertion is the 64-bit integer overflow regression guard:
+    # sent_ts > INT32_MAX, so if PythontoJSON uses PyLong_AsLong (32-bit on
+    # Windows) the C++ side raises OverflowError and the pong is never sent,
+    # causing pong_ts_values to be empty or contain incorrect (truncated) values.
+    ts_match = all(v == sent_ts for v in pong_ts_values) and len(pong_ts_values) >= 2
+    _assert(
+        "pong ts (>INT32_MAX) echoed back correctly -- 64-bit int overflow regression",
+        ts_match,
+        "sent_ts=%d (>2^31), pong ts values=%r" % (sent_ts, pong_ts_values)
+    )
+
+
+def check_c_hwid_targeting(conn: _WSConn, hwid_a: int, hwid_b: int) -> None:
+    """
+    README req 4 (hwid targeting):
+    Send plugin_command with hwid=hwid_a and {cmd:'ping',ts:<ms>}; assert exactly one pong
+    (from instance A) with the matching ts value.
+    """
+    if hwid_a == 0:
+        _report("hwid targeting (single instance pong)", False, "skipped -- hwids not discovered")
+        return
+
+    conn.drain()
+    sent_ts = int(time.time() * 1000)
+    cmd_payload = {"cmd": "ping", "ts": sent_ts}
+    conn.send({
+        "event": "plugin_command",
+        "plugin": _PLUGIN_KEY,
+        "hwid": hwid_a,
+        "data": cmd_payload,
+    })
+
+    deadline = time.monotonic() + _TIMEOUT
+    pong_hwids: set[int] = set()
+    pong_ts_values: list = []
+    buffered: list[dict] = []
+
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        with conn._lock:
+            incoming = list(conn._messages)
+            conn._messages.clear()
+        for m in incoming:
+            if (
+                m.get("event") == "plugin"
+                and m.get("plugin") == _PLUGIN_KEY
+                and isinstance(m.get("data"), dict)
+                and m["data"].get("type") == "pong"
+            ):
+                hwid = m.get("hwid")
+                if isinstance(hwid, int):
+                    pong_hwids.add(hwid)
+                pong_ts_values.append(m["data"].get("ts"))
+            else:
+                buffered.append(m)
+        if pong_hwids:
+            # Give a brief window to check whether a second pong arrives
+            time.sleep(1.0)
+            with conn._lock:
+                extra = list(conn._messages)
+                conn._messages.clear()
+            for m in extra:
+                if (
+                    m.get("event") == "plugin"
+                    and m.get("plugin") == _PLUGIN_KEY
+                    and isinstance(m.get("data"), dict)
+                    and m["data"].get("type") == "pong"
+                ):
+                    hwid = m.get("hwid")
+                    if isinstance(hwid, int):
+                        pong_hwids.add(hwid)
+                    pong_ts_values.append(m["data"].get("ts"))
+                else:
+                    buffered.append(m)
+            break
+
+    with conn._lock:
+        conn._messages[:0] = buffered
+
+    exactly_one = len(pong_hwids) == 1 and hwid_a in pong_hwids
+    _assert(
+        "hwid targeting (exactly one pong from target instance)",
+        exactly_one,
+        f"target hwid={hwid_a}, pong hwids received: {sorted(pong_hwids)}"
+    )
+    ts_match = pong_ts_values == [sent_ts]
+    _assert(
+        "hwid targeting pong ts echoed back correctly",
+        ts_match,
+        f"sent_ts={sent_ts}, pong ts values={pong_ts_values}"
+    )
+
+
+def check_d_topic_filtering() -> None:
+    """
+    README req 5 (topic filtering):
+    Open a second WebSocket that does NOT subscribe; verify it receives no 'plugin' events.
+    """
+    try:
+        with _WSConn(_ws_url, _user, _pass, label="unsubscribed-conn") as conn2:
+            if not conn2.wait_open(10.0):
+                _report("topic filtering (unsubscribed gets nothing)", False,
+                        "second connection failed to open")
+                return
+            # Give the server a moment then collect
+            deadline = time.monotonic() + _SHORT_TIMEOUT
+            msgs = conn2.collect(deadline)
+            plugin_events = [m for m in msgs if m.get("event") == "plugin"]
+            no_plugin = len(plugin_events) == 0
+            _assert(
+                "topic filtering (unsubscribed connection gets no plugin events)",
+                no_plugin,
+                f"received {len(plugin_events)} unexpected plugin events" if not no_plugin
+                else f"no plugin events received in {_SHORT_TIMEOUT}s window"
+            )
+    except RuntimeError as e:
+        _report("topic filtering (unsubscribed gets nothing)", False, str(e))
+
+
+def check_e_unknown_plugin(conn: _WSConn) -> None:
+    """
+    README req 6 (unknown plugin):
+    Send plugin_command for a bogus plugin name; assert ack delivered==0 and no crash.
+    """
+    conn.drain()
+    bogus_key = "NoSuchPlugin_xyz_9999"
+    conn.send({
+        "event": "plugin_command",
+        "plugin": bogus_key,
+        "data": {"cmd": "test"},
+    })
+
+    deadline = time.monotonic() + _TIMEOUT
+    ack: dict | None = None
+    buffered: list[dict] = []
+
+    while time.monotonic() < deadline:
+        time.sleep(0.05)
+        with conn._lock:
+            incoming = list(conn._messages)
+            conn._messages.clear()
+        for m in incoming:
+            if m.get("event") == "plugin_command_ack" and m.get("plugin") == bogus_key:
+                ack = m
+            else:
+                buffered.append(m)
+        if ack is not None:
+            break
+
+    with conn._lock:
+        conn._messages[:0] = buffered
+
+    _assert(
+        "unknown plugin: ack received",
+        ack is not None,
+        str(ack) if ack else "no ack within timeout"
+    )
+    if ack is not None:
+        delivered = ack.get("delivered", -1)
+        _assert(
+            "unknown plugin: delivered==0",
+            delivered == 0,
+            f"delivered={delivered}"
+        )
+        # No error field expected for unknown plugin (just delivered:0 per server code)
+        no_crash_indicator = "error" not in ack
+        _assert(
+            "unknown plugin: no error/crash indicator in ack",
+            no_crash_indicator,
+            f"ack fields: {list(ack.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    print(f"Plugin WebSocket Channel - end-to-end test")
+    print(f"  Server : {_ws_url}")
+    print(f"  Plugin : {_PLUGIN_KEY}")
+    print(f"  User   : {_user}")
+    print()
+
+    if not _HAS_WS_CLIENT:
+        print("ERROR: websocket-client is not installed.")
+        print("  pip install websocket-client")
+        return 2
+
+    hwid_a, hwid_b = 0, 0
+
+    try:
+        with _WSConn(_ws_url, _user, _pass, label="primary") as conn:
+            print("--- connect + subscribe ---")
+            if not check_connect_and_subscribe(conn):
+                print("\nCannot proceed without a working connection/subscription.")
+                return 1
+
+            print("\n--- check A: multi-instance fan-out + hwid tagging + payload forms ---")
+            hwid_a, hwid_b = check_a_multi_instance_fanout_and_hwid(conn)
+
+            print("\n--- check B: round-trip fan-out (plugin_command ping -> pong x2) ---")
+            try:
+                check_b_round_trip_fanout(conn)
+            except Exception as exc:
+                _report("check B (round-trip fan-out)", False, f"unexpected exception: {exc}")
+
+            print("\n--- check C: hwid targeting (single-instance pong delivery) ---")
+            try:
+                check_c_hwid_targeting(conn, hwid_a, hwid_b)
+            except Exception as exc:
+                _report("check C (hwid targeting)", False, f"unexpected exception: {exc}")
+
+            print("\n--- check D: topic filtering (unsubscribed connection) ---")
+            try:
+                check_d_topic_filtering()
+            except Exception as exc:
+                _report("check D (topic filtering)", False, f"unexpected exception: {exc}")
+
+            print("\n--- check E: unknown plugin (no crash, delivered==0) ---")
+            try:
+                check_e_unknown_plugin(conn)
+            except Exception as exc:
+                _report("check E (unknown plugin)", False, f"unexpected exception: {exc}")
+
+    except RuntimeError as e:
+        print(f"\nFATAL: {e}")
+        return 2
+
+    print()
+    print("=" * 60)
+    total = len(_results)
+    passed = sum(1 for _, ok, _ in _results if ok)
+    failed = total - passed
+    print(f"Result: {passed}/{total} checks passed, {failed} failed")
+
+    if _fail_count > 0:
+        print("\nFailed checks:")
+        for name, ok, detail in _results:
+            if not ok:
+                print(f"  - {name}: {detail}")
+        return 1
+
+    print("All checks PASSED.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/www/app/livesocket.js
+++ b/www/app/livesocket.js
@@ -20,6 +20,8 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 		var webSocket;
 		var requestsCount = 0;
 		var requestsQueue = [];
+		var pluginListeners = {};
+		var activePluginTopics = {};
 
 		init();
 
@@ -28,7 +30,11 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 			sendRequest: sendRequest,
 			subscribeTo: subscribeTo,
 			unsubscribeFrom: unsubscribeFrom,
-			unsubscribeDevices: unsubscribeDevices
+			unsubscribeDevices: unsubscribeDevices,
+			subscribePlugin: subscribePlugin,
+			unsubscribePlugin: unsubscribePlugin,
+			sendPluginCommand: sendPluginCommand,
+			onPluginMessage: onPluginMessage
 		};
 
 		function init() {
@@ -44,7 +50,18 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 				enqueue: true
 			});
 
-			webSocket.$on('$message', handleMessage)
+			webSocket.$on('$message', handleMessage);
+
+			webSocket.$on('$open', function () {
+				// Re-subscribe through subscribeTo so reconnect goes through the same
+				// requestid/ack path as initial subscriptions (via subscribePlugin).
+				// subscribeTo is safe here: the socket is open, $$send is available, and
+				// handleRequestResponse (registered on $message) will resolve the promise
+				// when the ack arrives.  No recursion risk — $open does not call $open.
+				Object.keys(activePluginTopics).forEach(function (name) {
+					subscribeTo('plugin:' + name);
+				});
+			});
 		}
 
 		function handleMessage(msg) {
@@ -61,6 +78,9 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 					return;
 				case "log":
 					handleLog(msg);
+					return;
+				case "plugin":
+					handlePluginMessage(msg);
 					return;
 			}
 
@@ -128,6 +148,34 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 					level: msg.level,
 					message: msg.message
 				});
+			}
+		}
+
+		function handlePluginMessage(msg) {
+			var name = msg.plugin;
+			if (typeof name === 'undefined') {
+				return;
+			}
+			var payload = { plugin: name, hwid: msg.hwid, data: msg.data };
+			// Deliver only via the callback registry (onPluginMessage).
+			// $rootScope.$broadcast was removed to avoid double-dispatch; all
+			// consumers should register via onPluginMessage instead.
+			var listeners = pluginListeners[name];
+			if (listeners) {
+				// Defensive copy so an unsubscribe inside a callback does not
+				// corrupt the iteration (fix-4).
+				listeners.slice().forEach(function (cb) {
+					try {
+						cb(payload);
+					} catch (e) {
+						console.error('[livesocket] plugin listener threw for "' + name + '":', e);
+					}
+				});
+			}
+			// Trigger a digest so data-bound UI reacts to the pushed payload,
+			// consistent with handleTimeUpdate's own explicit $digest pattern.
+			if (!$rootScope.$$phase) {
+				$rootScope.$digest();
 			}
 		}
 
@@ -211,6 +259,89 @@ define(['app.notifications', 'angular-websocket'], function (appNotificationsMod
 
 		function unsubscribeDevices() {
 			webSocket.$$send({ event: 'unsubscribe_devices' });
+		}
+
+		/**
+		 * Subscribe to plugin push messages by name.
+		 * The subscription is automatically restored on websocket reconnect.
+		 *
+		 * @param {string} name - Plugin name (matches the `plugin` field in pushed frames).
+		 * @returns {Promise} Resolves with the server ack when the subscribe frame is confirmed.
+		 */
+		function subscribePlugin(name) {
+			if (activePluginTopics[name]) {
+				return $q.when();
+			}
+			activePluginTopics[name] = true;
+			return subscribeTo('plugin:' + name);
+		}
+
+		/**
+		 * Cancel a plugin subscription by name.
+		 * Future pushes for this plugin name will not be delivered.
+		 *
+		 * @param {string} name - Plugin name to unsubscribe.
+		 * @returns {Promise} Resolves with the server ack.
+		 */
+		function unsubscribePlugin(name) {
+			delete activePluginTopics[name];
+			return unsubscribeFrom('plugin:' + name);
+		}
+
+		/**
+		 * Send a command to a plugin.
+		 * If hwid is supplied it must be an integer; if not, the call is rejected
+		 * with a console error and nothing is sent.
+		 * When hwid is omitted the key is not included in the frame.
+		 *
+		 * @param {string} name      - Plugin name.
+		 * @param {*}      data      - Arbitrary payload forwarded to the plugin.
+		 * @param {number} [hwid]    - Optional hardware-instance id (integer).
+		 */
+		function sendPluginCommand(name, data, hwid) {
+			if (typeof hwid !== 'undefined') {
+				if (typeof hwid !== 'number' || hwid !== Math.floor(hwid)) {
+					console.error('[livesocket] sendPluginCommand: hwid must be an integer, got:', hwid);
+					return;
+				}
+			}
+			var msg = { event: 'plugin_command', plugin: name, data: data };
+			if (typeof hwid !== 'undefined') {
+				msg.hwid = hwid;
+			}
+			var serialized = JSON.stringify(msg);
+			if (serialized.length > 65536) {
+				console.error('[livesocket] sendPluginCommand: payload too large (' + serialized.length + ' bytes); limit is 65536 bytes. Message not sent.');
+				return;
+			}
+			webSocket.$$send(msg);
+		}
+
+		/**
+		 * Register a callback for inbound plugin push messages.
+		 * Subscriptions are auto-restored on reconnect when subscribePlugin was used.
+		 *
+		 * @param {string}   name - Plugin name to listen for.
+		 * @param {Function} cb   - Called with `{plugin, hwid, data}` on each push.
+		 * @returns {Function} Unbind function — call it to remove this listener.
+		 */
+		function onPluginMessage(name, cb) {
+			if (!pluginListeners[name]) {
+				pluginListeners[name] = [];
+			}
+			pluginListeners[name].push(cb);
+			return function () {
+				var arr = pluginListeners[name];
+				if (!arr) { return; }
+				var idx = arr.indexOf(cb);
+				if (idx !== -1) {
+					arr.splice(idx, 1);
+					// Reclaim the slot when the last listener is removed (fix-1).
+					if (arr.length === 0) {
+						delete pluginListeners[name];
+					}
+				}
+			};
 		}
 
 


### PR DESCRIPTION
## Summary

Adds a bidirectional WebSocket channel between Python plugins and the web frontend.

- `Domoticz.WebSocketSend(payload)` — push a dict (JSON, full 64-bit int support) or string to frontend clients subscribed to `plugin:<PluginKey>`; non-blocking.
- `onWebSocketMessage(self, Data)` — optional plugin callback receiving commands sent from the frontend.
- Messages fan out across **all running instances** of a plugin and carry the originating `HardwareID`; commands can target one instance via `hwid`.
- Thread-safe instance registry with framework-driven lifecycle cleanup; Python-free bridge for non-blocking inbound delivery; rights check + 64 KiB payload cap on inbound commands.

## Frontend

`livesocket` gains `subscribePlugin` / `unsubscribePlugin` / `sendPluginCommand` / `onPluginMessage`, with reconnect re-subscription and idempotent subscribe.

## Example, tests, docs

- `plugins/examples/WebSocketChannelTest/` — example plugin + Forecast.html-style custom page (ping→pong, multi-instance fan-out, MeshCore-style atomic template install/remove).
- `test/python/test_plugin_websocket.py` — 15-check end-to-end suite (fan-out, hwid tagging, payload forms, round-trip, topic filtering, unknown-plugin handling, >2^31 integer regression guard).
- `docs/Developing_a_Python_plugin.wiki` updated.

## Verification

Implemented across F0–F7 with code-review gates per phase, then debugged and certified on a live Domoticz instance: end-to-end test **15/15 passing**.
