### PR TITLE
feat(mcp): render multi-channel and aggregate sensor families in get_sensor_history

### DIFF
--- a/main/WebServerHandleGraphCustom.cpp
+++ b/main/WebServerHandleGraphCustom.cpp
@@ -486,6 +486,52 @@ void HandleGraphCustomRange(const GraphContext& ctx, const request& req,
 				root["ValueUnits"] = (options.count("ValueUnits") ? options.at("ValueUnits") : std::string{});
 				root["Divider"] = divider;
 
+				// Built-in counter families carry no ValueUnits option, but their unit is
+				// fixed by device type. Populate it once here (the single place that owns
+				// the custom-range series) so consumers such as the MCP server can label
+				// values without re-deriving units. Gap-fill only: never overrides an
+				// option-provided unit, and does not touch the emitted values. This is a
+				// single per-response unit, correct because every family here uses one unit
+				// for all of its series. Current/CM113 is set in its own branch below (which
+				// already reads the A-vs-Watt display preference, so we do not re-read it
+				// here); LeafWetness intentionally has no unit.
+				// metertype: 0 = metric, 1 = imperial (matches the value conversion below).
+				if (root["ValueUnits"].asString().empty())
+				{
+					std::string vu;
+					if (dType == pTypeAirQuality)
+						vu = "ppm";
+					else if (dType == pTypeLux)
+						vu = "Lux";
+					else if (dType == pTypeUsage)
+						vu = "Watt";
+					else if (dType == pTypeWEIGHT)
+						vu = sql.m_weightsign; // verified "kg" or "lb" (SQLHelper.cpp:10542/10547)
+					else if (dType == pTypeRFXSensor && (dSubType == sTypeRFXSensorAD || dSubType == sTypeRFXSensorVolt))
+						vu = "mV";
+					else if (dType == pTypeGeneral)
+					{
+						if (dSubType == sTypeVoltage)
+							vu = "V";
+						else if (dSubType == sTypeCurrent)
+							vu = "A";
+						else if (dSubType == sTypePressure)
+							vu = "Bar";
+						else if (dSubType == sTypeSoundLevel)
+							vu = "dB";
+						else if (dSubType == sTypeSolarRadiation)
+							vu = "Watt/m2";
+						else if (dSubType == sTypeSoilMoisture)
+							vu = "cb";
+						else if (dSubType == sTypeVisibility)
+							vu = (metertype == 0) ? "km" : "mi";
+						else if (dSubType == sTypeDistance)
+							vu = (metertype == 0) ? "cm" : "in";
+					}
+					if (!vu.empty())
+						root["ValueUnits"] = vu;
+				}
+
 				int ii = 0;
 				if (dType == pTypeP1Power)
 				{
@@ -602,6 +648,8 @@ void HandleGraphCustomRange(const GraphContext& ctx, const request& req,
 						sql.GetPreferencesVar("CM113DisplayType", displaytype);
 						sql.GetPreferencesVar("ElectricVoltage", voltage);
 						root["displaytype"] = displaytype;
+						if (root["ValueUnits"].asString().empty())
+							root["ValueUnits"] = (displaytype == 1) ? "Watt" : "A";
 						bool bHaveL1 = false;
 						bool bHaveL2 = false;
 						bool bHaveL3 = false;

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -3949,6 +3949,10 @@ namespace mcp		// Model Context Protocol
 				sSetpointUnit = std::string("\xc2\xb0") + sTempUnit;
 		}
 
+		// Single per-response unit for the counter families (empty for temp/rain/etc).
+		const std::string sUnit = root.isMember("ValueUnits") ? root["ValueUnits"].asString() : "";
+		const std::string sUSuffix = sUnit.empty() ? "" : (" " + sUnit);
+
 		// Format the JSON result as human-readable text
 		if (sSensor == "temp")
 		{
@@ -3968,7 +3972,12 @@ namespace mcp		// Model Context Protocol
 		else if (sSensor == "fan")
 			sResult = "Daily fan speed history for \"" + sName + "\" (rpm min/max):\n";
 		else
-			sResult = "Daily history for \"" + sName + "\":\n";
+		{
+			sResult = "Daily history for \"" + sName + "\"";
+			if (!sUnit.empty())
+				sResult += " (" + sUnit + ")";
+			sResult += ":\n";
+		}
 
 		sResult += "Date        | Data\n";
 		sResult += "------------|--------------------------------------\n";
@@ -4026,12 +4035,50 @@ namespace mcp		// Model Context Protocol
 				if (row.isMember("v_max")) sLine += " max=" + row["v_max"].asString();
 				sResult += sLine + "\n";
 			}
-			else // counter (includes P1, energy, gas, water, generic counters)
+			else // counter families, dispatched by the key shape the core emits.
+			     // Contract with HandleGraphCustomRange: co2_*/lux_*/u_* => min/avg/max
+			     // aggregate; v1..v6 (v3 present) => multi-channel current L1/L2/L3;
+			     // v1(/v2) alone => P1 usage/delivery; v_min/v_max(/v_avg) => single-series
+			     // aggregate; v => plain value. The core emits each family's key set
+			     // atomically (all of min/avg/max, or all of v1..v6), so sibling keys are
+			     // read without a per-key guard. sUnit/sUSuffix are hoisted above (Step 1).
 			{
 				std::string sLine = sDate + " |";
-				if (row.isMember("v1")) sLine += " usage=" + row["v1"].asString();
-				if (row.isMember("v2")) sLine += " delivery=" + row["v2"].asString();
-				if (!row.isMember("v1") && row.isMember("v")) sLine += " value=" + row["v"].asString();
+
+				if (row.isMember("co2_min"))
+					sLine += " min " + row["co2_min"].asString() + " avg " + row["co2_avg"].asString() +
+						 " max " + row["co2_max"].asString() + sUSuffix;
+				else if (row.isMember("lux_min"))
+					sLine += " min " + row["lux_min"].asString() + " avg " + row["lux_avg"].asString() +
+						 " max " + row["lux_max"].asString() + sUSuffix;
+				else if (row.isMember("u_min"))
+					sLine += " min " + row["u_min"].asString() + " avg " + row["u_avg"].asString() +
+						 " max " + row["u_max"].asString() + sUSuffix;
+				else if (row.isMember("v3")) // multi-channel Current (CM113 / CM180i): v1/v2=L1, v3/v4=L2, v5/v6=L3
+				{
+					if (root.isMember("haveL1"))
+						sLine += " L1: " + row["v1"].asString() + "-" + row["v2"].asString() + sUSuffix;
+					if (root.isMember("haveL2"))
+						sLine += " L2: " + row["v3"].asString() + "-" + row["v4"].asString() + sUSuffix;
+					if (root.isMember("haveL3"))
+						sLine += " L3: " + row["v5"].asString() + "-" + row["v6"].asString() + sUSuffix;
+				}
+				else if (row.isMember("v1")) // P1 power: usage / delivery
+				{
+					sLine += " usage " + row["v1"].asString();
+					if (row.isMember("v2"))
+						sLine += " delivery " + row["v2"].asString();
+				}
+				else if (row.isMember("v_min"))
+				{
+					sLine += " min " + row["v_min"].asString();
+					if (row.isMember("v_avg"))
+						sLine += " avg " + row["v_avg"].asString();
+					sLine += " max " + row["v_max"].asString() + sUSuffix;
+				}
+				else if (row.isMember("v"))
+					sLine += " " + row["v"].asString() + sUSuffix;
+
 				sResult += sLine + "\n";
 			}
 		}

--- a/mcpserver/McpService.cpp
+++ b/mcpserver/McpService.cpp
@@ -3924,9 +3924,8 @@ namespace mcp		// Model Context Protocol
 
 		if (!root.isMember("result") || root["result"].empty())
 		{
-			std::string sMsg = "There is no graph history available for the \"" + sName + "\" sensor ";
-			sMsg += "between " + szDateStart + " and " + szDateEnd + ".\n";
-			sMsg += "This may mean graph logging is disabled for this device or no data has been recorded.\n";
+			std::string sMsg = "No daily history for \"" + sName + "\" between " + szDateStart + " and " + szDateEnd + ".\n";
+			sMsg += "The data may be outside this date range, or daily history may not be recorded for this device yet.\n";
 			sMsg += "Tip: try a wider date range or increase 'days'.";
 			mcp::setToolResult(jsonRPCRep, sMsg, true);
 			return true;


### PR DESCRIPTION
### What

Follow-up to #6878 (which restored the underlying data). `get_sensor_history` only formatted P1-style usage/delivery and a generic value, so the other `MultiMeter_Calendar` families came back as a bare date with no data: AirQuality, Lux, Usage, Weight, per-phase Current (CM113/CM180i), and the General/RFXSensor min/max families. They now render with units.

### Changes

- **Core (`HandleGraphCustomRange`):** emit a per-series unit label in `ValueUnits` for the built-in counter families, which previously left it empty. Gap-fill only (never overrides an option-provided unit), additive (no emitted value changes), and scoped to this function. Current/CM113 reuses the existing display-type read, so no extra DB query.
- **MCP (`get_sensor_history`):** render each family from the keys the core emits, labelled with the unit (per-phase L1/L2/L3 for multi-channel current, min/avg/max for the aggregate families). The empty-result message is reworded to stop asserting logging is disabled.

Example:

```
Daily history for "Current L1/L2/L3" (Watt):
2026-02-20 | L1: 0-3726 Watt   L2: 345-5934 Watt   L3: 0-3542 Watt

Daily history for "Lux Sensor" (Lux):
2026-02-25 | min 0 avg 1353.14 max 5031 Lux
```

### Validation

Clean build. Verified against a real device set via a live MCP session: multi-channel Current (per-phase, with unit), Lux/aggregate min/avg/max, P1 usage/delivery, generic meters, and the advisory message on an out-of-range window.
