### PR TITLE
MQTTAutoDiscover: subscribe to and dispatch

### DIFF
--- a/hardware/MQTTAutoDiscover.cpp
+++ b/hardware/MQTTAutoDiscover.cpp
@@ -1851,6 +1851,8 @@ void MQTTAutoDiscover::on_auto_discovery_message(const struct mosquitto_message*
 			SubscribeTopic(pSensor->percentage_state_topic, pSensor->qos);
 			SubscribeTopic(pSensor->action_topic, pSensor->qos);
 			SubscribeTopic(pSensor->preset_mode_state_topic, pSensor->qos);
+			SubscribeTopic(pSensor->fan_state_topic, pSensor->qos);
+			SubscribeTopic(pSensor->swing_state_topic, pSensor->qos);
 
 		}
 	}
@@ -1915,6 +1917,8 @@ void MQTTAutoDiscover::handle_auto_discovery_sensor_message(const struct mosquit
 			|| (pSensor->percentage_state_topic == topic)
 			|| (pSensor->preset_mode_state_topic == topic)
 			|| (pSensor->action_topic == topic)
+			|| (pSensor->fan_state_topic == topic)
+			|| (pSensor->swing_state_topic == topic)
 			)
 		{
 			matching_keys.emplace_back(itt.first, MatchType::State);


### PR DESCRIPTION
fan_mode_state_topic / swing_mode_state_topic for climate devices

Problem

For MQTT-autodiscovered climate devices, fan_mode_state_topic and swing_mode_state_topic are parsed from the discovery config and stored (hardware/MQTTAutoDiscover.cpp, lines ~1598-1601 and ~1622-1625: pSensor->fan_state_topic / pSensor->swing_state_topic), but they are never actually used afterwards:

Never subscribed. The subscribe block in on_auto_discovery_message (lines ~1836-1850) explicitly subscribes to mode_state_topic, temperature_state_topic, current_temperature_topic, preset_mode_state_topic, etc. — but not fan_state_topic or swing_state_topic. Never matched. The incoming-message dispatcher in handle_auto_discovery_sensor_message (lines ~1902-1915) checks mode_state_topic, temperature_state_topic, preset_mode_state_topic, etc. against the incoming topic to find the owning sensor — again, fan_state_topic and swing_state_topic are absent.

Net effect: even when a third-party bridge (in my case a Node-RED flow bridging LG ThinQ air conditioners) publishes correctly and consistently to the advertised fan_mode_state_topic, Domoticz's MQTT client never subscribes to that topic on the broker, so it never sees the update — not a delivery problem, Domoticz simply never asks for it. The climate device's fan-speed/swing state field is therefore permanently stale/unset in Domoticz, regardless of how correct the publisher is.

This matches user reports in #5416 ("MQTT Auto discovery ... Thermostat Fan mode" — Domoticz not creating/updating a fan mode device from fan_mode_state_topic/fan_mode_command_topic) and forum threads describing the same symptom for other MQTT-autodiscovery bridges (ESPHome, zigbee2mqtt, etc.).

Fix

Add fan_state_topic and swing_state_topic to both the subscribe list and the topic-match dispatcher, alongside the other climate sub-topics that are already handled the same way (preset_mode_state_topic etc.).

cpp
// on_auto_discovery_message – subscribe block
SubscribeTopic(pSensor->preset_mode_state_topic, pSensor->qos); SubscribeTopic(pSensor->fan_state_topic, pSensor->qos); SubscribeTopic(pSensor->swing_state_topic, pSensor->qos); cpp
// handle_auto_discovery_sensor_message – dispatch match || (pSensor->preset_mode_state_topic == topic)
|| (pSensor->action_topic == topic)
|| (pSensor->fan_state_topic == topic)
|| (pSensor->swing_state_topic == topic)

See attached patch (domoticz-mqtt-fan-swing-subscribe.patch) for the exact diff against development.

Testing
Verified against the current development branch source that both fields are parsed but absent from the two lists above (grep for fan_state_topic / swing_state_topic outside the parser only turns up the struct declaration). Not yet build-tested locally — I don't have a Domoticz build environment set up. Would appreciate a maintainer or anyone who can build this confirming that once the topic is subscribed and matched, handle_auto_discovery_climate's value-processing correctly updates the fan/swing state for the device (I could not fully inspect that function's body to confirm this end-to-end). If it needs additional handling downstream I'm happy to extend the patch. Related
#5416