### PR TITLE
Example logarithmic scaling interface for Lux charts

### DIFF
--- a/test/www-test/app/log/LuxLogScale.test.js
+++ b/test/www-test/app/log/LuxLogScale.test.js
@@ -1,0 +1,76 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+describe('LuxLogScale', function () {
+    let LuxLogScale;
+
+    before(function () {
+        const source = fs.readFileSync(
+            path.resolve(__dirname, '../../../../www/app/log/LuxLogScale.js'),
+            'utf8'
+        );
+        vm.runInNewContext(source, {
+            Math: Math,
+            define: function (factory) {
+                LuxLogScale = factory();
+            }
+        });
+    });
+
+    it('round-trips lux values including zero', function () {
+        [0, 1, 10, 100, 1000, 65000].forEach(function (value) {
+            const logarithmic = LuxLogScale.valueToLogarithmic(value);
+            const restored = LuxLogScale.logarithmicToValue(logarithmic);
+            assert.ok(Math.abs(restored - value) < 1e-9);
+        });
+    });
+
+    it('configures a zero-safe logarithmic axis', function () {
+        const axis = {
+            dzZoom: 'full',
+            update: function (options, redraw) {
+                this.options = options;
+                this.redraw = redraw;
+                this.logarithmic = {};
+            }
+        };
+
+        LuxLogScale.setAxisScale(axis, true);
+
+        assert.strictEqual(axis.options.type, 'logarithmic');
+        assert.strictEqual(axis.options.floor, 0);
+        assert.strictEqual(axis.options.tickPositioner, LuxLogScale.logarithmicTickPositions);
+        assert.strictEqual(axis.redraw, false);
+        assert.strictEqual(axis.positiveValuesOnly, false);
+        assert.strictEqual(axis.logarithmic.log2lin(0), 0);
+        assert.strictEqual(axis.logarithmic.lin2log(0), 0);
+        assert.strictEqual(axis.dzZoom, undefined);
+    });
+
+    it('creates readable lux ticks through the next power of ten', function () {
+        const ticks = LuxLogScale.logarithmicTickPositions.call({dataMax: 65000});
+        const values = Array.from(ticks, LuxLogScale.logarithmicToValue);
+
+        assert.deepStrictEqual(values.map(Math.round), [0, 1, 10, 100, 1000, 10000, 100000]);
+    });
+
+    it('restores a linear axis', function () {
+        const axis = {
+            update: function (options, redraw) {
+                this.options = options;
+                this.redraw = redraw;
+            }
+        };
+
+        LuxLogScale.setAxisScale(axis, false);
+
+        assert.strictEqual(axis.options.type, 'linear');
+        assert.strictEqual(axis.options.min, null);
+        assert.strictEqual(axis.options.max, null);
+        assert.strictEqual(axis.options.floor, null);
+        assert.strictEqual(axis.options.tickPositioner, null);
+        assert.strictEqual(axis.redraw, false);
+    });
+});

--- a/www/app/log/LuxLogScale.js
+++ b/www/app/log/LuxLogScale.js
@@ -1,0 +1,48 @@
+define(function () {
+    const logarithmBase = Math.LN10;
+
+    function valueToLogarithmic(value) {
+        return Math.log(value + 1) / logarithmBase;
+    }
+
+    function logarithmicToValue(value) {
+        return Math.pow(10, value) - 1;
+    }
+
+    function logarithmicTickPositions() {
+        const maximum = Math.max(this.dataMax || 0, 1);
+        const maximumPower = Math.ceil(Math.log(maximum) / logarithmBase);
+        const values = [0];
+
+        for (let power = 0; power <= maximumPower; power++) {
+            values.push(Math.pow(10, power));
+        }
+
+        return values.map(valueToLogarithmic);
+    }
+
+    function setAxisScale(axis, logarithmic) {
+        axis.update({
+            type: logarithmic ? 'logarithmic' : 'linear',
+            min: null,
+            max: null,
+            floor: logarithmic ? 0 : null,
+            tickPositioner: logarithmic ? logarithmicTickPositions : null
+        }, false);
+
+        if (logarithmic) {
+            axis.logarithmic.log2lin = valueToLogarithmic;
+            axis.logarithmic.lin2log = logarithmicToValue;
+            axis.positiveValuesOnly = false;
+        }
+
+        axis.dzZoom = undefined;
+    }
+
+    return {
+        logarithmicToValue: logarithmicToValue,
+        logarithmicTickPositions: logarithmicTickPositions,
+        setAxisScale: setAxisScale,
+        valueToLogarithmic: valueToLogarithmic
+    };
+});

