### PR TITLE
fix(mcp): get_scenes tool returned empty due to non-existent Scenes.Status column

### DIFF
--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -5084,7 +5084,7 @@ namespace mcp		// Model Context Protocol
 	bool getScenes(const Json::Value &jsonRequest, Json::Value &jsonRPCRep)
 	{
 		auto result = m_sql.safe_query(
-			"SELECT ID, Name, SceneType, LastUpdate, Status FROM Scenes ORDER BY Name");
+			"SELECT ID, Name, SceneType, nValue, LastUpdate FROM Scenes ORDER BY Name");
 
 		std::string sResult;
 		if (result.empty())
@@ -5099,12 +5099,10 @@ namespace mcp		// Model Context Protocol
 				std::string sIdx = row[0];
 				std::string sName = row[1];
 				int iSceneType = atoi(row[2].c_str());
-				std::string sLastUpdate = row[3];
-				std::string sStatus = row[4];
+				std::string sStatus = (atoi(row[3].c_str()) == 1) ? "On" : "Off";
+				std::string sLastUpdate = row[4];
 				std::string sType = (iSceneType == 1) ? "Group" : "Scene";
-				sResult += "- \"" + sName + "\" [" + sType + ", idx=" + sIdx;
-				if (!sStatus.empty())
-					sResult += ", Status=" + sStatus;
+				sResult += "- \"" + sName + "\" [" + sType + ", idx=" + sIdx + ", Status=" + sStatus;
 				if (!sLastUpdate.empty())
 					sResult += ", Last: " + sLastUpdate;
 				sResult += "]\n";


### PR DESCRIPTION
### Problem

The `get_scenes` MCP tool always returned **"No scenes or groups found."**, even on systems with scenes configured. The `domoticz://scenes` resource, reading the same `Scenes` table, correctly listed all scenes.

### Root cause

`getScenes()` queried a `Status` column that does not exist in the `Scenes` table:

```sql
SELECT ID, Name, SceneType, LastUpdate, Status FROM Scenes ORDER BY Name
```

The `Scenes` schema has no `Status` column (on/off state lives in `nValue`). `sqlite3_prepare_v2` fails on the unknown column, `query()` returns an empty result set (logging `no such column: Status`), and the tool reports no scenes. The `domoticz://scenes` resource was unaffected because it already reads `nValue`.

### Fix

Query `nValue` instead of `Status` and render On/Off, matching the working resource path:

```sql
SELECT ID, Name, SceneType, nValue, LastUpdate FROM Scenes ORDER BY Name
```

```cpp
std::string sStatus = (atoi(row[3].c_str()) == 1) ? "On" : "Off";
```

`LastUpdate` (a valid column) is preserved.

### Verification

- Reproduced live: before the fix the tool returned empty while the resource returned all scenes; confirmed the missing column is the cause.
- `mcpserver/McpService.cpp` compiles clean.