### PR TITLE
Fix plugin hardware Update/Delete button when a Mode value contains a single quote

### DIFF
--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -4403,9 +4403,14 @@ define(['app'], function (app) {
 							);
 						}
 						else {
+							// For plugins, UpdateHardware() reads every Mode value from the form
+							// fields, so the Mode1..Mode6 arguments are unused here. Interpolating
+							// them into the onclick handler broke it whenever a value contained a
+							// single quote or backslash (e.g. a Tuya local key), making the button
+							// silently dead. Pass only idx.
 							EnableUpdateAndDeleteButtons(
 								true,
-								"javascript:UpdateHardware(" + idx + ",'" + data["Mode1"] + "','" + data["Mode2"] + "','" + data["Mode3"] + "','" + data["Mode4"] + "','" + data["Mode5"] + "','" + data["Mode6"] + "')",
+								"javascript:UpdateHardware(" + idx + ")",
 								"javascript:DeleteHardware(" + idx + ")"
 							);
 						}


### PR DESCRIPTION
### Problem

When a **plugin** hardware entry is selected on the Hardware page, the Update button's `onclick` is built by interpolating the stored `Mode1..Mode6` values into single-quoted JavaScript string literals (`www/app/hardware/Hardware.js`, plugin branch of the row-select handler):

```js
"javascript:UpdateHardware(" + idx + ",'" + data["Mode1"] + "','" + data["Mode2"] + "', ... "')"
```

If any `Mode` value contains a single quote (`'`) — or a backslash — the string literal is closed early and the entire `onclick` becomes a JavaScript **syntax error**. The button then silently does nothing: Update, Disable and Delete all appear dead.

### Real-world impact

The **Tuya SmartPlug** plugin stores the device *local key* in `Mode2`. Tuya local keys are arbitrary bytes and frequently contain a `'`, e.g.:

```
;M^oR6@SK??X'M.z
```

Once such a key is saved, the hardware entry can no longer be edited or disabled from the Web UI — the only workaround is editing the value directly in the database. Setting the value the first time works (the request path uses `encodeURIComponent` correctly), which is why this only manifests on a later edit.

### Fix

`UpdateHardware()` does **not** use those arguments for plugins — it reads every `Mode` value from the live form fields. So the six interpolated arguments are redundant; passing only `idx` is behaviour-preserving and removes the injection entirely. `DeleteHardware` already receives only `idx`.

```diff
- "javascript:UpdateHardware(" + idx + ",'" + data["Mode1"] + "','" + data["Mode2"] + "','" + data["Mode3"] + "','" + data["Mode4"] + "','" + data["Mode5"] + "','" + data["Mode6"] + "')",
+ "javascript:UpdateHardware(" + idx + ")",
```

### Notes

- The non-plugin branch has the same latent issue but interpolates the values unquoted; it is left unchanged here since numeric Mode data is expected there and this PR keeps the change minimal and focused on the observed plugin regression.