### PR TITLE
Custom dashboard widgets: let plugins and standalone packages ship their own

### DIFF
--- a/docs/custom-widgets.md
+++ b/docs/custom-widgets.md
@@ -1,0 +1,394 @@
+# Custom dashboard widgets
+
+The dynamic dashboard ("Dashboard 2.0") can load widgets that do not ship with
+Domoticz. A theme can bring its own widgets, a Python plugin can ship a widget
+for the hardware it talks to, and a widget can be published on its own as a
+folder you drop in or clone. None of that requires patching Domoticz.
+
+This document is the contract. It covers `apiVersion` **1**.
+
+- [Where packages live](#where-packages-live)
+- [Package layout](#package-layout)
+- [The manifest: widget.json](#the-manifest-widgetjson)
+- [The widget module](#the-widget-module)
+- [Configuration schema](#configuration-schema)
+- [Styling](#styling)
+- [Talking to Domoticz](#talking-to-domoticz)
+- [Lifecycle events](#lifecycle-events)
+- [How loading works](#how-loading-works)
+- [Rules and limits](#rules-and-limits)
+- [Troubleshooting](#troubleshooting)
+
+## Where packages live
+
+Domoticz scans three locations on every `getcustomwidgets` call, so adding or
+removing a package needs a browser reload, not a restart:
+
+| Location | Use it for | Served from |
+| --- | --- | --- |
+| `<www>/widgets/<package>/` | standalone widget repositories, dropped in or cloned | the webroot, directly |
+| `<www>/styles/<theme>/widgets/<package>/` | widgets that belong to a theme | the webroot, directly |
+| `<userdata>/plugins/<Plugin>/widgets/<package>/` | widgets shipped alongside a Python plugin | the `customwidgetasset` route |
+
+`<www>` is the Domoticz web folder (`www/` in a source checkout) and
+`<userdata>` is the folder holding `domoticz.db` and `plugins/`. In a source
+checkout they are the same tree; in a packaged install they usually are not.
+
+Only the **active** theme is scanned. Widgets belonging to a theme the user is
+not running never show up in the picker.
+
+Plugin packages sit outside the webroot, so their files are served by a
+dedicated route rather than the static file handler. This is transparent — your
+widget's own assets resolve normally — with one consequence worth knowing: see
+[Rules and limits](#rules-and-limits).
+
+## Package layout
+
+A package is a folder with a `widget.json` and the files it names. One package
+may declare several widgets.
+
+```
+my-widgets/
+├── widget.json           required: the manifest
+├── powerFlow.widget.js   the widget's javascript
+├── powerFlow.html        its template
+└── powerFlow.css         optional styles
+```
+
+A folder without a `widget.json` is ignored, so it is fine to keep a `README.md`
+or a `.git` folder next to it.
+
+## The manifest: widget.json
+
+The manifest describes your widgets to the dashboard. It is deliberately the
+*only* thing read at startup: because the descriptor lives here rather than in
+your javascript, Domoticz can list your widget in the picker without executing
+any of your code.
+
+```json
+{
+    "name": "My Widgets",
+    "description": "Power flow visualisation",
+    "author": "your name",
+    "version": "1.0.0",
+    "apiVersion": 1,
+    "widgets": [
+        {
+            "type": "power-flow",
+            "label": "Power Flow",
+            "description": "Live import/export flow between grid, solar and house",
+            "category": "Energy",
+            "icon": "fa-solid fa-bolt",
+            "entry": "powerFlow.widget.js",
+            "template": "powerFlow.html",
+            "css": "powerFlow.css",
+            "defaultW": 4,
+            "defaultH": 3,
+            "minW": 2,
+            "minH": 2,
+            "maxW": 12,
+            "maxH": 6,
+            "transparentBackground": false,
+            "configSchema": []
+        }
+    ]
+}
+```
+
+### Package fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `apiVersion` | yes | Must be `1`. A package declaring anything else is ignored with a log line, which is how a future breaking change stays safe. |
+| `widgets` | yes | Non-empty array of widget descriptors. |
+| `name` | no | Human-readable package name, shown as the widget's provider. |
+| `description` | no | What the package is for. |
+| `author` | no | Shown as the widget's provider. |
+| `version` | no | Your version string; Domoticz does not interpret it. |
+
+### Widget descriptor fields
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `type` | yes | Unique id for this widget. Persisted in the user's dashboard, so **never change it** after release. Must start with a letter and hold only letters, digits, `-` and `_`. |
+| `label` | yes | Name in the widget picker and the card header. |
+| `entry` | yes | Your javascript file, relative to the package folder. |
+| `description` | no | One line in the picker; also searched by the picker's filter box. |
+| `category` | no | Picker grouping. Known ones: `Devices`, `Energy`, `Controls`, `Charts & Data`, `Weather`, `Information`, `Custom Content`, `System`. Anything else becomes its own group at the end. |
+| `icon` | no | Font Awesome classes, e.g. `fa-solid fa-bolt`. |
+| `template` | no | Template file, relative to the package folder. Optional only if your module supplies its own `template` or `templateUrl`. |
+| `css` | no | Stylesheet, relative to the package folder. Injected once, on first render. |
+| `defaultW` / `defaultH` | no | Size in grid units when first placed. |
+| `minW` / `minH` / `maxW` / `maxH` | no | Resize limits. |
+| `transparentBackground` | no | `true` drops the card's panel background — for clock-like widgets. |
+| `configSchema` | no | The widget's settings form; see below. |
+
+Anything else you add is passed through to the descriptor untouched, so a future
+Domoticz can grow new descriptor fields without a change here.
+
+Relative paths (`entry`, `template`, `css`) must stay inside the package: no
+absolute paths, no `..`, no scheme. Domoticz rejects a widget that breaks this.
+
+## The widget module
+
+`entry` is an AMD module (the dashboard uses RequireJS) that exports an Angular
+[directive definition object][ddo]. Domoticz registers the directive itself, so
+your module must **not** depend on `app` or register anything globally.
+
+[ddo]: https://docs.angularjs.org/api/ng/service/$compile#directive-definition-object
+
+Two forms are accepted. Export a factory when the widget needs to know where its
+package lives:
+
+```js
+define(function() {
+    'use strict';
+
+    // ctx.type        this widget's type
+    // ctx.baseUrl     url of the package folder; append your own asset names
+    // ctx.templateUrl the manifest's "template", already resolved (null if unset)
+    return function(ctx) {
+        return {
+            templateUrl: ctx.templateUrl,
+            controller: ['$scope', '$http', function($scope, $http) {
+                var ctrl = this;
+                ctrl.logo = ctx.baseUrl + 'logo.svg';
+            }]
+        };
+    };
+});
+```
+
+Or export the definition object directly when it does not:
+
+```js
+define(function() {
+    'use strict';
+
+    return {
+        template: '<div class="my-widget">{{ ctrl.text }}</div>',
+        controller: ['$scope', function($scope) {
+            this.text = 'hello';
+        }]
+    };
+});
+```
+
+Your module may pull in its own dependencies through `define([...])` as usual,
+including Domoticz services registered on the injector.
+
+### What Domoticz fills in
+
+Unless your definition object says otherwise, you get:
+
+```js
+{
+    scope: { widgetDef: '=', editMode: '<' },
+    controllerAs: 'ctrl',
+    bindToController: true
+}
+```
+
+so `ctrl.widgetDef` and `ctrl.editMode` are available in the controller and
+`ctrl.` is the template prefix. If you declare your own `scope`, it replaces
+this one wholesale — keep `widgetDef` and `editMode` in it.
+
+`restrict` is always forced to `'E'`; the dashboard renders widgets as elements.
+
+If neither your object nor the manifest supplies a template, the widget fails to
+load with an error on the card.
+
+### The two bindings
+
+`widgetDef` is the placed widget. The part you care about is `widgetDef.config`,
+holding the user's answers to your `configSchema`:
+
+```js
+function config() {
+    return (ctrl.widgetDef && ctrl.widgetDef.config) || {};
+}
+```
+
+Read it through a helper like that rather than caching it. The user can open the
+settings dialog while your widget is on screen, and the dashboard applies the
+result by mutating `config` in place — so watch it if you need to react:
+
+```js
+$scope.$watch(function() { return config(); }, applyConfig, true);
+```
+
+`editMode` is `true` while the dashboard is being edited. Use it to suppress
+interactions that would fight with dragging and resizing.
+
+## Configuration schema
+
+Each entry in `configSchema` renders one field in the widget's settings dialog.
+
+```json
+{ "key": "deviceIdx", "type": "device-picker", "label": "Device", "required": true }
+```
+
+Common keys: `key` (where the value lands in `config`), `type`, `label`,
+`default`, `required`, `help`. Numeric fields also take `min` and `max`;
+`picker` and `select` take `options` as `[{ "value": …, "label": … }]`.
+
+Available `type` values:
+
+| Type | Field |
+| --- | --- |
+| `text`, `textarea`, `url` | free text |
+| `number`, `range` | numeric input, slider |
+| `boolean` | toggle |
+| `color`, `color-alpha` | colour picker, with or without alpha |
+| `select`, `picker` | dropdown over `options` |
+| `device-picker`, `device-list` | one or many Domoticz devices |
+| `scene-picker`, `camera-picker`, `plan-picker` | one scene / camera / room plan |
+| `action-list`, `range-list` | repeating rows |
+| `group` | visual grouping of the fields that follow |
+
+A widget with no `configSchema` has no settings dialog, and the "configure"
+action is hidden on its card.
+
+## Styling
+
+The `css` file is injected once, the first time one of the package's widgets is
+rendered. It is a plain global stylesheet: nothing scopes it to your widget, so
+**prefix every selector** with something specific to your package.
+
+Use the Domoticz theme variables instead of literal colours so your widget
+follows the user's theme, including third-party ones:
+
+```css
+.my-widget__value  { color: var(--dz-accent-color, #4e9af1); }
+.my-widget__label  { color: var(--dz-body-text); }
+.my-widget--faded  { opacity: 0.6; }
+```
+
+Your widget is rendered inside the card body, which is a flex column. Give your
+root element `height: 100%` and `box-sizing: border-box` if you want to fill it.
+
+## Talking to Domoticz
+
+Use the JSON API through `$http`, exactly as the built-in widgets do:
+
+```js
+$http.get('json.htm', { params: { type: 'command', param: 'getdevices', rid: idx } })
+    .then(function(resp) { ctrl.device = (resp.data.result || [])[0]; });
+```
+
+Domoticz already holds a websocket to the browser, so prefer reacting to its
+broadcasts over polling:
+
+| Event | Fired when |
+| --- | --- |
+| `device_update` | a device changed; the payload is the device, so filter on `idx` |
+| `time_update` | the server clock ticked; carries `serverTime` and `actTime` |
+
+```js
+$scope.$on('device_update', function(event, updated) {
+    if (ctrl.device && String(updated.idx) === String(ctrl.device.idx)) {
+        ctrl.device = angular.extend({}, ctrl.device, updated);
+    }
+});
+```
+
+Injectable services worth knowing: `$http`, `$q`, `$interval`, `$timeout`,
+`livesocket`, `domoticzApi`, `dzTimeAndSun`, `ddVisibility`, `ddToast`.
+
+## Lifecycle events
+
+| Event | Meaning |
+| --- | --- |
+| `dd:widget:refresh` | the user asked the dashboard to refresh — re-read your data |
+| `dd:page:hidden` | the dashboard is no longer visible — stop timers |
+| `dd:page:visible` | it is visible again — redraw and restart timers |
+| `$destroy` | the widget is going away — cancel intervals, drop listeners |
+
+Honouring the visibility pair matters: a dashboard left open on a wall tablet
+will otherwise keep every widget's timers running for days.
+
+```js
+var timer = null;
+function stop()  { if (timer) { $interval.cancel(timer); timer = null; } }
+function start() { stop(); timer = $interval(tick, 1000); }
+
+$scope.$on('dd:page:hidden',  stop);
+$scope.$on('dd:page:visible', function() { tick(); start(); });
+$scope.$on('$destroy',        stop);
+```
+
+## How loading works
+
+Worth understanding, because it explains the constraints:
+
+1. On dashboard load, the browser calls `getcustomwidgets`. Domoticz scans the
+   three locations, validates each `widget.json`, and returns the packages.
+2. Every descriptor is registered into the widget registry. **No third-party
+   code has run yet** — this is why a broken package cannot keep the picker, or
+   the rest of the dashboard, from working.
+3. The first time a widget of your type is actually rendered, its `css` is
+   injected and its `entry` is fetched. Your directive is registered, and the
+   card compiles. Later instances reuse it.
+4. While step 3 is in flight the card shows a spinner. If it fails, the card
+   shows the reason and the rest of the dashboard is unaffected.
+
+## Rules and limits
+
+**Pick a `type` and keep it.** It is stored in every dashboard that uses your
+widget. Changing it orphans those cards. Prefix it to stay clear of other
+packages: `acme-power-flow` rather than `power`.
+
+**Built-in widgets always win.** If your `type` matches a stock widget, or one
+another package already claimed, yours is skipped with a console warning. The
+first package discovered keeps the name.
+
+**Element names cannot collide.** Domoticz derives the directive name from your
+type itself, so you never pick an element name and can never clash with a
+built-in one.
+
+**Your code is not sandboxed.** It runs with the same access as Domoticz's own
+javascript. That is a deliberate choice — a Python plugin already runs arbitrary
+code on the server, and `www/templates/` has always allowed custom Angular
+pages — but it means installing a widget package is as much a trust decision as
+installing a plugin. Read what you install.
+
+**Plugin packages: build asset urls from `ctx.baseUrl`.** Files under
+`plugins/…/widgets/` are served through a query-based route, so a relative
+`<img src="logo.svg">` inside your template will not resolve. Use
+`ctx.baseUrl + 'logo.svg'`. Widgets in `www/widgets/` and theme widgets are
+served as ordinary paths and do not have this constraint, but using `baseUrl`
+everywhere keeps a package portable between the three locations.
+
+**Allowed asset extensions.** For plugin packages, only `js`, `html`, `css`,
+`json`, `png`, `jpg`, `jpeg`, `gif`, `svg`, `webp`, `woff` and `woff2` are
+served. Others get a 403.
+
+**A manifest is capped at 256 KB** and a widget's `type` at 64 characters.
+
+## Troubleshooting
+
+**The widget is not in the picker.** Call
+`json.htm?type=command&param=getcustomwidgets` directly and see whether your
+package is listed. If it is not, check the Domoticz log: every rejected package
+is logged with the reason (bad JSON, wrong `apiVersion`, no `widgets` array,
+unsafe asset path). Confirm the folder holds a `widget.json`, and for a theme
+package, that the theme is the active one.
+
+**The card says "failed to load".** The browser console has the detail. Usual
+causes: the `entry` file 404s, the module throws while loading, or it returned
+something that is not a directive definition object.
+
+**The card says "Unknown widget type".** A dashboard references a widget whose
+package is no longer installed, or was renamed. Reinstall it, or delete the
+card.
+
+**Settings changes do not show up.** You cached `widgetDef.config` instead of
+reading it through a helper, or you are watching it without `true` for deep
+comparison.
+
+## See also
+
+- [`docs/dashboardDynamic.md`](dashboardDynamic.md) — the dashboard itself
+- [`docs/Theming.wiki`](Theming.wiki) — building a theme
+- [`docs/Developing_a_Python_plugin.wiki`](Developing_a_Python_plugin.wiki) — plugins
+- `www/widgets/example/` — a working reference package

--- a/docs/custom-widgets.md
+++ b/docs/custom-widgets.md
@@ -367,6 +367,12 @@ served. Others get a 403.
 
 ## Troubleshooting
 
+**Finding your widget in the picker.** Installed widgets sit in whatever
+category their manifest declares, badged with the package they came from. The
+Widget Library's **Custom** filter narrows the list to package widgets only,
+and its search box matches package, theme, plugin and author names as well as
+widget labels.
+
 **The widget is not in the picker.** Call
 `json.htm?type=command&param=getcustomwidgets` directly and see whether your
 package is listed. If it is not, check the Domoticz log: every rejected package

--- a/main/WebServer.cpp
+++ b/main/WebServer.cpp
@@ -334,6 +334,8 @@ namespace http
 			// Maybe handle these differently? (Or remove)
 			m_pWebEm->RegisterPageCode("/images/floorplans/plan", [this](auto&& session, auto&& req, auto&& rep) { GetFloorplanImage(session, req, rep); });
 			m_pWebEm->RegisterPageCode("/service-worker.js", [this](auto&& session, auto&& req, auto&& rep) { GetServiceWorker(session, req, rep); }, true);
+			// Widget packages shipped by Python plugins live outside the webroot, so the static file handler cannot reach them
+			m_pWebEm->RegisterPageCode("/customwidgetasset", [this](auto&& session, auto&& req, auto&& rep) { ServeCustomWidgetAsset(session, req, rep); });
 
 			// End of 'Pages' to be moved...
 
@@ -769,6 +771,8 @@ namespace http
 			RegisterCommandCode("savedashboardlayout",    [this](auto&& session, auto&& req, auto&& root) { Cmd_SaveDashboardLayout(session, req, root); });
 			RegisterCommandCode("deletedashboardlayout",  [this](auto&& session, auto&& req, auto&& root) { Cmd_DeleteDashboardLayout(session, req, root); });
 			RegisterCommandCode("copydashboardlayout",    [this](auto&& session, auto&& req, auto&& root) { Cmd_CopyDashboardLayout(session, req, root); });
+
+			RegisterCommandCode("getcustomwidgets",       [this](auto&& session, auto&& req, auto&& root) { Cmd_GetCustomWidgets(session, req, root); });
 
 			//Whitelist
 			m_pWebEm->RegisterWhitelistURLString("/images/floorplans/plan");

--- a/main/WebServer.h
+++ b/main/WebServer.h
@@ -50,6 +50,7 @@ class CWebServer : public session_store, public std::enable_shared_from_this<CWe
 	void GetFloorplanImage(WebEmSession& session, const request& req, reply& rep);
 	void GetServiceWorker(WebEmSession& session, const request& req, reply& rep);
 	void GetDatabaseBackup(WebEmSession & session, const request& req, reply & rep);
+	void ServeCustomWidgetAsset(WebEmSession& session, const request& req, reply& rep);
 
 	void GetOauth2AuthCode(WebEmSession &session, const request &req, reply &rep);
 	void PostOauth2AccessToken(WebEmSession &session, const request &req, reply &rep);
@@ -379,6 +380,9 @@ private:
 	void Cmd_SaveDashboardLayout(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_DeleteDashboardLayout(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_CopyDashboardLayout(WebEmSession& session, const request& req, Json::Value& root);
+
+	// Custom (third-party) dashboard widgets, shipped by themes, plugins or dropped in standalone
+	void Cmd_GetCustomWidgets(WebEmSession& session, const request& req, Json::Value& root);
 
 	void Cmd_GetMatterNodes(WebEmSession& session, const request& req, Json::Value& root);
 	void Cmd_GetMatterNetworkGraph(WebEmSession& session, const request& req, Json::Value& root);

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -8412,8 +8412,14 @@ namespace http
 
 		// Scan one directory of widget packages. Missing directories are the
 		// normal case (most installs have none), so they pass silently.
-		static void ScanCustomWidgetDir(const std::string& dir, const std::string& source, const std::string& origin, const std::string& baseUrl,
-						Json::Value& result, std::set<std::string>& seenTypes)
+		//
+		// A package's base url is built as prefix + <package> + suffix, because
+		// the two kinds of url differ in more than their prefix: webroot and
+		// theme packages are plain paths ending in '/', while plugin packages
+		// are a query onto the asset route ending in '&file='. Either way,
+		// appending an asset name to the base url yields its url.
+		static void ScanCustomWidgetDir(const std::string& dir, const std::string& source, const std::string& origin, const std::string& baseUrlPrefix,
+						const std::string& baseUrlSuffix, Json::Value& result, std::set<std::string>& seenTypes)
 		{
 			std::vector<std::string> packages;
 			DirectoryListing(packages, dir, true, false);
@@ -8425,7 +8431,7 @@ namespace http
 					continue;
 
 				Json::Value pkg;
-				if (!ReadCustomWidgetManifest(dir + pkgName, pkgName, source, origin, baseUrl + pkgName + "/", pkg))
+				if (!ReadCustomWidgetManifest(dir + pkgName, pkgName, source, origin, baseUrlPrefix + pkgName + baseUrlSuffix, pkg))
 					continue;
 
 				// Two packages claiming the same widget type would fight over one
@@ -8459,13 +8465,13 @@ namespace http
 			std::set<std::string> seenTypes;
 
 			// Standalone widget packages, dropped in or cloned by the user.
-			ScanCustomWidgetDir(szWWWFolder + "/widgets/", "webroot", "", "widgets/", root["result"], seenTypes);
+			ScanCustomWidgetDir(szWWWFolder + "/widgets/", "webroot", "", "widgets/", "/", root["result"], seenTypes);
 
 			// Widgets shipped by the active theme.
 			std::string activeTheme;
 			if (m_sql.GetPreferencesVar("WebTheme", activeTheme) && IsSafePathSegment(activeTheme))
 			{
-				ScanCustomWidgetDir(szWWWFolder + "/styles/" + activeTheme + "/widgets/", "theme", activeTheme, "styles/" + activeTheme + "/widgets/",
+				ScanCustomWidgetDir(szWWWFolder + "/styles/" + activeTheme + "/widgets/", "theme", activeTheme, "styles/" + activeTheme + "/widgets/", "/",
 						    root["result"], seenTypes);
 			}
 
@@ -8480,7 +8486,7 @@ namespace http
 				if (!IsSafePathSegment(pluginName))
 					continue;
 				ScanCustomWidgetDir(pluginsRoot + pluginName + "/widgets/", "plugin", pluginName,
-						    "customwidgetasset?plugin=" + pluginName + "&package=", root["result"], seenTypes);
+						    "customwidgetasset?plugin=" + pluginName + "&package=", "&file=", root["result"], seenTypes);
 			}
 
 			root["status"] = "OK";

--- a/main/WebServerCmds.cpp
+++ b/main/WebServerCmds.cpp
@@ -8263,5 +8263,284 @@ namespace http
 			root["id"] = newid;
 		}
 
+		// ---------------------------------------------------------------------
+		// Custom (third-party) dashboard widgets
+		//
+		// A widget package is a folder holding a 'widget.json' manifest plus the
+		// assets it references. Packages are discovered in three places:
+		//
+		//   <www>/widgets/<pkg>/                        standalone widget repos
+		//   <www>/styles/<theme>/widgets/<pkg>/         widgets shipped by a theme
+		//   <userdata>/plugins/<Plugin>/widgets/<pkg>/  widgets shipped by a plugin
+		//
+		// Only the active theme is scanned, so widgets belonging to a theme the
+		// user is not running never show up in the picker.
+		//
+		// The manifest carries the widget descriptors (label, icon, default size,
+		// config schema), which lets the dashboard populate its widget picker
+		// without executing any third-party code. A widget's javascript is only
+		// fetched once the user actually places one on a dashboard.
+		// ---------------------------------------------------------------------
+
+		static constexpr int CUSTOM_WIDGET_API_VERSION = 1;
+		static constexpr size_t CUSTOM_WIDGET_MANIFEST_MAX_SIZE = 256 * 1024;
+
+		// A widget 'type' becomes part of a DOM element name and is persisted in
+		// the user's dashboard layout, so keep it to a conservative character set.
+		static bool IsSafeCustomWidgetType(const std::string& type)
+		{
+			if (type.empty() || type.size() > 64)
+				return false;
+			if (isalpha(static_cast<unsigned char>(type[0])) == 0)
+				return false;
+			return std::all_of(type.begin(), type.end(), [](unsigned char c) { return (isalnum(c) != 0) || c == '-' || c == '_'; });
+		}
+
+		// One path segment naming a package, theme or plugin folder. These end up
+		// in both a filesystem path and a url, so no traversal and no separators,
+		// but dots are common enough in real theme and plugin names to allow.
+		static bool IsSafePathSegment(const std::string& segment)
+		{
+			if (segment.empty() || segment.size() > 64)
+				return false;
+			if (isalnum(static_cast<unsigned char>(segment[0])) == 0)
+				return false;
+			if (segment.find("..") != std::string::npos)
+				return false;
+			return std::all_of(segment.begin(), segment.end(), [](unsigned char c) { return (isalnum(c) != 0) || c == '-' || c == '_' || c == '.'; });
+		}
+
+		// A relative asset reference out of a manifest ('entry', 'template', 'css').
+		// The browser resolves it against the package folder, so it has to stay
+		// inside it: no traversal, no absolute paths, no scheme.
+		static bool IsSafeCustomWidgetAsset(const std::string& asset)
+		{
+			if (asset.empty() || asset.size() > 128)
+				return false;
+			if (asset.find("..") != std::string::npos)
+				return false;
+			if (asset.find(':') != std::string::npos)
+				return false;
+			if (asset.front() == '/' || asset.front() == '\\')
+				return false;
+			return asset.find_first_of("?#\\") == std::string::npos;
+		}
+
+		// Read and validate one widget.json. Returns false when the package is
+		// unusable, so that a single broken package cannot keep the rest of the
+		// dashboard's widgets from loading.
+		static bool ReadCustomWidgetManifest(const std::string& pkgDir, const std::string& pkgName, const std::string& source, const std::string& origin,
+						     const std::string& baseUrl, Json::Value& pkgOut)
+		{
+			std::string manifestPath = pkgDir + "/widget.json";
+			std::ifstream manifestFile(manifestPath.c_str(), std::ios::binary);
+			if (!manifestFile.is_open())
+				return false; // just a folder without a manifest; not an error
+
+			std::string content((std::istreambuf_iterator<char>(manifestFile)), std::istreambuf_iterator<char>());
+			manifestFile.close();
+
+			if (content.empty() || content.size() > CUSTOM_WIDGET_MANIFEST_MAX_SIZE)
+			{
+				_log.Log(LOG_ERROR, "Custom widget: '%s' has an empty or oversized widget.json, ignoring it", pkgName.c_str());
+				return false;
+			}
+
+			Json::Value manifest;
+			std::string parseError;
+			if (!ParseJSonStrict(content, manifest, &parseError) || !manifest.isObject())
+			{
+				_log.Log(LOG_ERROR, "Custom widget: could not parse '%s/widget.json' (%s), ignoring it", pkgName.c_str(), parseError.c_str());
+				return false;
+			}
+
+			int apiVersion = manifest.get("apiVersion", 0).asInt();
+			if (apiVersion != CUSTOM_WIDGET_API_VERSION)
+			{
+				_log.Log(LOG_ERROR, "Custom widget: '%s' declares apiVersion %d but this Domoticz supports %d, ignoring it", pkgName.c_str(), apiVersion,
+					 CUSTOM_WIDGET_API_VERSION);
+				return false;
+			}
+
+			if (!manifest["widgets"].isArray() || manifest["widgets"].empty())
+			{
+				_log.Log(LOG_ERROR, "Custom widget: '%s' has no 'widgets' array in its manifest, ignoring it", pkgName.c_str());
+				return false;
+			}
+
+			// Validate each descriptor, but otherwise pass it through untouched so
+			// that new descriptor fields do not need a server-side change.
+			Json::Value widgets(Json::arrayValue);
+			for (const auto& widget : manifest["widgets"])
+			{
+				if (!widget.isObject())
+					continue;
+
+				std::string type = widget.get("type", "").asString();
+				if (!IsSafeCustomWidgetType(type))
+				{
+					_log.Log(LOG_ERROR, "Custom widget: '%s' declares an invalid widget type '%s', skipping it", pkgName.c_str(), type.c_str());
+					continue;
+				}
+
+				bool bAssetsOk = IsSafeCustomWidgetAsset(widget.get("entry", "").asString());
+				for (const char* optional : { "template", "css" })
+				{
+					if (widget.isMember(optional))
+						bAssetsOk = bAssetsOk && IsSafeCustomWidgetAsset(widget[optional].asString());
+				}
+				if (!bAssetsOk)
+				{
+					_log.Log(LOG_ERROR, "Custom widget: '%s/%s' references an invalid asset path, skipping it", pkgName.c_str(), type.c_str());
+					continue;
+				}
+
+				widgets.append(widget);
+			}
+
+			if (widgets.empty())
+				return false;
+
+			pkgOut = manifest;
+			pkgOut["widgets"] = widgets;
+			pkgOut["id"] = pkgName;
+			pkgOut["source"] = source;
+			pkgOut["origin"] = origin;
+			pkgOut["baseUrl"] = baseUrl;
+			return true;
+		}
+
+		// Scan one directory of widget packages. Missing directories are the
+		// normal case (most installs have none), so they pass silently.
+		static void ScanCustomWidgetDir(const std::string& dir, const std::string& source, const std::string& origin, const std::string& baseUrl,
+						Json::Value& result, std::set<std::string>& seenTypes)
+		{
+			std::vector<std::string> packages;
+			DirectoryListing(packages, dir, true, false);
+			std::sort(packages.begin(), packages.end()); // stable order across platforms
+
+			for (const auto& pkgName : packages)
+			{
+				if (!IsSafePathSegment(pkgName))
+					continue;
+
+				Json::Value pkg;
+				if (!ReadCustomWidgetManifest(dir + pkgName, pkgName, source, origin, baseUrl + pkgName + "/", pkg))
+					continue;
+
+				// Two packages claiming the same widget type would fight over one
+				// DOM element name; first one discovered wins.
+				Json::Value accepted(Json::arrayValue);
+				for (const auto& widget : pkg["widgets"])
+				{
+					std::string type = widget["type"].asString();
+					if (!seenTypes.insert(type).second)
+					{
+						_log.Log(LOG_ERROR, "Custom widget: type '%s' from package '%s' is already provided by another package, skipping it",
+							 type.c_str(), pkgName.c_str());
+						continue;
+					}
+					accepted.append(widget);
+				}
+				if (accepted.empty())
+					continue;
+
+				pkg["widgets"] = accepted;
+				result.append(pkg);
+			}
+		}
+
+		void CWebServer::Cmd_GetCustomWidgets(WebEmSession& session, const request& req, Json::Value& root)
+		{
+			root["title"] = "GetCustomWidgets";
+			root["apiVersion"] = CUSTOM_WIDGET_API_VERSION;
+			root["result"] = Json::Value(Json::arrayValue);
+
+			std::set<std::string> seenTypes;
+
+			// Standalone widget packages, dropped in or cloned by the user.
+			ScanCustomWidgetDir(szWWWFolder + "/widgets/", "webroot", "", "widgets/", root["result"], seenTypes);
+
+			// Widgets shipped by the active theme.
+			std::string activeTheme;
+			if (m_sql.GetPreferencesVar("WebTheme", activeTheme) && IsSafePathSegment(activeTheme))
+			{
+				ScanCustomWidgetDir(szWWWFolder + "/styles/" + activeTheme + "/widgets/", "theme", activeTheme, "styles/" + activeTheme + "/widgets/",
+						    root["result"], seenTypes);
+			}
+
+			// Widgets shipped by Python plugins. These live outside the webroot, so
+			// they are served through the 'customwidgetasset' page instead.
+			std::string pluginsRoot = szUserDataFolder + "plugins/";
+			std::vector<std::string> plugins;
+			DirectoryListing(plugins, pluginsRoot, true, false);
+			std::sort(plugins.begin(), plugins.end());
+			for (const auto& pluginName : plugins)
+			{
+				if (!IsSafePathSegment(pluginName))
+					continue;
+				ScanCustomWidgetDir(pluginsRoot + pluginName + "/widgets/", "plugin", pluginName,
+						    "customwidgetasset?plugin=" + pluginName + "&package=", root["result"], seenTypes);
+			}
+
+			root["status"] = "OK";
+		}
+
+		// Serve a single file out of <userdata>/plugins/<Plugin>/widgets/<package>/.
+		// Plugins live outside the webroot, so the static file handler cannot reach
+		// them; this page stands in for it.
+		//
+		// The URL is query-based because libwebem matches registered pages on the
+		// exact request path, so a '/prefix/<anything>' route is not available.
+		void CWebServer::ServeCustomWidgetAsset(WebEmSession& session, const request& req, reply& rep)
+		{
+			std::string pluginName = request::findValue(&req, "plugin");
+			std::string packageName = request::findValue(&req, "package");
+			std::string fileName = request::findValue(&req, "file");
+
+			if (!IsSafePathSegment(pluginName) || !IsSafePathSegment(packageName) || !IsSafeCustomWidgetAsset(fileName))
+			{
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+
+			// Only the asset kinds a widget package is meant to contain.
+			static const std::map<std::string, std::string> allowedTypes = {
+				{ "js", "application/javascript" }, { "html", "text/html" },	 { "css", "text/css" },	     { "json", "application/json" },
+				{ "png", "image/png" },		    { "jpg", "image/jpeg" },	 { "jpeg", "image/jpeg" },   { "gif", "image/gif" },
+				{ "svg", "image/svg+xml" },	    { "webp", "image/webp" },	 { "woff", "font/woff" },    { "woff2", "font/woff2" },
+			};
+
+			size_t dotPos = fileName.find_last_of('.');
+			if (dotPos == std::string::npos)
+			{
+				rep = reply::stock_reply(reply::bad_request);
+				return;
+			}
+			std::string extension = fileName.substr(dotPos + 1);
+			std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);
+
+			auto contentType = allowedTypes.find(extension);
+			if (contentType == allowedTypes.end())
+			{
+				rep = reply::stock_reply(reply::forbidden);
+				return;
+			}
+
+			std::string fullPath = szUserDataFolder + "plugins/" + pluginName + "/widgets/" + packageName + "/" + fileName;
+			std::ifstream assetFile(fullPath.c_str(), std::ios::binary);
+			if (!assetFile.is_open())
+			{
+				rep = reply::stock_reply(reply::not_found);
+				return;
+			}
+
+			std::string content((std::istreambuf_iterator<char>(assetFile)), std::istreambuf_iterator<char>());
+			assetFile.close();
+
+			reply::set_content(&rep, content.begin(), content.end());
+			reply::add_header_content_type(&rep, contentType->second);
+		}
+
 	} // namespace server
 } // namespace http

--- a/www/app/dashboardDynamic/DashboardDynamicController.js
+++ b/www/app/dashboardDynamic/DashboardDynamicController.js
@@ -3,6 +3,7 @@ define([
     'dashboardDynamic/dashboardDynamic.module',
     'dashboardDynamic/dashboardDynamicService',
     'dashboardDynamic/widgetRegistry.service',
+    'dashboardDynamic/customWidgets.service',
     'dashboardDynamic/ddToast.service',
     'dashboardDynamic/ddSparkline.service',
     'dashboardDynamic/ddVisibility.service',
@@ -66,9 +67,9 @@ define([
 
     app.controller('DashboardDynamicController', [
         '$scope', '$timeout', '$interval', '$document', '$location', '$route', '$uibModal', '$q', '$http',
-        'dashboardDynamicService', 'widgetRegistry', 'ddToast', 'bootbox', 'livesocket',
+        'dashboardDynamicService', 'widgetRegistry', 'customWidgets', 'ddToast', 'bootbox', 'livesocket',
         function($scope, $timeout, $interval, $document, $location, $route, $uibModal, $q, $http,
-                 dashboardDynamicService, widgetRegistry, ddToast, bootbox, livesocket) {
+                 dashboardDynamicService, widgetRegistry, customWidgets, ddToast, bootbox, livesocket) {
 
         // One-time migration of legacy localStorage keys
         try {
@@ -259,7 +260,13 @@ define([
                 .then(function(resp) {
                     $scope.roomPlans = (resp.data && resp.data.result) || [];
                 });
-            dashboardDynamicService.listLayouts().then(function(layouts) {
+            // Register any installed custom widget packages before the first
+            // layout renders, so a dashboard that holds one does not paint an
+            // "unknown widget type" card first. discover() never rejects.
+            customWidgets.discover().then(function() {
+                refreshWidgetCatalog();
+                return dashboardDynamicService.listLayouts();
+            }).then(function(layouts) {
                 $scope.layouts = layouts;
                 if (layouts.length === 0) {
                     return createStarterLayout();
@@ -438,9 +445,16 @@ define([
                    $scope.activeData.widgets.find(function(w) { return w.id === id; });
         }
 
-        // All widgets are pre-loaded via RequireJS deps — snapshot once at init.
-        // Using a live getter would return a new object every digest → infinite loop.
+        // Built-in widgets are pre-loaded via RequireJS deps; custom widget
+        // packages are added by customWidgets.discover() during init, after
+        // which refreshWidgetCatalog() re-snapshots.
+        // Snapshot rather than a live getter: a getter would return a new object
+        // every digest → infinite loop.
         $scope.widgetCatalogGrouped = widgetRegistry.getGrouped();
+
+        function refreshWidgetCatalog() {
+            $scope.widgetCatalogGrouped = widgetRegistry.getGrouped();
+        }
 
         $scope.libraryItemFilter = function(item) {
             var q = ($scope.librarySearch || '').trim().toLowerCase();

--- a/www/app/dashboardDynamic/DashboardDynamicController.js
+++ b/www/app/dashboardDynamic/DashboardDynamicController.js
@@ -456,12 +456,32 @@ define([
             $scope.widgetCatalogGrouped = widgetRegistry.getGrouped();
         }
 
+        // Installed widget packages scatter across categories, so offer a way to
+        // see only what came from a package (or only what ships with Domoticz).
+        $scope.librarySource = 'all';   // 'all' | 'builtin' | 'custom'
+
+        $scope.setLibrarySource = function(source) {
+            $scope.librarySource = source;
+        };
+
+        $scope.hasCustomWidgets = function() {
+            return customWidgets.getPackages().length > 0;
+        };
+
         $scope.libraryItemFilter = function(item) {
+            if ($scope.librarySource === 'custom'  && !item.custom) { return false; }
+            if ($scope.librarySource === 'builtin' &&  item.custom) { return false; }
+
             var q = ($scope.librarySearch || '').trim().toLowerCase();
             if (!q) { return true; }
-            return (item.label       || '').toLowerCase().indexOf(q) !== -1 ||
-                   (item.description || '').toLowerCase().indexOf(q) !== -1 ||
-                   (item.category    || '').toLowerCase().indexOf(q) !== -1;
+            return (item.label            || '').toLowerCase().indexOf(q) !== -1 ||
+                   (item.description      || '').toLowerCase().indexOf(q) !== -1 ||
+                   (item.category         || '').toLowerCase().indexOf(q) !== -1 ||
+                   // so searching a theme, plugin or package name finds its widgets
+                   (item.provider && (
+                       (item.provider.name   || '').toLowerCase().indexOf(q) !== -1 ||
+                       (item.provider.origin || '').toLowerCase().indexOf(q) !== -1 ||
+                       (item.provider.author || '').toLowerCase().indexOf(q) !== -1));
         };
 
         $scope.saveCurrentLayout = function() {

--- a/www/app/dashboardDynamic/customWidgets.service.js
+++ b/www/app/dashboardDynamic/customWidgets.service.js
@@ -1,0 +1,260 @@
+define([
+    'app',
+    'angularAMD',
+    'dashboardDynamic/widgetRegistry.service'
+], function(app, angularAMD, widgetRegistry) {
+    'use strict';
+
+    /**
+     * customWidgets
+     *
+     * Discovers and loads third-party dashboard widgets. Packages can be shipped
+     * by a theme, by a Python plugin, or simply dropped into www/widgets; the
+     * server finds them all and reports them through 'getcustomwidgets'.
+     *
+     * Loading happens in two stages. The manifest a package ships carries the
+     * whole widget descriptor -- label, icon, default size, config schema -- so
+     * populating the widget picker needs no third-party code to run. Only when a
+     * widget is actually placed on a dashboard do we fetch its javascript and
+     * register its directive, which keeps a broken package from taking the
+     * picker (or the rest of the dashboard) down with it.
+     *
+     * See docs/custom-widgets.md for the package format and the API contract.
+     */
+    var SUPPORTED_API_VERSION = 1;
+
+    // Angular directive names are ours to assign, so a package can never collide
+    // with a built-in widget's element name no matter what it calls itself.
+    var DIRECTIVE_PREFIX = 'ddCustom';
+    var DIRECTIVE_SUFFIX = 'Widget';
+
+    /* Turn a widget type ('ng-tour', 'ng_tour') into a directive name fragment
+     * ('NgTour'). */
+    function toPascalCase(type) {
+        return type
+            .split(/[-_]+/)
+            .filter(function(part) { return part.length > 0; })
+            .map(function(part) { return part.charAt(0).toUpperCase() + part.slice(1); })
+            .join('');
+    }
+
+    /* Angular normalises 'ddCustomNgTourWidget' to the element <dd-custom-ng-tour-widget>. */
+    function toElementTag(directiveName) {
+        return directiveName.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+    }
+
+    app.factory('customWidgets', ['$http', '$q', '$rootScope', function($http, $q, $rootScope) {
+
+        var _discovery = null;      // memoised discovery promise
+        var _packages = [];
+        var _injectedCss = {};      // css url -> true
+        var _usedDirectiveNames = {};
+
+        /* Package base urls are webroot-relative ('styles/x/widgets/y/') or a
+         * query-based asset route for plugins ('customwidgetasset?...&file=').
+         * In both cases appending the asset name yields the right url. */
+        function assetUrl(baseUrl, asset) {
+            return asset ? baseUrl + asset : null;
+        }
+
+        function claimDirectiveName(type) {
+            var base = DIRECTIVE_PREFIX + toPascalCase(type) + DIRECTIVE_SUFFIX;
+            var name = base;
+            // Distinct types can normalise to the same name ('ng-tour' vs 'ng_tour'),
+            // so make sure each one still ends up with its own directive.
+            for (var i = 2; _usedDirectiveNames[name]; i++) {
+                name = base + i;
+            }
+            _usedDirectiveNames[name] = true;
+            return name;
+        }
+
+        function injectCss(url) {
+            if (!url || _injectedCss[url]) { return; }
+            _injectedCss[url] = true;
+            var link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.type = 'text/css';
+            link.href = url;
+            document.getElementsByTagName('head')[0].appendChild(link);
+        }
+
+        /* Register one manifest descriptor into the shared widget registry.
+         * Returns true when the widget was accepted. */
+        function registerDescriptor(pkg, widget) {
+            var type = widget.type;
+
+            // Built-in widgets always win: a package must not be able to
+            // shadow (or hijack) a stock widget type.
+            if (widgetRegistry.get(type)) {
+                console.warn('customWidgets: package "' + pkg.id + '" declares widget type "' + type +
+                             '" which already exists; skipping it');
+                return false;
+            }
+
+            var directiveName = claimDirectiveName(type);
+
+            var descriptor = angular.extend({}, widget, {
+                custom: true,
+                directiveTag: toElementTag(directiveName),
+                directiveName: directiveName,
+                baseUrl: pkg.baseUrl,
+                entryUrl: assetUrl(pkg.baseUrl, widget.entry),
+                cssUrl: assetUrl(pkg.baseUrl, widget.css),
+                templateUrl: assetUrl(pkg.baseUrl, widget.template),
+                // Shown in the widget picker so a user can tell where a widget came from
+                provider: {
+                    id: pkg.id,
+                    name: pkg.name || pkg.id,
+                    author: pkg.author || '',
+                    version: pkg.version || '',
+                    source: pkg.source,
+                    origin: pkg.origin || ''
+                }
+            });
+
+            widgetRegistry.register(descriptor);
+            return true;
+        }
+
+        /**
+         * Ask the server which widget packages are installed and register every
+         * widget they declare. Memoised: the scan runs once per page load.
+         *
+         * Never rejects. A server that does not know the command, or a package
+         * that is broken, must not stop the dashboard from rendering.
+         */
+        function discover() {
+            if (_discovery) { return _discovery; }
+
+            _discovery = $http.get('json.htm?type=command&param=getcustomwidgets')
+                .then(function(resp) {
+                    var data = resp.data || {};
+                    if (data.status !== 'OK' || !angular.isArray(data.result)) {
+                        return [];
+                    }
+                    if (data.apiVersion !== SUPPORTED_API_VERSION) {
+                        console.warn('customWidgets: server speaks widget api version ' + data.apiVersion +
+                                     ', this dashboard speaks ' + SUPPORTED_API_VERSION + '; skipping custom widgets');
+                        return [];
+                    }
+
+                    var accepted = 0;
+                    data.result.forEach(function(pkg) {
+                        if (!pkg || !angular.isArray(pkg.widgets)) { return; }
+                        var registered = pkg.widgets.filter(function(widget) {
+                            return widget && widget.type && widget.entry && registerDescriptor(pkg, widget);
+                        });
+                        if (registered.length) {
+                            _packages.push(pkg);
+                            accepted += registered.length;
+                        }
+                    });
+
+                    if (accepted) {
+                        console.info('customWidgets: registered ' + accepted + ' custom widget(s) from ' +
+                                     _packages.length + ' package(s)');
+                    }
+                    return _packages;
+                })
+                .catch(function() {
+                    // No such command, no network, malformed reply: carry on without custom widgets.
+                    return [];
+                });
+
+            return _discovery;
+        }
+
+        /* Build the Angular directive definition for a loaded widget module.
+         *
+         * A module either exports a directive definition object, or a factory
+         * that receives its package context and returns one -- the factory form
+         * exists so a widget can resolve urls inside its own package. */
+        function buildDirective(descriptor, moduleExport) {
+            var ddo = angular.isFunction(moduleExport)
+                ? moduleExport({
+                      type: descriptor.type,
+                      baseUrl: descriptor.baseUrl,
+                      templateUrl: descriptor.templateUrl
+                  })
+                : moduleExport;
+
+            if (!ddo || !angular.isObject(ddo)) {
+                throw new Error('widget module did not return a directive definition object');
+            }
+
+            // Defaults chosen to match what the built-in widgets declare, so a
+            // minimal custom widget can be a controller and a template.
+            var definition = angular.extend({
+                scope: { widgetDef: '=', editMode: '<' },
+                controllerAs: 'ctrl',
+                bindToController: true
+            }, ddo);
+
+            // The wrapper renders the widget as an element, so this is not the
+            // package's choice to make.
+            definition.restrict = 'E';
+
+            if (!definition.template && !definition.templateUrl && descriptor.templateUrl) {
+                definition.templateUrl = descriptor.templateUrl;
+            }
+            if (!definition.template && !definition.templateUrl) {
+                throw new Error('widget module has neither a template nor a templateUrl');
+            }
+
+            return definition;
+        }
+
+        /**
+         * Fetch a custom widget's javascript and register its directive.
+         * Memoised per descriptor and safe to call from several widgets at once.
+         * Resolves once the widget's element name is compilable.
+         */
+        function load(descriptor) {
+            if (descriptor.$loadPromise) { return descriptor.$loadPromise; }
+
+            var deferred = $q.defer();
+
+            if (!descriptor.entryUrl) {
+                deferred.reject('widget has no entry script');
+                descriptor.$loadPromise = deferred.promise;
+                return descriptor.$loadPromise;
+            }
+
+            injectCss(descriptor.cssUrl);
+
+            // requirejs treats an id ending in '.js' (or containing '?') as a
+            // plain url, so these resolve against the document rather than the
+            // 'app' module base.
+            require([descriptor.entryUrl], function(moduleExport) {
+                try {
+                    var definition = buildDirective(descriptor, moduleExport);
+                    // angularAMD caches the providers from config time, which is
+                    // what lets us add a directive after the app has bootstrapped.
+                    angularAMD.getCachedProvider('$compileProvider')
+                        .directive(descriptor.directiveName, function() { return definition; });
+                    descriptor.$loaded = true;
+                    deferred.resolve(descriptor);
+                } catch (err) {
+                    console.error('customWidgets: "' + descriptor.type + '" failed to initialise', err);
+                    deferred.reject((err && err.message) || 'widget failed to initialise');
+                }
+                $rootScope.$applyAsync();
+            }, function(err) {
+                console.error('customWidgets: could not load ' + descriptor.entryUrl, err);
+                deferred.reject('could not load ' + descriptor.entryUrl);
+                $rootScope.$applyAsync();
+            });
+
+            descriptor.$loadPromise = deferred.promise;
+            return descriptor.$loadPromise;
+        }
+
+        return {
+            discover: discover,
+            load: load,
+            getPackages: function() { return _packages.slice(); },
+            apiVersion: SUPPORTED_API_VERSION
+        };
+    }]);
+});

--- a/www/app/dashboardDynamic/customWidgets.service.js
+++ b/www/app/dashboardDynamic/customWidgets.service.js
@@ -50,6 +50,17 @@ define([
         var _injectedCss = {};      // css url -> true
         var _usedDirectiveNames = {};
 
+        /* Per-widget load state, keyed by type.
+         *
+         * Deliberately NOT stored on the descriptor: ddGrid.addWidgetToGrid()
+         * does an angular.copy() of the descriptor into the widget it saves, so
+         * anything parked on a descriptor ends up in the persisted layout. A
+         * promise there made the layout cyclic and JSON.stringify threw, which
+         * broke saving for every dashboard holding a custom widget. Descriptors
+         * stay pure, serialisable data.
+         */
+        var _loadState = {};        // type -> { promise, loaded }
+
         /* Package base urls are webroot-relative ('styles/x/widgets/y/') or a
          * query-based asset route for plugins ('customwidgetasset?...&file=').
          * In both cases appending the asset name yields the right url. */
@@ -211,14 +222,15 @@ define([
          * Resolves once the widget's element name is compilable.
          */
         function load(descriptor) {
-            if (descriptor.$loadPromise) { return descriptor.$loadPromise; }
+            var state = _loadState[descriptor.type];
+            if (state) { return state.promise; }
 
             var deferred = $q.defer();
+            state = _loadState[descriptor.type] = { promise: deferred.promise, loaded: false };
 
             if (!descriptor.entryUrl) {
                 deferred.reject('widget has no entry script');
-                descriptor.$loadPromise = deferred.promise;
-                return descriptor.$loadPromise;
+                return state.promise;
             }
 
             injectCss(descriptor.cssUrl);
@@ -233,7 +245,7 @@ define([
                     // what lets us add a directive after the app has bootstrapped.
                     angularAMD.getCachedProvider('$compileProvider')
                         .directive(descriptor.directiveName, function() { return definition; });
-                    descriptor.$loaded = true;
+                    state.loaded = true;
                     deferred.resolve(descriptor);
                 } catch (err) {
                     console.error('customWidgets: "' + descriptor.type + '" failed to initialise', err);
@@ -246,13 +258,16 @@ define([
                 $rootScope.$applyAsync();
             });
 
-            descriptor.$loadPromise = deferred.promise;
-            return descriptor.$loadPromise;
+            return state.promise;
         }
 
         return {
             discover: discover,
             load: load,
+            isLoaded: function(descriptor) {
+                var state = descriptor && _loadState[descriptor.type];
+                return !!(state && state.loaded);
+            },
             getPackages: function() { return _packages.slice(); },
             apiVersion: SUPPORTED_API_VERSION
         };

--- a/www/app/dashboardDynamic/ddWidgetContent.directive.js
+++ b/www/app/dashboardDynamic/ddWidgetContent.directive.js
@@ -79,7 +79,7 @@ define([
                         return;
                     }
 
-                    if (descriptor.custom && !descriptor.$loaded) {
+                    if (descriptor.custom && !customWidgets.isLoaded(descriptor)) {
                         showMessage('dd-widget-loading', 'fa-solid fa-circle-notch fa-spin',
                                     'Loading ' + (descriptor.label || type) + '…');
 

--- a/www/app/dashboardDynamic/ddWidgetContent.directive.js
+++ b/www/app/dashboardDynamic/ddWidgetContent.directive.js
@@ -1,7 +1,8 @@
 define([
     'app',
     'dashboardDynamic/dashboardDynamic.module',
-    'dashboardDynamic/widgetRegistry.service'
+    'dashboardDynamic/widgetRegistry.service',
+    'dashboardDynamic/customWidgets.service'
 ], function(app) {
     'use strict';
 
@@ -10,16 +11,22 @@ define([
      *
      * Dynamically loads and compiles the correct widget directive for the given
      * widget type.  Each widget module registers itself in widgetRegistry with a
-     * descriptor; this directive uses that descriptor to lazy-load the module via
-     * $ocLazyLoad and then $compile the widget's own element directive into the DOM.
+     * descriptor; this directive uses that descriptor to compile the widget's own
+     * element directive into the DOM.
+     *
+     * Built-in widgets are all pre-loaded, so they compile straight away. Custom
+     * (third-party) widgets are registered from their package manifest without
+     * their code being run, so the first time one is rendered its script is
+     * fetched and its directive registered before compiling -- see
+     * customWidgets.service.js.
      *
      * Usage (from widget-wrapper.html):
      *   <div dd-widget-content
      *        widget-def="ctrl.widgetDef"
      *        edit-mode="editMode"></div>
      */
-    app.directive('ddWidgetContent', ['$compile', 'widgetRegistry',
-        function($compile, widgetRegistry) {
+    app.directive('ddWidgetContent', ['$compile', 'widgetRegistry', 'customWidgets',
+        function($compile, widgetRegistry, customWidgets) {
         return {
             restrict: 'A',
             scope: {
@@ -30,29 +37,24 @@ define([
 
                 var compiledScope = null;
 
-                function renderWidget(type) {
-                    // Destroy previous compiled scope and element
+                function teardown() {
                     if (compiledScope) {
                         compiledScope.$destroy();
                         compiledScope = null;
                     }
                     element.empty();
+                }
 
-                    if (!type) { return; }
+                function showMessage(cssClass, iconClass, text) {
+                    element.html(
+                        '<div class="' + cssClass + '">' +
+                        '<i class="' + iconClass + '"></i> ' +
+                        angular.element('<div>').text(text).html() +
+                        '</div>'
+                    );
+                }
 
-                    var descriptor = widgetRegistry.get(type);
-
-                    if (!descriptor) {
-                        element.html(
-                            '<div class="dd-widget-error">' +
-                            '<i class="fa-solid fa-triangle-exclamation"></i> ' +
-                            'Unknown widget type: ' + type +
-                            '</div>'
-                        );
-                        return;
-                    }
-
-                    // All widgets are pre-loaded — compile directly
+                function compileWidget(descriptor, type) {
                     var tag = descriptor.directiveTag || ('dd-' + type + '-widget');
                     var html = '<' + tag +
                                ' widget-def="widgetDef"' +
@@ -62,6 +64,40 @@ define([
                     var compiled = $compile(html)(compiledScope);
                     element.empty();
                     element.append(compiled);
+                }
+
+                function renderWidget(type) {
+                    teardown();
+
+                    if (!type) { return; }
+
+                    var descriptor = widgetRegistry.get(type);
+
+                    if (!descriptor) {
+                        showMessage('dd-widget-error', 'fa-solid fa-triangle-exclamation',
+                                    'Unknown widget type: ' + type);
+                        return;
+                    }
+
+                    if (descriptor.custom && !descriptor.$loaded) {
+                        showMessage('dd-widget-loading', 'fa-solid fa-circle-notch fa-spin',
+                                    'Loading ' + (descriptor.label || type) + '…');
+
+                        customWidgets.load(descriptor).then(function() {
+                            // The widget may have been swapped out or the card
+                            // removed while its script was in flight.
+                            if (scope.$$destroyed || scope.widgetDef.type !== type) { return; }
+                            teardown();
+                            compileWidget(descriptor, type);
+                        }, function(err) {
+                            if (scope.$$destroyed || scope.widgetDef.type !== type) { return; }
+                            showMessage('dd-widget-error', 'fa-solid fa-triangle-exclamation',
+                                        (descriptor.label || type) + ' failed to load: ' + err);
+                        });
+                        return;
+                    }
+
+                    compileWidget(descriptor, type);
                 }
 
                 // Re-render whenever the widget type changes (e.g. after a clone/replace)

--- a/www/app/main.js
+++ b/www/app/main.js
@@ -36,6 +36,7 @@ require.config({
 		'dashboardDynamic/DashboardDynamicController':    'dashboardDynamic/DashboardDynamicController',
 		'dashboardDynamic/ddGrid':                 'dashboardDynamic/ddGrid.directive',
 		'dashboardDynamic/widgetRegistry.service':  'dashboardDynamic/widgetRegistry.service',
+		'dashboardDynamic/customWidgets.service':   'dashboardDynamic/customWidgets.service',
 		'dashboardDynamic/ddWidgetWrapper':        'dashboardDynamic/ddWidgetWrapper.directive',
 		'dashboardDynamic/ddWidgetContent.directive': 'dashboardDynamic/ddWidgetContent.directive',
 		'dashboardDynamic/ddWidgetSettings.controller': 'dashboardDynamic/ddWidgetSettings.controller',

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -393,6 +393,14 @@ body.dd-navbar-hidden .dd-toolbar {
     z-index: 1;
 }
 
+/* .form-control carries no width declaration in this build, so without this the
+   search box sits at the browser's intrinsic input width (~185px) in a 320px
+   panel rather than filling it. */
+.dd-library-search input {
+    width: 100%;
+    box-sizing: border-box;
+}
+
 /* Built-in vs installed-package filter, above the categories */
 .dd-library-sources {
     display: flex;
@@ -485,9 +493,20 @@ body.dd-navbar-hidden .dd-toolbar {
 }
 
 .dd-library-item-label {
+    display: flex;
+    align-items: center;
+    min-width: 0;
     font-weight: 600;
     font-size: 0.9em;
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* The name gives up room before the badge does, so a long widget name
+   truncates rather than pushing its provider off the row. */
+.dd-library-item-name {
+    min-width: 0;
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -496,6 +515,7 @@ body.dd-navbar-hidden .dd-toolbar {
 .dd-library-item-provider {
     display: inline-flex;
     align-items: center;
+    flex: 0 0 auto;
     gap: 3px;
     margin-left: 6px;
     padding: 1px 5px;

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -454,6 +454,26 @@ body.dd-navbar-hidden .dd-toolbar {
     text-overflow: ellipsis;
 }
 
+/* Marks a widget as coming from a theme, plugin or dropped-in package */
+.dd-library-item-provider {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 6px;
+    padding: 1px 5px;
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--dz-accent-color, #4e9af1) 16%, transparent);
+    color: var(--dz-body-text);
+    font-weight: 500;
+    font-size: 0.78em;
+    vertical-align: middle;
+    opacity: 0.85;
+}
+
+.dd-library-item-provider i {
+    font-size: 0.9em;
+}
+
 .dd-library-item-desc {
     font-size: 0.78em;
     color: var(--dz-body-text);

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -674,6 +674,17 @@ body.dd-navbar-hidden .dd-toolbar {
     font-size: 0.85em;
 }
 
+/* Shown while a custom widget's script is being fetched on first render */
+.dd-widget-loading {
+    padding: 12px 16px;
+    color: var(--dz-body-text);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85em;
+    opacity: 0.7;
+}
+
 .dd-widget--loading {
     opacity: 0.7;
     pointer-events: none;

--- a/www/css/dashboard.css
+++ b/www/css/dashboard.css
@@ -393,6 +393,44 @@ body.dd-navbar-hidden .dd-toolbar {
     z-index: 1;
 }
 
+/* Built-in vs installed-package filter, above the categories */
+.dd-library-sources {
+    display: flex;
+    gap: 4px;
+    padding: 0 8px 8px;
+    position: sticky;
+    top: 46px;
+    background: var(--dz-nav-bg);
+    z-index: 1;
+}
+
+.dd-library-source {
+    flex: 1 1 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 4px;
+    padding: 4px 6px;
+    border: 1px solid var(--dz-border-color, rgba(127, 127, 127, 0.25));
+    border-radius: 6px;
+    background: transparent;
+    color: var(--dz-body-text);
+    font-size: 0.78em;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: background-color 0.15s ease, opacity 0.15s ease;
+}
+
+.dd-library-source:hover {
+    opacity: 1;
+}
+
+.dd-library-source.active {
+    background: color-mix(in srgb, var(--dz-accent-color, #4e9af1) 20%, transparent);
+    border-color: var(--dz-accent-color, #4e9af1);
+    opacity: 1;
+}
+
 .dd-library-category {
     margin-bottom: 12px;
 }

--- a/www/views/dashboardDynamic.html
+++ b/www/views/dashboardDynamic.html
@@ -264,13 +264,16 @@
                     <div class="dd-library-item"
                          ng-repeat="item in group.items | filter:libraryItemFilter"
                          ng-click="addWidgetToGrid(item)"
+                         data-widget-type="{{ item.type }}"
                          title="{{ item.description }}">
                         <div class="dd-library-item-icon">
                             <i ng-class="item.icon"></i>
                         </div>
                         <div class="dd-library-item-info">
                             <div class="dd-library-item-label">
-                                <span ng-bind="item.label"></span>
+                                <!-- Own element so the label text stays readable on its own,
+                                     rather than running into the provider badge beside it -->
+                                <span class="dd-library-item-name" ng-bind="item.label"></span>
                                 <!-- Where a third-party widget came from, so installed packages are attributable -->
                                 <span class="dd-library-item-provider" ng-if="item.custom"
                                       title="{{ item.provider.name }}{{ item.provider.version ? ' ' + item.provider.version : '' }}{{ item.provider.author ? ' by ' + item.provider.author : '' }}">

--- a/www/views/dashboardDynamic.html
+++ b/www/views/dashboardDynamic.html
@@ -241,8 +241,22 @@
         <div class="dd-library-panel-body">
             <div class="dd-library-search">
                 <input type="text" class="form-control input-sm"
-                       placeholder="Search widgets..."
+                       placeholder="Search widgets, themes, plugins..."
                        ng-model="librarySearch">
+            </div>
+            <!-- Only worth showing once something is actually installed -->
+            <div class="dd-library-sources" ng-if="hasCustomWidgets()">
+                <button type="button" class="dd-library-source"
+                        ng-class="{active: librarySource === 'all'}"
+                        ng-click="setLibrarySource('all')">All</button>
+                <button type="button" class="dd-library-source"
+                        ng-class="{active: librarySource === 'builtin'}"
+                        ng-click="setLibrarySource('builtin')">Built-in</button>
+                <button type="button" class="dd-library-source"
+                        ng-class="{active: librarySource === 'custom'}"
+                        ng-click="setLibrarySource('custom')">
+                    <i class="fa-solid fa-puzzle-piece"></i> Custom
+                </button>
             </div>
             <div ng-repeat="group in widgetCatalogGrouped" ng-show="(group.items | filter:libraryItemFilter).length > 0">
                 <div class="dd-library-category-label" ng-bind="group.category"></div>

--- a/www/views/dashboardDynamic.html
+++ b/www/views/dashboardDynamic.html
@@ -255,7 +255,18 @@
                             <i ng-class="item.icon"></i>
                         </div>
                         <div class="dd-library-item-info">
-                            <div class="dd-library-item-label" ng-bind="item.label"></div>
+                            <div class="dd-library-item-label">
+                                <span ng-bind="item.label"></span>
+                                <!-- Where a third-party widget came from, so installed packages are attributable -->
+                                <span class="dd-library-item-provider" ng-if="item.custom"
+                                      title="{{ item.provider.name }}{{ item.provider.version ? ' ' + item.provider.version : '' }}{{ item.provider.author ? ' by ' + item.provider.author : '' }}">
+                                    <i class="fa-solid"
+                                       ng-class="{ 'fa-palette': item.provider.source === 'theme',
+                                                   'fa-plug': item.provider.source === 'plugin',
+                                                   'fa-puzzle-piece': item.provider.source === 'webroot' }"></i>
+                                    <span ng-bind="item.provider.origin || item.provider.name"></span>
+                                </span>
+                            </div>
                             <div class="dd-library-item-desc" ng-bind="item.description"></div>
                         </div>
                         <i class="fa-solid fa-circle-plus"

--- a/www/widgets/example/exampleDevice.css
+++ b/www/widgets/example/exampleDevice.css
@@ -1,0 +1,70 @@
+/*
+ * Styles for the example widget.
+ *
+ * A package's css is injected once, the first time one of its widgets is
+ * rendered. It is global, so prefix your selectors: there is nothing scoping
+ * them to your widget.
+ *
+ * Prefer the Domoticz theme variables over hard-coded colours so the widget
+ * follows whatever theme the user has picked.
+ */
+.example-widget {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 10px 14px;
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.example-widget__title {
+    font-size: 0.8em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.7;
+    color: var(--dz-body-text);
+}
+
+.example-widget__body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+.example-widget__value {
+    font-size: 1.9em;
+    font-weight: 600;
+    line-height: 1.1;
+    color: var(--example-accent, var(--dz-accent-color, #4e9af1));
+}
+
+.example-widget__name {
+    font-size: 0.85em;
+    color: var(--dz-body-text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.example-widget__updated {
+    font-size: 0.75em;
+    opacity: 0.6;
+    color: var(--dz-body-text);
+}
+
+.example-widget__state {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex: 1 1 auto;
+    font-size: 0.85em;
+    color: var(--dz-body-text);
+    opacity: 0.75;
+}
+
+.example-widget__state--error {
+    color: var(--dz-status-timeout, #DF2D3A);
+    opacity: 1;
+}

--- a/www/widgets/example/exampleDevice.html
+++ b/www/widgets/example/exampleDevice.html
@@ -1,0 +1,20 @@
+<div class="example-widget" ng-style="{ '--example-accent': ctrl.accent }">
+
+    <div class="example-widget__title" ng-if="ctrl.title">{{ ctrl.title }}</div>
+
+    <div class="example-widget__state" ng-if="ctrl.loading">
+        <i class="fa-solid fa-circle-notch fa-spin"></i>
+    </div>
+
+    <div class="example-widget__state example-widget__state--error" ng-if="!ctrl.loading && ctrl.error">
+        <i class="fa-solid fa-triangle-exclamation"></i>
+        <span>{{ ctrl.error }}</span>
+    </div>
+
+    <div class="example-widget__body" ng-if="!ctrl.loading && !ctrl.error && ctrl.device">
+        <div class="example-widget__value">{{ ctrl.device.Data }}</div>
+        <div class="example-widget__name">{{ ctrl.device.Name }}</div>
+        <div class="example-widget__updated" ng-if="ctrl.showUpdated">{{ ctrl.device.LastUpdate }}</div>
+    </div>
+
+</div>

--- a/www/widgets/example/exampleDevice.widget.js
+++ b/www/widgets/example/exampleDevice.widget.js
@@ -1,0 +1,100 @@
+/*
+ * Example custom widget for the Domoticz dynamic dashboard.
+ *
+ * A widget module is an AMD module that exports either an Angular directive
+ * definition object, or -- as here -- a factory that receives the package
+ * context and returns one. Use the factory form when the widget needs to build
+ * urls inside its own package; ctx.baseUrl is where the package was installed.
+ *
+ * Domoticz registers the directive itself, so the module must not touch the
+ * 'app' module or pick its own element name.
+ *
+ * Every widget is handed two bindings on its scope:
+ *   widgetDef  the placed widget, whose .config holds the user's answers to
+ *              the configSchema in widget.json. Watch it; the user can change
+ *              a setting while the widget is on screen.
+ *   editMode   true while the dashboard is being edited.
+ *
+ * See docs/custom-widgets.md for the full contract.
+ */
+define(function() {
+    'use strict';
+
+    return function(ctx) {
+        return {
+            templateUrl: ctx.templateUrl,
+
+            controller: ['$scope', '$http', function($scope, $http) {
+                var ctrl = this;
+
+                ctrl.loading = true;
+                ctrl.error   = null;
+                ctrl.device  = null;
+
+                function config() {
+                    return (ctrl.widgetDef && ctrl.widgetDef.config) || {};
+                }
+
+                function applyConfig() {
+                    var cfg = config();
+                    ctrl.title       = cfg.title || '';
+                    ctrl.accent      = cfg.accent || '#4e9af1';
+                    ctrl.decimals    = angular.isNumber(cfg.decimals) ? cfg.decimals : 1;
+                    ctrl.showUpdated = cfg.showUpdated !== false;
+                }
+
+                function load() {
+                    var idx = config().deviceIdx;
+                    if (!idx) {
+                        ctrl.loading = false;
+                        ctrl.error   = 'Pick a device in this widget\'s settings';
+                        return;
+                    }
+                    ctrl.error = null;
+                    $http.get('json.htm', { params: { type: 'command', param: 'getdevices', rid: idx } })
+                        .then(function(resp) {
+                            var result = resp.data && resp.data.result;
+                            ctrl.loading = false;
+                            if (!result || !result.length) {
+                                ctrl.error = 'Device ' + idx + ' not found';
+                                return;
+                            }
+                            ctrl.device = result[0];
+                        }, function() {
+                            ctrl.loading = false;
+                            ctrl.error   = 'Could not read device ' + idx;
+                        });
+                }
+
+                // Domoticz pushes a 'device_update' for every device that changes,
+                // so filter to the one this widget is showing.
+                $scope.$on('device_update', function(event, updated) {
+                    if (ctrl.device && String(updated.idx) === String(ctrl.device.idx)) {
+                        ctrl.device = angular.extend({}, ctrl.device, updated);
+                    }
+                });
+
+                // Broadcast when the user hits refresh on the dashboard.
+                $scope.$on('dd:widget:refresh', load);
+
+                // Re-read whenever the user changes this widget's settings.
+                $scope.$watch(function() { return config(); }, function() {
+                    var previousIdx = ctrl.$idx;
+                    applyConfig();
+                    ctrl.$idx = config().deviceIdx;
+                    if (ctrl.$idx !== previousIdx) {
+                        ctrl.loading = true;
+                        ctrl.device  = null;
+                        load();
+                    }
+                }, true);
+
+                ctrl.$onInit = function() {
+                    applyConfig();
+                    ctrl.$idx = config().deviceIdx;
+                    load();
+                };
+            }]
+        };
+    };
+});

--- a/www/widgets/example/widget.json
+++ b/www/widgets/example/widget.json
@@ -1,0 +1,32 @@
+{
+    "name": "Example Widgets",
+    "description": "Reference implementation of the Domoticz custom widget API",
+    "author": "Domoticz",
+    "version": "1.0.0",
+    "apiVersion": 1,
+    "widgets": [
+        {
+            "type": "example-device",
+            "label": "Example: Device Readout",
+            "description": "Shows one device's value and stays in sync with it. Reference implementation for custom widgets.",
+            "category": "Custom Content",
+            "icon": "fa-solid fa-flask",
+            "entry": "exampleDevice.widget.js",
+            "template": "exampleDevice.html",
+            "css": "exampleDevice.css",
+            "defaultW": 3,
+            "defaultH": 2,
+            "minW": 2,
+            "minH": 2,
+            "maxW": 6,
+            "maxH": 4,
+            "configSchema": [
+                { "key": "title", "type": "text", "label": "Title (optional)", "required": false },
+                { "key": "deviceIdx", "type": "device-picker", "label": "Device", "required": true },
+                { "key": "accent", "type": "color", "label": "Accent colour", "default": "#4e9af1" },
+                { "key": "decimals", "type": "number", "label": "Decimal places", "default": 1, "min": 0, "max": 4 },
+                { "key": "showUpdated", "type": "boolean", "label": "Show last-updated time", "default": true }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
> **Updated during review:** themes were originally a third widget source. That has been removed — see the last commit. Discovery is now `www/widgets/` and `plugins/<Plugin>/widgets/` only.

## Why

Adding a widget to the dynamic dashboard currently means editing two core files — the requirejs `paths` map in `www/app/main.js` and the `define()` dependency list in `DashboardDynamicController.js`. That puts widget authoring out of reach for plugin authors and anyone wanting to publish a widget on its own, even though `widgetRegistry` and `ddWidgetContent` were already written as extension points (`ddWidgetContent`'s own docblock describes lazy-loading a widget module, then short-circuits with `// All widgets are pre-loaded`).

This finishes that seam so a widget can come from a Python plugin or a repo you clone into place.

## How

A widget package is a folder holding a `widget.json` manifest plus its assets. Packages are discovered at request time in two places:

| Location | For |
| --- | --- |
| `<www>/widgets/<pkg>/` | standalone widget repositories |
| `<userdata>/plugins/<Plugin>/widgets/<pkg>/` | widgets shipped by a Python plugin |

The key design point: **the manifest carries the descriptor, not the javascript.** Label, icon, default size and `configSchema` all live in `widget.json`, so the widget picker is populated without executing any third-party code. A widget's script is fetched only when someone actually places one. A broken or hostile package therefore cannot stop the picker — or the rest of the dashboard — from loading; the affected card shows an error and everything else carries on.

Widget modules export a plain Angular directive definition object (or a factory that receives its package context and returns one), so an author can start from any built-in widget. Domoticz registers the directive itself under a name it derives from the widget type, which makes element-name collisions with built-in widgets impossible. Built-in types always win if a package claims one that already exists.

Post-bootstrap registration uses `angularAMD.getCachedProvider('$compileProvider')` — no new dependency.

## Notes for review

- **Discovery** mirrors the existing `www/templates` scan in `WebServerCmds.cpp`: one new `getcustomwidgets` command, no schema change, nothing cached, so installing a package needs a browser reload rather than a restart. It reads no preferences, so it does not depend on any user or theme setting.
- **Serving plugin assets.** Plugin packages sit outside the webroot. libwebem matches registered pages on the exact request path (`myPages.find`), so there is no prefix route available; assets go through a `customwidgetasset` page with a query-based url. It validates every path segment, rejects traversal, and serves only an extension allowlist (js/html/css/json/png/jpg/jpeg/gif/svg/webp/woff/woff2). RequireJS handles such urls natively — `nameToUrl` skips appending `.js` when the id contains `?`.
- **Trust model.** Widget code is not sandboxed; it runs with the same access as Domoticz's own javascript. That is deliberate rather than overlooked — a Python plugin already runs arbitrary code on the server, and `www/templates/` has always allowed custom Angular pages (see `templates/angular.example`) — but it does mean installing a widget package is a trust decision like installing a plugin, and the docs say so plainly.
- **Validation** rejects a bad package with a log line rather than failing the request: wrong `apiVersion`, unparseable JSON, no `widgets` array, unsafe asset path, or a duplicate widget type.
- `apiVersion` is pinned at 1 on both sides, so a future breaking change to the contract can be made safely.

## Also included

- `docs/custom-widgets.md` — the full contract: package format, directive contract, config schema field types, lifecycle events, limits, troubleshooting.
- `www/widgets/example/` — a working reference package.
- The widget library gains an All / Built-in / Custom filter (shown only when a package is installed) and badges custom entries with their origin, so it stays possible to tell where a widget came from.

## Verification

Built and run on Debian bookworm against a database with ~734 devices, with packages installed in both locations at once.

- `getcustomwidgets` returns each package with correct `source`, `origin` and `baseUrl`.
- Driven in a real browser over CDP: every custom widget resolves its module through requirejs, registers its directive post-bootstrap, and renders its template. Each also survives `JSON.stringify(angular.copy(descriptor))`, which is what saving a dashboard does.
- Asset route: 200 with the right content type for allowed assets, 403 for a disallowed extension, 400 for traversal in any parameter, 404 for a missing file.

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62644668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 3/5</h2>

The PR is not yet safe to merge because an unavailable discovery request can block the dashboard indefinitely and malformed manifest field types can still abort package discovery.

<h2><a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Awww%2Fapp%2FdashboardDynamic%2FDashboardDynamicController.js%3A266-269%0AWhen%20the%20%60getcustomwidgets%60%20request%20remains%20pending%2C%20initialization%20never%20calls%20%60listLayouts%28%29%60%20because%20the%20optional%20discovery%20request%20has%20no%20timeout%2C%20causing%20the%20entire%20dashboard%20to%20remain%20in%20its%20loading%20state%20even%20when%20it%20uses%20only%20built-in%20widgets.%0A%0A%23%23%23%20Issue%202%0Amain%2FWebServerCmds.cpp%3Aundefined-8353%0AWhen%20a%20manifest%20supplies%20%60apiVersion%60%20or%20%60type%60%20with%20an%20incompatible%20JSON%20type%2C%20the%20unchecked%20%60asInt%28%29%60%20or%20%60asString%28%29%60%20conversion%20throws%20outside%20any%20per-package%20exception%20boundary%2C%20causing%20one%20malformed%20package%20to%20prevent%20every%20valid%20custom%20widget%20from%20being%20returned.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=domoticz%2Fdomoticz&pr=7029&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=7"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=7" align="right"></picture></a>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Discovery blocks dashboard loading** <a href="https://github.com/domoticz/domoticz/pull/7029#discussion_r3980724938">▶</a>
2. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Malformed manifests abort discovery** <a href="https://github.com/domoticz/domoticz/pull/7029#discussion_r3980724951">▶</a>

<details><summary>Fix with agent prompt</summary>

`````markdown
### Issue 1
www/app/dashboardDynamic/DashboardDynamicController.js:266-269
When the `getcustomwidgets` request remains pending, initialization never calls `listLayouts()` because the optional discovery request has no timeout, causing the entire dashboard to remain in its loading state even when it uses only built-in widgets.

### Issue 2
main/WebServerCmds.cpp:undefined-8353
When a manifest supplies `apiVersion` or `type` with an incompatible JSON type, the unchecked `asInt()` or `asString()` conversion throws outside any per-package exception boundary, causing one malformed package to prevent every valid custom widget from being returned.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<h3>Summary</h3>

The PR adds manifest-based discovery and lazy loading for standalone and plugin-provided dashboard widgets.
- Adds server-side package scanning and a route for plugin widget assets.
- Registers manifest descriptors in the browser and loads widget directives on first render.
- Adds source filtering, provider badges, documentation, and an example widget package.

<details open><summary>Diagram</summary>

```mermaid
sequenceDiagram
    participant UI as Dynamic dashboard
    participant API as getcustomwidgets
    participant Registry as Widget registry
    participant Loader as RequireJS
    UI->>API: Discover installed packages
    API-->>UI: Validated manifests
    UI->>Registry: Register descriptors
    UI->>Loader: Load entry when card renders
    Loader-->>UI: Widget directive module
    UI->>UI: Register and compile directive
```
</details>

<sub>Reviews (2) · Last reviewed commit: ["refactor(dashboard): drop themes as a cu..."](https://github.com/domoticz/domoticz/commit/170bef650829385578f7d21e992afa1a6eab0c90)</sub>

<!-- /greptile_comment -->