### PR TITLE
fix(Netatmo): prevent error code 13 when weather station is not owned

### DIFF
--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -106,7 +106,7 @@ CNetatmo::CNetatmo(const int ID, const std::string& username, const std::string&
 	Debug(DEBUG_HARDWARE, "Netatmo Actif Scopes %s", m_scopes.c_str());
 
 	// Weatherdevice is available in HomesData + HomeStatus
-	//m_bPollWeatherData = (m_scopes.find("station_R") != std::string::npos);      //read_station
+	m_bPollWeatherData = (m_scopes.find("station_RW") != std::string::npos);      //read_station
 	m_bPollHomecoachData = (m_scopes.find("homecoach_RW") != std::string::npos);  //read_homecoach write_homecoach
 
 	m_bPollHomeStatus = find_scopes();

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -105,6 +105,7 @@ CNetatmo::CNetatmo(const int ID, const std::string& username, const std::string&
 
 	Debug(DEBUG_HARDWARE, "Netatmo Actif Scopes %s", m_scopes.c_str());
 
+	m_bPollWeatherData = false;
 	// Weatherdevice is available in HomesData + HomeStatus
 	//m_bPollWeatherData = (m_scopes.find("station_R") != std::string::npos);      //read_station
 	m_bPollHomecoachData = (m_scopes.find("homecoach_RW") != std::string::npos);  //read_homecoach write_homecoach

--- a/hardware/Netatmo.cpp
+++ b/hardware/Netatmo.cpp
@@ -106,7 +106,7 @@ CNetatmo::CNetatmo(const int ID, const std::string& username, const std::string&
 	Debug(DEBUG_HARDWARE, "Netatmo Actif Scopes %s", m_scopes.c_str());
 
 	// Weatherdevice is available in HomesData + HomeStatus
-	m_bPollWeatherData = (m_scopes.find("station_RW") != std::string::npos);      //read_station
+	//m_bPollWeatherData = (m_scopes.find("station_R") != std::string::npos);      //read_station
 	m_bPollHomecoachData = (m_scopes.find("homecoach_RW") != std::string::npos);  //read_homecoach write_homecoach
 
 	m_bPollHomeStatus = find_scopes();


### PR DESCRIPTION
Problem:
Netatmo spits out error code 13:
<img width="1848" height="364" alt="Netatmo error codes" src="https://github.com/user-attachments/assets/766e48c6-b26a-4c8a-8cbe-39b027e924c1" />

When inspecting the code m_bPollWeatherData seems to not be initialised anymore.
(so C++ default = true). Since I do not own a weather station netatmo keeps complaining about scope rights (error code 13).

Example logging before this patch (2026.3):
<img width="1779" height="205" alt="Netatmo 2026 3" src="https://github.com/user-attachments/assets/0238fe93-f37a-4291-922c-66d42cfbc096" />


Example logging after this patch (build 18233 (4140c8ea7-modified) with local fix):
<img width="566" height="316" alt="Netatmo after fix 2" src="https://github.com/user-attachments/assets/69ab2d08-fe84-42b2-a34a-e368ee55a994" />
