### PR TITLE
Add Blockly blocks for device LastUpdate age

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -36,12 +36,6 @@ struct ScriptNameReport {
 	std::string name;
 };
 
-struct LastUpdateTableEntry
-{
-	uint64_t id = 0;
-	std::string lastUpdate;
-};
-
 static int l_reportScriptName(lua_State *L)
 {
 	auto *report = static_cast<ScriptNameReport *>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -57,9 +51,9 @@ static int l_returnZero(lua_State *L)
 	return 1;
 }
 
-static void SetTableDefaultZero(lua_State *lua_state, const char *tableName)
+static void SetLuaTableDefaultToZero(lua_State *lua_state, const char *szTableName)
 {
-	lua_getglobal(lua_state, tableName);
+	lua_getglobal(lua_state, szTableName);
 	if (!lua_istable(lua_state, -1))
 	{
 		lua_pop(lua_state, 1);
@@ -74,17 +68,17 @@ static void SetTableDefaultZero(lua_State *lua_state, const char *tableName)
 	lua_pop(lua_state, 1);
 }
 
-static int64_t SecondsSinceLastUpdate(const std::string &lastUpdate, const time_t now, const int isdst)
+static int64_t GetSecondsSinceLastUpdate(const std::string &sLastUpdate, const time_t atime, const int iIsDST)
 {
-	if (lastUpdate.empty())
+	if (sLastUpdate.empty())
 		return 0;
 
-	time_t lastUpdateTime = 0;
-	struct tm lastUpdateTm = {};
-	if (!ParseSQLdatetime(lastUpdateTime, lastUpdateTm, lastUpdate, isdst) || (now < lastUpdateTime))
+	time_t tLastUpdate = 0;
+	struct tm tmLastUpdate = {};
+	if (!ParseSQLdatetime(tLastUpdate, tmLastUpdate, sLastUpdate, iIsDST) || (atime < tLastUpdate))
 		return 0;
 
-	return static_cast<int64_t>(now - lastUpdateTime);
+	return static_cast<int64_t>(atime - tLastUpdate);
 }
 
 bool g_bUseEventTrigger = true;
@@ -1864,30 +1858,29 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	lua_setglobal(lua_state, "print");
 
 	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
-
 	CLuaTable luaTable(lua_state, "device", (int)m_devicestates.size(), 0);
-	std::vector<LastUpdateTableEntry> deviceLastUpdates;
-	deviceLastUpdates.reserve(m_devicestates.size());
+	std::vector<std::pair<uint64_t, std::string>> vDeviceLastUpdates;
+	vDeviceLastUpdates.reserve(m_devicestates.size());
 
 	for (const auto &state : m_devicestates)
 	{
 		const _tDeviceStatus &sitem = state.second;
 		luaTable.AddString(sitem.ID, sitem.nValueWording);
-		deviceLastUpdates.push_back({ sitem.ID, sitem.lastUpdate });
+		vDeviceLastUpdates.emplace_back(sitem.ID, sitem.lastUpdate);
 	}
 	luaTable.Publish();
 	devicestatesMutexLock.unlock();
 
 	time_t atime = mytime(nullptr);
 	struct tm tm1 = {};
-	const int isdst = (localtime_r(&atime, &tm1) != nullptr) ? tm1.tm_isdst : -1;
-	luaTable.InitTable(lua_state, "lastupdateddevice", (int)deviceLastUpdates.size(), 0);
-	for (const auto &deviceLastUpdate : deviceLastUpdates)
+	const int iIsDST = (localtime_r(&atime, &tm1) != nullptr) ? tm1.tm_isdst : -1;
+	luaTable.InitTable(lua_state, "device_lastupdate", (int)vDeviceLastUpdates.size(), 0);
+	for (const auto &[ulDeviceID, sLastUpdate] : vDeviceLastUpdates)
 	{
-		luaTable.AddInteger(deviceLastUpdate.id, SecondsSinceLastUpdate(deviceLastUpdate.lastUpdate, atime, isdst));
+		luaTable.AddInteger(ulDeviceID, GetSecondsSinceLastUpdate(sLastUpdate, atime, iIsDST));
 	}
 	luaTable.Publish();
-	SetTableDefaultZero(lua_state, "lastupdateddevice");
+	SetLuaTableDefaultToZero(lua_state, "device_lastupdate");
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	
@@ -2104,7 +2097,7 @@ void CEventSystem::EvaluateDatabaseEvents(const _tEventQueue &item)
 						if (found == std::string::npos)
 							found = event.Conditions.find("weekday");
 						if (found == std::string::npos)
-							found = event.Conditions.find("lastupdateddevice");
+							found = event.Conditions.find("device_lastupdate");
 					}
 					else if ((item.reason == REASON_USERVARIABLE) && (item.id > 0))
 					{
@@ -2279,6 +2272,31 @@ std::string CEventSystem::ProcessVariableArgument(const std::string &Argument)
 			sstr << itt->second;
 			return sstr.str();
 		}
