### PR TITLE
fix(plugins): clamp PythonThreadCount to avoid negative count on shutdown

### DIFF
--- a/hardware/plugins/Plugins.cpp
+++ b/hardware/plugins/Plugins.cpp
@@ -2674,7 +2674,12 @@ namespace Plugins
 						if (pReturnValue.IsLong())
 						{
 							lRetVal = PyLong_AsLong(pReturnValue) - 1;
-							if (lRetVal)
+							if (lRetVal < 0)
+							{
+								Debug(DEBUG_PYTHON, "PythonThreadCount: active_count() returned 0 (abnormal at shutdown), treating as 0 threads.");
+								lRetVal = 0;
+							}
+							else if (lRetVal)
 							{
 								Log(LOG_ERROR, "Plugin has %d Python threads still running.", (int)lRetVal);
 							}


### PR DESCRIPTION
Plugins running an asyncio event loop in a worker thread (e.g. MeshCore) can leave Python's threading.active_count() reporting 0 at stop, so CPlugin::PythonThreadCount() returned -1. The shutdown wait loop treats any non-zero value as "threads still running", causing a bogus ~10s wait, repeated "Plugin has -1 Python threads still running." errors, and a spurious "Abandoning wait for Plugin thread shutdown, hang or crash may result."

Clamp negative counts to 0 (noted at debug level) so shutdown completes promptly for any asyncio-style plugin. Genuine positive thread counts retain the existing wait-and-warn behaviour unchanged.