### PR TITLE
fix(EventSystem): keep dzVents battery and signal level in sync with the database

### DIFF
--- a/main/EventSystem.cpp
+++ b/main/EventSystem.cpp
@@ -1443,8 +1443,9 @@ std::string CEventSystem::UpdateSingleState(
 	const unsigned char devType, const unsigned char subType, 
 	const _eSwitchType switchType, 
 	const std::string &lastUpdate, 
-	const unsigned char lastLevel, 
+	const unsigned char lastLevel,
 	const unsigned char batteryLevel,
+	const unsigned char signalLevel,
 	const std::map<std::string, std::string> & options
 )
 {
@@ -1463,7 +1464,8 @@ std::string CEventSystem::UpdateSingleState(
 	{
 		_tDeviceStatus replaceitem = itt->second;
 		replaceitem.deviceName = l_deviceName;
-		//replaceitem.batteryLevel = batteryLevel;
+		replaceitem.batteryLevel = batteryLevel;
+		replaceitem.signalLevel = signalLevel;
 		if (nValue != -1)
 			replaceitem.nValue = nValue;
 		if (!sValue.empty())
@@ -1494,7 +1496,8 @@ std::string CEventSystem::UpdateSingleState(
 		newitem.nValueWording = l_nValueWording;
 		newitem.lastUpdate = l_lastUpdate;
 		newitem.lastLevel = lastLevel;
-		//newitem.batteryLevel = batteryLevel;
+		newitem.batteryLevel = batteryLevel;
+		newitem.signalLevel = signalLevel;
 
 		if (!m_sql.m_bDisableDzVentsSystem)
 		{
@@ -1640,7 +1643,7 @@ void CEventSystem::ProcessDevice(
 		item.nValue = nValue;
 		item.sValue = osValue;
 
-		item.nValueWording = UpdateSingleState(ulDevID, devname, nValue, osValue, devType, subType, switchType, "", 255, batterylevel, options);
+		item.nValueWording = UpdateSingleState(ulDevID, devname, nValue, osValue, devType, subType, switchType, "", 255, batterylevel, signallevel, options);
 		boost::unique_lock<boost::shared_mutex> devicestatesMutexLock(m_devicestatesMutex);
 		auto itt = m_devicestates.find(ulDevID);
 		if (itt != m_devicestates.end())
@@ -1662,7 +1665,7 @@ void CEventSystem::ProcessDevice(
 		m_eventqueue.push(item);
 	}
 	else
-		UpdateSingleState(ulDevID, devname, nValue, osValue, devType, subType, switchType, lastUpdate, lastLevel, batterylevel, options);
+		UpdateSingleState(ulDevID, devname, nValue, osValue, devType, subType, switchType, lastUpdate, lastLevel, batterylevel, signallevel, options);
 }
 
 void CEventSystem::ProcessMinute()

--- a/main/EventSystem.h
+++ b/main/EventSystem.h
@@ -201,7 +201,7 @@ private:
 	void ProcessMinute();
 	void GetCurrentMeasurementStates();
 	std::string UpdateSingleState(uint64_t ulDevID, const std::string &devname, int nValue, const std::string &sValue, unsigned char devType, unsigned char subType, _eSwitchType switchType,
-				      const std::string &lastUpdate, unsigned char lastLevel, unsigned char batteryLevel, const std::map<std::string, std::string> &options);
+				      const std::string &lastUpdate, unsigned char lastLevel, unsigned char batteryLevel, unsigned char signalLevel, const std::map<std::string, std::string> &options);
 	void EvaluateEvent(const std::vector<_tEventQueue> &items);
 	void EvaluateDatabaseEvents(const _tEventQueue &item);
 	lua_State *ParseBlocklyLua(lua_State *lua_state, const _tEventItem &item);


### PR DESCRIPTION
## Problem

dzVents scripts read a stale battery level (and signal level) for any device updated through the generic update path (MQTT Auto Discovery, Python plugins, scripts). `device.batteryLevel` returns `nil` even though the `DeviceStatus.BatteryLevel` column and the JSON API (`getdevices`) hold the correct value. This is the dzVents side of #5806.

## Root cause

dzVents builds its Lua device table from the in-memory `CEventSystem::m_devicestates` map, reading `_tDeviceStatus.batteryLevel` directly (`main/dzVents.cpp`). That field is populated from the database only once, at startup (`GetCurrentStates`). The generic runtime refresh inside `CEventSystem::UpdateSingleState` was left commented out by the cleanup in 4eb71a55e ("Cleanup Energy Dashboard"):

```cpp
//replaceitem.batteryLevel = batteryLevel;
...
//newitem.batteryLevel = batteryLevel;
```

So for every non-RFXCom device the DB column updates but the value dzVents reads never does. Only the RFXCom path refreshes it, via the dedicated `UpdateBatteryLevel()` stopgap. The in-memory `255` ("no battery") sentinel is then surfaced to scripts as `nil` by the dzVents adapter.

`signalLevel` has the same latent issue: it is loaded at startup and never refreshed (it never had a parameter on `UpdateSingleState`).

## Fix

- Restore the two `batteryLevel` assignments in `UpdateSingleState`, **unconditionally**. The DB columns are written unconditionally with the same values `ProcessDevice` passes to `UpdateSingleState` (`SQLHelper.cpp`), so the in-memory struct must mirror the DB; a guard would let the two diverge.
- Add a `signalLevel` parameter to `UpdateSingleState` and assign it alongside, so signal level is kept in sync too.

dzVents is the only consumer of these in-memory struct fields, and assigning them does not trigger scenes/scripts (that is driven by `nValue`/`sValue`), so there is no behavior change beyond dzVents seeing live values.

## Testing

- Builds cleanly.
- Verified on a local instance: pushing runtime battery/signal updates via `udevice` makes a dzVents script read the live values immediately:

```
batteryLevel=nil signalLevel=12   (before any update)
batteryLevel=50  signalLevel=8    (after udevice battery=50 rssi=8)
batteryLevel=77  signalLevel=5    (after a second update)
```

Before this change the first state persisted (`nil`) regardless of later updates.

Part of #5806 (the dzVents side). Follow-ups for the MQTT Auto Discovery battery attribution are planned as separate PRs.
