### PR TITLE
fix(webui): open the color picker in the mode matching the stored color

### DIFF
--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -1779,6 +1779,17 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 
 	var color_m = (color.m==null)?3:color.m; // Default to 3: ColorModeRGB
 
+	// MQTT Auto Discovery and some hardware store the device state as Custom (mode 4) even when
+	// only one channel group is in use, which would always open the custom sliders. Open the
+	// picker in the matching simple mode instead: pure white in the White (or Temperature) view,
+	// pure color (and all channels off) in the RGB view. Mixed colors keep the custom view.
+	if (color_m == 4) {
+		var bHasColorValue = (color.r > 0 || color.g > 0 || color.b > 0);
+		var bHasWhiteValue = (color.cw > 0 || color.ww > 0);
+		if (!bHasColorValue && bHasWhiteValue) color_m = LEDType.bHasTemperature ? 2 : 1;
+		else if (!bHasWhiteValue) color_m = 3;
+	}
+
 	if (color_m != 1 && color_m != 2 && color_m != 3 && color_m != 4) color_m = 3; // Default to RGB if not valid
 	if (color_m == 4 && !LEDType.bHasCustom) color_m = 3; // Default to RGB if light does not support custom color
 	if (color_m == 1 && !LEDType.bHasWhite) color_m = 3; // Default to RGB if light does not support white


### PR DESCRIPTION
**Background**

Related to #6829 and #6909. Devices integrated through MQTT Auto Discovery store every incoming color state as Custom (mode 4), regardless of what the lamp is actually showing. Since the color picker opens in the mode of the stored color, these devices always open in the Custom sliders view. For a lamp that is off or plain white that means a black color wheel with three unlabeled sliders, which reads as broken, while the simple RGB or White view would be the natural starting point.

**What this PR changes**

When the picker opens with a mode 4 color that only uses one channel group, it now shows the matching simple view instead:

- all color channels zero and any white set: the White view (or the Temperature view for lights with color temperature)
- any color channel set and no white: the RGB color wheel
- all channels zero (lamp off): the RGB color wheel as the friendly default
- both groups in use: the Custom view, as before

Only the initial view choice changes. The stored color is not modified, explicit mode 1/2/3 colors behave exactly as before, and the pre-existing capability checks still run after the remap, so a mode is never offered that the light does not support. All popups share `ShowRGBWPicker`, so the dashboard, switches, scenes and the Angular picker component all benefit.

**How this was tested**

A Playwright harness drives the real `ShowRGBWPicker` in the served default theme with nine (SubType, stored color) cases covering RGBWZ and RGBWWZ: the four remap cases fail on unmodified code and pass with this change, and five no-change guards (explicit modes 1/2/3 and mixed mode 4 colors) pass before and after.
