### PR TITLE
fix(plugins): let `visible_when` hide a param's description and an empty group header

### DIFF
--- a/plugins/examples/TestExtendedSettings/plugin.py
+++ b/plugins/examples/TestExtendedSettings/plugin.py
@@ -31,6 +31,18 @@
             <param field="Timeout" type="number" label="Timeout (s)" min="1" max="60" default="10" width="100px"/>
             <param field="EnableNotifications" type="boolean" label="Enable Notifications" default="true"/>
         </group>
+        <param field="AllowControl" type="boolean" label="Allow Control" default="false">
+            <description>
+                Turn on to reveal the control settings below.
+            </description>
+        </param>
+        <group label="Control">
+            <param field="AllowReboot" type="boolean" label="Allow Reboot" default="false" visible_when="AllowControl=true">
+                <description>
+                    Permit the plugin to reboot the target device.
+                </description>
+            </param>
+        </group>
         <param field="Mode6" label="Legacy Debug" width="150px">
             <options>
                 <option label="None" value="0" default="true"/>

--- a/plugins/examples/TestExtendedSettings/plugin.py
+++ b/plugins/examples/TestExtendedSettings/plugin.py
@@ -20,7 +20,11 @@
                 <option label="HTTPS" value="https"/>
             </options>
         </param>