+	}
+	else if (Argument.find("device_lastupdate") != std::string::npos)
+	{
+		std::string sLastUpdate;
+		{
+			boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
+			auto itt = m_devicestates.find(dindex);
+			if (itt == m_devicestates.end())
+				return ret;
+			sLastUpdate = itt->second.lastUpdate;
+		}
+
+		time_t atime = mytime(nullptr);
+		struct tm tm1 = {};
+		const int iIsDST = (localtime_r(&atime, &tm1) != nullptr) ? tm1.tm_isdst : -1;
+		const int64_t iSeconds = GetSecondsSinceLastUpdate(sLastUpdate, atime, iIsDST);
+
+		std::stringstream sstr;
+		if (Argument.find("/3600") != std::string::npos)
+			sstr << (static_cast<double>(iSeconds) / 3600);
+		else if (Argument.find("/60") != std::string::npos)
+			sstr << (static_cast<double>(iSeconds) / 60);
+		else
+			sstr << iSeconds;
+		return sstr.str();
 	}
 	else if (Argument.find("variable") == 0)
 	{

--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -36,6 +36,12 @@ struct ScriptNameReport {
 	std::string name;
 };
 
+struct LastUpdateTableEntry
+{
+	uint64_t id = 0;
+	std::string lastUpdate;
+};
+
 static int l_reportScriptName(lua_State *L)
 {
 	auto *report = static_cast<ScriptNameReport *>(lua_touserdata(L, lua_upvalueindex(1)));
@@ -43,6 +49,42 @@ static int l_reportScriptName(lua_State *L)
 	std::lock_guard<std::mutex> lock(report->mtx);
 	report->name = name;
 	return 0;
+}
+
+static int l_returnZero(lua_State *L)
+{
+	lua_pushinteger(L, 0);
+	return 1;
+}
+
+static void SetTableDefaultZero(lua_State *lua_state, const char *tableName)
+{
+	lua_getglobal(lua_state, tableName);
+	if (!lua_istable(lua_state, -1))
+	{
+		lua_pop(lua_state, 1);
+		return;
+	}
+
+	lua_newtable(lua_state);
+	lua_pushliteral(lua_state, "__index");
+	lua_pushcfunction(lua_state, l_returnZero);
+	lua_settable(lua_state, -3);
+	lua_setmetatable(lua_state, -2);
+	lua_pop(lua_state, 1);
+}
+
+static int64_t SecondsSinceLastUpdate(const std::string &lastUpdate, const time_t now, const int isdst)
+{
+	if (lastUpdate.empty())
+		return 0;
+
+	time_t lastUpdateTime = 0;
+	struct tm lastUpdateTm = {};
+	if (!ParseSQLdatetime(lastUpdateTime, lastUpdateTm, lastUpdate, isdst) || (now < lastUpdateTime))
+		return 0;
+
+	return static_cast<int64_t>(now - lastUpdateTime);
 }
 
 bool g_bUseEventTrigger = true;
@@ -1822,16 +1864,30 @@ lua_State *CEventSystem::CreateBlocklyLuaState()
 	lua_setglobal(lua_state, "print");
 
 	boost::shared_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
-	
+
 	CLuaTable luaTable(lua_state, "device", (int)m_devicestates.size(), 0);
+	std::vector<LastUpdateTableEntry> deviceLastUpdates;
+	deviceLastUpdates.reserve(m_devicestates.size());
 
 	for (const auto &state : m_devicestates)
 	{
-		_tDeviceStatus sitem = state.second;
-		luaTable.AddString(sitem.ID, sitem. nValueWording);
+		const _tDeviceStatus &sitem = state.second;
+		luaTable.AddString(sitem.ID, sitem.nValueWording);
+		deviceLastUpdates.push_back({ sitem.ID, sitem.lastUpdate });
 	}
 	luaTable.Publish();
 	devicestatesMutexLock.unlock();
+
+	time_t atime = mytime(nullptr);
+	struct tm tm1 = {};
+	const int isdst = (localtime_r(&atime, &tm1) != nullptr) ? tm1.tm_isdst : -1;
+	luaTable.InitTable(lua_state, "lastupdateddevice", (int)deviceLastUpdates.size(), 0);
+	for (const auto &deviceLastUpdate : deviceLastUpdates)
+	{
+		luaTable.AddInteger(deviceLastUpdate.id, SecondsSinceLastUpdate(deviceLastUpdate.lastUpdate, atime, isdst));
+	}
+	luaTable.Publish();
+	SetTableDefaultZero(lua_state, "lastupdateddevice");
 
 	boost::shared_lock<boost::shared_mutex> uservariablesMutexLock(m_uservariablesMutex);
 	
@@ -2047,6 +2103,8 @@ void CEventSystem::EvaluateDatabaseEvents(const _tEventQueue &item)
 						found = event.Conditions.find("timeofday");
 						if (found == std::string::npos)
 							found = event.Conditions.find("weekday");
+						if (found == std::string::npos)
+							found = event.Conditions.find("lastupdateddevice");
 					}
 					else if ((item.reason == REASON_USERVARIABLE) && (item.id > 0))
 					{

--- a/www/app/events/blockly_blocks_domoticz.js
+++ b/www/app/events/blockly_blocks_domoticz.js
@@ -4,6 +4,11 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
     var switchesMR = [];
     var switchesSZ = [];
 
+    var lastUpdateDevicesAF = [];
+    var lastUpdateDevicesGL = [];
+    var lastUpdateDevicesMR = [];
+    var lastUpdateDevicesSZ = [];
+
     var utilities = [];
     var utilitiesAF = [];
     var utilitiesGL = [];
@@ -57,6 +62,36 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
     if (switchesGL.length === 0) { switchesGL.push(["No devices found", '0']); }
     if (switchesMR.length === 0) { switchesMR.push(["No devices found", '0']); }
     if (switchesSZ.length === 0) { switchesSZ.push(["No devices found", '0']); }
+
+    $.ajax({
+        url: "json.htm?type=command&param=getdevices&filter=all&used=true&order=Name&displayhidden=1",
+        async: false,
+        dataType: 'json',
+        success: function (data) {
+            if (typeof data.result != 'undefined') {
+                $.each(data.result, function (i, item) {
+                    if ("ghijkl".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
+                        lastUpdateDevicesGL.push([item.Name, item.idx])
+                    }
+                    else if ("mnopqr".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
+                        lastUpdateDevicesMR.push([item.Name, item.idx])
+                    }
+                    else if ("stuvwxyz".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
+                        lastUpdateDevicesSZ.push([item.Name, item.idx])
+                    }
+                    // numbers etc with the a list
+                    else {
+                        lastUpdateDevicesAF.push([item.Name, item.idx])
+                    }
+                })
+            }
+        }
+    });
+
+    if (lastUpdateDevicesAF.length === 0) { lastUpdateDevicesAF.push(["No devices found", '0']); }
+    if (lastUpdateDevicesGL.length === 0) { lastUpdateDevicesGL.push(["No devices found", '0']); }
+    if (lastUpdateDevicesMR.length === 0) { lastUpdateDevicesMR.push(["No devices found", '0']); }
+    if (lastUpdateDevicesSZ.length === 0) { lastUpdateDevicesSZ.push(["No devices found", '0']); }
 
     $.ajax({
         url: "json.htm?type=command&param=getdevices&filter=temp&used=true&order=Name&displayhidden=1",
@@ -230,6 +265,11 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
     switchesMR.sort();
     switchesSZ.sort();
 
+    lastUpdateDevicesAF.sort();
+    lastUpdateDevicesGL.sort();
+    lastUpdateDevicesMR.sort();
+    lastUpdateDevicesSZ.sort();
+
     utilities.sort();
     utilitiesAF.sort();
     utilitiesGL.sort();
@@ -306,6 +346,74 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
             this.setTooltip(Blockly.DOMOTICZSWITCHES_TOOLTIP);
         }
     };
+
+    Blockly.Blocks['lastupdateddeviceAF'] = {
+        // Device last update age getter.
+        category: null,
+        init: function () {
+            this.setColour(Blockly.Msg["MATH_HUE"]);
+            this.appendDummyInput()
+                .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
+                .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
+                .appendField('A-F ')
+                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesAF), 'Device');
+            this.setOutput(true, 'Number');
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+        }
+    };
+
+    Blockly.Blocks['lastupdateddeviceGL'] = {
+        // Device last update age getter.
+        category: null,
+        init: function () {
+            this.setColour(Blockly.Msg["MATH_HUE"]);
+            this.appendDummyInput()
+                .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
+                .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
+                .appendField('G-L ')
+                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesGL), 'Device');
+            this.setOutput(true, 'Number');
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+        }
+    };
+
+    Blockly.Blocks['lastupdateddeviceMR'] = {
+        // Device last update age getter.
+        category: null,
+        init: function () {
+            this.setColour(Blockly.Msg["MATH_HUE"]);
+            this.appendDummyInput()
+                .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
+                .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
+                .appendField('M-R ')
+                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesMR), 'Device');
+            this.setOutput(true, 'Number');
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+        }
+    };
+
+    Blockly.Blocks['lastupdateddeviceSZ'] = {
+        // Device last update age getter.
+        category: null,
+        init: function () {
+            this.setColour(Blockly.Msg["MATH_HUE"]);
+            this.appendDummyInput()
+                .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
+                .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
+                .appendField('S-Z ')
+                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesSZ), 'Device');
+            this.setOutput(true, 'Number');
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+        }
+    };
+
+    Blockly.Blocks['lastupdateddeviceAF'].UNITS =
+    Blockly.Blocks['lastupdateddeviceGL'].UNITS =
+    Blockly.Blocks['lastupdateddeviceMR'].UNITS =
+    Blockly.Blocks['lastupdateddeviceSZ'].UNITS =
+        [[Blockly.DOMOTICZCONTROLS_MSG_SECONDS, 'seconds'],
+            [Blockly.DOMOTICZCONTROLS_MSG_MINUTES, 'minutes'],
+            [Blockly.DOMOTICZCONTROLS_MSG_HOURS, 'hours']];
 
     Blockly.Blocks['utilityvariables'] = {
         // Variable getter.
@@ -1240,6 +1348,5 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
             ['>', 'GT'],
             ['\u2265', 'GTE']];
 });