--- a/www/app/log/RefreshingChart.js
+++ b/www/app/log/RefreshingChart.js
@@ -1,4 +1,4 @@
-define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoomer'], function (_, Base, DomoticzBase, DataLoader, ChartLoader, ChartZoomer) {
+define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoomer', 'log/LuxLogScale'], function (_, Base, DomoticzBase, DataLoader, ChartLoader, ChartZoomer, LuxLogScale) {
 
     function RefreshingChart(
             baseParams, angularParams, domoticzParams, params,
@@ -31,6 +31,7 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
         self.chart = containerEl.highcharts(chartDefinition).highcharts();
         // Disable the Highcharts Reset Zoom button
         self.chart.showResetZoom = function () {};
+        configureLuxScaleToggle();
         self.autoRefreshIsEnabled = params.autoRefreshIsEnabled;
         self.refreshTimestamp = 0;
 
@@ -74,6 +75,25 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
                     self.refreshTimestamp = 0;
                 }
             });
+        }
+
+        function configureLuxScaleToggle() {
+            self.$scope.luxScaleAvailable = self.device.SubType === 'Lux';
+            self.$scope.luxScaleLogarithmic = false;
+            self.$scope.setLuxScale = function (logarithmic) {
+                if (!self.$scope.luxScaleAvailable) {
+                    return;
+                }
+
+                self.$scope.luxScaleLogarithmic = logarithmic;
+                self.chart.yAxis.forEach(function (axis) {
+                    LuxLogScale.setAxisScale(axis, logarithmic);
+                });
+                self.chart.redraw();
+            };
+            self.$scope.toggleLuxScale = function () {
+                self.$scope.setLuxScale(!self.$scope.luxScaleLogarithmic);
+            };
         }
 
         function refreshChartDataEveryDeviceUpdate() {
@@ -539,6 +559,10 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
                     self.consoledebug('yAxis => index:' + x.userOptions.index + ', title:' + x.userOptions.title.text + ', opposite:' + x.userOptions.opposite + ', left:' + x.left + ', right:' + x.right + ', offset:' + x.offset + ', labelOffset:' + x.labelOffset + ', dataMin:' + x.dataMin + ', dataMax:' + x.dataMax + ', dzZoom:' + x.dzZoom);
                 });
                 if (plotX < 0 || self.chart.plotWidth < plotX && self.chart.yAxis.some(function (axis) { return axis.userOptions.opposite; })) {
+                    if (self.$scope.luxScaleAvailable) {
+                        self.$scope.toggleLuxScale();
+                        return;
+                    }
                     const axes = axesOrdered(self.chart.yAxis, plotX, self.chart.plotWidth);
                     const nextZoomValue = nextZoom(axes[0].dzZoom, e);
                     axes.splice(0, e.altKey ? axes.length : 1).forEach(function (axis) {
@@ -586,9 +610,6 @@ define(['lodash', 'Base', 'DomoticzBase', 'DataLoader', 'ChartLoader', 'ChartZoo
                     } else if (['Visibility'].includes(s)) {
                         axisMin = 0;
                         axisMax = 10;
-                    } else if (['Lux'].includes(s)) {
-                        axisMin = 0;
-                        axisMax = 10000;
                     } else if (['Usage', 'Temp + Humidity + Baro'].includes(t)) {
                         axisMin = 0;
                         axisMax = yAxis.dataMax;

--- a/www/app/log/chart-compare.html
+++ b/www/app/log/chart-compare.html
@@ -9,6 +9,8 @@
             <button class="zoom-button" ng-class="{'zoom-button-active': groupingBy === 'year'}" ng-click="groupBy('year')" ng-bind="groupByLabel('y')"></button>
             <button class="zoom-button" ng-class="{'zoom-button-active': groupingBy === 'quarter'}" ng-click="groupBy('quarter')" ng-bind="groupByLabel('q')"></button>
             <button class="zoom-button" ng-class="{'zoom-button-active': groupingBy === 'month'}" ng-click="groupBy('month')" ng-bind="groupByLabel('m')"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': !luxScaleLogarithmic}" ng-click="setLuxScale(false)" ng-bind="'Linear' | translate"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': luxScaleLogarithmic}" ng-click="setLuxScale(true)" ng-bind="'Logarithmic' | translate"></button>
         </div>
         <div class="chartcontainer"></div>
     </div>

--- a/www/app/log/chart-day.html
+++ b/www/app/log/chart-day.html
@@ -12,6 +12,8 @@
             <button class="zoom-button" ng-class="{'zoom-button-active': activeZoom === '3d'}" ng-click="zoomDays(3)" ng-bind="zoomLabel('3d')" ng-show="shortLogHistoryMaxDays > 3"></button>
             <button class="zoom-button" ng-class="{'zoom-button-active': activeZoom === 'today'}" ng-click="zoomToday()" ng-bind="zoomLabel('Day')"></button>
             <button class="zoom-reset" ng-click="zoomreset()" ng-bind="zoomLabel('Reset')" ng-show="zoomed"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': !luxScaleLogarithmic}" ng-click="setLuxScale(false)" ng-bind="'Linear' | translate"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': luxScaleLogarithmic}" ng-click="setLuxScale(true)" ng-bind="'Logarithmic' | translate"></button>
         </div>
         <div class="chartcontainer"></div>
     </div>

--- a/www/app/log/chart-month.html
+++ b/www/app/log/chart-month.html
@@ -8,6 +8,8 @@
         <div class="zoom-buttons-container">
             <button class="zoom-button" ng-class="{'zoom-button-active': activeZoom === '1w'}" ng-click="zoomDays(1*7)" ng-bind="zoomLabel('1w')"></button>
             <button class="zoom-reset" ng-click="zoomreset()" ng-bind="zoomLabel('Reset')" ng-show="zoomed"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': !luxScaleLogarithmic}" ng-click="setLuxScale(false)" ng-bind="'Linear' | translate"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': luxScaleLogarithmic}" ng-click="setLuxScale(true)" ng-bind="'Logarithmic' | translate"></button>
         </div>
         <div class="chartcontainer"></div>
     </div>

--- a/www/app/log/chart-year.html
+++ b/www/app/log/chart-year.html
@@ -11,6 +11,8 @@
             <button class="zoom-button" ng-class="{'zoom-button-active': activeZoom === '1M'}" ng-click="zoomMonths(1)" ng-bind="zoomLabel('1M')"></button>
             <button class="zoom-button" ng-class="{'zoom-button-active': activeZoom === '3M'}" ng-click="zoomMonths(3)" ng-bind="zoomLabel('3M')"></button>
             <button class="zoom-reset" ng-click="zoomreset()" ng-bind="zoomLabel('Reset')" ng-show="zoomed"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': !luxScaleLogarithmic}" ng-click="setLuxScale(false)" ng-bind="'Linear' | translate"></button>
+            <button class="zoom-button" ng-if="luxScaleAvailable" ng-class="{'zoom-button-active': luxScaleLogarithmic}" ng-click="setLuxScale(true)" ng-bind="'Logarithmic' | translate"></button>
         </div>
         <div class="chartcontainer"></div>
     </div>

--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -1,5 +1,7 @@
 {
     "Bar ranges must all go in the same direction. Use all ascending (e.g. -100 to 0) or all descending (e.g. 0 to -100).": "Bar ranges must all go in the same direction. Use all ascending (e.g. -100 to 0) or all descending (e.g. 0 to -100).",
     "Edit Camera": "Edit Camera",
+    "Linear": "Linear",
+    "Logarithmic": "Logarithmic",
     "Show Icon": "Show Icon"
 }


### PR DESCRIPTION
This draft implements an example of what a logarithmic scaling interface for Lux charts could look like.

It adds Linear and Logarithmic controls to the day, month, year, and comparison views. The logarithmic option handles zero values and uses readable powers-of-ten tick marks.

Refs #4203