### PR TITLE
Change CSS class for timed out devices in quick stat and energy dashboard widget

### DIFF
--- a/www/app/dashboardDynamic/widgets/ddEnergyDashboard.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddEnergyDashboard.widget.js
@@ -161,6 +161,7 @@ define([
                             usageDelivWatt:    parseWatt(gr.UsageDeliv),
                             counterToday:      gr.CounterToday || '',
                             counterDelivToday: gr.CounterDelivToday || '',
+                            timeout:           gr.HaveTimeout === true,
                             price:             gr.hasOwnProperty('price') ? (parseFloat(gr.price) || 0) : null
                         };
                     } else {
@@ -172,7 +173,8 @@ define([
                     if (sl) {
                         ctrl.solar = {
                             usageWatt:    Math.round(parseWatt(sl.Usage)),
-                            counterToday: sl.CounterToday || ''
+                            counterToday: sl.CounterToday || '',
+                            timeout:      sl.HaveTimeout === true
                         };
                     } else {
                         ctrl.solar = null;
@@ -185,6 +187,7 @@ define([
                             temp:        parseFloat(wt.Temp) || 0,
                             humidity:    parseFloat(wt.Humidity) || 0,
                             barometer:   parseInt(wt.Barometer, 10) || 0,
+                            timeout:     wt.HaveTimeout === true,
                             forecastStr: wt.ForecastStr || '',
                             scene:       getWeatherScene(wt.ForecastStr || ''),
                             dewPoint:    parseFloat(wt.DewPoint) || 0
@@ -200,7 +203,8 @@ define([
                         ctrl.gas = {
                             counterToday: gs.CounterToday || '',
                             counter:      gs.Counter || '',
-                            price: (!isNaN(rawGasPrice) && rawGasPrice !== 1000 && rawGasPrice !== 0) ? rawGasPrice : null
+                            price: (!isNaN(rawGasPrice) && rawGasPrice !== 1000 && rawGasPrice !== 0) ? rawGasPrice : null,
+                            timeout:      gs.HaveTimeout === true
                         };
                     } else {
                         ctrl.gas = null;
@@ -213,21 +217,22 @@ define([
                         ctrl.water = {
                             counterToday: wm.CounterToday || '',
                             counter:      wm.Counter || '',
-                            price: (!isNaN(rawWaterPrice) && rawWaterPrice !== 1000 && rawWaterPrice !== 0) ? rawWaterPrice : null
+                            price: (!isNaN(rawWaterPrice) && rawWaterPrice !== 1000 && rawWaterPrice !== 0) ? rawWaterPrice : null,
+                            timeout:      wm.HaveTimeout === true
                         };
                     } else {
                         ctrl.water = null;
                     }
 
                     // Battery energy meters
-                    var batImportedKwh = 0, batExportedKwh = 0;
+                    var batImportedKwh = 0, batExportedKwh = 0, timeout = false;
                     var bi = get(ids.battEnergyIn);
-                    if (bi) { batImportedKwh = parseKwh(bi.CounterToday); }
+                    if (bi) { batImportedKwh = parseKwh(bi.CounterToday); timeout = bi.HaveTimeout === true; }
                     var bo = get(ids.battEnergyOut);
-                    if (bo) { batExportedKwh = parseKwh(bo.CounterToday); }
+                    if (bo) { batExportedKwh = parseKwh(bo.CounterToday); timeout = timeout || bo.HaveTimeout === true; }
 
                     if (bi || bo) {
-                        ctrl.battery = { importedKwh: batImportedKwh, exportedKwh: batExportedKwh };
+                        ctrl.battery = { importedKwh: batImportedKwh, exportedKwh: batExportedKwh, timeout: timeout };
                     } else {
                         ctrl.battery = null;
                     }

--- a/www/app/dashboardDynamic/widgets/ddQuickStat.widget.js
+++ b/www/app/dashboardDynamic/widgets/ddQuickStat.widget.js
@@ -71,6 +71,7 @@ define([
                     item.typeClass   = extracted.typeClass;
                     item.icon        = item.configIcon || ddDeviceClassifier.autoDeviceIcon(d);
                     item.label       = item.configLabel || d.Name || String(d.idx);
+                    item.timeout     = d.HaveTimeout === true;
                 }
 
                 function loadAll() {

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -3520,6 +3520,10 @@ body.dd-standby::after {
     color: var(--dz-accent-color);
     opacity: 1;
 }
+.dd-qs--timeout {
+    background: color-mix(in srgb, var(--dz-status-timeout) 25%, transparent);
+    border-color: var(--dz-status-timeout);
+}
 .dd-log-icon {
     cursor: pointer;
     flex-shrink: 0;

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -2912,7 +2912,7 @@ dd-wcp-color {
     position: relative;
 }
 .dd-stat-card--timeout {
-    background: color-mix(in srgb, var(--dz-status-timeout) 25%, transparent);
+    background: color-mix(in srgb, var(--dz-status-timeout) 25%, var(--dz-panel-bg));
 }
 .dd-stat-label {
     font-size: 0.85em;
@@ -3523,8 +3523,8 @@ body.dd-standby::after {
     color: var(--dz-accent-color);
     opacity: 1;
 }
-.dd-qs--timeout {
-    background: color-mix(in srgb, var(--dz-status-timeout) 25%, transparent);
+.dd-qs-item--timeout {
+    background: color-mix(in srgb, var(--dz-status-timeout) 25%, var(--dz-panel-bg));
     border-color: var(--dz-status-timeout);
 }
 .dd-log-icon {

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -2911,6 +2911,9 @@ dd-wcp-color {
     overflow: hidden;
     position: relative;
 }
+.dd-stat-card--timeout {
+    background: color-mix(in srgb, var(--dz-status-timeout) 25%, transparent);
+}
 .dd-stat-label {
     font-size: 0.85em;
     color: var(--dz-body-text);

--- a/www/views/dashboardDynamic/widgets/energy-dashboard.html
+++ b/www/views/dashboardDynamic/widgets/energy-dashboard.html
@@ -6,7 +6,7 @@
     <div class="dd-fc-conditions">
 
         <!-- Weather card -->
-        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showWeather !== false">
+        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showWeather !== false" ng-class="{'dd-stat-card--timeout': ctrl.weather && ctrl.weather.timeout}">
             <div class="fc-weather-icon" ng-if="ctrl.weather" ng-switch="ctrl.weather.scene">
                 <div class="fcw-scene" ng-switch-when="fcw-sunny">
                     <div ng-if="!ctrl.isNight">
@@ -104,7 +104,7 @@
         </div>
 
         <!-- Grid card (always shown) -->
-        <div class="dd-stat-card">
+        <div class="dd-stat-card" ng-class="{'dd-stat-card--timeout': ctrl.grid && ctrl.grid.timeout}">
             <div class="dd-stat-label">{{'Grid' | translate}}</div>
             <a ng-if="ctrl.grid" class="dd-stat-link" ng-href="#/Devices/{{ctrl.ids.p1}}/Log">
                 <div class="dd-stat-line dd-energy-export" ng-if="ctrl.grid.usageDelivWatt > 0"><i class="fa fa-arrow-up"></i> {{ctrl.grid.usageDelivWatt}} W</div>
@@ -120,7 +120,7 @@
         </div>
 
         <!-- Solar card -->
-        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showSolar !== false">
+        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showSolar !== false" ng-class="{'dd-stat-card--timeout': ctrl.solar && ctrl.solar.timeout}">
             <div class="dd-stat-label">{{'Solar' | translate}}</div>
             <a ng-if="ctrl.solar" class="dd-stat-link" ng-href="#/Devices/{{ctrl.ids.solar}}/Log">
                 <div class="dd-stat-value dd-energy-solar"><i class="fa-solid fa-sun"></i> {{ctrl.solar.usageWatt}} W</div>
@@ -130,7 +130,7 @@
         </div>
 
         <!-- Gas card -->
-        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showGas !== false">
+        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showGas !== false" ng-class="{'dd-stat-card--timeout': ctrl.gas && ctrl.gas.timeout}">
             <div class="dd-stat-label">{{'Gas' | translate}}</div>
             <a ng-if="ctrl.gas" class="dd-stat-link" ng-href="#/Devices/{{ctrl.ids.gas}}/Log">
                 <div class="dd-stat-value dd-energy-gas"><i class="fa fa-fire"></i> {{ctrl.gas.counterToday}}</div>
@@ -144,7 +144,7 @@
         </div>
 
         <!-- Water card -->
-        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showWater !== false">
+        <div class="dd-stat-card" ng-if="ctrl.widgetDef.config.showWater !== false" ng-class="{'dd-stat-card--timeout': ctrl.water && ctrl.water.timeout}">
             <div class="dd-stat-label">{{'Water' | translate}}</div>
             <a ng-if="ctrl.water" class="dd-stat-link" ng-href="#/Devices/{{ctrl.ids.water}}/Log">
                 <div class="dd-stat-value dd-energy-water"><i class="fa-solid fa-droplet"></i> {{ctrl.water.counterToday}}</div>
@@ -158,7 +158,7 @@
         </div>
 
         <!-- Battery card -->
-        <div class="dd-stat-card dd-stat-card--wide" ng-if="ctrl.widgetDef.config.showBattery !== false">
+        <div class="dd-stat-card dd-stat-card--wide" ng-if="ctrl.widgetDef.config.showBattery !== false" ng-class="{'dd-stat-card--timeout': ctrl.battery && ctrl.battery.timeout}">
             <div class="dd-stat-label">{{'Battery' | translate}}</div>
             <div style="display:flex;gap:16px;justify-content:center;align-items:flex-start;">
                 <div ng-if="ctrl.battery">

--- a/www/views/dashboardDynamic/widgets/quick-stat.html
+++ b/www/views/dashboardDynamic/widgets/quick-stat.html
@@ -20,7 +20,7 @@
 
     <div class="dd-qs-item"
          ng-repeat="item in ctrl.items track by $index"
-         ng-class="{'dd-qs-item--on': item.isOn}">
+         ng-class="{'dd-qs-item--on': item.isOn, 'dd-qs--timeout': item.timeout}">
         <i ng-class="item.icon" class="dd-log-icon" ng-click="ctrl.goToLog(item)" title="View log"></i>
         <span class="dd-qs-label" ng-bind="item.label"></span>
         <span class="dd-qs-value-wrap" ng-class="{'dd-qs-value-link': !ctrl.editMode}" ng-click="!ctrl.editMode && ctrl.goToLog(item)">

--- a/www/views/dashboardDynamic/widgets/quick-stat.html
+++ b/www/views/dashboardDynamic/widgets/quick-stat.html
@@ -20,7 +20,7 @@
 
     <div class="dd-qs-item"
          ng-repeat="item in ctrl.items track by $index"
-         ng-class="{'dd-qs-item--on': item.isOn, 'dd-qs--timeout': item.timeout}">
+         ng-class="{'dd-qs-item--on': item.isOn, 'dd-qs-item--timeout': item.timeout}">
         <i ng-class="item.icon" class="dd-log-icon" ng-click="ctrl.goToLog(item)" title="View log"></i>
         <span class="dd-qs-label" ng-bind="item.label"></span>
         <span class="dd-qs-value-wrap" ng-class="{'dd-qs-value-link': !ctrl.editMode}" ng-click="!ctrl.editMode && ctrl.goToLog(item)">


### PR DESCRIPTION
Small change to update the CSS class of the items in the quick stat widget so that user can visually see the devices in timeout.

It looks like this:

<img width="311" height="99" alt="image" src="https://github.com/user-attachments/assets/f939e426-a648-4276-a1f9-4391e6232185" />

Similar change in the energy dashboard widget.