-
 
 

--- a/www/app/events/blockly_blocks_domoticz.js
+++ b/www/app/events/blockly_blocks_domoticz.js
@@ -4,10 +4,10 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
     var switchesMR = [];
     var switchesSZ = [];
 
-    var lastUpdateDevicesAF = [];
-    var lastUpdateDevicesGL = [];
-    var lastUpdateDevicesMR = [];
-    var lastUpdateDevicesSZ = [];
+    var deviceLastUpdatesAF = [];
+    var deviceLastUpdatesGL = [];
+    var deviceLastUpdatesMR = [];
+    var deviceLastUpdatesSZ = [];
 
     var utilities = [];
     var utilitiesAF = [];
@@ -71,27 +71,27 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
             if (typeof data.result != 'undefined') {
                 $.each(data.result, function (i, item) {
                     if ("ghijkl".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
-                        lastUpdateDevicesGL.push([item.Name, item.idx])
+                        deviceLastUpdatesGL.push([item.Name, item.idx])
                     }
                     else if ("mnopqr".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
-                        lastUpdateDevicesMR.push([item.Name, item.idx])
+                        deviceLastUpdatesMR.push([item.Name, item.idx])
                     }
                     else if ("stuvwxyz".indexOf(item.Name.charAt(0).toLowerCase()) > -1) {
-                        lastUpdateDevicesSZ.push([item.Name, item.idx])
+                        deviceLastUpdatesSZ.push([item.Name, item.idx])
                     }
                     // numbers etc with the a list
                     else {
-                        lastUpdateDevicesAF.push([item.Name, item.idx])
+                        deviceLastUpdatesAF.push([item.Name, item.idx])
                     }
                 })
             }
         }
     });
 
