### PR TITLE
ci(windows): add workflow_dispatch to allow manual stable release builds

### DIFF
--- a/.github/workflows/windows-release-build.yml
+++ b/.github/workflows/windows-release-build.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Adds a `workflow_dispatch:` trigger to the Windows stable release workflow so it can be started manually (Actions → Run workflow, or `gh workflow run windows-release-build.yml --ref master`) without needing a code push to `master`.

### Why now
After PR #6834 recovered the build version on `master` (15897 commits → version 18004), no Windows release was produced: that merge changed only `paths-ignore`d files (`History.txt`), so the `push`-triggered workflow was skipped. There is currently no way to start the build manually.

Merging this PR (with a **merge commit**) changes a `.yml` file (not in `paths-ignore`), which triggers a fresh stable build at the current `master` tip — and going forward the build can be re-run on demand via `workflow_dispatch`.
