### PR TITLE
Add ability to clear selected devices from widget settings

### DIFF
--- a/www/app/dashboardDynamic/ddWidgetSettings.controller.js
+++ b/www/app/dashboardDynamic/ddWidgetSettings.controller.js
@@ -146,9 +146,16 @@ define([
                             var lb = filter ? b.Name : deviceLabel(b);
                             return la.localeCompare(lb);
                         });
-                        $scope.pickerOptions[field.key] = $scope.deviceListByField[field.key].map(function(d) {
-                            return { value: String(d.idx), label: field.deviceFilter ? d.Name : deviceLabel(d) };
-                        });
+                        $scope.pickerOptions[field.key] =
+                        [{ value: '', label: '-- None --' }]
+                        .concat(
+                            $scope.deviceListByField[field.key].map(function(d) {
+                                return {
+                                    value: String(d.idx),
+                                    label: field.deviceFilter ? d.Name : deviceLabel(d)
+                                };
+                            })
+                        );
                     });
 
                     // Helper so the template can compute the label


### PR DESCRIPTION
**Problem**
`device-picker` fields currently do not provide a way to remove a previously selected device.
For example, when configuring a Custom Chart widget, users can select multiple devices to display. If one of those devices should later be removed from the chart, the only available workaround is to create a new widget and reselect all remaining devices.
The widget implementation already supports empty device slots, but the settings dialog does not expose a way to clear a selection.

**Solution**
Add an empty (`-- None --`) option to all `device-picker` dropdowns in the widget settings dialog.
Selecting this option clears the corresponding configuration value, allowing users to remove devices without recreating the widget.