-    if (lastUpdateDevicesAF.length === 0) { lastUpdateDevicesAF.push(["No devices found", '0']); }
-    if (lastUpdateDevicesGL.length === 0) { lastUpdateDevicesGL.push(["No devices found", '0']); }
-    if (lastUpdateDevicesMR.length === 0) { lastUpdateDevicesMR.push(["No devices found", '0']); }
-    if (lastUpdateDevicesSZ.length === 0) { lastUpdateDevicesSZ.push(["No devices found", '0']); }
+    if (deviceLastUpdatesAF.length === 0) { deviceLastUpdatesAF.push(["No devices found", '0']); }
+    if (deviceLastUpdatesGL.length === 0) { deviceLastUpdatesGL.push(["No devices found", '0']); }
+    if (deviceLastUpdatesMR.length === 0) { deviceLastUpdatesMR.push(["No devices found", '0']); }
+    if (deviceLastUpdatesSZ.length === 0) { deviceLastUpdatesSZ.push(["No devices found", '0']); }
 
     $.ajax({
         url: "json.htm?type=command&param=getdevices&filter=temp&used=true&order=Name&displayhidden=1",
@@ -265,10 +265,10 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
     switchesMR.sort();
     switchesSZ.sort();
 
-    lastUpdateDevicesAF.sort();
-    lastUpdateDevicesGL.sort();
-    lastUpdateDevicesMR.sort();
-    lastUpdateDevicesSZ.sort();
+    deviceLastUpdatesAF.sort();
+    deviceLastUpdatesGL.sort();
+    deviceLastUpdatesMR.sort();
+    deviceLastUpdatesSZ.sort();
 
     utilities.sort();
     utilitiesAF.sort();
@@ -347,7 +347,7 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
         }
     };
 
