### PR TITLE
Add web asset management functionality

### DIFF
--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -590,6 +590,10 @@ namespace http
 			RegisterCommandCode("deletecustomicon", [this](auto&& session, auto&& req, auto&& root) { Cmd_DeleteCustomIcon(session, req, root); });
 			RegisterCommandCode("updatecustomicon", [this](auto&& session, auto&& req, auto&& root) { Cmd_UpdateCustomIcon(session, req, root); });
 
+			RegisterCommandCode("uploadwebasset", [this](auto&& session, auto&& req, auto&& root) { Cmd_UploadWebAsset(session, req, root); });
+			RegisterCommandCode("getwebassets", [this](auto&& session, auto&& req, auto&& root) { Cmd_GetWebAssets(session, req, root); });
+			RegisterCommandCode("deletewebasset", [this](auto&& session, auto&& req, auto&& root) { Cmd_DeleteWebAsset(session, req, root); });
+
 			RegisterCommandCode("renamedevice", [this](auto&& session, auto&& req, auto&& root) { Cmd_RenameDevice(session, req, root); });
 			RegisterCommandCode("setdevused", [this](auto&& session, auto&& req, auto&& root) { Cmd_SetDeviceUsed(session, req, root); });
 

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -280,6 +280,9 @@ private:
 	void Cmd_UploadCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_DeleteCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_UpdateCustomIcon(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_UploadWebAsset(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_GetWebAssets(WebEmSession & session, const request& req, Json::Value &root);
+	void Cmd_DeleteWebAsset(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_RenameDevice(WebEmSession & session, const request& req, Json::Value &root);
 	void Cmd_SetDeviceUsed(WebEmSession & session, const request& req, Json::Value &root);
 

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -5788,6 +5788,23 @@ namespace http
 					return;
 				}
 				outfile.write(szContent.data(), static_cast<std::streamsize>(szContent.size()));
+				outfile.flush();
+				if (!outfile.good())
+				{
+					outfile.close();
+					_log.Log(LOG_ERROR, "UploadWebAsset: write failed for %s", szFile.c_str());
+					std::remove(szFile.c_str());
+					root["error"] = "Could not write asset";
+					return;
+				}
+				outfile.close();
+				if (!outfile.good())
+				{
+					_log.Log(LOG_ERROR, "UploadWebAsset: close failed for %s", szFile.c_str());
+					std::remove(szFile.c_str());
+					root["error"] = "Could not write asset";
+					return;
+				}
 			}
 
 			root["status"] = "OK";

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -5673,6 +5673,189 @@ namespace http
 			ReloadCustomSwitchIcons();
 		}
 
