### PR TITLE
feat(MQTTAutoDiscover): detect battery sensor by device_class, not only object_id

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -2746,6 +2746,11 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor(_tMQTTASensor* pSensor, cons
 		(pSensor->object_id == "battery")
 		|| (pSensor->object_id == "battery_low")
 		|| (pSensor->object_id == "battery_level")
+		//Also detect a battery percentage by the standard discovery marker, so it is not tied to a
+		//specific object_id naming. Restricted to numeric values; the main dispatch routes only
+		//component_type "sensor" here, so the isLow binary_sensor (which also carries device_class
+		//"battery") is not routed to this percentage path.
+		|| ((pSensor->device_class == "battery") && is_number(pSensor->last_value))
 		)
 	{
 		handle_auto_discovery_battery(pSensor, message);


### PR DESCRIPTION
## What

Detect a battery-percentage sensor by its `device_class` in addition to the existing hardcoded `object_id` matches.

In `handle_auto_discovery_sensor`, a sensor is routed to the battery handler when it carries `device_class == "battery"` with a numeric value, on top of the current `object_id == "battery" / "battery_low" / "battery_level"` matches, which are kept as a fallback.

## Why

zwave-js-ui (and the auto-discovery format generally) marks battery entities with a `device_class` field; matching on the hardcoded English `object_id` strings is fragile (it breaks if the publisher changes or localises the entity naming). Domoticz already routes several other entity types by `device_class` (gas, illuminance, door, motion), so this also makes battery consistent with the rest of the handler rather than the odd one out.

zwave-js-ui sets `device_class: battery` on both the numeric `level` sensor and the `isLow` binary_sensor: see [`api/lib/Gateway.ts` L1639-1667](https://github.com/zwave-js/zwave-js-ui/blob/v11.21.1/api/lib/Gateway.ts#L1639-L1667) and the constants [`Constants.ts` L59](https://github.com/zwave-js/zwave-js-ui/blob/v11.21.1/api/lib/Constants.ts#L59) / [L87](https://github.com/zwave-js/zwave-js-ui/blob/v11.21.1/api/lib/Constants.ts#L87).

## Safety / scope

- **Additive and backwards-compatible:** the existing `object_id` matches are untouched, so any publisher that does not set `device_class` keeps working unchanged.
- The `is_number(...)` guard means only numeric values take this path. `handle_auto_discovery_sensor` is only reached for `component_type == "sensor"` via the main dispatch, so the `isLow` `binary_sensor` (which also carries `device_class: "battery"`) is **not** routed into the percentage path.
- Builds cleanly. One-line condition change.

Part of #5806; a small conformance follow-up to #6865 (independent of it, can merge in any order).