-    Blockly.Blocks['lastupdateddeviceAF'] = {
+    Blockly.Blocks['devicelastupdateAF'] = {
         // Device last update age getter.
         category: null,
         init: function () {
@@ -356,13 +356,13 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
                 .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
                 .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
                 .appendField('A-F ')
-                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesAF), 'Device');
+                .appendField(new Blockly.FieldDropdown(deviceLastUpdatesAF), 'Device');
             this.setOutput(true, 'Number');
-            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_DEVICE_LASTUPDATE_TOOLTIP);
         }
     };
 
-    Blockly.Blocks['lastupdateddeviceGL'] = {
+    Blockly.Blocks['devicelastupdateGL'] = {
         // Device last update age getter.
         category: null,
         init: function () {
@@ -371,13 +371,13 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
                 .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
                 .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
                 .appendField('G-L ')
-                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesGL), 'Device');
+                .appendField(new Blockly.FieldDropdown(deviceLastUpdatesGL), 'Device');
             this.setOutput(true, 'Number');
-            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_DEVICE_LASTUPDATE_TOOLTIP);
         }
     };
 
-    Blockly.Blocks['lastupdateddeviceMR'] = {
+    Blockly.Blocks['devicelastupdateMR'] = {
         // Device last update age getter.
         category: null,
         init: function () {
@@ -386,13 +386,13 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
                 .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
                 .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
                 .appendField('M-R ')
-                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesMR), 'Device');
+                .appendField(new Blockly.FieldDropdown(deviceLastUpdatesMR), 'Device');
             this.setOutput(true, 'Number');
-            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_DEVICE_LASTUPDATE_TOOLTIP);
         }
     };
 
