### PR TITLE
fix(MQTTAutoDiscover): apply Z-Wave node battery to all its devices immediately

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2632,19 +2632,66 @@ void MQTTAutoDiscover::handle_auto_discovery_battery(_tMQTTASensor* pSensor, con
 	if (is_number(pSensor->last_value))
 	{
 		iLevel = atoi(pSensor->last_value.c_str());
-	} else {
-		//could be a boolean isLow indicator
+	}
+	else
+	{
+		//could be a boolean isLow indicator (dead path for zwave-js-ui, which sends isLow as a binary_sensor)
 		if (pSensor->last_value == "true")
 			iLevel = 0;
 	}
 
+	//Update the in-memory battery level for every sensor of this node, and collect the distinct
+	//DeviceID forms its device rows use (standalone = unique_id, combined temp/hum/baro =
+	//device_identifiers) so all of the node's rows can be updated in a single statement.
+	std::set<std::string> deviceIDs;
 	for (auto& itt : m_discovered_sensors)
 	{
 		_tMQTTASensor* pDevSensor = &itt.second;
 		if (pDevSensor->device_identifiers == pSensor->device_identifiers)
 		{
 			pDevSensor->BatteryLevel = iLevel;
+			deviceIDs.insert(pDevSensor->unique_id);
 		}
+	}
+	deviceIDs.insert(pSensor->device_identifiers);
+
+	//Build a quoted, comma-separated IN() list. DeviceIDs come from the broker, so escape each as
+	//a SQL string literal (double any single quote) before embedding.
+	std::string inList;
+	for (const auto& id : deviceIDs)
+	{
+		if (!inList.empty())
+			inList += ",";
+		inList += "'";
+		for (const char c : id)
+		{
+			if (c == '\'')
+				inList += '\'';
+			inList += c;
+		}
+		inList += "'";
+	}
+
+	//Persist the new battery level to every already-created device row of this node, so all of the
+	//node's devices show the current battery immediately instead of lazily updating only when each
+	//device next emits state. First select just the rows that will actually change (none in steady
+	//state, so this is a cheap indexed no-op), then update them in one statement and refresh the
+	//event system for exactly those rows. We touch BatteryLevel only (never nValue/sValue), so this
+	//does not trigger scenes/scripts.
+	std::vector<std::vector<std::string> > results = m_sql.safe_query(
+		"SELECT ID FROM DeviceStatus WHERE (HardwareID==%d) AND (BatteryLevel<>%d) AND (DeviceID IN (%s))",
+		m_HwdID, iLevel, inList.c_str());
+	if (results.empty())
+		return;
+
+	m_sql.safe_query(
+		"UPDATE DeviceStatus SET BatteryLevel=%d WHERE (HardwareID==%d) AND (BatteryLevel<>%d) AND (DeviceID IN (%s))",
+		iLevel, m_HwdID, iLevel, inList.c_str());
+
+	for (const auto& sd : results)
+	{
+		uint64_t rowID = std::stoull(sd[0]);
+		m_mainworker.m_eventsystem.UpdateBatteryLevel(rowID, (unsigned char)iLevel);
 	}
 }
 


### PR DESCRIPTION
## Problem

For Z-Wave nodes ingested via MQTT Auto Discovery (zwave-js-ui), a node's battery level lands on its many Domoticz devices inconsistently, and some devices show a stale `0%` (or the `255` "no battery" default) long after the battery actually recovered. This is the MQTT Auto Discovery side of #5806.

Observed on a live system: nodes that zwave-js reports at 100% show, in Domoticz, `0` or `255` on the rarely-updating per-node devices (the `isLow` / Notification-CC devices), while the frequently-updating temperature sensor of the same node reads correctly.

## Root cause

`handle_auto_discovery_battery` writes the battery level (from the Battery CC, `128/0/level`) only into the in-memory `BatteryLevel` of every sensor of the node, then returns. The database `BatteryLevel` column for a device is only written later, when **that** device next runs its own state handler. So each device row holds whatever the node's battery was the last time that device emitted state. Devices that update at different cadences (a temperature sensor every few minutes vs a rarely pressed scene button or an `isLow` event) therefore show battery snapshots from different points in time, and a device that has not emitted state since the battery changed stays at an old value (a genuine low `0`, or the `255` default if it updated before any battery message was seen).

## Fix

Keep the existing in-memory update, and additionally, when a battery level arrives, eagerly persist it to **every already-created Domoticz device row of that node**:

- Match both DeviceID forms a node's devices use: standalone devices keyed by `unique_id`, combined temp/hum/baro devices keyed by `device_identifiers`.
- De-duplicate by row ID, and write only when the stored value actually changed.
- Update `BatteryLevel` only (never `nValue`/`sValue`) and refresh the event system via `m_eventsystem.UpdateBatteryLevel`, mirroring how the RFXCom path keeps the DB and in-memory state in sync. Because `nValue`/`sValue` are untouched, this does not trigger scenes or scripts.

Result: all of a node's devices reflect the same, current battery immediately, and stale `0%`/`255` rows self-correct on the next battery report.

This is purely additive: device creation, DeviceID, Type/SubType, and the discovery format are unchanged.

## Notes

- Only the numeric Battery CC `level` sensor feeds this path; `isLow` is published as a separate `binary_sensor` and is unaffected (see zwave-js-ui's discovery generation: [`api/lib/Gateway.ts` L1639-1667](https://github.com/zwave-js/zwave-js-ui/blob/v11.21.1/api/lib/Gateway.ts#L1639-L1667), where `level` is a `sensor` and `isLow` is emitted as a `binary_sensor`).
- Builds cleanly.

Part of #5806 (the MQTT Auto Discovery side). Complements the dzVents-side fix in #6864. A small follow-up to route battery detection by `device_class` (rather than hardcoded `object_id` strings) is planned as a separate PR.
