### PR TITLE
fix(mqtt): White mode never commanded the white channel of auto-discovered RGBW lights

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5768,6 +5768,11 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 					iColdWhite = 255;
 					iWarmWhite = 255;
 				}
+				else if (pSensor->subType == sTypeColor_RGB_W_Z)
+				{
+					// single white channel: state updates store it in ww, the web UI sets both cw and ww
+					iColdWhite = std::max(color.cw, color.ww);
+				}
 				if (
 					(pSensor->subType == sTypeColor_RGB_W_Z)
 					|| (pSensor->subType == sTypeColor_RGB_CW_WW_Z)
@@ -5806,17 +5811,10 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 					}
 					else if (pSensor->subType == sTypeColor_RGB_W_Z)
 					{
-						// only a single 'white'. check if this is warm or coldwhite. 
-						// If not coldwhite it is warmwhite
-						// Single white is stored as coldwhite within Domoticz
-						//if (pSensor->color_temp_command_template.find("coldWhite") != std::string::npos)
-						{
-							colorDef["coldWhite"] = root["color"]["c"];
-						}
-						//if (pSensor->color_temp_command_template.find("warmWhite") != std::string::npos)
-						{
-							colorDef["warmWhite"] = root["color"]["c"];
-						}
+						// single white channel, sent as both warm and cold white;
+						// the gateway (e.g. Z-Wave JS) strips the component the device does not support
+						colorDef["coldWhite"] = root["color"]["c"];
+						colorDef["warmWhite"] = root["color"]["c"];
 					}
 
 					root["value"] = colorDef;

--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -5705,8 +5705,12 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 
 			bool bCouldUseBrightness = false;
 
+			// ColorModeWhite is meaningful for lights with a white channel (subtypes with a 'W');
+			// the color picker only offers White mode for those, so xy/hs conversions below
+			// see it in pathological cases only (a script sending mode 1 to an xy/hs light)
 			if (color.mode == ColorModeRGB ||
-				color.mode == ColorModeCustom)
+				color.mode == ColorModeCustom ||
+				color.mode == ColorModeWhite)
 			{
 				if (pSensor->supported_color_modes.find("xy") != pSensor->supported_color_modes.end())
 				{
@@ -5756,20 +5760,28 @@ bool MQTTAutoDiscover::SendSwitchCommand(const std::string& DeviceID, const std:
 					root["color"]["g"] = color.g;
 					root["color"]["b"] = color.b;
 				}
+				uint8_t iColdWhite = color.cw;
+				uint8_t iWarmWhite = color.ww;
+				if (color.mode == ColorModeWhite)
+				{
+					// ColorModeWhite has no valid color fields: white fully on, the dim level carries the brightness
+					iColdWhite = 255;
+					iWarmWhite = 255;
+				}
 				if (
 					(pSensor->subType == sTypeColor_RGB_W_Z)
 					|| (pSensor->subType == sTypeColor_RGB_CW_WW_Z)
 					|| (pSensor->subType == sTypeColor_RGB_CW_WW)
 					)
 				{
-					root["color"]["c"] = color.cw;
+					root["color"]["c"] = iColdWhite;
 				}
 				if (
 					(pSensor->subType == sTypeColor_RGB_CW_WW_Z)
 					|| (pSensor->subType == sTypeColor_RGB_CW_WW)
 					)
 				{
-					root["color"]["w"] = color.ww;
+					root["color"]["w"] = iWarmWhite;
 				}
 
 				// Check if the rgb_command_template suggests to use "red", "green"... instead of the default "r", "g"... (e.g. Fibaro FGRGBW)


### PR DESCRIPTION
**Background**

#6829 fixed the *detection* of single-white Z-Wave RGBW controllers (they now map to RGBWZ instead of RGBWWZ), but using such a device from the web UI still misbehaved: the color picker's White mode appeared to do nothing. Watching the MQTT traffic of a Fibaro FGRGBW-442 behind Z-Wave JS UI shows why. Selecting White published only a dimmer change and `{"state":"ON"}` to the color command topic, with no color value at all, so the controller kept whatever RGB color it was showing and the white channel was never driven. The only way to reach the white channel was the Custom (color + white mix) mode.

**Root cause**

`MQTTAutoDiscover::SendSwitchCommand` builds color payloads for `ColorModeRGB`/`ColorModeCustom` and for `ColorModeTemp`, but has no branch for `ColorModeWhite` (the mode the picker's White button sends). The command falls through and is published without a color value. This affects every MQTT Auto Discovery light with a white channel, not just Z-Wave ones.

**What this PR changes and why**

Commit 1 adds `ColorModeWhite` to the RGB/Custom branch. Per the color mode contract in `ColorSwitch.h`, mode White carries no valid color fields, so the payload is built as: color channels 0, white channels 255, with the actual brightness carried by the dim level. This matches how `ZWaveBase` has always handled White mode for natively integrated Z-Wave RGBW devices, so MQTT-discovered lights now behave the same as native ones.

Commit 2 fixes a related asymmetry that surfaces once white commands work. Incoming state for single-white lights stores the white level in `ww` (`warmWhite` is renamed to `w` and parsed into `color.ww`), but the command path read only `color.cw`. Re-sending a device-reported color (scenes, scripts) therefore silently dropped white to zero. The single white value is now `max(cw, ww)`, which accepts both the UI convention (sets both fields) and the state-parse convention (fills only `ww`). The stale comment claiming single white is stored as cold white contradicted the state parsing and was replaced.

For single-white devices the value is still sent as both `warmWhite` and `coldWhite`: gateways strip the component the node does not support (verified against Z-Wave JS, which does this explicitly since zwave-js GH#2527), and the discovery config does not tell us which single component the device has.

**What stays the same**

RGB and Custom mode payloads are unchanged (regression-tested), as are dual-white devices (RGBWWZ/RGBWW use their own `cw`/`ww` fields as before) and `color_temp`/`hs`/`xy` lights. A script sending mode 1 to an xy/hs-only light was a silent no-op before and remains out of scope; the assumption is documented in a comment.

**How this was tested**

Live-broker test rig: a local build discovered six synthetic config flavors (the exact Fibaro/Z-Wave JS payload from #6829, rgb+color_temp, rgb only, color_temp only, rgbw, rgbww) and the published command payloads were captured and asserted for White, RGB, Custom and the re-send case. All three fixed cases failed on the unmodified build and pass with this PR; the two regression cases pass on both. Additionally verified against a physical FGRGBW-442 through Z-Wave JS UI: the White payload drives the real white channel and the reported state confirms it.