-    Blockly.Blocks['lastupdateddeviceSZ'] = {
+    Blockly.Blocks['devicelastupdateSZ'] = {
         // Device last update age getter.
         category: null,
         init: function () {
@@ -401,16 +401,16 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
                 .appendField(new Blockly.FieldDropdown(this.UNITS), 'Unit')
                 .appendField(Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE)
                 .appendField('S-Z ')
-                .appendField(new Blockly.FieldDropdown(lastUpdateDevicesSZ), 'Device');
+                .appendField(new Blockly.FieldDropdown(deviceLastUpdatesSZ), 'Device');
             this.setOutput(true, 'Number');
-            this.setTooltip(Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP);
+            this.setTooltip(Blockly.DOMOTICZVARIABLES_DEVICE_LASTUPDATE_TOOLTIP);
         }
     };
 
-    Blockly.Blocks['lastupdateddeviceAF'].UNITS =
-    Blockly.Blocks['lastupdateddeviceGL'].UNITS =
-    Blockly.Blocks['lastupdateddeviceMR'].UNITS =
-    Blockly.Blocks['lastupdateddeviceSZ'].UNITS =
+    Blockly.Blocks['devicelastupdateAF'].UNITS =
+    Blockly.Blocks['devicelastupdateGL'].UNITS =
+    Blockly.Blocks['devicelastupdateMR'].UNITS =
+    Blockly.Blocks['devicelastupdateSZ'].UNITS =
         [[Blockly.DOMOTICZCONTROLS_MSG_SECONDS, 'seconds'],
             [Blockly.DOMOTICZCONTROLS_MSG_MINUTES, 'minutes'],
             [Blockly.DOMOTICZCONTROLS_MSG_HOURS, 'hours']];
@@ -1348,5 +1348,3 @@ define(['blockly', 'blockly-blocks', 'blockly-msg-en', 'app/events/blockly_messa
             ['>', 'GT'],
             ['\u2265', 'GTE']];
 });
-
-

