### PR TITLE
CustomChart widget - time range fix

### DIFF
--- a/www/app/dashboardDynamic/widgets/ddCustomChart.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddCustomChart.widget.js
@@ -330,7 +330,15 @@ define([
                         xAxis: {
                             type:      'datetime',
                             crosshair: true,
-                            labels:    { style: { fontSize: '10px', color: textColor } }
+                            labels:    { style: { fontSize: '10px', color: textColor } },
+                            min: (function() {
+                                var now = Date.now();
+                                if (cfg.range === 'day')   { return now - 24 * 3600 * 1000; }
+                                if (cfg.range === 'week')  { return now -  7 * 24 * 3600 * 1000; }
+                                if (cfg.range === 'month') { return now - 30 * 24 * 3600 * 1000; }
+                                return undefined;
+                            }()),
+                            max: Date.now()
                         },
                         yAxis:   yAxes,
                         tooltip: {


### PR DESCRIPTION
When selecting Time range: Last 24h, the CustomChart widget was showing data for the last 7 days. This change fixes this issue.