### PR TITLE
Adjust modal-header padding and close button fix position

### DIFF
--- a/www/css/bootstrap.css
+++ b/www/css/bootstrap.css
@@ -4447,12 +4447,12 @@ input[type="submit"].btn.btn-mini {
 }
 
 .modal-header {
-  padding: 9px 15px;
+  padding: 18px 15px;
   border-bottom: 1px solid #eee;
 }
 
 .modal-header .close {
-  margin-top: 2px;
+  margin-top: -12px;
 }
 
 .modal-header h3 {


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adjusts modal-header spacing and repositions the close control.
- Increases vertical modal-header padding from 9px to 18px.
- Applies a negative top margin to align close buttons within the enlarged header.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete functional regressions identified.

The CSS-only changes preserve the existing modal structure and close-button behavior while adjusting header spacing and alignment.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| www/css/bootstrap.css | Adjusts modal-header padding and close-button positioning without an established functional regression. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Adjust modal-header padding and close bu..."](https://github.com/domoticz/domoticz/commit/6097cd42100ddcbf66a90b361921fe7d1558fd6c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61123067)</sub>

<!-- /greptile_comment -->