### PR TITLE
fix(webui): add tooltips to the color picker mode buttons

### DIFF
--- a/www/i18n/to_be_translated.json
+++ b/www/i18n/to_be_translated.json
@@ -9,5 +9,8 @@
     "Origins": "Origins",
     "Also allow origins from local networks (no username/password)": "Also allow origins from local networks (no username/password)",
     "Warning: allowed origins can read and control the API from a browser on your local networks!": "Warning: allowed origins can read and control the API from a browser on your local networks!",
-    "Using '*' as allowed CORS origin lets every website read and control the API from a browser on your local networks. Are you sure?": "Using '*' as allowed CORS origin lets every website read and control the API from a browser on your local networks. Are you sure?"
+    "Using '*' as allowed CORS origin lets every website read and control the API from a browser on your local networks. Are you sure?": "Using '*' as allowed CORS origin lets every website read and control the API from a browser on your local networks. Are you sure?",
+    "White": "White",
+    "Color temperature": "Color temperature",
+    "Color and white mix": "Color and white mix"
 }

--- a/www/js/domoticz.js
+++ b/www/js/domoticz.js
@@ -1839,19 +1839,19 @@ function ShowRGBWPicker(selector, idx, Protected, MaxDimLevel, LevelInt, colorJS
 		}
 	}
 
-	$(selector + ' .pickermodergb').off().click(function(){
+	$(selector + ' .pickermodergb').attr('title', $.t('Color')).off().click(function(){
 		UpdateColorPicker(DimmerType!="rel"?"color":"color_no_master");
 	});
-	$(selector + ' .pickermodewhite').off().click(function(){
+	$(selector + ' .pickermodewhite').attr('title', $.t('White')).off().click(function(){
 		UpdateColorPicker(DimmerType!="rel"?"white":"white_no_master");
 	});
-	$(selector + ' .pickermodetemp').off().click(function(){
+	$(selector + ' .pickermodetemp').attr('title', $.t('Color temperature')).off().click(function(){
 		UpdateColorPicker(DimmerType!="rel"?"temperature":"temperature_no_master");
 	});
-	$(selector + ' .pickermodecustomw').off().click(function(){
+	$(selector + ' .pickermodecustomw').attr('title', $.t('Color and white mix')).off().click(function(){
 		UpdateColorPicker("customw");
 	});
-	$(selector + ' .pickermodecustomww').off().click(function(){
+	$(selector + ' .pickermodecustomww').attr('title', $.t('Color and white mix')).off().click(function(){
 		UpdateColorPicker("customww");
 	});
 


### PR DESCRIPTION
Related to #6829, #6909 and #6910. The mode buttons at the top of the RGBW color picker are unlabeled icons, and which button drives which channel group is guesswork: the grey ball (White) and the half-colored ball (Custom) are especially opaque for lights that have both a color and a white channel.

This adds translated `title` tooltips to the five mode buttons: Color, White, Color temperature, and Color and white mix for the two custom variants. The titles are set centrally in `ShowRGBWPicker` when the popup is built, so the dashboard and switches popups, the scenes view and the Angular `rgbw-picker` component are all covered without touching their templates. `White`, `Color temperature` and `Color and white mix` did not exist in the translation source yet and are registered in `www/i18n/to_be_translated.json`.

Tested with a Playwright harness asserting the title attributes on RGBWZ and RGBWWZ pickers in the served default theme (six assertions, all failing before and passing after).