+		static const size_t WEB_ASSET_MAX_SIZE = 8 * 1024 * 1024; // 8 MiB per file
+
+		static bool IsSafeWebAssetName(const std::string& szName)
+		{
+			if (szName.empty() || (szName.size() > 128))
+				return false;
+			if (szName.front() == '.')
+				return false;
+			if (szName.find("..") != std::string::npos)
+				return false;
+
+			for (const char c : szName)
+			{
+				if ((c >= '0') && (c <= '9'))
+					continue;
+				if ((c >= 'a') && (c <= 'z'))
+					continue;
+				if ((c >= 'A') && (c <= 'Z'))
+					continue;
+				if ((c == '.') || (c == '-') || (c == '_'))
+					continue;
+				return false;
+			}
+			return true;
+		}
+
+		static bool IsAllowedWebAssetType(const std::string& szName)
+		{
+			std::string szLower = szName;
+			stdlower(szLower);
+			const std::vector<std::string> allowed = { ".css", ".woff2", ".woff", ".ttf", ".otf", ".eot" };
+			for (const auto& ext : allowed)
+			{
+				if ((szLower.size() > ext.size()) &&
+					(szLower.compare(szLower.size() - ext.size(), ext.size(), ext) == 0))
+					return true;
+			}
+			return false;
+		}
+
+		static bool WebAssetDirExists(const std::string& szPath)
+		{
+			DIR* pDir = opendir(szPath.c_str());
+			if (pDir == nullptr)
+				return false;
+			closedir(pDir);
+			return true;
+		}
+
+		static std::string WebAssetFolder()
+		{
+			return szWWWFolder + "/assets";
+		}
+
+		void CWebServer::Cmd_UploadWebAsset(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["title"] = "UploadWebAsset";
+			if (session.rights != URIGHTS_ADMIN)
+			{
+				session.reply_status = reply::forbidden;
+				return; // Only admin user allowed
+			}
+
+			std::string szName = request::findValue(&req, "name");
+			std::string szData = request::findValue(&req, "data"); // base64 encoded
+
+			if (szName.empty() || szData.empty())
+			{
+				root["error"] = "Missing name or data";
+				return;
+			}
+			if (!IsSafeWebAssetName(szName))
+			{
+				root["error"] = "Invalid asset name";
+				return;
+			}
+			if (!IsAllowedWebAssetType(szName))
+			{
+				root["error"] = "Unsupported asset type";
+				return;
+			}
+
+			std::string szContent = base64_decode(szData);
+			if (szContent.empty())
+			{
+				root["error"] = "Could not decode asset data";
+				return;
+			}
+			if (szContent.size() > WEB_ASSET_MAX_SIZE)
+			{
+				root["error"] = "Asset too large";
+				return;
+			}
+
+			const std::string szFolder = WebAssetFolder();
+			if (!WebAssetDirExists(szFolder))
+			{
+				mkdir_deep(szFolder.c_str(), 0755);
+				if (!WebAssetDirExists(szFolder))
+				{
+					root["error"] = "Could not create assets folder";
+					return;
+				}
+			}
+
+			const std::string szFile = szFolder + "/" + szName;
+			{
+				std::ofstream outfile(szFile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
+				if (!outfile.is_open())
+				{
+					_log.Log(LOG_ERROR, "UploadWebAsset: could not write %s", szFile.c_str());
+					root["error"] = "Could not write asset";
+					return;
+				}
+				outfile.write(szContent.data(), static_cast<std::streamsize>(szContent.size()));
+			}
+
+			root["status"] = "OK";
+			root["path"] = "assets/" + szName;
+			root["size"] = static_cast<int>(szContent.size());   // capped well below INT_MAX
+		}
+
+		void CWebServer::Cmd_GetWebAssets(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["title"] = "GetWebAssets";
+			if (session.rights != URIGHTS_ADMIN)
+			{
+				session.reply_status = reply::forbidden;
+				return; // Only admin user allowed
+			}
+
+			root["status"] = "OK";
+
+			DIR* lDir = opendir(WebAssetFolder().c_str());
+			if (lDir == nullptr)
+				return; // no assets stored yet — an empty result is not an error
+
+			int ii = 0;
+			struct dirent* ent;
+			while ((ent = readdir(lDir)) != nullptr)
+			{
+				const std::string szFileName = ent->d_name;
+				if ((szFileName == ".") || (szFileName == ".."))
+					continue;
+				if (!IsAllowedWebAssetType(szFileName))
+					continue;
+				root["result"][ii]["name"] = szFileName;
+				root["result"][ii]["path"] = "assets/" + szFileName;
+				ii++;
+			}
+			closedir(lDir);
+		}
+
+		void CWebServer::Cmd_DeleteWebAsset(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["title"] = "DeleteWebAsset";
+			if (session.rights != URIGHTS_ADMIN)
+			{
+				session.reply_status = reply::forbidden;
+				return; // Only admin user allowed
+			}
+
+			std::string szName = request::findValue(&req, "name");
+			if (szName.empty() || !IsSafeWebAssetName(szName) || !IsAllowedWebAssetType(szName))
+			{
+				root["error"] = "Invalid asset name";
+				return;
+			}
+
+			const std::string szFile = WebAssetFolder() + "/" + szName;
+			if (!file_exist(szFile.c_str()))
+			{
+				root["error"] = "Asset not found";
+				return;
+			}
+			if (std::remove(szFile.c_str()) != 0)
+			{
+				root["error"] = "Could not remove asset";
+				return;
+			}
+			root["status"] = "OK";
+		}
+
 		void CWebServer::Cmd_RenameDevice(WebEmSession& session, const request& req, Json::Value& root)
 		{
 			if (session.rights != URIGHTS_ADMIN)

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -5779,11 +5779,12 @@ namespace http
 			}
 
 			const std::string szFile = szFolder + "/" + szName;
+			const std::string szTmpFile = szFile + ".tmp";
 			{
-				std::ofstream outfile(szFile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
+				std::ofstream outfile(szTmpFile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 				if (!outfile.is_open())
 				{
-					_log.Log(LOG_ERROR, "UploadWebAsset: could not write %s", szFile.c_str());
+					_log.Log(LOG_ERROR, "UploadWebAsset: could not write %s", szTmpFile.c_str());
 					root["error"] = "Could not write asset";
 					return;
 				}
@@ -5792,19 +5793,27 @@ namespace http
 				if (!outfile.good())
 				{
 					outfile.close();
-					_log.Log(LOG_ERROR, "UploadWebAsset: write failed for %s", szFile.c_str());
-					std::remove(szFile.c_str());
+					_log.Log(LOG_ERROR, "UploadWebAsset: write failed for %s", szTmpFile.c_str());
+					std::remove(szTmpFile.c_str());
 					root["error"] = "Could not write asset";
 					return;
 				}
 				outfile.close();
 				if (!outfile.good())
 				{
-					_log.Log(LOG_ERROR, "UploadWebAsset: close failed for %s", szFile.c_str());
-					std::remove(szFile.c_str());
+					_log.Log(LOG_ERROR, "UploadWebAsset: close failed for %s", szTmpFile.c_str());
+					std::remove(szTmpFile.c_str());
 					root["error"] = "Could not write asset";
 					return;
 				}
+			}
+
+			if (std::rename(szTmpFile.c_str(), szFile.c_str()) != 0)
+			{
+				_log.Log(LOG_ERROR, "UploadWebAsset: could not replace %s", szFile.c_str());
+				std::remove(szTmpFile.c_str());
+				root["error"] = "Could not write asset";
+				return;
 			}
 
 			root["status"] = "OK";

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -15,6 +15,9 @@
 #include <stdarg.h>
 #include <json/json.h>
 #include <algorithm>
+#ifdef WIN32
+#include <windows.h>
+#endif
 #include <openssl/sha.h>
 #include <openssl/evp.h>
 #include <openssl/rand.h>
@@ -5808,7 +5811,12 @@ namespace http
 				}
 			}
 
-			if (std::rename(szTmpFile.c_str(), szFile.c_str()) != 0)
+			#ifdef WIN32
+			bool bRenameOk = (MoveFileExA(szTmpFile.c_str(), szFile.c_str(), MOVEFILE_REPLACE_EXISTING) != 0);
+#else
+			bool bRenameOk = (std::rename(szTmpFile.c_str(), szFile.c_str()) == 0);
+#endif
+			if (!bRenameOk)
 			{
 				_log.Log(LOG_ERROR, "UploadWebAsset: could not replace %s", szFile.c_str());
 				std::remove(szTmpFile.c_str());

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -5782,7 +5782,7 @@ namespace http
 			}
 
 			const std::string szFile = szFolder + "/" + szName;
-			const std::string szTmpFile = szFile + ".tmp";
+			const std::string szTmpFile = szFile + "." + GenerateUUID() + ".tmp";
 			{
 				std::ofstream outfile(szTmpFile.c_str(), std::ios::out | std::ios::binary | std::ios::trunc);
 				if (!outfile.is_open())


### PR DESCRIPTION
This pull request adds new functionality to manage web assets (such as CSS and font files) through the web server's API. It introduces commands to upload, list, and delete web assets, with appropriate security checks and file validation. The changes include both the API command registration and the implementation of the related handler functions.

**New Web Asset Management API:**

* Added three new API commands to the web server: `uploadwebasset`, `getwebassets`, and `deletewebasset`, allowing administrators to upload, list, and delete web assets.
* Declared the corresponding handler methods (`Cmd_UploadWebAsset`, `Cmd_GetWebAssets`, `Cmd_DeleteWebAsset`) in the `CWebServer` class.

**Implementation Details and Security:**

* Implemented the handler functions to:
  - Validate asset names for safety and allowed extensions.
  - Restrict asset management to admin users only.
  - Enforce a maximum file size (8 MiB per file).
  - Store assets in a dedicated `assets` folder, creating it if necessary.
  - Provide JSON responses for success and error cases.
  - List only allowed asset types and ensure safe deletion of files.
  
  
  These endpoints can be used by the frontend to allow users to upload/use their own icon libraries.