### PR TITLE
WindChart - time range fix

### DIFF
--- a/www/app/dashboardDynamic/widgets/ddWindChart.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddWindChart.widget.js
@@ -7,6 +7,7 @@ define([
     // API parameters for each chartType
     var CHART_TYPE_API = {
         shortlog:  { sensor: 'wind',    range: 'day' },
+        week:      { sensor: 'wind',    range: 'day' },
         direction: { sensor: 'winddir', range: 'day' },
         frequency: { sensor: 'wind',    range: 'day' },
         month:     { sensor: 'wind',    range: 'month' },
@@ -15,6 +16,7 @@ define([
 
     var CHART_TYPE_LABELS = {
         shortlog:  'Last 24h',
+        week:      'Last 7 days',
         direction: 'Wind Direction',
         frequency: 'Speed Frequency',
         month:     'Last Month',
@@ -80,6 +82,7 @@ define([
                 label:   'Chart type',
                 options: [
                     { value: 'shortlog',  label: 'Last 24h' },
+                    { value: 'week',      label: 'Last 7 days' },
                     { value: 'direction', label: 'Wind Direction' },
                     { value: 'frequency', label: 'Speed Frequency' },
                     { value: 'month',     label: 'Last Month' },
@@ -268,7 +271,9 @@ define([
                     opts.legend       = { enabled: true, itemStyle: { fontSize: '10px', color: textColor } };
                     opts.xAxis = {
                         type:   'datetime',
-                        labels: { style: { fontSize: '10px' } }
+                        labels: { style: { fontSize: '10px' } },
+                        min:    cfg.chartType === 'week' ? Date.now() - 7 * 24 * 3600 * 1000 : Date.now() - 24 * 3600 * 1000,
+                        max:    Date.now()
                     };
                     opts.yAxis = {
                         title:  { text: 'm/s', style: { fontSize: '10px' } },


### PR DESCRIPTION
Similar to CustomChart, for the selected `Last 24h` range, the WindChart showed data from the last week, because `range=day` returns data from 7 days. The `Last 24h` filter was fixed and the `Last 7 days` option was added.