### PR TITLE
implement selector lov and alert support dzvents automation wizard

### DIFF
--- a/www/app/events/AutomationWizard.html
+++ b/www/app/events/AutomationWizard.html
@@ -85,12 +85,12 @@
                     </div>
                     <div class="aw-field" ng-if="$ctrl.conditionNeedsValue">
                         <label>{{:: 'Value' | translate }} <span ng-if="$ctrl.conditionUnit">({{$ctrl.conditionUnit}})</span></label>
-                        <select ng-if="$ctrl.triggerConfig.deviceCategory === 'selector' && $ctrl.triggerConfig.conditionLevelOptions && $ctrl.triggerConfig.conditionLevelOptions.length"
+                        <select ng-if="$ctrl.triggerConditionHasLevelOptions()"
                                 class="form-control"
                                 ng-model="$ctrl.triggerConfig.conditionValue"
                                 ng-options="opt.level as opt.name for opt in $ctrl.triggerConfig.conditionLevelOptions">
                         </select>
-                        <input ng-if="!($ctrl.triggerConfig.deviceCategory === 'selector' && $ctrl.triggerConfig.conditionLevelOptions && $ctrl.triggerConfig.conditionLevelOptions.length)"
+                        <input ng-if="!$ctrl.triggerConditionHasLevelOptions()"
                                type="number" class="form-control" step="0.1"
                                ng-model="$ctrl.triggerConfig.conditionValue">
                     </div>
@@ -291,12 +291,12 @@
                             </div>
                             <div class="aw-field" ng-if="$ctrl.wizardCondition.needsValue">
                                 <label>Value <span ng-if="$ctrl.wizardCondition.unit">({{$ctrl.wizardCondition.unit}})</span></label>
-                                <select ng-if="$ctrl.wizardCondition.levelOptions && $ctrl.wizardCondition.levelOptions.length"
+                                <select ng-if="$ctrl.wizardConditionHasLevelOptions()"
                                         class="form-control"
                                         ng-model="$ctrl.wizardCondition.value"
                                         ng-options="opt.level as opt.name for opt in $ctrl.wizardCondition.levelOptions">
                                 </select>
-                                <input ng-if="!($ctrl.wizardCondition.levelOptions && $ctrl.wizardCondition.levelOptions.length)"
+                                <input ng-if="!$ctrl.wizardConditionHasLevelOptions()"
                                        type="number" class="form-control" step="0.1" ng-model="$ctrl.wizardCondition.value">
                             </div>
                         </div>

--- a/www/app/events/AutomationWizard.html
+++ b/www/app/events/AutomationWizard.html
@@ -85,7 +85,13 @@
                     </div>
                     <div class="aw-field" ng-if="$ctrl.conditionNeedsValue">
                         <label>{{:: 'Value' | translate }} <span ng-if="$ctrl.conditionUnit">({{$ctrl.conditionUnit}})</span></label>
-                        <input type="number" class="form-control" step="0.1"
+                        <select ng-if="$ctrl.triggerConfig.deviceCategory === 'selector' && $ctrl.triggerConfig.conditionLevelOptions && $ctrl.triggerConfig.conditionLevelOptions.length"
+                                class="form-control"
+                                ng-model="$ctrl.triggerConfig.conditionValue"
+                                ng-options="opt.level as opt.name for opt in $ctrl.triggerConfig.conditionLevelOptions">
+                        </select>
+                        <input ng-if="!($ctrl.triggerConfig.deviceCategory === 'selector' && $ctrl.triggerConfig.conditionLevelOptions && $ctrl.triggerConfig.conditionLevelOptions.length)"
+                               type="number" class="form-control" step="0.1"
                                ng-model="$ctrl.triggerConfig.conditionValue">
                     </div>
                 </div>
@@ -285,7 +291,13 @@
                             </div>
                             <div class="aw-field" ng-if="$ctrl.wizardCondition.needsValue">
                                 <label>Value <span ng-if="$ctrl.wizardCondition.unit">({{$ctrl.wizardCondition.unit}})</span></label>
