### PR TITLE
FreeBSD Python lookup bugfix

### DIFF
--- a/hardware/plugins/DelayedLink.h
+++ b/hardware/plugins/DelayedLink.h
@@ -19,7 +19,7 @@
 #ifdef _DEBUG
 #    undef _DEBUG   // Not compatible with Py_LIMITED_API
 #endif
-#define Py_LIMITED_API 0x03040000 
+#define Py_LIMITED_API 0x03040000
 #include <Python.h>
 #include <structmember.h>
 #include "../../main/Logger.h"
@@ -53,7 +53,7 @@ namespace Plugins {
 		void* shared_lib_;
 #endif
 		PyObject* Py_None;
-			
+
 		// Shared library interface begin.
 		DECLARE_PYTHON_SYMBOL(const char*, Py_GetVersion, );
 		DECLARE_PYTHON_SYMBOL(int, Py_IsInitialized, );
@@ -180,8 +180,6 @@ namespace Plugins {
 			std::string extension;
 #ifdef WIN32
 			extension = ".dll"; // Windows uses .dll
-#elif defined(__FreeBSD__)
-			extension = "m";    // FreeBSD uses 'm' suffix
 #endif
 			// Loop through the set (it is already sorted in descending order)
             for (const auto& version : python_versions) {


### PR DESCRIPTION
The

```
#elif defined(__FreeBSD__)
                       extension = "m";    // FreeBSD uses 'm' suffix

```
code section is outdated and redundant and needs to removed, because it's preventing Domoticz from finding Python on a FreeBSD.

This is a current `ls` of a FreBSD 14.4 `/usr/local/lib`; all python libs are without the additional `m`.

```
$ ls -la | grep python
lrwxr-xr-x   1 root wheel      20 Apr 23 02:10 libpython3.11.so -> libpython3.11.so.1.0
lrwxr-xr-x   1 root wheel      20 Apr 23 02:11 libpython3.11.so.1 -> libpython3.11.so.1.0
-rw-r--r--   1 root wheel 6169904 Apr 23 02:10 libpython3.11.so.1.0
-rw-r--r--   1 root wheel   71225 Apr 23 02:11 libpython3.11.so.1.0-gdb.py
drwxr-xr-x  39 root wheel     208 Apr 30 10:23 python3.11
```

However, for backwards compatibility there's already a case for this in `FindLibrary`:

```
					// look in directories covered by ldconfig but 'm' variant
					if (!shared_lib_)
					{
						library = "lib" + sLibrary + "m.so";
						shared_lib_ = dlopen(library.c_str(), RTLD_LAZY | RTLD_GLOBAL);
					}
```

I compiled Domoticz (albeit 2025.2, that's the one currently in FreeBSD ports) with the change, and it's finally happy, after about 4-5 hours of trying to pass PATH hacks, only to realize that was not the problem.