--- a/www/app/events/blockly_messages_domoticz_en.js
+++ b/www/app/events/blockly_messages_domoticz_en.js
@@ -50,6 +50,7 @@ define(['blockly'], function() {
     Blockly.LANG_LOGIC_BOOLEAN_TOOLTIP = 'Returns either true or false.';
     Blockly.DOMOTICZSWITCHES_TOOLTIP = 'A list of switchable devices. Can be used in an IF statement to check current state, or in a "Set" block in a DO statement to change the state.';
     Blockly.DOMOTICZUSERVARIABLES_TOOLTIP = 'A list of user defined variables. Can be used in an IF statement to check current value, or in a "Set" block in a DO statement to change the value.';
+    Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP = 'Returns the age of a device last update as a number. Use with a Time or All trigger for stale-device checks.';
     Blockly.DOMOTICZVARIABLES_TEMPERATURE_TOOLTIP = 'This is a temperature measurement device. Use it in an IF statement to check valid temperature values,\ni.e. "if Bathroom temperature > 20". Cannot be used in Set blocks.';
     Blockly.DOMOTICZVARIABLES_HUMIDITY_TOOLTIP = 'This is a humidity measurement device. Use it in an IF statement to check valid humidity values, i.e. "if Bathroom humidity > 50". The percentage sign is omitted. Cannot be used in Set blocks.';
     Blockly.DOMOTICZVARIABLES_DEWPOINT_TOOLTIP = 'This is a dewpoint measurement device. Use it in an IF statement to check valid temperature values,\ni.e. "if Bathroom temperature > 20". Cannot be used in Set blocks.';
@@ -96,6 +97,8 @@ define(['blockly'], function() {
     Blockly.DOMOTICZCONTROLS_MSG_AFTER = 'After ';
     Blockly.DOMOTICZCONTROLS_MSG_SECONDS = 'seconds';
     Blockly.DOMOTICZCONTROLS_MSG_MINUTES = 'minutes';
+    Blockly.DOMOTICZCONTROLS_MSG_HOURS = 'hours';
+    Blockly.DOMOTICZCONTROLS_MSG_SINCE_LASTUPDATE = 'since last update of';
     Blockly.DOMOTICZCONTROLS_MSG_RANDOM = 'Random within';
     Blockly.DOMOTICZCONTROLS_MSG_SETLEVEL = 'Level (%)';
     Blockly.DOMOTICZCONTROLS_MSG_TIME = 'Time';
@@ -109,4 +112,3 @@ define(['blockly'], function() {
     Blockly.DOMOTICZCONTROLS_MSG_DEGREES = 'Degrees';
     Blockly.DOMOTICZCONTROLS_MSG_ZWAVEALARMS = 'Value';
 });
-

--- a/www/app/events/blockly_messages_domoticz_en.js
+++ b/www/app/events/blockly_messages_domoticz_en.js
@@ -50,7 +50,7 @@ define(['blockly'], function() {
     Blockly.LANG_LOGIC_BOOLEAN_TOOLTIP = 'Returns either true or false.';
     Blockly.DOMOTICZSWITCHES_TOOLTIP = 'A list of switchable devices. Can be used in an IF statement to check current state, or in a "Set" block in a DO statement to change the state.';
     Blockly.DOMOTICZUSERVARIABLES_TOOLTIP = 'A list of user defined variables. Can be used in an IF statement to check current value, or in a "Set" block in a DO statement to change the value.';
-    Blockly.DOMOTICZVARIABLES_LASTUPDATE_TOOLTIP = 'Returns the age of a device last update as a number. Use with a Time or All trigger for stale-device checks.';
+    Blockly.DOMOTICZVARIABLES_DEVICE_LASTUPDATE_TOOLTIP = 'Returns the age of a device last update as a number. Use with a Time or All trigger for stale-device checks.';
     Blockly.DOMOTICZVARIABLES_TEMPERATURE_TOOLTIP = 'This is a temperature measurement device. Use it in an IF statement to check valid temperature values,\ni.e. "if Bathroom temperature > 20". Cannot be used in Set blocks.';
     Blockly.DOMOTICZVARIABLES_HUMIDITY_TOOLTIP = 'This is a humidity measurement device. Use it in an IF statement to check valid humidity values, i.e. "if Bathroom humidity > 50". The percentage sign is omitted. Cannot be used in Set blocks.';
     Blockly.DOMOTICZVARIABLES_DEWPOINT_TOOLTIP = 'This is a dewpoint measurement device. Use it in an IF statement to check valid temperature values,\ni.e. "if Bathroom temperature > 20". Cannot be used in Set blocks.';

--- a/www/app/events/blockly_toolbox.xml
+++ b/www/app/events/blockly_toolbox.xml
@@ -21,6 +21,10 @@
         <block type="logic_weekday"></block>
         <block type="logic_timevalue"></block>
         <block type="logic_sunrisesunset"></block>
+        <block type="lastupdateddeviceAF"></block>
+        <block type="lastupdateddeviceGL"></block>
+        <block type="lastupdateddeviceMR"></block>
+        <block type="lastupdateddeviceSZ"></block>
     </category>
     <category name="Messages">
         <block type="send_notification"></block>

--- a/www/app/events/blockly_toolbox.xml
+++ b/www/app/events/blockly_toolbox.xml
@@ -21,10 +21,10 @@
         <block type="logic_weekday"></block>
         <block type="logic_timevalue"></block>
         <block type="logic_sunrisesunset"></block>
-        <block type="lastupdateddeviceAF"></block>
-        <block type="lastupdateddeviceGL"></block>
-        <block type="lastupdateddeviceMR"></block>
-        <block type="lastupdateddeviceSZ"></block>
+        <block type="devicelastupdateAF"></block>
+        <block type="devicelastupdateGL"></block>
+        <block type="devicelastupdateMR"></block>
+        <block type="devicelastupdateSZ"></block>
     </category>
     <category name="Messages">
         <block type="send_notification"></block>

--- a/www/app/events/blockly_xml_parser.js
+++ b/www/app/events/blockly_xml_parser.js
@@ -59,18 +59,18 @@ define(function () {
                 var fieldA = $(value).find('field')[0];
                 return 'variable[' + $(fieldA).text() + ']';
             }
-            else if (variableType.indexOf('lastupdateddevice') >= 0) {
+            else if (variableType.indexOf('devicelastupdate') >= 0) {
                 var fieldA = $(value).find('field[name=\'Device\']')[0];
                 var fieldUnit = $(value).find('field[name=\'Unit\']')[0];
-                var expression = '(lastupdateddevice[' + $(fieldA).text() + '] or 0)';
+                var valueText = '(device_lastupdate[' + $(fieldA).text() + '] or 0)';
                 var unit = $(fieldUnit).text();
                 if (unit == 'minutes') {
-                    return '(' + expression + '/60)';
+                    return '(' + valueText + '/60)';
                 }
                 else if (unit == 'hours') {
-                    return '(' + expression + '/3600)';
+                    return '(' + valueText + '/3600)';
                 }
-                return expression;
+                return valueText;
             }
             else if (variableType == 'temperaturevariables') {
                 var fieldA = $(value).find('field')[0];

--- a/www/app/events/blockly_xml_parser.js
+++ b/www/app/events/blockly_xml_parser.js
@@ -59,6 +59,19 @@ define(function () {
                 var fieldA = $(value).find('field')[0];
                 return 'variable[' + $(fieldA).text() + ']';
             }
+            else if (variableType.indexOf('lastupdateddevice') >= 0) {
+                var fieldA = $(value).find('field[name=\'Device\']')[0];
+                var fieldUnit = $(value).find('field[name=\'Unit\']')[0];
+                var expression = '(lastupdateddevice[' + $(fieldA).text() + '] or 0)';
+                var unit = $(fieldUnit).text();
+                if (unit == 'minutes') {
+                    return '(' + expression + '/60)';
+                }
+                else if (unit == 'hours') {
+                    return '(' + expression + '/3600)';
+                }
+                return expression;
+            }
             else if (variableType == 'temperaturevariables') {
                 var fieldA = $(value).find('field')[0];
                 return 'temperaturedevice[' + $(fieldA).text() + ']';


### PR DESCRIPTION
Adds Blockly Time blocks for checking how many seconds, minutes, or hours have passed since a device's `LastUpdate`. The blocks are populated from all used devices and generate Blockly Lua using the `device_lastupdate` table, allowing Time/All events to detect stale devices.

Closes #6853

Tested with `cmake --build . --target domoticz -j2` and verified the blocks in the UI.

![Blockly device last update blocks](https://raw.githubusercontent.com/adrighem/domoticz/pr-assets-blockly-last-update/blockly-device-last-update-blocks.png)