-                                <input type="number" class="form-control" step="0.1" ng-model="$ctrl.wizardCondition.value">
+                                <select ng-if="$ctrl.wizardCondition.levelOptions && $ctrl.wizardCondition.levelOptions.length"
+                                        class="form-control"
+                                        ng-model="$ctrl.wizardCondition.value"
+                                        ng-options="opt.level as opt.name for opt in $ctrl.wizardCondition.levelOptions">
+                                </select>
+                                <input ng-if="!($ctrl.wizardCondition.levelOptions && $ctrl.wizardCondition.levelOptions.length)"
+                                       type="number" class="form-control" step="0.1" ng-model="$ctrl.wizardCondition.value">
                             </div>
                         </div>
                     </div>

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -88,8 +88,19 @@ define(['app'], function (app) {
         ],
         'energy':      [
             { id: 'updateEnergy',      label: 'Set power (W)',    hasValue: true, unit: 'W',  def: 0, min: 0 }
+        ],
+        'alert':       [
+            { id: 'updateAlertSensor', label: 'Set alert level',  hasValue: true, unit: '', def: 'domoticz.ALERTLEVEL_GREY' }
         ]
     };
+
+    var ALERT_LEVELS = [
+        { level: 'domoticz.ALERTLEVEL_GREY',   name: 'Grey (No alert)'  },
+        { level: 'domoticz.ALERTLEVEL_GREEN',  name: 'Green (Info)'     },
+        { level: 'domoticz.ALERTLEVEL_YELLOW', name: 'Yellow (Warning)' },
+        { level: 'domoticz.ALERTLEVEL_ORANGE', name: 'Orange (Alert)'   },
+        { level: 'domoticz.ALERTLEVEL_RED',    name: 'Red (Emergency)'  }
+    ];
 
     var DEVICE_CONDITIONS = {
         switch:      [{ id: 'any', label: 'Any change' }, { id: 'on', label: 'Turns On' }, { id: 'off', label: 'Turns Off' }],
@@ -135,6 +146,8 @@ define(['app'], function (app) {
         custom:      [{ id: 'any', label: 'Any change' },
                       { id: 'above', label: 'Value above', hasValue: true, unit: '', def: 0 },
                       { id: 'below', label: 'Value below', hasValue: true, unit: '', def: 0 }],
+        alert:       [{ id: 'any', label: 'Any change' },
+                      { id: 'alert_level_is', label: 'Level is', hasValue: true, unit: '', def: 'domoticz.ALERTLEVEL_GREY' }],
     };
 
     var COND_EXPR = {
@@ -145,6 +158,7 @@ define(['app'], function (app) {
         level_above: 'device.level > {v}',
         level_below: 'device.level < {v}',
         level_is:    'device.level == {v}',
+        alert_level_is: 'device.color == {v}',
         above: {
             temperature: 'device.temperature > {v}', temphum: 'device.temperature > {v}',
             humidity: 'device.humidity > {v}', percentage: 'device.percentage > {v}',
@@ -186,6 +200,12 @@ define(['app'], function (app) {
         return fallbackDef !== undefined ? fallbackDef : 0;
     }
 
+    function getDeviceLevelOptions(category, dev) {
+        if (category === 'alert') return ALERT_LEVELS;
+        if (category === 'selector') return getSelectorLevels(dev);
+        return [];
+    }
+
     function getDeviceCategory(dev) {
         if (!dev) return 'switch';
         var type = (dev.Type       || '').toLowerCase();
@@ -217,6 +237,7 @@ define(['app'], function (app) {
         if (sub === 'kwh')             return 'power';
         if (sub === 'voltage')         return 'voltage';
         if (sub === 'lux')             return 'lux';
+        if (sub === 'alert')           return 'alert';
         return 'switch';
     }
 
@@ -400,7 +421,7 @@ define(['app'], function (app) {
                 } else {
                     arr.push(dev.idx);
                     vm.triggerConfig.deviceCategory = getDeviceCategory(dev);
-                    vm.triggerConfig.conditionLevelOptions = getSelectorLevels(dev);
+                    vm.triggerConfig.conditionLevelOptions = getDeviceLevelOptions(vm.triggerConfig.deviceCategory, dev);
                     vm.deviceConditions             = DEVICE_CONDITIONS[vm.triggerConfig.deviceCategory] || DEVICE_CONDITIONS['switch'];
                     var valid = vm.deviceConditions.some(function (c) { return c.id === vm.triggerConfig.condition; });
                     if (!valid) { vm.triggerConfig.condition = 'any'; }
@@ -504,7 +525,7 @@ define(['app'], function (app) {
             vm.onConditionDeviceChange = function () {
                 var dev = findDeviceByIdx(vm.wizardCondition.deviceIdx);
                 vm.wizardCondition.category = getDeviceCategory(dev);
-                vm.wizardCondition.levelOptions = getSelectorLevels(dev);
+                vm.wizardCondition.levelOptions = getDeviceLevelOptions(vm.wizardCondition.category, dev);
                 vm.wizardCondition.conditionStates = DEVICE_CONDITIONS[vm.wizardCondition.category] || DEVICE_CONDITIONS['switch'];
                 var valid = vm.wizardCondition.conditionStates.some(function (c) { return c.id === vm.wizardCondition.state; });
                 if (!valid) vm.wizardCondition.state = 'any';
@@ -570,8 +591,8 @@ define(['app'], function (app) {
                 action.config.deviceCategory = getDeviceCategory(dev);
                 action.config.levelOptions = null;
 
-                if (action.config.deviceCategory === 'selector') {
-                    action.config.levelOptions = getSelectorLevels(dev);
+                if (action.config.deviceCategory === 'selector' || action.config.deviceCategory === 'alert') {
+                    action.config.levelOptions = getDeviceLevelOptions(action.config.deviceCategory, dev);
                     if (action.config.levelOptions.length) {
                         action.config.actionValue = action.config.levelOptions[0].level;
                     }
@@ -591,7 +612,8 @@ define(['app'], function (app) {
 
             vm.triggerConditionHasLevelOptions = function () {
                 var opts = vm.triggerConfig.conditionLevelOptions;
-                return vm.triggerConfig.deviceCategory === 'selector' && !!(opts && opts.length);
+                var cat = vm.triggerConfig.deviceCategory;
+                return (cat === 'selector' || cat === 'alert') && !!(opts && opts.length);
             };
 
             vm.wizardConditionHasLevelOptions = function () {
@@ -973,6 +995,8 @@ define(['app'], function (app) {
                                 L.push(bi + dev + ".updateUV(" + numVal(c.actionValue, 0) + ")");
                             } else if (act === 'updateEnergy') {
                                 L.push(bi + dev + ".updateEnergy(" + numVal(c.actionValue, 0) + ")");
+                            } else if (act === 'updateAlertSensor') {
+                                L.push(bi + dev + ".updateAlertSensor(" + (c.actionValue || 'domoticz.ALERTLEVEL_GREY') + ", '')");
                             } else {
                                 L.push(bi + dev + "." + act + "()");
                             }

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -169,7 +169,7 @@ define(['app'], function (app) {
         if (!dev || !dev.LevelNames) return [];
         try {
             var names = atob(dev.LevelNames).split('|');
-            var hiddenOff = dev.LevelOffHidden === true || dev.LevelOffHidden === 'true';
+            var hiddenOff = dev.LevelOffHidden === true || dev.LevelOffHidden === 'true'; // API may return boolean or string
             return names
                 .map(function (name, i) { return { level: i * 10, name: name }; })
                 .filter(function (opt) { return !(hiddenOff && opt.level === 0); });
@@ -180,7 +180,10 @@ define(['app'], function (app) {
     }
 
     function defaultLevelValue(levelOptions, fallbackDef) {
-        return (levelOptions && levelOptions.length) ? levelOptions[0].level : (fallbackDef !== undefined ? fallbackDef : 0);
+        if (levelOptions && levelOptions.length) {
+            return levelOptions[0].level;
+        }
+        return fallbackDef !== undefined ? fallbackDef : 0;
     }
 
     function getDeviceCategory(dev) {

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -97,7 +97,8 @@ define(['app'], function (app) {
                       { id: 'level_above', label: 'Level above', hasValue: true, unit: '%', def: 50 },
                       { id: 'level_below', label: 'Level below', hasValue: true, unit: '%', def: 50 }],
         blinds:      [{ id: 'any', label: 'Any change' }, { id: 'open', label: 'Opens' }, { id: 'closed', label: 'Closes' }],
-        selector:    [{ id: 'any', label: 'Any change' }],
+        selector:    [{ id: 'any', label: 'Any change' },
+                      { id: 'level_is', label: 'Level is', hasValue: true, unit: '', def: 0 }],
         setpoint:    [{ id: 'any', label: 'Any change' }],
         motion:      [{ id: 'any', label: 'Any change' }, { id: 'on', label: 'Motion detected' }, { id: 'off', label: 'No motion' }],
         door:        [{ id: 'any', label: 'Any change' }, { id: 'open', label: 'Opens' }, { id: 'closed', label: 'Closes' }],
@@ -143,6 +144,7 @@ define(['app'], function (app) {
         closed:      "device.state == 'Closed'",
         level_above: 'device.level > {v}',
         level_below: 'device.level < {v}',
+        level_is:    'device.level == {v}',
         above: {
             temperature: 'device.temperature > {v}', temphum: 'device.temperature > {v}',
             humidity: 'device.humidity > {v}', percentage: 'device.percentage > {v}',
@@ -162,6 +164,19 @@ define(['app'], function (app) {
         hum_above:  'device.humidity > {v}',
         hum_below:  'device.humidity < {v}',
     };
+
+    function getSelectorLevels(dev) {
+        if (!dev || !dev.LevelNames) return [];
+        try {
+            var names = atob(dev.LevelNames).split('|');
+            var hiddenOff = dev.LevelOffHidden === true || dev.LevelOffHidden === 'true';
+            return names
+                .map(function (name, i) { return { level: i * 10, name: name }; })
+                .filter(function (opt) { return !(hiddenOff && opt.level === 0); });
+        } catch (e) {
+            return [];
+        }
+    }
 
     function getDeviceCategory(dev) {
         if (!dev) return 'switch';
@@ -377,6 +392,7 @@ define(['app'], function (app) {
                 } else {
                     arr.push(dev.idx);
                     vm.triggerConfig.deviceCategory = getDeviceCategory(dev);
+                    vm.triggerConfig.conditionLevelOptions = getSelectorLevels(dev);
                     vm.deviceConditions             = DEVICE_CONDITIONS[vm.triggerConfig.deviceCategory] || DEVICE_CONDITIONS['switch'];
                     var valid = vm.deviceConditions.some(function (c) { return c.id === vm.triggerConfig.condition; });
                     if (!valid) { vm.triggerConfig.condition = 'any'; }
@@ -464,7 +480,8 @@ define(['app'], function (app) {
                 vm.conditionNeedsValue = !!cond.hasValue;
                 vm.conditionUnit       = cond.unit || '';
                 if (cond.hasValue && vm.triggerConfig.conditionValue == null) {
-                    vm.triggerConfig.conditionValue = cond.def;
+                    var lvlOpts = vm.triggerConfig.conditionLevelOptions;
+                    vm.triggerConfig.conditionValue = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : cond.def;
                 }
                 if (!cond.hasValue) {
                     vm.triggerConfig.conditionValue = undefined;
@@ -480,20 +497,27 @@ define(['app'], function (app) {
             vm.onConditionDeviceChange = function () {
                 var dev = findDeviceByIdx(vm.wizardCondition.deviceIdx);
                 vm.wizardCondition.category = getDeviceCategory(dev);
+                vm.wizardCondition.levelOptions = getSelectorLevels(dev);
                 vm.wizardCondition.conditionStates = DEVICE_CONDITIONS[vm.wizardCondition.category] || DEVICE_CONDITIONS['switch'];
                 var valid = vm.wizardCondition.conditionStates.some(function (c) { return c.id === vm.wizardCondition.state; });
                 if (!valid) vm.wizardCondition.state = 'any';
                 var sel = vm.wizardCondition.conditionStates.find(function (c) { return c.id === vm.wizardCondition.state; }) || {};
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
-                if (sel.hasValue && vm.wizardCondition.value == null) vm.wizardCondition.value = sel.def;
+                if (sel.hasValue && vm.wizardCondition.value == null) {
+                    var lvlOpts = vm.wizardCondition.levelOptions;
+                    vm.wizardCondition.value = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : (sel.def !== undefined ? sel.def : 0);
+                }
             };
 
             vm.onConditionStateChange = function () {
                 var sel = vm.wizardCondition.conditionStates.find(function (c) { return c.id === vm.wizardCondition.state; }) || {};
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
-                if (sel.hasValue && vm.wizardCondition.value == null) vm.wizardCondition.value = sel.def;
+                if (sel.hasValue && vm.wizardCondition.value == null) {
+                    var lvlOpts = vm.wizardCondition.levelOptions;
+                    vm.wizardCondition.value = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : (sel.def !== undefined ? sel.def : 0);
+                }
                 if (!sel.hasValue) vm.wizardCondition.value = null;
             };
 
@@ -541,18 +565,10 @@ define(['app'], function (app) {
                 action.config.deviceCategory = getDeviceCategory(dev);
                 action.config.levelOptions = null;
 
-                if (action.config.deviceCategory === 'selector' && dev && dev.LevelNames) {
-                    try {
-                        var names  = atob(dev.LevelNames).split('|');
-                        var hidden = dev.LevelOffHidden === true || dev.LevelOffHidden === 'true';
-                        action.config.levelOptions = names
-                            .map(function (name, i) { return { level: i * 10, name: name }; })
-                            .filter(function (opt) { return !(hidden && opt.level === 0); });
-                        if (action.config.levelOptions.length) {
-                            action.config.actionValue = action.config.levelOptions[0].level;
-                        }
-                    } catch (e) {
-                        action.config.levelOptions = null;
+                if (action.config.deviceCategory === 'selector') {
+                    action.config.levelOptions = getSelectorLevels(dev);
+                    if (action.config.levelOptions.length) {
+                        action.config.actionValue = action.config.levelOptions[0].level;
                     }
                 }
 

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -174,6 +174,7 @@ define(['app'], function (app) {
                 .map(function (name, i) { return { level: i * 10, name: name }; })
                 .filter(function (opt) { return !(hiddenOff && opt.level === 0); });
         } catch (e) {
+            console.error('Failed to parse selector levels:', e);
             return [];
         }
     }
@@ -480,8 +481,8 @@ define(['app'], function (app) {
                 vm.conditionNeedsValue = !!cond.hasValue;
                 vm.conditionUnit       = cond.unit || '';
                 if (cond.hasValue && vm.triggerConfig.conditionValue == null) {
-                    var lvlOpts = vm.triggerConfig.conditionLevelOptions;
-                    vm.triggerConfig.conditionValue = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : cond.def;
+                    var levelOptions = vm.triggerConfig.conditionLevelOptions;
+                    vm.triggerConfig.conditionValue = (levelOptions && levelOptions.length) ? levelOptions[0].level : cond.def;
                 }
                 if (!cond.hasValue) {
                     vm.triggerConfig.conditionValue = undefined;
@@ -505,8 +506,8 @@ define(['app'], function (app) {
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
                 if (sel.hasValue && vm.wizardCondition.value == null) {
-                    var lvlOpts = vm.wizardCondition.levelOptions;
-                    vm.wizardCondition.value = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : (sel.def !== undefined ? sel.def : 0);
+                    var levelOptions = vm.wizardCondition.levelOptions;
+                    vm.wizardCondition.value = (levelOptions && levelOptions.length) ? levelOptions[0].level : (sel.def !== undefined ? sel.def : 0);
                 }
             };
 
@@ -515,8 +516,8 @@ define(['app'], function (app) {
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
                 if (sel.hasValue && vm.wizardCondition.value == null) {
-                    var lvlOpts = vm.wizardCondition.levelOptions;
-                    vm.wizardCondition.value = (lvlOpts && lvlOpts.length) ? lvlOpts[0].level : (sel.def !== undefined ? sel.def : 0);
+                    var levelOptions = vm.wizardCondition.levelOptions;
+                    vm.wizardCondition.value = (levelOptions && levelOptions.length) ? levelOptions[0].level : (sel.def !== undefined ? sel.def : 0);
                 }
                 if (!sel.hasValue) vm.wizardCondition.value = null;
             };
@@ -582,6 +583,16 @@ define(['app'], function (app) {
 
             vm.actionHasOptions = function (action) {
                 return !!(action.config && action.config.levelOptions && action.config.levelOptions.length);
+            };
+
+            vm.triggerConditionHasLevelOptions = function () {
+                var opts = vm.triggerConfig.conditionLevelOptions;
+                return vm.triggerConfig.deviceCategory === 'selector' && !!(opts && opts.length);
+            };
+
+            vm.wizardConditionHasLevelOptions = function () {
+                var opts = vm.wizardCondition.levelOptions;
+                return !!(opts && opts.length);
             };
 
             vm.getDeviceActionOptions = function (action) {

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -158,7 +158,7 @@ define(['app'], function (app) {
         level_above: 'device.level > {v}',
         level_below: 'device.level < {v}',
         level_is:    'device.level == {v}',
-        alert_level_is: 'device.color == {v}',
+        alert_level_is: 'device.color == {v}', // alert stores numeric level (0-4) in color; {v} is replaced with the domoticz.ALERTLEVEL_* constant name
         above: {
             temperature: 'device.temperature > {v}', temphum: 'device.temperature > {v}',
             humidity: 'device.humidity > {v}', percentage: 'device.percentage > {v}',
@@ -618,7 +618,8 @@ define(['app'], function (app) {
 
             vm.wizardConditionHasLevelOptions = function () {
                 var opts = vm.wizardCondition.levelOptions;
-                return !!(opts && opts.length);
+                var cat = vm.wizardCondition.category;
+                return (cat === 'selector' || cat === 'alert') && !!(opts && opts.length);
             };
 
             vm.getDeviceActionOptions = function (action) {
@@ -996,6 +997,7 @@ define(['app'], function (app) {
                             } else if (act === 'updateEnergy') {
                                 L.push(bi + dev + ".updateEnergy(" + numVal(c.actionValue, 0) + ")");
                             } else if (act === 'updateAlertSensor') {
+                                // second arg is the alert text; leave empty as the wizard does not expose a text field
                                 L.push(bi + dev + ".updateAlertSensor(" + (c.actionValue || 'domoticz.ALERTLEVEL_GREY') + ", '')");
                             } else {
                                 L.push(bi + dev + "." + act + "()");

--- a/www/app/events/AutomationWizard.js
+++ b/www/app/events/AutomationWizard.js
@@ -179,6 +179,10 @@ define(['app'], function (app) {
         }
     }
 
+    function defaultLevelValue(levelOptions, fallbackDef) {
+        return (levelOptions && levelOptions.length) ? levelOptions[0].level : (fallbackDef !== undefined ? fallbackDef : 0);
+    }
+
     function getDeviceCategory(dev) {
         if (!dev) return 'switch';
         var type = (dev.Type       || '').toLowerCase();
@@ -481,8 +485,7 @@ define(['app'], function (app) {
                 vm.conditionNeedsValue = !!cond.hasValue;
                 vm.conditionUnit       = cond.unit || '';
                 if (cond.hasValue && vm.triggerConfig.conditionValue == null) {
-                    var levelOptions = vm.triggerConfig.conditionLevelOptions;
-                    vm.triggerConfig.conditionValue = (levelOptions && levelOptions.length) ? levelOptions[0].level : cond.def;
+                    vm.triggerConfig.conditionValue = defaultLevelValue(vm.triggerConfig.conditionLevelOptions, cond.def);
                 }
                 if (!cond.hasValue) {
                     vm.triggerConfig.conditionValue = undefined;
@@ -506,8 +509,7 @@ define(['app'], function (app) {
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
                 if (sel.hasValue && vm.wizardCondition.value == null) {
-                    var levelOptions = vm.wizardCondition.levelOptions;
-                    vm.wizardCondition.value = (levelOptions && levelOptions.length) ? levelOptions[0].level : (sel.def !== undefined ? sel.def : 0);
+                    vm.wizardCondition.value = defaultLevelValue(vm.wizardCondition.levelOptions, sel.def);
                 }
             };
 
@@ -516,8 +518,7 @@ define(['app'], function (app) {
                 vm.wizardCondition.needsValue = !!sel.hasValue;
                 vm.wizardCondition.unit = sel.unit || '';
                 if (sel.hasValue && vm.wizardCondition.value == null) {
-                    var levelOptions = vm.wizardCondition.levelOptions;
-                    vm.wizardCondition.value = (levelOptions && levelOptions.length) ? levelOptions[0].level : (sel.def !== undefined ? sel.def : 0);
+                    vm.wizardCondition.value = defaultLevelValue(vm.wizardCondition.levelOptions, sel.def);
                 }
                 if (!sel.hasValue) vm.wizardCondition.value = null;
             };


### PR DESCRIPTION
Selector switch devices showed a free numeric input for level values in the Automation Wizard, requiring users to know the raw numeric level (0, 10, 20…) rather than the named levels configured on the device. This replaces those inputs with named-level dropdowns wherever a selector value is entered.

## JS (`AutomationWizard.js`)

- **`getSelectorLevels(dev)`** — shared helper: decodes base64 `LevelNames`, maps each entry to `{ level: index * 10, name }`, respects `LevelOffHidden`, logs parse errors
- **`defaultLevelValue(levelOptions, fallbackDef)`** — helper to consistently pick the first level value or fall back to a numeric default
- **`DEVICE_CONDITIONS.selector`** — extended with `level_is` (`hasValue: true`) so users can match an exact level in step 2
- **`COND_EXPR`** — added `level_is: 'device.level == {v}'`; generates `device.level == 10` etc.
- **`selectDevice`** — populates `triggerConfig.conditionLevelOptions` when a trigger device is added
- **`updateConditionValue`** — defaults `conditionValue` to first level option via helper
- **`onActionDeviceChange`** — refactored to use `getSelectorLevels` (removes inline try/catch)
- **`onConditionDeviceChange` / `onConditionStateChange`** — populate `wizardCondition.levelOptions`, default value via helper
- **`triggerConditionHasLevelOptions()` / `wizardConditionHasLevelOptions()`** — controller predicates to keep template logic clean

## HTML (`AutomationWizard.html`)

- **Step 2** trigger condition value: `<select ng-options>` for selector devices, numeric `<input>` otherwise
- **Step 3** wizard condition device value: same conditional pattern

```html
<!-- Step 2: selector shows named-level dropdown, others keep numeric input -->
<select ng-if="$ctrl.triggerConditionHasLevelOptions()" class="form-control"
        ng-model="$ctrl.triggerConfig.conditionValue"
        ng-options="opt.level as opt.name for opt in $ctrl.triggerConfig.conditionLevelOptions">
</select>
<input ng-if="!$ctrl.triggerConditionHasLevelOptions()" type="number" class="form-control"
       ng-model="$ctrl.triggerConfig.conditionValue">
```

Generated dzVents code is unchanged — numeric levels are still passed to `switchSelector()` and condition expressions.

**Alert device support**
Alert device support has been added (commit `AutomationWizard: add alert device support for conditions and actions`).

**What's been implemented:**

- **Detection**: `getDeviceCategory()` now recognises devices with `SubType === 'Alert'`
- **Conditions (steps 2 & 3)**: Alert devices show "Any change" or "Level is" with a named dropdown: Grey (No alert), Green (Info), Yellow (Warning), Orange (Alert), Red (Emergency)
- **Actions (step 4)**: Alert devices show a "Set alert level" dropdown with the same named levels
- **Generated code** uses the domoticz constants directly for readability, e.g.:
  - Condition: `device.color == domoticz.ALERTLEVEL_GREEN`
  - Action: `myAlertDevice.updateAlertSensor(domoticz.ALERTLEVEL_ORANGE, '')`