### PR TITLE
fix(webui): translate camera dialog buttons

### DIFF
--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -1,4 +1,5 @@
 {
     "Bar ranges must all go in the same direction. Use all ascending (e.g. -100 to 0) or all descending (e.g. 0 to -100).": "Bar ranges must all go in the same direction. Use all ascending (e.g. -100 to 0) or all descending (e.g. 0 to -100).",
+    "Edit Camera": "Edit Camera",
     "Show Icon": "Show Icon"
 }

--- a/www/views/cam.html
+++ b/www/views/cam.html
@@ -235,7 +235,7 @@
 			width: 720,
 			height: 520,
 			modal: true,
-			title: 'Edit Camera',
+			title: $.t('Edit Camera'),
 			buttons: dialog_editcamera_buttons,
 			close: function () {
 				$.testcamfeed = "";

--- a/www/views/cam.html
+++ b/www/views/cam.html
@@ -183,25 +183,25 @@
 		$("#dialog-add-edit-camera #cameraparamstable #cameraprotocol").change(function () {
 			OnCameraProtocolChange();
 		});
+		var dialog_addcamera_buttons = {};
+		dialog_addcamera_buttons[$.t("Cancel")] = function () {
+			$(this).dialog("close");
+		};
+		dialog_addcamera_buttons[$.t("Add")] = function () {
+			var csettings = GetCameraSettings();
+			if (typeof csettings == 'undefined') {
+				return;
+			}
+			$(this).dialog("close");
+			Addcamera();
+		};
 		$("#dialog-add-edit-camera").dialog({
 			resizable: false,
 			width: 720,
 			height: 520,
 			modal: true,
 			title: $.t('Add New Camera'),
-			buttons: {
-				"Cancel": function () {
-					$(this).dialog("close");
-				},
-				"Add": function () {
-					var csettings = GetCameraSettings();
-					if (typeof csettings == 'undefined') {
-						return;
-					}
-					$(this).dialog("close");
-					Addcamera();
-				}
-			},
+			buttons: dialog_addcamera_buttons,
 			close: function () {
 				$('#dialog-add-edit-camera #camfeed').attr("src", "images/camera_default.png");
 				$.testcamfeed = "";
@@ -218,25 +218,25 @@
 		$("#dialog-add-edit-camera #cameraparamstable #cameraprotocol").change(function () {
 			OnCameraProtocolChange();
 		});
+		var dialog_editcamera_buttons = {};
+		dialog_editcamera_buttons[$.t("Cancel")] = function () {
+			$(this).dialog("close");
+		};
+		dialog_editcamera_buttons[$.t("Update")] = function () {
+			var csettings = GetCameraSettings();
+			if (typeof csettings == 'undefined') {
+				return;
+			}
+			$(this).dialog("close");
+			Updatecamera(idx);
+		};
 		$("#dialog-add-edit-camera").dialog({
 			resizable: false,
 			width: 720,
 			height: 520,
 			modal: true,
 			title: 'Edit Camera',
-			buttons: {
-				"Cancel": function () {
-					$(this).dialog("close");
-				},
-				"Update": function () {
-					var csettings = GetCameraSettings();
-					if (typeof csettings == 'undefined') {
-						return;
-					}
-					$(this).dialog("close");
-					Updatecamera(idx);
-				}
-			},
+			buttons: dialog_editcamera_buttons,
 			close: function () {
 				$.testcamfeed = "";
 				$('#dialog-add-edit-camera #camfeed').attr("src", "images/camera_default.png");


### PR DESCRIPTION
Use the existing translation mechanism for the Add, Cancel, and Update buttons in the camera dialogs.
Refs #5453