### PR TITLE
gauge widget - color display fix

### DIFF
--- a/www/app/dashboardDynamic/widgets/ddGauge.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddGauge.widget.js
@@ -112,6 +112,7 @@ define([
                             }
                         }
                         if (matched) {
+                            if (matched.color) { return matched.color; }
                             if (matched.status === 'critical') { return 'var(--dz-accent-red)'; }
                             if (matched.status === 'warning')  { return 'var(--dz-widget-amber)'; }
                             return 'var(--dz-widget-energy-export)';


### PR DESCRIPTION
Despite the value ranges set, the widget always displayed the color `'var(--dz-widget-energy-export)'` because the `ranges` object does not contain a `.status` field, which is checked.
```javascript
if (matched) {
            if (matched.status === 'critical') { return 'var(--dz-accent-red)'; }
            if (matched.status === 'warning')  { return 'var(--dz-widget-amber)'; }
            return 'var(--dz-widget-energy-export)';
        }
        return 'var(--dz-widget-amber)';
```
```
[
  {
    "from": 0,
    "to": 40,
    "color": "#04bbbb"
  },
  {
    "from": 41,
    "to": 60,
    "color": "#05bb04"
  },
  {
    "from": 61,
    "to": 70,
    "color": "#bbaa01"
  },
  {
    "from": 71,
    "to": 100,
    "color": "#bb1301"
  }
]
```
<img width="552" height="540" alt="image" src="https://github.com/user-attachments/assets/9dff099b-d737-4a32-b599-cb9672a4d03f" />


This change adds setting `matched.color`, which fixes the problem.
```javascript
if (matched) {
            if (matched.color) { return matched.color; }
            if (matched.status === 'critical') { return 'var(--dz-accent-red)'; }
            if (matched.status === 'warning')  { return 'var(--dz-widget-amber)'; }
            return 'var(--dz-widget-energy-export)';
        }
        return 'var(--dz-widget-amber)';
```