### PR TITLE
fix(plugins): honor param-level default for dropdown settings

### DIFF
--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -5892,9 +5892,23 @@ define(['app'], function (app) {
 									if (typeof (param.options) != "undefined") {
 										// Select dropdown
 										PluginParams += '<td><select id="' + param.field + '" style="width:' + paramWidth + '" class="combobox ui-corner-all">';
+										// A per-option default="true" wins; if none is set, fall back to selecting the
+										// option whose value matches the param-level default (see dropdown default spec).
+										var hasOptionDefault = false;
+										$.each(param.options, function (i, option) {
+											if ((typeof (option.default) != "undefined") && (option.default == "true")) hasOptionDefault = true;
+										});
+										var fallbackValue = hasOptionDefault ? undefined : param.default;
+										var selectedApplied = false;
 										$.each(param.options, function (i, option) {
 											PluginParams += '<option data-i18n="' + option.label + '" value="' + option.value + '"';
-											if ((typeof (option.default) != "undefined") && (option.default == "true")) PluginParams += ' selected';
+											var isDefault = hasOptionDefault
+												? ((typeof (option.default) != "undefined") && (option.default == "true"))
+												: ((typeof (fallbackValue) != "undefined") && (String(option.value) === String(fallbackValue)));
+											if (isDefault && !selectedApplied) {
+												PluginParams += ' selected';
+												selectedApplied = true;
+											}
 											PluginParams += '>' + option.label + '</option>';
 										});
 										PluginParams += '</select></td>';


### PR DESCRIPTION
### Background

While building a new myenergi plugin I've been drinking my own champagne with the extended plugin settings from #6674, and hit a few small rough edges. This is the first of them.

### The problem

Every extended-settings param type takes its default from a `default="..."` attribute on `<param>` (text, number, boolean, slider, textarea). Dropdowns are the exception: a `<param>` with `<options>` only honors a per-option `default="true"`, and a `default="..."` on the param itself is silently ignored. So:

```xml
<param field="Mode" default="1">
  <options>
    <option label="Auto" value="0" />
    <option label="Hibernate" value="1" />
  </options>
</param>
```

preselects nothing, no error, and the author has to move the default onto the option instead. Same attribute name, different behaviour, no diagnostic.

### What this PR does

Frontend only (`www/app/hardware/Hardware.js`, dropdown branch of `renderParam`):

- Per-option `default="true"` still wins (unchanged).
- When no option carries `default="true"`, fall back to selecting the option whose value equals the param-level `default`.
- Coerce both sides to string so a numeric default (e.g. `default="1"`) matches a string option value.
- Mark at most one option `selected`, which also tidies a pre-existing case where multiple `default="true"` options emitted multiple `selected` attributes.

Backend already delivers both signals (`param.default` and per-option `default`), so no backend change. On edit the stored value still overrides the rendered default. Backward compatible by construction: the fallback only adds a selection where there currently is none.

### Validation

Verified the selection logic across option-default only, param-default only, both (option wins), numeric-default coercion, double-default (single selection), no match, and no defaults, and confirmed all of these render correctly in a running instance with a test plugin manifest. Front-end syntax checked.

### Related idea, worth a PR?

While laying out the myenergi settings I wanted paired fields on one row (e.g. `Serial | Name` per Harvi device) instead of one field per row; today `renderParam` emits one `<tr>` per param so they stack. I've sketched a `<group layout="table" columns="N">` where each param keeps its own `label: input` and they flow across the row, with a general rows-of-cells model underneath that could later grow to header rows and merged cells (`colspan`). Small, backward-compatible renderer + manifest-attribute change.

Before I build it: is that something you think adds value? Let me know.
