### PR TITLE
fix(plugins): preserve custom plugin password on blank save

### DIFF
--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -1594,6 +1594,124 @@ namespace http
 			return true;
 		}
 
+#ifdef ENABLE_PYTHON
+		// Parse a plugin manifest XML once: extract the <plugin key="..."> attribute and the set of
+		// field names declared as password fields. The password attribute is matched case-insensitively
+		// ("true"/"TRUE"/"1") so a manifest typo does not silently expose a secret. Pure: operates on
+		// the manifest XML string, no I/O. keyOut is empty when the manifest has no key attribute.
+		static void ParsePluginManifest(const std::string &manifestXml, std::string &keyOut, std::set<std::string> &passwordFieldsOut)
+		{
+			keyOut.clear();
+			passwordFieldsOut.clear();
+			TiXmlDocument xmlDoc;
+			xmlDoc.Parse(manifestXml.c_str());
+			if (xmlDoc.Error())
+				return;
+			TiXmlNode *pPluginNode = xmlDoc.FirstChild("plugin");
+			if (!pPluginNode)
+				return;
+			TiXmlElement *pPluginEle = pPluginNode->ToElement();
+			if (!pPluginEle)
+				return;
+			const char *pKey = pPluginEle->Attribute("key");
+			if (pKey)
+				keyOut = pKey;
+			TiXmlNode *pParamsNode = pPluginNode->FirstChild("params");
+			if (!pParamsNode)
+				return;
+			auto isPasswordAttr = [](const char *pPassword) -> bool {
+				if (!pPassword)
+					return false;
+				std::string v(pPassword);
+				for (auto &c : v)
+					c = (char)tolower((unsigned char)c);
+				return (v == "true" || v == "1");
+			};
+			auto checkParam = [&](TiXmlElement *pEle) {
+				const char *pField = pEle->Attribute("field");
+				if (pField && isPasswordAttr(pEle->Attribute("password")))
+					passwordFieldsOut.insert(pField);
+			};
+			for (TiXmlNode *pChild = pParamsNode->FirstChild(); pChild; pChild = pChild->NextSibling())
+			{
+				TiXmlElement *pEle = pChild->ToElement();
+				if (!pEle)
+					continue;
+				std::string tagName = pEle->Value();
+				if (tagName == "param")
+					checkParam(pEle);
+				else if (tagName == "group")
+				{
+					for (TiXmlNode *pGroupChild = pEle->FirstChild("param"); pGroupChild; pGroupChild = pGroupChild->NextSibling("param"))
+					{
+						TiXmlElement *pGroupEle = pGroupChild->ToElement();
+						if (pGroupEle)
+							checkParam(pGroupEle);
+					}
+				}
+			}
+		}
+
+		// Build a map from each plugin's manifest "key" attribute (which matches the Hardware.Extra
+		// column) to its set of password field names. GetManifest() is keyed by plugin DIRECTORY, not by
+		// the key attribute, so it must be walked and re-keyed. Only plugins that declare at least one
+		// password field appear.
+		static std::map<std::string, std::set<std::string>> BuildPluginPasswordFieldsByKey()
+		{
+			std::map<std::string, std::set<std::string>> byKey;
+			Plugins::CPluginSystem pluginSystem;
+			for (const auto &manifest : *pluginSystem.GetManifest())
+			{
+				std::string key;
+				std::set<std::string> fields;
+				ParsePluginManifest(manifest.second, key, fields);
+				if (!key.empty() && !fields.empty())
+					byKey[key] = fields;
+			}
+			return byKey;
+		}
+
+		// Pure merge for the plugin Settings write path. Given the incoming Settings JSON (from the edit
+		// form, where password fields were stripped to empty on the read side), the currently stored
+		// Settings JSON, and the plugin's password field names, return the JSON to persist. A password
+		// field that arrives empty or missing keeps its stored value ("leave blank to keep"). Fails
+		// graceful: never wipes a readable stored secret, never throws.
+		static std::string MergePluginSettingsPreservePasswords(const std::string &incomingSettings, const std::string &storedSettings, const std::set<std::string> &passwordFields)
+		{
+			if (passwordFields.empty())
+				return incomingSettings;
+
+			Json::Value incoming;
+			bool incomingOk = !incomingSettings.empty() && ParseJSon(incomingSettings, incoming) && incoming.isObject();
+			Json::Value stored;
+			bool storedOk = !storedSettings.empty() && ParseJSon(storedSettings, stored) && stored.isObject();
+
+			// Incoming unusable (blank/invalid): preserve everything rather than wipe stored secrets.
+			if (!incomingOk)
+			{
+				if (!incomingSettings.empty())
+					_log.Log(LOG_ERROR, "WebServer: incoming plugin Settings not parseable on save; preserving stored values");
+				return storedOk ? storedSettings : incomingSettings;
+			}
+			// Stored unreadable: nothing recoverable to preserve; keep the incoming values as-is. A
+			// corrupt stored blob is already lost; warn so it is not silent.
+			if (!storedOk)
+			{
+				if (!storedSettings.empty())
+					_log.Log(LOG_ERROR, "WebServer: stored plugin Settings not parseable on save; cannot preserve existing secrets");
+				return incomingSettings;
+			}
+
+			for (const auto &field : passwordFields)
+			{
+				bool blank = !incoming.isMember(field) || incoming[field].asString().empty();
+				if (blank && stored.isMember(field))
+					incoming[field] = stored[field];
+			}
+			return JSonToRawString(incoming);
+		}
+#endif
+
 		void CWebServer::Cmd_AddHardware(WebEmSession& session, const request& req, Json::Value& root)
 		{
 			if (session.rights != URIGHTS_ADMIN)
@@ -1863,6 +1981,20 @@ namespace http
 				else if (htype == HTYPE_PythonPlugin)
 				{
 					sport = request::findValue(&req, "serialport");
+#ifdef ENABLE_PYTHON
+					{
+						// Preserve custom password fields left blank on save ("leave blank to keep").
+						// Extra holds the plugin key; a password field submitted empty keeps its stored value.
+						std::map<std::string, std::set<std::string>> pluginPasswordFields = BuildPluginPasswordFieldsByKey();
+						auto itPwd = pluginPasswordFields.find(extra);
+						if (itPwd != pluginPasswordFields.end() && !itPwd->second.empty())
+						{
+							std::vector<std::vector<std::string>> storedRes = m_sql.safe_query("SELECT Settings FROM Hardware WHERE ID=%q", idx.c_str());
+							std::string storedSettings = storedRes.empty() ? "" : storedRes[0][0];
+							settings = MergePluginSettingsPreservePasswords(settings, storedSettings, itPwd->second);
+						}
+					}
+#endif
 					m_sql.safe_query("UPDATE Hardware SET Name='%q', Enabled=%d, Type=%d, LogLevel=%d, Address='%q', Port=%d, SerialPort='%q', Username='%q', Password='%q', "
 						"Extra='%q', Mode1='%q', Mode2='%q', Mode3='%q', Mode4='%q', Mode5='%q', Mode6='%q', DataTimeout=%d, Settings='%q' WHERE (ID == '%q')",
 						name.c_str(), (senabled == "true") ? 1 : 0, htype, iLogLevelEnabled, address.c_str(), port, sport.c_str(), username.c_str(), password.c_str(),
@@ -4546,55 +4678,15 @@ namespace http
 			if (!result.empty())
 			{
 #ifdef ENABLE_PYTHON
-				// Pre-build password field sets per plugin key to avoid per-entry XML parsing
+				// Map plugin key -> password field names, built once, but only when the result actually
+				// contains a plugin row (avoids parsing manifests for non-plugin queries).
 				std::map<std::string, std::set<std::string>> pluginPasswordFields;
 				{
-					Plugins::CPluginSystem PluginMgr;
-					std::map<std::string, std::string> *mPluginXml = PluginMgr.GetManifest();
-					for (const auto &type : *mPluginXml)
-					{
-						TiXmlDocument xmlDoc;
-						xmlDoc.Parse(type.second.c_str());
-						if (xmlDoc.Error())
-							continue;
-						TiXmlNode *pPluginNode = xmlDoc.FirstChild("plugin");
-						if (!pPluginNode)
-							continue;
-						TiXmlElement *pPluginEle = pPluginNode->ToElement();
-						if (!pPluginEle)
-							continue;
-						const char *pKey = pPluginEle->Attribute("key");
-						if (!pKey)
-							continue;
-						std::string pluginKey = pKey;
-						TiXmlNode *pParamsNode = pPluginNode->FirstChild("params");
-						if (!pParamsNode)
-							continue;
-						auto checkParam = [&](TiXmlElement *pEle) {
-							const char *pField = pEle->Attribute("field");
-							const char *pPassword = pEle->Attribute("password");
-							if (pField && pPassword && std::string(pPassword) == "true")
-								pluginPasswordFields[pluginKey].insert(pField);
-						};
-						for (TiXmlNode *pChild = pParamsNode->FirstChild(); pChild; pChild = pChild->NextSibling())
-						{
-							TiXmlElement *pEle = pChild->ToElement();
-							if (!pEle)
-								continue;
-							std::string tagName = pEle->Value();
-							if (tagName == "param")
-								checkParam(pEle);
-							else if (tagName == "group")
-							{
-								for (TiXmlNode *pGroupChild = pEle->FirstChild("param"); pGroupChild; pGroupChild = pGroupChild->NextSibling("param"))
-								{
-									TiXmlElement *pGroupEle = pGroupChild->ToElement();
-									if (pGroupEle)
-										checkParam(pGroupEle);
-								}
-							}
-						}
-					}
+					bool hasPlugin = false;
+					for (const auto &sd : result)
+						if ((_eHardwareTypes)atoi(sd[3].c_str()) == HTYPE_PythonPlugin) { hasPlugin = true; break; }
+					if (hasPlugin)
+						pluginPasswordFields = BuildPluginPasswordFieldsByKey();
 				}
 #endif
 				int ii = 0;
@@ -4646,16 +4738,24 @@ namespace http
 						if (ParseJSon(sd[18], settingsJson) && settingsJson.isObject())
 						{
 #ifdef ENABLE_PYTHON
-							// Strip password-type field values using pre-built cache
-							std::string pluginKey = sd[9]; // Extra holds plugin key
+							// Strip password-type field values so secrets never reach the browser, and
+							// report which ones are set so the UI can show "leave blank to keep".
+							std::string pluginKey = sd[9]; // Extra holds the plugin key
 							auto itPwdFields = pluginPasswordFields.find(pluginKey);
 							if (itPwdFields != pluginPasswordFields.end())
 							{
+								Json::Value pwdSet(Json::objectValue);
 								for (const auto &field : itPwdFields->second)
 								{
 									if (settingsJson.isMember(field))
+									{
+										if (!settingsJson[field].asString().empty())
+											pwdSet[field] = true;
 										settingsJson[field] = "";
+									}
 								}
+								if (!pwdSet.empty())
+									root["result"][ii]["SettingsPwdSet"] = pwdSet;
 							}
 #endif
 							root["result"][ii]["Settings"] = settingsJson;

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -258,7 +258,7 @@ define(['app'], function (app) {
 				var bIsOK = true;
 				// Make sure that all required fields have values
 				$(selector + " .text").each(function () {
-					if ((typeof (this.attributes.required) != "undefined") && (this.value == "")) {
+					if ((typeof (this.attributes.required) != "undefined") && (this.value == "") && (typeof (this.attributes["data-haspwd"]) == "undefined")) {
 						$(selector + " #" + this.id).focus();
 						ShowNotify($.t('Please enter value for required field'), 2500, true);
 						bIsOK = false;
@@ -1771,6 +1771,8 @@ define(['app'], function (app) {
 				var bIsOK = true;
 				// Make sure that all required fields have values
 				$(selector + " .text").each(function () {
+					// Add always creates a new device, so a required field must be filled; there is no
+					// stored value to "keep" (the data-haspwd exemption applies only on Update/edit).
 					if ((typeof (this.attributes.required) != "undefined") && (this.value == "")) {
 						$(selector + " #" + this.id).focus();
 						ShowNotify($.t('Please enter value for required field'), 2500, true);
@@ -4468,6 +4470,19 @@ define(['app'], function (app) {
 											$field.val(value);
 										}
 									});
+									// Mark stored password fields so the user sees they are set and can leave
+									// them blank to keep, and so required-validation does not force re-entry.
+									if (hwEntry.SettingsPwdSet && typeof hwEntry.SettingsPwdSet === "object") {
+										$.each(hwEntry.SettingsPwdSet, function (key, isSet) {
+											if (!isSet) return;
+											var $pf = $visibleTable.find("#" + key);
+											if ($pf.length === 0) return;
+											// Fixed-length dots (not the real length): language-neutral "a secret is
+											// stored" affordance. Placeholder only, never a value, so it is never submitted.
+											$pf.attr("placeholder", "••••••••");
+											$pf.attr("data-haspwd", "true");
+										});
+									}
 									// Trigger change events to re-evaluate conditional visibility
 									$visibleTable.find("select, input").trigger("change");
 								}
@@ -5390,6 +5405,9 @@ define(['app'], function (app) {
 						InitPluginWidgets($(this));
 					}
 				});
+				// Clear stored-password markers so they never leak across add/edit sessions on the
+				// reused plugin fields; edit-restore re-applies them for the current device via SettingsPwdSet.
+				$("#hardwarecontent #divpythonplugin input[type=password]").removeAttr("data-haspwd").removeAttr("placeholder");
 				$("#hardwarecontent #divpythonplugin").show();
 				return;
 			}
@@ -5943,7 +5961,7 @@ define(['app'], function (app) {
 											if (typeof (param.default) != "undefined") PluginParams += param.default;
 											PluginParams += '</textarea>';
 										} else {
-											if ((typeof (param.password) != "undefined") && (param.password == "true"))
+											if ((typeof (param.password) != "undefined") && (String(param.password).toLowerCase() == "true" || String(param.password) == "1"))
 												PluginParams += '<input type="password" ';
 											else
 												PluginParams += '<input type="text" ';


### PR DESCRIPTION
### Background

While building a new myenergi plugin I've been drinking my own champagne with the extended plugin settings from #6674, and ran into a few rough edges. This is the one that actually loses data.

### The problem

A plugin param declared `password="true"` is stored in `Hardware.Settings` and (correctly) stripped from the `gethardware` response so the secret never reaches the browser. But that means the field renders empty on the hardware edit page, and saving resubmits the empty value, overwriting the stored secret. In practice, changing any unrelated setting silently wipes the plugin's API key, with no indication the field was ever set.

### What this PR does

Backend (`main/WebServerCmds.cpp`):

- `Cmd_UpdateHardware` merges on save: a password field submitted empty or missing keeps its stored value ("leave blank to keep"), mirroring the existing Netatmo `Extra` preserve-on-empty pattern. Fails gracefully, never wipes a readable secret, never throws on malformed JSON.
- `Cmd_GetHardware` emits a small `SettingsPwdSet` map so the UI can show a password is set, without sending the secret.
- Manifest password-field detection is pulled into shared helpers, re-keyed by the plugin `key` attribute (the manifest map is keyed by directory), matched case-insensitively (`true`/`TRUE`/`1`), built only when the result contains a plugin row.

Frontend (`www/app/hardware/Hardware.js`):

- A set password field renders a fixed-length dot placeholder (language-neutral, nothing submitted as a value).
- Required-validation skips an empty-but-stored password field on edit only; Add always requires it. Stored-password markers are cleared on form (re)init so they can't leak across the reused plugin fields.

Scope: custom `password="true"` params only. The reserved `Password` column round-trip is untouched (separate follow-up below).

### Validation

- Merge logic unit-tested (7 cases: blank / missing / replace / empty-input / corrupt-stored) against jsoncpp.
- Manifest detection tested against the bundled TiXml parser (case-insensitive, `<group>` children, key attribute).
- Full build with `ENABLE_PYTHON`.
- Verified end-to-end on a running instance with a real plugin: read-side strip + `SettingsPwdSet`, keep-on-blank and replace via `updatehardware`, and the edit/add UI paths.

### Pre-existing issues noticed while here (deliberately NOT bundled)

- Reserved `Password` column is sent to the browser and repopulated on edit (opposite of custom password params). Confidentiality follow-up with its own risk.
- With `ENABLE_PYTHON` off, lingering plugin rows have `Settings` sent unstripped (the assignment sits outside the `#ifdef`).
- A plugin renaming or removing a password field orphans the stored secret (not recognisable from the current manifest).
- `renderParam` interpolates manifest strings into HTML unescaped (admin page only; a plugin already runs server-side Python).
