### PR TITLE
Fix Meter_Calendar tariff spike check for non-energy meters

### DIFF
--- a/main/SQLHelper.cpp
+++ b/main/SQLHelper.cpp
@@ -8381,10 +8381,13 @@ void CSQLHelper::AddCalendarUpdateMeter()
 				CalcMeterPrice(ID, divider, szDateStart, szDateEnd, price);
 				if (price != 0.0f && total_real > 0)
 				{
-					// Spike protection: discard price if implied tariff exceeds max plausible rate
-					constexpr float max_unit_price = 3.0f;  
-					if (std::abs(price) > (static_cast<float>(total_real) / divider) * max_unit_price)
-						price = 0;
+					// Spike protection only applies to energy tariffs; other meter types use different units.
+					if ((metertype == MTYPE_ENERGY) || (metertype == MTYPE_ENERGY_GENERATED))
+					{
+						constexpr float max_unit_price = 3.0f;
+						if (std::abs(price) > (static_cast<float>(total_real) / divider) * max_unit_price)
+							price = 0;
+					}
 				}
 				else if (total_real <= 0)
 					price = 0;


### PR DESCRIPTION
### Summary

Restrict the hard-coded 3.0/unit tariff spike protection in `AddCalendarUpdateMeter()` to energy meter types.

### Problem

The current check is also applied to gas, water and generic meters, although those meter types use different units and can legitimately have unit prices above 3.

For example, with:
- meter type: `MTYPE_GAS`
- divider: 1000
- unit price: 40.97
- raw daily delta: 29

The correct result is:
`29 / 1000 * 40.97 = 1.18813`

The current sanity limit is:
`29 / 1000 * 3.0 = 0.087`

The valid calculated price is therefore discarded and `Meter_Calendar.Price` becomes 0.

### Fix

Keep the existing 3.0/unit spike protection for `MTYPE_ENERGY` and `MTYPE_ENERGY_GENERATED`. Do not apply that energy-specific threshold to meter types using other units.

The separate P1/MultiMeter spike protection remains unchanged.

### Validation

- Reproduced on V2026.3-stable / f734fde31
- Local patched stable build validated against the affected meter
- Current development branch with this change builds successfully

Fixes #7005