-        <param field="Certificate" label="Certificate Path" width="200px" visible_when="Protocol=https" default=""/>
+        <param field="Certificate" label="Certificate Path" width="200px" visible_when="Protocol=https" default="">
+            <description>
+                Path to the client certificate. Only used when the protocol is HTTPS.
+            </description>
+        </param>
         <param field="ApiKey" label="API Key" password="true" width="200px" default=""/>
         <group label="Advanced Settings">
             <param field="RetryCount" type="number" label="Retry Count" min="0" max="10" default="3" width="100px"/>

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -5948,12 +5948,16 @@ define(['app'], function (app) {
 								}
 								var currentGroup = "";
 								var renderParam = function (param) {
-									if (typeof (param.description) != "undefined") {
-										PluginParams += '<tr><td></td><td>' + param.description + '</td></tr>';
-									}
+									// Build the visibility markers before the description row is emitted. A
+									// param's description belongs to its input, so one visible_when has to
+									// govern both rows, otherwise the help text is left behind on its own
+									// with no field under it.
 									var visibleWhen = (typeof (param.visible_when) != "undefined") ? param.visible_when : "";
 									var trStyle = visibleWhen ? ' style="display:none"' : '';
 									var trAttr = visibleWhen ? ' data-visible-when="' + escapeHtml(param.visible_when) + '"' : '';
+									if (typeof (param.description) != "undefined") {
+										PluginParams += '<tr' + trStyle + trAttr + '><td></td><td>' + param.description + '</td></tr>';
+									}
 									PluginParams += '<tr' + trStyle + trAttr + '><td align="right" style="width:110px"><label id="lbl' + escapeHtml(param.field) + '"><span data-i18n="' + escapeHtml(param.label) + '">' + escapeHtml(param.label) + '</span>:</label></td>';
 									var paramType = (typeof (param.type) != "undefined") ? param.type : "";
 									var paramWidth = (typeof (param.width) != "undefined") ? param.width : "200px";

--- a/www/app/hardware/Hardware.js
+++ b/www/app/hardware/Hardware.js
@@ -5302,6 +5302,28 @@ define(['app'], function (app) {
 				$label.text(initVal);
 			});
 
+			// A group header with every param inside it hidden by visible_when is an
+			// empty section, so hide the whole group row. The group <tr> holds both the
+			// header and the nested param table, so one row covers both.
+			// This tests each row's INLINE display: groups render collapsed, so every
+			// row inside has a display:none ancestor and :visible would report them all
+			// hidden regardless of their own visible_when state.
+			var updateGroupVisibility = function () {
+				$table.find("tr.plugin-group-row").each(function () {
+					var $groupRow = $(this);
+					var $groupParams = $groupRow.find("table tr");
+					if ($groupParams.length === 0)
+						return;
+					var bAnyVisible = $groupParams.filter(function () {
+						return this.style.display !== "none";
+					}).length > 0;
+					if (bAnyVisible)
+						$groupRow.show();
+					else
+						$groupRow.hide();
+				});
+			};
+
 			// Set up conditional visibility within this plugin table
 			$table.find("tr[data-visible-when]").each(function () {
 				var $row = $(this);
@@ -5329,6 +5351,9 @@ define(['app'], function (app) {
 				$depInput.on("change", updateVisibility);
 				updateVisibility();
 			});
+
+			$table.off("change.plugingroup").on("change.plugingroup", "input, select, textarea", updateGroupVisibility);
+			updateGroupVisibility();
 		}
 
 		CollectPluginSettings = function (selector) {
@@ -6052,7 +6077,7 @@ define(['app'], function (app) {
 										}
 										if (paramGroup !== "") {
 											// Open new collapsible group
-											PluginParams += '<tr><td colspan="2">' +
+											PluginParams += '<tr class="plugin-group-row"><td colspan="2">' +
 												'<div class="plugin-group" style="margin:5px 0; cursor:pointer;" onclick="var t=$(this).next(); t.toggle(); $(this).find(\'.fa\').toggleClass(\'fa-chevron-right fa-chevron-down\');">' +
 												'<i class="fa fa-chevron-right" style="margin-right:5px;"></i><b>' + escapeHtml(paramGroup) + '</b></div>' +
 												'<div style="display:none;"><table class="display" border="0" cellpadding="0" cellspacing="5">';


### PR DESCRIPTION
Two related rendering bugs in the extended plugin settings form. Both make a plugin's Hardware page
show settings UI that the user cannot act on.

## 1. A hidden param keeps its description

`renderParam` (`www/app/hardware/Hardware.js`) emitted the param's `<description>` row *before* it
computed the visibility markers, so `style="display:none"` and `data-visible-when` only ever landed
on the field row:

```js
if (typeof (param.description) != "undefined") {
    PluginParams += '<tr><td></td><td>' + param.description + '</td></tr>';   // no style, no attr
}
var visibleWhen = ...;
var trStyle = visibleWhen ? ' style="display:none"' : '';                     // field row only
var trAttr  = visibleWhen ? ' data-visible-when="..."' : '';                  // field row only
```

A param hidden by `visible_when` therefore rendered as a block of help text with no field under it.
The toggle in `InitPluginWidgets` selects `tr[data-visible-when]`, so the description row was
neither hidden at render time nor shown when the condition later became true.

Fix: compute the markers first and apply them to both rows, so one `visible_when` governs the input
and the text that explains it.

## 2. A group whose params are all hidden keeps its header

The `<group>` header row was never conditional. A group containing a single `visible_when` param
rendered as a section title with nothing to set under it whenever the condition was false.

Fix: `updateGroupVisibility()` hides the group row when every row in its nested table is hidden. The
group `<tr>` holds both the header and the nested param table, so one row covers both.

Two implementation notes, since neither is obvious from the diff:

- It is wired up through a delegated `change` handler on the plugin table rather than per dependent
  input. A delegated handler fires on bubble, so it always runs after the per-row handlers bound
  directly to the same input, which is what makes the group decision see final row state.
- It tests each row's **inline** `display` rather than `:visible`. Groups render collapsed, so every
  row inside already has a `display:none` ancestor and `:visible` would report them all hidden
  regardless of their own `visible_when` state.

## Changes

| File | Change |
|---|---|
| `www/app/hardware/Hardware.js` | Both fixes above, plus a `plugin-group-row` class on the group row so the visibility pass can find it |
| `plugins/examples/TestExtendedSettings/plugin.py` | A `<description>` on the conditional `Certificate` param, and an `AllowControl` boolean gating a `Control` group whose only param is conditional, so both cases are reproducible |

Frontend only. No C++ change was needed: `PluginManager.cpp` already parses `<param><description>`
and `visible_when`. No `.gz` regeneration: `www/app/` has no committed `.gz` siblings.

## Testing

Verified in a browser against a Domoticz instance running this branch's `www/` with the
`TestExtendedSettings` example plugin, using a Playwright script that reads every row of the plugin
params table and asserts hidden/shown state in three states: condition false, condition true, and
toggled back to false.

| Build | Result |
|---|---|
| `development` unmodified | 6 assertion failures |
| with fix 1 only | 2 failures, both the group header |
| with both fixes | pass |

Because this changes which rows are hidden, and `CollectPluginSettings` decides what to save by
testing row display, I also measured the saved settings rather than reasoning about them:

- Collected keys and values are identical between `development` and this branch, in both condition
  states. Params hidden by `visible_when` are still excluded; unconditional params inside a
  collapsed group are still collected.
- Add a plugin hardware with the conditional fields set, save, reselect it for edit: values persist,
  and the edit-restore path re-evaluates the field rows and the group row correctly.

No console errors or uncaught page errors on the Hardware page.

## Behavior change worth calling out

If a manifest names a `visible_when` field that does not exist, the description row is now hidden
along with its field, where previously the orphaned text remained on screen. That is the consistent
outcome, but it is a visible difference for a malformed manifest.

## Notes

The two fixes are one commit each, in that order, so you can take only the first if you prefer. Fix 1
is the reported bug and is a five line change; fix 2 is polish, self-contained in
`updateGroupVisibility()` plus the class on the group row. Say the word and I will drop the second
commit.

The group-emptiness test in fix 2 is deliberately a small standalone helper, because the
`<group columns="N">` table layout you greenlit on #6885 will want the same "are all children
hidden" question answered for a row of cells.
